### PR TITLE
provided non-throwing methods in CTPPSGeometry

### DIFF
--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -441,15 +441,16 @@ void TotemTimingDQMSource::dqmBeginRun(const edm::Run &iRun,
   const CTPPSGeometry *geom = geometry_.product();
   const TotemTimingDetId detid_top(0, TOTEM_TIMING_STATION_ID, TOTEM_TIMING_BOT_RP_ID, 0, 0 );
   const TotemTimingDetId detid_bot(0, TOTEM_TIMING_STATION_ID, TOTEM_TIMING_TOP_RP_ID, 0, 7 );
-  try
+  verticalShiftTop_ = 0;
+  verticalShiftBot_ = 0;
   {
-    const DetGeomDesc* det_top = geom->getSensor( detid_top );
-    verticalShiftTop_ = det_top->translation().y() + det_top->params().at( 1 );
-    const DetGeomDesc* det_bot = geom->getSensor( detid_bot );
-    verticalShiftBot_ = det_bot->translation().y() + det_bot->params().at( 1 );
-  } catch (const cms::Exception &) {
-    verticalShiftTop_ = 0;
-    verticalShiftBot_ = 0;
+    const DetGeomDesc* det_top = geom->getSensorNoThrow( detid_top );
+    if(det_top) {
+      verticalShiftTop_ = det_top->translation().y() + det_top->params().at( 1 );
+    }
+    const DetGeomDesc* det_bot = geom->getSensorNoThrow( detid_bot );
+    if(det_bot)
+      verticalShiftBot_ = det_bot->translation().y() + det_bot->params().at( 1 );
   }
 }
 

--- a/Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h
@@ -60,9 +60,11 @@ class CTPPSGeometry
     ///\brief returns geometry of a detector
     /// performs necessary checks, returns NULL if fails
     const DetGeomDesc* getSensor( unsigned int id ) const;
+    const DetGeomDesc* getSensorNoThrow( unsigned int id ) const noexcept;
 
     /// returns geometry of a RP box
     const DetGeomDesc* getRP( unsigned int id ) const;
+    const DetGeomDesc* getRPNoThrow( unsigned int id ) const noexcept;
 
     //----- objects iterators
 

--- a/Geometry/VeryForwardGeometryBuilder/src/CTPPSGeometry.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/CTPPSGeometry.cc
@@ -87,11 +87,23 @@ CTPPSGeometry::addRP( unsigned int id, const DetGeomDesc*& gD )
 const DetGeomDesc*
 CTPPSGeometry::getSensor( unsigned int id ) const
 {
-  auto it = sensors_map_.find( id );
-  if ( it == sensors_map_.end() )
+  auto g = getSensorNoThrow(id);
+  if(nullptr ==g) {
     throw cms::Exception("CTPPSGeometry") << "Not found detector with ID " << id << ", i.e. "
       << CTPPSDetId( id );
+  }
+  return g;
+}
 
+//----------------------------------------------------------------------------------------------------
+
+const DetGeomDesc*
+CTPPSGeometry::getSensorNoThrow( unsigned int id ) const noexcept
+{
+  auto it = sensors_map_.find( id );
+  if ( it == sensors_map_.end() ) {
+    return nullptr;
+  }
   return it->second;
 }
 
@@ -100,10 +112,23 @@ CTPPSGeometry::getSensor( unsigned int id ) const
 const DetGeomDesc*
 CTPPSGeometry::getRP( unsigned int id ) const
 {
-  auto it = rps_map_.find( id );
-  if ( it == rps_map_.end() )
+  auto rp = getRPNoThrow(id);
+  if(nullptr == rp) {     
     throw cms::Exception("CTPPSGeometry") << "Not found RP device with ID " << id << ", i.e. "
       << CTPPSDetId( id );
+  }
+  return rp;
+}
+
+//----------------------------------------------------------------------------------------------------
+
+const DetGeomDesc*
+CTPPSGeometry::getRPNoThrow( unsigned int id ) const noexcept
+{
+  auto it = rps_map_.find( id );
+  if ( it == rps_map_.end() ) {
+    return nullptr;
+  }
 
   return it->second;
 }

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -35,12 +35,7 @@ void TotemTimingRecHitProducerAlgorithm::build(
           z_width = 0;
 
     // retrieve the geometry element associated to this DetID ( if present )
-    const DetGeomDesc *det = nullptr;
-    try { // no other efficient way to check presence
-      det = geom->getSensor(detid);
-    } catch (const cms::Exception &) {
-      det = nullptr;
-    }
+    const DetGeomDesc *det = geom->getSensorNoThrow(detid);
 
     if (det) {
       x_pos = det->translation().x(), y_pos = det->translation().y();


### PR DESCRIPTION
Some clients of CTTPPSGeometry were catching exceptions when they expected the possibility that they were using an invalid geometry index. Added an explicitly non-throwing function to be used in
that case.

The throws were making it difficult to track down a bug in gdb where I needed to use `catch throw`.