### PR TITLE
Fixing ECAL-Trk energy combination such that it gets the uncorrected ecal energy err: 94XMAOD

### DIFF
--- a/RecoEgamma/EgammaTools/interface/ElectronEnergyCalibrator.h
+++ b/RecoEgamma/EgammaTools/interface/ElectronEnergyCalibrator.h
@@ -39,7 +39,10 @@ public:
 
   //set the minimum et to apply the correction to
   void setMinEt(float val){minEt_=val;}
-  
+  //sets whether to use the smeared ecal energy in the combination
+  //note, if this is true and the E/p combination is not trained using this smeared value, this is a bug
+  //the E/p combination must get the ecalEnergyErr used in its training
+  void setUseSmearCorrEcalEnergyErrInComb(bool val){useSmearCorrEcalEnergyErrInComb_=val;}
   /// Correct this electron.
   /// StreamID is needed when used with CMSSW Random Number Generator
   std::array<float,EGEnergySysIndex::kNrSysErrs> 
@@ -72,6 +75,7 @@ private:
   const EpCombinationTool *epCombinationTool_; //this is not owned
   TRandom *rng_; //this is not owned
   float minEt_;
+  bool useSmearCorrEcalEnergyErrInComb_;
 
   //default values to access if no correction available
   static const EnergyScaleCorrection::ScaleCorrection defaultScaleCorr_;

--- a/RecoEgamma/EgammaTools/interface/EpCombinationTool.h
+++ b/RecoEgamma/EgammaTools/interface/EpCombinationTool.h
@@ -26,6 +26,7 @@ public:
 
   void setEventContent(const edm::EventSetup& iSetup);
   std::pair<float, float> combine(const reco::GsfElectron& electron) const;
+  std::pair<float, float> combine(const reco::GsfElectron& electron,float corrEcalEnergyErr) const;
 
 private:
   EgammaRegressionContainer ecalTrkEnergyRegress_;

--- a/RecoEgamma/EgammaTools/plugins/CalibratedElectronProducers.cc
+++ b/RecoEgamma/EgammaTools/plugins/CalibratedElectronProducers.cc
@@ -112,6 +112,7 @@ CalibratedElectronProducerT<T>::CalibratedElectronProducerT( const edm::Paramete
   produceCalibratedObjs_(conf.getParameter<bool>("produceCalibratedObjs"))
 {
   energyCorrector_.setMinEt(conf.getParameter<double>("minEtToCalibrate"));  
+  energyCorrector_.setUseSmearCorrEcalEnergyErrInComb(conf.getParameter<bool>("useSmearCorrEcalEnergyErrInComb"));  
   
   if (conf.getParameter<bool>("semiDeterministic")) {
      semiDeterministicRng_.reset(new TRandom2());
@@ -137,6 +138,7 @@ void CalibratedElectronProducerT<T>::fillDescriptions(edm::ConfigurationDescript
   desc.add<double>("minEtToCalibrate",5.0);
   desc.add<bool>("produceCalibratedObjs",true);
   desc.add<bool>("semiDeterministic",true);
+  desc.add<bool>("useSmearCorrEcalEnergyErrInComb",false);
   std::vector<std::string> valMapsProduced;
   for(auto varToStore : valMapsToStore_) valMapsProduced.push_back(EGEnergySysIndex::name(varToStore));
   desc.add<std::vector<std::string> >("valueMapsStored",valMapsProduced)->setComment("provides to python configs the list of valuemaps stored, can not be overriden in the python config");

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -47,16 +47,26 @@ ecalTrkCombinationRegression = cms.PSet(
 )
 
 calibratedElectrons = cms.EDProducer("CalibratedElectronProducer",
-                                     calibratedEgammaSettings,                                   
+                                     calibratedEgammaSettings,
+                                     useSmearCorrEcalEnergyErrInComb = cms.bool(False),
                                      epCombConfig = ecalTrkCombinationRegression,
                                      src = cms.InputTag('gedGsfElectrons'),
                                      )
 
 calibratedPatElectrons = cms.EDProducer("CalibratedPatElectronProducer",
                                         calibratedEgammaPatSettings,
+                                        useSmearCorrEcalEnergyErrInComb = cms.bool(False),
                                         epCombConfig = ecalTrkCombinationRegression,
                                         src = cms.InputTag('slimmedElectrons'), 
                                        )
+#there was a bug in the 94X Fall17 reminiAOD, this bool set to True enables the bug as
+#this release must be able to reproduce the exact content of that miniAOD production
+#make no mistake, this is an incorrect configuration which will cause a scale shift at Et = 50 GeV
+from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
+run2_miniAOD_94XFall17.toModify(calibratedElectrons,useSmearCorrEcalEnergyErrInComb = True)
+run2_miniAOD_94XFall17.toModify(calibratedPatElectrons,useSmearCorrEcalEnergyErrInComb = True)
+
+
 
 calibratedPhotons = cms.EDProducer("CalibratedPhotonProducer",
                                    calibratedEgammaSettings,

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -46,25 +46,26 @@ ecalTrkCombinationRegression = cms.PSet(
     
 )
 
+#a bug was found, the smear corrected ecal energy err was used in the E/p combination
+#as the campaign has already started, we can not change the default nor the behaviour for the 94X Fall17 reminiAOD
+#therefore we set useSmearCorrEcalEnergyErrInComb = cms.bool(True) when it should be set to false
+#make no mistake, this is an incorrect configuration which will cause a scale shift at Et = 50 GeV
 calibratedElectrons = cms.EDProducer("CalibratedElectronProducer",
                                      calibratedEgammaSettings,
-                                     useSmearCorrEcalEnergyErrInComb = cms.bool(False),
+                                     useSmearCorrEcalEnergyErrInComb = cms.bool(True),
                                      epCombConfig = ecalTrkCombinationRegression,
                                      src = cms.InputTag('gedGsfElectrons'),
                                      )
 
 calibratedPatElectrons = cms.EDProducer("CalibratedPatElectronProducer",
                                         calibratedEgammaPatSettings,
-                                        useSmearCorrEcalEnergyErrInComb = cms.bool(False),
+                                        useSmearCorrEcalEnergyErrInComb = cms.bool(True),
                                         epCombConfig = ecalTrkCombinationRegression,
                                         src = cms.InputTag('slimmedElectrons'), 
                                        )
-#there was a bug in the 94X Fall17 reminiAOD, this bool set to True enables the bug as
-#this release must be able to reproduce the exact content of that miniAOD production
-#make no mistake, this is an incorrect configuration which will cause a scale shift at Et = 50 GeV
-from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
-run2_miniAOD_94XFall17.toModify(calibratedElectrons,useSmearCorrEcalEnergyErrInComb = True)
-run2_miniAOD_94XFall17.toModify(calibratedPatElectrons,useSmearCorrEcalEnergyErrInComb = True)
+#the 80XLegacy miniAOD had not started, hence we can fix it for that
+run2_miniAOD_80XLegacy.toModify(calibratedElectrons,useSmearCorrEcalEnergyErrInComb = False)
+run2_miniAOD_80XLegacy.toModify(calibratedPatElectrons,useSmearCorrEcalEnergyErrInComb = False)
 
 
 

--- a/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
@@ -148,8 +148,8 @@ setEnergyAndSystVarations(const float scale,const float smearNrSigma,const float
   energyData[EGEnergySysIndex::kSmearUp]   = calCombinedMom(ele,corrUp,smearUp).first;
   energyData[EGEnergySysIndex::kSmearDown] = calCombinedMom(ele,corrDn,smearDn).first;
   
+  const std::pair<float, float> combinedMomentum = calCombinedMom(ele,corr,smear);
   setEcalEnergy(ele,corr,smear);
-  const std::pair<float, float> combinedMomentum = epCombinationTool_->combine(ele);
   const float energyCorr =  combinedMomentum.first / oldP4.t();
 
   const math::XYZTLorentzVector newP4(oldP4.x() * energyCorr,
@@ -189,7 +189,7 @@ std::pair<float,float> ElectronEnergyCalibrator::calCombinedMom(reco::GsfElectro
   const float oldTrkMomErr = ele.trackMomentumError();
  
   setEcalEnergy(ele,scale,smear);
-  const auto& combinedMomentum = epCombinationTool_->combine(ele);
+  const auto& combinedMomentum = epCombinationTool_->combine(ele,oldEcalEnergyErr*scale);
   
   ele.setCorrectedEcalEnergy(oldEcalEnergy);
   ele.setCorrectedEcalEnergyError(oldEcalEnergyErr);

--- a/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
@@ -13,7 +13,8 @@ ElectronEnergyCalibrator::ElectronEnergyCalibrator(const EpCombinationTool &comb
   correctionRetriever_(correctionFile), 
   epCombinationTool_(&combinator), 
   rng_(nullptr),
-  minEt_(1.0)
+  minEt_(1.0),
+  useSmearCorrEcalEnergyErrInComb_(false)
 {
   
 }
@@ -189,7 +190,8 @@ std::pair<float,float> ElectronEnergyCalibrator::calCombinedMom(reco::GsfElectro
   const float oldTrkMomErr = ele.trackMomentumError();
  
   setEcalEnergy(ele,scale,smear);
-  const auto& combinedMomentum = epCombinationTool_->combine(ele,oldEcalEnergyErr*scale);
+  float ecalEnergyErrForComb = useSmearCorrEcalEnergyErrInComb_ ?  ele.correctedEcalEnergyError() : oldEcalEnergyErr*scale;
+  const auto& combinedMomentum = epCombinationTool_->combine(ele,ecalEnergyErrForComb);
   
   ele.setCorrectedEcalEnergy(oldEcalEnergy);
   ele.setCorrectedEcalEnergyError(oldEcalEnergyErr);

--- a/RecoEgamma/EgammaTools/src/EpCombinationTool.cc
+++ b/RecoEgamma/EgammaTools/src/EpCombinationTool.cc
@@ -44,12 +44,19 @@ void EpCombinationTool::setEventContent(const edm::EventSetup& iSetup)
 
 std::pair<float, float> EpCombinationTool::combine(const reco::GsfElectron& ele)const
 {
+  return combine(ele,ele.correctedEcalEnergyError());
+}
+
+//when doing the E/p combination, its very important to ensure the ecalEnergyErr
+//that the regression is trained on is used, not the actual ecalEnergyErr of the electron
+//these differ when you correct the ecalEnergyErr by smearing value needed to get data/MC to agree 
+std::pair<float, float> EpCombinationTool::combine(const reco::GsfElectron& ele,const float corrEcalEnergyErr)const
+{
   const float scRawEnergy = ele.superCluster()->rawEnergy(); 
   const float esEnergy = ele.superCluster()->preshowerEnergy();
   
 
   const float corrEcalEnergy = ele.correctedEcalEnergy();
-  const float corrEcalEnergyErr = ele.correctedEcalEnergyError();
   const float ecalMean = ele.correctedEcalEnergy() / (scRawEnergy+esEnergy);
   const float ecalSigma =  corrEcalEnergyErr / corrEcalEnergy;
 


### PR DESCRIPTION
Dear All, 

This is the backport of https://github.com/cms-sw/cmssw/pull/23677 which fixes the bug in that the smeared ecal energy error was being used in the E/p combination.

This additionally adds code so the old behaviour can be produced. The old behaviour is happens for Fall17 re-miniAOD but not 2016 legacy. 