### PR TITLE
Make egamma MVA estimators members of stream producer instead of global cache

### DIFF
--- a/RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h
+++ b/RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h
@@ -12,7 +12,7 @@ class AnyMVAEstimatorRun2Base {
 
  public:
   // Constructor, destructor
- AnyMVAEstimatorRun2Base(const edm::ParameterSet& conf) : conf(conf) {}
+ AnyMVAEstimatorRun2Base(const edm::ParameterSet& conf) : conf_(conf) {}
   virtual ~AnyMVAEstimatorRun2Base(){};
 
   // Functions that must be provided in derived classes
@@ -41,17 +41,16 @@ class AnyMVAEstimatorRun2Base {
   // Implement these methods only if needed in the derived classes (use "override"
   // for certainty).
 
-  // DEPRECATED
   // This method needs to be used only once after this MVA estimator is constructed
   virtual void setConsumes(edm::ConsumesCollector &&cc) const {};
-  // This method needs to be called for each event
-  virtual void getEventContent(const edm::Event& iEvent) const final {};
+
+ private:
 
   //
   // Data members
   //
   // Configuration
-  const edm::ParameterSet conf;
+  const edm::ParameterSet conf_;
 
 };
 


### PR DESCRIPTION
In response to https://github.com/cms-sw/cmssw/issues/23766, where the electron MVA category was randomly -1 in the new implementation based on the `StringCutObjectSelector<>` and `StringCutObjectFunction<>`.

The implementation was inspired form how the class was implemented before the MVA object cache:

https://github.com/cms-sw/cmssw/tree/c8acec802bbb10fa02111738fca461b70b1f1d81