### PR TITLE
EMTF emulate directly from unpacked CPPF digis

### DIFF
--- a/DataFormats/L1TMuon/interface/EMTFHit.h
+++ b/DataFormats/L1TMuon/interface/EMTFHit.h
@@ -16,6 +16,7 @@
 #include "DataFormats/RPCDigi/interface/RPCDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/L1TMuon/interface/EMTF/ME.h"
 
 namespace l1t {
@@ -44,12 +45,14 @@ namespace l1t {
     CSCDetId CreateCSCDetId() const;
     // void ImportRPCDetId (const RPCDetId& _detId);
     // void ImportGEMDetId (const GEMDetId& _detId);
-    // RPCDetId CreateRPCDetId() const;
+    RPCDetId CreateRPCDetId() const;
     // GEMDetId CreateGEMDetId() const;
     // void ImportCSCCorrelatedLCTDigi (const CSCCorrelatedLCTDigi& _digi);
     CSCCorrelatedLCTDigi CreateCSCCorrelatedLCTDigi() const;
     // void ImportRPCDigi (const RPCDigi& _digi);
     // RPCDigi CreateRPCDigi() const;
+    // void ImportCPPFDigi (const CPPFDigi& _digi);
+    CPPFDigi CreateCPPFDigi() const;
     // void ImportGEMPadDigi (const GEMPadDigi& _digi);
     // GEMPadDigi CreateGEMPadDigi() const;
 
@@ -61,6 +64,7 @@ namespace l1t {
     //void SetGEMDetId   (const GEMDetId& id)                 { gem_DetId         = id;        }
     //void SetCSCLCTDigi (const CSCCorrelatedLCTDigi& digi)   { csc_LCTDigi       = digi;      }
     //void SetRPCDigi    (const RPCDigi& digi)                { rpc_Digi          = digi;      }
+    //void SetCPPFDigi   (const CPPFDigi& digi)               { cppf_Digi         = digi;      }
     //void SetGEMPadDigi (const GEMPadDigi& digi)             { gem_PadDigi       = digi;      }
     void SetCSCDetId   (const CSCDetId& id)                 { rawDetId = id.rawId(); }
     void SetRPCDetId   (const RPCDetId& id)                 { rawDetId = id.rawId(); }
@@ -72,6 +76,7 @@ namespace l1t {
     //GEMDetId GEM_DetId                          () const { return gem_DetId;    }
     //CSCCorrelatedLCTDigi CSC_LCTDigi            () const { return csc_LCTDigi;  }
     //RPCDigi RPC_Digi                            () const { return rpc_Digi;     }
+    //CPPFDigi CPPF_Digi                          () const { return cppf_Digi;    }
     //GEMPadDigi GEM_PadDigi                      () const { return gem_PadDigi;  }
     CSCDetId CSC_DetId                          () const { return CSCDetId(rawDetId); }
     RPCDetId RPC_DetId                          () const { return RPCDetId(rawDetId); }
@@ -202,6 +207,7 @@ namespace l1t {
     //GEMDetId gem_DetId;
     //CSCCorrelatedLCTDigi csc_LCTDigi;
     //RPCDigi rpc_Digi;
+    //CPPFDigi cppf_Digi;
     //GEMPadDigi gem_PadDigi;
 
     uint32_t rawDetId;  // raw CMSSW DetId

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -15,17 +15,17 @@ namespace l1t {
     int theta_ = theta_fp/4;
     if (roll < 1 || roll > 3) {
       switch (station * 2 + ring) { // Infer roll from integer theta value, by station / ring
-      case  4: roll_ = ( theta_ < 17 ? 1 : (theta_ > 18 ? 3 : 2) ); break; // RE1/2
-      case  6: roll_ = ( theta_ < 16 ? 1 : (theta_ > 17 ? 3 : 2) ); break; // RE2/2
-      case  8: roll_ = ( theta_ < 12 ? 1 : (theta_ > 13 ? 3 : 2) ); break; // RE3/2
-      case  9: roll_ = ( theta_ < 20 ? 1 : (theta_ > 21 ? 3 : 2) ); break; // RE3/3
-      case 10: roll_ = ( theta_ < 11 ? 1 : (theta_ > 11 ? 3 : 2) ); break; // RE4/2
-      case 11: roll_ = ( theta_ < 18 ? 1 : (theta_ > 19 ? 3 : 2) ); break; // RE4/3
+      case  4: roll_ = ( theta_ < 17 ? 3 : (theta_ > 18 ? 1 : 2) ); break; // RE1/2
+      case  6: roll_ = ( theta_ < 16 ? 3 : (theta_ > 17 ? 1 : 2) ); break; // RE2/2
+      case  8: roll_ = ( theta_ < 12 ? 3 : (theta_ > 13 ? 1 : 2) ); break; // RE3/2
+      case  9: roll_ = ( theta_ < 20 ? 3 : (theta_ > 21 ? 1 : 2) ); break; // RE3/3
+      case 10: roll_ = ( theta_ < 11 ? 3 : (theta_ > 11 ? 1 : 2) ); break; // RE4/2
+      case 11: roll_ = ( theta_ < 18 ? 3 : (theta_ > 19 ? 1 : 2) ); break; // RE4/3
       default: roll_ = 2; // Default to 2 if no valid value found
       }
     }
 
-    return RPCDetId( endcap, ring, station, sector, 1, subsector, roll_ );
+    return RPCDetId( endcap, ring, station, sector_RPC, 1, subsector_RPC, roll_ );
     // Layer always filled as 1, as layer 2 is only used in the barrel
   }
 
@@ -35,11 +35,12 @@ namespace l1t {
 
     int board_   = 1 + ((chamber % 36) / 9);  // RPC chamber to CPPF board mapping
     int channel_ = (chamber % 9);             // RPC chamber to CPPF output link mapping
+    int sector_  = (sector_idx + 1) - 6 * (endcap == -1);
     int link_    = ( neighbor ? 0 : 1 + ( ((chamber + 33) % 36) % 6) );  // RPC chamber to EMTF input link mapping
     int nStrips_ = ( strip_low < 0 ? -99 : 1 + strip_hi - strip_low);    // Cluster size in number of strips
 
     return CPPFDigi( RPC_DetId(), bx, phi_fp/4, theta_fp/4, valid, board_, channel_,
-		     sector, link_, strip_low, nStrips_, phi_glob, theta );
+		     sector_, link_, strip_low, nStrips_, phi_glob, theta );
   }
 
   CSCCorrelatedLCTDigi EMTFHit::CreateCSCCorrelatedLCTDigi() const {

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -10,10 +10,37 @@ namespace l1t {
     // See http://cmslxr.fnal.gov/source/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc#0198
   }
 
-  // // Not yet implemented - AWB 15.03.17
-  // RPCDetId EMTFHit::CreateRPCDetId() const {
-  //   return RPCDetId( endcap, ring, station, sector, rpc_layer, subsector, roll );
-  // }
+  RPCDetId EMTFHit::CreateRPCDetId() const {
+    int roll_  = roll;
+    int theta_ = theta_fp/4;
+    if (roll < 1 || roll > 3) {
+      switch (station * 2 + ring) { // Infer roll from integer theta value, by station / ring
+      case  4: roll_ = ( theta_ < 17 ? 1 : (theta_ > 18 ? 3 : 2) ); break; // RE1/2
+      case  6: roll_ = ( theta_ < 16 ? 1 : (theta_ > 17 ? 3 : 2) ); break; // RE2/2
+      case  8: roll_ = ( theta_ < 12 ? 1 : (theta_ > 13 ? 3 : 2) ); break; // RE3/2
+      case  9: roll_ = ( theta_ < 20 ? 1 : (theta_ > 21 ? 3 : 2) ); break; // RE3/3
+      case 10: roll_ = ( theta_ < 11 ? 1 : (theta_ > 11 ? 3 : 2) ); break; // RE4/2
+      case 11: roll_ = ( theta_ < 18 ? 1 : (theta_ > 19 ? 3 : 2) ); break; // RE4/3
+      default: roll_ = 2; // Default to 2 if no valid value found
+      }
+    }
+
+    return RPCDetId( endcap, ring, station, sector, 1, subsector, roll_ );
+    // Layer always filled as 1, as layer 2 is only used in the barrel
+  }
+
+  CPPFDigi EMTFHit::CreateCPPFDigi() const {
+
+    if (is_RPC != 1) return CPPFDigi();
+
+    int board_   = 1 + ((chamber % 36) / 9);  // RPC chamber to CPPF board mapping
+    int channel_ = (chamber % 9);             // RPC chamber to CPPF output link mapping
+    int link_    = ( neighbor ? 0 : 1 + ( ((chamber + 33) % 36) % 6) );  // RPC chamber to EMTF input link mapping
+    int nStrips_ = ( strip_low < 0 ? -99 : 1 + strip_hi - strip_low);    // Cluster size in number of strips
+
+    return CPPFDigi( RPC_DetId(), bx, phi_fp/4, theta_fp/4, valid, board_, channel_,
+		     sector, link_, strip_low, nStrips_, phi_glob, theta );
+  }
 
   CSCCorrelatedLCTDigi EMTFHit::CreateCSCCorrelatedLCTDigi() const {
     return CSCCorrelatedLCTDigi( 1, valid, quality, wire, strip,

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -123,7 +123,8 @@ namespace l1t {
         res_hit = static_cast<EMTFCollections*>(coll)->getEMTFHits();
         EMTFHit Hit_;
 
-	// Also unpack into RPC digis? - AWB 15.03.17
+        CPPFDigiCollection* res_CPPF;
+        res_CPPF = static_cast<EMTFCollections*>(coll)->getEMTFCPPFs();
 
 	////////////////////////////
 	// Unpack the RPC Data Record
@@ -195,6 +196,8 @@ namespace l1t {
 
 	(res->at(iOut)).push_RPC(RPC_);
 	res_hit->push_back(Hit_);
+
+	res_CPPF->push_back( Hit_.CreateCPPFDigi() );
 	
 	// Finished with unpacking one RPC Data Record
 	return true;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -170,8 +170,8 @@ namespace l1t {
 	// Each chamber can send up to 2 stubs per BX
 	// Also count stubs in corresponding CSC chamber; RPC hit counting is on top of LCT counting
 	Hit_.set_stub_num(0);
-	// // See if matching hit is already in event record (from neighboring sector) 
-	// bool duplicate_hit_exists = false;
+	// See if matching hit is already in event record
+	bool exact_duplicate = false;
 	for (auto const & iHit : *res_hit) {
 	  
 	  if ( Hit_.BX()      == iHit.BX()      && 
@@ -180,24 +180,32 @@ namespace l1t {
 	       Hit_.Chamber() == iHit.Chamber() ) {
 
 	    if ( (iHit.Is_CSC() == 1 && iHit.Ring() == 2) ||
-		 (iHit.Is_RPC() == 1) ) { // RPC rings 2 and 3 both map to CSC ring 2 
-
+		 (iHit.Is_RPC() == 1) ) { // RPC rings 2 and 3 both map to CSC ring 2
 	      if ( Hit_.Neighbor() == iHit.Neighbor() ) {
 		Hit_.set_stub_num( Hit_.Stub_num() + 1);
-	      } // else if ( iHit.Is_RPC()   == 1               &&
-	      	// 	  iHit.Ring()     == Hit_.Ring()     &&
-	      	// 	  iHit.Theta_fp() == Hit_.Theta_fp() &&
-	      	// 	  iHit.Phi_fp()   == Hit_.Phi_fp()   ) {
-	      	// duplicate_hit_exists = true;
-	      // }
+		if ( iHit.Is_RPC() == 1                 &&
+		     iHit.Ring()     == Hit_.Ring()     &&
+		     iHit.Theta_fp() == Hit_.Theta_fp() &&
+		     iHit.Phi_fp()   == Hit_.Phi_fp()   ) {
+		  exact_duplicate = true;
+		}
+	      }
 	    }
 	  }
 	} // End loop: for (auto const & iHit : *res_hit)
 
-	(res->at(iOut)).push_RPC(RPC_);
-	res_hit->push_back(Hit_);
+        if (exact_duplicate) edm::LogWarning("L1T|EMTF") << "EMTF unpacked duplicate CPPF digis: BX " << Hit_.BX()
+                                                         << ", endcap " << Hit_.Endcap() << ", station " << Hit_.Station()
+                                                         << ", sector " << Hit_.Sector() << ", neighbor " << Hit_.Neighbor()
+                                                         << ", ring " << Hit_.Ring() << ", chamber " << Hit_.Chamber()
+                                                         << ", theta " << Hit_.Theta_fp() / 4 << ", phi " << Hit_.Phi_fp() / 4 << std::endl;
 
-	res_CPPF->push_back( Hit_.CreateCPPFDigi() );
+
+	(res->at(iOut)).push_RPC(RPC_);
+	if (!exact_duplicate)
+	  res_hit->push_back(Hit_);
+	if (!exact_duplicate)
+	  res_CPPF->push_back( Hit_.CreateCPPFDigi() );
 	
 	// Finished with unpacking one RPC Data Record
 	return true;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
@@ -10,12 +10,33 @@ namespace l1t {
       // Sort by processor to match uGMT unpacked order
       L1TMuonEndCap::sort_uGMT_muons(*regionalMuonCands_);
 
+      // Apply ZeroSuppression: Only save RPC hits if there is at least one CSC LCT in the sector
+      bool has_LCT[12] = {false};
+      for (int iSect = 0; iSect < 12; iSect++) {
+	for (const auto& h : *EMTFHits_) {
+	  if (h.Is_CSC() && h.Sector_idx() == iSect) {
+	    has_LCT[iSect] = true; break;
+	  }
+	}
+      }
+      for (const auto& h : *EMTFHits_) {
+	if (has_LCT[h.Sector_idx()] || h.Is_RPC() == 0) {
+	  EMTFHits_ZS_->push_back( h );
+	}
+      }
+      for (const auto& c : *EMTFCPPFs_) {
+	int sect_idx = c.emtf_sector() - 1 + 6 * (c.rpcId().region() == -1);
+	if (has_LCT[sect_idx]) {
+	  EMTFCPPFs_ZS_->push_back( c );
+	}
+      }
+
       event_.put(std::move(regionalMuonCands_));
       event_.put(std::move(EMTFDaqOuts_));
-      event_.put(std::move(EMTFHits_));
+      event_.put(std::move(EMTFHits_ZS_));
       event_.put(std::move(EMTFTracks_));
       event_.put(std::move(EMTFLCTs_));
-      event_.put(std::move(EMTFCPPFs_));
+      event_.put(std::move(EMTFCPPFs_ZS_));
     }
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
@@ -15,6 +15,7 @@ namespace l1t {
       event_.put(std::move(EMTFHits_));
       event_.put(std::move(EMTFTracks_));
       event_.put(std::move(EMTFLCTs_));
+      event_.put(std::move(EMTFCPPFs_));
     }
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
@@ -9,6 +9,7 @@
 #include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 
 #include "EventFilter/L1TRawToDigi/interface/UnpackerCollections.h"
@@ -27,25 +28,28 @@ namespace l1t {
 	EMTFDaqOuts_(new EMTFDaqOutCollection()),
 	EMTFHits_(new EMTFHitCollection()),
 	EMTFTracks_(new EMTFTrackCollection()),
-	EMTFLCTs_(new CSCCorrelatedLCTDigiCollection())
+	EMTFLCTs_(new CSCCorrelatedLCTDigiCollection()),
+	EMTFCPPFs_(new CPPFDigiCollection())
 	  {};
       
       ~EMTFCollections() override;
       
       inline RegionalMuonCandBxCollection* getRegionalMuonCands() { return regionalMuonCands_.get(); }
       // How does this work?  I haven't even defined a "get()" function for the EMTFDaqOutCollection. - AWB 28.01.16
-      inline EMTFDaqOutCollection* getEMTFDaqOuts() { return EMTFDaqOuts_.get(); }
-      inline EMTFHitCollection*    getEMTFHits()    { return EMTFHits_.get();    }       
-      inline EMTFTrackCollection*  getEMTFTracks()  { return EMTFTracks_.get();  }       
-      inline CSCCorrelatedLCTDigiCollection* getEMTFLCTs() { return EMTFLCTs_.get(); }
+      inline EMTFDaqOutCollection*           getEMTFDaqOuts() { return EMTFDaqOuts_.get(); }
+      inline EMTFHitCollection*              getEMTFHits()    { return EMTFHits_.get();    }
+      inline EMTFTrackCollection*            getEMTFTracks()  { return EMTFTracks_.get();  }
+      inline CSCCorrelatedLCTDigiCollection* getEMTFLCTs()    { return EMTFLCTs_.get();    }
+      inline CPPFDigiCollection*             getEMTFCPPFs()   { return EMTFCPPFs_.get();   }
       
     private:
       
-      std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCands_;
-      std::unique_ptr<EMTFDaqOutCollection>         EMTFDaqOuts_;
-      std::unique_ptr<EMTFHitCollection>            EMTFHits_;
-      std::unique_ptr<EMTFTrackCollection>          EMTFTracks_;
+      std::unique_ptr<RegionalMuonCandBxCollection>   regionalMuonCands_;
+      std::unique_ptr<EMTFDaqOutCollection>           EMTFDaqOuts_;
+      std::unique_ptr<EMTFHitCollection>              EMTFHits_;
+      std::unique_ptr<EMTFTrackCollection>            EMTFTracks_;
       std::unique_ptr<CSCCorrelatedLCTDigiCollection> EMTFLCTs_;
+      std::unique_ptr<CPPFDigiCollection>             EMTFCPPFs_;
       
     };
   }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
@@ -27,29 +27,35 @@ namespace l1t {
 	regionalMuonCands_(new RegionalMuonCandBxCollection()),
 	EMTFDaqOuts_(new EMTFDaqOutCollection()),
 	EMTFHits_(new EMTFHitCollection()),
+	EMTFHits_ZS_(new EMTFHitCollection()),
 	EMTFTracks_(new EMTFTrackCollection()),
 	EMTFLCTs_(new CSCCorrelatedLCTDigiCollection()),
-	EMTFCPPFs_(new CPPFDigiCollection())
+	EMTFCPPFs_(new CPPFDigiCollection()),
+	EMTFCPPFs_ZS_(new CPPFDigiCollection())
 	  {};
       
       ~EMTFCollections() override;
       
       inline RegionalMuonCandBxCollection* getRegionalMuonCands() { return regionalMuonCands_.get(); }
       // How does this work?  I haven't even defined a "get()" function for the EMTFDaqOutCollection. - AWB 28.01.16
-      inline EMTFDaqOutCollection*           getEMTFDaqOuts() { return EMTFDaqOuts_.get(); }
-      inline EMTFHitCollection*              getEMTFHits()    { return EMTFHits_.get();    }
-      inline EMTFTrackCollection*            getEMTFTracks()  { return EMTFTracks_.get();  }
-      inline CSCCorrelatedLCTDigiCollection* getEMTFLCTs()    { return EMTFLCTs_.get();    }
-      inline CPPFDigiCollection*             getEMTFCPPFs()   { return EMTFCPPFs_.get();   }
+      inline EMTFDaqOutCollection*           getEMTFDaqOuts()  { return EMTFDaqOuts_.get();  }
+      inline EMTFHitCollection*              getEMTFHits()     { return EMTFHits_.get();     }
+      inline EMTFHitCollection*              getEMTFHits_ZS()  { return EMTFHits_ZS_.get();  }
+      inline EMTFTrackCollection*            getEMTFTracks()   { return EMTFTracks_.get();   }
+      inline CSCCorrelatedLCTDigiCollection* getEMTFLCTs()     { return EMTFLCTs_.get();     }
+      inline CPPFDigiCollection*             getEMTFCPPFs()    { return EMTFCPPFs_.get();    }
+      inline CPPFDigiCollection*             getEMTFCPPFs_ZS() { return EMTFCPPFs_ZS_.get(); }
       
     private:
       
       std::unique_ptr<RegionalMuonCandBxCollection>   regionalMuonCands_;
       std::unique_ptr<EMTFDaqOutCollection>           EMTFDaqOuts_;
       std::unique_ptr<EMTFHitCollection>              EMTFHits_;
+      std::unique_ptr<EMTFHitCollection>              EMTFHits_ZS_;
       std::unique_ptr<EMTFTrackCollection>            EMTFTracks_;
       std::unique_ptr<CSCCorrelatedLCTDigiCollection> EMTFLCTs_;
       std::unique_ptr<CPPFDigiCollection>             EMTFCPPFs_;
+      std::unique_ptr<CPPFDigiCollection>             EMTFCPPFs_ZS_;
       
     };
   }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
@@ -48,6 +48,7 @@ namespace l1t {
          prod.produces<EMTFHitCollection>();
          prod.produces<EMTFTrackCollection>();
          prod.produces<CSCCorrelatedLCTDigiCollection>();
+         prod.produces<CPPFDigiCollection>();
       }
 
       std::unique_ptr<UnpackerCollections>

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
@@ -12,10 +12,11 @@ namespace l1t {
       auto tag = cfg.getParameter<edm::InputTag>("InputLabel");
 
       regionalMuonCandToken_ = cc.consumes<RegionalMuonCandBxCollection>(tag);
-      EMTFDaqOutToken_ = cc.consumes<EMTFDaqOutCollection>(tag);
-      EMTFHitToken_ = cc.consumes<EMTFHitCollection>(tag);
-      EMTFTrackToken_ = cc.consumes<EMTFTrackCollection>(tag);
-      EMTFLCTToken_ = cc.consumes<CSCCorrelatedLCTDigiCollection>(tag);   
+      EMTFDaqOutToken_       = cc.consumes<EMTFDaqOutCollection>(tag);
+      EMTFHitToken_          = cc.consumes<EMTFHitCollection>(tag);
+      EMTFTrackToken_        = cc.consumes<EMTFTrackCollection>(tag);
+      EMTFLCTToken_          = cc.consumes<CSCCorrelatedLCTDigiCollection>(tag);
+      EMTFCPPFToken_         = cc.consumes<CPPFDigiCollection>(tag);
     }
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
@@ -5,6 +5,7 @@
 #include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "EventFilter/L1TRawToDigi/interface/PackerTokens.h"
@@ -20,6 +21,7 @@ namespace l1t {
       inline const edm::EDGetTokenT<EMTFHitCollection>& getEMTFHitToken() const { return EMTFHitToken_; }
       inline const edm::EDGetTokenT<EMTFTrackCollection>& getEMTFTrackToken() const { return EMTFTrackToken_; }
       inline const edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection>& getEMTFLCTToken() const { return EMTFLCTToken_; }
+      inline const edm::EDGetTokenT<CPPFDigiCollection>& getEMTFCPPFToken() const { return EMTFCPPFToken_; }
       
     private:
       
@@ -28,6 +30,7 @@ namespace l1t {
       edm::EDGetTokenT<EMTFHitCollection> EMTFHitToken_;
       edm::EDGetTokenT<EMTFTrackCollection> EMTFTrackToken_;
       edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> EMTFLCTToken_;
+      edm::EDGetTokenT<CPPFDigiCollection> EMTFCPPFToken_;
       
     };
   }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
@@ -61,7 +61,7 @@ namespace l1t {
 
 	// Convert integer values to degrees
         _hit.set_phi_loc  ( L1TMuonEndCap::calc_phi_loc_deg        ( _hit.Phi_fp() ) );
-        _hit.set_phi_glob ( L1TMuonEndCap::calc_phi_glob_deg       ( _hit.Phi_loc(), _hit.Sector() ) );
+        _hit.set_phi_glob ( L1TMuonEndCap::calc_phi_glob_deg       ( _hit.Phi_loc(), _evt_sector ) );
         _hit.set_theta    ( L1TMuonEndCap::calc_theta_deg_from_int ( _hit.Theta_fp() ) );
         _hit.set_eta      ( L1TMuonEndCap::calc_eta_from_theta_deg ( _hit.Theta(), _hit.Endcap() ) );
 	

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
@@ -55,8 +55,8 @@ namespace l1t {
 	_hit.set_is_RPC    ( true  );
 	_hit.set_subsystem ( 2 );
 	
+        _hit.SetRPCDetId ( _hit.CreateRPCDetId() );
         // // Not yet implemented - AWB 15.03.17
-        // _hit.SetRPCDetId ( _hit.CreateRPCDetId() );
         // _hit.SetRPCDigi  ( _hit.CreateRPCDigi() );
 
 	// Convert integer values to degrees

--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
@@ -39,6 +39,11 @@ class CSCDetId;
 class RPCDigi;
 class RPCDetId;
 
+// CPPF digi types
+namespace l1t {
+  class CPPFDigi;
+}
+
 // GEM digi types
 class GEMPadDigi;
 class GEMDetId;
@@ -60,14 +65,19 @@ namespace L1TMuon {
     // within a subsystem
     // for RPCs you have to unroll the digi-link and raw det-id
     struct RPCData {
-      RPCData() : strip(0), strip_low(0), strip_hi(0), layer(0), bx(0), valid(0), time(0.) {}
+      RPCData() : strip(0), strip_low(0), strip_hi(0), phi_int(0), theta_int(0),
+	          emtf_sector(0), layer(0), bx(0), valid(0), time(0.), isCPPF(false) {}
       uint16_t strip;
-      uint16_t strip_low; // for use in clustering
-      uint16_t strip_hi;  // for use in clustering
+      uint16_t strip_low;   // for use in clustering
+      uint16_t strip_hi;    // for use in clustering
+      uint16_t phi_int;     // for CPPFDigis in EMTF
+      uint16_t theta_int;   // for CPPFDigis in EMTF
+      uint16_t emtf_sector; // for CPPFDigis in EMTF
       uint16_t layer;
-      int16_t bx;
+      int16_t  bx;
       uint16_t valid;
-      double time;  // why double?
+      double   time;  // why double?
+      bool     isCPPF;
     };
 
     struct CSCData {
@@ -153,6 +163,8 @@ namespace L1TMuon {
                      const unsigned strip,
                      const unsigned layer,
                      const int bx);
+    TriggerPrimitive(const RPCDetId& detid,  // constructor from CPPFDigi
+                     const l1t::CPPFDigi& digi);
 
     // GEM
     TriggerPrimitive(const GEMDetId& detid,

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -5,6 +5,7 @@
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhDigi.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThDigi.h"
 #include "DataFormats/RPCDigi/interface/RPCDigi.h"
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
 
@@ -155,6 +156,23 @@ TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid,
   _rpc.time = -999999.;
 }
 
+// constructor from CPPF data
+TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid,
+				   const l1t::CPPFDigi& digi):
+  _id(detid),
+  _subsystem(TriggerPrimitive::kRPC) {
+  calculateGlobalSector(detid,_globalsector,_subsector);
+  _rpc.strip       = ( digi.first_strip() < 0 ? 0 : digi.first_strip() + (digi.cluster_size() / 2) );
+  _rpc.strip_low   = ( digi.first_strip() < 0 ? 0 : digi.first_strip() );
+  _rpc.strip_hi    = ( digi.first_strip() < 0 ? 0 : digi.first_strip() + digi.cluster_size() - 1 );
+  _rpc.phi_int     = digi.phi_int();
+  _rpc.theta_int   = digi.theta_int();
+  _rpc.emtf_sector = digi.emtf_sector();
+  _rpc.layer       = detid.layer();
+  _rpc.bx          = digi.bx();
+  _rpc.valid       = digi.valid();
+  _rpc.isCPPF      = true;
+}
 
 // constructor from GEM data
 TriggerPrimitive::TriggerPrimitive(const GEMDetId& detid,
@@ -243,10 +261,14 @@ bool TriggerPrimitive::operator==(const TriggerPrimitive& tp) const {
            this->_rpc.strip == tp._rpc.strip &&
            this->_rpc.strip_low == tp._rpc.strip_low &&
            this->_rpc.strip_hi == tp._rpc.strip_hi &&
+           this->_rpc.phi_int == tp._rpc.phi_int &&
+           this->_rpc.theta_int == tp._rpc.theta_int &&
+           this->_rpc.emtf_sector == tp._rpc.emtf_sector &&
            this->_rpc.layer == tp._rpc.layer &&
            this->_rpc.bx == tp._rpc.bx &&
            this->_rpc.valid == tp._rpc.valid &&
            //this->_rpc.time == tp._rpc.time &&
+           this->_rpc.isCPPF == tp._rpc.isCPPF &&
            this->_gem.pad == tp._gem.pad &&
            this->_gem.pad_low == tp._gem.pad_low &&
            this->_gem.pad_hi == tp._gem.pad_hi &&
@@ -371,10 +393,14 @@ void TriggerPrimitive::print(std::ostream& out) const {
     out << "Strip         : " << _rpc.strip << std::endl;
     out << "Strip Low     : " << _rpc.strip_low << std::endl;
     out << "Strip High    : " << _rpc.strip_hi << std::endl;
+    out << "Integer phi   : " << _rpc.phi_int << std::endl;
+    out << "Integer theta : " << _rpc.theta_int << std::endl;
+    out << "EMTF sector   : " << _rpc.emtf_sector << std::endl;
     out << "Layer         : " << _rpc.layer << std::endl;
     out << "Valid         : " << _rpc.valid << std::endl;
     out << "Time          : " << _rpc.time << std::endl;
-    break;
+    out << "IsCPPF        : " << _rpc.isCPPF << std::endl;
+   break;
   case kGEM:
     if (!_gem.isME0)
       out << detId<GEMDetId>() << std::endl;

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -134,6 +134,9 @@ TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid,
   _rpc.strip = digi.strip();
   _rpc.strip_low = digi.strip();
   _rpc.strip_hi = digi.strip();
+  _rpc.phi_int = 0;
+  _rpc.theta_int = 0;
+  _rpc.emtf_sector = 0;
   _rpc.layer = detid.layer();
   _rpc.bx = digi.bx();
   _rpc.valid = 1;
@@ -150,6 +153,9 @@ TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid,
   _rpc.strip = strip;
   _rpc.strip_low = strip;
   _rpc.strip_hi = strip;
+  _rpc.phi_int = 0;
+  _rpc.theta_int = 0;
+  _rpc.emtf_sector = 0;
   _rpc.layer = layer;
   _rpc.bx = bx;
   _rpc.valid = 1;
@@ -162,6 +168,7 @@ TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid,
   _id(detid),
   _subsystem(TriggerPrimitive::kRPC) {
   calculateGlobalSector(detid,_globalsector,_subsector);
+  // In unpacked CPPF digis, the strip number and cluster size are not available, and are set to -99
   _rpc.strip       = ( digi.first_strip() < 0 ? 0 : digi.first_strip() + (digi.cluster_size() / 2) );
   _rpc.strip_low   = ( digi.first_strip() < 0 ? 0 : digi.first_strip() );
   _rpc.strip_hi    = ( digi.first_strip() < 0 ? 0 : digi.first_strip() + digi.cluster_size() - 1 );

--- a/L1Trigger/L1TMuonEndCap/interface/Common.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Common.h
@@ -1,6 +1,7 @@
 #ifndef L1TMuonEndCap_Common_h
 #define L1TMuonEndCap_Common_h
 
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
 #include "DataFormats/L1TMuon/interface/EMTFRoad.h"
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"

--- a/L1Trigger/L1TMuonEndCap/interface/Common.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Common.h
@@ -44,6 +44,7 @@ typedef TTTriggerPrimitive::TTData  TTData;
 
 typedef emtf::CSCTag  CSCTag;
 typedef emtf::RPCTag  RPCTag;
+typedef emtf::CPPFTag CPPFTag;
 typedef emtf::GEMTag  GEMTag;
 typedef emtf::IRPCTag IRPCTag;
 typedef emtf::ME0Tag  ME0Tag;

--- a/L1Trigger/L1TMuonEndCap/interface/EMTFSubsystemTag.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EMTFSubsystemTag.h
@@ -5,6 +5,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "DataFormats/RPCDigi/interface/RPCDigi.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
@@ -22,6 +23,11 @@ namespace emtf {
   struct RPCTag {
     typedef RPCDigi           digi_type;
     typedef RPCDigiCollection digi_collection;
+  };
+
+  struct CPPFTag {
+    typedef l1t::CPPFDigi           digi_type;
+    typedef l1t::CPPFDigiCollection digi_collection;
   };
 
   struct GEMTag {

--- a/L1Trigger/L1TMuonEndCap/interface/PrimitiveConversion.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PrimitiveConversion.h
@@ -41,7 +41,7 @@ public:
       EMTFHit& conv_hit
   ) const;
 
-  void convert_rpc_details(EMTFHit& conv_hit) const;
+  void convert_rpc_details(EMTFHit& conv_hit, const bool use_cppf_lut) const;
 
   // GEM functions
   void convert_gem(

--- a/L1Trigger/L1TMuonEndCap/interface/SectorProcessor.h
+++ b/L1Trigger/L1TMuonEndCap/interface/SectorProcessor.h
@@ -100,7 +100,7 @@ private:
 
   // For track building
   int thetaWindow_, thetaWindowZone0_;
-  bool useRPC_, useSingleHits_;
+  bool useRPC_, useCPPF_, useSingleHits_;
   bool bugSt2PhDiff_, bugME11Dupes_, bugAmbigThetaWin_, twoStationSameBX_;
 
   // For ghost cancellation

--- a/L1Trigger/L1TMuonEndCap/interface/TrackFinder.h
+++ b/L1Trigger/L1TMuonEndCap/interface/TrackFinder.h
@@ -40,11 +40,11 @@ private:
 
   const edm::ParameterSet config_;
 
-  const edm::EDGetToken tokenCSC_, tokenRPC_, tokenGEM_;
+  const edm::EDGetToken tokenCSC_, tokenRPC_, tokenCPPF_, tokenGEM_;
 
   int verbose_, primConvLUT_;
 
-  bool fwConfig_, useCSC_, useRPC_, useGEM_;
+  bool fwConfig_, useCSC_, useRPC_, useCPPF_, useGEM_;
 
   std::string era_;
 };

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -7,7 +7,7 @@ L1TMuonEndCapTrackProducer::L1TMuonEndCapTrackProducer(const edm::ParameterSet& 
     config_(iConfig)
 {
   // Make output products
-  produces<l1t::CPPFDigiCollection>          ("");      // CPPF Digis emulated by EMTF using RPCDigis from Legacy RPC PAC
+  // produces<l1t::CPPFDigiCollection>          ("");      // CPPF Digis emulated by EMTF using RPCDigis from Legacy RPC PAC
   produces<EMTFHitCollection>                ("");      // All CSC LCTs and RPC clusters received by EMTF
   produces<EMTFTrackCollection>              ("");      // All output EMTF tracks, in same format as unpacked data
   produces<l1t::RegionalMuonCandBxCollection>("EMTF");  // EMTF tracks output to uGMT
@@ -19,40 +19,40 @@ L1TMuonEndCapTrackProducer::~L1TMuonEndCapTrackProducer() {
 
 void L1TMuonEndCapTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Create pointers to output products
-  auto out_cppfs   = std::make_unique<l1t::CPPFDigiCollection>();
-  auto out_hits    = std::make_unique<EMTFHitCollection>();
-  auto out_hits_ZS = std::make_unique<EMTFHitCollection>();
-  auto out_tracks  = std::make_unique<EMTFTrackCollection>();
-  auto out_cands   = std::make_unique<l1t::RegionalMuonCandBxCollection>();
+  // auto out_cppfs   = std::make_unique<l1t::CPPFDigiCollection>();
+  auto out_hits_tmp = std::make_unique<EMTFHitCollection>();
+  auto out_hits_ZS  = std::make_unique<EMTFHitCollection>();
+  auto out_tracks   = std::make_unique<EMTFTrackCollection>();
+  auto out_cands    = std::make_unique<l1t::RegionalMuonCandBxCollection>();
 
   // Main EMTF emulator process, produces tracks from hits in each sector in each event
-  track_finder_->process(iEvent, iSetup, *out_hits, *out_tracks);
+  track_finder_->process(iEvent, iSetup, *out_hits_tmp, *out_tracks);
 
   // Apply ZeroSuppression: Only save RPC hits if there is at least one CSC LCT in the sector
   bool has_LCT[12] = {false};
   for (int iSect = 0; iSect < 12; iSect++) {
-    for (const auto& h : *out_hits) {
+    for (const auto& h : *out_hits_tmp) {
       if (h.Is_CSC() && h.Sector_idx() == iSect) {
 	has_LCT[iSect] = true; break;
       }
     }
   }
-  for (const auto& h : *out_hits) {
+  for (const auto& h : *out_hits_tmp) {
     if (has_LCT[h.Sector_idx()] || h.Is_RPC() == 0) {
       out_hits_ZS->push_back( h );
     }
   }
 
-  // Fill collection of emulated CPPFDigis
-  for (const auto& h : *out_hits_ZS) {
-    if (h.Is_RPC()) out_cppfs->push_back( h.CreateCPPFDigi() );
-  }
+  // // Fill collection of emulated CPPFDigis
+  // for (const auto& h : *out_hits_ZS) {
+  //   if (h.Is_RPC()) out_cppfs->push_back( h.CreateCPPFDigi() );
+  // }
 
   // Convert into uGMT format
   uGMT_converter_->convert_all(iEvent, *out_tracks, *out_cands);
 
   // Fill the output products
-  iEvent.put(std::move(out_cppfs),     "");
+  // iEvent.put(std::move(out_cppfs),     "");
   iEvent.put(std::move(out_hits_ZS),   "");
   iEvent.put(std::move(out_tracks),    "");
   iEvent.put(std::move(out_cands), "EMTF");

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -19,16 +19,32 @@ L1TMuonEndCapTrackProducer::~L1TMuonEndCapTrackProducer() {
 
 void L1TMuonEndCapTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Create pointers to output products
-  auto out_cppfs  = std::make_unique<l1t::CPPFDigiCollection>();
-  auto out_hits   = std::make_unique<EMTFHitCollection>();
-  auto out_tracks = std::make_unique<EMTFTrackCollection>();
-  auto out_cands  = std::make_unique<l1t::RegionalMuonCandBxCollection>();
+  auto out_cppfs   = std::make_unique<l1t::CPPFDigiCollection>();
+  auto out_hits    = std::make_unique<EMTFHitCollection>();
+  auto out_hits_ZS = std::make_unique<EMTFHitCollection>();
+  auto out_tracks  = std::make_unique<EMTFTrackCollection>();
+  auto out_cands   = std::make_unique<l1t::RegionalMuonCandBxCollection>();
 
   // Main EMTF emulator process, produces tracks from hits in each sector in each event
   track_finder_->process(iEvent, iSetup, *out_hits, *out_tracks);
 
-  // Fill collection of emulated CPPFDigis
+  // Apply ZeroSuppression: Only save RPC hits if there is at least one CSC LCT in the sector
+  bool has_LCT[12] = {false};
+  for (int iSect = 0; iSect < 12; iSect++) {
+    for (const auto& h : *out_hits) {
+      if (h.Is_CSC() && h.Sector_idx() == iSect) {
+	has_LCT[iSect] = true; break;
+      }
+    }
+  }
   for (const auto& h : *out_hits) {
+    if (has_LCT[h.Sector_idx()] || h.Is_RPC() == 0) {
+      out_hits_ZS->push_back( h );
+    }
+  }
+
+  // Fill collection of emulated CPPFDigis
+  for (const auto& h : *out_hits_ZS) {
     if (h.Is_RPC()) out_cppfs->push_back( h.CreateCPPFDigi() );
   }
 
@@ -36,10 +52,10 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& iEvent, const edm::EventSet
   uGMT_converter_->convert_all(iEvent, *out_tracks, *out_cands);
 
   // Fill the output products
-  iEvent.put(std::move(out_cppfs) , "");
-  iEvent.put(std::move(out_hits)  , "");
-  iEvent.put(std::move(out_tracks), "");
-  iEvent.put(std::move(out_cands) , "EMTF");
+  iEvent.put(std::move(out_cppfs),     "");
+  iEvent.put(std::move(out_hits_ZS),   "");
+  iEvent.put(std::move(out_tracks),    "");
+  iEvent.put(std::move(out_cands), "EMTF");
 }
 
 // void L1TMuonEndCapTrackProducer::beginJob() {

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -23,12 +23,14 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
     #   * 'emtfStage2Digis' : real trigger primitives as received by EMTF, unpacked in EventFilter/L1TRawToDigi/
     CSCInput = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
     RPCInput = cms.InputTag('simMuonRPCDigis'),
+    CPPFInput = cms.InputTag('simCPPFDigis'),  ## Cannot use in MC workflow, does not exist yet.  CPPFEnable set to False - AWB 01.06.18
     GEMInput = cms.InputTag('simMuonGEMPadDigis'),
 
     # Run with CSC, RPC, GEM
-    CSCEnable = cms.bool(True),  # Use CSC LCTs from the MPCs in track-building
-    RPCEnable = cms.bool(True),  # Use clustered RPC hits from CPPF in track-building
-    GEMEnable = cms.bool(False), # Use hits from GEMs in track-building
+    CSCEnable = cms.bool(True),   # Use CSC LCTs from the MPCs in track-building
+    RPCEnable = cms.bool(True),   # Use clustered RPC hits from CPPF in track-building
+    CPPFEnable = cms.bool(False), # Use CPPF-emulated clustered RPC hits from CPPF as the RPC hits
+    GEMEnable = cms.bool(False),  # Use hits from GEMs in track-building
 
     # Era (options: 'Run2_2016', 'Run2_2017', 'Run2_2018')
     Era = cms.string('Run2_2018'),
@@ -117,9 +119,12 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
 )
 
 simEmtfDigisData = simEmtfDigisMC.clone(
-    CSCInput = cms.InputTag('emtfStage2Digis'),
-    RPCInput = cms.InputTag('muonRPCDigis'),
-    GEMInput = cms.InputTag('muonGEMPadDigis'),
+    CSCInput  = cms.InputTag('emtfStage2Digis'),
+    RPCInput  = cms.InputTag('muonRPCDigis'),
+    CPPFInput = cms.InputTag('emtfStage2Digis'),
+    GEMInput  = cms.InputTag('muonGEMPadDigis'),
+
+    CPPFEnable = cms.bool(True), # Use CPPF-emulated clustered RPC hits from CPPF as the RPC hits
 )
 
 simEmtfDigis = simEmtfDigisMC.clone()

--- a/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
@@ -67,6 +67,28 @@ void EMTFSubsystemCollector::extractPrimitives(
   return;
 }
 
+// Specialized for CPPF
+template<>
+void EMTFSubsystemCollector::extractPrimitives(
+    emtf::CPPFTag tag, // Defined in interface/EMTFSubsystemTag.h, maps to CPPFDigi
+    const edm::Event& iEvent,
+    const edm::EDGetToken& token,
+    TriggerPrimitiveCollection& out
+) const {
+  edm::Handle<emtf::CPPFTag::digi_collection> cppfDigis;
+  iEvent.getByToken(token, cppfDigis);
+
+  TriggerPrimitiveCollection muon_primitives;
+
+  for (auto digi : *cppfDigis) {
+    muon_primitives.emplace_back(digi.rpcId(), digi);
+  }
+
+  // Output
+  std::copy(muon_primitives.begin(), muon_primitives.end(), std::back_inserter(out));
+  return;
+}
+
 // Specialized for GEM
 template<>
 void EMTFSubsystemCollector::extractPrimitives(

--- a/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
@@ -78,14 +78,11 @@ void EMTFSubsystemCollector::extractPrimitives(
   edm::Handle<emtf::CPPFTag::digi_collection> cppfDigis;
   iEvent.getByToken(token, cppfDigis);
 
-  TriggerPrimitiveCollection muon_primitives;
-
+  // Output
   for (auto digi : *cppfDigis) {
-    muon_primitives.emplace_back(digi.rpcId(), digi);
+    out.emplace_back(digi.rpcId(), digi);
   }
 
-  // Output
-  std::copy(muon_primitives.begin(), muon_primitives.end(), std::back_inserter(out));
   return;
 }
 

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -461,7 +461,7 @@ void PrimitiveConversion::convert_rpc(
   int tp_station   = tp_detId.station();    // 1 - 4
   int tp_ring      = tp_detId.ring();       // 2 - 3 (increasing theta)
   int tp_roll      = tp_detId.roll();       // 1 - 3 (decreasing theta; aka A - C; space between rolls is 9 - 15 in theta_fp)
-  //int tp_layer     = tp_detId.layer();
+  //int tp_layer     = tp_detId.layer();      // Always 1 in the Endcap, 1 or 2 in the Barrel
 
   int tp_bx        = tp_data.bx;
   int tp_strip     = ((tp_data.strip_low + tp_data.strip_hi) / 2);  // in full-strip unit

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveMatching.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveMatching.cc
@@ -462,9 +462,12 @@ void PrimitiveMatching::insert_hits(
       //(conv_hit_i.Wire()       == conv_hit_j.Wire()) &&
       (conv_hit_i.Pattern()    == conv_hit_j.Pattern()) &&
       (conv_hit_i.BX()         == conv_hit_j.BX()) &&
-      (conv_hit_i.Strip_low()  == conv_hit_j.Strip_low()) && // For RPC clusters
-      (conv_hit_i.Strip_hi()   == conv_hit_j.Strip_hi()) &&  // For RPC clusters
-      (conv_hit_i.Roll()       == conv_hit_j.Roll()) &&      // For RPC clusters
+      ( (conv_hit_i.Is_RPC()     == false) ||
+	( (conv_hit_i.Strip_low()  == conv_hit_j.Strip_low()) &&
+	  (conv_hit_i.Strip_hi()   == conv_hit_j.Strip_hi()) &&
+	  (conv_hit_i.Roll()       == conv_hit_j.Roll()) &&
+	  (conv_hit_i.Phi_fp()     == conv_hit_j.Phi_fp()) &&
+	  (conv_hit_i.Theta_fp()   == conv_hit_j.Theta_fp()) ) ) &&
       true
     ) {
       // All duplicates with the same strip but different wire must have same phi_fp

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveSelection.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveSelection.cc
@@ -222,7 +222,7 @@ void PrimitiveSelection::process(
         tmp_primitives.erase(tmp_primitives.begin()+2, tmp_primitives.end());
 
       // Skip cluster size cut if primitives are from CPPF emulator or EMTF unpacker (already clustered)
-      if (tmp_primitives.size() > 0 && tmp_primitives.at(0).getRPCData().isCPPF)
+      if (!tmp_primitives.empty() && tmp_primitives.at(0).getRPCData().isCPPF)
 	break;
 
       // Apply cluster size cut

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveSelection.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveSelection.cc
@@ -209,6 +209,14 @@ void PrimitiveSelection::process(
       //int selected = map_tp_it->first;
       TriggerPrimitiveCollection& tmp_primitives = map_tp_it->second;  // pass by reference
 
+      // Check to see if unpacked CPPF digis have <= 2 digis per chamber, as expected
+      if (tmp_primitives.size() > 2 && tmp_primitives.at(0).getRPCData().isCPPF) {
+	edm::LogWarning("L1T") << "\n******************* EMTF EMULATOR: SUPER-BIZZARE CASE *******************";
+	edm::LogWarning("L1T") << "Found " << tmp_primitives.size() << " CPPF digis in the same chamber";
+	for (const auto & tp : tmp_primitives) tp.print(std::cout);
+	edm::LogWarning("L1T") << "************************* ONLY KEEP FIRST TWO *************************\n\n";
+      }
+
       // Keep the first two clusters
       if (tmp_primitives.size() > 2)
         tmp_primitives.erase(tmp_primitives.begin()+2, tmp_primitives.end());

--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -15,12 +15,14 @@ TrackFinder::TrackFinder(const edm::ParameterSet& iConfig, edm::ConsumesCollecto
     config_(iConfig),
     tokenCSC_(iConsumes.consumes<CSCTag::digi_collection>(iConfig.getParameter<edm::InputTag>("CSCInput"))),
     tokenRPC_(iConsumes.consumes<RPCTag::digi_collection>(iConfig.getParameter<edm::InputTag>("RPCInput"))),
+    tokenCPPF_(iConsumes.consumes<CPPFTag::digi_collection>(iConfig.getParameter<edm::InputTag>("CPPFInput"))),
     tokenGEM_(iConsumes.consumes<GEMTag::digi_collection>(iConfig.getParameter<edm::InputTag>("GEMInput"))),
     verbose_(iConfig.getUntrackedParameter<int>("verbosity")),
     primConvLUT_(iConfig.getParameter<edm::ParameterSet>("spPCParams16").getParameter<int>("PrimConvLUT")),
     fwConfig_(iConfig.getParameter<bool>("FWConfig")),
     useCSC_(iConfig.getParameter<bool>("CSCEnable")),
     useRPC_(iConfig.getParameter<bool>("RPCEnable")),
+    useCPPF_(iConfig.getParameter<bool>("CPPFEnable")),
     useGEM_(iConfig.getParameter<bool>("GEMEnable")),
     era_(iConfig.getParameter<std::string>("Era"))
 {
@@ -132,7 +134,9 @@ void TrackFinder::process(
   EMTFSubsystemCollector collector;
   if (useCSC_)
     collector.extractPrimitives(CSCTag(), iEvent, tokenCSC_, muon_primitives);
-  if (useRPC_)
+  if (useRPC_ && useCPPF_)
+    collector.extractPrimitives(CPPFTag(), iEvent, tokenCPPF_, muon_primitives);
+  else if (useRPC_)
     collector.extractPrimitives(RPCTag(), iEvent, tokenRPC_, muon_primitives);
   if (useGEM_)
     collector.extractPrimitives(GEMTag(), iEvent, tokenGEM_, muon_primitives);


### PR DESCRIPTION
To this point, the EMTF emulator has been taking in raw RPC hits and performing an emulation of the CPPF logic: clustering, sorting, and computing theta and phi coordinates for the hits.  With this PR, the new sequence for re-emulating data is:

1) EMTF unpacks the received CPPF digis into a CPPFDigiCollection
2) EMTF emulator uses this CPPFDigiCollection in the track-building

This brings the fraction of tracks with perfect data-emulator agreement up from ~92% to > 98%.  The emulator logic in MC is unaffected, as there is no CPPFDigi producer in MC at the moment.  The main practical benefit is better data-emulator agreement for DQM monitoring, and for offline performance studies.

Of potential interest to @jiafulow , @rekovic , @thomreis , @maseguracern , @camilocarrillo , @jhgoh , @mileva, @brieucf

Best regards,
Andrew