### PR TITLE
[10.1.X] add a veto DB update boolean in the SiPixelAli harvesting to decide to block the payload creation

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -86,6 +86,7 @@ class MillePedeFileReader {
                                                             1000000. }}; // tZ
 
     bool updateDB_{false};
+    bool vetoUpdateDB_{false};
     int Nrec_{0};
 
     std::array<double, 6> Xobs_     = {{0.,0.,0.,0.,0.,0.}};

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -181,9 +181,9 @@ void MillePedeDQMModule
     maxErrortYcut_[detIndex] = myMap[alignable].getErrorThetaYcut() ;
  
     tZcut_[detIndex]         = myMap[alignable].getThetaZcut() ;
-    sigtZcut_[detIndex]      = myMap[alignable].getSigThetaYcut() ;
-    maxMovetZcut_[detIndex]  = myMap[alignable].getMaxMoveThetaYcut() ;
-    maxErrortZcut_[detIndex] = myMap[alignable].getErrorThetaYcut() ;
+    sigtZcut_[detIndex]      = myMap[alignable].getSigThetaZcut() ;
+    maxMovetZcut_[detIndex]  = myMap[alignable].getMaxMoveThetaZcut() ;
+    maxErrortZcut_[detIndex] = myMap[alignable].getErrorThetaZcut() ;
 
   }
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -35,7 +35,7 @@ void MillePedeFileReader
 
 bool MillePedeFileReader
 ::storeAlignments() {
-  return updateDB_;
+  return (updateDB_&&!vetoUpdateDB_);
 }
 
 
@@ -96,6 +96,7 @@ void MillePedeFileReader
   }
 
   updateDB_ = false;
+  vetoUpdateDB_ = false;
   std::ifstream resFile;
   resFile.open(millePedeResFile_.c_str());
 
@@ -175,16 +176,16 @@ void MillePedeFileReader
         if (std::abs(ObsMove) > thresholds_[detLabel][alignableIndex]) {
 	  edm::LogWarning("MillePedeFileReader")<<"Aborting payload creation."
 						<<" Exceeding maximum thresholds for movement: "<<std::abs(ObsMove)<<" for"<< detLabel <<"("<<coord<<")" ;	  
-          updateDB_    = false;
-          break;
+	  vetoUpdateDB_ = true;
+          continue;
 
         } else if (std::abs(ObsMove) > cutoffs_[detLabel][alignableIndex]) {
 
           if (std::abs(ObsErr) > errors_[detLabel][alignableIndex]) {
 	    edm::LogWarning("MillePedeFileReader")<<"Aborting payload creation." 
-						  <<" Exceeding maximum thresholds for error: "<<std::abs(ObsErr)<<" for"<< detLabel <<"("<<coord<<")" ;	  	  
-            updateDB_    = false;
-            break;
+						  <<" Exceeding maximum thresholds for error: "<<std::abs(ObsErr)<<" for"<< detLabel <<"("<<coord<<")" ;	  	 
+	    vetoUpdateDB_ = true;
+            continue;
           } else {
             if (std::abs(ObsMove/ObsErr) < significances_[detLabel][alignableIndex]) {
               continue;


### PR DESCRIPTION
backport of #23697 

Greetings, 
this PR solves two bugs in the SiPixelAli PCL alignment DQM monitoring, that were uncovered in the discussion of [this e-mail thread](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3738.html):
   * the previous logic of the SiPixelAli DQM harvester forced to break from a while loop on the coordinates if there is a movement exceeding thresholds. This in turn entailed that if there was a movement exceeding the thresholds the DQM monitoring was crippled (all the other alignable parts were not plotted). I introduce a new boolean to decide whether to veto the upload, still not breaking the loop (so that all parts are plotted)
   * a bug in `MillePedeDQMModule.cc` causing the thresholds on several parameters for `theta_Z` alignable to be taken instead from the `theta_Y`. 

Tested with 
```bash
cmsDriver.py pedeStep --data --conditions 101X_dataRun2_Express_v8 --scenario pp -s ALCAHARVEST:SiPixelAli --dasquery='file dataset=/StreamExpress/Run2018B-PromptCalibProdSiPixelAli-Express-v1/ALCAPROMPT run=318622' -n -1
```
The situation before the fix:

![image](https://user-images.githubusercontent.com/5082376/41982380-95f65c82-7a2b-11e8-9879-da23e2502154.png)

becomes after the fixes:

![image](https://user-images.githubusercontent.com/5082376/41982202-190af49e-7a2b-11e8-819d-5a63416b34e3.png)

***N.B.: no change in behavior for the actual payload creation is intended here, the changes shall affect only the monitoring***
