### PR TITLE
Improvements and fixes for the BPH-trigger offline DQM code

### DIFF
--- a/DQMOffline/Trigger/plugins/BPHMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.cc
@@ -558,7 +558,7 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
     	      if (seagull_ && ((m.charge()* deltaPhi(m.phi(), m1.phi())) > 0.) ) continue;
     	      if( !matchToTrigger(hltpath1,m1))continue;          
     	      if( !matchToTrigger(hltpath1,m))continue;          
-    	      DiMuMass_.numerator ->Fill(DiMuMass);      
+	      DiMuMass_.numerator ->Fill(DiMuMass, PrescaleWeight);
     	    }
           if ((Jpsi_) && (!Upsilon_)){
             if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;

--- a/DQMOffline/Trigger/plugins/BPHMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.cc
@@ -15,19 +15,23 @@ BPHMonitor::BPHMonitor( const edm::ParameterSet& iConfig ) :
   , bsToken_ ( mayConsume<reco::BeamSpot> (iConfig.getParameter<edm::InputTag>("beamSpot")))
   , trToken_ ( mayConsume<reco::TrackCollection> (iConfig.getParameter<edm::InputTag>("tracks")))
   , phToken_ ( mayConsume<reco::PhotonCollection> (iConfig.getParameter<edm::InputTag>("photons")))
+  , vtxToken_( mayConsume<reco::VertexCollection>( iConfig.getParameter<edm::InputTag>("offlinePVs") ) )
   , phi_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("phiPSet") ) )
   , pt_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("ptPSet") ) )
+  , dMu_pt_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("dMu_ptPSet") ) )
   , eta_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("etaPSet") ) )
   , d0_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("d0PSet") ) )
   , z0_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("z0PSet") ) )
   , dR_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("dRPSet") ) )
   , mass_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("massPSet") ) )
+  , Bmass_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("BmassPSet") ) )
   , dca_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("dcaPSet") ) )
   , ds_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("dsPSet") ) )
   , cos_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("cosPSet") ) )
   , prob_binning_ ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("probPSet") ) )
   , num_genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"),consumesCollector(), *this))
   , den_genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet"),consumesCollector(), *this))
+  , hltPrescale_ (new HLTPrescaleProvider(iConfig, consumesCollector(), *this))
   , muoSelection_ ( iConfig.getParameter<std::string>("muoSelection") )
   , muoSelection_ref ( iConfig.getParameter<std::string>("muoSelection_ref") )
   , muoSelection_tag ( iConfig.getParameter<std::string>("muoSelection_tag") )
@@ -35,6 +39,8 @@ BPHMonitor::BPHMonitor( const edm::ParameterSet& iConfig ) :
   , nmuons_ ( iConfig.getParameter<int>("nmuons" ) )
   , tnp_ ( iConfig.getParameter<bool>("tnp" ) )
   , L3_ ( iConfig.getParameter<int>("L3" ) )
+  , ptCut_ ( iConfig.getParameter<int>("ptCut" ) )
+  , displaced_ ( iConfig.getParameter<int>("displaced" ) )
   , trOrMu_ ( iConfig.getParameter<int>("trOrMu" ) )
   , Jpsi_ ( iConfig.getParameter<int>("Jpsi" ) )
   , Upsilon_ ( iConfig.getParameter<int>("Upsilon" ) ) // if ==1 path with Upsilon constraint
@@ -53,10 +59,11 @@ BPHMonitor::BPHMonitor( const edm::ParameterSet& iConfig ) :
   , kaon_mass ( iConfig.getParameter<double>("kaon_mass" ) )
   , mu_mass ( iConfig.getParameter<double>("mu_mass" ) )
   , min_dR ( iConfig.getParameter<double>("min_dR" ) )
+  , max_dR ( iConfig.getParameter<double>("max_dR" ) )
   , minprob ( iConfig.getParameter<double>("minprob" ) )
   , mincos ( iConfig.getParameter<double>("mincos" ) )
   , minDS ( iConfig.getParameter<double>("minDS" ) )
-  , hltTrigResTag_ (mayConsume<edm::TriggerResults>( iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet").getParameter<edm::InputTag>("hltInputTag")))
+  , hltInputTag_1 ( iConfig.getParameter<edm::InputTag>("hltTriggerSummaryAOD"))
   , hltInputTag_ (mayConsume<trigger::TriggerEvent>( iConfig.getParameter<edm::InputTag>("hltTriggerSummaryAOD")))
   , hltpaths_num ( iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet").getParameter<std::vector<std::string>>("hltPaths"))
   , hltpaths_den ( iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet").getParameter<std::vector<std::string>>("hltPaths"))
@@ -121,6 +128,8 @@ BPHMonitor::BPHMonitor( const edm::ParameterSet& iConfig ) :
   DiMuDCA_.denominator = nullptr;
   DiMuMass_.numerator = nullptr;
   DiMuMass_.denominator = nullptr;
+  BMass_.numerator = nullptr;
+  BMass_.denominator = nullptr;
   DiMudR_.numerator = nullptr;
   DiMudR_.denominator = nullptr;
 
@@ -131,6 +140,7 @@ BPHMonitor::~BPHMonitor()
 {
   if (num_genTriggerEventFlag_) delete num_genTriggerEventFlag_;
   if (den_genTriggerEventFlag_) delete den_genTriggerEventFlag_;
+  delete hltPrescale_;
 }
 
 MEbinning BPHMonitor::getHistoPSet(edm::ParameterSet pset)
@@ -218,7 +228,6 @@ void BPHMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 				edm::Run const        & iRun,
 				edm::EventSetup const & iSetup) 
 {  
-  
   std::string histname, histtitle, istnp, trMuPh;
   bool Ph_ = false; if (enum_ == 7) Ph_ = true;
   if (tnp_) istnp = "Tag_and_Probe/"; else istnp = "";
@@ -238,32 +247,50 @@ void BPHMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
     histname = trMuPh+"Eta"; histtitle = trMuPh+"_Eta";
     bookME(ibooker,muEta_,histname,histtitle, eta_binning_);
     setMETitle(muEta_,trMuPh+"_#eta","events / 0.2");
+    
+    if (enum_ ==9)
+      {
+	histname = "BMass"; histtitle = "BMass";
+	bookME(ibooker,BMass_,histname,histtitle, Bmass_binning_);
+	setMETitle(BMass_,"B_#mass","events /");
+
+      }
   }
   else {
-    histname = trMuPh+"1Pt"; histtitle = trMuPh+"1_P_{t}";
-    bookME(ibooker,mu1Pt_,histname,histtitle, pt_binning_);
-    setMETitle(mu1Pt_,trMuPh+"_Pt[GeV]","events / 1 GeV");
+    if (enum_ !=8)
+      {
+	histname = trMuPh+"1Pt"; histtitle = trMuPh+"1_P_{t}";
+	bookME(ibooker,mu1Pt_,histname,histtitle, pt_binning_);
+	setMETitle(mu1Pt_,trMuPh+"_Pt[GeV]","events / 1 GeV");
 
-    histname = trMuPh+"1Phi"; histtitle = trMuPh+"1Phi";
-    bookME(ibooker,mu1Phi_,histname,histtitle, phi_binning_);
-    setMETitle(mu1Phi_,trMuPh+"_#phi","events / 0.1 rad");
+	histname = trMuPh+"1Phi"; histtitle = trMuPh+"1Phi";
+	bookME(ibooker,mu1Phi_,histname,histtitle, phi_binning_);
+	setMETitle(mu1Phi_,trMuPh+"_#phi","events / 0.1 rad");
   
-    histname = trMuPh+"1Eta"; histtitle = trMuPh+"1_Eta";
-    bookME(ibooker,mu1Eta_,histname,histtitle, eta_binning_);
-    setMETitle(mu1Eta_,trMuPh+"_#eta","events / 0.2");
+	histname = trMuPh+"1Eta"; histtitle = trMuPh+"1_Eta";
+	bookME(ibooker,mu1Eta_,histname,histtitle, eta_binning_);
+	setMETitle(mu1Eta_,trMuPh+"_#eta","events / 0.2");
 
-    histname = trMuPh+"2Pt"; histtitle = trMuPh+"2_P_{t}";
-    bookME(ibooker,mu2Pt_,histname,histtitle, pt_binning_);
-    setMETitle(mu2Pt_,trMuPh+"_Pt[GeV]","events / 1 GeV");
+	histname = trMuPh+"2Pt"; histtitle = trMuPh+"2_P_{t}";
+	bookME(ibooker,mu2Pt_,histname,histtitle, pt_binning_);
+	setMETitle(mu2Pt_,trMuPh+"_Pt[GeV]","events / 1 GeV");
 
-    histname = trMuPh+"2Phi"; histtitle = trMuPh+"2Phi";
-    bookME(ibooker,mu2Phi_,histname,histtitle, phi_binning_);
-    setMETitle(mu2Phi_,trMuPh+"_#phi","events / 0.1 rad");
+	histname = trMuPh+"2Phi"; histtitle = trMuPh+"2Phi";
+	bookME(ibooker,mu2Phi_,histname,histtitle, phi_binning_);
+	setMETitle(mu2Phi_,trMuPh+"_#phi","events / 0.1 rad");
 
-    histname = trMuPh+"2Eta"; histtitle = trMuPh+"2_Eta";
-    bookME(ibooker,mu2Eta_,histname,histtitle, eta_binning_);
-    setMETitle(mu2Eta_,trMuPh+"_#eta","events / 0.2");
+	histname = trMuPh+"2Eta"; histtitle = trMuPh+"2_Eta";
+	bookME(ibooker,mu2Eta_,histname,histtitle, eta_binning_);
+	setMETitle(mu2Eta_,trMuPh+"_#eta","events / 0.2");
+	if (enum_ ==11)
+	  {
+	    histname = "BMass"; histtitle = "BMass";
+	    bookME(ibooker,BMass_,histname,histtitle, Bmass_binning_);
+	    setMETitle(BMass_,"B_#mass","events /");
 
+	  }
+
+      }
     if (enum_ == 6) {
       histname = trMuPh+"3Eta"; histtitle = trMuPh+"3Eta";
       bookME(ibooker,mu3Eta_,histname,histtitle, eta_binning_);
@@ -276,6 +303,7 @@ void BPHMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
       histname = trMuPh+"3Phi"; histtitle = trMuPh+"3Phi";
       bookME(ibooker,mu3Phi_,histname,histtitle, phi_binning_);
       setMETitle(mu3Phi_,trMuPh+"3_#phi","events / 0.1 rad");
+
     }
     else if (enum_ == 2 || enum_ == 4 || enum_ == 5 || enum_ == 8) {
       histname = "DiMuEta"; histtitle = "DiMuEta";
@@ -283,7 +311,7 @@ void BPHMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
       setMETitle(DiMuEta_,"DiMu#eta","events / 0.2");
 
       histname = "DiMuPt"; histtitle = "DiMu_P_{t}";
-      bookME(ibooker,DiMuPt_,histname,histtitle, pt_binning_);
+      bookME(ibooker,DiMuPt_,histname,histtitle, dMu_pt_binning_);
       setMETitle(DiMuPt_,"DiMu_Pt[GeV]","events / 1 GeV");
 
       histname = "DiMuPhi"; histtitle = "DiMuPhi";
@@ -294,10 +322,12 @@ void BPHMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 	histname = "DiMudR"; histtitle = "DiMudR";
 	bookME(ibooker,DiMudR_,histname,histtitle, dR_binning_);
 	setMETitle(DiMudR_,"DiMu_#dR","events /");
+
 	if (enum_ == 4) {
 	  histname = "DiMuMass"; histtitle = "DiMuMass";
 	  bookME(ibooker,DiMuMass_,histname,histtitle, mass_binning_);
 	  setMETitle(DiMuMass_,"DiMu_#mass","events /");
+
 	}
       } else if (enum_ == 8) {
 	histname = "DiMuProb"; histtitle = "DiMuProb";
@@ -315,25 +345,18 @@ void BPHMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 	histname = "DiMuDCA"; histtitle = "DiMuDCA";
 	bookME(ibooker,DiMuDCA_,histname,histtitle, dca_binning_);
 	setMETitle(DiMuDCA_,"DiMu_#dca","events /");
+
       }
     } // if (enum_ == 2 || enum_ == 4 || enum_ == 5 || enum_ == 8)
-  }
-
-  if (trOrMu_) {
-    if (false) { // not filled anywhere
-      histname = trMuPh+"_d0"; histtitle = trMuPh+"_d0";
-      bookME(ibooker,mud0_,histname,histtitle, d0_binning_);
-      setMETitle(mud0_,trMuPh+"_d0","events / bin");
-
-      histname = trMuPh+"_z0"; histtitle = trMuPh+"_z0";
-      bookME(ibooker,muz0_,histname,histtitle, z0_binning_);
-      setMETitle(muz0_,trMuPh+"_z0","events / bin");
-    }
   }
 
   // Initialize the GenericTriggerEventFlag
   if ( num_genTriggerEventFlag_ && num_genTriggerEventFlag_->on() ) num_genTriggerEventFlag_->initRun( iRun, iSetup );
   if ( den_genTriggerEventFlag_ && den_genTriggerEventFlag_->on() ) den_genTriggerEventFlag_->initRun( iRun, iSetup );
+  bool changed = true;
+
+  hltPrescale_->init(iRun,iSetup,"HLT",changed);
+  hltConfig_ = hltPrescale_->hltConfigProvider();
 }
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -349,6 +372,7 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   edm::Handle<reco::MuonCollection> muoHandle;
   iEvent.getByToken( muoToken_, muoHandle );
 
+
   edm::Handle<reco::TrackCollection> trHandle;
   iEvent.getByToken( trToken_, trHandle );
 
@@ -358,35 +382,44 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
   edm::Handle<edm::TriggerResults> handleTriggerTrigRes; 
 
-  edm::Handle<trigger::TriggerEvent> handleTriggerEvent; 
   edm::ESHandle<MagneticField> bFieldHandle;
-  // Filter out events if Trigger Filtering is requested
-  double PrescaleWeight = 1;  
-  
-  if (tnp_> 0) { // TnP method 
+
+ 
+
+  int PrescaleWeight =1;
+  const std::string & hltpath = getTriggerName(hltpaths_den[0]);
+  const std::string & hltpath1 = getTriggerName(hltpaths_num[0]);
+
+
+
+  if (den_genTriggerEventFlag_->on() &&  den_genTriggerEventFlag_->accept( iEvent, iSetup) && num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) ) 
+    {
+      PrescaleWeight = Prescale(hltpath1, hltpath, iEvent, iSetup, hltPrescale_);
+
+    }
+  if (tnp_>0) {//TnP method 
     if (den_genTriggerEventFlag_->on() && ! den_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
     iEvent.getByToken( hltInputTag_, handleTriggerEvent);
     if (handleTriggerEvent->sizeFilters()== 0) return;
-    const std::string & hltpath = hltpaths_num[0]; 
     std::vector<reco::Muon> tagMuons;
     for ( auto const & m : *muoHandle ) { // applying tag selection 
-      if (false && !matchToTrigger(hltpath,m, handleTriggerEvent)) continue;
+      if ( !matchToTrigger(hltpath,m))continue;
       if ( muoSelection_ref( m ) ) tagMuons.push_back(m);
     }
     for (int i = 0; i<int(tagMuons.size());i++) {
       for ( auto const & m : *muoHandle ) { 
-	if (false && !matchToTrigger(hltpath,m, handleTriggerEvent)) continue;
-	if ((tagMuons[i].pt() == m.pt())) continue; // not the same  
-	if ((tagMuons[i].p4()+m.p4()).M() >minmass_&& (tagMuons[i].p4()+m.p4()).M() <maxmass_) { // near to J/psi mass
-	  muPhi_.denominator->Fill(m.phi());
-	  muEta_.denominator->Fill(m.eta());
-	  muPt_.denominator ->Fill(m.pt());
-	  if (muoSelection_( m )) {
-	    muPhi_.numerator->Fill(m.phi(),PrescaleWeight);
-	    muEta_.numerator->Fill(m.eta(),PrescaleWeight);
-	    muPt_.numerator ->Fill(m.pt(),PrescaleWeight);
-	  }
-	} 
+        if ( !matchToTrigger(hltpath,m))continue;
+        if ((tagMuons[i].pt() == m.pt())) continue; //not the same  
+        if ((tagMuons[i].p4()+m.p4()).M() >minmass_&& (tagMuons[i].p4()+m.p4()).M() <maxmass_) { //near to J/psi mass
+          muPhi_.denominator->Fill(m.phi());
+          muEta_.denominator->Fill(m.eta());
+          muPt_.denominator ->Fill(m.pt());
+          if (muoSelection_( m ) && num_genTriggerEventFlag_->on() && num_genTriggerEventFlag_->accept( iEvent, iSetup)) {
+            muPhi_.numerator->Fill(m.phi(),PrescaleWeight);
+            muEta_.numerator->Fill(m.eta(),PrescaleWeight);
+            muPt_.numerator ->Fill(m.pt(),PrescaleWeight);
+          }
+        }      
       }
  
     }
@@ -397,15 +430,22 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
     if (den_genTriggerEventFlag_->on() && ! den_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
     iEvent.getByToken( hltInputTag_, handleTriggerEvent);
     if (handleTriggerEvent->sizeFilters()== 0) return;
-    const std::string & hltpath = hltpaths_den[0]; 
     for (auto const & m : *muoHandle ) {
-      if (false && !matchToTrigger(hltpath,m, handleTriggerEvent)) continue;
+      if ( !matchToTrigger(hltpath,m))continue;
       if (!muoSelection_ref(m)) continue; 
       for (auto const & m1 : *muoHandle ) {
         if (&m - &(*muoHandle)[0]  >=  &m1 - &(*muoHandle)[0]) continue;
-        //if (m1.pt() == m.pt()) continue; // probably not needed if using the above check
-	if (!muoSelection_ref(m1)) continue; 
-	if (false && !matchToTrigger(hltpath,m1, handleTriggerEvent)) continue;
+        if (!(m1.pt() > m.pt())) continue; //to get rid of double counting
+	if (ptCut_)
+	  {
+	    if (!muoSelection_(m1)) continue; 
+	  }
+	else
+	  {
+	    if (!muoSelection_ref(m1)) continue;
+	  } 
+
+	if ( !matchToTrigger(hltpath,m1))continue;
 	if (enum_ != 10) {
 	  if (!DMSelection_ref(m1.p4() + m.p4())) continue;
 	  if (m.charge()*m1.charge() > 0 ) continue;
@@ -432,551 +472,525 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 	GlobalPoint displacementFromBeamspotJpsi( -1*((vertexBeamSpot.x0() - jVertex.x()) + (jVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()),
 						  -1*((vertexBeamSpot.y0() - jVertex.y()) + (jVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()),
 						  0);
-	reco::Vertex::Point vperpj(displacementFromBeamspotJpsi.x(), displacementFromBeamspotJpsi.y(), 0.);
-	float jpsi_cos = vperpj.Dot(jpperp) / (vperpj.R()*jpperp.R());
-	TrajectoryStateClosestToPoint mu1TS = mu1TT.impactPointTSCP();
-	TrajectoryStateClosestToPoint mu2TS = mu2TT.impactPointTSCP();
-	ClosestApproachInRPhi cApp;
-	if (mu1TS.isValid() && mu2TS.isValid()) {
-	  cApp.calculate(mu1TS.theState(), mu2TS.theState());
-	}
-	double DiMuMass = (m1.p4()+m.p4()).M();
-	switch(enum_) { // enum_ = 1...9, represents different sets of variables for different paths, we want to have different hists for different paths
-	case 1: tnp_=true; // already filled hists for tnp method
-	case 2:
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  if (dimuonCL < minprob) continue;
-	  mu1Phi_.denominator->Fill(m.phi());
-	  mu1Eta_.denominator->Fill(m.eta());
-	  mu1Pt_.denominator ->Fill(m.pt());
-	  mu2Phi_.denominator->Fill(m1.phi());
-	  mu2Eta_.denominator->Fill(m1.eta());
-	  mu2Pt_.denominator ->Fill(m1.pt());
-	  DiMuPt_.denominator ->Fill((m1.p4()+m.p4()).Pt() );
-	  DiMuEta_.denominator ->Fill((m1.p4()+m.p4()).Eta() );
-	  DiMuPhi_.denominator ->Fill((m1.p4()+m.p4()).Phi());
-	  break;
-	case 3:
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  if (dimuonCL < minprob) continue;
-	  mu1Eta_.denominator->Fill(m.eta());
-	  mu1Pt_.denominator ->Fill(m.pt());
-	  mu2Eta_.denominator->Fill(m1.eta());
-	  mu2Pt_.denominator ->Fill(m1.pt());
-	  break; 
-	case 4:
-	  if (dimuonCL < minprob) continue;
-	  DiMuMass_.denominator ->Fill(DiMuMass);
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  mu1Phi_.denominator->Fill(m.phi());
-	  mu1Eta_.denominator->Fill(m.eta());
-	  mu1Pt_.denominator ->Fill(m.pt());
-	  mu2Phi_.denominator->Fill(m1.phi());
-	  mu2Eta_.denominator->Fill(m1.eta());
-	  mu2Pt_.denominator ->Fill(m1.pt());
-	  DiMuPt_.denominator ->Fill((m1.p4()+m.p4()).Pt() );
-	  DiMuEta_.denominator ->Fill((m1.p4()+m.p4()).Eta() );
-	  DiMuPhi_.denominator ->Fill((m1.p4()+m.p4()).Phi());
-	  DiMudR_.denominator ->Fill(reco::deltaR(m,m1));
-	  break;
-	case 5:
-	  if (dimuonCL < minprob) continue;
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
+        reco::Vertex::Point vperpj(displacementFromBeamspotJpsi.x(), displacementFromBeamspotJpsi.y(), 0.);
+        float jpsi_cos = vperpj.Dot(jpperp) / (vperpj.R()*jpperp.R());
+        TrajectoryStateClosestToPoint mu1TS = mu1TT.impactPointTSCP();
+        TrajectoryStateClosestToPoint mu2TS = mu2TT.impactPointTSCP();
+        ClosestApproachInRPhi cApp;
+        if (mu1TS.isValid() && mu2TS.isValid()) {
+          cApp.calculate(mu1TS.theState(), mu2TS.theState());
+        }
+        if (!cApp.calculate(mu1TS.theState(), mu2TS.theState()))continue;
+        double DiMuMass = (m1.p4()+m.p4()).M();
+        switch(enum_) { // enum_ = 1...9, represents different sets of variables for different paths, we want to have different hists for different paths
+
+        case 1: tnp_=true; // already filled hists for tnp method
+
+        case 2:
+          if ((Jpsi_) && (!Upsilon_)) {
+            if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
+          }
+          if ((!Jpsi_) && (Upsilon_)) {
+            if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
+          }
+          if (dimuonCL < minprob) continue;
+          mu1Phi_.denominator->Fill(m.phi());
+          mu1Eta_.denominator->Fill(m.eta());
+          mu1Pt_.denominator ->Fill(m.pt());
+          mu2Phi_.denominator->Fill(m1.phi());
+          mu2Eta_.denominator->Fill(m1.eta());
+          mu2Pt_.denominator ->Fill(m1.pt());
+          DiMuPt_.denominator ->Fill((m1.p4()+m.p4()).Pt() );
+          DiMuEta_.denominator ->Fill((m1.p4()+m.p4()).Eta() );
+          DiMuPhi_.denominator ->Fill((m1.p4()+m.p4()).Phi());
+          if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+    	    {
+    	      if( !matchToTrigger(hltpath1,m1))continue;
+    	      if( !matchToTrigger(hltpath1,m))continue;
+    	      mu1Phi_.numerator->Fill(m.phi(),PrescaleWeight);
+    	      mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
+    	      mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
+    	      mu2Phi_.numerator->Fill(m1.phi(),PrescaleWeight);
+    	      mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
+    	      mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
+    	      DiMuPt_.numerator ->Fill((m1.p4()+m.p4()).Pt() ,PrescaleWeight);
+    	      DiMuEta_.numerator ->Fill((m1.p4()+m.p4()).Eta() ,PrescaleWeight);
+    	      DiMuPhi_.numerator ->Fill((m1.p4()+m.p4()).Phi(),PrescaleWeight);
+            
+    	    }
+          
+          break;
+
+        case 3:
+          if ((Jpsi_) && (!Upsilon_)){
+            if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
+          }
+          if ((!Jpsi_) && (Upsilon_)){
+            if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
+          }
+          if (dimuonCL<minprob) continue;
+          mu1Phi_.denominator->Fill(m.phi());
+          mu1Eta_.denominator->Fill(m.eta());
+          mu1Pt_.denominator ->Fill(m.pt());
+          mu2Phi_.denominator->Fill(m1.phi());
+          mu2Eta_.denominator->Fill(m1.eta());
+          mu2Pt_.denominator ->Fill(m1.pt());
+          if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+    	    {
+    	      if( !matchToTrigger(hltpath1,m1))continue;
+    	      if( !matchToTrigger(hltpath1,m))continue;
+    	      mu1Phi_.numerator->Fill(m.phi(),PrescaleWeight);
+    	      mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
+    	      mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
+    	      mu2Phi_.numerator->Fill(m1.phi(),PrescaleWeight);
+    	      mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
+    	      mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
+            
+    	    }
+          
+          break; 
+
+        case 4:
+          if (dimuonCL<minprob) continue;
+          DiMuMass_.denominator ->Fill(DiMuMass);
+          if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup))
+    	    {
+    	      if (seagull_ && ((m.charge()* deltaPhi(m.phi(), m1.phi())) > 0.) ) continue;
+    	      if( !matchToTrigger(hltpath1,m1))continue;          
+    	      if( !matchToTrigger(hltpath1,m))continue;          
+    	      DiMuMass_.numerator ->Fill(DiMuMass);      
+    	    }
+          if ((Jpsi_) && (!Upsilon_)){
+            if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
+          }
+          if ((!Jpsi_) && (Upsilon_)){
+            if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
+          }
+          mu1Phi_.denominator->Fill(m.phi());
+          mu1Eta_.denominator->Fill(m.eta());
+          mu1Pt_.denominator ->Fill(m.pt());
+          mu2Phi_.denominator->Fill(m1.phi());
+          mu2Eta_.denominator->Fill(m1.eta());
+          mu2Pt_.denominator ->Fill(m1.pt());
+          DiMuPt_.denominator ->Fill((m1.p4()+m.p4()).Pt() );
+          DiMuEta_.denominator ->Fill((m1.p4()+m.p4()).Eta() );
+          DiMuPhi_.denominator ->Fill((m1.p4()+m.p4()).Phi());
+          DiMudR_.denominator ->Fill(reco::deltaR(m,m1));
+          if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+    	    {
+    	      if (seagull_ && ((m.charge()* deltaPhi(m.phi(), m1.phi())) > 0.) ) continue;
+    	      if( !matchToTrigger(hltpath1,m1))continue;
+    	      if( !matchToTrigger(hltpath1,m))continue;
+    	      mu1Phi_.numerator->Fill(m.phi(),PrescaleWeight);
+    	      mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
+    	      mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
+    	      mu2Phi_.numerator->Fill(m1.phi(),PrescaleWeight);
+    	      mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
+    	      mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
+    	      DiMuPt_.numerator ->Fill((m1.p4()+m.p4()).Pt() ,PrescaleWeight);
+    	      DiMuEta_.numerator ->Fill((m1.p4()+m.p4()).Eta() ,PrescaleWeight);
+    	      DiMuPhi_.numerator ->Fill((m1.p4()+m.p4()).Phi(),PrescaleWeight);
+    	      DiMudR_.numerator ->Fill(reco::deltaR(m,m1),PrescaleWeight);
+            
+    	    }
+          
+          break;
+
+        case 5:
+          if (dimuonCL<minprob) continue;
+          if ((Jpsi_) && (!Upsilon_)){
+            if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
+          }
   
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  mu1Phi_.denominator->Fill(m.phi());
-	  mu1Eta_.denominator->Fill(m.eta());
-	  mu1Pt_.denominator ->Fill(m.pt());
-	  mu2Phi_.denominator->Fill(m1.phi());
-	  mu2Eta_.denominator->Fill(m1.eta());
-	  mu2Pt_.denominator ->Fill(m1.pt());
-	  DiMuPt_.denominator ->Fill((m1.p4()+m.p4()).Pt() );
-	  DiMuEta_.denominator ->Fill((m1.p4()+m.p4()).Eta() );
-	  DiMuPhi_.denominator ->Fill((m1.p4()+m.p4()).Phi());
-	  DiMudR_.denominator ->Fill(reco::deltaR(m,m1));
-	  break;
-	case 6: 
-	  if (dimuonCL < minprob) continue;
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  for (auto const & m2 : *muoHandle) { // triple muon paths
-	    if (false && !matchToTrigger(hltpath,m2, handleTriggerEvent)) continue;
-	    if (m2.pt() == m.pt()) continue;
-	    mu1Phi_.denominator->Fill(m.phi());
-	    mu1Eta_.denominator->Fill(m.eta());
-	    mu1Pt_.denominator ->Fill(m.pt());
-	    mu2Phi_.denominator->Fill(m1.phi());
-	    mu2Eta_.denominator->Fill(m1.eta());
-	    mu2Pt_.denominator ->Fill(m1.pt());
-	    mu3Phi_.denominator->Fill(m2.phi());
-	    mu3Eta_.denominator->Fill(m2.eta());
-	    mu3Pt_.denominator ->Fill(m2.pt());
+          if ((!Jpsi_) && (Upsilon_)){
+            if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
+          }
+          mu1Phi_.denominator->Fill(m.phi());
+          mu1Eta_.denominator->Fill(m.eta());
+          mu1Pt_.denominator ->Fill(m.pt());
+          mu2Phi_.denominator->Fill(m1.phi());
+          mu2Eta_.denominator->Fill(m1.eta());
+          mu2Pt_.denominator ->Fill(m1.pt());
+          DiMuPt_.denominator ->Fill((m1.p4()+m.p4()).Pt() );
+          DiMuEta_.denominator ->Fill((m1.p4()+m.p4()).Eta() );
+          DiMuPhi_.denominator ->Fill((m1.p4()+m.p4()).Phi());
+          DiMudR_.denominator ->Fill(reco::deltaR(m,m1));
+          if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+    	    {
+    	      if (seagull_ && ((m.charge()* deltaPhi(m.phi(), m1.phi())) > 0.) ) continue;
+    	      if( !matchToTrigger(hltpath1,m1))continue;
+    	      if( !matchToTrigger(hltpath1,m))continue;
+    	      mu1Phi_.numerator->Fill(m.phi(),PrescaleWeight);
+    	      mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
+    	      mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
+    	      mu2Phi_.numerator->Fill(m1.phi(),PrescaleWeight);
+    	      mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
+    	      mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
+    	      DiMuPt_.numerator ->Fill((m1.p4()+m.p4()).Pt() ,PrescaleWeight);
+    	      DiMuEta_.numerator ->Fill((m1.p4()+m.p4()).Eta() ,PrescaleWeight);
+    	      DiMuPhi_.numerator ->Fill((m1.p4()+m.p4()).Phi(),PrescaleWeight);
+    	      DiMudR_.numerator ->Fill(reco::deltaR(m,m1),PrescaleWeight);
+            
+    	    }      
+          
+          break;
+
+        case 6: 
+          if (dimuonCL<minprob) continue;
+          if ((Jpsi_) && (!Upsilon_)){
+            if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
+          }
+          if ((!Jpsi_) && (Upsilon_)){
+            if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
+          }
+          for (auto const & m2 : *muoHandle) {//triple muon paths
+            if( !matchToTrigger(hltpath,m2))continue;
+            if (m2.pt() == m.pt()) continue;
+            mu1Phi_.denominator->Fill(m.phi());
+            mu1Eta_.denominator->Fill(m.eta());
+            mu1Pt_.denominator ->Fill(m.pt());
+            mu2Phi_.denominator->Fill(m1.phi());
+            mu2Eta_.denominator->Fill(m1.eta());
+            mu2Pt_.denominator ->Fill(m1.pt());
+            mu3Phi_.denominator->Fill(m2.phi());
+            mu3Eta_.denominator->Fill(m2.eta());
+            mu3Pt_.denominator ->Fill(m2.pt());
+            if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+    	      {
+		if( !matchToTrigger(hltpath1,m1))continue;
+		if( !matchToTrigger(hltpath1,m))continue;
+		if( !matchToTrigger(hltpath1,m2))continue;
+		mu1Phi_.numerator->Fill(m.phi(),PrescaleWeight);
+		mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
+		mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
+		mu2Phi_.numerator->Fill(m1.phi(),PrescaleWeight);
+		mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
+		mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
+		mu3Phi_.numerator->Fill(m2.phi(),PrescaleWeight);
+		mu3Eta_.numerator->Fill(m2.eta(),PrescaleWeight);
+		mu3Pt_.numerator ->Fill(m2.pt(),PrescaleWeight);
+               
+    	      }
+            
 	  } 
-	  break; 
+          break;    
   
-	case 7: // the hists for photon monitoring will be filled on 515 line
-	  tnp_=false;
-	  break;
- 
-	case 8: // vtx monitoring, filling probability, DS, DCA, cos of pointing angle to the PV, eta, pT of dimuon
-	  if ((Jpsi_) && (!Upsilon_)) {
+        case 7:// the hists for photon monitoring will be filled on 515 line
+          if(!phHandle->empty())
+    	    { 
+    	      for (auto const & p : *phHandle)
+		{
+		  if( !matchToTrigger(hltpath,p))continue;
+		  phPhi_.denominator->Fill(p.phi());
+		  phEta_.denominator->Fill(p.eta());
+		  phPt_.denominator ->Fill(p.pt());
+		  if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+		    {
+		      if( !matchToTrigger(hltpath1,p))continue;
+		      if( !matchToTrigger(hltpath1,m))continue;
+		      if( !matchToTrigger(hltpath1,m1))continue;
+		      phPhi_.numerator->Fill(p.phi(),PrescaleWeight);
+		      phEta_.numerator->Fill(p.eta(),PrescaleWeight);
+		      phPt_.numerator ->Fill(p.pt(),PrescaleWeight);
+                  
+		    }
+              
+		}
+    	    } 
+          break;
+          
+        case 8://vtx monitoring, filling probability, DS, DCA, cos of pointing angle to the PV, eta, pT of dimuon
+	  if (displaced_)
+	    {
+	      if ((displacementFromBeamspotJpsi.perp()/sqrt(jerr.rerr(displacementFromBeamspotJpsi)))<minDS) continue;
+
+	    }
+	  if ((Jpsi_) && (!Upsilon_)){
 	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
 	  }
-  
+      
 	  if ((!Jpsi_) && (Upsilon_)) {
 	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
 	  }
-  
+      
 	  DiMuProb_.denominator ->Fill( dimuonCL);
-	  if (dimuonCL < minprob) continue;
-	  DiMuDS_.denominator ->Fill( displacementFromBeamspotJpsi.perp() / sqrt(jerr.rerr(displacementFromBeamspotJpsi)));
+    
+	  if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+	    {
+	      if( !matchToTrigger(hltpath1,m1))continue;
+	      if( !matchToTrigger(hltpath1,m))continue;
+	      DiMuProb_.numerator ->Fill( dimuonCL,PrescaleWeight);          
+	    }
+	  if (dimuonCL<minprob) continue;
+	  DiMuDS_.denominator ->Fill( displacementFromBeamspotJpsi.perp()/sqrt(jerr.rerr(displacementFromBeamspotJpsi)));
 	  DiMuPVcos_.denominator ->Fill(jpsi_cos );
 	  DiMuPt_.denominator ->Fill((m1.p4()+m.p4()).Pt() );
 	  DiMuEta_.denominator ->Fill((m1.p4()+m.p4()).Eta() );
+	  DiMuPhi_.denominator ->Fill((m1.p4()+m.p4()).Phi() );
 	  DiMuDCA_.denominator ->Fill( cApp.distance());
+	  if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+	    {
+	      if( !matchToTrigger(hltpath1,m1))continue;
+	      if( !matchToTrigger(hltpath1,m))continue;
+	      DiMuDS_.numerator ->Fill( displacementFromBeamspotJpsi.perp()/sqrt(jerr.rerr(displacementFromBeamspotJpsi)),PrescaleWeight);
+	      DiMuPVcos_.numerator ->Fill(jpsi_cos ,PrescaleWeight);
+	      DiMuPt_.numerator ->Fill((m1.p4()+m.p4()).Pt() ,PrescaleWeight);
+	      DiMuEta_.numerator ->Fill((m1.p4()+m.p4()).Eta() ,PrescaleWeight);
+	      DiMuPhi_.numerator ->Fill((m1.p4()+m.p4()).Phi() ,PrescaleWeight);
+	      DiMuDCA_.numerator ->Fill( cApp.distance(),PrescaleWeight);
+                
+	    }          
+              
 	  break;
-	case 9:
-	  if (dimuonCL < minprob) continue;
-	  if (fabs(jpsi_cos) < mincos) continue;
-	  if ((displacementFromBeamspotJpsi.perp() / sqrt(jerr.rerr(displacementFromBeamspotJpsi))) < minDS) continue;
-  
-	  if (trHandle.isValid()) {
-	    ////////////////////////
-  
-	    for (auto const & t : *trHandle) {
- 
-	      if (!trSelection_ref(t)) continue;
-	      if (false && !matchToTrigger(hltpath,t, handleTriggerEvent)) continue;
-	      const reco::Track& itrk1 = t ; 
- 
-	      if ((reco::deltaR(t,m1) <= min_dR)) continue; // checking overlapping
-	      if ((reco::deltaR(t,m) <= min_dR)) continue;
- 
-	      if (! itrk1.quality(reco::TrackBase::highPurity)) continue;
-  
-	      reco::Particle::LorentzVector pB, p1, p2, p3;
-	      double trackMass2 = kaon_mass * kaon_mass;
-	      double MuMass2 = mu_mass * mu_mass; // 0.1056583745 *0.1056583745;
-	      double e1 = sqrt(m.momentum().Mag2()  + MuMass2 );
-	      double e2 = sqrt(m1.momentum().Mag2()  + MuMass2 );
-	      double e3 = sqrt(itrk1.momentum().Mag2() + trackMass2  );
- 
-	      p1 = reco::Particle::LorentzVector(m.px() , m.py() , m.pz() , e1  );
-	      p2 = reco::Particle::LorentzVector(m1.px() , m1.py() , m1.pz() , e2  );
-	      p3 = reco::Particle::LorentzVector(itrk1.px(), itrk1.py(), itrk1.pz(), e3  );
-	      pB = p1 + p2 + p3;
-	      if ( pB.mass() > maxmassJpsiTk || pB.mass() < minmassJpsiTk) continue;
-	      reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
-  
-	      std::vector<reco::TransientTrack> t_tks;
-	      t_tks.push_back(mu1TT);
-	      t_tks.push_back(mu2TT);
-	      t_tks.push_back(trTT);
- 
-	      KalmanVertexFitter kvf;
-	      TransientVertex tv  = kvf.vertex(t_tks);
-	      reco::Vertex vertex = tv;
-	      if (!tv.isValid()) continue;
-	      float JpsiTkCL = 0;
-	      if ((vertex.chi2() >= 0.0) && (vertex.ndof() > 0) ) 
-		JpsiTkCL = TMath::Prob(vertex.chi2(), vertex.ndof() );
-	      math::XYZVector pperp(m.px() + m1.px() + itrk1.px(),
-				    m.py() + m1.py() + itrk1.py(),
-				    0.);
-	      GlobalPoint secondaryVertex = tv.position();
-	      GlobalError err             = tv.positionError();
-	      GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() - secondaryVertex.x()) + 
-							(secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()), 
-						    -1*((vertexBeamSpot.y0() - secondaryVertex.y()) + 
-							(secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 
-						    0);
-	      reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
-	      float jpsiKcos = vperp.Dot(pperp) / (vperp.R()*pperp.R());
-	      if (JpsiTkCL < minprob) continue;
-	      if (fabs(jpsiKcos) < mincos) continue;
-	      if ((displacementFromBeamspot.perp() / sqrt(err.rerr(displacementFromBeamspot)))<minDS) continue;
-	      muPhi_.denominator->Fill(t.phi());
-	      muEta_.denominator->Fill(t.eta());
-	      muPt_.denominator ->Fill(t.pt());
- 
-	      /////////////////////////
+
+      	case 9:
+          if (dimuonCL<minprob) continue;
+          if (fabs(jpsi_cos)<mincos) continue;
+          if ((displacementFromBeamspotJpsi.perp()/sqrt(jerr.rerr(displacementFromBeamspotJpsi)))<minDS) continue;
+      	  if (trHandle.isValid())
+    	    { 
+	      for (auto const & t : *trHandle) 
+		{
+		  if(!trSelection_ref(t)) continue;
+		  const reco::Track& itrk1       = t ;                                                
+		  if((reco::deltaR(t,m1) <= min_dR)) continue; // checking overlapping
+		  if((reco::deltaR(t,m) <= min_dR)) continue;
+		  if (! itrk1.quality(reco::TrackBase::highPurity))     continue;
+		  reco::Particle::LorentzVector pB, p1, p2, p3;
+		  double trackMass2 = kaon_mass * kaon_mass;
+		  double MuMass2 = mu_mass * mu_mass;//0.1056583745 *0.1056583745;
+		  double e1   = sqrt(m.momentum().Mag2()  + MuMass2          );
+		  double e2   = sqrt(m1.momentum().Mag2()  + MuMass2          );
+		  double e3   = sqrt(itrk1.momentum().Mag2() + trackMass2  );
+		  p1   = reco::Particle::LorentzVector(m.px() , m.py() , m.pz() , e1  );
+		  p2   = reco::Particle::LorentzVector(m1.px() , m1.py() , m1.pz() , e2  );
+		  p3   = reco::Particle::LorentzVector(itrk1.px(), itrk1.py(), itrk1.pz(), e3  );
+		  pB   = p1 + p2 + p3;
+		  if( pB.mass()> maxmassJpsiTk || pB.mass()< minmassJpsiTk) continue;
+		  reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
+		  std::vector<reco::TransientTrack> t_tks;
+		  t_tks.push_back(mu1TT);
+		  t_tks.push_back(mu2TT);
+		  t_tks.push_back(trTT);
+		  KalmanVertexFitter kvf;
+		  TransientVertex tv  = kvf.vertex(t_tks);
+		  reco::Vertex vertex = tv;
+		  if (!tv.isValid()) continue;
+		  float JpsiTkCL = 0;
+		  if ((vertex.chi2()>=0.0) && (vertex.ndof()>0) )   
+		    JpsiTkCL = TMath::Prob(vertex.chi2(), vertex.ndof() );
+		  math::XYZVector pperp(m.px() + m1.px() + itrk1.px(),
+					m.py() + m1.py() + itrk1.py(),
+					0.);
+		  GlobalPoint secondaryVertex = tv.position();
+		  GlobalError err             = tv.positionError();
+		  GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() - secondaryVertex.x()) + 
+							    (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()), 
+							-1*((vertexBeamSpot.y0() - secondaryVertex.y()) + 
+							    (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 
+							0);
+		  reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
+		  float jpsiKcos = vperp.Dot(pperp)/(vperp.R()*pperp.R());
+		  if (JpsiTkCL<minprob) continue;
+		  if (fabs(jpsiKcos)<mincos) continue;
+		  if ((displacementFromBeamspot.perp()/sqrt(err.rerr(displacementFromBeamspot)))<minDS) continue;
+		  muPhi_.denominator->Fill(t.phi());
+		  muEta_.denominator->Fill(t.eta());
+		  muPt_.denominator ->Fill(t.pt());
+		  BMass_.denominator ->Fill(pB.mass());
+                
+		  if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+		    {
+		      if( !matchToTrigger(hltpath1,m1))continue;
+		      if( !matchToTrigger(hltpath1,m))continue;
+		      if( !matchToTrigger(hltpath1,t))
+			{
+			  continue;
+        
+			}
+		      muPhi_.numerator->Fill(t.phi(),PrescaleWeight);
+		      muEta_.numerator->Fill(t.eta(),PrescaleWeight);
+		      muPt_.numerator ->Fill(t.pt(),PrescaleWeight);
+		      BMass_.numerator ->Fill(pB.mass(),PrescaleWeight);
+                  
+		    }   
+              
+  	        }
 	    }
-	  }
-	  break;
-	case 10:
-	  if (trHandle.isValid()) {
-	    for (auto const & t : *trHandle) {
-	      if (!trSelection_ref(t)) continue;
-	      if (false && !matchToTrigger(hltpath,t, handleTriggerEvent)) continue;
-	      const reco::Track& itrk1 = t ; 
-	      if ((reco::deltaR(t,m1) <= min_dR)) continue; // checking overlapping
-	      if ((reco::deltaR(t,m) <= min_dR)) continue;
-	      if (! itrk1.quality(reco::TrackBase::highPurity)) continue;
-	      reco::Particle::LorentzVector pB, p2, p3;
-	      double trackMass2 = kaon_mass * kaon_mass;
-	      double MuMass2 = mu_mass * mu_mass; // 0.1056583745 *0.1056583745;
-	      double e2 = sqrt(m1.momentum().Mag2()  + MuMass2 );
-	      double e3 = sqrt(itrk1.momentum().Mag2() + trackMass2  );
-	      p2 = reco::Particle::LorentzVector(m1.px() , m1.py() , m1.pz() , e2  );
-	      p3 = reco::Particle::LorentzVector(itrk1.px(), itrk1.py(), itrk1.pz(), e3  );
-	      pB = p2 + p3;
-	      if ( pB.mass() > maxmassJpsiTk || pB.mass()< minmassJpsiTk) continue;
-	      reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
-	      std::vector<reco::TransientTrack> t_tks;
-	      t_tks.push_back(mu2TT);
-	      t_tks.push_back(trTT);
-	      KalmanVertexFitter kvf;
-	      TransientVertex tv  = kvf.vertex(t_tks);
-	      reco::Vertex vertex = tv;
-	      if (!tv.isValid()) continue;
-	      float JpsiTkCL = 0;
-	      if ((vertex.chi2() >= 0.0) && (vertex.ndof() > 0) ) 
-		JpsiTkCL = TMath::Prob(vertex.chi2(), vertex.ndof() );
-	      math::XYZVector pperp(m1.px() + itrk1.px(),
-				    m1.py() + itrk1.py(),
-				    0.);
-	      GlobalPoint secondaryVertex = tv.position();
-	      GlobalError err             = tv.positionError();
-	      GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() - secondaryVertex.x()) + 
-							(secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()), 
-						    -1*((vertexBeamSpot.y0() - secondaryVertex.y()) + 
-							(secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 
-						    0);
-	      reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
-	      if (JpsiTkCL<minprob) continue;
-	      muPhi_.denominator->Fill(m1.phi());
-	      muEta_.denominator->Fill(m1.eta());
-	      muPt_.denominator ->Fill(m1.pt());
+    	  break;
+
+    	case 10:
+  	  if (trHandle.isValid())
+	    {
+	      for (auto const & t : *trHandle)
+		{
+		  if(!trSelection_ref(t)) continue;
+		  const reco::Track& itrk1       = t ;                                                
+		  if((reco::deltaR(t,m1) <= min_dR)) continue;//checking overlaping
+		  if((reco::deltaR(t,m) <= min_dR)) continue;
+		  if (! itrk1.quality(reco::TrackBase::highPurity))     continue;
+		  reco::Particle::LorentzVector pB, p2, p3;
+		  double trackMass2 = kaon_mass * kaon_mass;
+		  double MuMass2 = mu_mass * mu_mass;//0.1056583745 *0.1056583745;
+		  double e2   = sqrt(m1.momentum().Mag2()  + MuMass2          );
+		  double e3   = sqrt(itrk1.momentum().Mag2() + trackMass2  );
+		  p2   = reco::Particle::LorentzVector(m1.px() , m1.py() , m1.pz() , e2  );
+		  p3   = reco::Particle::LorentzVector(itrk1.px(), itrk1.py(), itrk1.pz(), e3  );
+		  pB   = p2 + p3;
+		  if( pB.mass()> maxmassJpsiTk || pB.mass()< minmassJpsiTk) continue;
+		  reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
+		  std::vector<reco::TransientTrack> t_tks;
+		  t_tks.push_back(mu2TT);
+		  t_tks.push_back(trTT);
+		  KalmanVertexFitter kvf;
+		  TransientVertex tv  = kvf.vertex(t_tks);
+		  reco::Vertex vertex = tv;
+		  if (!tv.isValid()) continue;
+		  float JpsiTkCL = 0;
+		  if ((vertex.chi2()>=0.0) && (vertex.ndof()>0) )   
+		    JpsiTkCL = TMath::Prob(vertex.chi2(), vertex.ndof() );
+		  math::XYZVector pperp(m1.px() + itrk1.px(),
+					m1.py() + itrk1.py(),
+					0.);
+		  GlobalPoint secondaryVertex = tv.position();
+		  GlobalError err             = tv.positionError();
+		  GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() - secondaryVertex.x()) + 
+							    (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()), 
+							-1*((vertexBeamSpot.y0() - secondaryVertex.y()) + 
+							    (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 
+							0);
+		  reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
+		  if (JpsiTkCL<minprob) continue;
+		  muPhi_.denominator->Fill(m1.phi());
+		  muEta_.denominator->Fill(m1.eta());
+		  muPt_.denominator ->Fill(m1.pt());
+		  if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+		    {
+		      if( !matchToTrigger(hltpath1,m1))continue;
+		      if( !matchToTrigger(hltpath1,m))continue;
+		      if( !matchToTrigger(hltpath1,t))
+			{
+			  continue;
+
+			}
+		      muPhi_.numerator->Fill(m1.phi(),PrescaleWeight);
+		      muEta_.numerator->Fill(m1.eta(),PrescaleWeight);
+		      muPt_.numerator ->Fill(m1.pt(),PrescaleWeight);
+              	    
+		    }
+        
+		}
 	    }
-	  }
 	  break;
+
 	case 11:
-	  case11_selection(dimuonCL, jpsi_cos, displacementFromBeamspotJpsi, jerr, trHandle, hltpath, handleTriggerEvent, m, m1, bFieldHandle, vertexBeamSpot, mu1Phi_.denominator, mu1Eta_.denominator, mu1Pt_.denominator, mu2Phi_.denominator, mu2Eta_.denominator, mu2Pt_.denominator);
-	  break;
+  	  if (dimuonCL < minprob) continue;
+  	  if (fabs(jpsi_cos) < mincos) continue;
+  	  if ((displacementFromBeamspotJpsi.perp() / sqrt(jerr.rerr(displacementFromBeamspotJpsi))) < minDS) continue;
+  	  if (trHandle.isValid()) {
+ 	    for (auto const & t : *trHandle) {
+ 	      if (!trSelection_ref(t)) continue;
+ 	      if ((reco::deltaR(t,m) <= min_dR)) continue; // checking overlapping
+ 	      if ((reco::deltaR(t,m1) <= min_dR)) continue;  // checking overlapping
+ 	      for (auto const & t1 : *trHandle) {
+      		if (&t - &(*trHandle)[0]  >=  &t1 - &(*trHandle)[0]) continue; // not enough, need the following DeltaR checks
+      		if (!trSelection_ref(t1)) continue;
+      		if ((reco::deltaR(t1,m) <= min_dR)) continue;  // checking overlapping
+      		if ((reco::deltaR(t1,m1) <= min_dR)) continue; // checking overlapping
+      		if ((reco::deltaR(t,t1) <= min_dR)) continue;  // checking overlapping
+      		const reco::Track& itrk1 = t ;
+      		const reco::Track& itrk2 = t1 ;
+      		if (! itrk1.quality(reco::TrackBase::highPurity)) continue;
+      		if (! itrk2.quality(reco::TrackBase::highPurity)) continue;
+      		reco::Particle::LorentzVector pB, pTkTk, p1, p2, p3, p4;
+      		double trackMass2 = kaon_mass * kaon_mass;
+      		double MuMass2 = mu_mass * mu_mass; // 0.1056583745 *0.1056583745;
+      		double e1 = sqrt(m.momentum().Mag2()  + MuMass2 );
+      		double e2 = sqrt(m1.momentum().Mag2()  + MuMass2 );
+      		double e3 = sqrt(itrk1.momentum().Mag2() + trackMass2  );
+      		double e4 = sqrt(itrk2.momentum().Mag2() + trackMass2  );
+      		p1 = reco::Particle::LorentzVector(m.px() , m.py() , m.pz() , e1  );
+      		p2 = reco::Particle::LorentzVector(m1.px() , m1.py() , m1.pz() , e2  );
+      		p3 = reco::Particle::LorentzVector(itrk1.px(), itrk1.py(), itrk1.pz(), e3  );
+      		p4 = reco::Particle::LorentzVector(itrk2.px(), itrk2.py(), itrk2.pz(), e4  );
+      		pTkTk = p3 + p4;
+      		if (pTkTk.mass() > maxmassTkTk || pTkTk.mass() < minmassTkTk) continue;
+      		pB = p1 + p2 + p3 + p4;
+      		if ( pB.mass() > maxmassJpsiTk || pB.mass()< minmassJpsiTk) continue;
+      		reco::TransientTrack mu1TT(m.track(), &(*bFieldHandle));
+      		reco::TransientTrack mu2TT(m1.track(), &(*bFieldHandle));
+      		reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
+      		reco::TransientTrack tr1TT(itrk2, &(*bFieldHandle));
+      		std::vector<reco::TransientTrack> t_tks;
+      		t_tks.push_back(mu1TT);
+      		t_tks.push_back(mu2TT);
+      		t_tks.push_back(trTT);
+      		t_tks.push_back(tr1TT);
+      		KalmanVertexFitter kvf;
+      		TransientVertex tv  = kvf.vertex(t_tks); // this will compare the tracks
+      		reco::Vertex vertex = tv;
+      		if (!tv.isValid()) continue;
+      		float JpsiTkCL = 0;
+      		if ((vertex.chi2() >= 0.0) && (vertex.ndof() > 0) )
+      		  JpsiTkCL = TMath::Prob(vertex.chi2(), vertex.ndof() );
+      		math::XYZVector pperp(m.px() + m1.px() + itrk1.px() + itrk2.px(),
+      				      m.py() + m1.py() + itrk1.py() + itrk2.py(),
+      				      0.);
+      		GlobalPoint secondaryVertex = tv.position();
+      		GlobalError err             = tv.positionError();
+      		GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() - secondaryVertex.x()) +
+      							  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()),
+      						      -1*((vertexBeamSpot.y0() - secondaryVertex.y()) +
+      							  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()),
+      						      0);
+      		reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
+      		float jpsiKcos = vperp.Dot(pperp) / (vperp.R()*pperp.R());
+      		if (JpsiTkCL < minprob) continue;
+      		if (fabs(jpsiKcos) < mincos) continue;
+      		if ((displacementFromBeamspot.perp() / sqrt(err.rerr(displacementFromBeamspot))) < minDS) continue;
+      
+      		mu1Phi_.denominator->Fill(t.phi());
+      		mu1Eta_.denominator->Fill(t.eta());
+      		mu1Pt_.denominator ->Fill(t.pt());
+      		mu2Phi_.denominator->Fill(t1.phi());
+      		mu2Eta_.denominator->Fill(t1.eta());
+      		mu2Pt_.denominator ->Fill(t1.pt());
+		BMass_.denominator ->Fill(pB.mass());
+      
+      		if (num_genTriggerEventFlag_->on() &&  num_genTriggerEventFlag_->accept( iEvent, iSetup) )
+    		  {
+		    if( !matchToTrigger(hltpath1,m1))continue;
+		    if( !matchToTrigger(hltpath1,m))continue;
+		    if( !matchToTrigger(hltpath1,t))
+		      {
+			continue;
+
+		      }
+		    if( !matchToTrigger(hltpath1,t1))
+		      {
+			continue;
+
+		      }
+		    mu1Phi_.numerator->Fill(t.phi(),PrescaleWeight);
+		    mu1Eta_.numerator->Fill(t.eta(),PrescaleWeight);
+		    mu1Pt_.numerator ->Fill(t.pt(),PrescaleWeight);
+		    mu2Phi_.numerator->Fill(t1.phi(),PrescaleWeight);
+		    mu2Eta_.numerator->Fill(t1.eta(),PrescaleWeight);
+		    mu2Pt_.numerator ->Fill(t1.pt(),PrescaleWeight);
+		    BMass_.numerator ->Fill(pB.mass(),PrescaleWeight);
+            
+     		  }
+          
+ 	      } // for (auto const & t1 : *trHandle)
+ 	    } // for (auto const & t : *trHandle)
+   	  } // if (trHandle.isValid())
+  	
+  	  break;
 	} 
       }
     }
-
-
-    if (enum_ == 7) { // photons
-      const std::string & hltpath = hltpaths_den[0];
-      for (auto const & p : *phHandle) {
-	if (false && !matchToTrigger(hltpath,p, handleTriggerEvent)) continue;
-	phPhi_.denominator->Fill(p.phi());
-	phEta_.denominator->Fill(p.eta());
-	phPt_.denominator ->Fill(p.pt());
-      }
-
-    } 
-    //
-    /////////
-    // filling numerator hists
-    if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
-    iEvent.getByToken( hltInputTag_, handleTriggerEvent);
-    if (handleTriggerEvent->sizeFilters()== 0) return;
-    const std::string & hltpath1 = hltpaths_num[0]; 
-    for (auto const & m : *muoHandle ) {
-      if (false && !matchToTrigger(hltpath1,m, handleTriggerEvent)) continue;
-      if (!muoSelection_ref(m)) continue; 
-      for (auto const & m1 : *muoHandle ) {
-	if (seagull_ && ((m.charge()* deltaPhi(m.phi(), m1.phi())) > 0.) ) continue;
-	if (m.charge()*m1.charge() > 0 ) continue;
-	if (m1.pt() == m.pt()) continue;
-	if (!muoSelection_ref(m1)) continue; 
-	if (false && !matchToTrigger(hltpath1,m1, handleTriggerEvent)) continue;
-	if (!DMSelection_ref(m1.p4() + m.p4())) continue;
-	iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
-	const reco::BeamSpot& vertexBeamSpot = *beamSpot;
-	std::vector<reco::TransientTrack> j_tks;
-	reco::TransientTrack mu1TT(m.track(), &(*bFieldHandle));
-	reco::TransientTrack mu2TT(m1.track(), &(*bFieldHandle));
-	j_tks.push_back(mu1TT);
-	j_tks.push_back(mu2TT);
-	KalmanVertexFitter jkvf;
-	TransientVertex jtv = jkvf.vertex(j_tks);
-	if (!jtv.isValid()) continue;
-	reco::Vertex jpsivertex = jtv;
-	float dimuonCL = 0;
-	if ( (jpsivertex.chi2() >= 0) && (jpsivertex.ndof() > 0) ) // I think these values are "unphysical"(no one will need to change them ever)so the can be fixed
-	  dimuonCL = TMath::Prob(jpsivertex.chi2(), jpsivertex.ndof() );
-	math::XYZVector jpperp(m.px() + m1.px() ,
-			       m.py() + m1.py() ,
-			       0.);
-	GlobalPoint jVertex = jtv.position();
-	GlobalError jerr    = jtv.positionError();
-	GlobalPoint displacementFromBeamspotJpsi( -1*((vertexBeamSpot.x0() - jVertex.x()) + (jVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()),
-						  -1*((vertexBeamSpot.y0() - jVertex.y()) + (jVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()),
-						  0);
-	reco::Vertex::Point vperpj(displacementFromBeamspotJpsi.x(), displacementFromBeamspotJpsi.y(), 0.);
-	float jpsi_cos = vperpj.Dot(jpperp) / (vperpj.R()*jpperp.R());
-	TrajectoryStateClosestToPoint mu1TS = mu1TT.impactPointTSCP();
-	TrajectoryStateClosestToPoint mu2TS = mu2TT.impactPointTSCP();
-	ClosestApproachInRPhi cApp;
-	if (mu1TS.isValid() && mu2TS.isValid()) {
-	  cApp.calculate(mu1TS.theState(), mu2TS.theState());
-	}
-	double DiMuMass = (m1.p4()+m.p4()).M();
-	switch(enum_) { // enum_ = 1...9, represents different sets of variables for different paths, we want to have different hists for different paths
-	case 1: tnp_=true; // already filled hists for tnp method
-	case 2:
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  if (dimuonCL < minprob) continue;
-	  mu1Phi_.numerator->Fill(m.phi(),PrescaleWeight);
-	  mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
-	  mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
-	  mu2Phi_.numerator->Fill(m1.phi(),PrescaleWeight);
-	  mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
-	  mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
-	  DiMuPt_.numerator ->Fill((m1.p4()+m.p4()).Pt() ,PrescaleWeight);
-	  DiMuEta_.numerator ->Fill((m1.p4()+m.p4()).Eta() ,PrescaleWeight);
-	  DiMuPhi_.numerator ->Fill((m1.p4()+m.p4()).Phi(),PrescaleWeight);
-	  break;
-	case 3:
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  if (dimuonCL < minprob) continue;
-	  mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
-	  mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
-	  mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
-	  mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
-	  break; 
-	case 4:
-	  if (dimuonCL < minprob) continue;
-	  DiMuMass_.numerator ->Fill(DiMuMass);
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  mu1Phi_.numerator->Fill(m.phi(),PrescaleWeight);
-	  mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
-	  mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
-	  mu2Phi_.numerator->Fill(m1.phi(),PrescaleWeight);
-	  mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
-	  mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
-	  DiMuPt_.numerator ->Fill((m1.p4()+m.p4()).Pt() ,PrescaleWeight);
-	  DiMuEta_.numerator ->Fill((m1.p4()+m.p4()).Eta() ,PrescaleWeight);
-	  DiMuPhi_.numerator ->Fill((m1.p4()+m.p4()).Phi(),PrescaleWeight);
-	  DiMudR_.numerator ->Fill(reco::deltaR(m,m1),PrescaleWeight);
-	  break;
-	case 5:
-	  if (dimuonCL < minprob) continue;
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  mu1Phi_.numerator->Fill(m.phi(),PrescaleWeight);
-	  mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
-	  mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
-	  mu2Phi_.numerator->Fill(m1.phi(),PrescaleWeight);
-	  mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
-	  mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
-	  DiMuPt_.numerator ->Fill((m1.p4()+m.p4()).Pt() ,PrescaleWeight);
-	  DiMuEta_.numerator ->Fill((m1.p4()+m.p4()).Eta() ,PrescaleWeight);
-	  DiMuPhi_.numerator ->Fill((m1.p4()+m.p4()).Phi(),PrescaleWeight);
-	  DiMudR_.numerator ->Fill(reco::deltaR(m,m1),PrescaleWeight);
-	  break;
-	case 6: 
-	  if (dimuonCL < minprob) continue;
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  for (auto const & m2 : *muoHandle) { // triple muon paths
-	    if (false && !matchToTrigger(hltpath1,m2, handleTriggerEvent)) continue;
-	    if (m2.pt() == m.pt()) continue;
-	    mu1Phi_.numerator->Fill(m.phi(),PrescaleWeight);
-	    mu1Eta_.numerator->Fill(m.eta(),PrescaleWeight);
-	    mu1Pt_.numerator ->Fill(m.pt(),PrescaleWeight);
-	    mu2Phi_.numerator->Fill(m1.phi(),PrescaleWeight);
-	    mu2Eta_.numerator->Fill(m1.eta(),PrescaleWeight);
-	    mu2Pt_.numerator ->Fill(m1.pt(),PrescaleWeight);
-	    mu3Phi_.numerator->Fill(m2.phi(),PrescaleWeight);
-	    mu3Eta_.numerator->Fill(m2.eta(),PrescaleWeight);
-	    mu3Pt_.numerator ->Fill(m2.pt(),PrescaleWeight);
-	  } 
-	  break; 
-	case 7: // the hists for photon monitoring will be filled on 515 line
-	  tnp_=false;
-	  break;
-	case 8: // vtx monitoring, filling probability, DS, DCA, cos of pointing angle to the PV, eta, pT of dimuon
-	  if ((Jpsi_) && (!Upsilon_)) {
-	    if (DiMuMass> maxmassJpsi || DiMuMass< minmassJpsi) continue;
-	  }
-	  if ((!Jpsi_) && (Upsilon_)) {
-	    if (DiMuMass> maxmassUpsilon || DiMuMass< minmassUpsilon) continue;
-	  }
-	  DiMuProb_.numerator ->Fill( dimuonCL,PrescaleWeight);
-	  if (dimuonCL < minprob) continue;
-	  DiMuDS_.numerator ->Fill( displacementFromBeamspotJpsi.perp() / sqrt(jerr.rerr(displacementFromBeamspotJpsi)),PrescaleWeight);
-	  DiMuPVcos_.numerator ->Fill(jpsi_cos ,PrescaleWeight);
-	  DiMuPt_.numerator ->Fill((m1.p4()+m.p4()).Pt() ,PrescaleWeight);
-	  DiMuEta_.numerator ->Fill((m1.p4()+m.p4()).Eta() ,PrescaleWeight);
-	  DiMuDCA_.numerator ->Fill( cApp.distance(),PrescaleWeight);
-	  break;
-	case 9:
-	  if (dimuonCL < minprob) continue;
-	  if (fabs(jpsi_cos) < mincos) continue;
-	  if ((displacementFromBeamspotJpsi.perp() / sqrt(jerr.rerr(displacementFromBeamspotJpsi))) < minDS) continue;
-	  if (trHandle.isValid()) {
-	    for (auto const & t : *trHandle) {
-	      if (!trSelection_ref(t)) continue;
-	      if (false && !matchToTrigger(hltpath1,t, handleTriggerEvent)) continue;
-	      const reco::Track& itrk1 = t ; 
-	      if ((reco::deltaR(t,m1) <= min_dR)) continue; // checking overlapping
-	      if ((reco::deltaR(t,m) <= min_dR)) continue;
-	      if (! itrk1.quality(reco::TrackBase::highPurity)) continue;
-	      reco::Particle::LorentzVector pB, p1, p2, p3;
-	      double trackMass2 = kaon_mass * kaon_mass;
-	      double MuMass2 = mu_mass * mu_mass; // 0.1056583745 *0.1056583745;
-	      double e1 = sqrt(m.momentum().Mag2()  + MuMass2 );
-	      double e2 = sqrt(m1.momentum().Mag2()  + MuMass2 );
-	      double e3 = sqrt(itrk1.momentum().Mag2() + trackMass2  );
-	      p1 = reco::Particle::LorentzVector(m.px() , m.py() , m.pz() , e1  );
-	      p2 = reco::Particle::LorentzVector(m1.px() , m1.py() , m1.pz() , e2  );
-	      p3 = reco::Particle::LorentzVector(itrk1.px(), itrk1.py(), itrk1.pz(), e3  );
-	      pB = p1 + p2 + p3;
-	      if ( pB.mass() > maxmassJpsiTk || pB.mass()< minmassJpsiTk) continue;
-	      reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
-	      std::vector<reco::TransientTrack> t_tks;
-	      t_tks.push_back(mu1TT);
-	      t_tks.push_back(mu2TT);
-	      t_tks.push_back(trTT);
-	      KalmanVertexFitter kvf;
-	      TransientVertex tv  = kvf.vertex(t_tks);
-	      reco::Vertex vertex = tv;
-	      if (!tv.isValid()) continue;
-	      float JpsiTkCL = 0;
-	      if ((vertex.chi2() >= 0.0) && (vertex.ndof() > 0) ) 
-		JpsiTkCL = TMath::Prob(vertex.chi2(), vertex.ndof() );
-	      math::XYZVector pperp(m.px() + m1.px() + itrk1.px(),
-				    m.py() + m1.py() + itrk1.py(),
-				    0.);
-	      GlobalPoint secondaryVertex = tv.position();
-	      GlobalError err             = tv.positionError();
-	      GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() - secondaryVertex.x()) + 
-							(secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()), 
-						    -1*((vertexBeamSpot.y0() - secondaryVertex.y()) + 
-							(secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 
-						    0);
-	      reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
-	      float jpsiKcos = vperp.Dot(pperp) / (vperp.R()*pperp.R());
-	      if (JpsiTkCL<minprob) continue;
-	      if (fabs(jpsiKcos)<mincos) continue;
-	      if ((displacementFromBeamspot.perp() / sqrt(err.rerr(displacementFromBeamspot)))<minDS) continue;
-	      muPhi_.numerator->Fill(t.phi(),PrescaleWeight);
-	      muEta_.numerator->Fill(t.eta(),PrescaleWeight);
-	      muPt_.numerator ->Fill(t.pt(),PrescaleWeight);
-	    }
-	  }
-	  break;
-
-	case 10:
-	  if (trHandle.isValid()) {
-	    for (auto const & t : *trHandle) {
-	      if (!trSelection_ref(t)) continue;
-	      if (false && !matchToTrigger(hltpath1,t, handleTriggerEvent)) continue;
-	      const reco::Track& itrk1 = t ; 
-	      if ((reco::deltaR(t,m1) <= min_dR)) continue; // checking overlapping
-	      if ((reco::deltaR(t,m) <= min_dR)) continue;
-	      if (! itrk1.quality(reco::TrackBase::highPurity)) continue;
-	      reco::Particle::LorentzVector pB, p2, p3;
-	      double trackMass2 = kaon_mass * kaon_mass;
-	      double MuMass2 = mu_mass * mu_mass; // 0.1056583745 *0.1056583745;
-	      double e2 = sqrt(m1.momentum().Mag2()  + MuMass2 );
-	      double e3 = sqrt(itrk1.momentum().Mag2() + trackMass2  );
-	      p2 = reco::Particle::LorentzVector(m1.px() , m1.py() , m1.pz() , e2  );
-	      p3 = reco::Particle::LorentzVector(itrk1.px(), itrk1.py(), itrk1.pz(), e3  );
-	      pB = p2 + p3;
-	      if ( pB.mass() > maxmassJpsiTk || pB.mass()< minmassJpsiTk) continue;
-	      reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
-	      std::vector<reco::TransientTrack> t_tks;
-	      t_tks.push_back(mu2TT);
-	      t_tks.push_back(trTT);
-	      if (t_tks.size()!=2) continue;
-	      KalmanVertexFitter kvf;
-	      TransientVertex tv  = kvf.vertex(t_tks);
-	      reco::Vertex vertex = tv;
-	      if (!tv.isValid()) continue;
-	      float JpsiTkCL = 0;
-	      if ((vertex.chi2() >= 0.0) && (vertex.ndof() > 0) ) 
-		JpsiTkCL = TMath::Prob(vertex.chi2(), vertex.ndof() );
-	      math::XYZVector pperp(m1.px() + itrk1.px(),
-				    m1.py() + itrk1.py(),
-				    0.);
-	      GlobalPoint secondaryVertex = tv.position();
-	      GlobalError err             = tv.positionError();
-	      GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() - secondaryVertex.x()) + 
-							(secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()), 
-						    -1*((vertexBeamSpot.y0() - secondaryVertex.y()) + 
-							(secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 
-						    0);
-	      reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
-	      if (JpsiTkCL<minprob) continue;
-	      muPhi_.numerator->Fill(m1.phi(),PrescaleWeight);
-	      muEta_.numerator->Fill(m1.eta(),PrescaleWeight);
-	      muPt_.numerator ->Fill(m1.pt(),PrescaleWeight);
-	    }
-	  }
-	  break;
-	case 11:
-	  case11_selection(dimuonCL, jpsi_cos, displacementFromBeamspotJpsi, jerr, trHandle, hltpath, handleTriggerEvent, m, m1, bFieldHandle, vertexBeamSpot, mu1Phi_.numerator, mu1Eta_.numerator, mu1Pt_.numerator, mu2Phi_.numerator, mu2Eta_.numerator, mu2Pt_.numerator);
-	  break;
-	} 
-      }
-    }
-    if (enum_ == 7) { // photons
-      const std::string &hltpath = hltpaths_num[0];
-      for (auto const & p : *phHandle) {
-	if (false && !matchToTrigger(hltpath,p, handleTriggerEvent)) continue;
-	phPhi_.numerator->Fill(p.phi(),PrescaleWeight);
-	phEta_.numerator->Fill(p.eta(),PrescaleWeight);
-	phPt_.numerator ->Fill(p.pt(),PrescaleWeight);
-      }
-    }
-  }
+  } 
 }
-
-
-
 
 void BPHMonitor::fillHistoPSetDescription(edm::ParameterSetDescription & pset)
 {
@@ -1001,7 +1015,7 @@ void BPHMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   desc.add<edm::InputTag>( "beamSpot",edm::InputTag("offlineBeamSpot") );
   desc.add<edm::InputTag>( "muons", edm::InputTag("muons") );
   desc.add<edm::InputTag>( "hltTriggerSummaryAOD", edm::InputTag("hltTriggerSummaryAOD","","HLT") );
-  desc.add<std::string>("muoSelection", "abs(eta)<1.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits> 0");
+  desc.add<std::string>("muoSelection", "");
   desc.add<std::string>("muoSelection_ref", "isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits> 0");
   desc.add<std::string>("muoSelection_tag",  "isGlobalMuon && isPFMuon && isTrackerMuon && abs(eta) < 2.4 && innerTrack.hitPattern.numberOfValidPixelHits > 0 && innerTrack.hitPattern.trackerLayersWithMeasurement > 5 && globalTrack.hitPattern.numberOfValidMuonHits > 0 && globalTrack.normalizedChi2 < 10"); // tight selection for tag muon
   desc.add<std::string>("muoSelection_probe", "isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits> 0");
@@ -1011,17 +1025,19 @@ void BPHMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   desc.add<int>("nmuons", 1);
   desc.add<bool>( "tnp", false );
   desc.add<int>( "L3", 0 );
+  desc.add<int>( "ptCut", 0 );
+  desc.add<int>( "displaced", 0 );
   desc.add<int>( "trOrMu", 0 ); // if =0, track param monitoring
   desc.add<int>( "Jpsi", 0 );
   desc.add<int>( "Upsilon", 0 );
   desc.add<int>( "enum", 1 ); // 1...9, 9 sets of variables to be filled, depends on the hlt path
-  desc.add<int>( "seagull", 1 ); // 1...9, 9 sets of variables to be filled, depends on the hlt path
+  desc.add<int>( "seagull", 1 ); 
   desc.add<double>( "maxmass", 3.596 );
   desc.add<double>( "minmass", 2.596 );
   desc.add<double>( "maxmassJpsi", 3.2 );
   desc.add<double>( "minmassJpsi", 3. );
-  desc.add<double>( "maxmassUpsilon", 8.1 );
-  desc.add<double>( "minmassUpsilon", 8. );
+  desc.add<double>( "maxmassUpsilon", 10.0 );
+  desc.add<double>( "minmassUpsilon", 8.8 );
   desc.add<double>( "maxmassTkTk", 10);
   desc.add<double>( "minmassTkTk", 0);
   desc.add<double>( "maxmassJpsiTk", 5.46 );
@@ -1029,6 +1045,7 @@ void BPHMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   desc.add<double>( "kaon_mass", 0.493677 );
   desc.add<double>( "mu_mass", 0.1056583745);
   desc.add<double>( "min_dR", 0.001);
+  desc.add<double>( "max_dR", 1.4);
   desc.add<double>( "minprob", 0.005 );
   desc.add<double>( "mincos", 0.95 );
   desc.add<double>( "minDS", 3. );
@@ -1049,7 +1066,6 @@ void BPHMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   genericTriggerEventPSet.add<bool>("errorReplyHlt",false);
   genericTriggerEventPSet.add<bool>("errorReplyL1",true);
   genericTriggerEventPSet.add<bool>("l1BeforeMask",true);
-  genericTriggerEventPSet.add<unsigned int>("verbosityLevel",0);
   desc.add<edm::ParameterSetDescription>("numGenericTriggerEventPSet", genericTriggerEventPSet);
   desc.add<edm::ParameterSetDescription>("denGenericTriggerEventPSet", genericTriggerEventPSet);
 
@@ -1057,21 +1073,27 @@ void BPHMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   edm::ParameterSetDescription phiPSet;
   edm::ParameterSetDescription etaPSet;
   edm::ParameterSetDescription ptPSet;
+  edm::ParameterSetDescription dMu_ptPSet;
   edm::ParameterSetDescription d0PSet;
   edm::ParameterSetDescription z0PSet;
   edm::ParameterSetDescription dRPSet;
   edm::ParameterSetDescription massPSet;
+  edm::ParameterSetDescription BmassPSet;
   edm::ParameterSetDescription dcaPSet;
   edm::ParameterSetDescription dsPSet;
   edm::ParameterSetDescription cosPSet;
   edm::ParameterSetDescription probPSet;
+  edm::ParameterSetDescription TCoPSet;
+  edm::ParameterSetDescription PUPSet;
   fillHistoPSetDescription(phiPSet);
   fillHistoPSetDescription(ptPSet);
+  fillHistoPSetDescription(dMu_ptPSet);
   fillHistoPSetDescription(etaPSet);
   fillHistoPSetDescription(z0PSet);
   fillHistoPSetDescription(d0PSet);
   fillHistoPSetDescription(dRPSet);
   fillHistoPSetDescription(massPSet);
+  fillHistoPSetDescription(BmassPSet);
   fillHistoPSetDescription(dcaPSet);
   fillHistoPSetDescription(dsPSet);
   fillHistoPSetDescription(cosPSet);
@@ -1080,128 +1102,182 @@ void BPHMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   histoPSet.add<edm::ParameterSetDescription>("etaPSet", etaPSet);
   histoPSet.add<edm::ParameterSetDescription>("phiPSet", phiPSet);
   histoPSet.add<edm::ParameterSetDescription>("ptPSet", ptPSet);
+  histoPSet.add<edm::ParameterSetDescription>("dMu_ptPSet", dMu_ptPSet);
   histoPSet.add<edm::ParameterSetDescription>("z0PSet", z0PSet);
   histoPSet.add<edm::ParameterSetDescription>("dRPSet", dRPSet);
   histoPSet.add<edm::ParameterSetDescription>("massPSet", massPSet);
+  histoPSet.add<edm::ParameterSetDescription>("BmassPSet", BmassPSet);
   histoPSet.add<edm::ParameterSetDescription>("dcaPSet", dcaPSet);
   histoPSet.add<edm::ParameterSetDescription>("dsPSet", dsPSet);
   histoPSet.add<edm::ParameterSetDescription>("cosPSet", cosPSet);
   histoPSet.add<edm::ParameterSetDescription>("probPSet", probPSet);
   desc.add<edm::ParameterSetDescription>("histoPSet",histoPSet);
-
   descriptions.add("bphMonitoring", desc);
 }
+
+std::string BPHMonitor::getTriggerName(std::string partialName) {
+
+  const std::string trigger_name_tmp = partialName.substr(0,partialName.find("v*"));
+  const unsigned int Ntriggers(hltConfig_.size());
+  std::string trigger_name = "";
+  for (unsigned int i=0;i<Ntriggers;i++) {
+    trigger_name = hltConfig_.triggerName(i);
+    if ( trigger_name.find(trigger_name_tmp) != std::string::npos ) break;
+  }
+
+  return trigger_name;
+}
+
 template <typename T>
-bool BPHMonitor::matchToTrigger(const std::string  &theTriggerName , T t, edm::Handle<trigger::TriggerEvent> handleTriggerEvent) {
-  //bool BPHMonitor::matchToTrigger(std::string theTriggerName,T t, edm::Handle<trigger::TriggerEventWithRefs> handleTriggerEvent) {
- 
-  bool matchedToTrigger = false;
-  if (handleTriggerEvent->sizeFilters() > 0) {
-    const trigger::TriggerObjectCollection & toc(handleTriggerEvent->getObjects()); //Handle< trigger::TriggerEvent > handleTriggerEvent;
-    for ( size_t ia = 0; ia < handleTriggerEvent->sizeFilters(); ++ ia) {
-      std::string fullname = handleTriggerEvent->filterTag(ia).encode();
-      std::string name;
-      size_t p = fullname.find_first_of(':');
-      if ( p != std::string::npos) {name = fullname.substr(0, p);}
-      else {name = fullname;}
-      const trigger::Keys & k = handleTriggerEvent->filterKeys(ia);
-      for (trigger::Keys::const_iterator ki = k.begin(); ki !=k.end(); ++ki ) {
-	reco::Particle theTriggerParticle = toc[*ki].particle();
-	if (name.find(theTriggerName) != string::npos) {
-	  if ((reco::deltaR(t.eta(), t.phi(),theTriggerParticle.eta(),theTriggerParticle.phi()) <= 0.2)) {
-	    matchedToTrigger = true;
-	  }
-	} 
-      }
+bool BPHMonitor::matchToTrigger(const std::string  &theTriggerName , T t){
+
+  bool matched = false;
+  //validity check
+  if ( !hltConfig_.inited() ) return false;
+  
+  //Find the precise trigger name
+  std::string trigger_name = getTriggerName(theTriggerName);
+  const unsigned int trigger_index = hltConfig_.triggerIndex(trigger_name);
+
+  //loop over all the modules for this trigger
+  //by default use the last one
+  unsigned int Nmodules = hltConfig_.size(trigger_index);
+  const vector<string>& moduleLabels(hltConfig_.moduleLabels(trigger_index));
+  unsigned int fIdx=0;
+  for (unsigned int i=0;i<Nmodules;i++)
+    {
+      const unsigned int tmp_fIdx = handleTriggerEvent->filterIndex(edm::InputTag(moduleLabels[i],"",hltInputTag_1.process()));
+      if ( tmp_fIdx< handleTriggerEvent->sizeFilters() ) //index of not used filters are set to sizeFilters()
+	{
+	  fIdx = tmp_fIdx;
+	}//good index
     }
 
-    return matchedToTrigger;
-  }
-  else {cout <<theTriggerName <<"\t\tNo HLT filters" <<endl; return false;}
+  //loop over all the objects in the filter of choice
+  const trigger::Keys& KEYS(handleTriggerEvent->filterKeys(fIdx));
+  const trigger::size_type nK(KEYS.size());
+  const trigger::TriggerObjectCollection& TOC(handleTriggerEvent->getObjects());
+  for (trigger::size_type i=0; i!=nK; ++i) 
+    {
+      const trigger::TriggerObject& TO(TOC[KEYS[i]]);
+      //perform matching: deltaR and pt check
+      if( (reco::deltaR(t.eta(), t.phi(),TO.eta(),TO.phi()) <= 0.2) && (TMath::Abs(t.pt()-TO.pt()) < 0.12) )
+	{
+	  matched = true;
+	}
+    }
+
+  return matched;
+
 }
 
-void BPHMonitor::case11_selection(const float & dimuonCL, const float & jpsi_cos, const GlobalPoint & displacementFromBeamspotJpsi, const GlobalError & jerr, const edm::Handle<reco::TrackCollection> & trHandle, const std::string & hltpath, const edm::Handle<trigger::TriggerEvent> & handleTriggerEvent, const reco::Muon& m, const reco::Muon& m1, const edm::ESHandle<MagneticField> & bFieldHandle, const reco::BeamSpot & vertexBeamSpot, MonitorElement* phi1, MonitorElement* eta1, MonitorElement* pT1, MonitorElement* phi2, MonitorElement* eta2, MonitorElement* pT2) {
-  //cout <<"\nInside case11_selection" <<endl;
-  if (dimuonCL < minprob) return;
-  if (fabs(jpsi_cos) < mincos) return;
-  if ((displacementFromBeamspotJpsi.perp() / sqrt(jerr.rerr(displacementFromBeamspotJpsi))) < minDS) return;
-  if (trHandle.isValid()) {
-    ////////////////////////
-    for (auto const & t : *trHandle) {
-      if (!trSelection_ref(t)) continue;
-      if (false && !matchToTrigger(hltpath,t, handleTriggerEvent)) continue;
-      if ((reco::deltaR(t,m) <= min_dR)) continue; // checking overlapping
-      if ((reco::deltaR(t,m1) <= min_dR)) continue;  // checking overlapping
-      for (auto const & t1 : *trHandle) {
-	if (&t - &(*trHandle)[0]  >=  &t1 - &(*trHandle)[0]) continue; // not enough, need the following DeltaR checks
-	//if (t.pt() == t1.pt()) continue;
-	if (!trSelection_ref(t1)) continue;
-	if (false && !matchToTrigger(hltpath,t1, handleTriggerEvent)) continue;
-	if ((reco::deltaR(t1,m) <= min_dR)) continue;  // checking overlapping
-	if ((reco::deltaR(t1,m1) <= min_dR)) continue; // checking overlapping
-	if ((reco::deltaR(t,t1) <= min_dR)) continue;  // checking overlapping
-	const reco::Track& itrk1 = t ;
-	const reco::Track& itrk2 = t1 ;
-	if (! itrk1.quality(reco::TrackBase::highPurity)) continue;
-	if (! itrk2.quality(reco::TrackBase::highPurity)) continue;
-	reco::Particle::LorentzVector pB, pTkTk, p1, p2, p3, p4;
-	double trackMass2 = kaon_mass * kaon_mass;
-	double MuMass2 = mu_mass * mu_mass; // 0.1056583745 *0.1056583745;
-	double e1 = sqrt(m.momentum().Mag2()  + MuMass2 );
-	double e2 = sqrt(m1.momentum().Mag2()  + MuMass2 );
-	double e3 = sqrt(itrk1.momentum().Mag2() + trackMass2  );
-	double e4 = sqrt(itrk2.momentum().Mag2() + trackMass2  );
-	p1 = reco::Particle::LorentzVector(m.px() , m.py() , m.pz() , e1  );
-	p2 = reco::Particle::LorentzVector(m1.px() , m1.py() , m1.pz() , e2  );
-	p3 = reco::Particle::LorentzVector(itrk1.px(), itrk1.py(), itrk1.pz(), e3  );
-	p4 = reco::Particle::LorentzVector(itrk2.px(), itrk2.py(), itrk2.pz(), e4  );
-	pTkTk = p3 + p4;
-	if (pTkTk.mass() > maxmassTkTk || pTkTk.mass() < minmassTkTk) continue;
-	pB = p1 + p2 + p3 + p4;
-	if ( pB.mass() > maxmassJpsiTk || pB.mass()< minmassJpsiTk) continue;
-	reco::TransientTrack mu1TT(m.track(), &(*bFieldHandle));
-	reco::TransientTrack mu2TT(m1.track(), &(*bFieldHandle));
-	reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
-	reco::TransientTrack tr1TT(itrk2, &(*bFieldHandle));
-	std::vector<reco::TransientTrack> t_tks;
-	t_tks.push_back(mu1TT);
-	t_tks.push_back(mu2TT);
-	t_tks.push_back(trTT);
-	t_tks.push_back(tr1TT);
-	KalmanVertexFitter kvf;
-	TransientVertex tv  = kvf.vertex(t_tks); // this will compare the tracks
-	reco::Vertex vertex = tv;
-	if (!tv.isValid()) continue;
-	float JpsiTkCL = 0;
-	if ((vertex.chi2() >= 0.0) && (vertex.ndof() > 0) )
-	  JpsiTkCL = TMath::Prob(vertex.chi2(), vertex.ndof() );
-	math::XYZVector pperp(m.px() + m1.px() + itrk1.px() + itrk2.px(),
-			      m.py() + m1.py() + itrk1.py() + itrk2.py(),
-			      0.);
-	GlobalPoint secondaryVertex = tv.position();
-	GlobalError err             = tv.positionError();
-	GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() - secondaryVertex.x()) +
-						  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()),
-					      -1*((vertexBeamSpot.y0() - secondaryVertex.y()) +
-						  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()),
-					      0);
-	reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
-	float jpsiKcos = vperp.Dot(pperp) / (vperp.R()*pperp.R());
-	if (JpsiTkCL < minprob) continue;
-	if (fabs(jpsiKcos) < mincos) continue;
-	if ((displacementFromBeamspot.perp() / sqrt(err.rerr(displacementFromBeamspot))) < minDS) continue;
+int BPHMonitor::Prescale(const std::string  hltpath1, const std::string  hltpath, edm::Event const& iEvent, edm::EventSetup const& iSetup,  HLTPrescaleProvider* hltPrescale_)
+{
+  int PrescaleHLT_num = 1;
+  int PrescaleHLT_den = 1;
+  double Prescale_num = 1;
+  int TotalPrescale =1;
+  double  L1P=1, HLTP=1;
+  bool flag=true;
+  std::vector<bool> theSame_den;    
+  std::vector<bool> theSame_num;    
+  //retrieving HLT prescale
+  PrescaleHLT_den = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).second;
+  PrescaleHLT_num = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).second;
+  HLTP =PrescaleHLT_num/std::__gcd(PrescaleHLT_num, PrescaleHLT_den);
 
-	phi1->Fill(t.phi());
-	eta1->Fill(t.eta());
-	pT1->Fill(t.pt());
-	phi2->Fill(t1.phi());
-	eta2->Fill(t1.eta());
-	pT2->Fill(t1.pt());
-      } // for (auto const & t1 : *trHandle)
-    } // for (auto const & t : *trHandle)
-  } // if (trHandle.isValid())
+  //retrieving L1 prescale
+  //Checking if we have the same l1 seeds in den and num
+  //taking into account that they can be written in different order in num and den
+  //and some of them can be also switched off
+
+  //check if for each den l1 there is the same l1 seed in num 
+  if ( !(hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.empty() )
+    {  
+      for (size_t iSeed=0; iSeed < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.size(); ++iSeed)
+	{
+	  std::string l1_den = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.at(iSeed).first;
+	  int l1_denp = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.at(iSeed).second;
+	  if (l1_denp<1) continue;
+	  flag = false;
+	  for (size_t iSeed1=0; iSeed1 < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.size(); ++iSeed1)
+	    {
+	      std::string l1_num = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed1).first;
+	      int l1_nump= (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed1).second;
+	      if (!l1_num.compare(l1_den) && (l1_nump>=1))//the same seed  
+		{
+		  flag = true;
+		  break;
+		}
+	    }
+	  theSame_den.push_back(flag);
+	}
+    }
+  //check if for each num l1 there is the same l1 seed in den 
+  if ( !(hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.empty() )
+    {
+      for (size_t iSeed=0; iSeed < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.size(); ++iSeed)
+	{
+	  std::string l1_num = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed).first;
+	  int l1_nump = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed).second;
+	  if (l1_nump<1) continue;
+	  flag = false;
+	  for (size_t iSeed1=0; iSeed1 < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.size(); ++iSeed1)
+	    {
+	      std::string l1_den = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.at(iSeed1).first;
+	      int l1_denp= (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.at(iSeed1).second;
+	      if (!l1_den.compare(l1_num) && (l1_denp>=1))//the same seed
+		{
+		  flag = true;
+		  break;
+		}
+	    }
+	  theSame_num.push_back(flag);
+	}
+    } 
+  flag = true;    
+
+  if (theSame_num.size() == theSame_den.size())
+    {
+      for(size_t i=0; i<theSame_num.size() ; ++i)
+	{
+	  if ((!theSame_num.at(i)) || (!theSame_den.at(i)))
+	    {
+	      flag = false;
+	      break;
+	    }
+	}
+    }
+
+  if (flag && (theSame_num.size() == theSame_den.size())) 
+    {
+      L1P = 1; //den and num have the same set of l1 seeds
+    }
+  else
+    {
+      if ( !(hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.empty() )   
+	{
+	  Prescale_num =1;
+	  for (size_t iSeed=0; iSeed < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.size(); ++iSeed) 
+	    {
+        
+	      int l1 = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed).second;
+	      if (l1<1) continue; 
+	      if (l1==1){
+		Prescale_num =1;
+		break;
+	      }
+	      else Prescale_num *= 1 - (1.0/(l1));
+	    }
+	  if (Prescale_num!=1 )Prescale_num = 1.0 / (1 - Prescale_num);
+	}
+      L1P = Prescale_num;
+    }    
+  TotalPrescale = (int)(L1P*HLTP + 0.5);
+
+  return TotalPrescale;
+
 }
 
-// Define this as a plug-in
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(BPHMonitor);

--- a/DQMOffline/Trigger/plugins/BPHMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.cc
@@ -386,7 +386,7 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
  
 
-  int PrescaleWeight =1;
+  double PrescaleWeight = 1.0;
   const std::string & hltpath = getTriggerName(hltpaths_den[0]);
   const std::string & hltpath1 = getTriggerName(hltpaths_num[0]);
 
@@ -1171,12 +1171,11 @@ bool BPHMonitor::matchToTrigger(const std::string  &theTriggerName , T t){
 
 }
 
-int BPHMonitor::Prescale(const std::string  hltpath1, const std::string  hltpath, edm::Event const& iEvent, edm::EventSetup const& iSetup,  HLTPrescaleProvider* hltPrescale_)
+double BPHMonitor::Prescale(const std::string  hltpath1, const std::string  hltpath, edm::Event const& iEvent, edm::EventSetup const& iSetup,  HLTPrescaleProvider* hltPrescale_)
 {
   int PrescaleHLT_num = 1;
   int PrescaleHLT_den = 1;
   double Prescale_num = 1;
-  int TotalPrescale =1;
   double  L1P=1, HLTP=1;
   bool flag=true;
   std::vector<bool> theSame_den;    
@@ -1272,10 +1271,9 @@ int BPHMonitor::Prescale(const std::string  hltpath1, const std::string  hltpath
 	  if (Prescale_num!=1 )Prescale_num = 1.0 / (1 - Prescale_num);
 	}
       L1P = Prescale_num;
-    }    
-  TotalPrescale = (int)(L1P*HLTP + 0.5);
+    }
 
-  return TotalPrescale;
+  return L1P * HLTP;
 
 }
 

--- a/DQMOffline/Trigger/plugins/BPHMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.cc
@@ -1066,6 +1066,7 @@ void BPHMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   genericTriggerEventPSet.add<bool>("errorReplyHlt",false);
   genericTriggerEventPSet.add<bool>("errorReplyL1",true);
   genericTriggerEventPSet.add<bool>("l1BeforeMask",true);
+  genericTriggerEventPSet.add<unsigned int>("verbosityLevel",0);
   desc.add<edm::ParameterSetDescription>("numGenericTriggerEventPSet", genericTriggerEventPSet);
   desc.add<edm::ParameterSetDescription>("denGenericTriggerEventPSet", genericTriggerEventPSet);
 

--- a/DQMOffline/Trigger/plugins/BPHMonitor.h
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.h
@@ -96,7 +96,7 @@ protected:
   template <typename T>
   bool matchToTrigger(const std::string  &theTriggerName , T t);
 
-  int Prescale(const std::string  num, const std::string  den, edm::Event const& iEvent, edm::EventSetup const& iSetup,  HLTPrescaleProvider* hltPrescale_);
+  double Prescale(const std::string  num, const std::string  den, edm::Event const& iEvent, edm::EventSetup const& iSetup,  HLTPrescaleProvider* hltPrescale_);
 
 
 private:

--- a/DQMOffline/Trigger/plugins/BPHMonitor.h
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.h
@@ -44,6 +44,8 @@
 #include "DataFormats/HLTReco/interface/TriggerObject.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "CommonTools/TriggerUtils/interface/PrescaleWeightProvider.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 
 class GenericTriggerEventFlag;
 
@@ -90,9 +92,11 @@ protected:
   void setMETitle(METME& me, std::string titleX, std::string titleY);
 
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+
   template <typename T>
-  bool matchToTrigger(const std::string &theTriggerName ,T t, edm::Handle<trigger::TriggerEvent> handleTriggerEvent);
-  //bool matchToTrigger(std::string theTriggerName,T t, edm::Handle<trigger::TriggerEventWithRefs> handleTriggerEvent);
+  bool matchToTrigger(const std::string  &theTriggerName , T t);
+
+  int Prescale(const std::string  num, const std::string  den, edm::Event const& iEvent, edm::EventSetup const& iSetup,  HLTPrescaleProvider* hltPrescale_);
 
 
 private:
@@ -106,14 +110,16 @@ private:
   edm::EDGetTokenT<reco::BeamSpot>        bsToken_;
   edm::EDGetTokenT<reco::TrackCollection>       trToken_;
   edm::EDGetTokenT<reco::PhotonCollection>       phToken_;
-
+  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
   MEbinning           phi_binning_;
   MEbinning           pt_binning_;
+  MEbinning           dMu_pt_binning_;
   MEbinning           eta_binning_;
   MEbinning           d0_binning_;
   MEbinning           z0_binning_;
   MEbinning           dR_binning_;
   MEbinning           mass_binning_;
+  MEbinning           Bmass_binning_;
   MEbinning           dca_binning_;
   MEbinning           ds_binning_;
   MEbinning           cos_binning_;
@@ -142,7 +148,6 @@ private:
   METME mu3z0_;
 
 
-///
   METME  phPhi_   ;
   METME  phEta_   ;
   METME  phPt_   ;
@@ -154,13 +159,13 @@ private:
   METME  DiMuDS_   ;
   METME  DiMuDCA_   ;
   METME  DiMuMass_   ;
+  METME  BMass_   ;
   METME  DiMudR_   ;
 
 
-//
-
   GenericTriggerEventFlag* num_genTriggerEventFlag_;
   GenericTriggerEventFlag* den_genTriggerEventFlag_;
+  HLTPrescaleProvider* hltPrescale_;
   StringCutObjectSelector<reco::Muon,true>        muoSelection_;
   StringCutObjectSelector<reco::Muon,true>        muoSelection_ref;
   StringCutObjectSelector<reco::Muon,true>        muoSelection_tag;
@@ -168,6 +173,8 @@ private:
   int nmuons_;
   bool tnp_;
   int L3_;
+  int ptCut_;
+  int displaced_;
   int trOrMu_;
   int Jpsi_;
   int Upsilon_;
@@ -186,17 +193,25 @@ private:
   double kaon_mass;
   double mu_mass;
   double min_dR;
+  double max_dR;
 
   double minprob;
   double mincos;
   double minDS;
   edm::EDGetTokenT<edm::TriggerResults>  hltTrigResTag_;
-  edm::EDGetTokenT<trigger::TriggerEvent>  hltInputTag_;
+  edm::InputTag  hltInputTag_1;
+  edm::EDGetTokenT<trigger::TriggerEvent> hltInputTag_;
   std::vector<std::string> hltpaths_num;
   std::vector<std::string> hltpaths_den;
   StringCutObjectSelector<reco::Track,true>        trSelection_;
   StringCutObjectSelector<reco::Track,true>        trSelection_ref;
   StringCutObjectSelector<reco::Candidate::LorentzVector,true>        DMSelection_ref;
+
+  edm::Handle<trigger::TriggerEvent> handleTriggerEvent;
+
+  HLTConfigProvider hltConfig_;
+  edm::Handle<edm::TriggerResults> HLTR;
+  std::string getTriggerName(std::string partialName);
 };
 
 #endif // METMONITOR_H

--- a/DQMOffline/Trigger/python/BPHMonitor_cff.py
+++ b/DQMOffline/Trigger/python/BPHMonitor_cff.py
@@ -69,12 +69,13 @@ Dimuon0_er = hltBPHmonitoring.clone()
 Dimuon0_er.FolderName = cms.string('HLT/BPH/DiMu0_Lowmass_L1_er/')
 Dimuon0_er.tnp = cms.bool(False)
 Dimuon0_er.enum = cms.int32(3)
+Dimuon0_er.Jpsi = cms.int32(1)
 Dimuon0_er.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
 #Dimuon0_er.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-Dimuon0_er.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_v*")
+Dimuon0_er.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_v*")
 #Dimuon0_er.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ_OS")
 Dimuon0_er.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_er.DMSelection_ref = cms.string("abs(Eta)<1.5 ")
+Dimuon0_er.DMSelection_ref = cms.string("abs(Eta)<1.5")
 
 ###
 Dimuon0_Upsilon_er = hltBPHmonitoring.clone()
@@ -96,24 +97,45 @@ DMu4_3_Bs_dRcut = hltBPHmonitoring.clone()
 DMu4_3_Bs_dRcut.FolderName = cms.string('HLT/BPH/DMu4_3_Bs_L1_dR/')
 DMu4_3_Bs_dRcut.tnp = cms.bool(False)
 DMu4_3_Bs_dRcut.enum = cms.int32(4)
+DMu4_3_Bs_dRcut.ptCut = cms.int32(1)
 DMu4_3_Bs_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_3_Bs_v*")
 #DMu4_3_Bs_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
 DMu4_3_Bs_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
 #DMu4_3_Bs_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-DMu4_3_Bs_dRcut.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_3_Bs_dRcut.DMSelection_ref = cms.string("abs(Eta)<1.5")
+DMu4_3_Bs_dRcut.muoSelection_ref = cms.string("pt>4.5 && abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
+DMu4_3_Bs_dRcut.muoSelection = cms.string("pt>3.5 && abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
+DMu4_3_Bs_dRcut.DMSelection_ref = cms.string("abs(Eta)<1.5 && Pt>5.5 && M<5.9 && M>4.6")
+DMu4_3_Bs_dRcut.histoPSet.dRPSet = cms.PSet(
+  nbins = cms.int32 ( 30 ),
+  xmin  = cms.double(0.4),
+  xmax  = cms.double(1.9),
+)
+DMu4_3_Bs_dRcut.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 (9),
+  xmin  = cms.double(  4.4),
+  xmax  = cms.double(6.2),
+)
+
 
 DMu4_3_Jpsi_dRcut = hltBPHmonitoring.clone()
 DMu4_3_Jpsi_dRcut.FolderName = cms.string('HLT/BPH/DMu4_3_Jpsi_L1_dR/')
 DMu4_3_Jpsi_dRcut.tnp = cms.bool(False)
 DMu4_3_Jpsi_dRcut.enum = cms.int32(4)
 DMu4_3_Jpsi_dRcut.Jpsi = cms.int32(1)
+DMu4_3_Jpsi_dRcut.ptCut = cms.int32(1)
 DMu4_3_Jpsi_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_3_Jpsi_v*")
 #DMu4_3_Jpsi_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
 DMu4_3_Jpsi_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
 #DMu4_3_Jpsi_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-DMu4_3_Jpsi_dRcut.muoSelection_ref = cms.string("pt>5.0 &&  abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
+DMu4_3_Jpsi_dRcut.muoSelection_ref = cms.string("pt>4.5 &&  abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
+DMu4_3_Jpsi_dRcut.muoSelection = cms.string("pt>3.5 && abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
 DMu4_3_Jpsi_dRcut.DMSelection_ref = cms.string("abs(Eta)<1.5")
+DMu4_3_Jpsi_dRcut.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 10 ),
+  xmin  = cms.double(2.8),
+  xmax  = cms.double(3.3),
+)
+
 
 Dimuon14_Phi_dRcut = hltBPHmonitoring.clone()
 Dimuon14_Phi_dRcut.FolderName = cms.string('HLT/BPH/DiMu14_Phi_L1_dR/')
@@ -125,7 +147,18 @@ Dimuon14_Phi_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon
 Dimuon14_Phi_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
 #Dimuon14_Phi_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
 Dimuon14_Phi_dRcut.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon14_Phi_dRcut.DMSelection_ref = cms.string("Pt>15 & abs(Eta)<1.2")
+Dimuon14_Phi_dRcut.DMSelection_ref = cms.string("M>0.95 & M<1.1 & Pt>15 & abs(Eta)<1.2")
+Dimuon14_Phi_dRcut.histoPSet.dRPSet = cms.PSet(
+  nbins = cms.int32 ( 35 ),
+  xmin  = cms.double(0),
+  xmax  = cms.double(0.7),
+)
+Dimuon14_Phi_dRcut.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 10 ),
+  xmin  = cms.double(0.95),
+  xmax  = cms.double(1.1),
+)
+
 
 DMu4_LowMassNonResonantTrk_Displaced_dRcut = hltBPHmonitoring.clone()
 DMu4_LowMassNonResonantTrk_Displaced_dRcut.FolderName = cms.string('HLT/BPH/DMu4_LowMassNonResonantTrk_Displaced_L1_dR/')
@@ -136,7 +169,12 @@ DMu4_LowMassNonResonantTrk_Displaced_dRcut.numGenericTriggerEventPSet.hltPaths =
 DMu4_LowMassNonResonantTrk_Displaced_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
 #DMu4_LowMassNonResonantTrk_Displaced_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
 DMu4_LowMassNonResonantTrk_Displaced_dRcut.muoSelection_ref = cms.string("pt>5 & abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut.DMSelection_ref = cms.string("abs(Eta)<1.5")
+DMu4_LowMassNonResonantTrk_Displaced_dRcut.DMSelection_ref = cms.string("((M>1.1 & M<2.8) | (M>4.1 & M<4.7)) & abs(Eta)<1.5")
+DMu4_LowMassNonResonantTrk_Displaced_dRcut.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 10 ),
+  xmin  = cms.double(1.),
+  xmax  = cms.double(3.),
+)
 
 DMu4_LowMassNonResonantTrk_Displaced_dRcut_low = hltBPHmonitoring.clone()
 DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.FolderName = cms.string('HLT/BPH/DMu4_LowMassNonResonantTrk_Displaced_L1_dR_low/')
@@ -147,31 +185,50 @@ DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.hltPat
 DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
 #DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
 DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.muoSelection_ref = cms.string("pt>5 & abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.DMSelection_ref = cms.string("abs(Eta)<2.4")
+DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.DMSelection_ref = cms.string("((M>1.1 & M<2.8) | (M>4.1 & M<4.7)) & abs(Eta)<2.4")
+DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.max_dR = cms.double(1.2)
+DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 10 ),
+  xmin  = cms.double(1.),
+  xmax  = cms.double(3.),
+)
 
 
 DMu4_JpsiTrk_Displaced_dRcut = hltBPHmonitoring.clone()
 DMu4_JpsiTrk_Displaced_dRcut.FolderName = cms.string('HLT/BPH/DMu4_JpsiTrk_Displaced_L1_dR/')
 DMu4_JpsiTrk_Displaced_dRcut.tnp = cms.bool(False)
 DMu4_JpsiTrk_Displaced_dRcut.enum = cms.int32(4)
+DMu4_JpsiTrk_Displaced_dRcut.Jpsi = cms.int32(1)
 DMu4_JpsiTrk_Displaced_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_JpsiTrk_Displaced_v*")
 #DMu4_JpsiTrk_Displaced_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
 DMu4_JpsiTrk_Displaced_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
 #DMu4_JpsiTrk_Displaced_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
 DMu4_JpsiTrk_Displaced_dRcut.muoSelection_ref = cms.string("pt>5 & abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
 DMu4_JpsiTrk_Displaced_dRcut.DMSelection_ref = cms.string("abs(Eta)<1.5")
+DMu4_JpsiTrk_Displaced_dRcut.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 10 ),
+  xmin  = cms.double(2.8),
+  xmax  = cms.double(3.3),
+)
+
 
 DMu4_JpsiTrk_Displaced_dRcut_low = hltBPHmonitoring.clone()
 DMu4_JpsiTrk_Displaced_dRcut_low.FolderName = cms.string('HLT/BPH/DMu4_JpsiTrk_Displaced_L1_dR_low/')
 DMu4_JpsiTrk_Displaced_dRcut_low.tnp = cms.bool(False)
 DMu4_JpsiTrk_Displaced_dRcut_low.enum = cms.int32(4)
+DMu4_JpsiTrk_Displaced_dRcut_low.Jpsi = cms.int32(1)
 DMu4_JpsiTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_JpsiTrk_Displaced_v*")
 #DMu4_JpsiTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2")
 DMu4_JpsiTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
 #DMu4_JpsiTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
 DMu4_JpsiTrk_Displaced_dRcut_low.muoSelection_ref = cms.string("pt>5 & abs(eta)<2.4  &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
 DMu4_JpsiTrk_Displaced_dRcut_low.DMSelection_ref = cms.string("abs(Eta)<2.4")
-
+DMu4_JpsiTrk_Displaced_dRcut_low.max_dR = cms.double(1.2)
+DMu4_JpsiTrk_Displaced_dRcut_low.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 10 ),
+  xmin  = cms.double(2.8),
+  xmax  = cms.double(3.3),
+)
 
 DMu4_PsiPrimeTrk_Displaced_dRcut = hltBPHmonitoring.clone()
 DMu4_PsiPrimeTrk_Displaced_dRcut.FolderName = cms.string('HLT/BPH/DMu4_PsiPrimeTrk_Displaced_L1_dR/')
@@ -182,7 +239,13 @@ DMu4_PsiPrimeTrk_Displaced_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstri
 DMu4_PsiPrimeTrk_Displaced_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
 #DMu4_PsiPrimeTrk_Displaced_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
 DMu4_PsiPrimeTrk_Displaced_dRcut.muoSelection_ref = cms.string("pt>5 & abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_PsiPrimeTrk_Displaced_dRcut.DMSelection_ref = cms.string("abs(Eta)<1.5")
+DMu4_PsiPrimeTrk_Displaced_dRcut.DMSelection_ref = cms.string("M>3.4 & M<3.95 & abs(Eta)<1.5")
+DMu4_PsiPrimeTrk_Displaced_dRcut.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 12 ),
+  xmin  = cms.double(3.3),
+  xmax  = cms.double(3.9),
+)
+
 
 
 DMu4_PsiPrimeTrk_Displaced_dRcut_low = hltBPHmonitoring.clone()
@@ -194,7 +257,13 @@ DMu4_PsiPrimeTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.hltPaths = cms.v
 DMu4_PsiPrimeTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
 #DMu4_PsiPrimeTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
 DMu4_PsiPrimeTrk_Displaced_dRcut_low.muoSelection_ref = cms.string("pt>5 & abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.DMSelection_ref = cms.string("abs(Eta)<2.4")
+DMu4_PsiPrimeTrk_Displaced_dRcut_low.DMSelection_ref = cms.string("M>3.4 & M<3.95 & abs(Eta)<2.4")
+DMu4_PsiPrimeTrk_Displaced_dRcut_low.max_dR = cms.double(1.2)
+DMu4_PsiPrimeTrk_Displaced_dRcut_low.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 12 ),
+  xmin  = cms.double(3.3),
+  xmax  = cms.double(3.9),
+)
 
 
 Dimuon25_Jpsi_dRcut = hltBPHmonitoring.clone()
@@ -208,6 +277,16 @@ Dimuon25_Jpsi_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuo
 #Dimuon25_Jpsi_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
 Dimuon25_Jpsi_dRcut.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
 Dimuon25_Jpsi_dRcut.DMSelection_ref = cms.string("Pt>26 & abs(Eta)<1.5")
+Dimuon25_Jpsi_dRcut.histoPSet.dRPSet = cms.PSet(
+  nbins = cms.int32 ( 20 ),
+  xmin  = cms.double(0.),
+  xmax  = cms.double(1.),
+)
+Dimuon25_Jpsi_dRcut.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 10 ),
+  xmin  = cms.double(2.8),
+  xmax  = cms.double(3.3),
+)
 
 
 Dimuon18_PsiPrime_dRcut = hltBPHmonitoring.clone()
@@ -219,33 +298,12 @@ Dimuon18_PsiPrime_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_D
 Dimuon18_PsiPrime_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
 #Dimuon18_PsiPrime_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
 Dimuon18_PsiPrime_dRcut.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon18_PsiPrime_dRcut.DMSelection_ref = cms.string("Pt>19 & abs(Eta)<1.5")
-
-
-Dimuon12_Upsilon_dRcut = hltBPHmonitoring.clone()
-Dimuon12_Upsilon_dRcut.FolderName = cms.string('HLT/BPH/DiMu12_Upsilon_L1_dR/')
-Dimuon12_Upsilon_dRcut.tnp = cms.bool(False)
-Dimuon12_Upsilon_dRcut.enum = cms.int32(4)
-Dimuon12_Upsilon_dRcut.Upsilon = cms.int32(1)
-Dimuon12_Upsilon_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon12_Upsilon_eta1p5_v*")
-#Dimuon12_Upsilon_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
-Dimuon12_Upsilon_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#Dimuon12_Upsilon_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-Dimuon12_Upsilon_dRcut.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon12_Upsilon_dRcut.DMSelection_ref = cms.string("Pt>13 & abs(Eta)<1.5")
-
-Dimuon0_Upsilon_masscut = hltBPHmonitoring.clone()
-Dimuon0_Upsilon_masscut.FolderName = cms.string('HLT/BPH/DiMu0_Upsilon_L1_masscut/')
-Dimuon0_Upsilon_masscut.tnp = cms.bool(False)
-Dimuon0_Upsilon_masscut.enum = cms.int32(5)
-Dimuon0_Upsilon_masscut.Upsilon = cms.int32(1)
-Dimuon0_Upsilon_masscut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_L1_4p5er2p0M_v*")
-#Dimuon0_Upsilon_masscut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18")
-Dimuon0_Upsilon_masscut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*")
-#Dimuon0_Upsilon_masscut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS")
-Dimuon0_Upsilon_masscut.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.0 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_Upsilon_masscut.DMSelection_ref = cms.string("M<18 & M>7 & Pt>11 & abs(Eta)<1.2")
-
+Dimuon18_PsiPrime_dRcut.DMSelection_ref = cms.string("M>3.4 & M<3.95 & Pt>19 & abs(Eta)<1.5")
+Dimuon18_PsiPrime_dRcut.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 12 ),
+  xmin  = cms.double(3.3),
+  xmax  = cms.double(3.9),
+)
 
 Dimuon25_Jpsi_dRcut_low = hltBPHmonitoring.clone()
 Dimuon25_Jpsi_dRcut_low.FolderName = cms.string('HLT/BPH/DiMu25_Jpsi_L1_dR_low/')
@@ -258,20 +316,35 @@ Dimuon25_Jpsi_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_D
 #Dimuon25_Jpsi_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
 Dimuon25_Jpsi_dRcut_low.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
 Dimuon25_Jpsi_dRcut_low.DMSelection_ref = cms.string("Pt>26 & abs(Eta)<2.4")
+Dimuon25_Jpsi_dRcut_low.max_dR = cms.double(1.2)
+Dimuon25_Jpsi_dRcut_low.histoPSet.dRPSet = cms.PSet(
+  nbins = cms.int32 ( 18 ),
+  xmin  = cms.double(0.),
+  xmax  = cms.double(0.9),
+)
+Dimuon25_Jpsi_dRcut_low.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 10 ),
+  xmin  = cms.double(2.8),
+  xmax  = cms.double(3.3),
+)
 
 
-Dimuon18_Jpsi_dRcut_low = hltBPHmonitoring.clone()
-Dimuon18_Jpsi_dRcut_low.FolderName = cms.string('HLT/BPH/DiMu18_Jpsi_L1_dR_low/')
-Dimuon18_Jpsi_dRcut_low.tnp = cms.bool(False)
-Dimuon18_Jpsi_dRcut_low.enum = cms.int32(4)
-Dimuon18_Jpsi_dRcut_low.Jpsi = cms.int32(1)
-Dimuon18_Jpsi_dRcut_low.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon18_PsiPrime_v*")
-#Dimuon18_Jpsi_dRcut_low.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2")
-Dimuon18_Jpsi_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
-#Dimuon18_Jpsi_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
-Dimuon18_Jpsi_dRcut_low.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon18_Jpsi_dRcut_low.DMSelection_ref = cms.string("Pt>19 & abs(Eta)<2.4")
-
+Dimuon18_PsiPrime_dRcut_low = hltBPHmonitoring.clone()
+Dimuon18_PsiPrime_dRcut_low.FolderName = cms.string('HLT/BPH/DiMu18_PsiPrime_L1_dR_low/')
+Dimuon18_PsiPrime_dRcut_low.tnp = cms.bool(False)
+Dimuon18_PsiPrime_dRcut_low.enum = cms.int32(4)
+Dimuon18_PsiPrime_dRcut_low.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon18_PsiPrime_v*")
+#Dimuon18_PsiPrime_dRcut_low.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2")
+Dimuon18_PsiPrime_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
+#Dimuon18_PsiPrime_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
+Dimuon18_PsiPrime_dRcut_low.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
+Dimuon18_PsiPrime_dRcut_low.DMSelection_ref = cms.string("M>3.4 & M<3.95 & Pt>19 & abs(Eta)<2.4")
+Dimuon18_PsiPrime_dRcut_low.max_dR = cms.double(1.2)
+Dimuon18_PsiPrime_dRcut_low.histoPSet.massPSet = cms.PSet(
+  nbins = cms.int32 ( 10 ),
+  xmin  = cms.double(3.4),
+  xmax  = cms.double(4.0),
+)
 
 ###
 ###mass cut
@@ -295,12 +368,12 @@ Dimuon12_masscut2.FolderName = cms.string('HLT/BPH/DiMu12_Upsilon_L1_masscut2/')
 Dimuon12_masscut2.tnp = cms.bool(False)
 Dimuon12_masscut2.enum = cms.int32(5)
 Dimuon12_masscut2.Upsilon = cms.int32(1)
-Dimuon12_masscut2.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon12_Upsilon_eta1p5_v*")
+Dimuon12_masscut2.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon12_Upsilon_y1p4_v*")
 #Dimuon12_masscut2.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18")
 Dimuon12_masscut2.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*")
 #Dimuon12_masscut2.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS")
 Dimuon12_masscut2.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.0 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon12_masscut2.DMSelection_ref = cms.string("M<18 & M>7 & Pt>13 & abs(Eta)<1.5")
+Dimuon12_masscut2.DMSelection_ref = cms.string("Pt>13 & abs(y)<1.5")
 
 
 Trimuon2_masscut4 = hltBPHmonitoring.clone()
@@ -340,6 +413,11 @@ Trimuon2_masscut6.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0
 #Trimuon2_masscut6.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ_OS")
 Trimuon2_masscut6.muoSelection_ref = cms.string("pt>3 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
 Trimuon2_masscut6.DMSelection_ref = cms.string("M<9 & abs(Eta)<2.4")
+Trimuon2_masscut6.histoPSet.dRPSet = cms.PSet(
+  nbins = cms.int32 ( 30 ),
+  xmin  = cms.double(0.),
+  xmax  = cms.double(1.5),
+)
 
 ###triple muon
 
@@ -493,6 +571,7 @@ Dimuon0_tightVtx_Jpsi.FolderName = cms.string('HLT/BPH/DiMu0_L1_tightVtx_Jpsi/')
 Dimuon0_tightVtx_Jpsi.tnp = cms.bool(False)
 Dimuon0_tightVtx_Jpsi.Jpsi = cms.int32(1)
 Dimuon0_tightVtx_Jpsi.enum = cms.int32(8)
+Dimuon0_tightVtx_Jpsi.displaced = cms.int32(1)
 Dimuon0_tightVtx_Jpsi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_Jpsi_Displaced_v*")
 #Dimuon0_tightVtx_Jpsi.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
 Dimuon0_tightVtx_Jpsi.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_Jpsi_NoVertexing_v*")
@@ -518,6 +597,7 @@ Dimuon0_addTrack_Jpsi.trOrMu = cms.int32(True)
 Dimuon0_addTrackTrack_Jpsi = hltBPHmonitoring.clone()
 Dimuon0_addTrackTrack_Jpsi.FolderName = cms.string('HLT/BPH/DiMu0_L1_addTrackTrack_Jpsi/')
 Dimuon0_addTrackTrack_Jpsi.tnp = cms.bool(False)
+Dimuon0_addTrackTrack_Jpsi.trOrMu = cms.int32(True)
 Dimuon0_addTrackTrack_Jpsi.enum = cms.int32(11)
 Dimuon0_addTrackTrack_Jpsi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_JpsiTrkTrk_Displaced_v*")
 #Dimuon0_addTrackTrack_Jpsi.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
@@ -530,13 +610,13 @@ DM2_Jpsi_addTrackTrack_Phi = hltBPHmonitoring.clone()
 DM2_Jpsi_addTrackTrack_Phi.FolderName = cms.string('HLT/BPH/DM2_Jpsi_addTrackTrack_Phi/')
 DM2_Jpsi_addTrackTrack_Phi.tnp = cms.bool(False)
 DM2_Jpsi_addTrackTrack_Phi.enum = cms.int32(11)
+DM2_Jpsi_addTrackTrack_Phi.Jpsi = cms.int32(1)
 DM2_Jpsi_addTrackTrack_Phi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu2_Jpsi_DoubleTrk1_Phi1p05_v*")
 #DM2_Jpsi_addTrackTrack_Phi.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
 DM2_Jpsi_addTrackTrack_Phi.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_NoVertexing_v*")
 #DM2_Jpsi_addTrackTrack_Phi.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
 #DM2_Jpsi_addTrackTrack_Phi.muoSelection = cms.string("pt>2 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
 DM2_Jpsi_addTrackTrack_Phi.muoSelection_ref = cms.string("pt>2 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DM2_Jpsi_addTrackTrack_Phi.DMSelection_ref = cms.string("M<3.3 & M>2.9")
 DM2_Jpsi_addTrackTrack_Phi.minprob = cms.double(0.1)
 DM2_Jpsi_addTrackTrack_Phi.mincos = cms.double(0.)
 DM2_Jpsi_addTrackTrack_Phi.minDS = cms.double(0.)
@@ -599,6 +679,13 @@ DimuonX_HLT_OS_Vtx.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Dimuon
 DimuonX_HLT_OS_Vtx.muoSelection_ref = cms.string('abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0')
 
 
+#hltBPHmonitoring.histoPSet.ptPSet = cms.PSet(
+#    edges = cms.vdouble(-0.5, 0, 2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 25, 30, 35, 40, 50, 70),
+#)
+#hltBPHmonitoring.histoPSet.dMu_ptPSet = cms.PSet(
+#    edges = cms.vdouble(-0.5, 0, 2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 25, 30, 35, 40, 50, 70),
+#)
+
 ###
 
 bphHLTmonitoring = cms.Sequence(
@@ -612,20 +699,18 @@ bphHLTmonitoring = cms.Sequence(
     + DMu4_3_Bs_dRcut
     + DMu4_3_Jpsi_dRcut
     + Dimuon14_Phi_dRcut
-    + DMu4_LowMassNonResonantTrk_Displaced_dRcut
-    + DMu4_JpsiTrk_Displaced_dRcut
-    + DMu4_PsiPrimeTrk_Displaced_dRcut
+#    + DMu4_LowMassNonResonantTrk_Displaced_dRcut
+#    + DMu4_JpsiTrk_Displaced_dRcut
+#    + DMu4_PsiPrimeTrk_Displaced_dRcut
     + Dimuon25_Jpsi_dRcut
     + Dimuon18_PsiPrime_dRcut
-    + Dimuon12_Upsilon_dRcut
     + Dimuon25_Jpsi_dRcut_low
-    + Dimuon18_Jpsi_dRcut_low
-    + DMu4_PsiPrimeTrk_Displaced_dRcut_low
-    + DMu4_JpsiTrk_Displaced_dRcut_low
-    + DMu4_LowMassNonResonantTrk_Displaced_dRcut_low
+    + Dimuon18_PsiPrime_dRcut_low
+#    + DMu4_PsiPrimeTrk_Displaced_dRcut_low
+#    + DMu4_JpsiTrk_Displaced_dRcut_low
+#    + DMu4_LowMassNonResonantTrk_Displaced_dRcut_low
     + Dimuon20_masscut1
     + Dimuon12_masscut2
-    + Dimuon0_Upsilon_masscut
     + Trimuon2_masscut4
     + Trimuon2_masscut5
     + Trimuon2_masscut6
@@ -647,7 +732,7 @@ bphHLTmonitoring = cms.Sequence(
     + DM2_Jpsi_addTkMuTkMu_Phi
     + Dimuon0_addTrackMu_Onia
     + Dimuon0_addTrackMu_Phi1
-   # + DimuonX_HLT_OS_Vtx
+    #+ DimuonX_HLT_OS_Vtx
 )
 
 

--- a/DQMOffline/Trigger/python/BPHMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BPHMonitor_cfi.py
@@ -8,21 +8,27 @@ hltBPHmonitoring = bphMonitoring.clone()
 #)
 hltBPHmonitoring.FolderName = cms.string('HLT/BPH/Dimuon_10_Jpsi_Barrel/')
 hltBPHmonitoring.tnp = cms.bool(True)
+hltBPHmonitoring.max_dR = cms.double(1.4)
 hltBPHmonitoring.minmass = cms.double(2.596)
 hltBPHmonitoring.maxmass = cms.double(3.596)
 hltBPHmonitoring.Upsilon = cms.int32(0)
 hltBPHmonitoring.Jpsi = cms.int32(0)
 hltBPHmonitoring.seagull = cms.int32(0)
+hltBPHmonitoring.ptCut = cms.int32(0)
+hltBPHmonitoring.displaced = cms.int32(0)
 hltBPHmonitoring.histoPSet.ptPSet = cms.PSet(
-    edges = cms.vdouble(-0.5, 0, 2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 25, 30, 35, 40, 50, 70),
+    edges = cms.vdouble(-0.5, 0, 2, 4, 8, 10, 12, 16, 20, 25, 30, 35, 40, 50),
+)
+hltBPHmonitoring.histoPSet.dMu_ptPSet = cms.PSet(
+    edges = cms.vdouble(6, 8, 12, 16,  20,  25, 30, 35, 40, 50, 70)
 )
 hltBPHmonitoring.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.int32 (  64  ),
+  nbins = cms.int32 (  8  ),
   xmin  = cms.double(   -3.2),
   xmax  = cms.double(3.2),
 )
 hltBPHmonitoring.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.int32 (  24  ),
+  nbins = cms.int32 (  12  ),
   xmin  = cms.double(   -2.4),
   xmax  = cms.double(2.4),
 )
@@ -38,37 +44,42 @@ hltBPHmonitoring.histoPSet.z0PSet = cms.PSet(
 )
 
 hltBPHmonitoring.histoPSet.dRPSet = cms.PSet(
-  nbins = cms.int32 (  20 ),
+  nbins = cms.int32 (  26 ),
   xmin  = cms.double(   0),
-  xmax  = cms.double(2.0),
+  xmax  = cms.double(1.3),
 )
 
 hltBPHmonitoring.histoPSet.massPSet = cms.PSet(
-  nbins = cms.int32 ( 30 ),
+  nbins = cms.int32 ( 140 ),
   xmin  = cms.double(  0),
-  xmax  = cms.double(30.0),
+  xmax  = cms.double(7.),
 )
+hltBPHmonitoring.histoPSet.BmassPSet = cms.PSet(
+  nbins = cms.int32 ( 20 ),
+  xmin  = cms.double(5.1),
+  xmax  = cms.double(5.5),
+)
+
 hltBPHmonitoring.histoPSet.dcaPSet = cms.PSet(
-  nbins = cms.int32 ( 40 ),
+  nbins = cms.int32 ( 10 ),
   xmin  = cms.double(  0),
-  xmax  = cms.double(2.),
+  xmax  = cms.double(0.5),
 )
 
 hltBPHmonitoring.histoPSet.dsPSet = cms.PSet(
-  nbins = cms.int32 ( 50),
+  nbins = cms.int32 ( 15),
   xmin  = cms.double(  0),
-  xmax  = cms.double( 50),
+  xmax  = cms.double( 60),
 )
 
 hltBPHmonitoring.histoPSet.cosPSet = cms.PSet(
-  nbins = cms.int32 ( 20),
-  xmin  = cms.double(  0.8),
+  nbins = cms.int32 ( 10),
+  xmin  = cms.double(  0.9),
   xmax  = cms.double(1),
 )
+
 hltBPHmonitoring.histoPSet.probPSet = cms.PSet(
-  nbins = cms.int32 ( 40),
-  xmin  = cms.double(  0),
-  xmax  = cms.double(1),
+    edges =cms.vdouble(0.01,0.02,0.04,0.06,0.08,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0)
 )
 
 hltBPHmonitoring.tracks       = cms.InputTag("generalTracks") # tracks??
@@ -107,4 +118,3 @@ hltBPHmonitoring.denGenericTriggerEventPSet.hltPaths  = cms.vstring( "HLT_Mu7p5_
 hltBPHmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
 hltBPHmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
 hltBPHmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-


### PR DESCRIPTION
In this pull-request many features of the offline DQM code used for BPH triggers have been fixed and optimised, and few more functionalities have been added.
Here a list of the major changes:

- **New general structure** of the code: for each efficiency type (defined as the "cases" in the big "switch") the numerator histos are filled in a nested environment just after the denominator filling, instead of defining two separate environments with specific selection criteria for each of them.
- **Fixed trigger matching** feature: the `bool BPHMonitor::matchToTrigger` function is now using the HLTConfigProvider method to access the trigger-object collections.
- **New correction for prescaled triggers**: while using the reference method to produce efficiencies, if the numerator path is prescaled it would flatly decrease the resulting efficiency by that prescale value. By filling the numerator histograms with weighted events, according to that prescale, the reduction effect is corrected.
- **Better tuning of the offline selections** (especially the dimuon invariant masses), to select the correct regions where to compute the efficiency. This helps in some modules to select a pure region for the signal, in other modules (based on background events) to select the appropriate kinematic region.
- **Customised and optimised binning**: to reduce the global number of bins, especially where they are not needed, the binning of the histograms has been refined
- **Removal of few meaningless efficiencies**: some modules defined in the list of the cff file (devoted to the L1 efficiency of dR(MuMu) cut in 2mu+trk triggers) have been removed, since their efficiency definition is not correct (using at denominator a 2mu trigger, they will always be biased by the inefficiency of the track reconstruction at HLT)