### PR TITLE
TopMonitoring: Updated fully hadronic paths and ele, fully hadronic t…

### DIFF
--- a/DQMOffline/Trigger/python/TopMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TopMonitoring_cff.py
@@ -7,7 +7,7 @@ topEleJet_jet.FolderName = cms.string('HLT/TOP/EleJet/JetMonitor')
 topEleJet_jet.nmuons = cms.uint32(0)
 topEleJet_jet.nelectrons = cms.uint32(1)
 topEleJet_jet.njets = cms.uint32(1)
-topEleJet_jet.eleSelection = cms.string('pt>50 & abs(eta)<2.1 & (dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1')
+topEleJet_jet.eleSelection = cms.string('pt>50 & abs(eta)<2.1')
 topEleJet_jet.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topEleJet_jet.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
 topEleJet_jet.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
@@ -25,7 +25,7 @@ topEleJet_ele.FolderName = cms.string('HLT/TOP/EleJet/ElectronMonitor')
 topEleJet_ele.nmuons = cms.uint32(0)
 topEleJet_ele.nelectrons = cms.uint32(1)
 topEleJet_ele.njets = cms.uint32(1)
-topEleJet_ele.eleSelection = cms.string('pt>25 & abs(eta)<2.1 & (dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1')
+topEleJet_ele.eleSelection = cms.string('pt>25 & abs(eta)<2.1')
 topEleJet_ele.jetSelection = cms.string('pt>50 & abs(eta)<2.4')
 topEleJet_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
 topEleJet_ele.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
@@ -50,7 +50,7 @@ topEleJet_all.FolderName = cms.string('HLT/TOP/EleJet/GlobalMonitor')
 topEleJet_all.nmuons = cms.uint32(0)
 topEleJet_all.nelectrons = cms.uint32(1)
 topEleJet_all.njets = cms.uint32(1)
-topEleJet_all.eleSelection = cms.string('pt>25 & abs(eta)<2.1 & (dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1')
+topEleJet_all.eleSelection = cms.string('pt>25 & abs(eta)<2.1')
 topEleJet_all.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topEleJet_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
 topEleJet_all.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
@@ -67,7 +67,7 @@ topEleHT_ht.FolderName = cms.string('HLT/TOP/EleHT/HTMonitor')
 topEleHT_ht.nmuons = cms.uint32(0)
 topEleHT_ht.nelectrons = cms.uint32(1)
 topEleHT_ht.njets = cms.uint32(2)
-topEleHT_ht.eleSelection = cms.string('pt>50 & abs(eta)<2.1 & (dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1')
+topEleHT_ht.eleSelection = cms.string('pt>50 & abs(eta)<2.1')
 topEleHT_ht.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topEleHT_ht.HTcut = cms.double(100)
 topEleHT_ht.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
@@ -88,7 +88,7 @@ topEleHT_ele.FolderName = cms.string('HLT/TOP/EleHT/ElectronMonitor')
 topEleHT_ele.nmuons = cms.uint32(0)
 topEleHT_ele.nelectrons = cms.uint32(1)
 topEleHT_ele.njets = cms.uint32(2)
-topEleHT_ele.eleSelection = cms.string('pt>25 & abs(eta)<2.1 & (dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1')
+topEleHT_ele.eleSelection = cms.string('pt>25 & abs(eta)<2.1')
 topEleHT_ele.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topEleHT_ele.HTcut = cms.double(200)
 topEleHT_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
@@ -114,7 +114,7 @@ topEleHT_all.FolderName = cms.string('HLT/TOP/EleHT/GlobalMonitor')
 topEleHT_all.nmuons = cms.uint32(0)
 topEleHT_all.nelectrons = cms.uint32(1)
 topEleHT_all.njets = cms.uint32(2)
-topEleHT_all.eleSelection = cms.string('pt>25 & abs(eta)<2.1 & (dr03TkSumPt+dr04EcalRecHitSumEt+dr04HcalTowerSumEt)/pt<0.1')
+topEleHT_all.eleSelection = cms.string('pt>25 & abs(eta)<2.1')
 topEleHT_all.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topEleHT_all.HTcut = cms.double(100)
 topEleHT_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
@@ -136,7 +136,7 @@ topSingleMuonHLTMonitor_Mu24.FolderName = cms.string('HLT/TOP/SingleLepton/Singl
 topSingleMuonHLTMonitor_Mu24.nmuons = cms.uint32(1)
 topSingleMuonHLTMonitor_Mu24.nelectrons = cms.uint32(0)
 topSingleMuonHLTMonitor_Mu24.njets = cms.uint32(0)
-topSingleMuonHLTMonitor_Mu24.eleSelection = cms.string('pt>30 & abs(eta)<2.4 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topSingleMuonHLTMonitor_Mu24.eleSelection = cms.string('pt>30 & abs(eta)<2.4')
 topSingleMuonHLTMonitor_Mu24.muoSelection = cms.string('pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15')
 topSingleMuonHLTMonitor_Mu24.jetSelection = cms.string('pt>20 & abs(eta)<2.4')
 topSingleMuonHLTMonitor_Mu24.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_eta2p1_v*', 'HLT_IsoMu24_v*')
@@ -146,7 +146,7 @@ topSingleMuonHLTMonitor_Mu27.FolderName = cms.string('HLT/TOP/SingleLepton/Singl
 topSingleMuonHLTMonitor_Mu27.nmuons = cms.uint32(1)
 topSingleMuonHLTMonitor_Mu27.nelectrons = cms.uint32(0)
 topSingleMuonHLTMonitor_Mu27.njets = cms.uint32(0)
-topSingleMuonHLTMonitor_Mu27.eleSelection = cms.string('pt>30 & abs(eta)<2.4 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topSingleMuonHLTMonitor_Mu27.eleSelection = cms.string('pt>30 & abs(eta)<2.4')
 topSingleMuonHLTMonitor_Mu27.muoSelection = cms.string('pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15')
 topSingleMuonHLTMonitor_Mu27.jetSelection = cms.string('pt>20 & abs(eta)<2.4')
 topSingleMuonHLTMonitor_Mu27.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
@@ -157,7 +157,7 @@ topSingleMuonHLTMonitor_Mu50.FolderName = cms.string('HLT/TOP/SingleLepton/Singl
 topSingleMuonHLTMonitor_Mu50.nmuons = cms.uint32(1)
 topSingleMuonHLTMonitor_Mu50.nelectrons = cms.uint32(0)
 topSingleMuonHLTMonitor_Mu50.njets = cms.uint32(0)
-topSingleMuonHLTMonitor_Mu50.eleSelection = cms.string('pt>30 & abs(eta)<2.4 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topSingleMuonHLTMonitor_Mu50.eleSelection = cms.string('pt>30 & abs(eta)<2.4')
 topSingleMuonHLTMonitor_Mu50.muoSelection = cms.string('pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15')
 topSingleMuonHLTMonitor_Mu50.jetSelection = cms.string('pt>20 & abs(eta)<2.4')
 topSingleMuonHLTMonitor_Mu50.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu50_v*')
@@ -169,7 +169,7 @@ topDiElectronHLTMonitor.FolderName = cms.string('HLT/TOP/DiLepton/DiElectron/Ele
 topDiElectronHLTMonitor.nmuons = cms.uint32(0)
 topDiElectronHLTMonitor.nelectrons = cms.uint32(2)
 topDiElectronHLTMonitor.njets = cms.uint32(0)
-topDiElectronHLTMonitor.eleSelection = cms.string('pt>15 & abs(eta)<2.4  & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topDiElectronHLTMonitor.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
 topDiElectronHLTMonitor.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
 topDiElectronHLTMonitor.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topDiElectronHLTMonitor.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*')
@@ -184,7 +184,7 @@ topDiMuonHLTMonitor_noDz.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mu17_M
 topDiMuonHLTMonitor_noDz.nmuons = cms.uint32(2)
 topDiMuonHLTMonitor_noDz.nelectrons = cms.uint32(0)
 topDiMuonHLTMonitor_noDz.njets = cms.uint32(0)
-topDiMuonHLTMonitor_noDz.eleSelection = cms.string('pt>15 & abs(eta)<2.4  & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topDiMuonHLTMonitor_noDz.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
 topDiMuonHLTMonitor_noDz.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
 topDiMuonHLTMonitor_noDz.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topDiMuonHLTMonitor_noDz.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*')
@@ -194,7 +194,7 @@ topDiMuonHLTMonitor_Dz.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mu17_Mu8
 topDiMuonHLTMonitor_Dz.nmuons = cms.uint32(2)
 topDiMuonHLTMonitor_Dz.nelectrons = cms.uint32(0)
 topDiMuonHLTMonitor_Dz.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Dz.eleSelection = cms.string('pt>15 & abs(eta)<2.4  & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')              
+topDiMuonHLTMonitor_Dz.eleSelection = cms.string('pt>15 & abs(eta)<2.4')              
 topDiMuonHLTMonitor_Dz.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
 topDiMuonHLTMonitor_Dz.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Dz.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
@@ -209,7 +209,7 @@ topDiMuonHLTMonitor_Mass8.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mass8
 topDiMuonHLTMonitor_Mass8.nmuons = cms.uint32(2)
 topDiMuonHLTMonitor_Mass8.nelectrons = cms.uint32(0)
 topDiMuonHLTMonitor_Mass8.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Mass8.eleSelection = cms.string('pt>15 & abs(eta)<2.4  & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topDiMuonHLTMonitor_Mass8.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Mass8.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
 topDiMuonHLTMonitor_Mass8.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Mass8.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*')
@@ -220,7 +220,7 @@ topDiMuonHLTMonitor_Mass3p8.FolderName = cms.string('HLT/TopHLTOffline/TopMonito
 topDiMuonHLTMonitor_Mass3p8.nmuons = cms.uint32(2)
 topDiMuonHLTMonitor_Mass3p8.nelectrons = cms.uint32(0)
 topDiMuonHLTMonitor_Mass3p8.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Mass3p8.eleSelection = cms.string('pt>15 & abs(eta)<2.4  & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topDiMuonHLTMonitor_Mass3p8.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Mass3p8.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
 topDiMuonHLTMonitor_Mass3p8.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Mass3p8.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*')
@@ -230,7 +230,7 @@ topDiMuonHLTMonitor_Mass8Mon.FolderName = cms.string('HLT/TopHLTOffline/TopMonit
 topDiMuonHLTMonitor_Mass8Mon.nmuons = cms.uint32(2)
 topDiMuonHLTMonitor_Mass8Mon.nelectrons = cms.uint32(0)
 topDiMuonHLTMonitor_Mass8Mon.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Mass8Mon.eleSelection = cms.string('pt>15 & abs(eta)<2.4  & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topDiMuonHLTMonitor_Mass8Mon.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Mass8Mon.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
 topDiMuonHLTMonitor_Mass8Mon.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Mass8Mon.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*')
@@ -241,7 +241,7 @@ topDiMuonHLTMonitor_Mass3p8Mon.FolderName = cms.string('HLT/TopHLTOffline/TopMon
 topDiMuonHLTMonitor_Mass3p8Mon.nmuons = cms.uint32(2)
 topDiMuonHLTMonitor_Mass3p8Mon.nelectrons = cms.uint32(0)
 topDiMuonHLTMonitor_Mass3p8Mon.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Mass3p8Mon.eleSelection = cms.string('pt>15 & abs(eta)<2.4  & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topDiMuonHLTMonitor_Mass3p8Mon.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Mass3p8Mon.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
 topDiMuonHLTMonitor_Mass3p8Mon.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Mass3p8Mon.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*')
@@ -253,7 +253,7 @@ topElecMuonHLTMonitor.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/OR/')
 topElecMuonHLTMonitor.nmuons = cms.uint32(1)
 topElecMuonHLTMonitor.nelectrons = cms.uint32(1)
 topElecMuonHLTMonitor.njets = cms.uint32(0)
-topElecMuonHLTMonitor.eleSelection = cms.string('pt>15 & abs(eta)<2.4 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt < 0.1')
+topElecMuonHLTMonitor.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
 topElecMuonHLTMonitor.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)') 
 topElecMuonHLTMonitor.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topElecMuonHLTMonitor.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*','HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*', 'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*','HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*','HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*', 'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*')
@@ -352,18 +352,20 @@ fullyhadronic_DoubleBTag_all.FolderName   = cms.string('HLT/TOP/FullyHadronic/Do
 # Selections
 fullyhadronic_DoubleBTag_all.leptJetDeltaRmin = cms.double(0.0)
 fullyhadronic_DoubleBTag_all.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_all.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_all.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_all.HTcut            = cms.double(450)
+fullyhadronic_DoubleBTag_all.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_DoubleBTag_all.HTdefinition     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_DoubleBTag_all.HTcut            = cms.double(500)
 fullyhadronic_DoubleBTag_all.nbjets           = cms.uint32(2)
-fullyhadronic_DoubleBTag_all.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_all.workingpoint     = cms.double(0.8484) # Medium
+fullyhadronic_DoubleBTag_all.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_DoubleBTag_all.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_DoubleBTag_all.workingpoint     = cms.double(0.4941) #  Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+
 # Binning
 fullyhadronic_DoubleBTag_all.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_DoubleBTag_all.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
 fullyhadronic_DoubleBTag_all.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
 # Triggers 
-fullyhadronic_DoubleBTag_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2_v*')
+fullyhadronic_DoubleBTag_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*')
 fullyhadronic_DoubleBTag_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
 
 fullyhadronic_DoubleBTag_jet = hltTOPmonitoring.clone()
@@ -373,16 +375,18 @@ fullyhadronic_DoubleBTag_jet.leptJetDeltaRmin = cms.double(0.0)
 fullyhadronic_DoubleBTag_jet.njets            = cms.uint32(6)
 fullyhadronic_DoubleBTag_jet.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
 fullyhadronic_DoubleBTag_jet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_jet.HTcut            = cms.double(450)
+fullyhadronic_DoubleBTag_jet.HTcut            = cms.double(500)
 fullyhadronic_DoubleBTag_jet.nbjets           = cms.uint32(2)
 fullyhadronic_DoubleBTag_jet.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_jet.workingpoint = cms.double(0.8484) # Medium
+fullyhadronic_DoubleBTag_jet.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_DoubleBTag_jet.workingpoint     = cms.double(0.4941) #  Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+
 # Binning 
 fullyhadronic_DoubleBTag_jet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_DoubleBTag_jet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
 fullyhadronic_DoubleBTag_jet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
 # Triggers
-fullyhadronic_DoubleBTag_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT380_SixPFJet32_v*')
+fullyhadronic_DoubleBTag_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_v*')
 fullyhadronic_DoubleBTag_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT370_v*')
 
 fullyhadronic_DoubleBTag_bjet = hltTOPmonitoring.clone()
@@ -390,37 +394,39 @@ fullyhadronic_DoubleBTag_bjet.FolderName   = cms.string('HLT/TOP/FullyHadronic/D
 # Selections
 fullyhadronic_DoubleBTag_bjet.leptJetDeltaRmin = cms.double(0.0)
 fullyhadronic_DoubleBTag_bjet.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_bjet.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_bjet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_bjet.HTcut            = cms.double(450)
+fullyhadronic_DoubleBTag_bjet.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_DoubleBTag_bjet.HTdefinition     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_DoubleBTag_bjet.HTcut            = cms.double(500)
 fullyhadronic_DoubleBTag_bjet.nbjets           = cms.uint32(2)
-fullyhadronic_DoubleBTag_bjet.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_bjet.workingpoint     = cms.double(0.5426) # Loose
+fullyhadronic_DoubleBTag_bjet.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_DoubleBTag_bjet.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_DoubleBTag_bjet.workingpoint     = cms.double(0.1522) # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
 # Binning
 fullyhadronic_DoubleBTag_bjet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_DoubleBTag_bjet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
 fullyhadronic_DoubleBTag_bjet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
 # Triggers
-fullyhadronic_DoubleBTag_bjet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2_v*')
-fullyhadronic_DoubleBTag_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT380_SixPFJet32_v*')
+fullyhadronic_DoubleBTag_bjet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*')
+fullyhadronic_DoubleBTag_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_v*')
 
 fullyhadronic_DoubleBTag_ref = hltTOPmonitoring.clone()
 fullyhadronic_DoubleBTag_ref.FolderName   = cms.string('HLT/TOP/FullyHadronic/DoubleBTag/RefMonitor/')
 # Selections
 fullyhadronic_DoubleBTag_ref.leptJetDeltaRmin = cms.double(0.0)
 fullyhadronic_DoubleBTag_ref.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_ref.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_ref.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_ref.HTcut            = cms.double(360)
+fullyhadronic_DoubleBTag_ref.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_DoubleBTag_ref.HTdefinition     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_DoubleBTag_ref.HTcut            = cms.double(500)
 fullyhadronic_DoubleBTag_ref.nbjets           = cms.uint32(0)
-fullyhadronic_DoubleBTag_ref.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_ref.workingpoint     = cms.double(0.8484) # Medium
+fullyhadronic_DoubleBTag_ref.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_DoubleBTag_ref.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_DoubleBTag_ref.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
 # Binning
 fullyhadronic_DoubleBTag_ref.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_DoubleBTag_ref.histoPSet.jetPtBinning = cms.vdouble(0,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
 fullyhadronic_DoubleBTag_ref.histoPSet.HTBinning    = cms.vdouble(0,360,380,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
 # Triggers
-fullyhadronic_DoubleBTag_ref.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT380_SixPFJet32_v*')
+fullyhadronic_DoubleBTag_ref.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_v*')
 fullyhadronic_DoubleBTag_ref.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
 
 fullyhadronic_SingleBTag_all = hltTOPmonitoring.clone()
@@ -428,18 +434,19 @@ fullyhadronic_SingleBTag_all.FolderName= cms.string('HLT/TOP/FullyHadronic/Singl
 # Selections
 fullyhadronic_SingleBTag_all.leptJetDeltaRmin = cms.double(0.0)
 fullyhadronic_SingleBTag_all.njets            = cms.uint32(6)
-fullyhadronic_SingleBTag_all.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_all.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_all.HTcut            = cms.double(450)
+fullyhadronic_SingleBTag_all.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_SingleBTag_all.HTdefinition     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_SingleBTag_all.HTcut            = cms.double(500)
 fullyhadronic_SingleBTag_all.nbjets           = cms.uint32(2)
-fullyhadronic_SingleBTag_all.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_all.workingpoint     = cms.double(0.8484) # Medium
+fullyhadronic_SingleBTag_all.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_SingleBTag_all.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_SingleBTag_all.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
 # Binning
 fullyhadronic_SingleBTag_all.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_SingleBTag_all.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
 fullyhadronic_SingleBTag_all.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
 # Triggers
-fullyhadronic_SingleBTag_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT430_SixPFJet40_PFBTagDeepCSV_1p5_v*')
+fullyhadronic_SingleBTag_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59_v*')
 fullyhadronic_SingleBTag_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
 
 fullyhadronic_SingleBTag_jet = hltTOPmonitoring.clone()
@@ -449,16 +456,17 @@ fullyhadronic_SingleBTag_jet.leptJetDeltaRmin = cms.double(0.0)
 fullyhadronic_SingleBTag_jet.njets            = cms.uint32(6)
 fullyhadronic_SingleBTag_jet.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
 fullyhadronic_SingleBTag_jet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_jet.HTcut            = cms.double(450)
+fullyhadronic_SingleBTag_jet.HTcut            = cms.double(500)
 fullyhadronic_SingleBTag_jet.nbjets           = cms.uint32(2)
 fullyhadronic_SingleBTag_jet.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_jet.workingpoint     = cms.double(0.8484) # Medium
+fullyhadronic_SingleBTag_jet.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_SingleBTag_jet.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
 # Binning
 fullyhadronic_SingleBTag_jet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_SingleBTag_jet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
 fullyhadronic_SingleBTag_jet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
 # Triggers
-fullyhadronic_SingleBTag_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT430_SixPFJet40_v*')
+fullyhadronic_SingleBTag_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_v*')
 fullyhadronic_SingleBTag_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT430_v*')
 
 fullyhadronic_SingleBTag_bjet = hltTOPmonitoring.clone()
@@ -466,37 +474,39 @@ fullyhadronic_SingleBTag_bjet.FolderName= cms.string('HLT/TOP/FullyHadronic/Sing
 # Selection
 fullyhadronic_SingleBTag_bjet.leptJetDeltaRmin = cms.double(0.0)
 fullyhadronic_SingleBTag_bjet.njets            = cms.uint32(6)
-fullyhadronic_SingleBTag_bjet.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_bjet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_bjet.HTcut            = cms.double(450)
+fullyhadronic_SingleBTag_bjet.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_SingleBTag_bjet.HTdefinition     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_SingleBTag_bjet.HTcut            = cms.double(500)
 fullyhadronic_SingleBTag_bjet.nbjets           = cms.uint32(2)
-fullyhadronic_SingleBTag_bjet.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_bjet.workingpoint     = cms.double(0.5426) # Loose
+fullyhadronic_SingleBTag_bjet.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_SingleBTag_bjet.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_SingleBTag_bjet.workingpoint     = cms.double(0.1522) # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
 # Binning
 fullyhadronic_SingleBTag_bjet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_SingleBTag_bjet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
 fullyhadronic_SingleBTag_bjet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
 # Triggers
-fullyhadronic_SingleBTag_bjet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT430_SixPFJet40_PFBTagDeepCSV_1p5_v*')
-fullyhadronic_SingleBTag_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT430_SixPFJet40_v*')
+fullyhadronic_SingleBTag_bjet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59_v*')
+fullyhadronic_SingleBTag_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_v*')
 
 fullyhadronic_SingleBTag_ref = hltTOPmonitoring.clone()
 fullyhadronic_SingleBTag_ref.FolderName= cms.string('HLT/TOP/FullyHadronic/SingleBTag/RefMonitor/')
 # Selection
 fullyhadronic_SingleBTag_ref.leptJetDeltaRmin = cms.double(0.0)
 fullyhadronic_SingleBTag_ref.njets            = cms.uint32(6)
-fullyhadronic_SingleBTag_ref.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_ref.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_ref.HTcut            = cms.double(400)
+fullyhadronic_SingleBTag_ref.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_SingleBTag_ref.HTdefinition     = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_SingleBTag_ref.HTcut            = cms.double(500)
 fullyhadronic_SingleBTag_ref.nbjets           = cms.uint32(0)
-fullyhadronic_SingleBTag_ref.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_ref.workingpoint     = cms.double(0.8484) # Medium
+fullyhadronic_SingleBTag_ref.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
+fullyhadronic_SingleBTag_ref.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_SingleBTag_ref.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
 # Binning
 fullyhadronic_SingleBTag_ref.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_SingleBTag_ref.histoPSet.jetPtBinning = cms.vdouble(0,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
 fullyhadronic_SingleBTag_ref.histoPSet.HTBinning    = cms.vdouble(0,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
 # Triggers
-fullyhadronic_SingleBTag_ref.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT430_SixPFJet40_v*')
+fullyhadronic_SingleBTag_ref.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_v*')
 fullyhadronic_SingleBTag_ref.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
 
 # TripleBTag
@@ -510,7 +520,8 @@ fullyhadronic_TripleBTag_all.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4
 fullyhadronic_TripleBTag_all.HTcut            = cms.double(500)
 fullyhadronic_TripleBTag_all.nbjets           = cms.uint32(4)
 fullyhadronic_TripleBTag_all.bjetSelection    = cms.string('pt>45 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_all.workingpoint     = cms.double(0.8484) # Medium 
+fullyhadronic_TripleBTag_all.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_TripleBTag_all.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
 # Binning
 fullyhadronic_TripleBTag_all.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_TripleBTag_all.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
@@ -529,7 +540,8 @@ fullyhadronic_TripleBTag_jet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4
 fullyhadronic_TripleBTag_jet.HTcut            = cms.double(500)
 fullyhadronic_TripleBTag_jet.nbjets           = cms.uint32(4)
 fullyhadronic_TripleBTag_jet.bjetSelection    = cms.string('pt>45 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_jet.workingpoint = cms.double(0.8484) # Medium
+fullyhadronic_TripleBTag_jet.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_TripleBTag_jet.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
 # Binning
 fullyhadronic_TripleBTag_jet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_TripleBTag_jet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
@@ -548,7 +560,8 @@ fullyhadronic_TripleBTag_bjet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.
 fullyhadronic_TripleBTag_bjet.HTcut            = cms.double(500)
 fullyhadronic_TripleBTag_bjet.nbjets           = cms.uint32(4)
 fullyhadronic_TripleBTag_bjet.bjetSelection    = cms.string('pt>45 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_bjet.workingpoint     = cms.double(0.5426) # Loose
+fullyhadronic_TripleBTag_bjet.btagalgo         = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll")
+fullyhadronic_TripleBTag_bjet.workingpoint     = cms.double(0.1522) # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
 # Binning
 fullyhadronic_TripleBTag_bjet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
 fullyhadronic_TripleBTag_bjet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
@@ -557,67 +570,6 @@ fullyhadronic_TripleBTag_bjet.histoPSet.HTBinning    = cms.vdouble(0,460,480,500
 fullyhadronic_TripleBTag_bjet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5_v*')
 fullyhadronic_TripleBTag_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v*')
 
-#DeepCSV
-
-fullyhadronic_DoubleBTag_DeepCSV_all = hltTOPmonitoring.clone()
-fullyhadronic_DoubleBTag_DeepCSV_all.FolderName   = cms.string('HLT/TOP/FullyHadronic/DoubleBTag/GlobalMonitor_DeepCSV/')
-# Selections
-fullyhadronic_DoubleBTag_DeepCSV_all.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_DoubleBTag_DeepCSV_all.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_DeepCSV_all.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_DeepCSV_all.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_DeepCSV_all.HTcut            = cms.double(450)
-fullyhadronic_DoubleBTag_DeepCSV_all.nbjets           = cms.uint32(2)
-fullyhadronic_DoubleBTag_DeepCSV_all.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_DeepCSV_all.btagalgo         = cms.InputTag("pfDeepCSVJetTags")
-fullyhadronic_DoubleBTag_DeepCSV_all.workingpoint     = cms.double(0.6324) # DeepCSV Medium
-# Binning
-fullyhadronic_DoubleBTag_DeepCSV_all.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_DoubleBTag_DeepCSV_all.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_DoubleBTag_DeepCSV_all.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers 
-fullyhadronic_DoubleBTag_DeepCSV_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2_v*')
-fullyhadronic_DoubleBTag_DeepCSV_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
-fullyhadronic_DoubleBTag_DeepCSV_jet = hltTOPmonitoring.clone()
-fullyhadronic_DoubleBTag_DeepCSV_jet.FolderName   = cms.string('HLT/TOP/FullyHadronic/DoubleBTag/JetMonitor_DeepCSV/')
-# Selections
-fullyhadronic_DoubleBTag_DeepCSV_jet.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_DoubleBTag_DeepCSV_jet.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_DeepCSV_jet.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_DeepCSV_jet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_DeepCSV_jet.HTcut            = cms.double(450)
-fullyhadronic_DoubleBTag_DeepCSV_jet.nbjets           = cms.uint32(2)
-fullyhadronic_DoubleBTag_DeepCSV_jet.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_DeepCSV_jet.btagalgo         = cms.InputTag("pfDeepCSVJetTags")
-fullyhadronic_DoubleBTag_DeepCSV_jet.workingpoint = cms.double(0.6324) # DeepCSV Medium
-# Binning 
-fullyhadronic_DoubleBTag_DeepCSV_jet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_DoubleBTag_DeepCSV_jet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_DoubleBTag_DeepCSV_jet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_DoubleBTag_DeepCSV_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2_v*')
-fullyhadronic_DoubleBTag_DeepCSV_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT370_v*')
-
-fullyhadronic_DoubleBTag_DeepCSV_bjet = hltTOPmonitoring.clone()
-fullyhadronic_DoubleBTag_DeepCSV_bjet.FolderName   = cms.string('HLT/TOP/FullyHadronic/DoubleBTag/BJetMonitor_DeepCSV/')
-# Selections
-fullyhadronic_DoubleBTag_DeepCSV_bjet.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_DoubleBTag_DeepCSV_bjet.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_DeepCSV_bjet.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_DeepCSV_bjet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_DeepCSV_bjet.HTcut            = cms.double(450)
-fullyhadronic_DoubleBTag_DeepCSV_bjet.nbjets           = cms.uint32(2)
-fullyhadronic_DoubleBTag_DeepCSV_bjet.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_DeepCSV_bjet.btagalgo         = cms.InputTag("pfDeepCSVJetTags")
-fullyhadronic_DoubleBTag_DeepCSV_bjet.workingpoint     = cms.double(0.45)
-# Binning
-fullyhadronic_DoubleBTag_DeepCSV_bjet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_DoubleBTag_DeepCSV_bjet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_DoubleBTag_DeepCSV_bjet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_DoubleBTag_DeepCSV_bjet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2_v*')
-fullyhadronic_DoubleBTag_DeepCSV_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT380_SixPFJet32_v*')
 
 from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM
 
@@ -666,9 +618,6 @@ topHLTDQMSourceExtra = cms.Sequence(
     + topElecMuonHLTMonitor_Mu12Ele23_ref
     + topElecMuonHLTMonitor_Mu8Ele23_ref
     + topElecMuonHLTMonitor_Mu23Ele12_ref
-    + topDiMuonHLTMonitor_Dz_Mu17_Mu8
-    + fullyhadronic_DoubleBTag_DeepCSV_all
-    + fullyhadronic_DoubleBTag_DeepCSV_jet
-    + fullyhadronic_DoubleBTag_DeepCSV_bjet,
+    + topDiMuonHLTMonitor_Dz_Mu17_Mu8,
      cms.Task(egmGsfElectronIDsForDQM) # Use of electron VID requires this module being executed first
 )


### PR DESCRIPTION
Fully hadronic paths have been updated according to [1]. The b-tagging algorithm changed from CSV to DeepCSV. Tighter cuts in the fully hadronic selection have been applied. 
In the electron selection, the loose isolation cut has been removed (a cut on the relIso is included in electron ID)

[1] https://its.cern.ch/jira/browse/CMSHLT-1857