### PR TITLE
Plot module residuals

### DIFF
--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
@@ -1962,12 +1962,16 @@ vector <TH1*>  PlotAlignmentValidation::findmodule (TFile* f, unsigned int modul
  }
 
 void PlotAlignmentValidation::residual_by_moduleID( unsigned int moduleid){
-	TString histname = "residual_module_";
-	histname.Append(to_string(moduleid));
 	TCanvas *cx = new TCanvas("x_residual");
 	TCanvas *cy = new TCanvas("y_residual");
+	TLegend *legendx =new TLegend(0.55, 0.7, 1, 0.9);
+        TLegend *legendy =new TLegend(0.55, 0.7, 1, 0.9);
 	
-    	
+    	legendx->SetTextSize(0.016);
+	legendx->SetTextAlign(12);
+        legendy->SetTextSize(0.016);
+        legendy->SetTextAlign(12);
+
 	
 	
 	
@@ -1978,8 +1982,8 @@ void PlotAlignmentValidation::residual_by_moduleID( unsigned int moduleid){
 		TString legendname = it->getName(); //this goes in the legend
 	    	vector<TH1*> hist = findmodule(file, moduleid);
 			
-		TString filenamex = legendname+" NEntries: "+to_string(int(hist[0]->GetEntries()));
-        	hist[0]->SetTitle(filenamex);
+		TString histnamex = legendname+" NEntries: "+to_string(int(hist[0]->GetEntries()));
+        	hist[0]->SetTitle(histnamex);
         	hist[0]->SetStats(0);
         	hist[0]->Rebin(50);
         	hist[0]->SetBit(TH1::kNoTitle);
@@ -1987,30 +1991,33 @@ void PlotAlignmentValidation::residual_by_moduleID( unsigned int moduleid){
         	hist[0]->SetLineStyle(linestyle);
         	cx->cd();
 		hist[0]->Draw("Same");
+		legendx->AddEntry(hist[0], histnamex, "l");
+				
 			
-			
-		TString filenamey = legendname+" NEntries: "+to_string(int(hist[1]->GetEntries()));
-        	hist[1]->SetTitle(filenamey);
+		TString histnamey = legendname+" NEntries: "+to_string(int(hist[1]->GetEntries()));
+        	hist[1]->SetTitle(histnamey);
         	hist[1]->SetStats(0);
         	hist[1]->Rebin(50);
         	hist[1]->SetBit(TH1::kNoTitle);
         	hist[1]->SetLineColor(color);
         	hist[1]->SetLineStyle(linestyle);
         	cy->cd();
-			hist[1]->Draw("Same");
+		hist[1]->Draw("Same");
+		legendy->AddEntry(hist[1], histnamey, "l");
+	
 	}
 	
 	TString filenamex = "x_residual_"+to_string(moduleid);
         TString filenamey = "y_residual_"+to_string(moduleid);
         cx->cd();
-        gPad->BuildLegend(0.6,0.75,0.9,0.9);
+	legendx->Draw();
         cx->SaveAs(outputDir + "/" +filenamex+".root");
         cx->SaveAs(outputDir + "/" +filenamex+".pdf");
         cx->SaveAs(outputDir + "/" +filenamex+".png");
         cx->SaveAs(outputDir + "/" +filenamex+".eps");
 
         cy->cd();
-        gPad->BuildLegend(0.6,0.75,0.9,0.9);
+	legendy->Draw();
         cy->SaveAs(outputDir + "/" +filenamey+".root");
         cy->SaveAs(outputDir + "/" +filenamey+".pdf");
         cy->SaveAs(outputDir + "/" +filenamey+".png");

--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
@@ -1964,9 +1964,8 @@ vector <TH1*>  PlotAlignmentValidation::findmodule (TFile* f, unsigned int modul
 void PlotAlignmentValidation::residual_by_moduleID( unsigned int moduleid){
 	TString histname = "residual_module_";
 	histname.Append(to_string(moduleid));
-	TFile * f = new TFile (histname+".root","RECREATE");
-	TCanvas *cx = new TCanvas("h_x_residual");
-	TCanvas *cy = new TCanvas("h_y_residual");
+	TCanvas *cx = new TCanvas("x_residual");
+	TCanvas *cy = new TCanvas("y_residual");
 	
     	
 	
@@ -2001,14 +2000,21 @@ void PlotAlignmentValidation::residual_by_moduleID( unsigned int moduleid){
 			hist[1]->Draw("Same");
 	}
 	
-	cx->cd();
-	gPad->BuildLegend(0.6,0.6,0.9,0.9);
-	cy->cd();
-	gPad->BuildLegend(0.6,0.6,0.9,0.9);
+	TString filenamex = "x_residual_"+to_string(moduleid);
+        TString filenamey = "y_residual_"+to_string(moduleid);
+        cx->cd();
+        gPad->BuildLegend(0.6,0.75,0.9,0.9);
+        cx->SaveAs(outputDir + "/" +filenamex+".root");
+        cx->SaveAs(outputDir + "/" +filenamex+".pdf");
+        cx->SaveAs(outputDir + "/" +filenamex+".png");
+        cx->SaveAs(outputDir + "/" +filenamex+".eps");
+
+        cy->cd();
+        gPad->BuildLegend(0.6,0.75,0.9,0.9);
+        cy->SaveAs(outputDir + "/" +filenamey+".root");
+        cy->SaveAs(outputDir + "/" +filenamey+".pdf");
+        cy->SaveAs(outputDir + "/" +filenamey+".png");
+        cy->SaveAs(outputDir + "/" +filenamey+".eps");
 	
-    f->cd();
-    cx->Write();
-    cy->Write();
-    f->Close();
-	
+
 }

--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
@@ -1923,3 +1923,92 @@ return 2*(1-ROOT::Math::tdistribution_cdf(abs(t),v));
 }
 
 const TString PlotAlignmentValidation::summaryfilename = "OfflineValidationSummary.txt";
+
+
+
+vector <TH1*>  PlotAlignmentValidation::findmodule (TFile* f, unsigned int moduleid){
+		
+		
+		//TFile *f = TFile::Open(filename, "READ");
+		TString histnamex;
+		TString histnamey;
+        //read necessary branch/folder
+        auto t = (TTree*)f->Get("TrackerOfflineValidationStandalone/TkOffVal");
+
+        TkOffTreeVariables *variables=0;
+        t->SetBranchAddress("TkOffTreeVariables", &variables);
+        unsigned int number_of_entries=t->GetEntries();
+        for (int i=0;i<number_of_entries;i++){
+                t->GetEntry(i);
+                 if (variables->moduleId==moduleid){
+                        histnamex=variables->histNameX;
+                        histnamey=variables->histNameY;
+						break;
+                        }
+        }
+		 
+	vector <TH1*> h;
+		
+        auto h1 = (TH1*)f->FindObjectAny(histnamex);
+	auto h2 = (TH1*)f->FindObjectAny(histnamey);
+        
+	h1->SetDirectory(0);
+	h2->SetDirectory(0);
+        
+	h.push_back(h1);
+	h.push_back(h2);
+		
+	return h;
+ }
+
+void PlotAlignmentValidation::residual_by_moduleID( unsigned int moduleid){
+	TString histname = "residual_module_";
+	histname.Append(to_string(moduleid));
+	TFile * f = new TFile (histname+".root","RECREATE");
+	TCanvas *cx = new TCanvas("h_x_residual");
+	TCanvas *cy = new TCanvas("h_y_residual");
+	
+    	
+	
+	
+	
+	for (auto it : sourceList) {
+		TFile* file = it->getFile();
+		int color = it->getLineColor();
+		int linestyle = it->getLineStyle();   //this you set by doing h->SetLineStyle(linestyle)
+		TString legendname = it->getName(); //this goes in the legend
+	    	vector<TH1*> hist = findmodule(file, moduleid);
+			
+		TString filenamex = legendname+" NEntries: "+to_string(int(hist[0]->GetEntries()));
+        	hist[0]->SetTitle(filenamex);
+        	hist[0]->SetStats(0);
+        	hist[0]->Rebin(50);
+        	hist[0]->SetBit(TH1::kNoTitle);
+        	hist[0]->SetLineColor(color);
+        	hist[0]->SetLineStyle(linestyle);
+        	cx->cd();
+		hist[0]->Draw("Same");
+			
+			
+		TString filenamey = legendname+" NEntries: "+to_string(int(hist[1]->GetEntries()));
+        	hist[1]->SetTitle(filenamey);
+        	hist[1]->SetStats(0);
+        	hist[1]->Rebin(50);
+        	hist[1]->SetBit(TH1::kNoTitle);
+        	hist[1]->SetLineColor(color);
+        	hist[1]->SetLineStyle(linestyle);
+        	cy->cd();
+			hist[1]->Draw("Same");
+	}
+	
+	cx->cd();
+	gPad->BuildLegend(0.6,0.6,0.9,0.9);
+	cy->cd();
+	gPad->BuildLegend(0.6,0.6,0.9,0.9);
+	
+    f->cd();
+    cx->Write();
+    cy->Write();
+    f->Close();
+	
+}

--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.h
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.h
@@ -99,6 +99,7 @@ public:
   void plotHitMaps();
   void setOutputDir( std::string dir );
   void setTreeBaseDir( std::string dir = "TrackerOfflineValidationStandalone");
+  void residual_by_moduleID(unsigned int moduleid);
   int numberOfLayers(int phase, int subdetector);
   int maxNumberOfLayers(int subdetector);
   
@@ -175,6 +176,8 @@ private :
   void plotDMRHistogram(DMRPlotInfo& plotinfo, int direction = 0, int layer = 0);
   void modifySSHistAndLegend(THStack* hs, TLegend* legend);
   void openSummaryFile();
+  vector <TH1*> findmodule (TFile* f, unsigned int moduleid);
+
 };
 
 #endif // PLOTALIGNNMENTVALIDATION_H_

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -109,5 +109,9 @@ void TkAlExtendedOfflineValidation()
   p.plotDMR(".oO[DMRMethod]Oo.",.oO[DMRMinimum]Oo.,".oO[DMROptions]Oo.");
   p.plotSurfaceShapes(".oO[SurfaceShapes]Oo.");
   p.plotChi2("root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./.oO[validationId]Oo._result.root");
+  vector<int> moduleids = {.oO[moduleid]Oo.};
+  for (auto moduleid : moduleids) {
+  	p.residual_by_moduleID(moduleid);
+  }
 }
 """

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
@@ -184,7 +184,7 @@ class PlottingOptionsOffline(BasePlottingOptions):
                 "SurfaceShapes":"coarse",
                 "bigtext":"false",
                 "mergeOfflineParJobsScriptPath": ".oO[scriptsdir]Oo./TkAlOfflineJobsMerge.C",
-                "usefit": "false",
+                "usefit": "false","moduleid": ""
                }
     validationclass = OfflineValidation
     def __init__(self, config):

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -41,7 +41,7 @@ import Alignment.OfflineValidation.TkAlAllInOneTool.globalDictionaries \
 
 
 ####################--- Classes ---############################
-class ParallelMergeJob:
+class ParallelMergeJob(object):
     
     def __init__(self, _name, _path, _dependency):
         self.name=_name
@@ -68,7 +68,7 @@ class ParallelMergeJob:
             "-w %(conditions)s "
             "%(script)s"%repMap)
 
-class ValidationJob:
+class ValidationJob(object):
 
     # these count the jobs of different varieties that are being run
     crabCount = 0
@@ -372,7 +372,7 @@ def createMergeScript( path, validations, options ):
                 repMapTemp["RunValidationPlots"] = validationType.doRunPlots(validations)
                 
                 #create script file
-                fileName="TkAlMerge"+validation.alignmentToValidate.name
+                fileName="TkAlMergeOfflineValidation"+validation.name+validation.alignmentToValidate.name
                 filePath = os.path.join(path, fileName+".sh")
                 theFile = open( filePath, "w" )
                 theFile.write( replaceByMap( configTemplates.mergeParallelOfflineTemplate, repMapTemp ) )

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -131,18 +131,18 @@ class ValidationJob:
             if len( firstAlignList ) > 1:
                 firstRun = firstAlignList[1]
             else:
-                firstRun = "1"
+                raise AllInOneError("Have to provide a run number for geometry comparison")
             firstAlign = Alignment( firstAlignName, self.__config, firstRun )
             firstAlignName = firstAlign.name
             secondAlignList = alignmentsList[1].split()
             secondAlignName = secondAlignList[0].strip()
-            if len( secondAlignList ) > 1:
-                secondRun = secondAlignList[1]
-            else:
-                secondRun = "1"
             if secondAlignName == "IDEAL":
                 secondAlign = secondAlignName
             else:
+                if len( secondAlignList ) > 1:
+                    secondRun = secondAlignList[1]
+                else:
+                    raise AllInOneError("Have to provide a run number for geometry comparison")
                 secondAlign = Alignment( secondAlignName, self.__config,
                                          secondRun )
                 secondAlignName = secondAlign.name


### PR DESCRIPTION
Added a function which plots x and y residuals for a specified module. This option is useful when one has to check a particular module which, for instance, moves very far during alignment. (In our case it moved more than by 1 mm)

Post on Hypernews:
https://hypernews.cern.ch/HyperNews/CMS/get/tif-alignment/702.html

