### PR TITLE
DQM code for comparison of Muon and CaloLayer2 input collections between 6 uGT boards

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2uGTCaloLayer2Comp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGTCaloLayer2Comp.h
@@ -23,7 +23,7 @@
  * collections of jets, e/g, tau and sum objects as they come out of CaloLayer2
  * and are unpacked by uGT. The purpose of the comparisions is to identify
  * issues with the data transmission links or the unpacking process in the uGT
- * FPGA firmare.
+ * FPGA firmare. The module is also used to compare the inputs of all uGT boards.
  *
  * Summary differentiates between different types of errors and errors with
  * different objects in attempt to identify issues with specific links. In the
@@ -100,15 +100,15 @@ class L1TStage2uGTCaloLayer2Comp : public DQMEDAnalyzer {
    * the same positions within the calol2/ugt collections. The number and type
    * of discrepancies are accumulated in different bins of a summary histogram.
    *
-   * @param edm::Handle<l1t::JetBXCollection>& calol2Col Reference to jet
-   *    collection from CaloLayer2
-   * @param edm::Handle<l1t::JetBXCollection>& uGTCol Reference to jet
-   *    collection from uGT
+   * @param edm::Handle<l1t::JetBXCollection>& col1 Reference to jet
+   *    collection 1
+   * @param edm::Handle<l1t::JetBXCollection>& col2 Reference to jet
+   *    collection 2
    *
    * @return bool Flag of whether the agreement was perfect
    */
-  bool compareJets(const edm::Handle<l1t::JetBxCollection> & calol2Col,
-                   const edm::Handle<l1t::JetBxCollection> & uGTCol);
+  bool compareJets(const edm::Handle<l1t::JetBxCollection> & col1,
+                   const edm::Handle<l1t::JetBxCollection> & col2);
 
   /**
    * Encapsulates the code required for performing a comparison of
@@ -120,15 +120,15 @@ class L1TStage2uGTCaloLayer2Comp : public DQMEDAnalyzer {
    * the same positions within the calol2/ugt collections. The number and type
    * of discrepancies are accumulated in different bins of a summary histogram.
    *
-   * @param edm::Handle<l1t::EGammaBXCollection>& calol2Col Reference to e/gamma
-   *    collection from CaloLayer2
-   * @param edm::Handle<l1t::EGammaBXCollection>& uGTCol Reference to e/gamma
-   *    collection from uGT
+   * @param edm::Handle<l1t::EGammaBXCollection>& col1 Reference to e/gamma
+   *    collection 1
+   * @param edm::Handle<l1t::EGammaBXCollection>& col2 Reference to e/gamma
+   *    collection 2
    *
    * @return bool Flag of whether the agreement was perfect
    */
-  bool compareEGs(const edm::Handle<l1t::EGammaBxCollection> & calol2Col,
-                  const edm::Handle<l1t::EGammaBxCollection> & uGTCol);
+  bool compareEGs(const edm::Handle<l1t::EGammaBxCollection> & col1,
+                  const edm::Handle<l1t::EGammaBxCollection> & col2);
 
   /**
    * Encapsulates the code required for performing a comparison of
@@ -139,15 +139,15 @@ class L1TStage2uGTCaloLayer2Comp : public DQMEDAnalyzer {
    * if the size of collections is the same and when so, compares the taus in
    * the same positions within the calol2/ugt collections. The number and type
    *
-   * @param edm::Handle<l1t::TauBXCollection>& calol2Col Reference to tau
-   *    collection from CaloLayer2
-   * @param edm::Handle<l1t::TauBXCollection>& uGTCol Reference to tau
-   *    collection from uGT
+   * @param edm::Handle<l1t::TauBXCollection>& col1 Reference to tau
+   *    collection 1
+   * @param edm::Handle<l1t::TauBXCollection>& col2 Reference to tau
+   *    collection 2
    *
    * @return bool Flag of whether the agreement was perfect
    */
-  bool compareTaus(const edm::Handle<l1t::TauBxCollection> & calol2Col,
-                   const edm::Handle<l1t::TauBxCollection> & uGTCol);
+  bool compareTaus(const edm::Handle<l1t::TauBxCollection> & col1,
+                   const edm::Handle<l1t::TauBxCollection> & col2);
 
   /**
    * Encapsulates the code required for performing a comparison of
@@ -158,29 +158,33 @@ class L1TStage2uGTCaloLayer2Comp : public DQMEDAnalyzer {
    * over the collection and depending of the their type
    * sums are compared separately but all sum errors are accumulated together.
    *
-   * @param edm::Handle<l1t::TauBXCollection>& calol2Col Reference to sum
-   *    collection from CaloLayer2
-   * @param edm::Handle<l1t::TauBXCollection>& uGTCol Reference to sum
-   *    collection from uGT
+   * @param edm::Handle<l1t::TauBXCollection>& col1 Reference to sum
+   *    collection 1
+   * @param edm::Handle<l1t::TauBXCollection>& col2 Reference to sum
+   *    collection 2
    *
    * @return bool Flag of whether the agreement was perfect
    */
-  bool compareSums(const edm::Handle<l1t::EtSumBxCollection> & calol2Col,
-                   const edm::Handle<l1t::EtSumBxCollection> & uGTCol);
+  bool compareSums(const edm::Handle<l1t::EtSumBxCollection> & col1,
+                   const edm::Handle<l1t::EtSumBxCollection> & col2);
 
   // Holds the name of directory in DQM where module hostograms will be shown.
   // Value is taken from python configuration file (passed in class constructor)
   std::string monitorDir;
 
-  // collections to hold entities reconstructed from calol2 and ugt
-  edm::EDGetTokenT<l1t::JetBxCollection> calol2JetCollection;
-  edm::EDGetTokenT<l1t::JetBxCollection> uGTJetCollection;
-  edm::EDGetTokenT<l1t::EGammaBxCollection> calol2EGammaCollection;
-  edm::EDGetTokenT<l1t::EGammaBxCollection> uGTEGammaCollection;
-  edm::EDGetTokenT<l1t::TauBxCollection> calol2TauCollection;
-  edm::EDGetTokenT<l1t::TauBxCollection> uGTTauCollection;
-  edm::EDGetTokenT<l1t::EtSumBxCollection> calol2EtSumCollection;
-  edm::EDGetTokenT<l1t::EtSumBxCollection> uGTEtSumCollection;
+  // names of calol2 or ugt collections that are being compared
+  std::string collection1Title;
+  std::string collection2Title;
+
+  // collections to hold entities reconstructed from calol2 or ugt
+  edm::EDGetTokenT<l1t::JetBxCollection> JetCollection1;
+  edm::EDGetTokenT<l1t::JetBxCollection> JetCollection2;
+  edm::EDGetTokenT<l1t::EGammaBxCollection> EGammaCollection1;
+  edm::EDGetTokenT<l1t::EGammaBxCollection> EGammaCollection2;
+  edm::EDGetTokenT<l1t::TauBxCollection> TauCollection1;
+  edm::EDGetTokenT<l1t::TauBxCollection> TauCollection2;
+  edm::EDGetTokenT<l1t::EtSumBxCollection> EtSumCollection1;
+  edm::EDGetTokenT<l1t::EtSumBxCollection> EtSumCollection2;
 
   enum numeratorBins {
     EVENTBAD = 1,   // number of (no.) bad events (where an error was found)

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -45,6 +45,7 @@ l1tStage2OnlineDQM = cms.Sequence(
 # sequence to run only for validation events
 l1tStage2OnlineDQMValidationEvents = cms.Sequence(
     l1tStage2BmtfValidationEventOnlineDQMSeq +
-    l1tStage2uGMTValidationEventOnlineDQMSeq
+    l1tStage2uGMTValidationEventOnlineDQMSeq +
+    l1tStage2uGTValidationEventOnlineDQMSeq
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2uGTBoardComp_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTBoardComp_cff.py
@@ -1,0 +1,110 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+# Comparison of the unpacked uGT muon collections from uGT board 1 to those of boards 2 to 6.
+
+l1tStage2uGTMuon1vsMuon2 = DQMEDAnalyzer(
+    "L1TStage2MuonComp",
+    muonCollection1 = cms.InputTag("gtStage2Digis", "Muon"),
+    muonCollection2 = cms.InputTag("gtStage2Digis", "Muon2"),
+    muonCollection1Title = cms.untracked.string("Muons uGT Board 1"),
+    muonCollection2Title = cms.untracked.string("Muons uGT Board 2"),
+    summaryTitle = cms.untracked.string("Summary of Comparison between Muons from uGT Board 1 and uGT Board 2"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard2/Muons"),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGTMuon1vsMuon3 = l1tStage2uGTMuon1vsMuon2.clone()
+l1tStage2uGTMuon1vsMuon3.muonCollection2 = cms.InputTag("gtStage2Digis", "Muon3")
+l1tStage2uGTMuon1vsMuon3.muonCollection2Title = cms.untracked.string("Muons uGT Board 3")
+l1tStage2uGTMuon1vsMuon3.summaryTitle = cms.untracked.string("Summary of Comparison between Muons from uGT Board 1 and uGT Board 3")
+l1tStage2uGTMuon1vsMuon3.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/Muons")
+
+l1tStage2uGTMuon1vsMuon4 = l1tStage2uGTMuon1vsMuon2.clone()
+l1tStage2uGTMuon1vsMuon4.muonCollection2 = cms.InputTag("gtStage2Digis", "Muon4")
+l1tStage2uGTMuon1vsMuon4.muonCollection2Title = cms.untracked.string("Muons uGT Board 4")
+l1tStage2uGTMuon1vsMuon4.summaryTitle = cms.untracked.string("Summary of Comparison between Muons from uGT Board 1 and uGT Board 4")
+l1tStage2uGTMuon1vsMuon4.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/Muons")
+
+l1tStage2uGTMuon1vsMuon5 = l1tStage2uGTMuon1vsMuon2.clone()
+l1tStage2uGTMuon1vsMuon5.muonCollection2 = cms.InputTag("gtStage2Digis", "Muon5")
+l1tStage2uGTMuon1vsMuon5.muonCollection2Title = cms.untracked.string("Muons uGT Board 5")
+l1tStage2uGTMuon1vsMuon5.summaryTitle = cms.untracked.string("Summary of Comparison between Muons from uGT Board 1 and uGT Board 5")
+l1tStage2uGTMuon1vsMuon5.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/Muons")
+
+l1tStage2uGTMuon1vsMuon6 = l1tStage2uGTMuon1vsMuon2.clone()
+l1tStage2uGTMuon1vsMuon6.muonCollection2 = cms.InputTag("gtStage2Digis", "Muon6")
+l1tStage2uGTMuon1vsMuon6.muonCollection2Title = cms.untracked.string("Muons uGT Board 6")
+l1tStage2uGTMuon1vsMuon6.summaryTitle = cms.untracked.string("Summary of Comparison between Muons from uGT Board 1 and uGT Board 6")
+l1tStage2uGTMuon1vsMuon6.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/Muons")
+
+l1tStage2uGTBoardCompMuonsSeq = cms.Sequence(
+    l1tStage2uGTMuon1vsMuon2 +
+    l1tStage2uGTMuon1vsMuon3 +
+    l1tStage2uGTMuon1vsMuon4 +
+    l1tStage2uGTMuon1vsMuon5 +
+    l1tStage2uGTMuon1vsMuon6
+)
+
+# Comparison of the unpacked uGT CaloLayer2 collections from uGT board 1 to those of boards 2 to 6.
+
+l1tStage2uGTCalo1vsCalo2 = DQMEDAnalyzer(
+    "L1TStage2uGTCaloLayer2Comp",
+    collection1Title  = cms.untracked.string("uGT Board 1"),
+    collection2Title  = cms.untracked.string("uGT Board 2"),
+    JetCollection1    = cms.InputTag("gtStage2Digis", "Jet"),
+    JetCollection2    = cms.InputTag("gtStage2Digis", "Jet2"),
+    EGammaCollection1 = cms.InputTag("gtStage2Digis", "EGamma"),
+    EGammaCollection2 = cms.InputTag("gtStage2Digis", "EGamma2"),
+    TauCollection1    = cms.InputTag("gtStage2Digis", "Tau"),
+    TauCollection2    = cms.InputTag("gtStage2Digis", "Tau2"),
+    EtSumCollection1  = cms.InputTag("gtStage2Digis", "EtSum"),
+    EtSumCollection2  = cms.InputTag("gtStage2Digis", "EtSum2"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard2/CaloLayer2"),
+)
+
+l1tStage2uGTCalo1vsCalo3 = l1tStage2uGTCalo1vsCalo2.clone()
+l1tStage2uGTCalo1vsCalo3.collection2Title  = cms.untracked.string("uGT Board 3") 
+l1tStage2uGTCalo1vsCalo3.JetCollection2    = cms.InputTag("gtStage2Digis", "Jet3")
+l1tStage2uGTCalo1vsCalo3.EGammaCollection2 = cms.InputTag("gtStage2Digis", "EGamma3")
+l1tStage2uGTCalo1vsCalo3.TauCollection2    = cms.InputTag("gtStage2Digis", "Tau3")
+l1tStage2uGTCalo1vsCalo3.EtSumCollection2  = cms.InputTag("gtStage2Digis", "EtSum3")
+l1tStage2uGTCalo1vsCalo3.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/CaloLayer2")
+
+l1tStage2uGTCalo1vsCalo4 = l1tStage2uGTCalo1vsCalo2.clone()
+l1tStage2uGTCalo1vsCalo4.collection2Title  = cms.untracked.string("uGT Board 4") 
+l1tStage2uGTCalo1vsCalo4.JetCollection2    = cms.InputTag("gtStage2Digis", "Jet4")
+l1tStage2uGTCalo1vsCalo4.EGammaCollection2 = cms.InputTag("gtStage2Digis", "EGamma4")
+l1tStage2uGTCalo1vsCalo4.TauCollection2    = cms.InputTag("gtStage2Digis", "Tau4")
+l1tStage2uGTCalo1vsCalo4.EtSumCollection2  = cms.InputTag("gtStage2Digis", "EtSum4")
+l1tStage2uGTCalo1vsCalo4.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/CaloLayer2")
+
+l1tStage2uGTCalo1vsCalo5 = l1tStage2uGTCalo1vsCalo2.clone()
+l1tStage2uGTCalo1vsCalo5.collection2Title  = cms.untracked.string("uGT Board 5") 
+l1tStage2uGTCalo1vsCalo5.JetCollection2    = cms.InputTag("gtStage2Digis", "Jet5")
+l1tStage2uGTCalo1vsCalo5.EGammaCollection2 = cms.InputTag("gtStage2Digis", "EGamma5")
+l1tStage2uGTCalo1vsCalo5.TauCollection2    = cms.InputTag("gtStage2Digis", "Tau5")
+l1tStage2uGTCalo1vsCalo5.EtSumCollection2  = cms.InputTag("gtStage2Digis", "EtSum5")
+l1tStage2uGTCalo1vsCalo5.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/CaloLayer2")
+
+l1tStage2uGTCalo1vsCalo6 = l1tStage2uGTCalo1vsCalo2.clone()
+l1tStage2uGTCalo1vsCalo6.collection2Title  = cms.untracked.string("uGT Board 6") 
+l1tStage2uGTCalo1vsCalo6.JetCollection2    = cms.InputTag("gtStage2Digis", "Jet6")
+l1tStage2uGTCalo1vsCalo6.EGammaCollection2 = cms.InputTag("gtStage2Digis", "EGamma6")
+l1tStage2uGTCalo1vsCalo6.TauCollection2    = cms.InputTag("gtStage2Digis", "Tau6")
+l1tStage2uGTCalo1vsCalo6.EtSumCollection2  = cms.InputTag("gtStage2Digis", "EtSum6")
+l1tStage2uGTCalo1vsCalo6.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/CaloLayer2")
+
+l1tStage2uGTBoardCompCaloLayer2Seq = cms.Sequence(
+    l1tStage2uGTCalo1vsCalo2 +
+    l1tStage2uGTCalo1vsCalo3 +
+    l1tStage2uGTCalo1vsCalo4 +
+    l1tStage2uGTCalo1vsCalo5 +
+    l1tStage2uGTCalo1vsCalo6
+)
+
+l1tStage2uGTBoardCompSeq = cms.Sequence(
+    l1tStage2uGTBoardCompMuonsSeq +
+    l1tStage2uGTBoardCompCaloLayer2Seq
+)

--- a/DQM/L1TMonitor/python/L1TStage2uGTCaloLayer2Comp_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTCaloLayer2Comp_cfi.py
@@ -3,13 +3,15 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tStage2uGTCaloLayer2Comp = DQMEDAnalyzer(
     "L1TStage2uGTCaloLayer2Comp",
-    calol2JetCollection    = cms.InputTag("caloStage2Digis", "Jet"),
-    uGTJetCollection       = cms.InputTag("gtStage2Digis", "Jet"),
-    calol2EGammaCollection = cms.InputTag("caloStage2Digis", "EGamma"),
-    uGTEGammaCollection    = cms.InputTag("gtStage2Digis", "EGamma"),
-    calol2TauCollection    = cms.InputTag("caloStage2Digis", "Tau"),
-    uGTTauCollection       = cms.InputTag("gtStage2Digis", "Tau"),
-    calol2EtSumCollection  = cms.InputTag("caloStage2Digis", "EtSum"),
-    uGTEtSumCollection     = cms.InputTag("gtStage2Digis", "EtSum"),
+    collection1Title = cms.untracked.string("CaloLayer2"),
+    collection2Title = cms.untracked.string("uGT"),
+    JetCollection1    = cms.InputTag("caloStage2Digis", "Jet"),
+    JetCollection2    = cms.InputTag("gtStage2Digis",   "Jet"),
+    EGammaCollection1 = cms.InputTag("caloStage2Digis", "EGamma"),
+    EGammaCollection2 = cms.InputTag("gtStage2Digis",   "EGamma"),
+    TauCollection1    = cms.InputTag("caloStage2Digis", "Tau"),
+    TauCollection2    = cms.InputTag("gtStage2Digis",   "Tau"),
+    EtSumCollection1  = cms.InputTag("caloStage2Digis", "EtSum"),
+    EtSumCollection2  = cms.InputTag("gtStage2Digis",   "EtSum"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGT/calol2ouput_vs_uGTinput")
 )

--- a/DQM/L1TMonitor/python/L1TStage2uGT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGT_cff.py
@@ -7,6 +7,9 @@ from DQM.L1TMonitor.L1TStage2uGTTiming_cfi import *
 # Calo L2 output to uGT input comparison
 from DQM.L1TMonitor.L1TStage2uGTCaloLayer2Comp_cfi import *
 
+# uGT Board Comparison
+from DQM.L1TMonitor.L1TStage2uGTBoardComp_cff import *
+
 # compares the unpacked uGMT muon collection to the unpacked uGT muon collection
 # only muons that do not match are filled in the histograms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
@@ -28,4 +31,9 @@ l1tStage2uGTOnlineDQMSeq = cms.Sequence(
     l1tStage2uGTTiming +
     l1tStage2uGTCaloLayer2Comp +
     l1tStage2uGMTOutVsuGTIn
+)
+
+# validation sequence
+l1tStage2uGTValidationEventOnlineDQMSeq = cms.Sequence(
+    l1tStage2uGTBoardCompSeq
 )

--- a/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
@@ -2,30 +2,16 @@
 
 L1TStage2uGTCaloLayer2Comp::L1TStage2uGTCaloLayer2Comp (const edm::ParameterSet& ps)
   : monitorDir(ps.getUntrackedParameter<std::string>("monitorDir", "")),
-    calol2JetCollection(consumes <l1t::JetBxCollection>(
-			  ps.getParameter<edm::InputTag>(
-			    "calol2JetCollection"))),
-    uGTJetCollection(consumes <l1t::JetBxCollection>(
-		       ps.getParameter<edm::InputTag>(
-			 "uGTJetCollection"))),
-    calol2EGammaCollection(consumes <l1t::EGammaBxCollection>(
-			     ps.getParameter<edm::InputTag>(
-			       "calol2EGammaCollection"))),
-    uGTEGammaCollection(consumes <l1t::EGammaBxCollection>(
-			  ps.getParameter<edm::InputTag>(
-			    "uGTEGammaCollection"))),
-    calol2TauCollection(consumes <l1t::TauBxCollection>(
-			  ps.getParameter<edm::InputTag>(
-			    "calol2TauCollection"))),
-    uGTTauCollection(consumes <l1t::TauBxCollection>(
-		       ps.getParameter<edm::InputTag>(
-			 "uGTTauCollection"))),
-    calol2EtSumCollection(consumes <l1t::EtSumBxCollection>(
-			    ps.getParameter<edm::InputTag>(
-			      "calol2EtSumCollection"))),
-    uGTEtSumCollection(consumes <l1t::EtSumBxCollection>(
-			 ps.getParameter<edm::InputTag>(
-			   "uGTEtSumCollection"))),
+    collection1Title(ps.getUntrackedParameter<std::string>("collection1Title")),
+    collection2Title(ps.getUntrackedParameter<std::string>("collection2Title")),
+    JetCollection1(consumes <l1t::JetBxCollection>(ps.getParameter<edm::InputTag>("JetCollection1"))),
+    JetCollection2(consumes <l1t::JetBxCollection>(ps.getParameter<edm::InputTag>("JetCollection2"))),
+    EGammaCollection1(consumes <l1t::EGammaBxCollection>(ps.getParameter<edm::InputTag>("EGammaCollection1"))),
+    EGammaCollection2(consumes <l1t::EGammaBxCollection>(ps.getParameter<edm::InputTag>("EGammaCollection2"))),
+    TauCollection1(consumes <l1t::TauBxCollection>(ps.getParameter<edm::InputTag>("TauCollection1"))),
+    TauCollection2(consumes <l1t::TauBxCollection>(ps.getParameter<edm::InputTag>("TauCollection2"))),
+    EtSumCollection1(consumes <l1t::EtSumBxCollection>(ps.getParameter<edm::InputTag>("EtSumCollection1"))),
+    EtSumCollection2(consumes <l1t::EtSumBxCollection>(ps.getParameter<edm::InputTag>("EtSumCollection2"))),
     verbose(ps.getUntrackedParameter<bool> ("verbose", false))
 {}
 
@@ -39,7 +25,7 @@ void L1TStage2uGTCaloLayer2Comp::bookHistograms(
   // the index of the first bin in histogram should match value of first enum
   comparisonNum = ibooker.book1D(
     "errorSummaryNum",
-    "CaloLayer2-uGT link check - Numerator (# disagreements)", 15, 1, 16);
+    collection1Title+" vs "+collection2Title+" Comparison - Numerator (# Disagreements)", 15, 1, 16);
 
   comparisonNum->setBinLabel(EVENTBAD, "# bad evts");
   comparisonNum->setBinLabel(EVENTBADJETCOL, "# evts w/ bad jet col size");
@@ -59,7 +45,7 @@ void L1TStage2uGTCaloLayer2Comp::bookHistograms(
 
   comparisonDenum = ibooker.book1D(
     "errorSummaryDen",
-    "CaloLayer2-uGT link check - Denumerator (# objects)", 15, 1, 16);
+    collection1Title+" vs "+collection2Title+" Comparison - Denominator (# Objects)", 15, 1, 16);
 
   comparisonDenum->setBinLabel(EVENTS1, "# evts");
   comparisonDenum->setBinLabel(EVENTS2, "# evts");
@@ -86,40 +72,40 @@ void L1TStage2uGTCaloLayer2Comp::analyze (
   const edm::EventSetup & c) {
 
   // define collections to hold lists of objects in event
-  edm::Handle<l1t::JetBxCollection> jetColCalol2;
-  edm::Handle<l1t::JetBxCollection> jetColuGT;
-  edm::Handle<l1t::EGammaBxCollection> egColCalol2;
-  edm::Handle<l1t::EGammaBxCollection> egColuGT;
-  edm::Handle<l1t::TauBxCollection> tauColCalol2;
-  edm::Handle<l1t::TauBxCollection> tauColuGT;
-  edm::Handle<l1t::EtSumBxCollection> sumColCalol2;
-  edm::Handle<l1t::EtSumBxCollection> sumColuGT;
+  edm::Handle<l1t::JetBxCollection> jetCol1;
+  edm::Handle<l1t::JetBxCollection> jetCol2;
+  edm::Handle<l1t::EGammaBxCollection> egCol1;
+  edm::Handle<l1t::EGammaBxCollection> egCol2;
+  edm::Handle<l1t::TauBxCollection> tauCol1;
+  edm::Handle<l1t::TauBxCollection> tauCol2;
+  edm::Handle<l1t::EtSumBxCollection> sumCol1;
+  edm::Handle<l1t::EtSumBxCollection> sumCol2;
 
   // map event contents to above collections
-  e.getByToken(calol2JetCollection, jetColCalol2);
-  e.getByToken(uGTJetCollection, jetColuGT);
-  e.getByToken(calol2EGammaCollection, egColCalol2);
-  e.getByToken(uGTEGammaCollection, egColuGT);
-  e.getByToken(calol2TauCollection, tauColCalol2);
-  e.getByToken(uGTTauCollection, tauColuGT);
-  e.getByToken(calol2EtSumCollection, sumColCalol2);
-  e.getByToken(uGTEtSumCollection, sumColuGT);
+  e.getByToken(JetCollection1, jetCol1);
+  e.getByToken(JetCollection2, jetCol2);
+  e.getByToken(EGammaCollection1, egCol1);
+  e.getByToken(EGammaCollection2, egCol2);
+  e.getByToken(TauCollection1, tauCol1);
+  e.getByToken(TauCollection2, tauCol2);
+  e.getByToken(EtSumCollection1, sumCol1);
+  e.getByToken(EtSumCollection2, sumCol2);
 
   bool eventGood = true;
 
-  if (!compareJets(jetColCalol2, jetColuGT)) {
+  if (!compareJets(jetCol1, jetCol2)) {
     eventGood = false;
   }
 
-  if (!compareEGs(egColCalol2, egColuGT)) {
+  if (!compareEGs(egCol1, egCol2)) {
     eventGood = false;
   }
 
-  if (!compareTaus(tauColCalol2, tauColuGT)) {
+  if (!compareTaus(tauCol1, tauCol2)) {
     eventGood = false;
   }
 
-  if (!compareSums(sumColCalol2, sumColuGT)) {
+  if (!compareSums(sumCol1, sumCol2)) {
     eventGood = false;
   }
 
@@ -136,41 +122,41 @@ void L1TStage2uGTCaloLayer2Comp::analyze (
 
 // comparison method for jets
 bool L1TStage2uGTCaloLayer2Comp::compareJets(
-  const edm::Handle<l1t::JetBxCollection> & calol2Col,
-  const edm::Handle<l1t::JetBxCollection> & uGTCol)
+  const edm::Handle<l1t::JetBxCollection> & col1,
+  const edm::Handle<l1t::JetBxCollection> & col2)
 {
   bool eventGood = true;
 
-  l1t::JetBxCollection::const_iterator calol2It = calol2Col->begin();
-  l1t::JetBxCollection::const_iterator uGTIt = uGTCol->begin();
+  l1t::JetBxCollection::const_iterator col1It = col1->begin();
+  l1t::JetBxCollection::const_iterator col2It = col2->begin();
 
   // process jets
-  if (calol2Col->size() != uGTCol->size()) {
+  if (col1->size() != col2->size()) {
     comparisonNum->Fill(EVENTBADJETCOL);
     return false;
   }
 
   int nJets = 0;
-  if (calol2It != calol2Col->end() ||
-      uGTIt != uGTCol->end()) {
+  if (col1It != col1->end() ||
+      col2It != col2->end()) {
     while(true) {
 
       ++nJets;
 
       // object pt mismatch
-      if (calol2It->hwPt() != uGTIt->hwPt()) {
+      if (col1It->hwPt() != col2It->hwPt()) {
 	comparisonNum->Fill(JETBADET);
  	eventGood = false;
       }
 
       // object position mismatch (phi)
-      if (calol2It->hwPhi() != uGTIt->hwPhi()){
+      if (col1It->hwPhi() != col2It->hwPhi()){
 	comparisonNum->Fill(JETBADPHI);
 	eventGood = false;
       }
 
       // object position mismatch (eta)
-      if (calol2It->hwEta() != uGTIt->hwEta()) {
+      if (col1It->hwEta() != col2It->hwEta()) {
 	comparisonNum->Fill(JETBADETA);
 	eventGood = false;
       }
@@ -181,15 +167,15 @@ bool L1TStage2uGTCaloLayer2Comp::compareJets(
       comparisonDenum->Fill(JETS3);
 
       // increment position of pointers
-      ++calol2It;
-      ++uGTIt;
+      ++col1It;
+      ++col2It;
 
-      if (calol2It == calol2Col->end() ||
-	  uGTIt == uGTCol->end())
+      if (col1It == col1->end() ||
+	  col2It == col2->end())
 	break;
     }
   } else {
-    if (calol2Col->size() != 0 || uGTCol->size() != 0) {
+    if (col1->size() != 0 || col2->size() != 0) {
       comparisonNum->Fill(EVENTBADJETCOL);
       return false;
     }
@@ -202,40 +188,40 @@ bool L1TStage2uGTCaloLayer2Comp::compareJets(
 
 // comparison method for e/gammas
 bool L1TStage2uGTCaloLayer2Comp::compareEGs(
-  const edm::Handle<l1t::EGammaBxCollection> & calol2Col,
-  const edm::Handle<l1t::EGammaBxCollection> & uGTCol)
+  const edm::Handle<l1t::EGammaBxCollection> & col1,
+  const edm::Handle<l1t::EGammaBxCollection> & col2)
 {
   bool eventGood = true;
 
-  l1t::EGammaBxCollection::const_iterator calol2It = calol2Col->begin();
-  l1t::EGammaBxCollection::const_iterator uGTIt = uGTCol->begin();
+  l1t::EGammaBxCollection::const_iterator col1It = col1->begin();
+  l1t::EGammaBxCollection::const_iterator col2It = col2->begin();
 
   // check length of collections
-  if (calol2Col->size() != uGTCol->size()) {
+  if (col1->size() != col2->size()) {
     comparisonNum->Fill(EVENTBADEGCOL);
     return false;
   }
 
   // processing continues only of length of object collections is the same
-  if (calol2It != calol2Col->end() ||
-      uGTIt != uGTCol->end()) {
+  if (col1It != col1->end() ||
+      col2It != col2->end()) {
 
     while(true) {
 
       // object pt mismatch
-      if (calol2It->hwPt() != uGTIt->hwPt()) {
+      if (col1It->hwPt() != col2It->hwPt()) {
 	comparisonNum->Fill(EGBADET);
 	eventGood = false;
       }
 
       // object position mismatch (phi)
-      if (calol2It->hwPhi() != uGTIt->hwPhi()) {
+      if (col1It->hwPhi() != col2It->hwPhi()) {
 	comparisonNum->Fill(EGBADPHI);
 	eventGood = false;
       }
 
       // object position mismatch (eta)
-      if (calol2It->hwEta() != uGTIt->hwEta()) {
+      if (col1It->hwEta() != col2It->hwEta()) {
 	comparisonNum->Fill(EGBADETA);
 	eventGood = false;
       }
@@ -246,15 +232,15 @@ bool L1TStage2uGTCaloLayer2Comp::compareEGs(
       comparisonDenum->Fill(EGS3);
 
       // increment position of pointers
-      ++calol2It;
-      ++uGTIt;
+      ++col1It;
+      ++col2It;
 
-      if (calol2It == calol2Col->end() ||
-	  uGTIt == uGTCol->end())
+      if (col1It == col1->end() ||
+	  col2It == col2->end())
 	break;
     }
   } else {
-    if (calol2Col->size() != 0 || uGTCol->size() != 0) {
+    if (col1->size() != 0 || col2->size() != 0) {
       comparisonNum->Fill(EVENTBADEGCOL);
       return false;
     }
@@ -267,39 +253,39 @@ bool L1TStage2uGTCaloLayer2Comp::compareEGs(
 
 // comparison method for taus
 bool L1TStage2uGTCaloLayer2Comp::compareTaus(
-  const edm::Handle<l1t::TauBxCollection> & calol2Col,
-  const edm::Handle<l1t::TauBxCollection> & uGTCol)
+  const edm::Handle<l1t::TauBxCollection> & col1,
+  const edm::Handle<l1t::TauBxCollection> & col2)
 {
   bool eventGood = true;
 
-  l1t::TauBxCollection::const_iterator calol2It = calol2Col->begin();
-  l1t::TauBxCollection::const_iterator uGTIt = uGTCol->begin();
+  l1t::TauBxCollection::const_iterator col1It = col1->begin();
+  l1t::TauBxCollection::const_iterator col2It = col2->begin();
 
   // check length of collections
-  if (calol2Col->size() != uGTCol->size()) {
+  if (col1->size() != col2->size()) {
     comparisonNum->Fill(EVENTBADTAUCOL);
     return false;
   }
 
   // processing continues only of length of object collections is the same
-  if (calol2It != calol2Col->end() ||
-      uGTIt != uGTCol->end()) {
+  if (col1It != col1->end() ||
+      col2It != col2->end()) {
 
     while(true) {
       // object Et mismatch
-      if (calol2It->hwPt() != uGTIt->hwPt()) {
+      if (col1It->hwPt() != col2It->hwPt()) {
 	comparisonNum->Fill(TAUBADET);
 	eventGood = false;
       }
 
       // object position mismatch (phi)
-      if (calol2It->hwPhi() != uGTIt->hwPhi()) {
+      if (col1It->hwPhi() != col2It->hwPhi()) {
 	comparisonNum->Fill(TAUBADPHI);
 	eventGood = false;
       }
 
       // object position mismatch (eta)
-      if (calol2It->hwEta() != uGTIt->hwEta()) {
+      if (col1It->hwEta() != col2It->hwEta()) {
 	comparisonNum->Fill(TAUBADETA);
 	eventGood = false;
       }
@@ -310,15 +296,15 @@ bool L1TStage2uGTCaloLayer2Comp::compareTaus(
       comparisonDenum->Fill(TAUS3);
 
       // increment position of pointers
-      ++calol2It;
-      ++uGTIt;
+      ++col1It;
+      ++col2It;
 
-      if (calol2It == calol2Col->end() ||
-	  uGTIt == uGTCol->end())
+      if (col1It == col1->end() ||
+	  col2It == col2->end())
 	break;
     }
   } else {
-    if (calol2Col->size() != 0 || uGTCol->size() != 0) {
+    if (col1->size() != 0 || col2->size() != 0) {
       comparisonNum->Fill(EVENTBADTAUCOL);
       return false;
     }
@@ -331,42 +317,42 @@ bool L1TStage2uGTCaloLayer2Comp::compareTaus(
 
 // comparison method for sums
 bool L1TStage2uGTCaloLayer2Comp::compareSums(
-  const edm::Handle<l1t::EtSumBxCollection> & calol2Col,
-  const edm::Handle<l1t::EtSumBxCollection> & uGTCol)
+  const edm::Handle<l1t::EtSumBxCollection> & col1,
+  const edm::Handle<l1t::EtSumBxCollection> & col2)
 {
   bool eventGood = true;
 
-  double calol2Et  = 0;
-  double uGTEt     = 0;
-  double calol2Phi = 0;
-  double uGTPhi    = 0;
+  double col1Et  = 0;
+  double col2Et  = 0;
+  double col1Phi = 0;
+  double col2Phi = 0;
 
   // if the calol2 or ugt collections have different size, mark the event as
   // bad (this should never occur in normal running)
-  if (calol2Col->size() != uGTCol->size()) {
+  if (col1->size() != col2->size()) {
     comparisonNum->Fill(EVENTBADSUMCOL);
     return false;
   }
 
-  l1t::EtSumBxCollection::const_iterator calol2It = calol2Col->begin();
-  l1t::EtSumBxCollection::const_iterator uGTIt = uGTCol->begin();
+  l1t::EtSumBxCollection::const_iterator col1It = col1->begin();
+  l1t::EtSumBxCollection::const_iterator col2It = col2->begin();
 
-  while (calol2It != calol2Col->end() && uGTIt != uGTCol->end()) {
+  while (col1It != col1->end() && col2It != col2->end()) {
 
     // ETT, ETTEM, HTT, TowCnt, MBHFP0, MBHFM0, MBHFP1 or MBHFM1
-    if ((l1t::EtSum::EtSumType::kTotalEt == calol2It->getType()) ||    // ETT
-	(l1t::EtSum::EtSumType::kTotalEtEm == calol2It->getType()) ||  // ETTEM
-	(l1t::EtSum::EtSumType::kTotalHt == calol2It->getType()) ||    // HTT
-	(l1t::EtSum::EtSumType::kTowerCount == calol2It->getType()) || // TowCnt
-    	(l1t::EtSum::EtSumType::kMinBiasHFP0 == calol2It->getType()) ||// MBHFP0
-	(l1t::EtSum::EtSumType::kMinBiasHFM0 == calol2It->getType()) ||// MBHFM0
-	(l1t::EtSum::EtSumType::kMinBiasHFP1 == calol2It->getType()) ||// MBHFP1
-	(l1t::EtSum::EtSumType::kMinBiasHFM1 == calol2It->getType())) {// MBHFM1
+    if ((l1t::EtSum::EtSumType::kTotalEt == col1It->getType()) ||    // ETT
+	(l1t::EtSum::EtSumType::kTotalEtEm == col1It->getType()) ||  // ETTEM
+	(l1t::EtSum::EtSumType::kTotalHt == col1It->getType()) ||    // HTT
+	(l1t::EtSum::EtSumType::kTowerCount == col1It->getType()) || // TowCnt
+    	(l1t::EtSum::EtSumType::kMinBiasHFP0 == col1It->getType()) ||// MBHFP0
+	(l1t::EtSum::EtSumType::kMinBiasHFM0 == col1It->getType()) ||// MBHFM0
+	(l1t::EtSum::EtSumType::kMinBiasHFP1 == col1It->getType()) ||// MBHFP1
+	(l1t::EtSum::EtSumType::kMinBiasHFM1 == col1It->getType())) {// MBHFM1
 
-      calol2Et = calol2It->hwPt();
-      uGTEt = uGTIt->hwPt();
+      col1Et = col1It->hwPt();
+      col2Et = col2It->hwPt();
 
-      if (calol2Et != uGTEt) {
+      if (col1Et != col2Et) {
 	eventGood = false;
 	comparisonNum->Fill(BADSUM);
       }
@@ -376,18 +362,18 @@ bool L1TStage2uGTCaloLayer2Comp::compareSums(
     }
 
     // MET, METHF, MHT or MHTHF
-    if ((l1t::EtSum::EtSumType::kMissingEt == calol2It->getType()) ||   // MET
-	(l1t::EtSum::EtSumType::kMissingEtHF == calol2It->getType()) || // METHF
-	(l1t::EtSum::EtSumType::kMissingHt == calol2It->getType()) ||   // MHT
-	(l1t::EtSum::EtSumType::kMissingHtHF == calol2It->getType())) { // MHTHF
+    if ((l1t::EtSum::EtSumType::kMissingEt == col1It->getType()) ||   // MET
+	(l1t::EtSum::EtSumType::kMissingEtHF == col1It->getType()) || // METHF
+	(l1t::EtSum::EtSumType::kMissingHt == col1It->getType()) ||   // MHT
+	(l1t::EtSum::EtSumType::kMissingHtHF == col1It->getType())) { // MHTHF
 
-      calol2Et = calol2It->hwPt();
-      uGTEt = uGTIt->hwPt();
+      col1Et = col1It->hwPt();
+      col2Et = col2It->hwPt();
 
-      calol2Phi = calol2It->hwPhi();
-      uGTPhi = uGTIt->hwPhi();
+      col1Phi = col1It->hwPhi();
+      col2Phi = col2It->hwPhi();
 
-      if ((calol2Et != uGTEt) || (calol2Phi != uGTPhi)) {
+      if ((col1Et != col2Et) || (col1Phi != col2Phi)) {
 	eventGood = false;
 	comparisonNum->Fill(BADSUM);
       }
@@ -396,8 +382,8 @@ bool L1TStage2uGTCaloLayer2Comp::compareSums(
       comparisonDenum->Fill(SUMS);
     }
 
-    ++calol2It;
-    ++uGTIt;
+    ++col1It;
+    ++col2It;
   }
 
   // return a boolean that states whether the sum data in the event is in


### PR DESCRIPTION
This is the backport to 10_1_X of the following 10_2_X PR: https://github.com/cms-sw/cmssw/pull/23686

Online L1T DQM code used to compare and to ensure that all 6 uGT boards receive the same input data from uGMT and CaloLayer2. The request is summarised in the following JIRA ticket: https://its.cern.ch/jira/browse/CMSLITDPG-329

The code allows for the comparison of the corresponding standard BX collections: Muon, EGamma, EtSum, Jet and Tau, with those that are appended by an index ranging from 2-6, corresponding to the board number.

The code re-uses the existing L1TStage2MuonComp and L1TStage2uGTCaloLayer2Comp L1T DQM modules, so the major change is the addition of a L1TStage2uGTBoardComp_cff.py configuration file fragment. For the CaloLayer2Comp module, minor changes were implemented to generalise the parameter names that are taken as input. It has no effect on the histograms produced for the CaloLayer2 output vs uGT input comparisons (apart from the histogram title).

This additional data is read-out for validation events only, so the DQM module runs in the validation sequence only.

Relevant to this PR is the update to the uGT and CaloLayer2 unpackers, which was required to unpack this new data and fill the relevant object collections: https://github.com/cms-sw/cmssw/pull/23257 (Backport to 10_1_X: https://github.com/cms-sw/cmssw/pull/23628)