### PR TITLE
Remove explicit types from parameter overrides in DigiToRawDM_cff

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRawDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawDM_cff.py
@@ -4,29 +4,29 @@ from Configuration.StandardSequences.DigiToRaw_cff import *
 #
 # Re-define inputs to look at the DataMixer output
 #
-siPixelRawData.InputLabel = cms.InputTag("mixData:siPixelDigisDM")
-SiStripDigiToRaw.InputDigis = cms.InputTag("mixData", "siStripDigisDM")
+siPixelRawData.InputLabel = "mixData:siPixelDigisDM"
+SiStripDigiToRaw.InputDigis = "mixData:siStripDigisDM"
 #
 ecalPacker.Label = 'DMEcalDigis'
 ecalPacker.InstanceEB = 'ebDigis'
 ecalPacker.InstanceEE = 'eeDigis'
 ecalPacker.labelEBSRFlags = "DMEcalDigis:ebSrFlags"
 ecalPacker.labelEESRFlags = "DMEcalDigis:eeSrFlags"
-ecalPacker.labelTT = cms.InputTag('DMEcalTriggerPrimitiveDigis')
-esDigiToRaw.Label = cms.string('DMEcalPreshowerDigis')
+ecalPacker.labelTT = 'DMEcalTriggerPrimitiveDigis'
+esDigiToRaw.Label = 'DMEcalPreshowerDigis'
 #
-hcalRawDataVME.HBHE = cms.untracked.InputTag("DMHcalDigis")
-hcalRawDataVME.HF = cms.untracked.InputTag("DMHcalDigis")
-hcalRawDataVME.HO = cms.untracked.InputTag("DMHcalDigis") 
-hcalRawDataVME.ZDC = cms.untracked.InputTag("mixData")
-hcalRawDataVME.TRIG = cms.untracked.InputTag("DMHcalTriggerPrimitiveDigis")
+hcalRawDataVME.HBHE = "DMHcalDigis"
+hcalRawDataVME.HF = "DMHcalDigis"
+hcalRawDataVME.HO = "DMHcalDigis"
+hcalRawDataVME.ZDC = "mixData"
+hcalRawDataVME.TRIG = "DMHcalTriggerPrimitiveDigis"
 #
-cscpacker.wireDigiTag = cms.InputTag("mixData","MuonCSCWireDigisDM")
-cscpacker.stripDigiTag = cms.InputTag("mixData","MuonCSCStripDigisDM")
-cscpacker.comparatorDigiTag = cms.InputTag("mixData","MuonCSCComparatorDigisDM")
-dtpacker.digiColl = cms.InputTag('mixData')
-#dtpacker.digiColl = cms.InputTag('simMuonDTDigis')
-rpcpacker.InputLabel = cms.InputTag("mixData")
+cscpacker.wireDigiTag = "mixData:MuonCSCWireDigisDM"
+cscpacker.stripDigiTag = "mixData:MuonCSCStripDigisDM"
+cscpacker.comparatorDigiTag = "mixData:MuonCSCComparatorDigisDM"
+dtpacker.digiColl = 'mixData'
+#dtpacker.digiColl = 'simMuonDTDigis'
+rpcpacker.InputLabel = "mixData"
 
 DigiToRaw.remove(castorRawData)
 
@@ -35,16 +35,16 @@ DigiToRaw.remove(castorRawData)
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( hcalRawDataVME,
-    HBHE = cms.untracked.InputTag(""),
-    HF = cms.untracked.InputTag(""),
-    TRIG = cms.untracked.InputTag(""),
+    HBHE = "",
+    HF = "",
+    TRIG = "",
 )
 run2_HCAL_2017.toModify( hcalRawDatauHTR,
-    HBHEqie8 = cms.InputTag("DMHcalDigis"),
-    HFqie8 = cms.InputTag("DMHcalDigis"),
-    QIE10 = cms.InputTag("DMHcalDigis","HFQIE10DigiCollection"),
-    QIE11 = cms.InputTag("DMHcalDigis","HBHEQIE11DigiCollection"),
-    TP = cms.InputTag("DMHcalTriggerPrimitiveDigis"),
+    HBHEqie8 = "DMHcalDigis",
+    HFqie8 = "DMHcalDigis",
+    QIE10 = "DMHcalDigis:HFQIE10DigiCollection",
+    QIE11 = "DMHcalDigis:HBHEQIE11DigiCollection",
+    TP = "DMHcalTriggerPrimitiveDigis",
 )
 
 
@@ -52,14 +52,14 @@ if 'caloLayer1RawFed1354' in globals():
     from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 
     stage2L1Trigger.toModify(caloLayer1RawFed1354,
-                             ecalDigis= cms.InputTag("DMEcalTriggerPrimitiveDigis"),
-                             hcalDigis= cms.InputTag("DMHcalTriggerPrimitiveDigis")
+                             ecalDigis= "DMEcalTriggerPrimitiveDigis",
+                             hcalDigis= "DMHcalTriggerPrimitiveDigis"
                              )
     stage2L1Trigger.toModify(caloLayer1RawFed1356,
-                             ecalDigis= cms.InputTag("DMEcalTriggerPrimitiveDigis"),
-                             hcalDigis= cms.InputTag("DMHcalTriggerPrimitiveDigis")
+                             ecalDigis= "DMEcalTriggerPrimitiveDigis",
+                             hcalDigis= "DMHcalTriggerPrimitiveDigis"
                              )
     stage2L1Trigger.toModify(caloLayer1RawFed1358,
-                             ecalDigis= cms.InputTag("DMEcalTriggerPrimitiveDigis"),
-                             hcalDigis= cms.InputTag("DMHcalTriggerPrimitiveDigis")
+                             ecalDigis= "DMEcalTriggerPrimitiveDigis",
+                             hcalDigis= "DMHcalTriggerPrimitiveDigis"
                              )


### PR DESCRIPTION
This PR is a follow-up to the issue with missing pileup in DTs in premixing from couple months ago (that was fixed in #23091). If the parameter overrides would not have had the explicit types, we would have caught the problem (inconsistent parameters) already with the PR that introduced the bug. To prevent similar incidents in the future, this PR removes all explicit right-hand-side types from `DigiToRawDM_cff.py`.

Tested in 10_2_0_pre6, no changes expected.

@mdhildreth @kpedro88 