### PR TITLE
Fix case where external work was only module running on a stream

### DIFF
--- a/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
@@ -564,6 +564,7 @@ def createPDFImage(pdfFile, shownStacks, processingSteps, numStreams, stalledMod
     streamRunningTimes = [[] for x in xrange(numStreams)]
     streamExternalWorkRunningTimes = [[] for x in xrange(numStreams)]
     maxNumberOfConcurrentModulesOnAStream = 1
+    externalWorkModulesInJob = False
     previousTime = [0 for x in xrange(numStreams)]
 
     # The next five variables are only used to check for out of order transitions
@@ -651,6 +652,7 @@ def createPDFImage(pdfFile, shownStacks, processingSteps, numStreams, stalledMod
                 if checkOrder:
                     countExternalWork[s][n] += 1
                 if displayExternalWork:
+                    externalWorkModulesInJob = True
                     if (not checkOrder) or countExternalWork[s][n] > 0:
                         externalWorkModules.add(n)
                         streamExternalWorkRunningTimes[s].append(Point(time,+1))
@@ -720,7 +722,7 @@ def createPDFImage(pdfFile, shownStacks, processingSteps, numStreams, stalledMod
                 allStackTimes[info.color].append((info.begin, info.delta))
 
     # Now superimpose the number of concurrently running modules on to the graph.
-    if maxNumberOfConcurrentModulesOnAStream > 1:
+    if maxNumberOfConcurrentModulesOnAStream > 1 or externalWorkModulesInJob:
 
         for i,perStreamRunningTimes in enumerate(streamRunningTimes):
 
@@ -777,7 +779,7 @@ def createPDFImage(pdfFile, shownStacks, processingSteps, numStreams, stalledMod
                 axStack.broken_barh(finalxs, (0, height), facecolors=color, edgecolors=color, linewidth=0)
 
         axStack.set_xlabel("Time (sec)");
-        axStack.set_ylabel("# threads");
+        axStack.set_ylabel("# modules");
         axStack.set_xlim(ax.get_xlim())
         axStack.tick_params(top='off')
 


### PR DESCRIPTION
There was a bug where if there was an external work and we only ever had one module running at a time on a stream, the external work was not added to the stacked graph at the bottom.