### PR TITLE
[muon] Enabled trigger matching and minor improvements to the matching algorithm

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -28,7 +28,9 @@ def miniAOD_customizeCommon(process):
     process.patMuons.computeMiniIso = cms.bool(True)
     process.patMuons.computeMuonMVA = cms.bool(True)
     process.patMuons.computeSoftMuonMVA = cms.bool(True)
-    
+
+    process.patMuons.addTriggerMatching = True
+
     #
     # disable embedding of electron and photon associated objects already stored by the ReducedEGProducer
     process.patElectrons.embedGsfElectronCore = False  ## process.patElectrons.embed in AOD externally stored gsf electron core
@@ -450,7 +452,6 @@ def miniAOD_customizeCommon(process):
     from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
     process.load("RecoEgamma.EgammaTools.slimmedEgammaFromMultiCl_cff")
     phase2_hgcal.toModify(task, func=lambda t: t.add(process.slimmedEgammaFromMultiClTask))
-
 
 
 def miniAOD_customizeMC(process):


### PR DESCRIPTION
- Small changes in the L1 object matching requirements to address some conner cases like L1 objects defined in X-Y plain etc.
- Re-enable the trigger matching. I don't expect any issues with clones since by default the trigger matching is disabled. For patMuons the HLT process name is properly synchronized with the patTrigger and slimmedPatTrigger in the ConfigBuilder. It's critical to have this in the final CMSSW_10_2_X release, but it's not really needed for the release validation, since it only adds new information without touching already existing data.
