### PR TITLE
Mismatch ratio DQM plots for comparison of Muon and CaloLayer2 input collections between 6 uGT boards 

### DIFF
--- a/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
@@ -4,12 +4,17 @@ from DQM.L1TMonitor.L1TStage2uGT_cff import l1tStage2uGMTOutVsuGTIn
 
 # directory path shortening
 ugtDqmDir = 'L1T/L1TStage2uGT'
+ugtBoardCompDqmDir = ugtDqmDir+'/uGTBoardComparisons'
+
+# input histograms
+errHistNumStr = 'errorSummaryNum'
+errHistDenStr = 'errorSummaryDen'
 
 # CaloL2 vs. uGT
 l1tStage2uGTvsCaloLayer2RatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugtDqmDir + '/calol2ouput_vs_uGTinput'),
-    inputNum = cms.untracked.string(ugtDqmDir + '/calol2ouput_vs_uGTinput/errorSummaryNum'),
-    inputDen = cms.untracked.string(ugtDqmDir + '/calol2ouput_vs_uGTinput/errorSummaryDen'),
+    inputNum = cms.untracked.string(ugtDqmDir + '/calol2ouput_vs_uGTinput/'+errHistNumStr),
+    inputDen = cms.untracked.string(ugtDqmDir + '/calol2ouput_vs_uGTinput/'+errHistDenStr),
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between CaloLayer2 outputs and uGT inputs'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
@@ -19,13 +24,100 @@ l1tStage2uGTvsCaloLayer2RatioClient = DQMEDHarvester("L1TStage2RatioClient",
 # Muons vs. uGT
 l1tStage2uGMTOutVsuGTInRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugtDqmDir+'/uGMToutput_vs_uGTinput'),
-    inputNum = cms.untracked.string(ugtDqmDir+'/uGMToutput_vs_uGTinput/errorSummaryNum'),
-    inputDen = cms.untracked.string(ugtDqmDir+'/uGMToutput_vs_uGTinput/errorSummaryDen'),
+    inputNum = cms.untracked.string(ugtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistNumStr),
+    inputDen = cms.untracked.string(ugtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistDenStr),
     ignoreBin = cms.untracked.vint32(l1tStage2uGMTOutVsuGTIn.ignoreBin),
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT output muons and uGT input muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
     binomialErr = cms.untracked.bool(True)
+)
+
+## uGT Board Comparisons
+
+l1tStage2uGTMuon1vsMuon2RatioClient = DQMEDHarvester("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard2/Muons'),
+    inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard2/Muons/'+errHistNumStr),
+    inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard2/Muons/'+errHistDenStr),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 2'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2uGTMuon1vsMuon3RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
+l1tStage2uGTMuon1vsMuon3RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/Muons')
+l1tStage2uGTMuon1vsMuon3RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistNumStr)
+l1tStage2uGTMuon1vsMuon3RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistDenStr)
+l1tStage2uGTMuon1vsMuon3RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 3')
+
+l1tStage2uGTMuon1vsMuon4RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
+l1tStage2uGTMuon1vsMuon4RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/Muons')
+l1tStage2uGTMuon1vsMuon4RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistNumStr)
+l1tStage2uGTMuon1vsMuon4RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistDenStr)
+l1tStage2uGTMuon1vsMuon4RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 4')
+
+l1tStage2uGTMuon1vsMuon5RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
+l1tStage2uGTMuon1vsMuon5RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/Muons')
+l1tStage2uGTMuon1vsMuon5RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistNumStr)
+l1tStage2uGTMuon1vsMuon5RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistDenStr)
+l1tStage2uGTMuon1vsMuon5RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 5')
+
+l1tStage2uGTMuon1vsMuon6RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
+l1tStage2uGTMuon1vsMuon6RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/Muons')
+l1tStage2uGTMuon1vsMuon6RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistNumStr)
+l1tStage2uGTMuon1vsMuon6RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistDenStr)
+l1tStage2uGTMuon1vsMuon6RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 6')
+
+l1tStage2uGTBoardCompMuonsRatioClientSeq = cms.Sequence(
+    l1tStage2uGTMuon1vsMuon2RatioClient +
+    l1tStage2uGTMuon1vsMuon3RatioClient +
+    l1tStage2uGTMuon1vsMuon4RatioClient +
+    l1tStage2uGTMuon1vsMuon5RatioClient +
+    l1tStage2uGTMuon1vsMuon6RatioClient
+)
+
+l1tStage2uGTCalo1vsCalo2RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
+l1tStage2uGTCalo1vsCalo2RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2')
+l1tStage2uGTCalo1vsCalo2RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistNumStr)
+l1tStage2uGTCalo1vsCalo2RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistDenStr)
+l1tStage2uGTCalo1vsCalo2RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 2')
+
+l1tStage2uGTCalo1vsCalo3RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
+l1tStage2uGTCalo1vsCalo3RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2')
+l1tStage2uGTCalo1vsCalo3RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistNumStr)
+l1tStage2uGTCalo1vsCalo3RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistDenStr)
+l1tStage2uGTCalo1vsCalo3RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 3')
+
+l1tStage2uGTCalo1vsCalo4RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
+l1tStage2uGTCalo1vsCalo4RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2')
+l1tStage2uGTCalo1vsCalo4RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistNumStr)
+l1tStage2uGTCalo1vsCalo4RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistDenStr)
+l1tStage2uGTCalo1vsCalo4RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 4')
+
+l1tStage2uGTCalo1vsCalo5RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
+l1tStage2uGTCalo1vsCalo5RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2')
+l1tStage2uGTCalo1vsCalo5RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistNumStr)
+l1tStage2uGTCalo1vsCalo5RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistDenStr)
+l1tStage2uGTCalo1vsCalo5RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 5')
+
+l1tStage2uGTCalo1vsCalo6RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
+l1tStage2uGTCalo1vsCalo6RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2')
+l1tStage2uGTCalo1vsCalo6RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistNumStr)
+l1tStage2uGTCalo1vsCalo6RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistDenStr)
+l1tStage2uGTCalo1vsCalo6RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 6')
+
+l1tStage2uGTBoardCompCaloLayer2RatioClientSeq = cms.Sequence(
+    l1tStage2uGTCalo1vsCalo2RatioClient +
+    l1tStage2uGTCalo1vsCalo3RatioClient +
+    l1tStage2uGTCalo1vsCalo4RatioClient +
+    l1tStage2uGTCalo1vsCalo5RatioClient +
+    l1tStage2uGTCalo1vsCalo6RatioClient
+)
+
+l1tStage2uGTBoardCompRatioClientSeq = cms.Sequence(
+    l1tStage2uGTBoardCompMuonsRatioClientSeq +
+    l1tStage2uGTBoardCompCaloLayer2RatioClientSeq
 )
 
 # uGT timing
@@ -54,5 +146,6 @@ l1tStage2uGTRatioTimingPlots = DQMEDHarvester("DQMGenericClient",
 l1tStage2uGTClient = cms.Sequence(
     l1tStage2uGTvsCaloLayer2RatioClient +
     l1tStage2uGMTOutVsuGTInRatioClient +
+    l1tStage2uGTBoardCompRatioClientSeq + 
     l1tStage2uGTRatioTimingPlots
 )


### PR DESCRIPTION
This is the backport to 10_1_X of the following 10_2_X PR: https://github.com/cms-sw/cmssw/pull/23706

Online L1T DQM code which uses the DQM harvester to produce mismatch ratio plots from the summary DQM plots that compare the Muon and CaloLayer2 input collections between all 6 uGT boards. The request is summarised in the following JIRA ticket: https://its.cern.ch/jira/browse/CMSLITDPG-329

The relevant DQM plots are produced by the code in the following 10_2_X PR: #23686 (10_1_X backport: #23695). The latter code requires the changes in the L1T unpackers made in the following 10_2_X PR: #23257 (10_1_X backport: #23628). Therefore, both PRs are required for the code to work.