### PR TITLE
Remove empty plots from HLT DQM in Express

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -75,7 +75,7 @@ HLTMonitoring = cms.Sequence( OfflineHLTMonitoring )
 HLTMonitoringPA = cms.Sequence( OfflineHLTMonitoringPA )
 DQMOffline = cms.Sequence( DQMOfflinePreDPG *
                            DQMOfflinePrePOG *
-                           HLTMonitoring *
+                           OfflineHLTMonitoringNoTRK *
                            # dqmFastTimerServiceLuminosity *
                            DQMMessageLogger )
 

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -195,6 +195,15 @@ OfflineHLTMonitoring = cms.Sequence(
     vertexingMonitorHLT # vertexing
     )
 
+OfflineHLTMonitoringNoTRK = cms.Sequence(
+    dqmInfoHLTMon *
+    lumiMonitorHLTsequence * # lumi                                                                                                                                                                                   
+    BTVHLTOfflineSource *
+    trackingMonitorHLTDisplacedJet* #DisplacedJet Tracking
+    egmTrackingMonitorHLT * # egm tracking
+    vertexingMonitorHLT # vertexing                       
+    )
+
 # sequences run @tier0 on HLTMonitor PD w/ HI (PbPb, XeXe), pPb, ppRef
 OfflineHLTMonitoringPA = cms.Sequence(
     dqmInfoHLTMon *


### PR DESCRIPTION
This PR delete a bunch of empty files in Express DQM. In particular removes the Pixel, Strip and Tracking plots which are not filled in Express.