### PR TITLE
Minor premixing cleanup

### DIFF
--- a/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
+++ b/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
@@ -117,4 +117,4 @@ void PreMixingEcalWorker::beginLuminosityBlock(edm::LuminosityBlock const& lumi,
   myEcalDigitizer_.beginLuminosityBlock(lumi,setup);
 }
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingEcalWorker, "PreMixingEcalWorker");
+DEFINE_PREMIXING_WORKER(PreMixingEcalWorker);

--- a/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
@@ -83,4 +83,4 @@ void PreMixingHGCalWorker::put(edm::Event &e,const edm::EventSetup& ES, std::vec
   digitizer_.finalizeEvent(e, ES, &rng->getEngine(e.streamID()));
 }
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingHGCalWorker, "PreMixingHGCalWorker");
+DEFINE_PREMIXING_WORKER(PreMixingHGCalWorker);

--- a/SimCalorimetry/HcalSimProducers/plugins/PreMixingHcalWorker.cc
+++ b/SimCalorimetry/HcalSimProducers/plugins/PreMixingHcalWorker.cc
@@ -153,4 +153,4 @@ void PreMixingHcalWorker::put(edm::Event &e,const edm::EventSetup& ES, std::vect
   myHcalDigitizer_.finalizeEvent( e, ES);
 }
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingHcalWorker, "PreMixingHcalWorker");
+DEFINE_PREMIXING_WORKER(PreMixingHcalWorker);

--- a/SimGeneral/CaloAnalysis/plugins/PreMixingCaloParticleWorker.cc
+++ b/SimGeneral/CaloAnalysis/plugins/PreMixingCaloParticleWorker.cc
@@ -142,4 +142,4 @@ void PreMixingCaloParticleWorker::put(edm::Event& iEvent, edm::EventSetup const&
   iEvent.put(std::move(newParticles_), particleCollectionDM_);
 }
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingCaloParticleWorker, "PreMixingCaloParticleWorker");
+DEFINE_PREMIXING_WORKER(PreMixingCaloParticleWorker);

--- a/SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h
+++ b/SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h
@@ -12,4 +12,6 @@ namespace edm {
 
 using PreMixingWorkerFactory = edmplugin::PluginFactory< PreMixingWorker* (const edm::ParameterSet&, edm::ProducerBase&, edm::ConsumesCollector&& iC) >;
 
+#define DEFINE_PREMIXING_WORKER(TYPE) DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, TYPE, #TYPE)
+
 #endif

--- a/SimGeneral/PreMixingModule/plugins/PreMixingCrossingFrameWorker.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingCrossingFrameWorker.cc
@@ -81,8 +81,6 @@ namespace edm {
 }
 
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
-namespace edm {
-  using PreMixingCrossingFramePSimHitWorker = PreMixingCrossingFrameWorker<PSimHit>;
-}
+using PreMixingCrossingFramePSimHitWorker = edm::PreMixingCrossingFrameWorker<PSimHit>;
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, edm::PreMixingCrossingFramePSimHitWorker, "PreMixingCrossingFramePSimHitWorker");
+DEFINE_PREMIXING_WORKER(PreMixingCrossingFramePSimHitWorker);

--- a/SimGeneral/PreMixingModule/plugins/PreMixingDigiAccumulatorWorker.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingDigiAccumulatorWorker.cc
@@ -11,38 +11,36 @@
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
 
-namespace edm {
-  class PreMixingDigiAccumulatorWorker: public PreMixingWorker {
-  public:
-    PreMixingDigiAccumulatorWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC):
-      accumulator_(DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(ps.getParameter<edm::ParameterSet>("accumulator"), producer, iC))
-    {}
-    ~PreMixingDigiAccumulatorWorker() override = default;
+class PreMixingDigiAccumulatorWorker: public PreMixingWorker {
+public:
+  PreMixingDigiAccumulatorWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC):
+    accumulator_(edm::DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(ps.getParameter<edm::ParameterSet>("accumulator"), producer, iC))
+  {}
+  ~PreMixingDigiAccumulatorWorker() override = default;
 
-    void initializeEvent(const edm::Event &e, const edm::EventSetup& ES) override {
-      accumulator_->initializeEvent(e, ES);
-    }
+  void initializeEvent(const edm::Event &e, const edm::EventSetup& ES) override {
+    accumulator_->initializeEvent(e, ES);
+  }
 
-    void initializeBunchCrossing(edm::Event const& e, edm::EventSetup const& ES, int bunchCrossing) override {
-      accumulator_->initializeBunchCrossing(e, ES, bunchCrossing);
-    }
-    void finalizeBunchCrossing(edm::Event& e, edm::EventSetup const& ES, int bunchCrossing) override {
-      accumulator_->finalizeBunchCrossing(e, ES, bunchCrossing);
-    }
+  void initializeBunchCrossing(edm::Event const& e, edm::EventSetup const& ES, int bunchCrossing) override {
+    accumulator_->initializeBunchCrossing(e, ES, bunchCrossing);
+  }
+  void finalizeBunchCrossing(edm::Event& e, edm::EventSetup const& ES, int bunchCrossing) override {
+    accumulator_->finalizeBunchCrossing(e, ES, bunchCrossing);
+  }
     
-    void addSignals(const edm::Event &e, const edm::EventSetup& ES) override {
-      accumulator_->accumulate(e, ES);
-    }
-    void addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& ES) override {
-      accumulator_->accumulate(pep, ES, pep.principal().streamID());
-    }
-    void put(edm::Event &e,const edm::EventSetup& ES, std::vector<PileupSummaryInfo> const& ps, int bs) override {
-      accumulator_->finalizeEvent(e, ES);
-    }
+  void addSignals(const edm::Event &e, const edm::EventSetup& ES) override {
+    accumulator_->accumulate(e, ES);
+  }
+  void addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& ES) override {
+    accumulator_->accumulate(pep, ES, pep.principal().streamID());
+  }
+  void put(edm::Event &e,const edm::EventSetup& ES, std::vector<PileupSummaryInfo> const& ps, int bs) override {
+    accumulator_->finalizeEvent(e, ES);
+  }
 
-  private:
-    std::unique_ptr<DigiAccumulatorMixMod> accumulator_;
-  };
-}
+private:
+  std::unique_ptr<DigiAccumulatorMixMod> accumulator_;
+};
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, edm::PreMixingDigiAccumulatorWorker, "PreMixingDigiAccumulatorWorker");
+DEFINE_PREMIXING_WORKER(PreMixingDigiAccumulatorWorker);

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -91,18 +91,15 @@ mixData = cms.EDProducer("PreMixingModule",
                 killModules = False,
                 MissCalibrate = False,
             ),
-            #
             workerType = cms.string("PreMixingSiPixelWorker"),
-            #
             pixeldigiCollectionSig = cms.InputTag("simSiPixelDigis"),
             pixeldigiCollectionPile = cms.InputTag("siPixelDigis","","@MIXING"),
             PixelDigiCollectionDM = cms.string('siPixelDigisDM'),                   
         ),
         strip = cms.PSet(
             SiStripSimBlock,
-            #
             workerType = cms.string("PreMixingSiStripWorker"),
-            #
+
             SistripLabelSig = cms.InputTag("simSiStripDigis","ZeroSuppressed"),
             SiStripPileInputTag = cms.InputTag("siStripDigis","ZeroSuppressed","@MIXING"),
             # Dead APV Vector
@@ -114,40 +111,38 @@ mixData = cms.EDProducer("PreMixingModule",
         ),
         ecal = cms.PSet(
             ecalDigitizer.clone(accumulatorType = None, makeDigiSimLinks=None),
-            #
             workerType = cms.string("PreMixingEcalWorker"),
-            #
+
             EBdigiProducerSig = cms.InputTag("simEcalUnsuppressedDigis"),
             EEdigiProducerSig = cms.InputTag("simEcalUnsuppressedDigis"),
             ESdigiProducerSig = cms.InputTag("simEcalPreshowerDigis"),
-            #
+
             EBPileInputTag = cms.InputTag("ecalDigis","ebDigis","@MIXING"),
             EEPileInputTag = cms.InputTag("ecalDigis","eeDigis","@MIXING"),
             ESPileInputTag = cms.InputTag("ecalPreshowerDigis","","@MIXING"),
-            #
+
             EBDigiCollectionDM   = cms.string(''),
             EEDigiCollectionDM   = cms.string(''),
             ESDigiCollectionDM   = cms.string(''),
         ),
         hcal = cms.PSet(
             hcalSimBlock,
-            #
             workerType = cms.string("PreMixingHcalWorker"),
-            #
+
             HBHEdigiCollectionSig  = cms.InputTag("simHcalUnsuppressedDigis"),
             HOdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
             HFdigiCollectionSig    = cms.InputTag("simHcalUnsuppressedDigis"),
             QIE10digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
             QIE11digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
             ZDCdigiCollectionSig   = cms.InputTag("simHcalUnsuppressedDigis"),
-            #
+
             HBHEPileInputTag = cms.InputTag("hcalDigis","","@MIXING"),
             HOPileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
             HFPileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
             QIE10PileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
             QIE11PileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
             ZDCPileInputTag  = cms.InputTag(""),
-            #
+
             HBHEDigiCollectionDM = cms.string(''),
             HODigiCollectionDM   = cms.string(''),
             HFDigiCollectionDM   = cms.string(''),
@@ -157,21 +152,18 @@ mixData = cms.EDProducer("PreMixingModule",
         ),
         dt = cms.PSet(
             workerType = cms.string("PreMixingDTWorker"),
-            #
             digiTagSig = cms.InputTag("simMuonDTDigis"),
             pileInputTag = cms.InputTag("muonDTDigis","","@MIXING"),
             collectionDM = cms.string(''),
         ),
         rpc = cms.PSet(
             workerType = cms.string("PreMixingRPCWorker"),
-            #
             digiTagSig = cms.InputTag("simMuonRPCDigis"),                   
             pileInputTag = cms.InputTag("simMuonRPCDigis",""),
             collectionDM = cms.string(''),
         ),
         csc = cms.PSet(
             workerType = cms.string("PreMixingCSCWorker"),
-            #
             strip = cms.PSet(
                 digiTagSig = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigi"),
                 pileInputTag = cms.InputTag("muonCSCDigis","MuonCSCStripDigi","@MIXING"),
@@ -190,49 +182,42 @@ mixData = cms.EDProducer("PreMixingModule",
         ),
         trackingTruth = cms.PSet(
             workerType = cms.string("PreMixingTrackingParticleWorker"),
-            #
             labelSig = cms.InputTag("mix","MergedTrackTruth"),
             pileInputTag = cms.InputTag("mix","MergedTrackTruth"),
             collectionDM = cms.string('MergedTrackTruth'),
         ),
         pixelSimLink = cms.PSet(
             workerType = cms.string("PreMixingPixelDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simSiPixelDigis"),
             pileInputTag = cms.InputTag("simSiPixelDigis"),
             collectionDM = cms.string('PixelDigiSimLink'),
         ),
         stripSimLink = cms.PSet(
             workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simSiStripDigis"),
             pileInputTag = cms.InputTag("simSiStripDigis"),
             collectionDM = cms.string('StripDigiSimLink'),
         ),
         dtSimLink = cms.PSet(
             workerType = cms.string("PreMixingDTDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simMuonDTDigis"),
             pileInputTag = cms.InputTag("simMuonDTDigis"),
             collectionDM = cms.string('simMuonDTDigis'),
         ),
         rpcSimLink = cms.PSet(
             workerType = cms.string("PreMixingRPCDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simMuonRPCDigis","RPCDigiSimLink"),
             pileInputTag = cms.InputTag("simMuonRPCDigis","RPCDigiSimLink"),
             collectionDM = cms.string('RPCDigiSimLink'),
         ),
         cscStripSimLink = cms.PSet(
             workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigiSimLinks"),
             pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigiSimLinks"),
             collectionDM = cms.string('MuonCSCStripDigiSimLinks'),
         ),
         cscWireSimLink = cms.PSet(
             workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigiSimLinks"),
             pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigiSimLinks"),
             collectionDM = cms.string('MuonCSCWireDigiSimLinks'),
@@ -276,9 +261,8 @@ phase2_tracker.toModify(mixData,
         # Replace pixel with Phase2 tracker
         pixel = cms.PSet(
             phase2TrackerDigitizer,
-            #
             workerType = cms.string("PreMixingPhase2TrackerWorker"),
-            #
+
             pixelLabelSig = cms.InputTag("simSiPixelDigis:Pixel"),
             pixelPileInputTag = cms.InputTag("simSiPixelDigis:Pixel"),
             trackerLabelSig = cms.InputTag("simSiPixelDigis:Tracker"),
@@ -291,7 +275,6 @@ phase2_tracker.toModify(mixData,
         ),
         phase2OTSimLink = cms.PSet(
             workerType = cms.string("PreMixingPixelDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simSiPixelDigis:Tracker"),
             pileInputTag = cms.InputTag("simSiPixelDigis:Tracker"),
             collectionDM = cms.string("Phase2OTDigiSimLink"),
@@ -329,31 +312,24 @@ phase2_hgcal.toModify(mixData,
     workers = dict(
         hgcee = cms.PSet(
             hgceeDigitizer,
-            #
             workerType = cms.string("PreMixingHGCalWorker"),
-            #
             digiTagSig = cms.InputTag("mix", "HGCDigisEE"),
             pileInputTag = cms.InputTag("mix", "HGCDigisEE"),
         ),
         hgchefront = cms.PSet(
             hgchefrontDigitizer,
-            #
             workerType = cms.string("PreMixingHGCalWorker"),
-            #
             digiTagSig = cms.InputTag("mix", "HGCDigisHEfront"),
             pileInputTag = cms.InputTag("mix", "HGCDigisHEfront"),
         ),
         hgcheback = cms.PSet(
             hgchebackDigitizer,
-            #
             workerType = cms.string("PreMixingHGCalWorker"),
-            #
             digiTagSig = cms.InputTag("mix", "HGCDigisHEback"),
             pileInputTag = cms.InputTag("mix", "HGCDigisHEback"),
         ),
         caloTruth = cms.PSet(
             workerType = cms.string("PreMixingCaloParticleWorker"),
-            #
             labelSig = cms.InputTag("mix", "MergedCaloTruth"),
             pileInputTag = cms.InputTag("mix", "MergedCaloTruth"),
             collectionDM = cms.string("MergedCaloTruth"),
@@ -373,49 +349,42 @@ phase2_muon.toModify(mixData,
         ),
         gem = cms.PSet(
             workerType = cms.string("PreMixingGEMWorker"),
-            #
             digiTagSig = cms.InputTag("simMuonGEMDigis"),
             pileInputTag = cms.InputTag("simMuonGEMDigis",""),
             collectionDM = cms.string(''),
         ),
         me0 = cms.PSet(
             workerType = cms.string("PreMixingME0Worker"),
-            #
             digiTagSig = cms.InputTag("simMuonME0Digis"),
             pileInputTag = cms.InputTag("simMuonME0Digis",""),
             collectionDM = cms.string(''),
         ),
         me0SimHit = cms.PSet(
             workerType = cms.string("PreMixingCrossingFramePSimHitWorker"),
-            #
             labelSig = cms.InputTag("mix", "g4SimHitsMuonME0Hits"),
             pileInputTag = cms.InputTag("mix", "g4SimHitsMuonME0Hits"),
             collectionDM = cms.string("g4SimHitsMuonME0Hits"),
         ),
         gemSimLink = cms.PSet(
             workerType = cms.string("PreMixingGEMDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simMuonGEMDigis"),
             pileInputTag = cms.InputTag("simMuonGEMDigis"),
             collectionDM = cms.string('GEMDigiSimLink'),
         ),
         gemStripSimLink = cms.PSet(
             workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simMuonGEMDigis"),
             pileInputTag = cms.InputTag("simMuonGEMDigis"),
             collectionDM = cms.string('GEMStripDigiSimLink'),
         ),
         me0SimLink = cms.PSet(
             workerType = cms.string("PreMixingME0DigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simMuonMe0Digis"),
             pileInputTag = cms.InputTag("simMuonME0Digis"),
             collectionDM = cms.string('ME0DigiSimLink'),
         ),
         me0StripSimLink = cms.PSet(
             workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
-            #
             labelSig = cms.InputTag("simMuonME0Digis"),
             pileInputTag = cms.InputTag("simMuonME0Digis"),
             collectionDM = cms.string('ME0StripDigiSimLink'),

--- a/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackerDigiSimLinkWorkers.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackerDigiSimLinkWorkers.cc
@@ -7,5 +7,5 @@
 using PreMixingPixelDigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVector<PixelDigiSimLink> >;
 using PreMixingStripDigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVector<StripDigiSimLink> >;
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingPixelDigiSimLinkWorker , "PreMixingPixelDigiSimLinkWorker");
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingStripDigiSimLinkWorker , "PreMixingStripDigiSimLinkWorker");
+DEFINE_PREMIXING_WORKER(PreMixingPixelDigiSimLinkWorker);
+DEFINE_PREMIXING_WORKER(PreMixingStripDigiSimLinkWorker);

--- a/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackingParticleWorker.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackingParticleWorker.cc
@@ -151,4 +151,4 @@ void PreMixingTrackingParticleWorker::put(edm::Event& iEvent, edm::EventSetup co
   iEvent.put(std::move(NewVertexList_), TrackingParticleCollectionDM_);
 }
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingTrackingParticleWorker, "PreMixingTrackingParticleWorker");
+DEFINE_PREMIXING_WORKER(PreMixingTrackingParticleWorker);

--- a/SimMuon/CSCDigitizer/plugins/PreMixingCSCWorker.cc
+++ b/SimMuon/CSCDigitizer/plugins/PreMixingCSCWorker.cc
@@ -130,4 +130,4 @@ private:
   PreMixingMuonWorker<CSCComparatorDigiCollection> comparatorWorker_;
 };
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingCSCWorker, "PreMixingCSCWorker");
+DEFINE_PREMIXING_WORKER(PreMixingCSCWorker);

--- a/SimMuon/DTDigitizer/plugins/PreMixingDTDigiSimLinkWorker.cc
+++ b/SimMuon/DTDigitizer/plugins/PreMixingDTDigiSimLinkWorker.cc
@@ -16,4 +16,4 @@ void PreMixingDigiSimLinkWorker<DTDigiSimLinkCollection>::addPileups(PileUpEvent
 
 using PreMixingDTDigiSimLinkWorker = PreMixingDigiSimLinkWorker<DTDigiSimLinkCollection>;
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingDTDigiSimLinkWorker , "PreMixingDTDigiSimLinkWorker");
+DEFINE_PREMIXING_WORKER(PreMixingDTDigiSimLinkWorker);

--- a/SimMuon/DTDigitizer/plugins/PreMixingDTWorker.cc
+++ b/SimMuon/DTDigitizer/plugins/PreMixingDTWorker.cc
@@ -4,4 +4,4 @@
 
 using PreMixingDTWorker = PreMixingMuonWorker<DTDigiCollection>;
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingDTWorker , "PreMixingDTWorker");
+DEFINE_PREMIXING_WORKER(PreMixingDTWorker);

--- a/SimMuon/GEMDigitizer/plugins/PreMixingGEMDigiSimLinkWorkers.cc
+++ b/SimMuon/GEMDigitizer/plugins/PreMixingGEMDigiSimLinkWorkers.cc
@@ -8,5 +8,5 @@ using PreMixingME0DigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVect
 
 // register plugins
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingGEMDigiSimLinkWorker , "PreMixingGEMDigiSimLinkWorker");
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingME0DigiSimLinkWorker , "PreMixingME0DigiSimLinkWorker");
+DEFINE_PREMIXING_WORKER(PreMixingGEMDigiSimLinkWorker);
+DEFINE_PREMIXING_WORKER(PreMixingME0DigiSimLinkWorker);

--- a/SimMuon/GEMDigitizer/plugins/PreMixingGEMWorkers.cc
+++ b/SimMuon/GEMDigitizer/plugins/PreMixingGEMWorkers.cc
@@ -6,5 +6,5 @@
 using PreMixingGEMWorker = PreMixingMuonWorker<GEMDigiCollection>;
 using PreMixingME0Worker = PreMixingMuonWorker<ME0DigiCollection>;
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingGEMWorker, "PreMixingGEMWorker");
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingME0Worker, "PreMixingME0Worker");
+DEFINE_PREMIXING_WORKER(PreMixingGEMWorker);
+DEFINE_PREMIXING_WORKER(PreMixingME0Worker);

--- a/SimMuon/RPCDigitizer/plugins/PreMixingRPCDigiSimLinkWorker.cc
+++ b/SimMuon/RPCDigitizer/plugins/PreMixingRPCDigiSimLinkWorker.cc
@@ -5,4 +5,4 @@
 
 using PreMixingRPCDigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVector<RPCDigiSimLink> >;
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingRPCDigiSimLinkWorker , "PreMixingRPCDigiSimLinkWorker");
+DEFINE_PREMIXING_WORKER(PreMixingRPCDigiSimLinkWorker);

--- a/SimMuon/RPCDigitizer/plugins/PreMixingRPCWorker.cc
+++ b/SimMuon/RPCDigitizer/plugins/PreMixingRPCWorker.cc
@@ -5,4 +5,4 @@
 
 using PreMixingRPCWorker = PreMixingMuonWorker<RPCDigiCollection>;
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingRPCWorker, "PreMixingRPCWorker");
+DEFINE_PREMIXING_WORKER(PreMixingRPCWorker);

--- a/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
@@ -101,4 +101,4 @@ void PreMixingPhase2TrackerWorker::put(edm::Event &e, edm::EventSetup const& iSe
   decltype(accumulator_){}.swap(accumulator_); // release memory
 }
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingPhase2TrackerWorker, "PreMixingPhase2TrackerWorker");
+DEFINE_PREMIXING_WORKER(PreMixingPhase2TrackerWorker);

--- a/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
@@ -314,4 +314,4 @@ void PreMixingSiPixelWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
   SiHitStorage_.clear();
 }
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingSiPixelWorker, "PreMixingSiPixelWorker");
+DEFINE_PREMIXING_WORKER(PreMixingSiPixelWorker);

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -644,4 +644,4 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
   signals_.clear();
 }
 
-DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingSiStripWorker, "PreMixingSiStripWorker");
+DEFINE_PREMIXING_WORKER(PreMixingSiStripWorker);


### PR DESCRIPTION
This PR addresses two (simple) comments by @kpedro88 from the review of #23065:
* Add a macro to simplify the declaration of worker plugins
* Remove unnecessary empty comments from the configuration

Tested in 10_2_0_pre6, no changes expected.

@mdhildreth @kpedro88 