### PR TITLE
proxy forwarding for PV and Z->mumu validations

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -165,6 +165,7 @@ process.p = cms.Path(process.goodvertexSkim*
 PVValidationScriptTemplate="""
 #!/bin/bash
 source /afs/cern.ch/cms/caf/setup.sh
+export X509_USER_PROXY=.oO[scriptsdir]Oo./.user_proxy
 
 echo  -----------------------
 echo  Job started at `date`

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
@@ -200,6 +200,7 @@ process.p = cms.Path(
 zMuMuScriptTemplate="""
 #!/bin/bash
 source /afs/cern.ch/cms/caf/setup.sh
+export X509_USER_PROXY=.oO[scriptsdir]Oo./.user_proxy
 
 echo  -----------------------
 echo  Job started at `date`


### PR DESCRIPTION
Simple bugfix.  I covered most of the validations we run in 84974aa5704cd0ed971b5ca765dc7be327a4afe8, but missed setting the env variable in these two cases.