### PR TITLE
update all POWHEG workflows

### DIFF
--- a/Configuration/Generator/python/GGHZZ4L_JHUGen_Pow_NNPDF30_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/GGHZZ4L_JHUGen_Pow_NNPDF30_LHE_13TeV_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 # https://github.com/cms-sw/genproductions/blob/4927fb8fec2afc72cc98ff2e5fb5bf0db930f971/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M125.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/gg_H_quark-mass-effects_NNPDF30_13TeV_M125_JHUGen_ZZ4L/v3/gg_H_quark-mass-effects_NNPDF30_13TeV_M125_JHUGen_ZZ4L_tarball.tar.gz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/ggH_JHUGen/gg_H_quark-mass-effects_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_ggH_new_jhu.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/GGHZZ4L_JHUGen_Pow_NNPDF30_LHE_13TeV_cfi.py
+++ b/Configuration/Generator/python/GGHZZ4L_JHUGen_Pow_NNPDF30_LHE_13TeV_cfi.py
@@ -8,7 +8,7 @@ from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 # https://github.com/cms-sw/genproductions/blob/4927fb8fec2afc72cc98ff2e5fb5bf0db930f971/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M125.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/gg_H_quark-mass-effects_NNPDF30_13TeV_M125_JHUGen_ZZ4L/v3/gg_H_quark-mass-effects_NNPDF30_13TeV_M125_JHUGen_ZZ4L_tarball.tar.gz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/ggH_JHUGen/gg_H_quark-mass-effects_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_ggH_new_jhu.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/GGToH_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/GGToH_Pow_LHE_13TeV_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/gg_H_quark-mass-effects_NNPDF30_13TeV_M125/v2/gg_H_quark-mass-effects_NNPDF30_13TeV_M125_tarball.tar.gz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/ggH/gg_H_quark-mass-effects_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_ggH_new.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/TT_weight_NNPDF3.0/TT_weight_NNPDF3.0_tarball.tar.gz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/TTBar/hvq_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_ttbar_new.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/VBFHZZ4Nu_Pow_NNPDF30_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/VBFHZZ4Nu_Pow_NNPDF30_LHE_13TeV_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # https://github.com/cms-sw/genproductions/tree/master/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M-125.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/VBF_H_NNPDF30_13TeV_M125/v1/VBFH_NNPDF30_M-125_13TeV_tarball.tar.gz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/VBFH/VBF_H_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_VBF_new.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/VBFHZZ4Nu_Pow_NNPDF30_LHE_13TeV_cfi.py
+++ b/Configuration/Generator/python/VBFHZZ4Nu_Pow_NNPDF30_LHE_13TeV_cfi.py
@@ -7,7 +7,7 @@ from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 # https://github.com/cms-sw/genproductions/tree/master/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M-125.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/VBF_H_NNPDF30_13TeV_M125/v1/VBFH_NNPDF30_M-125_13TeV_tarball.tar.gz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/VBFH/VBF_H_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_VBF_new.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/VBFHbb_Pow_NNPDF30_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/VBFHbb_Pow_NNPDF30_LHE_13TeV_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # https://github.com/cms-sw/genproductions/blob/cbd9f361d33cfe95b76668588168103e986126ff/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M-125.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/VBF_H_NNPDF30_13TeV_M125/v1/VBFH_NNPDF30_M-125_13TeV_tarball.tar.gz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/VBFH/VBF_H_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_VBF_new.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/VBFHbb_Pow_NNPDF30_LHE_13TeV_cfi.py
+++ b/Configuration/Generator/python/VBFHbb_Pow_NNPDF30_LHE_13TeV_cfi.py
@@ -7,7 +7,7 @@ from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 # https://github.com/cms-sw/genproductions/blob/cbd9f361d33cfe95b76668588168103e986126ff/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M-125.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/VBF_H_NNPDF30_13TeV_M125/v1/VBFH_NNPDF30_M-125_13TeV_tarball.tar.gz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/VBFH/VBF_H_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_VBF_new.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/VHToH_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/VHToH_Pow_LHE_13TeV_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # https://github.com/cms-sw/genproductions/blob/329fda9f8d07c2d4d4e75c9a00279dcd6e78cda7/bin/Powheg/production/VH_from_Hbb/HWplusJ_HanythingJ_NNPDF30_13TeV_M125.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/HWplusJ_HanythingJ_NNPDF30_13TeV_M125/v2_folding/HWplusJ_HanythingJ_NNPDF30_13TeV_M125_tarball.tar.gz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/VH/HWJ_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_VH_new.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),


### PR DESCRIPTION
Update all validation workflow with gridpack using the "rpath" option for GCC/gfortran libraries (avoids incompatibilities with LHAPDF and other linked libraries when changing OS and/or GCC main version)