### PR TITLE
Changed category not defined error to warning in ElectronMVA

### DIFF
--- a/RecoEgamma/EgammaTools/src/GBRForestTools.cc
+++ b/RecoEgamma/EgammaTools/src/GBRForestTools.cc
@@ -62,7 +62,9 @@ std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const edm::File
       tmpstr = "";
   } else if (reco::details::hasEnding(weightFile.fullPath(), ".gz") || reco::details::hasEnding(weightFile.fullPath(), ".gzip")) {
       gzipped = true;
-      tmpstr = std::string(reco::details::readGzipFile(weightFile.fullPath()));
+      char *buffer = reco::details::readGzipFile(weightFile.fullPath());
+      tmpstr = std::string(buffer);
+      free(buffer);
   }
   std::stringstream is(tmpstr);
 

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2.cc
@@ -105,7 +105,7 @@ mvaValue( const edm::Ptr<reco::Candidate>& candPtr, const edm::EventBase & iEven
 
   const int iCategory = findCategory( candPtr );
 
-  if (iCategory < 0) return 0;
+  if (iCategory < 0) return -999;
 
   std::vector<float> vars;
 

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2.cc
@@ -104,6 +104,9 @@ float ElectronMVAEstimatorRun2::
 mvaValue( const edm::Ptr<reco::Candidate>& candPtr, const edm::EventBase & iEvent) const {
 
   const int iCategory = findCategory( candPtr );
+
+  if (iCategory < 0) return 0;
+
   std::vector<float> vars;
 
   const edm::Ptr<reco::GsfElectron> gsfPtr{ candPtr };
@@ -148,7 +151,10 @@ int ElectronMVAEstimatorRun2::findCategory( const edm::Ptr<reco::Candidate>& can
       if (categoryFunctions_[i](*gsfEle)) return i;
   }
 
-  throw cms::Exception("MVA failure: ")
-    << " category not defined for particle in " << name_ << tag_ << std::endl;
+  edm::LogWarning  ("MVA warning") <<
+      "category not defined for particle with pt " << gsfEle->pt() << " GeV, eta " <<
+          gsfEle->superCluster()->eta() << " in " << name_ << tag_;
+
+  return -1;
 
 }


### PR DESCRIPTION
Hello, unfortunately it's me again.

There were again some errors in the most recent IB due to the new electron MVA, related to the new category check I introduced [1]. I was unable to reproduce these errors locally so far*, but we can see that this problem affects not all electrons in the workflow. It crashes after a few 100 events.

By testing 1329.1 locally (which succeeded locally and failed in the IB), I observed that there were some electrons below 5 GeV in the crashing event, for which the MVA value gets computed. This is not foreseen by egamma, and if the category errors are exclusively on these very low pt electrons, everything is fine.

Hence I propose the following fix: let's change the _category not defined error_ to a warning that spits out pt and eta and just return -999 for the MVA if the category is not defined. We can check later in the logs if any electron in the kinematic region that the ID is designed for (pt > 5 GeV, |eta| < 2.5) failed, keeping an eye on the previously failing workflows which were:

1325.6
1325.8
1329.1
16.0 
134.903
136.777
136.797
10001.0

All due to the _category not defined_ error. The last one was actually a workflow that cms-bot successfully tested here at the end: https://github.com/cms-sw/cmssw/pull/23700. 

[1] https://github.com/cms-sw/cmssw/blob/master/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2.cc#L151

\* 1325.6 1325.8 and 16.0 gave me DAS errors, 1329.1 succeeded and for the others I didn't have time so far. Working on it.