### PR TITLE
Revert "Run2-hcx180 Fix a bug for HcalDetId which affects DQM of calibration channels"

### DIFF
--- a/DataFormats/HcalDetId/src/HcalDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalDetId.cc
@@ -8,18 +8,7 @@ const HcalDetId HcalDetId::Undefined(HcalEmpty,0,0,0);
 HcalDetId::HcalDetId() : DetId() {
 }
 
-HcalDetId::HcalDetId(uint32_t rawid) {
-  if ((DetId::Detector(rawid>>DetId::kDetOffset)&0xF) != Hcal) {
-    id_ = rawid;
-  } else  {
-    HcalSubdetector subdet = (HcalSubdetector)((rawid>>DetId::kSubdetOffset)&0x7);
-    if ((subdet==HcalBarrel) || (subdet==HcalEndcap) ||
-	(subdet==HcalOuter) || (subdet==HcalForward)) {
-      id_ = newForm(rawid);
-    } else {
-      id_ = rawid;
-    }
-  }
+HcalDetId::HcalDetId(uint32_t rawid) : DetId(newForm(rawid)) {
 }
 
 HcalDetId::HcalDetId(HcalSubdetector subdet, int tower_ieta, int tower_iphi, int depth) : DetId(Hcal,subdet) {
@@ -38,12 +27,7 @@ HcalDetId::HcalDetId(const DetId& gen) {
 	 subdet!=HcalTriggerTower && subdet!=HcalOther)) {
       throw cms::Exception("Invalid DetId") << "Cannot initialize HcalDetId from " << std::hex << gen.rawId() << std::dec; 
     }  
-    if ((subdet==HcalBarrel) || (subdet==HcalEndcap) ||
-	(subdet==HcalOuter) || (subdet==HcalForward)) {
-      id_ = newForm(gen.rawId());
-    } else {
-      id_ = gen.rawId();
-    }
+    id_ = newForm(gen.rawId());
   } else {
     id_ = gen.rawId();
   }
@@ -58,12 +42,7 @@ HcalDetId& HcalDetId::operator=(const DetId& gen) {
 	 subdet!=HcalTriggerTower && subdet!=HcalOther)) {
       throw cms::Exception("Invalid DetId") << "Cannot assign HcalDetId from " << std::hex << gen.rawId() << std::dec; 
     }
-    if ((subdet==HcalBarrel) || (subdet==HcalEndcap) ||
-	(subdet==HcalOuter) || (subdet==HcalForward)) {
-      id_ = newForm(gen.rawId());
-    } else {
-      id_ = gen.rawId();
-    }
+    id_ = newForm(gen.rawId());
   } else {
     id_ = gen.rawId();
   }
@@ -257,7 +236,7 @@ std::ostream& operator<<(std::ostream& s,const HcalDetId& id) {
   case(HcalForward) : return s << "(HF " << id.ieta() << ',' << id.iphi() << ',' << id.depth() << ')';
   case(HcalOuter) : return s << "(HO " << id.ieta() << ',' << id.iphi() << ')';
   case(HcalTriggerTower) : return s << "(HT " << id.ieta() << ',' << id.iphi() << ')';
-  default : return s << std::hex << id.rawId() << std::dec;
+  default : return s << id.rawId();
   }
 }
 


### PR DESCRIPTION
Reverts cms-sw/cmssw#23688

This fix is causing a list of reproducible crashes in the IB CMSSW_9_4_X_2018-07-03-2300 in 2016 workflows within DQM with the exception

----- Begin Fatal Exception 04-Jul-2018 10:09:31 CEST-----------------------
An exception of category 'Conditions not found' occurred while
   [0] Processing  Event run: 283877 lumi: 17 event: 27631378 stream: 1
   [1] Running path 'dqmoffline_step'
   [2] Calling method for module DigiTask/'digiTask'
Exception Message:
Unavailable Conditions of type HcalQIEData for cell (0x4e280440) (CastorRadFacility 1 / 2 / 0)
----- End Fatal Exception -------------------------------------------------

triggered from

https://cmssdt.cern.ch/lxr/source/CondFormats/CastorObjects/interface/CastorCondObjectContainer.h#0090

as used in the module https://cmssdt.cern.ch/lxr/source/DQM/HcalTasks/python/DigiTask.py for what I can see. 

I temporarily revert it, pending a clarification and a fix for this problem.
