### PR TITLE
Add emplace method to Event, LuminosityBlock and Run

### DIFF
--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -28,10 +28,15 @@ namespace edm {
     typedef T wrapped_type; // used with the dictionary to identify Wrappers
     Wrapper() : WrapperBase(), present(false), obj() {}
     explicit Wrapper(std::unique_ptr<T> ptr);
+    
+    template<typename... Args>
+    explicit Wrapper( Args&&... );
     ~Wrapper() override {}
     T const* product() const {return (present ? &obj : nullptr);}
     T const* operator->() const {return product();}
 
+    T& bareProduct() { return obj;}
+    
     //these are used by FWLite
     static std::type_info const& productTypeInfo() {return typeid(T);}
     static std::type_info const& typeInfo() {return typeid(Wrapper<T>);}
@@ -84,6 +89,14 @@ private:
     if (present) {
       obj = std::move(*ptr);
     }
+  }
+
+  template<typename T>
+  template<typename... Args>
+  Wrapper<T>::Wrapper(Args&&... args) :
+  WrapperBase(),
+  present(true),
+  obj(std::forward<Args>(args)...) {
   }
 
   template<typename T>

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -125,6 +125,15 @@ namespace edm {
     void
     put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product);
 
+    ///puts a new product
+    template<typename PROD, typename... Args>
+    void
+    emplace(EDPutTokenT<PROD> token, Args&&... args);
+    
+    template<typename PROD, typename... Args>
+    void
+    emplace(EDPutToken token, Args&&... args);
+
     Provenance
     getProvenance(BranchID const& theID) const;
 
@@ -150,6 +159,10 @@ namespace edm {
     template<typename PROD>
     void
     putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
+
+    template<typename PROD, typename... Args>
+    void
+    emplaceImpl(EDPutToken::value_type token, Args&&... args);
 
     typedef std::vector<edm::propagate_const<std::unique_ptr<WrapperBase>>> ProductPtrVec;
     ProductPtrVec& putProducts() {return putProducts_;}
@@ -208,10 +221,10 @@ namespace edm {
   LuminosityBlock::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
     if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
-      principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, provRecorder_.productInstanceLabel(token));
     }
     if(UNLIKELY(token.isUninitialized())) {
-      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("LuminosityBlock", typeid(PROD));
     }
     putImpl(token.index(),std::move(product));
   }
@@ -221,16 +234,56 @@ namespace edm {
   LuminosityBlock::put(EDPutToken token, std::unique_ptr<PROD> product) {
     if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
-      principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, provRecorder_.productInstanceLabel(token));
     }
     if(UNLIKELY(token.isUninitialized())) {
-      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("LuminosityBlock", typeid(PROD));
     }
     if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
       principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
     }
     
     putImpl(token.index(),std::move(product));
+  }
+
+  template<typename PROD, typename... Args>
+  void
+  LuminosityBlock::emplace(EDPutTokenT<PROD> token, Args&&... args) {
+    if(UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("LuminosityBlock", typeid(PROD));
+    }
+    emplaceImpl<PROD>(token.index(),std::forward<Args>(args)...);
+  }
+  
+  template<typename PROD, typename... Args>
+  void
+  LuminosityBlock::emplace(EDPutToken token, Args&&... args) {
+    if(UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("LuminosityBlock", typeid(PROD));
+    }
+    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+    
+    emplaceImpl(token.index(),std::forward<Args>(args)...);
+  }
+  
+  template<typename PROD, typename... Args>
+  void
+  LuminosityBlock::emplaceImpl(EDPutToken::value_type index, Args&&... args) {
+    
+    assert(index < putProducts().size());
+    
+    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::forward<Args>(args)...));
+    
+    // The following will call post_insert if T has such a function,
+    // and do nothing if T has no such function.
+    std::conditional_t<detail::has_postinsert<PROD>::value,
+    DoPostInsert<PROD>,
+    DoNotPostInsert<PROD>> maybe_inserter;
+    maybe_inserter(&(wp->bareProduct()));
+    
+    putProducts()[index]=std::move(wp);
   }
 
   template<typename PROD>

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -90,6 +90,7 @@ class testEvent: public CppUnit::TestFixture {
   CPPUNIT_TEST(putAnIntProduct);
   CPPUNIT_TEST(putAndGetAnIntProduct);
   CPPUNIT_TEST(putAndGetAnIntProductByToken);
+  CPPUNIT_TEST(emplaceAndGetAnIntProductByToken);
   CPPUNIT_TEST(getByProductID);
   CPPUNIT_TEST(transaction);
   CPPUNIT_TEST(getByLabel);
@@ -110,6 +111,7 @@ class testEvent: public CppUnit::TestFixture {
   void putAnIntProduct();
   void putAndGetAnIntProduct();
   void putAndGetAnIntProductByToken();
+  void emplaceAndGetAnIntProductByToken();
   void getByProductID();
   void transaction();
   void getByLabel();
@@ -150,6 +152,10 @@ class testEvent: public CppUnit::TestFixture {
   std::unique_ptr<ProducerBase> putProductUsingToken(std::unique_ptr<T> product,
                                                      std::string const& productInstanceLabel,
                                                      bool doCommit=true);
+  template <class T>
+  std::unique_ptr<ProducerBase> emplaceProduct(T product,
+                                               std::string const& productInstanceLabel,
+                                               bool doCommit=true);
 
   std::shared_ptr<ProductRegistry>   availableProducts_;
   std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
@@ -285,6 +291,28 @@ testEvent::putProductUsingToken(std::unique_ptr<T> product,
   const_cast<std::vector<edm::ProductResolverIndex>&>(prod->putTokenIndexToProductResolverIndex()).push_back(index);
   currentEvent_->setProducer(prod.get(),nullptr);
   currentEvent_->put(token,std::move(product));
+  if(doCommit) {
+    currentEvent_->commit_(std::vector<ProductResolverIndex>());
+  }
+  return prod;
+}
+
+template <class T>
+std::unique_ptr<ProducerBase>
+testEvent::emplaceProduct(T product,
+                          std::string const& productInstanceLabel,
+                          bool doCommit) {
+  auto prod = std::make_unique<ProducerBase>();
+  EDPutTokenT<edmtest::IntProduct> token = prod->produces<edmtest::IntProduct>(productInstanceLabel);
+  auto index =principal_->productLookup().index(PRODUCT_TYPE,
+                                                edm::TypeID(typeid(T)),
+                                                currentModuleDescription_->moduleLabel().c_str(),
+                                                productInstanceLabel.c_str(),
+                                                currentModuleDescription_->processName().c_str());
+  CPPUNIT_ASSERT(index != std::numeric_limits<unsigned int>::max());
+  const_cast<std::vector<edm::ProductResolverIndex>&>(prod->putTokenIndexToProductResolverIndex()).push_back(index);
+  currentEvent_->setProducer(prod.get(),nullptr);
+  currentEvent_->emplace(token,std::move(product));
   if(doCommit) {
     currentEvent_->commit_(std::vector<ProductResolverIndex>());
   }
@@ -500,6 +528,19 @@ void testEvent::putAndGetAnIntProduct() {
 
 void testEvent::putAndGetAnIntProductByToken() {
   auto p = putProductUsingToken(std::make_unique<edmtest::IntProduct>(4),"int1");
+  
+  InputTag should_match("modMulti", "int1", "CURRENT");
+  InputTag should_not_match("modMulti", "int1", "NONESUCH");
+  Handle<edmtest::IntProduct> h;
+  currentEvent_->getByLabel(should_match, h);
+  CPPUNIT_ASSERT(h.isValid());
+  CPPUNIT_ASSERT(!currentEvent_->getByLabel(should_not_match, h));
+  CPPUNIT_ASSERT(!h.isValid());
+  CPPUNIT_ASSERT_THROW(*h, cms::Exception);
+}
+
+void testEvent::emplaceAndGetAnIntProductByToken() {
+  auto p = emplaceProduct(edmtest::IntProduct{4},"int1");
   
   InputTag should_match("modMulti", "int1", "CURRENT");
   InputTag should_not_match("modMulti", "int1", "NONESUCH");

--- a/FWCore/Integration/test/ThingProducer.cc
+++ b/FWCore/Integration/test/ThingProducer.cc
@@ -25,13 +25,13 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    auto result = std::make_unique<ThingCollection>();  //Empty
+    ThingCollection result;  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
-    alg_.run(*result);
+    alg_.run(result);
 
     // Step D: Put outputs into event
-    if (!noPut_) e.put(evToken_,std::move(result));
+    if (!noPut_) e.emplace(evToken_,std::move(result));
   }
 
   // Functions that gets called by framework every luminosity block
@@ -39,26 +39,26 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    auto result = std::make_unique<ThingCollection>();  //Empty
+    ThingCollection result;  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
-    alg_.run(*result);
+    alg_.run(result);
 
     // Step D: Put outputs into lumi block
-    if (!noPut_) lb.put(blToken_, std::move(result));
+    if (!noPut_) lb.emplace(blToken_, std::move(result));
   }
 
   void ThingProducer::globalEndLuminosityBlockProduce(edm::LuminosityBlock& lb, edm::EventSetup const&) const {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    auto result = std::make_unique<ThingCollection>();  //Empty
+    ThingCollection result;  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
-    alg_.run(*result);
+    alg_.run(result);
 
     // Step D: Put outputs into lumi block
-    if (!noPut_) lb.put(elToken_,std::move(result));
+    if (!noPut_) lb.emplace(elToken_,std::move(result));
   }
 
   // Functions that gets called by framework every run
@@ -66,26 +66,26 @@ namespace edmtest {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    auto result = std::make_unique<ThingCollection>();  //Empty
+    ThingCollection result;  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
-    alg_.run(*result);
+    alg_.run(result);
 
     // Step D: Put outputs into event
-    if (!noPut_) r.put(brToken_,std::move(result));
+    if (!noPut_) r.emplace(brToken_,std::move(result));
   }
 
   void ThingProducer::globalEndRunProduce(edm::Run& r, edm::EventSetup const&) const {
     // Step A: Get Inputs 
 
     // Step B: Create empty output 
-    auto result = std::make_unique<ThingCollection>();  //Empty
+    ThingCollection result;  //Empty
 
     // Step C: Invoke the algorithm, passing in inputs (NONE) and getting back outputs.
-    alg_.run(*result);
+    alg_.run(result);
 
     // Step D: Put outputs into event
-    if (!noPut_) r.put(erToken_,std::move(result));
+    if (!noPut_) r.emplace(erToken_,std::move(result));
   }
 
   void ThingProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/FWCore/PythonFramework/test/PythonTestProducer.cc
+++ b/FWCore/PythonFramework/test/PythonTestProducer.cc
@@ -52,8 +52,7 @@ namespace edmtest {
       
       outputList_.append(h->value );
       
-      iEvent.put(put_,std::make_unique<int>( h->value +value_ ));
-      //iEvent.put(put_,std::make_unique<int>( h->value ) );
+      iEvent.emplace(put_, h->value +value_ );
     }
 }
 


### PR DESCRIPTION
The emplace method allows one to avoid making a temporary std::unique_ptr and therefor avoid an unnecessary new/delete.