### PR TITLE
Add support for splitting files with mergeable run products

### DIFF
--- a/CondFormats/Common/interface/FileBlobCollection.h
+++ b/CondFormats/Common/interface/FileBlobCollection.h
@@ -23,6 +23,7 @@ class FileBlobCollection {
   std::vector<FileBlob>::const_iterator begin() const;
   std::vector<FileBlob>::const_iterator end() const;
   bool mergeProduct(FileBlobCollection const &other);
+  void swap(FileBlobCollection& iOther);
 
  private:
   std::vector<FileBlob> fileBlobs;

--- a/CondFormats/Common/src/FileBlobCollection.cc
+++ b/CondFormats/Common/src/FileBlobCollection.cc
@@ -21,3 +21,7 @@ bool FileBlobCollection::mergeProduct(FileBlobCollection const &other) {
                    other.fileBlobs.end());
   return true;
 }
+
+void FileBlobCollection::swap(FileBlobCollection& iOther) {
+  fileBlobs.swap(iOther.fileBlobs);
+}

--- a/DataFormats/Common/interface/MergeableCounter.h
+++ b/DataFormats/Common/interface/MergeableCounter.h
@@ -4,8 +4,10 @@
 namespace edm {
 
   struct MergeableCounter {
+    MergeableCounter() : value() {}
     ~MergeableCounter() {}
     bool mergeProduct(MergeableCounter const & newThing);
+    void swap(MergeableCounter& iOther);
     int value;
   };
 

--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -13,7 +13,9 @@ is the storage unit of such information.
 
 namespace edm {
   class BranchDescription;
+  class MergeableRunProductMetadataBase;
   class WrapperBase;
+
   class ProductData {
   public:
     ProductData();
@@ -64,6 +66,10 @@ namespace edm {
       prov_.setProductID(pid);
       prov_.setStore(provRetriever);
       prov_.setProcessHistory(ph);
+    }
+
+    void setMergeableRunProductMetadata(MergeableRunProductMetadataBase const* mrpm) {
+      prov_.setMergeableRunProductMetadata(mrpm);
     }
 
     // NOTE: We should probably think hard about whether these

--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -58,6 +58,8 @@ private:
     bool mergeProduct_(WrapperBase const* newProduct) override;
     bool hasIsProductEqual_() const override;
     bool isProductEqual_(WrapperBase const* newProduct) const override;
+    bool hasSwap_() const override;
+    void swapProduct_(WrapperBase* newProduct) override;
 
     void do_fillView(ProductID const& id,
                              std::vector<void const*>& pointers,
@@ -150,6 +152,20 @@ private:
     return detail::doIsProductEqual<T>()(obj, wrappedNewProduct->obj);
   }
   
+  template<typename T>
+  inline
+  bool Wrapper<T>::hasSwap_() const {
+    return detail::getHasSwapFunction<T>()();
+  }
+
+  template<typename T>
+  inline
+  void Wrapper<T>::swapProduct_(WrapperBase* newProduct) {
+    Wrapper<T>* wrappedNewProduct = dynamic_cast<Wrapper<T>*>(newProduct);
+    assert(wrappedNewProduct != nullptr);
+    detail::doSwapProduct<T>()(obj, wrappedNewProduct->obj);
+  }
+
   namespace soa {
     template<class T>
     struct MakeTableExaminer {

--- a/DataFormats/Common/interface/WrapperBase.h
+++ b/DataFormats/Common/interface/WrapperBase.h
@@ -55,6 +55,8 @@ namespace edm {
     bool mergeProduct(WrapperBase const* newProduct) {return mergeProduct_(newProduct);}
     bool hasIsProductEqual() const {return hasIsProductEqual_();}
     bool isProductEqual(WrapperBase const* newProduct) const {return isProductEqual_(newProduct);}
+    bool hasSwap() const {return hasSwap_();}
+    void swapProduct(WrapperBase* newProduct) {swapProduct_(newProduct);}
 
     std::shared_ptr<soa::TableExaminerBase> tableExaminer() const {
       return tableExaminer_();
@@ -73,6 +75,8 @@ namespace edm {
     virtual bool mergeProduct_(WrapperBase const* newProduct ) = 0;
     virtual bool hasIsProductEqual_() const = 0;
     virtual bool isProductEqual_(WrapperBase const* newProduct) const = 0;
+    virtual bool hasSwap_() const = 0;
+    virtual void swapProduct_(WrapperBase* newProduct) = 0;
 
     virtual void do_fillView(ProductID const& id,
                              std::vector<void const*>& pointers,

--- a/DataFormats/Common/interface/WrapperDetail.h
+++ b/DataFormats/Common/interface/WrapperDetail.h
@@ -141,6 +141,42 @@ namespace edm {
         return true; // Should never be called
       }
     };
+
+    // bool hasSwap_() will return true if T::swap(T&) is declared and false otherwise
+    // void swapProduct_() will call T::swap(T&) if it is defined otherwise it does nothing
+    // Definitions for the following struct and function templates are not needed; we only require the declarations.
+    template<typename T, void (T::*)(T&)> struct swap_function;
+    template<typename T> static yes_tag has_swap(swap_function<T, &T::swap>* dummy);
+    template<typename T> static no_tag has_swap(...);
+
+    template<typename T>
+    struct has_swap_function {
+      static constexpr bool value =
+      std::is_same<decltype(has_swap<T>(nullptr)), yes_tag>::value;
+    };
+
+    template<typename T, bool = has_swap_function<T>::value> struct getHasSwapFunction;
+    template<typename T> struct getHasSwapFunction<T, true> {
+      bool operator()() {
+        return true;
+      }
+    };
+    template<typename T> struct getHasSwapFunction<T, false> {
+      bool operator()() {
+        return false;
+      }
+    };
+    template<typename T, bool = has_swap_function<T>::value> struct doSwapProduct;
+    template<typename T> struct doSwapProduct<T, true> {
+      void operator()(T& thisProduct, T& newProduct) {
+        thisProduct.swap(newProduct);
+      }
+    };
+    template<typename T> struct doSwapProduct<T, false> {
+      void operator()(T&, T&) {
+        return; // Should never be called
+      }
+    };
   }
 }
 #endif

--- a/DataFormats/Common/interface/setIsMergeable.h
+++ b/DataFormats/Common/interface/setIsMergeable.h
@@ -1,0 +1,40 @@
+#ifndef DataFormats_Common_setIsMergeable_h
+#define DataFormats_Common_setIsMergeable_h
+// -*- C++ -*-
+//
+// Package:     Common
+// Class  :     setIsMergeable
+//
+/*
+ Description: Should be called only after the BranchDescription::init
+              function has been called either directly or through
+              the BranchDescription constructor.
+
+              Helper function used to set the isMergeable data member
+              in BranchDescription. It would be much more convenient
+              to have been able to put this inside the BranchDescription
+              class itself in the init function, but the WrapperBase
+              class in package DataFormats/Common is needed to implement
+              this and that cannot be used in package DataFormats/Provenance
+              because it would create a circular dependency.
+
+              Anything creating a BranchDescription or reading one from
+              a ROOT file will need to call this directly if they need
+              the isMergeable data member to be set properly. Note that
+              the isMergeable data member will default to false so if
+              you know there are no mergeable run or lumi products, calling
+              this is unnecessary.
+*/
+//
+// Original Author:  W. David Dagenhart
+//         Created:  21 June 2018
+//
+
+namespace edm {
+
+  class BranchDescription;
+
+  void setIsMergeable(BranchDescription&);
+}
+
+#endif

--- a/DataFormats/Common/src/MergeableCounter.cc
+++ b/DataFormats/Common/src/MergeableCounter.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/Common/interface/MergeableCounter.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <ostream>
+#include <utility>
 
 namespace edm 
 {
@@ -16,4 +17,7 @@ namespace edm
     return true;
   }
 
+  void MergeableCounter::swap(MergeableCounter& iOther) {
+    std::swap(value, iOther.value);
+  }
 }

--- a/DataFormats/Common/src/setIsMergeable.cc
+++ b/DataFormats/Common/src/setIsMergeable.cc
@@ -1,0 +1,34 @@
+
+#include "DataFormats/Common/interface/setIsMergeable.h"
+
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/getAnyPtr.h"
+
+#include "TClass.h"
+
+#include <memory>
+
+namespace edm {
+
+  void setIsMergeable(BranchDescription& desc) {
+
+    // Save some time here with the knowledge that the isMergeable
+    // data member can only be true for run or lumi products.
+    // It defaults to false. Also if it is true that means it
+    // was already set.
+    if (desc.branchType() == InRun || desc.branchType() == InLumi) {
+      if (!desc.isMergeable()) {
+        TClass* wrapperBaseTClass = TypeWithDict::byName("edm::WrapperBase").getClass();
+        TClass* tClass = desc.wrappedType().getClass();
+        void* p = tClass->New();
+        int offset = tClass->GetBaseClassOffset(wrapperBaseTClass);
+        std::unique_ptr<WrapperBase> wrapperBase = getAnyPtr<WrapperBase>(p, offset);
+        if (wrapperBase->isMergeable()) {
+          desc.setIsMergeable(true);
+        }
+      }
+    }
+  }
+}

--- a/DataFormats/NanoAOD/interface/MergeableCounterTable.h
+++ b/DataFormats/NanoAOD/interface/MergeableCounterTable.h
@@ -87,7 +87,14 @@ class MergeableCounterTable {
             if (!tryMerge(floatCols_, other.floatCols_)) return false;
             if (!tryMerge(vfloatCols_, other.vfloatCols_)) return false;
             return true; 
-         }
+        }
+
+        void swap(MergeableCounterTable& iOther) {
+          floatCols_.swap(iOther.floatCols_);
+          vfloatCols_.swap(iOther.vfloatCols_);
+          intCols_.swap(iOther.intCols_);
+          vintCols_.swap(iOther.vintCols_);
+        }
 
    private:
         std::vector<FloatColumn> floatCols_;

--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -114,6 +114,9 @@ namespace edm {
     std::string const& wrappedName() const {return transient_.wrappedName_;}
     void setWrappedName(std::string const& name) {transient_.wrappedName_ = name;}
 
+    bool isMergeable() const { return transient_.isMergeable_; }
+    void setIsMergeable(bool v) { transient_.isMergeable_ = v; }
+
     void updateFriendlyClassName();
 
     void initializeTransients() {transient_.reset();}
@@ -169,6 +172,10 @@ namespace edm {
 
       // if Run or Lumi based, can only get at end transition
       bool availableOnlyAtEndTransition_;
+
+      // True if the product definition has a mergeProduct function
+      // and the branchType is Run or Lumi
+      bool isMergeable_;
     };
 
   private:

--- a/DataFormats/Provenance/interface/BranchType.h
+++ b/DataFormats/Provenance/interface/BranchType.h
@@ -74,6 +74,7 @@ namespace edm {
     std::string const& fileIdentifierBranchName();
     std::string const& fileIndexBranchName(); // backward compatibility
     std::string const& indexIntoFileBranchName();
+    std::string const& mergeableRunProductMetadataBranchName();
 
     // Event History Tree // backward compatibility
     std::string const& eventHistoryTreeName(); // backward compatibility

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -197,6 +197,7 @@ The interface is too complex for general use.
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/value_ptr.h"
 
@@ -586,6 +587,8 @@ namespace edm {
 
         void copyPosition(IndexIntoFileItrImpl const& position);
 
+        void getLumisInRun(std::vector<LuminosityBlockNumber_t> & lumis) const;
+
       protected:
 
         void setInvalid();
@@ -605,6 +608,7 @@ namespace edm {
         virtual EntryType getRunOrLumiEntryType(int index) const = 0;
         virtual bool isSameLumi(int index1, int index2) const = 0;
         virtual bool isSameRun(int index1, int index2) const = 0;
+        virtual LuminosityBlockNumber_t lumi(int index) const = 0;
 
         IndexIntoFile const* indexIntoFile_;
         int size_;
@@ -650,6 +654,7 @@ namespace edm {
         EntryType getRunOrLumiEntryType(int index) const override;
         bool isSameLumi(int index1, int index2) const override;
         bool isSameRun(int index1, int index2) const override;
+        LuminosityBlockNumber_t lumi(int index) const override;
       };
 
       //*****************************************************************************
@@ -684,6 +689,7 @@ namespace edm {
         EntryType getRunOrLumiEntryType(int index) const override;
         bool isSameLumi(int index1, int index2) const override;
         bool isSameRun(int index1, int index2) const override;
+        LuminosityBlockNumber_t lumi(int index) const override;
       };
 
       //*****************************************************************************
@@ -806,6 +812,8 @@ namespace edm {
 
         /// Copy the position without modifying the pointer to the IndexIntoFile or size
         void copyPosition(IndexIntoFileItr const& position);
+
+        void getLumisInRun(std::vector<LuminosityBlockNumber_t> & lumis) const {impl_->getLumisInRun(lumis);}
 
       private:
         //for testing
@@ -1127,6 +1135,17 @@ namespace edm {
   class Compare_Index {
   public:
     bool operator()(IndexIntoFile::RunOrLumiIndexes const& lh, IndexIntoFile::RunOrLumiIndexes const& rh);
+  };
+
+  // This class exists only to allow forward declarations of IndexIntoFile::IndexIntoFileItr
+  class IndexIntoFileItrHolder {
+  public:
+    IndexIntoFileItrHolder(IndexIntoFile::IndexIntoFileItr const& iIter) : iter_(iIter) { }
+    void getLumisInRun(std::vector<LuminosityBlockNumber_t> & lumis) const {
+      iter_.getLumisInRun(lumis);
+    }
+  private:
+    IndexIntoFile::IndexIntoFileItr const& iter_;
   };
 }
 

--- a/DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h
+++ b/DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h
@@ -1,0 +1,9 @@
+#include <string>
+
+namespace edm {
+
+  class MergeableRunProductMetadataBase {
+  public:
+    virtual bool knownImproperlyMerged(std::string const& processThatCreatedProduct) const = 0;
+  };
+}

--- a/DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h
+++ b/DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h
@@ -4,6 +4,10 @@ namespace edm {
 
   class MergeableRunProductMetadataBase {
   public:
+
+    virtual ~MergeableRunProductMetadataBase();
+
     virtual bool knownImproperlyMerged(std::string const& processThatCreatedProduct) const = 0;
   };
 }
+

--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -27,8 +27,10 @@ existence.
 */
 
 namespace edm {
+  class MergeableRunProductMetadataBase;
   class ProductProvenance;
   class ProductProvenanceRetriever;
+
   class Provenance {
   public:
     Provenance();
@@ -44,6 +46,7 @@ namespace edm {
     std::shared_ptr<BranchDescription const> const& constBranchDescriptionPtr() const {return stable().constBranchDescriptionPtr();}
 
     ProductProvenance const* productProvenance() const;
+    bool knownImproperlyMerged() const;
     BranchID const& branchID() const {return stable().branchID();}
     std::string const& branchName() const {return stable().branchName();}
     std::string const& className() const {return stable().className();}
@@ -81,6 +84,10 @@ namespace edm {
 
     void setProductID(ProductID const& pid) {stable().setProductID(pid);}
 
+    void setMergeableRunProductMetadata(MergeableRunProductMetadataBase const* mrpm) {
+      mergeableRunProductMetadata_ = mrpm;
+    }
+
     void setBranchDescription(std::shared_ptr<BranchDescription const> const& p) {stable().setBranchDescription(p);}
 
     void swap(Provenance&);
@@ -88,6 +95,7 @@ namespace edm {
   private:
     StableProvenance stableProvenance_;
     ProductProvenanceRetriever const* store_;
+    MergeableRunProductMetadataBase const* mergeableRunProductMetadata_;
   };
 
   inline

--- a/DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h
+++ b/DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h
@@ -1,0 +1,152 @@
+#ifndef DataFormats_Provenance_StoredMergeableRunProductMetadata_h
+#define DataFormats_Provenance_StoredMergeableRunProductMetadata_h
+
+/** \class edm::StoredMergeableRunProductMetadata
+
+This class holds information used to decide how to merge together
+run products when multiple run entries with the same run number
+and ProcessHistoryID are read from input files contiguously. This
+class is persistent and stores the information that needs to be
+remembered from one process to the next. Most of the work related
+to this decision is performed by the class MergeableRunProductMetadata.
+The main purpose of this class is to hold the information that
+needs to be persistently stored. PoolSource and PoolOutputModule
+interface with this class to read and write it.
+
+Note that the information is not stored for each product.
+The information is stored for each run entry in Run TTree
+in the input file and also for each process in which at least
+one mergeable run product was selected to be written to the
+output file. It is not necessary to save information
+for each product individually, it will be the same for every
+product created in the same process and in the same run entry.
+
+The main piece of information stored is the list of luminosity
+block numbers processed when the product was created. Often,
+this list can be obtained from the IndexIntoFile and we do not
+need to duplicate this information here and so as an optimization
+we don't. There are also cases where we can detect that the merging
+has created invalid run products where part of the content
+has probably been double counted. We save a value to record
+this problem.
+
+To improve performance, the data structure has been flattened
+into 4 vectors instead of containing a vector containing vectors
+containing vectors.
+
+When the user of this class fails to find a run entry with a
+particular process, the assumption should be made that the lumi
+numbers are in IndexIntoFile and valid.
+
+Another optimization is that if in all cases the lumi numbers
+can be obtained from IndexIntoFile and are valid, then all
+the vectors are cleared and a boolean value is set to indicate
+this.
+
+\author W. David Dagenhart, created 23 May, 2018
+
+*/
+
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
+#include <string>
+#include <vector>
+
+namespace edm {
+
+  class StoredMergeableRunProductMetadata {
+  public:
+
+    // This constructor exists for ROOT I/O
+    StoredMergeableRunProductMetadata();
+
+    // This constructor is used when creating a new object
+    // each time an output file is opened.
+    StoredMergeableRunProductMetadata(std::vector<std::string> const& processesWithMergeableRunProducts);
+
+    std::vector<std::string> const& processesWithMergeableRunProducts() const {
+      return processesWithMergeableRunProducts_;
+    }
+
+    class SingleRunEntry {
+    public:
+
+      SingleRunEntry();
+      SingleRunEntry(unsigned long long iBeginProcess, unsigned long long iEndProcess);
+
+      unsigned long long beginProcess() const { return beginProcess_; }
+      unsigned long long endProcess() const { return endProcess_; }
+
+    private:
+
+      // indexes into singleRunEntryAndProcesses_ for a single run entry
+      unsigned long long beginProcess_;
+      unsigned long long endProcess_;
+    };
+
+    class SingleRunEntryAndProcess {
+    public:
+
+      SingleRunEntryAndProcess();
+      SingleRunEntryAndProcess(unsigned long long iBeginLumi,
+                               unsigned long long iEndLumi,
+                               unsigned int iProcess,
+                               bool iValid,
+                               bool iUseIndexIntoFile);
+
+
+      unsigned long long beginLumi() const { return beginLumi_; }
+      unsigned long long endLumi() const { return endLumi_; }
+
+      unsigned int process() const { return process_; }
+
+      bool valid() const { return valid_; }
+      bool useIndexIntoFile() const { return useIndexIntoFile_; }
+
+    private:
+
+      // indexes into lumis_ for products created in one process and
+      // written into a single run entry.
+      unsigned long long beginLumi_;
+      unsigned long long endLumi_;
+
+      // index into processesWithMergeableRunProducts_
+      unsigned int process_;
+
+      // If false this indicates the way files were split and merged
+      // has created run products that are invalid and probably
+      // double count some of their content.
+      bool valid_;
+
+      // If true the lumi numbers can be obtained from IndexIntoFile
+      // and are not stored in the vector named lumis_
+      bool useIndexIntoFile_;
+    };
+
+    // These four functions are called by MergeableRunProductMetadata which
+    // fills the vectors.
+    std::vector<SingleRunEntry>& singleRunEntries() { return singleRunEntries_; }
+    std::vector<SingleRunEntryAndProcess>& singleRunEntryAndProcesses() { return singleRunEntryAndProcesses_; }
+    std::vector<LuminosityBlockNumber_t>& lumis() { return lumis_; }
+    bool& allValidAndUseIndexIntoFile() { return allValidAndUseIndexIntoFile_; }
+
+    // Called by RootOutputFile immediately before writing the object
+    // when an output file is closed.
+    void optimizeBeforeWrite();
+
+    bool getLumiContent(unsigned long long runEntry,
+                        std::string const& process,
+                        bool& valid,
+                        std::vector<LuminosityBlockNumber_t>::const_iterator & lumisBegin,
+                        std::vector<LuminosityBlockNumber_t>::const_iterator & lumisEnd) const;
+
+  private:
+
+    std::vector<std::string> processesWithMergeableRunProducts_;
+    std::vector<SingleRunEntry> singleRunEntries_;  // index is the run entry
+    std::vector<SingleRunEntryAndProcess> singleRunEntryAndProcesses_;
+    std::vector<LuminosityBlockNumber_t> lumis_;
+    bool allValidAndUseIndexIntoFile_;
+  };
+}
+#endif

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -29,8 +29,9 @@ namespace edm {
     onDemand_(false),
     dropped_(false),
     transient_(false),
-    availableOnlyAtEndTransition_(false){
-   }
+    availableOnlyAtEndTransition_(false),
+    isMergeable_(false) {
+  }
 
   void
   BranchDescription::Transients::reset() {

--- a/DataFormats/Provenance/src/BranchType.cc
+++ b/DataFormats/Provenance/src/BranchType.cc
@@ -86,6 +86,7 @@ namespace edm {
     std::string const fileIdentifier = "FileIdentifier";
     std::string const fileIndex = "FileIndex";
     std::string const indexIntoFile = "IndexIntoFile";
+    std::string const mergeableRunProductMetadata = "MergeableRunProductMetadata";
     std::string const eventHistory = "EventHistory";
     std::string const eventBranchMapper = "EventBranchMapper";
 
@@ -232,6 +233,11 @@ namespace edm {
     // Branch on MetaData Tree
     std::string const& indexIntoFileBranchName() {
       return indexIntoFile;
+    }
+
+    // Branch on MetaData Tree
+    std::string const& mergeableRunProductMetadataBranchName() {
+      return mergeableRunProductMetadata;
     }
 
     // Branch on Event History Tree

--- a/DataFormats/Provenance/src/MergeableRunProductMetadataBase.cc
+++ b/DataFormats/Provenance/src/MergeableRunProductMetadataBase.cc
@@ -1,0 +1,6 @@
+#include "DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h"
+
+namespace edm {
+  MergeableRunProductMetadataBase::~MergeableRunProductMetadataBase() { }
+}
+

--- a/DataFormats/Provenance/src/Provenance.cc
+++ b/DataFormats/Provenance/src/Provenance.cc
@@ -1,4 +1,6 @@
 #include "DataFormats/Provenance/interface/Provenance.h"
+
+#include "DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h"
 #include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
@@ -19,12 +21,14 @@ namespace edm {
 
   Provenance::Provenance(std::shared_ptr<BranchDescription const> const& p, ProductID const& pid) :
     stableProvenance_(p, pid),
-    store_() {
+    store_(),
+    mergeableRunProductMetadata_() {
   }
 
   Provenance::Provenance(StableProvenance const& stable) :
     stableProvenance_(stable),
-    store_() {
+    store_(),
+    mergeableRunProductMetadata_() {
   }
 
   ProductProvenance const*
@@ -33,6 +37,17 @@ namespace edm {
       return nullptr;
     }
     return store_->branchIDToProvenance(originalBranchID());
+  }
+
+  bool
+  Provenance::knownImproperlyMerged() const {
+    if (mergeableRunProductMetadata_ && branchDescription().isMergeable()) {
+      // This part handles the cases where the product is
+      // a mergeable run product from the input.
+      return mergeableRunProductMetadata_->knownImproperlyMerged(processName());
+    }
+    // All other cases
+    return false;
   }
 
   void
@@ -55,5 +70,6 @@ namespace edm {
   Provenance::swap(Provenance& iOther) {
     stableProvenance_.swap(iOther.stableProvenance_);
     std::swap(store_,iOther.store_);
+    std::swap(mergeableRunProductMetadata_,iOther.mergeableRunProductMetadata_);
  }
 }

--- a/DataFormats/Provenance/src/StoredMergeableRunProductMetadata.cc
+++ b/DataFormats/Provenance/src/StoredMergeableRunProductMetadata.cc
@@ -1,0 +1,81 @@
+#include "DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h"
+
+namespace edm {
+
+  StoredMergeableRunProductMetadata::StoredMergeableRunProductMetadata() :
+    allValidAndUseIndexIntoFile_(true) { }
+
+  StoredMergeableRunProductMetadata::
+  StoredMergeableRunProductMetadata(std::vector<std::string> const& processesWithMergeableRunProducts):
+    processesWithMergeableRunProducts_(processesWithMergeableRunProducts),
+    allValidAndUseIndexIntoFile_(true) { }
+
+  StoredMergeableRunProductMetadata::SingleRunEntry::SingleRunEntry() :
+    beginProcess_(0),
+    endProcess_(0) { }
+
+  StoredMergeableRunProductMetadata::SingleRunEntry::SingleRunEntry(unsigned long long iBeginProcess,
+                                                                    unsigned long long iEndProcess) :
+    beginProcess_(iBeginProcess),
+    endProcess_(iEndProcess) { }
+
+  StoredMergeableRunProductMetadata::SingleRunEntryAndProcess::SingleRunEntryAndProcess() :
+    beginLumi_(0),
+    endLumi_(0),
+    process_(0),
+    valid_(false),
+    useIndexIntoFile_(false) { }
+
+  StoredMergeableRunProductMetadata::SingleRunEntryAndProcess::
+  SingleRunEntryAndProcess(unsigned long long iBeginLumi,
+                           unsigned long long iEndLumi,
+                           unsigned int iProcess,
+                           bool iValid,
+                           bool iUseIndexIntoFile)  :
+    beginLumi_(iBeginLumi),
+    endLumi_(iEndLumi),
+    process_(iProcess),
+    valid_(iValid),
+    useIndexIntoFile_(iUseIndexIntoFile) { }
+
+  void StoredMergeableRunProductMetadata::optimizeBeforeWrite() {
+    if (allValidAndUseIndexIntoFile_) {
+      processesWithMergeableRunProducts_.clear();
+      singleRunEntries_.clear();
+      singleRunEntryAndProcesses_.clear();
+      lumis_.clear();
+    }
+  }
+
+  bool StoredMergeableRunProductMetadata::
+  getLumiContent(unsigned long long runEntry,
+                 std::string const& process,
+                 bool& valid,
+                 std::vector<LuminosityBlockNumber_t>::const_iterator & lumisBegin,
+                 std::vector<LuminosityBlockNumber_t>::const_iterator & lumisEnd) const {
+
+    valid = true;
+    if (allValidAndUseIndexIntoFile_) {
+      return false;
+    }
+
+    SingleRunEntry const& singleRunEntry = singleRunEntries_.at(runEntry);
+    for (unsigned long long j = singleRunEntry.beginProcess(); j < singleRunEntry.endProcess(); ++j) {
+      SingleRunEntryAndProcess const& singleRunEntryAndProcess = singleRunEntryAndProcesses_.at(j);
+      // This string comparison could be optimized away by storing an index mapping in
+      // MergeableRunProductMetadata that gets recalculated each time a new input
+      // file is opened
+      if (processesWithMergeableRunProducts_.at(singleRunEntryAndProcess.process()) == process) {
+        valid = singleRunEntryAndProcess.valid();
+        if (singleRunEntryAndProcess.useIndexIntoFile()) {
+          return false;
+        } else {
+          lumisBegin = lumis_.begin() + singleRunEntryAndProcess.beginLumi();
+          lumisEnd = lumis_.begin() + singleRunEntryAndProcess.endLumi();
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -25,6 +25,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
+#include "DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h"
 #include "DataFormats/Provenance/interface/StoredProductProvenance.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -131,6 +131,18 @@
   <version ClassVersion="10" checksum="262935904"/>
  </class>
  <class name="edm::IndexIntoFile::Transients" ClassVersion="0"/>
+
+ <class name="edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess" ClassVersion="3">
+  <version ClassVersion="3" checksum="3004083460"/>
+ </class>
+ <class name="std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>"/>
+ <class name="edm::StoredMergeableRunProductMetadata::SingleRunEntry" ClassVersion="3">
+  <version ClassVersion="3" checksum="294451415"/>
+ </class>
+ <class name="std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>"/>
+ <class name="edm::StoredMergeableRunProductMetadata" ClassVersion="3">
+  <version ClassVersion="3" checksum="2293482595"/>
+ </class>
  <class name="edm::ProcessHistoryID"/>
  <class name="std::set<edm::ProcessHistoryID >"/>
  <class name="std::vector<edm::ProcessHistory>"/>

--- a/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
@@ -355,5 +355,10 @@ void TestIndexIntoFile1::testConstructor() {
   CPPUNIT_ASSERT(indexIntoFile.eventNumbers().empty());
   CPPUNIT_ASSERT(indexIntoFile.setRunOrLumiEntries().empty());
   CPPUNIT_ASSERT(indexIntoFile.setProcessHistoryIDs().empty());
-}
 
+  std::vector<LuminosityBlockNumber_t> lumis;
+  lumis.push_back(1);
+  edm::IndexIntoFile::IndexIntoFileItr iter = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
+  iter.getLumisInRun(lumis);
+  CPPUNIT_ASSERT(lumis.empty());
+}

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -883,6 +883,8 @@ void TestIndexIntoFile3::testOverlappingLumis() {
   eventEntries.emplace_back(4, 6);
   indexIntoFile.sortEventEntries();
 
+  std::vector<LuminosityBlockNumber_t> lumis;
+
   edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
   edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
   int i = 0;
@@ -926,7 +928,13 @@ void TestIndexIntoFile3::testOverlappingLumis() {
     int i = 0;
     for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
       //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
-      if (i == 0)       check(iterFirst, kRun,   0, 2,  1, 0, 2);
+      if (i == 0) {
+        check(iterFirst, kRun,   0, 2,  1, 0, 2);
+
+        iterFirst.getLumisInRun(lumis);
+        std::vector<LuminosityBlockNumber_t> expected { 102, 103, 104 };
+        CPPUNIT_ASSERT(lumis == expected);
+      }
       else if (i == 1)  check(iterFirst, kLumi,  0, 2,  1, 0, 2);
       else if (i == 2)  check(iterFirst, kEvent, 0, 2,  1, 0, 2);
       else if (i == 3)  check(iterFirst, kEvent, 0, 2,  1, 1, 2);
@@ -1000,6 +1008,10 @@ void TestIndexIntoFile3::testOverlappingLumis() {
         check(iterFirst, kRun, 0, 2, 1, 0, 3);
         CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
         CPPUNIT_ASSERT(iterFirst.size() == 10);
+
+        iterFirst.getLumisInRun(lumis);
+        std::vector<LuminosityBlockNumber_t> expected { 101, 102 };
+        CPPUNIT_ASSERT(lumis == expected);
       }
       //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
       else if (i == 1)  check(iterFirst, kLumi,  0, 2,  1, 0, 3);
@@ -1010,7 +1022,13 @@ void TestIndexIntoFile3::testOverlappingLumis() {
       else if (i == 6)  check(iterFirst, kLumi,  0, 4,  3, 0, 1);
       else if (i == 7)  check(iterFirst, kEvent, 0, 4,  3, 0, 1);
       else if (i == 8) check(iterFirst, kEvent, 0, 4,  4, 0, 1);
-      else if (i == 9) check(iterFirst, kRun,   5, 7, -1, 0, 0);
+      else if (i == 9) {
+        check(iterFirst, kRun,   5, 7, -1, 0, 0);
+
+        iterFirst.getLumisInRun(lumis);
+        std::vector<LuminosityBlockNumber_t> expected { 101, 102 };
+        CPPUNIT_ASSERT(lumis == expected);
+      }
       else if (i == 10) check(iterFirst, kRun,   6, 7, -1, 0, 0);
       else if (i == 11) check(iterFirst, kLumi,  6, 7, -1, 0, 0);
       else if (i == 12) check(iterFirst, kLumi,  6, 8,  9, 0, 1);

--- a/DataFormats/TestObjects/interface/ThingWithMerge.h
+++ b/DataFormats/TestObjects/interface/ThingWithMerge.h
@@ -9,6 +9,7 @@ namespace edmtest {
     ~ThingWithMerge() { }
     ThingWithMerge():a() { }
     bool mergeProduct(ThingWithMerge const& newThing);
+    void swap(ThingWithMerge& iOther);
     cms_int32_t a;
   };
 

--- a/DataFormats/TestObjects/src/ThingWithMerge.cc
+++ b/DataFormats/TestObjects/src/ThingWithMerge.cc
@@ -2,10 +2,16 @@
 
 #include "DataFormats/TestObjects/interface/ThingWithMerge.h"
 
+#include <utility>
+
 namespace edmtest {
 
   bool ThingWithMerge::mergeProduct(ThingWithMerge const& newThing) {
     a += newThing.a;
     return true;
+  }
+
+  void ThingWithMerge::swap(ThingWithMerge& iOther) {
+    std::swap(a, iOther.a);
   }
 }

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -14,6 +14,7 @@ configured in the user's main() function, and is set running.
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Framework/interface/MergeableRunProductProcesses.h"
 #include "FWCore/Framework/interface/PathsAndConsumesOfModules.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/Framework/src/PrincipalCache.h"
@@ -44,6 +45,7 @@ namespace edm {
 
   class ExceptionToActionTable;
   class BranchIDListHelper;
+  class MergeableRunProductMetadata;
   class ThinnedAssociationsHelper;
   class EDLooperBase;
   class HistoryAppender;
@@ -227,7 +229,7 @@ namespace edm {
     std::pair<ProcessHistoryID,RunNumber_t> readAndMergeRun();
     void readLuminosityBlock(LuminosityBlockProcessingStatus&);
     int readAndMergeLumi(LuminosityBlockProcessingStatus&);
-    void writeRunAsync(WaitingTaskHolder, ProcessHistoryID const& phid, RunNumber_t run);
+    void writeRunAsync(WaitingTaskHolder, ProcessHistoryID const& phid, RunNumber_t run, MergeableRunProductMetadata const*);
     void deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run);
     void writeLumiAsync(WaitingTaskHolder, std::shared_ptr<LuminosityBlockProcessingStatus> );
     void deleteLumiFromCache(LuminosityBlockProcessingStatus&);
@@ -300,6 +302,7 @@ namespace edm {
     std::shared_ptr<ProcessConfiguration const>       processConfiguration_;
     ProcessContext                                processContext_;
     PathsAndConsumesOfModules                     pathsAndConsumesOfModules_;
+    MergeableRunProductProcesses mergeableRunProductProcesses_;
     edm::propagate_const<std::unique_ptr<Schedule>> schedule_;
     std::vector<edm::SerialTaskQueue> streamQueues_;
     std::unique_ptr<edm::LimitedTaskQueue> lumiQueue_;

--- a/FWCore/Framework/interface/MergeableRunProductMetadata.h
+++ b/FWCore/Framework/interface/MergeableRunProductMetadata.h
@@ -59,7 +59,7 @@ namespace edm {
     ~MergeableRunProductMetadata() override;
 
     // Called each time a new input file is opened
-    void readFile();
+    void preReadFile();
 
     // Called each time a run entry is read from an input file. This
     // should be called before the run products themselves are read

--- a/FWCore/Framework/interface/MergeableRunProductMetadata.h
+++ b/FWCore/Framework/interface/MergeableRunProductMetadata.h
@@ -1,0 +1,160 @@
+#ifndef FWCore_Framework_MergeableRunProductMetadata_h
+#define FWCore_Framework_MergeableRunProductMetadata_h
+
+/** \class edm::MergeableRunProductMetadata
+
+This class holds information used to decide how to merge together
+mergeable run products when multiple run entries with the same
+run number and ProcessHistoryID are read from input files
+contiguously.
+
+Most of the information here is associated with the current
+run being processed. Most of it is cleared when a new run
+is started. If multiple runs are being processed concurrently,
+then there will be an object instantiated for each concurrent
+run. (At the present time concurrent runs are not possible, but
+there plans to implement that in the future). The primary
+RunPrincipal for the current run owns the object.
+
+This class gets information from the input file from the
+StoredMergeableRunProductMetadata object and IndexIntoFile object.
+It uses that information to make the decision how to merge
+run products read from data, and puts information into the
+StoredMergeableRunProductMetadata written into the output file
+to use in later processing steps.
+
+If there are SubProcesses, they use the same object as the top
+level process because they share the same input.
+
+There will be a TWIKI page on the Framework page of the Software
+Guide which explains the details about how this works. There
+are significant limitations related to what the Framework does
+and does not do managing mergeable run products.
+
+\author W. David Dagenhart, created 9 July, 2018
+
+*/
+
+#include "DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h"
+#include "FWCore/Framework/interface/MergeableRunProductProcesses.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
+#include "tbb/concurrent_vector.h"
+
+#include <string>
+#include <vector>
+
+namespace edm {
+
+  class IndexIntoFileItrHolder;
+  class StoredMergeableRunProductMetadata;
+
+  class MergeableRunProductMetadata : public MergeableRunProductMetadataBase {
+  public:
+
+    enum MergeDecision { MERGE, REPLACE, IGNORE };
+
+    MergeableRunProductMetadata(MergeableRunProductProcesses const&);
+
+    // Called each time a new input file is opened
+    void readFile();
+
+    // Called each time a run entry is read from an input file. This
+    // should be called before the run products themselves are read
+    // because it sets the decision whether to merge, replace, or ignore
+    // run products as they read.
+    void readRun(
+      long long inputRunEntry,
+      StoredMergeableRunProductMetadata const& inputStoredMergeableRunProductMetadata,
+      IndexIntoFileItrHolder const& inputIndexIntoFileItr);
+
+    // Called to record which lumis were processed by the current run
+    void writeLumi(LuminosityBlockNumber_t lumi);
+
+    void preWriteRun();
+    void postWriteRun();
+
+    void addEntryToStoredMetadata(StoredMergeableRunProductMetadata&) const;
+
+    MergeDecision getMergeDecision(std::string const& processThatCreatedProduct) const;
+
+    // If Runs were split on lumi boundaries, but then the files were merged
+    // in a way that made it impossible to properly merge run products, this
+    // function will return true. The Framework usually does not know
+    // enough to detect other cases where there is a merging problem.
+    bool knownImproperlyMerged(std::string const& processThatCreatedProduct) const override;
+
+    std::string const& getProcessName(unsigned int index) const {
+      return mergeableRunProductProcesses_->getProcessName(index);
+    }
+
+    class MetadataForProcess {
+    public:
+
+      MetadataForProcess() = default;
+
+      std::vector<LuminosityBlockNumber_t>& lumis() { return lumis_; }
+      std::vector<LuminosityBlockNumber_t> const& lumis() const { return lumis_; }
+
+      MergeDecision mergeDecision() const { return mergeDecision_; }
+      void setMergeDecision(MergeDecision v) { mergeDecision_ = v; }
+
+      bool valid() const { return valid_; }
+      void setValid(bool v) { valid_ = v; }
+
+      bool useIndexIntoFile() const { return useIndexIntoFile_; }
+      void setUseIndexIntoFile(bool v) { useIndexIntoFile_ = v; }
+
+      bool allLumisProcessed() const { return allLumisProcessed_; }
+      void setAllLumisProcessed(bool v) { allLumisProcessed_ = v; }
+
+      void reset();
+
+    private:
+
+      std::vector<LuminosityBlockNumber_t> lumis_;
+      MergeDecision mergeDecision_ = MERGE;
+      bool valid_ = true;
+      bool useIndexIntoFile_ = false;
+      bool allLumisProcessed_ = false;
+    };
+
+    MetadataForProcess const* metadataForOneProcess(std::string const& processName) const;
+
+    // The next few functions are only intended to be used in tests.
+    std::vector<MetadataForProcess> const&
+    metadataForProcesses() const { return metadataForProcesses_; }
+
+    std::vector<LuminosityBlockNumber_t> const &
+    lumisFromIndexIntoFile() const { return lumisFromIndexIntoFile_; }
+
+    bool gotLumisFromIndexIntoFile() const { return gotLumisFromIndexIntoFile_; }
+
+    tbb::concurrent_vector<LuminosityBlockNumber_t> const&
+    lumisProcessed() const { return lumisProcessed_; }
+
+  private:
+
+    void mergeLumisFromIndexIntoFile();
+
+    bool addProcess(StoredMergeableRunProductMetadata& storedMetadata,
+                    MetadataForProcess const& metadataForProcess,
+                    unsigned int storedProcessIndex,
+                    unsigned long long beginProcess,
+                    unsigned long long endProcess) const;
+
+    MergeableRunProductProcesses const* mergeableRunProductProcesses_;
+
+    // This vector has an entry for each process that has a
+    // mergeable run product in the input. It has an exact one to
+    // correspondence with mergeableRunProductProcesses_ and
+    // is in the same order.
+    std::vector<MetadataForProcess> metadataForProcesses_;
+
+    std::vector<LuminosityBlockNumber_t> lumisFromIndexIntoFile_;
+    bool gotLumisFromIndexIntoFile_ = false;
+
+    tbb::concurrent_vector<LuminosityBlockNumber_t> lumisProcessed_;
+  };
+}
+#endif

--- a/FWCore/Framework/interface/MergeableRunProductMetadata.h
+++ b/FWCore/Framework/interface/MergeableRunProductMetadata.h
@@ -56,6 +56,8 @@ namespace edm {
 
     MergeableRunProductMetadata(MergeableRunProductProcesses const&);
 
+    ~MergeableRunProductMetadata() override;
+
     // Called each time a new input file is opened
     void readFile();
 

--- a/FWCore/Framework/interface/MergeableRunProductProcesses.h
+++ b/FWCore/Framework/interface/MergeableRunProductProcesses.h
@@ -1,0 +1,40 @@
+#ifndef FWCore_Framework_MergeableRunProductProcesses_h
+#define FWCore_Framework_MergeableRunProductProcesses_h
+
+#include <string>
+#include <vector>
+
+namespace edm {
+
+  class ProductRegistry;
+
+  class MergeableRunProductProcesses {
+  public:
+
+    MergeableRunProductProcesses();
+
+    std::vector<std::string> const& processesWithMergeableRunProducts() const {
+      return processesWithMergeableRunProducts_;
+    }
+
+    std::string const& getProcessName(unsigned int index) const {
+      return processesWithMergeableRunProducts_[index];
+    }
+
+    std::vector<std::string>::size_type size() const {
+      return processesWithMergeableRunProducts_.size();
+    }
+
+    // Called once in a job right after the ProductRegistry is frozen.
+    // After that the names stored in this class are never modified.
+    void setProcessesWithMergeableRunProducts(ProductRegistry const& productRegistry);
+
+  private:
+
+    // Holds the process names for processes that created mergeable
+    // run products that are in the input of the current job.
+    // Note this does not include the current process.
+    std::vector<std::string> processesWithMergeableRunProducts_;
+  };
+}
+#endif

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -32,9 +32,11 @@ output stream.
 #include <vector>
 #include <map>
 #include <atomic>
+#include <set>
 
 namespace edm {
 
+  class MergeableRunProductMetadata;
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
@@ -191,7 +193,7 @@ namespace edm {
     //------------------------------------------------------------------
     // private member functions
     //------------------------------------------------------------------
-    void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const* mcc);
+    void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const* mcc, MergeableRunProductMetadata const*);
     void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const* mcc);
     void doOpenFile(FileBlock const& fb);
     void doRespondToOpenInputFile(FileBlock const& fb);
@@ -229,6 +231,8 @@ namespace edm {
     virtual void openFile(FileBlock const&) {}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
+
+    virtual void setProcessesWithSelectedMergeableRunProducts(std::set<std::string> const&) {}
 
     bool hasAcquire() const { return false; }
     bool hasAccumulator() const { return false; }

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -41,6 +41,7 @@ pointer to a ProductResolver, when queried.
 namespace edm {
 
   class HistoryAppender;
+  class MergeableRunProductMetadata;
   class ModuleCallingContext;
   class ProcessHistoryRegistry;
   class ProductResolverIndexHelper;
@@ -185,7 +186,7 @@ namespace edm {
 
     ProductData const* findProductByTag(TypeID const& typeID, InputTag const& tag, ModuleCallingContext const* mcc) const;
 
-    void readAllFromSourceAndMergeImmediately();
+    void readAllFromSourceAndMergeImmediately(MergeableRunProductMetadata const* mergeableRunProductMetadata = nullptr);
     
     std::vector<unsigned int> const& lookupProcessOrder() const { return lookupProcessOrder_; }
 

--- a/FWCore/Framework/interface/ProductResolverBase.h
+++ b/FWCore/Framework/interface/ProductResolverBase.h
@@ -21,6 +21,7 @@ ProductResolver: Class to handle access to a WrapperBase and its related informa
 #include <string>
 
 namespace edm {
+  class MergeableRunProductMetadata;
   class ProductProvenanceRetriever;
   class DelayedReader;
   class ModuleCallingContext;
@@ -73,8 +74,8 @@ namespace edm {
       return prefetchAsync_(waitTask, principal, skipCurrentProcess, token, sra, mcc);
     }
 
-    void retrieveAndMerge(Principal const& principal) const {
-      retrieveAndMerge_(principal);
+    void retrieveAndMerge(Principal const& principal, MergeableRunProductMetadata const* mergeableRunProductMetadata) const {
+      retrieveAndMerge_(principal, mergeableRunProductMetadata);
     }
     void resetProductData() { resetProductData_(false); }
 
@@ -135,6 +136,9 @@ namespace edm {
     // Initializes the event independent portion of the provenance, plus the process history ID, the product ID, and the provRetriever.
     void setProvenance(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(provRetriever, ph, pid); }
 
+    // Initializes the portion of the provenance related to mergeable run products.
+    void setMergeableRunProductMetadata(MergeableRunProductMetadata const* mrpm) { setMergeableRunProductMetadata_(mrpm); }
+
     // Initializes the process history.
     void setProcessHistory(ProcessHistory const& ph) { setProcessHistory_(ph); }
 
@@ -155,8 +159,8 @@ namespace edm {
     }
 
     // If the product already exists we merge, else will put
-    void putOrMergeProduct(std::unique_ptr<WrapperBase> edp) const {
-      putOrMergeProduct_(std::move(edp));
+    void putOrMergeProduct(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const* mergeableRunProductMetadata = nullptr) const {
+      putOrMergeProduct_(std::move(edp), mergeableRunProductMetadata);
     }
     
     virtual void connectTo(ProductResolverBase const&, Principal const*) = 0;
@@ -174,7 +178,7 @@ namespace edm {
                                 SharedResourcesAcquirer* sra,
                                 ModuleCallingContext const* mcc) const = 0;
     
-    virtual void retrieveAndMerge_(Principal const& principal) const;
+    virtual void retrieveAndMerge_(Principal const& principal, MergeableRunProductMetadata const* mergeableRunProductMetadata) const;
 
 
     virtual bool unscheduledWasNotRun_() const = 0;
@@ -184,12 +188,13 @@ namespace edm {
     virtual bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const = 0;
 
     virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const = 0;
-    virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> edp) const = 0;
+    virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const* mergeableRunProductMetadata) const = 0;
     virtual BranchDescription const& branchDescription_() const = 0;
     virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) = 0;
     virtual Provenance const* provenance_() const = 0;
     virtual std::string const& resolvedModuleLabel_() const = 0;
     virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) = 0;
+    virtual void setMergeableRunProductMetadata_(MergeableRunProductMetadata const*);
     virtual void setProcessHistory_(ProcessHistory const& ph) = 0;
     virtual ProductProvenance const* productProvenancePtr_() const = 0;
     virtual void resetProductData_(bool deleteEarly) = 0;

--- a/FWCore/Framework/interface/RunForOutput.h
+++ b/FWCore/Framework/interface/RunForOutput.h
@@ -33,12 +33,14 @@ namespace edmtest {
 }
 
 namespace edm {
+  class MergeableRunProductMetadata;
   class ModuleCallingContext;
   
   class RunForOutput : public OccurrenceForOutput {
   public:
     RunForOutput(RunPrincipal const& rp, ModuleDescription const& md,
-        ModuleCallingContext const*, bool isAtEnd);
+                 ModuleCallingContext const*, bool isAtEnd,
+                 MergeableRunProductMetadata const* = nullptr);
     ~RunForOutput() override;
 
     RunAuxiliary const& runAuxiliary() const {return aux_;}
@@ -46,6 +48,7 @@ namespace edm {
     RunNumber_t run() const {return aux_.run();}
     Timestamp const& beginTime() const {return aux_.beginTime();}
     Timestamp const& endTime() const {return aux_.endTime();}
+    MergeableRunProductMetadata const* mergeableRunProductMetadata() const { return mergeableRunProductMetadata_; }
 
   private:
     friend class edmtest::TestOutputModule; // For testing
@@ -54,6 +57,8 @@ namespace edm {
     runPrincipal() const;
 
     RunAuxiliary const& aux_;
+
+    MergeableRunProductMetadata const* mergeableRunProductMetadata_;
 
     static const std::string emptyString_;
   };

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -99,7 +99,7 @@ namespace edm {
 
     MergeableRunProductMetadata* mergeableRunProductMetadata() {return mergeableRunProductMetadataPtr_.get();}
 
-    void readFile();
+    void preReadFile();
 
   private:
 

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -19,12 +19,15 @@ is the DataBlock.
 
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Framework/interface/Principal.h"
 
 namespace edm {
 
   class HistoryAppender;
+  class MergeableRunProductProcesses;
+  class MergeableRunProductMetadata;
   class ModuleCallingContext;
 
   class RunPrincipal : public Principal {
@@ -38,8 +41,9 @@ namespace edm {
         ProcessConfiguration const& pc,
         HistoryAppender* historyAppender,
         unsigned int iRunIndex,
-        bool isForPrimaryProcess=true);
-    ~RunPrincipal() override {}
+        bool isForPrimaryProcess=true,
+        MergeableRunProductProcesses const* mergeableRunProductProcesses = nullptr);
+    ~RunPrincipal() override;
 
     void fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader = nullptr);
 
@@ -93,6 +97,10 @@ namespace edm {
     void put(ProductResolverIndex index,
              std::unique_ptr<WrapperBase> edp) const;
 
+    MergeableRunProductMetadata* mergeableRunProductMetadata() {return mergeableRunProductMetadataPtr_.get();}
+
+    void readFile();
+
   private:
 
     unsigned int transitionIndex_() const override;
@@ -100,6 +108,11 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<RunAuxiliary>> aux_;
     ProcessHistoryID m_reducedHistoryID;
     RunIndex index_;
+
+    // For the primary input RunPrincipals created by the EventProcessor,
+    // there should be one MergeableRunProductMetadata object created
+    // per concurrent run. In all other cases, this should just be null.
+    edm::propagate_const<std::unique_ptr<MergeableRunProductMetadata>> mergeableRunProductMetadataPtr_;
   };
 }
 #endif

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -99,6 +99,7 @@ namespace edm {
   class BranchIDListHelper;
   class EventSetup;
   class ExceptionCollector;
+  class MergeableRunProductMetadata;
   class OutputModuleCommunicator;
   class ProcessContext;
   class ProductRegistry;
@@ -173,7 +174,8 @@ namespace edm {
     void writeRunAsync(WaitingTaskHolder iTask,
                        RunPrincipal const& rp,
                        ProcessContext const*,
-                       ActivityRegistry*);
+                       ActivityRegistry*,
+                       MergeableRunProductMetadata const*);
 
     // Call closeFile() on all OutputModules.
     void closeOutputFiles();

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -30,6 +30,7 @@ namespace edm {
   class BranchIDListHelper;
   class HistoryAppender;
   class IOVSyncValue;
+  class MergeableRunProductMetadata;
   class ParameterSet;
   class ProductRegistry;
   class PreallocationConfiguration;
@@ -114,7 +115,7 @@ namespace edm {
     void deleteLumiFromCache(LuminosityBlockPrincipal&);
 
     // Write the run
-    void writeRunAsync(WaitingTaskHolder, ProcessHistoryID const& parentPhID, int runNumber);
+    void writeRunAsync(WaitingTaskHolder, ProcessHistoryID const& parentPhID, int runNumber, MergeableRunProductMetadata const*);
 
     void deleteRunFromCache(ProcessHistoryID const& parentPhID, int runNumber);
 

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <atomic>
 #include <mutex>
+#include <set>
 
 // user include files
 #include "DataFormats/Provenance/interface/BranchID.h"
@@ -43,6 +44,7 @@
 // forward declarations
 namespace edm {
 
+  class MergeableRunProductMetadata;
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
@@ -212,7 +214,7 @@ namespace edm {
 
       void updateBranchIDListsWithKeptAliases();
 
-      void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*);
+      void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*, MergeableRunProductMetadata const*);
       void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*);
       void doOpenFile(FileBlock const& fb);
       void doRespondToOpenInputFile(FileBlock const& fb);
@@ -269,6 +271,8 @@ namespace edm {
       virtual void doEndLuminosityBlockSummary_(LuminosityBlockForOutput const&, EventSetup const&){}
       virtual void doRespondToOpenInputFile_(FileBlock const&) {}
       virtual void doRespondToCloseInputFile_(FileBlock const&) {}
+
+      virtual void setProcessesWithSelectedMergeableRunProducts(std::set<std::string> const&) {}
 
       bool hasAcquire() const { return false; }
       bool hasAccumulator() const { return false; }

--- a/FWCore/Framework/interface/insertSelectedProcesses.h
+++ b/FWCore/Framework/interface/insertSelectedProcesses.h
@@ -1,0 +1,14 @@
+#ifndef FWCore_Framework_insertSelectedProcesses_h
+#define FWCore_Framework_insertSelectedProcesses_h
+
+#include <set>
+#include <string>
+
+namespace edm {
+
+  class BranchDescription;
+
+  void insertSelectedProcesses(BranchDescription const& desc,
+                               std::set<std::string>& processes);
+}
+#endif

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <atomic>
 #include <mutex>
+#include <set>
 
 // user include files
 #include "DataFormats/Provenance/interface/BranchID.h"
@@ -44,6 +45,7 @@
 // forward declarations
 namespace edm {
 
+  class MergeableRunProductMetadata;
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
@@ -218,7 +220,7 @@ namespace edm {
 
       void updateBranchIDListsWithKeptAliases();
 
-      void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*);
+      void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*, MergeableRunProductMetadata const*);
       void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*);
       void doOpenFile(FileBlock const& fb);
       void doRespondToOpenInputFile(FileBlock const& fb);
@@ -275,6 +277,8 @@ namespace edm {
       virtual void doEndLuminosityBlockSummary_(LuminosityBlockForOutput const&, EventSetup const&){}
       virtual void doRespondToOpenInputFile_(FileBlock const&) {}
       virtual void doRespondToCloseInputFile_(FileBlock const&) {}
+
+      virtual void setProcessesWithSelectedMergeableRunProducts(std::set<std::string> const&) {}
 
       bool hasAcquire() const { return false; }
       bool hasAccumulator() const { return false; }

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <map>
 #include <atomic>
+#include <set>
 
 // user include files
 #include "DataFormats/Provenance/interface/BranchID.h"
@@ -45,6 +46,7 @@
 // forward declarations
 namespace edm {
 
+  class MergeableRunProductMetadata;
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
@@ -206,7 +208,7 @@ namespace edm {
       
       virtual SharedResourcesAcquirer createAcquirer();
       
-      void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*);
+      void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*, MergeableRunProductMetadata const*);
       void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*);
       void doOpenFile(FileBlock const& fb);
       void doRespondToOpenInputFile(FileBlock const& fb);
@@ -249,6 +251,8 @@ namespace edm {
       virtual void doEndLuminosityBlock_(LuminosityBlockForOutput const&){}
       virtual void doRespondToOpenInputFile_(FileBlock const&) {}
       virtual void doRespondToCloseInputFile_(FileBlock const&) {}
+
+      virtual void setProcessesWithSelectedMergeableRunProducts(std::set<std::string> const&) {}
 
       bool hasAcquire() const { return false; }
       bool hasAccumulator() const { return false; }

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -827,7 +827,7 @@ namespace edm {
     size_t size = preg_->size();
     SendSourceTerminationSignalIfException sentry(actReg_.get());
 
-    principalCache_.readFile();
+    principalCache_.preReadFile();
 
     fb_ = input_->readFile();
     if(size < preg_->size()) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/LooperFactory.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/MergeableRunProductMetadata.h"
 #include "FWCore/Framework/interface/ModuleChanger.h"
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/interface/ProcessingController.h"
@@ -505,6 +506,7 @@ namespace edm {
     act_table_ = std::move(items.act_table_);
     actReg_ = items.actReg_;
     preg_ = items.preg();
+    mergeableRunProductProcesses_.setProcessesWithMergeableRunProducts(*preg_);
     branchIDListHelper_ = items.branchIDListHelper();
     thinnedAssociationsHelper_ = items.thinnedAssociationsHelper();
     processConfiguration_ = items.processConfiguration();
@@ -825,6 +827,8 @@ namespace edm {
     size_t size = preg_->size();
     SendSourceTerminationSignalIfException sentry(actReg_.get());
 
+    principalCache_.readFile();
+
     fb_ = input_->readFile();
     if(size < preg_->size()) {
       principalCache_.adjustIndexesAfterProductRegistryAddition();
@@ -1018,8 +1022,12 @@ namespace edm {
     if(globalBeginSucceeded) {
       auto t = edm::make_empty_waiting_task();
       t->increment_ref_count();
-      writeRunAsync(edm::WaitingTaskHolder{t.get()}, phid, run);
+      RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
+      MergeableRunProductMetadata* mergeableRunProductMetadata = runPrincipal.mergeableRunProductMetadata();
+      mergeableRunProductMetadata->preWriteRun();
+      writeRunAsync(edm::WaitingTaskHolder{t.get()}, phid, run, mergeableRunProductMetadata);
       t->wait_for_all();
+      mergeableRunProductMetadata->postWriteRun();
       if(t->exceptionPtr()) {
         std::rethrow_exception(*t->exceptionPtr());
       }
@@ -1403,7 +1411,9 @@ namespace edm {
         << "Illegal attempt to insert run into cache\n"
         << "Contact a Framework Developer\n";
     }
-    auto rp = std::make_shared<RunPrincipal>(input_->runAuxiliary(), preg(), *processConfiguration_, historyAppender_.get(), 0);
+    auto rp = std::make_shared<RunPrincipal>(input_->runAuxiliary(), preg(),
+                                             *processConfiguration_, historyAppender_.get(),
+                                             0, true, &mergeableRunProductProcesses_);
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
       input_->readRun(*rp, *historyAppender_);
@@ -1461,19 +1471,22 @@ namespace edm {
     return input_->luminosityBlock();
   }
 
-  void EventProcessor::writeRunAsync(WaitingTaskHolder task, ProcessHistoryID const& phid, RunNumber_t run) {
-    auto subsT = edm::make_waiting_task(tbb::task::allocate_root(), [this,phid,run,task](std::exception_ptr const* iExcept) mutable {
+  void EventProcessor::writeRunAsync(WaitingTaskHolder task, ProcessHistoryID const& phid, RunNumber_t run,
+                                     MergeableRunProductMetadata const* mergeableRunProductMetadata) {
+    auto subsT = edm::make_waiting_task(tbb::task::allocate_root(), [this,phid,run,task,mergeableRunProductMetadata]
+                                                                    (std::exception_ptr const* iExcept) mutable {
       if(iExcept) {
         task.doneWaiting(*iExcept);
       } else {
         ServiceRegistry::Operate op(serviceToken_);
         for(auto&s : subProcesses_) {
-          s.writeRunAsync(task,phid,run);
+          s.writeRunAsync(task,phid,run,mergeableRunProductMetadata);
         }
       }
     });
     ServiceRegistry::Operate op(serviceToken_);
-    schedule_->writeRunAsync(WaitingTaskHolder(subsT), principalCache_.runPrincipal(phid, run), &processContext_, actReg_.get());
+    schedule_->writeRunAsync(WaitingTaskHolder(subsT), principalCache_.runPrincipal(phid, run),
+                             &processContext_, actReg_.get(), mergeableRunProductMetadata);
   }
 
   void EventProcessor::deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run) {
@@ -1495,7 +1508,10 @@ namespace edm {
     });
     ServiceRegistry::Operate op(serviceToken_);
 
-    schedule_->writeLumiAsync(WaitingTaskHolder{subsT}, *(iStatus->lumiPrincipal()), &processContext_, actReg_.get());
+    std::shared_ptr<LuminosityBlockPrincipal> const& lumiPrincipal = iStatus->lumiPrincipal();
+    lumiPrincipal->runPrincipal().mergeableRunProductMetadata()->writeLumi(lumiPrincipal->luminosityBlock());
+
+    schedule_->writeLumiAsync(WaitingTaskHolder{subsT}, *lumiPrincipal, &processContext_, actReg_.get());
   }
 
   void EventProcessor::deleteLumiFromCache(LuminosityBlockProcessingStatus& iStatus) {

--- a/FWCore/Framework/src/MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/src/MergeableRunProductMetadata.cc
@@ -20,7 +20,7 @@ namespace edm {
   MergeableRunProductMetadata::~MergeableRunProductMetadata() {
   }
 
-  void MergeableRunProductMetadata::readFile() {
+  void MergeableRunProductMetadata::preReadFile() {
     mergeLumisFromIndexIntoFile();
   }
 

--- a/FWCore/Framework/src/MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/src/MergeableRunProductMetadata.cc
@@ -1,0 +1,379 @@
+
+#include "FWCore/Framework/interface/MergeableRunProductMetadata.h"
+
+#include "DataFormats/Provenance/interface/IndexIntoFile.h"
+#include "DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h"
+#include "FWCore/Framework/interface/MergeableRunProductProcesses.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <algorithm>
+#include <memory>
+
+namespace edm {
+
+  MergeableRunProductMetadata::
+  MergeableRunProductMetadata(MergeableRunProductProcesses const& mergeableRunProductProcesses) :
+    mergeableRunProductProcesses_(&mergeableRunProductProcesses),
+    metadataForProcesses_(mergeableRunProductProcesses.size()) {
+  }
+
+  void MergeableRunProductMetadata::readFile() {
+    mergeLumisFromIndexIntoFile();
+  }
+
+  void MergeableRunProductMetadata::readRun(
+    long long inputRunEntry,
+    StoredMergeableRunProductMetadata const& inputStoredMergeableRunProductMetadata,
+    IndexIntoFileItrHolder const& inputIndexIntoFileItr) {
+
+    unsigned int processIndex {0};
+    for (auto & metadataForProcess : metadataForProcesses_) {
+
+      bool valid = true;
+      std::vector<LuminosityBlockNumber_t>::const_iterator lumisInRunBeingReadBegin;
+      std::vector<LuminosityBlockNumber_t>::const_iterator lumisInRunBeingReadEnd;
+
+      std::string const& processName = mergeableRunProductProcesses_->processesWithMergeableRunProducts()[processIndex];
+
+      if (inputStoredMergeableRunProductMetadata.getLumiContent(inputRunEntry,
+                                                                processName,
+                                                                valid,
+                                                                lumisInRunBeingReadBegin,
+                                                                lumisInRunBeingReadEnd)) {
+
+        // This is a reference to the container accumulating the luminosity
+        // block numbers for the run entries read associated with the current
+        // run being processed that correspond to the luminosity block content
+        // for the mergeable run products created in the process.
+        std::vector<LuminosityBlockNumber_t>& lumis = metadataForProcess.lumis();
+
+        // In the following, iter1 refers to the lumis associated with run entries already read
+        // and iter2 refers to the lumis associated with the current run entry being read.
+
+        bool elementsIn2NotIn1 = false;
+        bool elementsIn1NotIn2 = false;
+        bool sharedElements = false;
+
+        std::vector<LuminosityBlockNumber_t> temp;
+        temp.reserve(lumis.size() + (lumisInRunBeingReadEnd - lumisInRunBeingReadBegin));
+        std::vector<LuminosityBlockNumber_t>::const_iterator end1 = lumis.end();
+        std::vector<LuminosityBlockNumber_t>::const_iterator end2 = lumisInRunBeingReadEnd;
+        for (std::vector<LuminosityBlockNumber_t>::const_iterator iter1 = lumis.begin(),
+             iter2 = lumisInRunBeingReadBegin;
+             iter1 != end1 || iter2 != end2;) {
+          if (iter1 == end1) {
+            temp.push_back(*iter2);
+            ++iter2;
+            elementsIn2NotIn1 = true;
+            continue;
+          } else if (iter2 == end2) {
+            temp.push_back(*iter1);
+            ++iter1;
+            elementsIn1NotIn2 = true;
+            continue;
+          } else if (*iter1 < *iter2) {
+            temp.push_back(*iter1);
+            ++iter1;
+            elementsIn1NotIn2 = true;
+          } else if (*iter1 > *iter2) {
+            temp.push_back(*iter2);
+            ++iter2;
+            elementsIn2NotIn1 = true;
+          } else {
+            // they must be equal
+            sharedElements = true;
+            temp.push_back(*iter1);
+            ++iter1;
+            ++iter2;
+          }
+        }
+        lumis.swap(temp);
+        if (!sharedElements && elementsIn2NotIn1 && elementsIn1NotIn2) {
+          metadataForProcess.setMergeDecision(MERGE);
+          if (!valid) {
+            metadataForProcess.setValid(false);
+          }
+        } else if (!elementsIn2NotIn1) {
+          metadataForProcess.setMergeDecision(IGNORE);
+        } else if (!elementsIn1NotIn2) {
+          metadataForProcess.setMergeDecision(REPLACE);
+          if (!valid) {
+            metadataForProcess.setValid(false);
+          }
+        } else {
+          // In this case there is no way to get the correct answer.
+          // The result will always be invalid.
+          metadataForProcess.setMergeDecision(MERGE);
+          metadataForProcess.setValid(false);
+        }
+
+      } else {
+
+        metadataForProcess.setMergeDecision(MERGE);
+        if (!valid) {
+          metadataForProcess.setValid(false);
+        }
+        metadataForProcess.setUseIndexIntoFile(true);
+        if (!gotLumisFromIndexIntoFile_) {
+          inputIndexIntoFileItr.getLumisInRun(lumisFromIndexIntoFile_);
+          gotLumisFromIndexIntoFile_ = true;
+        }
+      }
+      ++processIndex;
+    } // end of loop over processes
+  } // end of readRun function
+
+  void MergeableRunProductMetadata::writeLumi(LuminosityBlockNumber_t lumi) {
+
+    if (metadataForProcesses_.empty()) {
+      return;
+    }
+    lumisProcessed_.push_back(lumi);
+  }
+
+  void MergeableRunProductMetadata::preWriteRun() {
+
+    if (metadataForProcesses_.empty()) {
+      return;
+    }
+
+    mergeLumisFromIndexIntoFile();
+
+    // Sort the lumiProcessed vector and ignore the duplicate
+    // entries
+
+    // Not sure if this copy is necessary. I'm copying because
+    // I am not sure the standard algorithms work on TBB containers.
+    // I couldn't find anything saying they did when I searched ...
+    std::vector<LuminosityBlockNumber_t> lumisProcessed;
+    lumisProcessed.reserve(lumisProcessed_.size());
+    for (auto const& lumi : lumisProcessed_) {
+      lumisProcessed.push_back(lumi);
+    }
+
+    std::sort(lumisProcessed.begin(), lumisProcessed.end());
+    auto uniqueEnd = std::unique(lumisProcessed.begin(), lumisProcessed.end());
+
+    for (auto & metadataForProcess : metadataForProcesses_) {
+
+      // Did we process all the lumis in this process that were processed
+      // in the process that created the mergeable run products.
+      metadataForProcess.setAllLumisProcessed(
+        std::includes(lumisProcessed.begin(), uniqueEnd,
+                      metadataForProcess.lumis().begin(),
+                      metadataForProcess.lumis().end()));
+    }
+  }
+
+  void MergeableRunProductMetadata::postWriteRun() {
+
+    lumisProcessed_.clear();
+    for (auto & metadataForProcess : metadataForProcesses_) {
+      metadataForProcess.reset();
+    }
+  }
+
+  void MergeableRunProductMetadata::
+  addEntryToStoredMetadata(StoredMergeableRunProductMetadata& storedMetadata) const {
+
+    if (metadataForProcesses_.empty()) {
+      return;
+    }
+
+    std::vector<std::string> const& storedProcesses = storedMetadata.processesWithMergeableRunProducts();
+    if (storedProcesses.empty()) {
+      return;
+    }
+
+    unsigned long long beginProcess = storedMetadata.singleRunEntryAndProcesses().size();
+    unsigned long long endProcess = beginProcess;
+
+
+    std::vector<std::string> const& processesWithMergeableRunProducts =
+      mergeableRunProductProcesses_->processesWithMergeableRunProducts();
+
+    for (unsigned int storedProcessIndex = 0;
+         storedProcessIndex < storedProcesses.size();
+         ++storedProcessIndex) {
+
+      // Look for a matching process. It is intentional that no process
+      // is added when there is no match. storedProcesses only contains
+      // processes which created mergeable run products selected by the
+      // output module to be written out. processesWithMergeableRunProducts_
+      // only has processes which created mergeable run products that were
+      // read from the input data files. Note storedProcesses may be
+      // missing processes because the output module dropped products.
+      // The other vector may be missing processes because of SubProcesses.
+      for (unsigned int transientProcessIndex = 0;
+           transientProcessIndex < processesWithMergeableRunProducts.size();
+           ++transientProcessIndex) {
+
+        // This string comparison could be optimized away by storing an index mapping in
+        // OutputModuleBase calculated once early in a job. (? Given how rare
+        // mergeable run products are this optimization may not be worth doing)
+        if (processesWithMergeableRunProducts[transientProcessIndex] ==
+            storedProcesses[storedProcessIndex]) {
+
+          if (addProcess(storedMetadata,
+                         metadataForProcesses_.at(transientProcessIndex),
+                         storedProcessIndex,
+                         beginProcess,
+                         endProcess)) {
+            ++endProcess;
+          }
+          break;
+        }
+      }
+    }
+    storedMetadata.singleRunEntries().emplace_back(beginProcess, endProcess);
+  }
+
+  bool MergeableRunProductMetadata::
+  addProcess(StoredMergeableRunProductMetadata& storedMetadata,
+             MetadataForProcess const& metadataForProcess,
+             unsigned int storedProcessIndex,
+             unsigned long long beginProcess,
+             unsigned long long endProcess) const {
+
+    if (metadataForProcess.valid() &&
+        metadataForProcess.allLumisProcessed()) {
+      return false;
+    }
+
+    storedMetadata.allValidAndUseIndexIntoFile() = false;
+
+    unsigned long long iBeginLumi = 0;
+    unsigned long long iEndLumi = 0;
+
+    // See if we need to store the set of lumi numbers corresponding
+    // to this process and run entry. If they were all processed then
+    // we can just get the lumi numbers out of IndexIntoFile and do
+    // not need to store them here
+    if (!metadataForProcess.allLumisProcessed()) {
+      // If we need to store the numbers, then we can check to
+      // make sure this does not duplicate the lumi numbers we
+      // stored for another process. If we did then we can just
+      // just reference same indices and avoid copying a duplicate
+      // sequence of lumi numbers. It is sufficient to check the
+      // size only. As you go back in the time sequence of processes
+      // the only thing that can happen is more lumi numbers appear
+      // at steps where a run was only partially processed.
+      bool found = false;
+      for (unsigned long long kProcess = beginProcess;
+           kProcess < endProcess;
+           ++kProcess) {
+        StoredMergeableRunProductMetadata::SingleRunEntryAndProcess const& storedSingleRunEntryAndProcess =
+          storedMetadata.singleRunEntryAndProcesses().at(kProcess);
+
+        if (metadataForProcess.lumis().size() ==
+            (storedSingleRunEntryAndProcess.endLumi() - storedSingleRunEntryAndProcess.beginLumi())) {
+
+          iBeginLumi = storedSingleRunEntryAndProcess.beginLumi();
+          iEndLumi = storedSingleRunEntryAndProcess.endLumi();
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        std::vector<LuminosityBlockNumber_t>& storedLumis = storedMetadata.lumis();
+        std::vector<LuminosityBlockNumber_t> const& metdataLumis = metadataForProcess.lumis();
+        iBeginLumi = storedLumis.size();
+        storedLumis.insert( storedLumis.end(), metdataLumis.begin(), metdataLumis.end() );
+        iEndLumi = storedLumis.size();
+      }
+    }
+    storedMetadata.singleRunEntryAndProcesses().emplace_back(iBeginLumi,
+                                                             iEndLumi,
+                                                             storedProcessIndex,
+                                                             metadataForProcess.valid(),
+                                                             metadataForProcess.allLumisProcessed());
+    return true;
+  }
+
+  MergeableRunProductMetadata::MergeDecision
+  MergeableRunProductMetadata::getMergeDecision(std::string const& processThatCreatedProduct) const {
+
+    MetadataForProcess const* metadataForProcess = metadataForOneProcess(processThatCreatedProduct);
+    if (metadataForProcess) {
+      return metadataForProcess->mergeDecision();
+    }
+    throw Exception(errors::LogicError)
+      << "MergeableRunProductMetadata::getMergeDecision could not find process.\n"
+      << "It should not be possible for this error to occur.\n"
+      << "Contact a Framework developer\n";
+    return MERGE;
+  }
+
+  bool
+  MergeableRunProductMetadata::knownImproperlyMerged(std::string const& processThatCreatedProduct) const {
+
+    MetadataForProcess const* metadataForProcess = metadataForOneProcess(processThatCreatedProduct);
+    if (metadataForProcess) {
+      return !metadataForProcess->valid();
+    }
+    return false;
+  }
+
+  void MergeableRunProductMetadata::MetadataForProcess::reset() {
+    lumis_.clear();
+    mergeDecision_ = MERGE;
+    useIndexIntoFile_ = false;
+    valid_ = true;
+    allLumisProcessed_ = false;
+  }
+
+  MergeableRunProductMetadata::MetadataForProcess const*
+  MergeableRunProductMetadata::metadataForOneProcess(std::string const& processName) const {
+    unsigned int processIndex = 0;
+    for (auto const& metadataForProcess : metadataForProcesses_) {
+      // This string comparison could be optimized away by storing an index in
+      // BranchDescription as a transient calculated once early in a job.
+      if (getProcessName(processIndex) == processName) {
+        return &metadataForProcess;
+      }
+      ++processIndex;
+    }
+    return nullptr;
+  }
+
+  void MergeableRunProductMetadata::mergeLumisFromIndexIntoFile() {
+
+    for (auto & metadataForProcess : metadataForProcesses_) {
+      if (metadataForProcess.useIndexIntoFile()) {
+        metadataForProcess.setUseIndexIntoFile(false);
+
+        std::vector<LuminosityBlockNumber_t> temp;
+        temp.reserve(metadataForProcess.lumis().size() + lumisFromIndexIntoFile_.size());
+        std::vector<LuminosityBlockNumber_t>::const_iterator end1 = metadataForProcess.lumis().end();
+        std::vector<LuminosityBlockNumber_t>::const_iterator end2 = lumisFromIndexIntoFile_.end();
+        for (std::vector<LuminosityBlockNumber_t>::const_iterator iter1 = metadataForProcess.lumis().begin(),
+             iter2 = lumisFromIndexIntoFile_.begin();
+             iter1 != end1 || iter2 != end2;) {
+          if (iter1 == end1) {
+            temp.push_back(*iter2);
+            ++iter2;
+            continue;
+          } else if (iter2 == end2) {
+            temp.push_back(*iter1);
+            ++iter1;
+            continue;
+          } else if (*iter1 < *iter2) {
+            temp.push_back(*iter1);
+            ++iter1;
+          } else if (*iter1 > *iter2) {
+            temp.push_back(*iter2);
+            ++iter2;
+          } else {
+            // they must be equal
+            temp.push_back(*iter1);
+            ++iter1;
+            ++iter2;
+          }
+        }
+        metadataForProcess.lumis().swap(temp);
+      }
+    }
+    lumisFromIndexIntoFile_.clear();
+    gotLumisFromIndexIntoFile_ = false;
+  }
+}

--- a/FWCore/Framework/src/MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/src/MergeableRunProductMetadata.cc
@@ -17,6 +17,9 @@ namespace edm {
     metadataForProcesses_(mergeableRunProductProcesses.size()) {
   }
 
+  MergeableRunProductMetadata::~MergeableRunProductMetadata() {
+  }
+
   void MergeableRunProductMetadata::readFile() {
     mergeLumisFromIndexIntoFile();
   }

--- a/FWCore/Framework/src/MergeableRunProductProcesses.cc
+++ b/FWCore/Framework/src/MergeableRunProductProcesses.cc
@@ -1,0 +1,35 @@
+
+#include "FWCore/Framework/interface/MergeableRunProductProcesses.h"
+
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "FWCore/Utilities/interface/getAnyPtr.h"
+
+#include "TClass.h"
+
+#include <memory>
+#include <set>
+
+namespace edm {
+
+  MergeableRunProductProcesses::MergeableRunProductProcesses() { }
+
+  void MergeableRunProductProcesses::setProcessesWithMergeableRunProducts(ProductRegistry const& productRegistry) {
+    TClass* wrapperBaseTClass = TypeWithDict::byName("edm::WrapperBase").getClass();
+    std::set<std::string> processSet;
+    for (auto const& prod : productRegistry.productList()) {
+      BranchDescription const& desc = prod.second;
+      if (desc.branchType() == InRun && !desc.produced() && desc.present()) {
+        TClass* cp = desc.wrappedType().getClass();
+        void* p = cp->New();
+        int offset = cp->GetBaseClassOffset(wrapperBaseTClass);
+        std::unique_ptr<WrapperBase> edp = getAnyPtr<WrapperBase>(p, offset);
+        if (edp->isMergeable()) {
+          processSet.insert(desc.processName());
+        }
+      }
+    }
+    processesWithMergeableRunProducts_.assign(processSet.begin(), processSet.end());
+  }
+}

--- a/FWCore/Framework/src/OutputModuleCommunicator.h
+++ b/FWCore/Framework/src/OutputModuleCommunicator.h
@@ -31,6 +31,7 @@
 namespace edm {
 
   class ActivityRegistry;
+  class MergeableRunProductMetadata;
   class ProcessContext;
   class ThinnedAssociationsHelper;
   class WaitingTaskHolder;
@@ -55,7 +56,8 @@ namespace edm {
     virtual void writeRunAsync(WaitingTaskHolder iTask,
                                RunPrincipal const& rp,
                                ProcessContext const*,
-                               ActivityRegistry*) = 0;
+                               ActivityRegistry*,
+                               MergeableRunProductMetadata const*) = 0;
     
     virtual void writeLumiAsync(WaitingTaskHolder iTask,
                                 LuminosityBlockPrincipal const& lbp,

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -70,7 +70,8 @@ namespace edm {
   OutputModuleCommunicatorT<T>::writeRunAsync(WaitingTaskHolder iTask,
                                               edm::RunPrincipal const& rp,
                                               ProcessContext const* processContext,
-                                              ActivityRegistry* activityRegistry) {
+                                              ActivityRegistry* activityRegistry,
+                                              MergeableRunProductMetadata const* mergeableRunProductMetadata) {
     auto token = ServiceRegistry::instance().presentToken();
     GlobalContext globalContext(GlobalContext::Transition::kWriteRun,
                                 LuminosityBlockID(rp.run(), 0),
@@ -78,7 +79,7 @@ namespace edm {
                                 LuminosityBlockIndex::invalidLuminosityBlockIndex(),
                                 rp.endTime(),
                                 processContext);
-    auto t = [&mod = module(), &rp, globalContext, token, desc = &description(), activityRegistry, iTask]() mutable {
+    auto t = [&mod = module(), &rp, globalContext, token, desc = &description(), activityRegistry, mergeableRunProductMetadata, iTask]() mutable {
       std::exception_ptr ex;
       try {
         ServiceRegistry::Operate op(token);
@@ -90,7 +91,7 @@ namespace edm {
                                [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
                                  activityRegistry->postModuleWriteRunSignal_(globalContext, mcc);
                                }));
-        mod.doWriteRun(rp, &mcc);
+        mod.doWriteRun(rp, &mcc, mergeableRunProductMetadata);
       } catch(...) {
         ex = std::current_exception();
       }

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -8,6 +8,7 @@
 
 namespace edm {
   class ActivityRegistry;
+  class MergeableRunProductMetadata;
   class OutputModule;
   class ThinnedAssociationsHelper;
 
@@ -47,7 +48,8 @@ namespace edm {
     void writeRunAsync(WaitingTaskHolder iTask,
                        edm::RunPrincipal const& rp,
                        ProcessContext const*,
-                       ActivityRegistry*) override;
+                       ActivityRegistry*,
+                       MergeableRunProductMetadata const*) override;
     
     void writeLumiAsync(WaitingTaskHolder iTask,
                         edm::LuminosityBlockPrincipal const& lbp,

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -913,11 +913,11 @@ namespace edm {
   }
   
   void
-  Principal::readAllFromSourceAndMergeImmediately() {
+  Principal::readAllFromSourceAndMergeImmediately(MergeableRunProductMetadata const* mergeableRunProductMetadata) {
     if(not reader()) {return;}
     
     for(auto & prod : *this) {
-      prod->retrieveAndMerge(*this);
+      prod->retrieveAndMerge(*this, mergeableRunProductMetadata);
     }
   }
 }

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -158,6 +158,13 @@ namespace edm {
   }
 
   void
+  PrincipalCache::readFile() {
+    if (runPrincipal_) {
+      runPrincipal_->readFile();
+    }
+  }
+
+  void
   PrincipalCache::throwRunMissing() const {
     throw edm::Exception(edm::errors::LogicError)
       << "PrincipalCache::runPrincipal\n"

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -158,9 +158,9 @@ namespace edm {
   }
 
   void
-  PrincipalCache::readFile() {
+  PrincipalCache::preReadFile() {
     if (runPrincipal_) {
-      runPrincipal_->readFile();
+      runPrincipal_->preReadFile();
     }
   }
 

--- a/FWCore/Framework/src/PrincipalCache.h
+++ b/FWCore/Framework/src/PrincipalCache.h
@@ -76,6 +76,8 @@ namespace edm {
 
     void setProcessHistoryRegistry(ProcessHistoryRegistry const& phr) {processHistoryRegistry_ = &phr;}
 
+    void readFile();
+
   private:
 
     void throwRunMissing() const;

--- a/FWCore/Framework/src/PrincipalCache.h
+++ b/FWCore/Framework/src/PrincipalCache.h
@@ -76,7 +76,7 @@ namespace edm {
 
     void setProcessHistoryRegistry(ProcessHistoryRegistry const& phr) {processHistoryRegistry_ = &phr;}
 
-    void readFile();
+    void preReadFile();
 
   private:
 

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -3,6 +3,7 @@
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/interface/ProductRegistryHelper.h"
+#include "DataFormats/Common/interface/setIsMergeable.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
@@ -88,6 +89,7 @@ namespace edm {
                               type,
                               true,
                               isEndTransition(p->transition_));
+      setIsMergeable(pdesc);
 
       if (pdesc.transient()) {
         if (!checkDictionary(missingDictionaries, pdesc.wrappedName(), pdesc.wrappedType())) {

--- a/FWCore/Framework/src/ProductResolverBase.cc
+++ b/FWCore/Framework/src/ProductResolverBase.cc
@@ -38,10 +38,13 @@ namespace edm {
   }
 
   void
-  ProductResolverBase::retrieveAndMerge_(Principal const& principal) const {
+  ProductResolverBase::retrieveAndMerge_(Principal const&, MergeableRunProductMetadata const*) const {
   }
 
-  
+  void
+  ProductResolverBase::setMergeableRunProductMetadata_(MergeableRunProductMetadata const*) {
+  }
+
   void
   ProductResolverBase::write(std::ostream& os) const {
     // This is grossly inadequate. It is also not critical for the

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -23,6 +23,7 @@ a set of related EDProducts. This is the storage unit of such information.
 #include <string>
 
 namespace edm {
+  class MergeableRunProductMetadata;
   class ProductProvenanceRetriever;
   class DelayedReader;
   class ModuleCallingContext;
@@ -62,6 +63,7 @@ namespace edm {
     //Handle the boilerplate code needed for resolveProduct_
     template <bool callResolver, typename FUNC>
     Resolution resolveProductImpl( FUNC resolver) const;
+    void setMergeableRunProductMetadataInProductData(MergeableRunProductMetadata const*);
 
   private:
 
@@ -70,9 +72,9 @@ namespace edm {
     ProductData const& getProductData() const {return productData_;}
     virtual bool isFromCurrentProcess() const = 0;
     // merges the product with the pre-existing product
-    void mergeProduct(std::unique_ptr<WrapperBase> edp) const;
+    void mergeProduct(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const;
 
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     bool productUnavailable_() const final;
     bool productResolved_() const final;
     bool productWasDeleted_() const final;
@@ -116,9 +118,11 @@ namespace edm {
                          ServiceToken const& token,
                          SharedResourcesAcquirer* sra,
                          ModuleCallingContext const* mcc) const override;
-    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+      void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
 
-      void retrieveAndMerge_(Principal const& principal) const override;
+      void retrieveAndMerge_(Principal const& principal, MergeableRunProductMetadata const* mergeableRunProductMetadata) const override;
+
+      void setMergeableRunProductMetadata_(MergeableRunProductMetadata const*) override;
 
       bool unscheduledWasNotRun_() const final {return false;}
 
@@ -233,7 +237,7 @@ namespace edm {
       }
 
       void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+      void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
       BranchDescription const& branchDescription_() const override {return *bd_;}
       void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {bd_ = bd;}
       Provenance const* provenance_() const final { return realProduct_.provenance(); }
@@ -290,7 +294,7 @@ namespace edm {
     }
 
     void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     BranchDescription const& branchDescription_() const override {return *bd_;}
     void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {bd_ = bd;}
     Provenance const* provenance_() const final {return realProduct_->provenance();
@@ -351,7 +355,7 @@ namespace edm {
       bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
 
       void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+      void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
       BranchDescription const& branchDescription_() const override;
       void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
       Provenance const* provenance_() const override;
@@ -408,7 +412,7 @@ namespace edm {
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
 
     void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod, MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
     BranchDescription const& branchDescription_() const override;
     void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
     Provenance const* provenance_() const override;

--- a/FWCore/Framework/src/RunForOutput.cc
+++ b/FWCore/Framework/src/RunForOutput.cc
@@ -7,9 +7,11 @@
 namespace edm {
 
   RunForOutput::RunForOutput(RunPrincipal const& rp, ModuleDescription const& md,
-           ModuleCallingContext const* moduleCallingContext, bool isAtEnd) :
+                             ModuleCallingContext const* moduleCallingContext, bool isAtEnd,
+                             MergeableRunProductMetadata const* mrpm) :
         OccurrenceForOutput(rp, md, moduleCallingContext, isAtEnd), 
-        aux_(rp.aux()) {
+        aux_(rp.aux()),
+        mergeableRunProductMetadata_(mrpm) {
   }
 
   RunForOutput::~RunForOutput() {

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Framework/interface/ProductResolverBase.h"
+#include "FWCore/Framework/interface/MergeableRunProductMetadata.h"
 
 namespace edm {
   RunPrincipal::RunPrincipal(
@@ -11,10 +12,17 @@ namespace edm {
     ProcessConfiguration const& pc,
     HistoryAppender* historyAppender,
     unsigned int iRunIndex,
-    bool isForPrimaryProcess) :
+    bool isForPrimaryProcess,
+    MergeableRunProductProcesses const* mergeableRunProductProcesses) :
     Base(reg, reg->productLookup(InRun), pc, InRun, historyAppender, isForPrimaryProcess),
-      aux_(aux), index_(iRunIndex) {
+    aux_(aux), index_(iRunIndex) {
+
+    if (mergeableRunProductProcesses) { // primary RunPrincipals of EventProcessor
+      mergeableRunProductMetadataPtr_ = (std::make_unique<MergeableRunProductMetadata>(*mergeableRunProductProcesses));
+    }
   }
+
+  RunPrincipal::~RunPrincipal() {}
 
   void
   RunPrincipal::fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader) {
@@ -23,6 +31,7 @@ namespace edm {
 
     for(auto& prod : *this) {
       prod->setProcessHistory(processHistory());
+      prod->setMergeableRunProductMetadata(mergeableRunProductMetadataPtr_.get());
     }
   }
 
@@ -43,6 +52,13 @@ namespace edm {
   unsigned int
   RunPrincipal::transitionIndex_() const {
     return index().value();
+  }
+
+  void
+  RunPrincipal::readFile() {
+    if (mergeableRunProductMetadataPtr_) {
+      mergeableRunProductMetadataPtr_->readFile();
+    }
   }
 
 }

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -55,9 +55,9 @@ namespace edm {
   }
 
   void
-  RunPrincipal::readFile() {
+  RunPrincipal::preReadFile() {
     if (mergeableRunProductMetadataPtr_) {
-      mergeableRunProductMetadataPtr_->readFile();
+      mergeableRunProductMetadataPtr_->preReadFile();
     }
   }
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Framework/interface/Schedule.h"
 
+#include "DataFormats/Common/interface/setIsMergeable.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
@@ -564,6 +565,10 @@ namespace edm {
       c->selectProducts(preg, thinnedAssociationsHelper);
     }
 
+    for(auto & product : preg.productListUpdator()) {
+      setIsMergeable(product.second);
+    }
+
     {
       // We now get a collection of types that may be consumed.
       std::set<TypeID> productTypesConsumed;
@@ -994,9 +999,10 @@ namespace edm {
   void Schedule::writeRunAsync(WaitingTaskHolder task,
                                RunPrincipal const& rp,
                                ProcessContext const* processContext,
-                               ActivityRegistry* activityRegistry) {
+                               ActivityRegistry* activityRegistry,
+                               MergeableRunProductMetadata const* mergeableRunProductMetadata) {
     for(auto& c: all_output_communicators_) {
-      c->writeRunAsync(task, rp, processContext, activityRegistry);
+      c->writeRunAsync(task, rp, processContext, activityRegistry, mergeableRunProductMetadata);
     }
   }
 

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -22,6 +22,7 @@
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/Framework/interface/insertSelectedProcesses.h"
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
 #include "FWCore/Framework/interface/OutputModuleDescription.h"
@@ -96,6 +97,7 @@ namespace edm {
       std::map<BranchID, BranchDescription const*> trueBranchIDToKeptBranchDesc;
       std::vector<BranchDescription const*> associationDescriptions;
       std::set<BranchID> keptProductsInEvent;
+      std::set<std::string> processesWithSelectedMergeableRunProducts;
 
       for(auto const& it : preg.productList()) {
         BranchDescription const& desc = it.second;
@@ -108,12 +110,16 @@ namespace edm {
           associationDescriptions.push_back(&desc);
         } else if(selected(desc)) {
           keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);
+          insertSelectedProcesses(desc,
+                                  processesWithSelectedMergeableRunProducts);
         } else {
           // otherwise, output nothing,
           // and mark the fact that there is a newly dropped branch of this type.
           hasNewlyDroppedBranch_[desc.branchType()] = true;
         }
       }
+
+      setProcessesWithSelectedMergeableRunProducts(processesWithSelectedMergeableRunProducts);
 
       thinnedAssociationsHelper.selectAssociationProducts(associationDescriptions,
                                                           keptProductsInEvent,
@@ -302,8 +308,9 @@ namespace edm {
     
     void
     OutputModuleBase::doWriteRun(RunPrincipal const& rp,
-                                 ModuleCallingContext const* mcc) {
-      RunForOutput r(rp, moduleDescription_, mcc, true);
+                                 ModuleCallingContext const* mcc,
+                                 MergeableRunProductMetadata const* mrpm) {
+      RunForOutput r(rp, moduleDescription_, mcc, true, mrpm);
       r.setConsumer(this);
       writeRun(r);
     }

--- a/FWCore/Framework/src/insertSelectedProcesses.cc
+++ b/FWCore/Framework/src/insertSelectedProcesses.cc
@@ -1,0 +1,33 @@
+#include "FWCore/Framework/interface/insertSelectedProcesses.h"
+
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/getAnyPtr.h"
+#include "FWCore/Utilities/interface/TypeWithDict.h"
+
+#include "TClass.h"
+
+#include <memory>
+
+namespace edm {
+
+  void insertSelectedProcesses(BranchDescription const& desc,
+                               std::set<std::string>& processes) {
+
+    // Select input processes in which mergeable run products were produced
+    if (desc.branchType() == InRun && !desc.produced()) {
+
+      // Determine if the product is "mergeable"
+      TClass* tClass = desc.wrappedType().getClass();
+      void* p = tClass->New();
+      TClass* wrapperBaseTClass = TypeWithDict::byName("edm::WrapperBase").getClass();
+      int offset = tClass->GetBaseClassOffset(wrapperBaseTClass);
+      std::unique_ptr<WrapperBase> edp = getAnyPtr<WrapperBase>(p, offset);
+      if (edp->isMergeable()) {
+        // record the process names in a set (which is ordered and unique)
+        processes.insert(desc.processName());
+      }
+    }
+  }
+}

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -319,4 +319,7 @@
   <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test transition_test.sh"/>
   <use   name="FWCore/Utilities"/>
 </bin>
-
+<bin file="test_catch2_main.cc,test_catch2notTP_*.cc" name="TestFWCoreFrameworkCatch2notTP">
+  <use name="catch2"/>
+  <use   name="FWCore/Framework"/>
+</bin>

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -236,7 +236,7 @@ m_ep()
     iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
-    iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry);
+    iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry, nullptr);
     t->wait_for_all();
     if(t->exceptionPtr() != nullptr) {
       std::rethrow_exception(*t->exceptionPtr());

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -235,7 +235,7 @@ m_ep()
     iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
-    iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry);
+    iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry, nullptr);
     t->wait_for_all();
     if(t->exceptionPtr() != nullptr) {
       std::rethrow_exception(*t->exceptionPtr());

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -313,7 +313,7 @@ m_ep()
     iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
-    iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry);
+    iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry, nullptr);
     t->wait_for_all();
     if(t->exceptionPtr() != nullptr) {
       std::rethrow_exception(*t->exceptionPtr());

--- a/FWCore/Framework/test/test_catch2_main.cc
+++ b/FWCore/Framework/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
@@ -1,0 +1,723 @@
+#include "catch.hpp"
+
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/IndexIntoFile.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "DataFormats/Provenance/interface/ProcessConfiguration.h"
+#include "DataFormats/Provenance/interface/ProcessHistory.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+#include "DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h"
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/ThingWithMerge.h"
+#include "FWCore/Framework/interface/MergeableRunProductMetadata.h"
+#include "FWCore/Framework/interface/MergeableRunProductProcesses.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/TypeWithDict.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
+
+  SECTION("test nested class MetadataForProcess") {
+
+    edm::MergeableRunProductMetadata::MetadataForProcess metaDataForProcess;
+    REQUIRE(metaDataForProcess.lumis().empty());
+    REQUIRE(metaDataForProcess.valid());
+    REQUIRE(!metaDataForProcess.useIndexIntoFile());
+    REQUIRE(!metaDataForProcess.allLumisProcessed());
+    REQUIRE(metaDataForProcess.mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+
+    std::vector<edm::LuminosityBlockNumber_t>& lumis = metaDataForProcess.lumis();
+    lumis.push_back(11);
+    edm::MergeableRunProductMetadata::MetadataForProcess const& acref(metaDataForProcess);
+    REQUIRE(acref.lumis().at(0) == 11);
+
+    metaDataForProcess.setMergeDecision(edm::MergeableRunProductMetadata::IGNORE);
+    metaDataForProcess.setValid(false);
+    metaDataForProcess.setUseIndexIntoFile(true);
+    metaDataForProcess.setAllLumisProcessed(true);
+
+    REQUIRE(!metaDataForProcess.valid());
+    REQUIRE(metaDataForProcess.useIndexIntoFile());
+    REQUIRE(metaDataForProcess.allLumisProcessed());
+    REQUIRE(metaDataForProcess.mergeDecision() == edm::MergeableRunProductMetadata::IGNORE);
+
+    metaDataForProcess.reset();
+    REQUIRE(metaDataForProcess.lumis().empty());
+    REQUIRE(metaDataForProcess.valid());
+    REQUIRE(!metaDataForProcess.useIndexIntoFile());
+    REQUIRE(!metaDataForProcess.allLumisProcessed());
+    REQUIRE(metaDataForProcess.mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+  }
+
+  SECTION("test constructor") {
+    // edm::MergeableRunProductMetadata mergeableRunProductMetadata(nullptr);
+    // REQUIRE(mergeableRunProductMetadata.metadataForProcesses().empty());
+
+    edm::MergeableRunProductProcesses mergeableRunProductProcesses;
+    edm::MergeableRunProductMetadata mergeableRunProductMetadata2(mergeableRunProductProcesses);
+    REQUIRE(mergeableRunProductMetadata2.metadataForProcesses().empty());
+  }
+
+  SECTION("test main functions") {
+
+    edm::ProductRegistry productRegistry;
+    edm::ParameterSet dummyPset;
+    dummyPset.registerIt();
+
+    // not mergeable
+    edm::BranchDescription prod1(edm::InRun,
+                                "label",
+                                "PROD",
+                                "edmtest::Thing",
+                                "edmtestThing",
+                                "instance",
+                                "aModule",
+                                dummyPset.id(),
+                                edm::TypeWithDict::byName("edmtest::Thing"),
+                                false);
+    productRegistry.copyProduct(prod1);
+
+    // This one should be used
+    edm::BranchDescription prod2(edm::InRun,
+                                "aLabel",
+                                "APROD",
+                                "edmtest::ThingWithMerge",
+                                "edmtestThingWithMerge",
+                                "instance",
+                                "aModule",
+                                dummyPset.id(),
+                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                false);
+    productRegistry.copyProduct(prod2);
+
+    //not in a Run
+    edm::BranchDescription prod3(edm::InLumi,
+                                "bLabel",
+                                "BPROD",
+                                "edmtest::ThingWithMerge",
+                                "edmtestThingWithMerge",
+                                "instance",
+                                "aModule",
+                                dummyPset.id(),
+                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                false);
+    productRegistry.copyProduct(prod3);
+
+    // produced
+    edm::BranchDescription prod4(edm::InRun,
+                                "cLabel",
+                                "CPROD",
+                                "edmtest::ThingWithMerge",
+                                "edmtestThingWithMerge",
+                                "instance",
+                                "aModule",
+                                dummyPset.id(),
+                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                true);
+    productRegistry.addProduct(prod4);
+
+    // dropped
+    edm::BranchDescription prod5(edm::InRun,
+                                "dLabel",
+                                "DPROD",
+                                "edmtest::ThingWithMerge",
+                                "edmtestThingWithMerge",
+                                "instance",
+                                "aModule",
+                                dummyPset.id(),
+                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                false);
+    prod5.setDropped(true);
+    productRegistry.copyProduct(prod5);
+
+    // Should be used but the same process name
+    edm::BranchDescription prod6(edm::InRun,
+                                "eLabel",
+                                "APROD",
+                                "edmtest::ThingWithMerge",
+                                "edmtestThingWithMerge",
+                                "instance",
+                                "aModule",
+                                dummyPset.id(),
+                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                false);
+    productRegistry.copyProduct(prod6);
+
+    // Should be used
+    edm::BranchDescription prod7(edm::InRun,
+                                "fLabel",
+                                "AAPROD",
+                                "edmtest::ThingWithMerge",
+                                "edmtestThingWithMerge",
+                                "instance",
+                                "aModule",
+                                dummyPset.id(),
+                                edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                false);
+    productRegistry.copyProduct(prod7);
+
+    edm::MergeableRunProductProcesses mergeableRunProductProcesses;
+
+    REQUIRE(mergeableRunProductProcesses.size() == 0);
+
+    mergeableRunProductProcesses.setProcessesWithMergeableRunProducts(productRegistry);
+
+    REQUIRE(mergeableRunProductProcesses.size() == 2);
+
+    std::vector<std::string> expected { "AAPROD", "APROD" };
+    REQUIRE(mergeableRunProductProcesses.processesWithMergeableRunProducts() == expected);
+
+    std::vector<std::string> storedProcesses { "AAAPROD", "AAPROD", "APROD", "ZPROD" };
+    edm::StoredMergeableRunProductMetadata storedMetadata(storedProcesses);
+    REQUIRE(storedMetadata.processesWithMergeableRunProducts() == storedProcesses);
+    REQUIRE(storedMetadata.allValidAndUseIndexIntoFile());
+
+    unsigned long long iBeginProcess { 100 };
+    unsigned long long iEndProcess { 101 };
+    edm::StoredMergeableRunProductMetadata::SingleRunEntry singleRunEntry(iBeginProcess, iEndProcess);
+    REQUIRE(singleRunEntry.beginProcess() == 100);
+    REQUIRE(singleRunEntry.endProcess() == 101);
+
+    unsigned long long iBeginLumi { 200 };
+    unsigned long long iEndLumi { 201 };
+    unsigned int iProcess { 202 };
+    bool iValid { true };
+    bool iUseIndexIntoFile { false };
+    edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess singleRunEntryAndProcess(
+      iBeginLumi,
+      iEndLumi,
+      iProcess,
+      iValid,
+      iUseIndexIntoFile);
+    REQUIRE(singleRunEntryAndProcess.beginLumi() == 200);
+    REQUIRE(singleRunEntryAndProcess.endLumi() == 201);
+    REQUIRE(singleRunEntryAndProcess.process() == 202);
+    REQUIRE(singleRunEntryAndProcess.valid() == true);
+    REQUIRE(singleRunEntryAndProcess.useIndexIntoFile() == false);
+
+    // Fill storedMetadata with fake data
+    // 9 run entries
+    // Let AAPROD be not present for all run entries
+    // Let APROD be there with a vector
+    //              not there at all (no entries for any process)
+    //              there invalid with no vector
+    //              not there at all
+    //              there with a vector and invalid
+    // Let AAAPROD and ZPROD be there for all entries 0, 2, 3, 4
+    std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>& singleRunEntries = storedMetadata.singleRunEntries();
+    singleRunEntries.emplace_back(0,3);
+    singleRunEntries.emplace_back(3,3);
+    singleRunEntries.emplace_back(3,6);
+    singleRunEntries.emplace_back(6,8);
+    singleRunEntries.emplace_back(8,11);
+    singleRunEntries.emplace_back(11,12);
+    singleRunEntries.emplace_back(12,13);
+    singleRunEntries.emplace_back(13,14);
+    singleRunEntries.emplace_back(14,15);
+
+    std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>& singleRunEntryAndProcesses = storedMetadata.singleRunEntryAndProcesses();
+    std::vector<edm::LuminosityBlockNumber_t>& lumis = storedMetadata.lumis();
+
+    // arguments: beginLumi, endLumi, process Index, valid, useIndexIntoFile
+    unsigned int iAAAPROD { 0 };
+    // unsigned int iAAPROD { 1 };
+    unsigned int iAPROD { 2 };
+    unsigned int iZPROD { 3 };
+
+    // 0th run entry
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(1);
+    lumis.emplace_back(2);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAAAPROD, true, false);
+
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(101);
+    lumis.emplace_back(102);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAPROD, true, false);
+
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(1);
+    lumis.emplace_back(2);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iZPROD, true, false);
+
+    // nothing in the 1st entry
+
+    // 2nd run entry
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(1);
+    lumis.emplace_back(2);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAAAPROD, true, false);
+
+    iBeginLumi = lumis.size();
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAPROD, false, true);
+
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(1);
+    lumis.emplace_back(2);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iZPROD, true, false);
+
+    // 3rd run entry
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(1);
+    lumis.emplace_back(2);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAAAPROD, true, false);
+
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(1);
+    lumis.emplace_back(2);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iZPROD, true, false);
+
+    // 4th run entry
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(1);
+    lumis.emplace_back(2);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAAAPROD, true, false);
+
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(111);
+    lumis.emplace_back(112);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAPROD, false, false);
+
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(1);
+    lumis.emplace_back(2);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iZPROD, true, false);
+
+    // 5th entry
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(91);
+    lumis.emplace_back(92);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAPROD, true, false);
+
+    // 6th entry
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(121);
+    lumis.emplace_back(122);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAPROD, true, false);
+
+    // 7th entry
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(95);
+    lumis.emplace_back(101);
+    lumis.emplace_back(105);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAPROD, true, false);
+
+    // 8th entry
+    iBeginLumi = lumis.size();
+    lumis.emplace_back(1000);
+    lumis.emplace_back(1002);
+    lumis.emplace_back(1003);
+    lumis.emplace_back(1004);
+    iEndLumi = lumis.size();
+    singleRunEntryAndProcesses.emplace_back(iBeginLumi, iEndLumi, iAPROD, true, false);
+
+    storedMetadata.allValidAndUseIndexIntoFile() = false;
+
+    bool valid;
+    std::vector<edm::LuminosityBlockNumber_t>::const_iterator lumisBegin;
+    std::vector<edm::LuminosityBlockNumber_t>::const_iterator lumisEnd;
+    REQUIRE(storedMetadata.getLumiContent(0, std::string("APROD"), valid, lumisBegin, lumisEnd));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> test(lumisBegin, lumisEnd);
+      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102 };
+      REQUIRE(test == expected);
+      REQUIRE(valid);
+    }
+    REQUIRE(!storedMetadata.getLumiContent(1, std::string("APROD"), valid, lumisBegin, lumisEnd));
+    REQUIRE(valid);
+    REQUIRE(!storedMetadata.getLumiContent(2, std::string("APROD"), valid, lumisBegin, lumisEnd));
+    REQUIRE(!valid);
+    REQUIRE(!storedMetadata.getLumiContent(3, std::string("APROD"), valid, lumisBegin, lumisEnd));
+    REQUIRE(valid);
+    REQUIRE(storedMetadata.getLumiContent(4, std::string("APROD"), valid, lumisBegin, lumisEnd));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> test(lumisBegin, lumisEnd);
+      std::vector<edm::LuminosityBlockNumber_t> expected { 111, 112 };
+      REQUIRE(test == expected);
+      REQUIRE(!valid);
+    }
+
+    edm::IndexIntoFile indexIntoFile;
+
+    edm::ProcessHistoryID fakePHID1;
+    edm::ProcessConfiguration pc;
+    auto processHistory1 = std::make_unique<edm::ProcessHistory>();
+    edm::ProcessHistory& ph1 = *processHistory1;
+    processHistory1->push_back(pc);
+    fakePHID1 = ph1.id();
+
+    edm::ProcessHistoryID fakePHID2;
+    auto processHistory2 = std::make_unique<edm::ProcessHistory>();
+    edm::ProcessHistory& ph2 = *processHistory2;
+    processHistory2->push_back(pc);
+    processHistory2->push_back(pc);
+    fakePHID2 = ph2.id();
+
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 7, 0); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 6, 1); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 0, 0); // Lumi
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 0, 1); // Lumi
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 5, 2); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 4, 3); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1001, 0, 2); // Lumi
+    indexIntoFile.addEntry(fakePHID1, 11, 1003, 5, 4); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1003, 4, 5); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 1003, 0, 3); // Lumi
+    indexIntoFile.addEntry(fakePHID1, 11,   0, 0, 0); // Run
+    indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 1); // Run
+    indexIntoFile.addEntry(fakePHID2, 11, 1001, 0, 4); // Lumi
+    indexIntoFile.addEntry(fakePHID2, 11, 1003, 0, 5); // Lumi
+    indexIntoFile.addEntry(fakePHID2, 11, 1003, 4, 6); // Event
+    indexIntoFile.addEntry(fakePHID2, 11, 1003, 0, 6); // Lumi
+    indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 2); // Run
+    indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+    edm::IndexIntoFile::IndexIntoFileItr iter = indexIntoFile.begin(edm::IndexIntoFile::firstAppearanceOrder);
+
+
+    edm::MergeableRunProductMetadata mergeableRunProductMetadata(mergeableRunProductProcesses);
+
+    edm::MergeableRunProductMetadata::MetadataForProcess const* APRODMetadataForProcess =
+      mergeableRunProductMetadata.metadataForOneProcess("APROD");
+    REQUIRE(APRODMetadataForProcess);
+
+    edm::MergeableRunProductMetadata::MetadataForProcess const* NullMetadataForProcess =
+      mergeableRunProductMetadata.metadataForOneProcess("DOESNOTEXIST");
+    REQUIRE(NullMetadataForProcess == nullptr);
+
+    mergeableRunProductMetadata.readRun(0, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::REPLACE);
+      REQUIRE(mergeableRunProductMetadata.getMergeDecision("APROD") == edm::MergeableRunProductMetadata::REPLACE);
+      REQUIRE(APRODMetadataForProcess->valid());
+      REQUIRE(!mergeableRunProductMetadata.knownImproperlyMerged("APROD"));
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+    // Same one again for test purposes
+    mergeableRunProductMetadata.readRun(0, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::IGNORE);
+      REQUIRE(mergeableRunProductMetadata.getMergeDecision("APROD") == edm::MergeableRunProductMetadata::IGNORE);
+      REQUIRE(APRODMetadataForProcess->valid());
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+    // disjoint with newly read ones coming first
+    mergeableRunProductMetadata.readRun(5, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 101, 102 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+      REQUIRE(mergeableRunProductMetadata.getMergeDecision("APROD") == edm::MergeableRunProductMetadata::MERGE);
+      REQUIRE(APRODMetadataForProcess->valid());
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+    // disjoint with newly read ones coming last
+    mergeableRunProductMetadata.readRun(6, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 101, 102, 121, 122 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+      REQUIRE(APRODMetadataForProcess->valid());
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+    // impossible to merge case, shared elements and both also have at least one non-shared element
+    mergeableRunProductMetadata.readRun(7, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+      REQUIRE(!APRODMetadataForProcess->valid());
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+    mergeableRunProductMetadata.readFile();
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+    }
+    mergeableRunProductMetadata.readRun(3, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+      REQUIRE(!APRODMetadataForProcess->valid());
+      REQUIRE(APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+    mergeableRunProductMetadata.readFile();
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122, 1001, 1003 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+    }
+
+    mergeableRunProductMetadata.postWriteRun();
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected;
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+      REQUIRE(APRODMetadataForProcess->valid());
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+    mergeableRunProductMetadata.readRun(0, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::REPLACE);
+      REQUIRE(APRODMetadataForProcess->valid());
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+    mergeableRunProductMetadata.readRun(4, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected { 101, 102, 111, 112 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+      REQUIRE(!APRODMetadataForProcess->valid());
+      REQUIRE(mergeableRunProductMetadata.knownImproperlyMerged("APROD"));
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+    mergeableRunProductMetadata.readFile();
+    mergeableRunProductMetadata.postWriteRun();
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected3;
+      REQUIRE(expected3 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
+      REQUIRE(!mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
+
+      mergeableRunProductMetadata.readRun(1, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+
+      std::vector<edm::LuminosityBlockNumber_t> expected;
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+      REQUIRE(APRODMetadataForProcess->valid());
+      REQUIRE(APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+
+      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1001, 1003 };
+      REQUIRE(expected2 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
+      REQUIRE(mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
+    }
+    mergeableRunProductMetadata.readFile();
+    {
+      std::vector<edm::LuminosityBlockNumber_t> expected3;
+      REQUIRE(expected3 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
+      REQUIRE(!mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
+
+      std::vector<edm::LuminosityBlockNumber_t> expected {1001, 1003 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+    }
+
+    mergeableRunProductMetadata.postWriteRun();
+    {
+      mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+
+      std::vector<edm::LuminosityBlockNumber_t> expected;
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      REQUIRE(APRODMetadataForProcess->mergeDecision() == edm::MergeableRunProductMetadata::MERGE);
+      REQUIRE(!APRODMetadataForProcess->valid());
+      REQUIRE(APRODMetadataForProcess->useIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+
+      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1001, 1003 };
+      REQUIRE(expected2 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
+      REQUIRE(mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
+    }
+    {
+      mergeableRunProductMetadata.readRun(8, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+      std::vector<edm::LuminosityBlockNumber_t> expected { 1000, 1002, 1003, 1004 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+      REQUIRE(APRODMetadataForProcess->lumis() == expected);
+      mergeableRunProductMetadata.readFile();
+      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1000, 1001, 1002, 1003, 1004 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected2);
+    }
+    mergeableRunProductMetadata.postWriteRun();
+
+    {
+      mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+      mergeableRunProductMetadata.readRun(8, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+
+      std::vector<edm::LuminosityBlockNumber_t> expected1 { 1001, 1003 };
+      REQUIRE(expected1 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
+      REQUIRE(mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
+
+      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1000, 1002, 1003, 1004 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected2);
+
+      mergeableRunProductMetadata.writeLumi(1004);
+      mergeableRunProductMetadata.writeLumi(1002);
+      mergeableRunProductMetadata.writeLumi(1002);
+      mergeableRunProductMetadata.preWriteRun();
+
+      std::vector<edm::LuminosityBlockNumber_t> expected3;
+      REQUIRE(expected3 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
+      REQUIRE(!mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
+      REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
+
+      std::vector<edm::LuminosityBlockNumber_t> expected4 { 1000, 1001, 1002, 1003, 1004 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected4);
+
+    }
+    mergeableRunProductMetadata.postWriteRun();
+    REQUIRE(mergeableRunProductMetadata.lumisProcessed().empty());
+    {
+      // ----------------------------------------------------
+
+      std::vector<std::string> storedProcessesOutput { "AAAPROD", "AAPROD", "APROD", "ZPROD" };
+      edm::StoredMergeableRunProductMetadata storedMetadataOutput(storedProcesses);
+
+      mergeableRunProductMetadata.readRun(1, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+      mergeableRunProductMetadata.writeLumi(1003);
+      mergeableRunProductMetadata.writeLumi(1001);
+      mergeableRunProductMetadata.preWriteRun();
+      mergeableRunProductMetadata.addEntryToStoredMetadata(storedMetadataOutput);
+      mergeableRunProductMetadata.postWriteRun();
+
+      REQUIRE(storedMetadataOutput.allValidAndUseIndexIntoFile());
+
+      // ---------------------------------------------------
+
+      mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+      mergeableRunProductMetadata.readRun(8, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+
+      std::vector<edm::LuminosityBlockNumber_t> expected1 { 1001, 1003 };
+      REQUIRE(expected1 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
+      REQUIRE(mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
+
+      std::vector<edm::LuminosityBlockNumber_t> expected2 { 1000, 1002, 1003, 1004 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected2);
+
+      mergeableRunProductMetadata.writeLumi(1004);
+      mergeableRunProductMetadata.writeLumi(1002);
+      mergeableRunProductMetadata.writeLumi(1002);
+      mergeableRunProductMetadata.writeLumi(1000);
+      mergeableRunProductMetadata.writeLumi(1001);
+      mergeableRunProductMetadata.writeLumi(1003);
+      mergeableRunProductMetadata.preWriteRun();
+
+      std::vector<edm::LuminosityBlockNumber_t> expected3;
+      REQUIRE(expected3 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
+      REQUIRE(!mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
+      REQUIRE(APRODMetadataForProcess->allLumisProcessed());
+
+      std::vector<edm::LuminosityBlockNumber_t> expected4 { 1000, 1001, 1002, 1003, 1004 };
+      REQUIRE(APRODMetadataForProcess->lumis() == expected4);
+
+      mergeableRunProductMetadata.addEntryToStoredMetadata(storedMetadataOutput);
+
+      // ----------------------------------------------------
+
+      mergeableRunProductMetadata.postWriteRun();
+      mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+      mergeableRunProductMetadata.preWriteRun();
+      mergeableRunProductMetadata.addEntryToStoredMetadata(storedMetadataOutput);
+
+      // ----------------------------------------------------
+
+      mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+      mergeableRunProductMetadata.readRun(8, storedMetadata, edm::IndexIntoFileItrHolder(iter));
+      mergeableRunProductMetadata.writeLumi(1004);
+      mergeableRunProductMetadata.writeLumi(1002);
+      mergeableRunProductMetadata.writeLumi(1002);
+      mergeableRunProductMetadata.writeLumi(1000);
+      mergeableRunProductMetadata.writeLumi(1001);
+      mergeableRunProductMetadata.preWriteRun();
+      mergeableRunProductMetadata.addEntryToStoredMetadata(storedMetadataOutput);
+      mergeableRunProductMetadata.postWriteRun();
+
+      // ---------------------------------------------------
+
+      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>& singleRunEntries = storedMetadataOutput.singleRunEntries();
+      REQUIRE(singleRunEntries.size() == 4);
+      REQUIRE(singleRunEntries[0].beginProcess() == 0);
+      REQUIRE(singleRunEntries[0].endProcess() == 0);
+      REQUIRE(singleRunEntries[1].beginProcess() == 0);
+      REQUIRE(singleRunEntries[1].endProcess() == 1);
+      REQUIRE(singleRunEntries[2].beginProcess() == 1);
+      REQUIRE(singleRunEntries[2].endProcess() == 3);
+      REQUIRE(singleRunEntries[3].beginProcess() == 3);
+      REQUIRE(singleRunEntries[3].endProcess() == 5);
+
+      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>& singleRunEntryAndProcesses = storedMetadataOutput.singleRunEntryAndProcesses();
+      REQUIRE(singleRunEntryAndProcesses.size() == 5);
+
+      REQUIRE(singleRunEntryAndProcesses[0].beginLumi() == 0);
+      REQUIRE(singleRunEntryAndProcesses[0].endLumi() == 0);
+      REQUIRE(singleRunEntryAndProcesses[0].process() == 2);
+      REQUIRE(!singleRunEntryAndProcesses[0].valid());
+      REQUIRE(singleRunEntryAndProcesses[0].useIndexIntoFile());
+
+      REQUIRE(singleRunEntryAndProcesses[1].beginLumi() == 0);
+      REQUIRE(singleRunEntryAndProcesses[1].endLumi() == 2);
+      REQUIRE(singleRunEntryAndProcesses[1].process() == 1);
+      REQUIRE(singleRunEntryAndProcesses[1].valid());
+      REQUIRE(!singleRunEntryAndProcesses[1].useIndexIntoFile());
+
+      REQUIRE(singleRunEntryAndProcesses[2].beginLumi() == 0);
+      REQUIRE(singleRunEntryAndProcesses[2].endLumi() == 2);
+      REQUIRE(singleRunEntryAndProcesses[2].process() == 2);
+      REQUIRE(!singleRunEntryAndProcesses[2].valid());
+      REQUIRE(!singleRunEntryAndProcesses[2].useIndexIntoFile());
+
+      REQUIRE(singleRunEntryAndProcesses[3].beginLumi() == 2);
+      REQUIRE(singleRunEntryAndProcesses[3].endLumi() == 4);
+      REQUIRE(singleRunEntryAndProcesses[3].process() == 1);
+      REQUIRE(singleRunEntryAndProcesses[3].valid());
+      REQUIRE(!singleRunEntryAndProcesses[3].useIndexIntoFile());
+
+      REQUIRE(singleRunEntryAndProcesses[4].beginLumi() == 4);
+      REQUIRE(singleRunEntryAndProcesses[4].endLumi() == 9);
+      REQUIRE(singleRunEntryAndProcesses[4].process() == 2);
+      REQUIRE(!singleRunEntryAndProcesses[4].valid());
+      REQUIRE(!singleRunEntryAndProcesses[4].useIndexIntoFile());
+
+      std::vector<edm::LuminosityBlockNumber_t>& lumis = storedMetadataOutput.lumis();
+      REQUIRE(lumis.size() == 9);
+      REQUIRE(lumis[0] == 1001);
+      REQUIRE(lumis[1] == 1003);
+      REQUIRE(lumis[2] == 1001);
+      REQUIRE(lumis[3] == 1003);
+      REQUIRE(lumis[4] == 1000);
+      REQUIRE(lumis[5] == 1001);
+      REQUIRE(lumis[6] == 1002);
+      REQUIRE(lumis[7] == 1003);
+      REQUIRE(lumis[8] == 1004);
+
+      REQUIRE(!storedMetadataOutput.allValidAndUseIndexIntoFile());
+    }
+  }
+}

--- a/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
@@ -458,7 +458,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
       REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
     }
-    mergeableRunProductMetadata.readFile();
+    mergeableRunProductMetadata.preReadFile();
     {
       std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122 };
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
@@ -473,7 +473,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(APRODMetadataForProcess->useIndexIntoFile());
       REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
     }
-    mergeableRunProductMetadata.readFile();
+    mergeableRunProductMetadata.preReadFile();
     {
       std::vector<edm::LuminosityBlockNumber_t> expected { 91, 92, 95, 101, 102, 105, 121, 122, 1001, 1003 };
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
@@ -508,7 +508,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(!APRODMetadataForProcess->useIndexIntoFile());
       REQUIRE(!APRODMetadataForProcess->allLumisProcessed());
     }
-    mergeableRunProductMetadata.readFile();
+    mergeableRunProductMetadata.preReadFile();
     mergeableRunProductMetadata.postWriteRun();
     {
       std::vector<edm::LuminosityBlockNumber_t> expected3;
@@ -528,7 +528,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(expected2 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
       REQUIRE(mergeableRunProductMetadata.gotLumisFromIndexIntoFile());
     }
-    mergeableRunProductMetadata.readFile();
+    mergeableRunProductMetadata.preReadFile();
     {
       std::vector<edm::LuminosityBlockNumber_t> expected3;
       REQUIRE(expected3 == mergeableRunProductMetadata.lumisFromIndexIntoFile());
@@ -561,7 +561,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
       mergeableRunProductMetadata.readRun(2, storedMetadata, edm::IndexIntoFileItrHolder(iter));
       REQUIRE(APRODMetadataForProcess->lumis() == expected);
-      mergeableRunProductMetadata.readFile();
+      mergeableRunProductMetadata.preReadFile();
       std::vector<edm::LuminosityBlockNumber_t> expected2 { 1000, 1001, 1002, 1003, 1004 };
       REQUIRE(APRODMetadataForProcess->lumis() == expected2);
     }

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -93,6 +93,10 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_RunMerge.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="TestIntegration.cpp" name="TestIntegrationRunMerge2">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_RunMerge2.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
   <bin   file="TestIntegration.cpp" name="TestIntegrationRefMerge">
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_RefMerge.sh"/>
     <use   name="FWCore/Utilities"/>

--- a/FWCore/Integration/test/readSubProcessOutput_cfg.py
+++ b/FWCore/Integration/test/readSubProcessOutput_cfg.py
@@ -21,48 +21,24 @@ process.out = cms.OutputModule("PoolOutputModule",
 process.testproducts = cms.EDAnalyzer("TestMergeResults",
 
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
         10001,   10002,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   10002,  10003,   # * events
         10001,   10002,  10003,   # end run 2
-        10001,   10002,  10003,   # * begin run 2
-        10001,   10002,  10003,   # * events
         10001,   10002,  10003    # end run 3
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,      # start
-        0,           0,      0,      # begin file 1
-        100001,   100002,  100003,   # begin run 1
-        100001,   100002,  100003,   # * events
-        100001,   100002,  100003,   # * end run 1
-        100001,   100002,  100003,   # begin run 2
-        100001,   100002,  100003,   # * events
-        100001,   100002,  100003,   # * end run 2
-        100001,   100002,  100003,   # begin run 2
-        100001,   100002,  100003,   # * events
-        100001,   100002,  100003    # * end run 3
+        100001,   100002,  100003,   # end run 1
+        100001,   100002,  100003,   # end run 2
+        100001,   100002,  100003    # end run 3
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
         101,       102,    103    # end run 1 lumi 1
 # There are more, but all with the same pattern as the first        
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        1001,     1002,   1003,   # begin run 1 lumi 1
-        1001,     1002,   1003,   # * events
-        1001,     1002,   1003    # * end run 1 lumi 1
+        1001,     1002,   1003    # end run 1 lumi 1
     ),
 
     expectedProcessHistoryInRuns = cms.untracked.vstring(

--- a/FWCore/Integration/test/run_RunMerge2.sh
+++ b/FWCore/Integration/test/run_RunMerge2.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+test=testRunMerge
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+echo LOCAL_TMP_DIR = ${LOCAL_TMP_DIR}
+
+pushd ${LOCAL_TMP_DIR}
+  echo ${test}PROD100 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}PROD100_cfg.py || die "cmsRun ${test}PROD100_cfg.py" $?
+
+  echo ${test}PROD101 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}PROD101_cfg.py || die "cmsRun ${test}PROD101_cfg.py" $?
+
+  echo ${test}PROD102 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}PROD102_cfg.py || die "cmsRun ${test}PROD102_cfg.py" $?
+
+  echo ${test}SPLIT100 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}SPLIT100_cfg.py || die "cmsRun ${test}SPLIT100_cfg.py" $?
+
+  echo ${test}SPLIT101 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}SPLIT101_cfg.py || die "cmsRun ${test}SPLIT101_cfg.py" $?
+
+  echo ${test}SPLIT102 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}SPLIT102_cfg.py || die "cmsRun ${test}SPLIT102_cfg.py" $?
+
+  echo ${test}SPLIT103 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}SPLIT103_cfg.py || die "cmsRun ${test}SPLIT103_cfg.py" $?
+
+  echo ${test}MERGE100 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}MERGE100_cfg.py || die "cmsRun ${test}MERGE100_cfg.py" $?
+
+  echo ${test}MERGE101 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}MERGE101_cfg.py || die "cmsRun ${test}MERGE101_cfg.py" $?
+
+  echo ${test}MERGE102 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}MERGE102_cfg.py || die "cmsRun ${test}MERGE102_cfg.py" $?
+
+  echo ${test}TEST100 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}TEST100_cfg.py || die "cmsRun ${test}TEST100_cfg.py" $?
+
+  echo ${test}TEST101 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}TEST101_cfg.py || die "cmsRun ${test}TEST101_cfg.py" $?
+
+  echo ${test}COPY100 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}COPY100_cfg.py || die "cmsRun ${test}COPY100_cfg.py" $?
+
+  echo ${test}COPY101 ------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}COPY101_cfg.py || die "cmsRun ${test}COPY101_cfg.py" $?
+
+popd
+
+exit 0

--- a/FWCore/Integration/test/testLooperEventNavigation1_cfg.py
+++ b/FWCore/Integration/test/testLooperEventNavigation1_cfg.py
@@ -23,6 +23,10 @@ process.source = cms.Source("PoolSource",
     #, processingMode = cms.untracked.string('RunsAndLumis')
     #, duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
     , noEventSort = cms.untracked.bool(True)
+    , inputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop edmtestThingWithMerge_makeThingToBeDropped1_*_*'
+    )
 )
 
 

--- a/FWCore/Integration/test/testLooperEventNavigation_cfg.py
+++ b/FWCore/Integration/test/testLooperEventNavigation_cfg.py
@@ -19,6 +19,10 @@ process.source = cms.Source("PoolSource",
     #, processingMode = cms.untracked.string('RunsAndLumis')
     #, duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
     , noEventSort = cms.untracked.bool(False)
+    , inputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop edmtestThingWithMerge_makeThingToBeDropped1_*_*'
+    )
 )
 
 

--- a/FWCore/Integration/test/testRunMergeCOPY100_cfg.py
+++ b/FWCore/Integration/test/testRunMergeCOPY100_cfg.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("COPY")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.threshold = 'ERROR'
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMergeTEST100.root'
+    ),
+    duplicateCheckMode = cms.untracked.string('noDuplicateCheck')
+)
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+
+    expectedBeginRunProd = cms.untracked.vint32(
+        10001,   40008,  10003,
+        10001,   20004,  10003
+    ),
+
+    expectedEndRunProd = cms.untracked.vint32(
+        100001,   400008,  100003,
+        100001,   200004,  100003
+    ),
+
+    expectedEndRunProdImproperlyMerged = cms.untracked.vint32(
+        0,   1,  0,
+        0,   0,  0
+    )
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeCOPY100.root')
+)
+
+process.e = cms.EndPath(process.test * process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeCOPY101_cfg.py
+++ b/FWCore/Integration/test/testRunMergeCOPY101_cfg.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("COPY")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.threshold = 'ERROR'
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMergeTEST101.root'
+    ),
+    duplicateCheckMode = cms.untracked.string('noDuplicateCheck')
+)
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+
+    expectedBeginRunProd = cms.untracked.vint32(
+        10001,   20004,  10003,
+        10001,   10002,  10003
+    ),
+
+    expectedEndRunProd = cms.untracked.vint32(
+        100001,   200004,  100003,
+        100001,   100002,  100003
+    ),
+
+    expectedEndRunProdImproperlyMerged = cms.untracked.vint32(
+        0,   0,  0,
+        0,   0,  0
+    )
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeCOPY101.root')
+)
+
+process.e = cms.EndPath(process.test * process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeMERGE100_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE100_cfg.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MERGE")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMergeSPLIT100.root',
+        'file:testRunMergeSPLIT101.root'
+    ),
+    lumisToProcess = cms.untracked.VLuminosityBlockRange('41:6-41:15'),
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+
+    expectedBeginRunProd = cms.untracked.vint32(
+        10001,   20004,  10003
+    ),
+
+    expectedEndRunProd = cms.untracked.vint32(
+        100001,   200004,  100003
+    ),
+
+    expectedEndRunProdImproperlyMerged = cms.untracked.vint32(
+        0,   0,  0
+    )
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeMERGE100.root')
+)
+
+process.e = cms.EndPath(process.test * process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeMERGE101_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE101_cfg.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MERGE")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.threshold = 'ERROR'
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMergeSPLIT103.root',
+        'file:testRunMergeSPLIT102.root'
+    ),
+    lumisToProcess = cms.untracked.VLuminosityBlockRange('41:16-41:25', '42:16-42:20')
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+
+    expectedBeginRunProd = cms.untracked.vint32(
+        10001,   20004,  10003,
+        10001,   10002,  10003
+    ),
+
+    expectedEndRunProd = cms.untracked.vint32(
+        100001,   200004,  100003,
+        100001,   100002,  100003
+    ),
+
+    expectedEndRunProdImproperlyMerged = cms.untracked.vint32(
+        0,   0,  0,
+        0,   0,  0
+    )
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeMERGE101.root')
+)
+
+process.e = cms.EndPath(process.test * process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeMERGE102_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE102_cfg.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MERGE")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.threshold = 'ERROR'
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMergeSPLIT100.root',
+        'file:testRunMergeSPLIT101.root'
+    ),
+    lumisToProcess = cms.untracked.VLuminosityBlockRange('42:6-42:15')
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+
+    expectedBeginRunProd = cms.untracked.vint32(
+        10001,   20004,  10003
+    ),
+
+    expectedEndRunProd = cms.untracked.vint32(
+        100001,   200004,  100003
+    ),
+
+    expectedEndRunProdImproperlyMerged = cms.untracked.vint32(
+        0,   0,  0
+    )
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeMERGE102.root')
+)
+
+process.e = cms.EndPath(process.test * process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeMERGE2_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE2_cfg.py
@@ -28,7 +28,8 @@ process.source = cms.Source("PoolSource",
     inputCommands = cms.untracked.vstring(
         'keep *', 
         'drop *_C_*_*',
-        'drop *_*_*_EXTRA'
+        'drop *_*_*_EXTRA',
+        'drop edmtestThingWithMerge_makeThingToBeDropped1_*_*'
     )
     , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
 )
@@ -37,204 +38,80 @@ process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
 
 process.test = cms.EDAnalyzer("TestMergeResults",
                             
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 0
-        10001,   10002,  10003,   # * begin run 100
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 1
         10001,   10002,  10003,   # end run 100
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 2
         10001,   10002,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 3
+        10001,   10002,  10003,   # end run 1, no merge of runs because ProcessHistoryID different
         10001,   10002,  10003,   # end run 2
-        10001,   10002,  10004,   # * begin run 1
-        10001,   10002,  10004,   # * events
         10001,   10002,  10004    # end run 1
     ),
                             
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 0
-        100001, 100002, 100003,   # begin run 100
-        100001, 100002, 100003,   # * events
-        100001, 100002, 100003,   # begin file 1
-        100001, 100002, 100003,   # * end run 100
-        100001, 100002, 100003,   # begin run 1
-        100001, 100002, 100003,   # * events
-        100001, 100002, 100003,   # begin file 2
-        100001, 100002, 100003,   # * end run 1
-        100001, 100002, 100003,   # begin run 1
-        100001, 100002, 100003,   # * events
-        100001, 100002, 100003,   # * end run 1
-        100001, 100002, 100003,   # begin run 2
-        100001, 100002, 100003,   # * events
-        100001, 100002, 100003,   # begin file 3
-        100001, 100002, 100003,   # * end run 2
-        100001, 100002, 100004,   # begin run 1
-        100001, 100002, 100004,   # * events
-        100001, 100002, 100004    # * end run 1
+        100001, 100002, 100003,   # end run 100
+        100001, 100002, 100003,   # end run 1
+        100001, 100002, 100003,   # end run 1, no merge of runs because ProcessHistoryID different
+        100001, 100002, 100003,   # end run 2
+        100001, 100002, 100004    # end run 1
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 0
-        101,       102,    103,   # * begin run 100 lumi 100
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 1
         101,       102,    103,   # end run 100 lumi 100
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 2
         101,       102,    103,   # end run 1 lumi 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # end run 1 lumi 1
-        101,       102,    103,   # * begin run 2 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 3
+        101,       102,    103,   # end run 1 lumi 1, no merge of runs because ProcessHistoryID different
         101,       102,    103,   # end run 2 lumi 1
-        101,       102,    104,   # * begin run 1 lumi 1
-        101,       102,    104,   # * events
         101,       102,    104    # end run 1 lumi 1
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 0
-        1001,     1002,   1003,   # begin run 100 lumi 100
-        1001,     1002,   1003,   # * events
-        1001,     1002,   1003,   # begin file 1
-        1001,     1002,   1003,   # * end run 100 lumi 100
-        1001,     1002,   1003,   # begin run 1 lumi 1
-        1001,     1002,   1003,   # * events
-        1001,     1002,   1003,   # begin file 2
-        1001,     1002,   1003,   # * end run 1 lumi 1
-        1001,     1002,   1003,   # begin run 1 lumi 1
-        1001,     1002,   1003,   # * events
-        1001,     1002,   1003,   # * end run 1 lumi 1
-        1001,     1002,   1003,   # begin run 2 lumi 1
-        1001,     1002,   1003,   # * events
-        1001,     1002,   1003,   # begin file 3
-        1001,     1002,   1003,   # * end run 2 lumi 1
-        1001,     1002,   1004,   # begin run 1 lumi 1
-        1001,     1002,   1004,   # * events
-        1001,     1002,   1004    # * end run 1 lumi 1
+        1001,     1002,   1003,   # end run 100 lumi 100
+        1001,     1002,   1003,   # end run 1 lumi 1
+        1001,     1002,   1003,   # end run 1 lumi 1, no merge of runs because ProcessHistoryID different
+        1001,     1002,   1003,   # end run 2 lumi 1
+        1001,     1002,   1004    # end run 1 lumi 1
     ),
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 0
-        10001,   10002,  10003,   # * begin run 100
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 1
         10001,   10002,  10003,   # end run 100
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 2
         10001,   10002,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
         10001,   10002,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 3
         10001,   10002,  10003,   # end run 2
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
         10001,   10002,  10003    # end run 1
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 0
-        0,           0,      0,   # begin run 100
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 1
-        100001, 100002, 100003,   # * end run 100
-        0,           0,      0,   # begin run 1
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 2
-        100001, 100002, 100003,   # * end run 1
-        0,           0,      0,   # begin run 1
-        0,           0,      0,   # * events
-        100001, 100002, 100003,   # * end run 1
-        0,           0,      0,   # begin run 2
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 3
-        100001, 100002, 100003,   # * end run 2
-        0,           0,      0,   # * begin run 1
-        0,           0,      0,   # * events
-        100001, 100002, 100003    # * end run 1
+        100001, 100002, 100003,   # end run 100
+        100001, 100002, 100003,   # end run 1
+        100001, 100002, 100003,   # end run 1
+        100001, 100002, 100003,   # end run 2
+        100001, 100002, 100003    # end run 1
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 0
-        101,       102,    103,   # * begin run 100 lumi 100
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 1
         101,       102,    103,   # end run 100 lumi 100
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 2
         101,       102,    103,   # end run 1 lumi 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
         101,       102,    103,   # end run 1 lumi 1
-        101,       102,    103,   # * begin run 2 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 3
         101,       102,    103,   # end run 2 lumi 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
         101,       102,    103    # end run 1 lumi 1
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 0
-        0,           0,      0,   # begin run 100 lumi 100
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 1
-        1001,     1002,   1003,   # * end run 100 lumi 100
-        0,           0,      0,   # begin run 1 lumi 1
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 2
-        1001,     1002,   1003,   # * end run 1 lumi 1
-        0,           0,      0,   # begin run 1 lumi 1
-        0,           0,      0,   # * events
-        1001,     1002,   1003,   # * end run 1 lumi 1
-        0,           0,      0,   # begin run 2 lumi 1
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 3
-        1001,     1002,   1003,   # * end run 2 lumi 1
-        0,           0,      0,   # * begin run 1 lumi 1
-        0,           0,      0,   # * events
-        1001,     1002,   1003    # * end run 1 lumi 1
+        1001,     1002,   1003,   # end run 100 lumi 100
+        1001,     1002,   1003,   # end run 1 lumi 1
+        1001,     1002,   1003,   # end run 1 lumi 1
+        1001,     1002,   1003,   # end run 2 lumi 1
+        1001,     1002,   1003    # end run 1 lumi 1
     ),
 
     expectedDroppedEvent1 = cms.untracked.vint32(13, 13, -1, -1, -1, 13),

--- a/FWCore/Integration/test/testRunMergeMERGE4_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE4_cfg.py
@@ -26,7 +26,8 @@ process.source = cms.Source("PoolSource",
     ),
     inputCommands = cms.untracked.vstring(
         'keep *', 
-        'drop *_C_*_*'
+        'drop *_C_*_*',
+        'drop edmtestThingWithMerge_makeThingToBeDropped1_*_*'
     )
     , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
 )
@@ -35,148 +36,64 @@ process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
 
 process.test = cms.EDAnalyzer("TestMergeResults",
                             
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
-        10001,   20004,  10003,   # * begin file 2
-        10001,   20004,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 3
-        10001,   10002,  10003,   # end run 2
-        10001,   10002,  10004,   # * begin run 1
-        10001,   10002,  10004,   # * events
-        10001,   10002,  10004    # end run 1
+        10001,   20004,  10003,   # File boundary before this causing merge
+        10001,   10002,  10003,
+        10001,   10002,  10004
     ),
                             
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        100001, 100002, 100003,   # begin run 1
-        100001, 100002, 100003,   # * events
-        100001, 200004, 100003,   # * begin file 2
-        100001, 200004, 100003,   # * end run 1
-        100001, 100002, 100003,   # begin run 2
-        100001, 100002, 100003,   # * events
-        100001, 100002, 100003,   # begin file 3
-        100001, 100002, 100003,   # * end run 2
-        100001, 100002, 100004,   # begin run 1
-        100001, 100002, 100004,   # * events
-        100001, 100002, 100004    # * end run 1
+        100001, 200004, 100003,   # File boundary before this causing merge
+        100001, 100002, 100003,
+        100001, 100002, 100004
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
-        101,       204,    103,   # * begin file 2
-        101,       204,    103,   # end run 1 lumi 1
-        101,       102,    103,   # * begin run 2 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 3
-        101,       102,    103,   # end run 2 lumi 1
-        101,       102,    104,   # * begin run 1 lumi 1
-        101,       102,    104,   # * events
-        101,       102,    104    # end run 1 lumi 1
+        101,       204,    103,   # File boundary before this causing merge
+        101,       102,    103,
+        101,       102,    104
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        1001,     1002,   1003,   # begin run 1 lumi 1
-        1001,     1002,   1003,   # * events
-        1001,     2004,   1003,   # * begin file 2
-        1001,     2004,   1003,   # * end run 1 lumi 1
-        1001,     1002,   1003,   # begin run 2 lumi 1
-        1001,     1002,   1003,   # * events
-        1001,     1002,   1003,   # begin file 3
-        1001,     1002,   1003,   # * end run 2 lumi 1
-        1001,     1002,   1004,   # begin run 1 lumi 1
-        1001,     1002,   1004,   # * events
-        1001,     1002,   1004    # * end run 1 lumi 1
+        1001,     2004,   1003,   # File boundary before this causing merge
+        1001,     1002,   1003,
+        1001,     1002,   1004
     ),
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # * begin file 2
-        10001,   10002,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 3
-        10001,   10002,  10003,   # end run 2
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003    # end run 1
+        10001,   10002,  10003,
+        10001,   10002,  10003,
+        10001,   10002,  10003
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        0,           0,      0,   # begin run 1
-        0,           0,      0,   # * events
-        0,           0,      0,   # * begin file 2
-        100001, 100002, 100003,   # * end run 1
-        0,           0,      0,   # begin run 2
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 3
-        100001, 100002, 100003,   # * end run 2
-        0,           0,      0,   # begin run 1
-        0,           0,      0,   # * events
-        100001, 100002, 100003    # * end run 1
+        100001, 100002, 100003,
+        100001, 100002, 100003,
+        100001, 100002, 100003
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # * begin file 2
-        101,       102,    103,   # end run 1 lumi 1
-        101,       102,    103,   # * begin run 2 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 3
-        101,       102,    103,   # end run 2 lumi 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103    # end run 1 lumi 1
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        0,           0,      0,   # begin run 1 lumi 1
-        0,           0,      0,   # * events
-        0,           0,      0,   # * begin file 2
-        1001,     1002,   1003,   # * end run 1 lumi 1
-        0,           0,      0,   # begin run 2 lumi 1
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 3
-        1001,     1002,   1003,   # * end run 2 lumi 1
-        0,           0,      0,   # begin run 1 lumi 1
-        0,           0,      0,   # * events
-        1001,     1002,   1003    # * end run 1 lumi 1
+        1001,     1002,   1003,
+        1001,     1002,   1003,
+        1001,     1002,   1003
     ),
 
     expectedDroppedEvent1 = cms.untracked.vint32(13, -1, -1, -1, 13),

--- a/FWCore/Integration/test/testRunMergeMERGE_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE_cfg.py
@@ -26,7 +26,8 @@ process.source = cms.Source("PoolSource",
     ),
     inputCommands = cms.untracked.vstring(
         'keep *', 
-        'drop *_C_*_*'
+        'drop *_C_*_*',
+        'drop edmtestThingWithMerge_makeThingToBeDropped1_*_*'
     )
     , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
 )
@@ -35,148 +36,64 @@ process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
 
 process.test = cms.EDAnalyzer("TestMergeResults",
                             
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
-        10001,   20004,  10003,   # * begin file 2
-        10001,   20004,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 3
-        10001,   10002,  10003,   # end run 2
-        10001,   10002,  10004,   # * begin run 1
-        10001,   10002,  10004,   # * events
-        10001,   10002,  10004    # end run 1
+        10001,   20004,  10003,   # File boundary before this causing merge
+        10001,   10002,  10003,
+        10001,   10002,  10004
     ),
                             
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        100001, 100002, 100003,   # begin run 1
-        100001, 100002, 100003,   # * events
-        100001, 200004, 100003,   # * begin file 2
-        100001, 200004, 100003,   # * end run 1
-        100001, 100002, 100003,   # begin run 2
-        100001, 100002, 100003,   # * events
-        100001, 100002, 100003,   # begin file 3
-        100001, 100002, 100003,   # * end run 2
-        100001, 100002, 100004,   # begin run 1
-        100001, 100002, 100004,   # * events
-        100001, 100002, 100004    # * end run 1
+        100001, 200004, 100003,   # File boundary before this causing merge
+        100001, 100002, 100003,
+        100001, 100002, 100004
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
-        101,       204,    103,   # * begin file 2
-        101,       204,    103,   # end run 1 lumi 1
-        101,       102,    103,   # * begin run 2 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 3
-        101,       102,    103,   # end run 2 lumi 1
-        101,       102,    104,   # * begin run 1 lumi 1
-        101,       102,    104,   # * events
-        101,       102,    104    # end run 1 lumi 1
+        101,       204,    103,   # File boundary before this causing merge
+        101,       102,    103,
+        101,       102,    104
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        1001,     1002,   1003,   # begin run 1 lumi 1
-        1001,     1002,   1003,   # * events
-        1001,     2004,   1003,   # * begin file 2
-        1001,     2004,   1003,   # * end run 1 lumi 1
-        1001,     1002,   1003,   # begin run 2 lumi 1
-        1001,     1002,   1003,   # * events
-        1001,     1002,   1003,   # begin file 3
-        1001,     1002,   1003,   # * end run 2 lumi 1
-        1001,     1002,   1004,   # begin run 1 lumi 1
-        1001,     1002,   1004,   # * events
-        1001,     1002,   1004    # * end run 1 lumi 1
+        1001,     2004,   1003,   # File boundary before this causing merge
+        1001,     1002,   1003,
+        1001,     1002,   1004
     ),
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # * begin file 2
-        10001,   10002,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003,   # begin file 3
-        10001,   10002,  10003,   # end run 2
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
-        10001,   10002,  10003    # end run 1
+        10001,   10002,  10003,
+        10001,   10002,  10003,
+        10001,   10002,  10003
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        0,           0,      0,   # begin run 1
-        0,           0,      0,   # * events
-        0,           0,      0,   # * begin file 2
-        100001, 100002, 100003,   # * end run 1
-        0,           0,      0,   # begin run 2
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 3
-        100001, 100002, 100003,   # * end run 2
-        0,           0,      0,   # begin run 1
-        0,           0,      0,   # * events
-        100001, 100002, 100003    # * end run 1
+        100001, 100002, 100003,
+        100001, 100002, 100003,
+        100001, 100002, 100003
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # * begin file 2
-        101,       102,    103,   # end run 1 lumi 1
-        101,       102,    103,   # * begin run 2 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103,   # begin file 3
-        101,       102,    103,   # end run 2 lumi 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
-        101,       102,    103    # end run 1 lumi 1
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        0,           0,      0,   # begin run 1 lumi 1
-        0,           0,      0,   # * events
-        0,           0,      0,   # * begin file 2
-        1001,     1002,   1003,   # * end run 1 lumi 1
-        0,           0,      0,   # begin run 2 lumi 1
-        0,           0,      0,   # * events
-        0,           0,      0,   # begin file 3
-        1001,     1002,   1003,   # * end run 2 lumi 1
-        0,           0,      0,   # begin run 1 lumi 1
-        0,           0,      0,   # * events
-        1001,     1002,   1003    # * end run 1 lumi 1
+        1001,     1002,   1003,
+        1001,     1002,   1003,
+        1001,     1002,   1003
     ),
 
     expectedDroppedEvent1 = cms.untracked.vint32(13, -1, -1, -1, 13),

--- a/FWCore/Integration/test/testRunMergePROD0_cfg.py
+++ b/FWCore/Integration/test/testRunMergePROD0_cfg.py
@@ -65,48 +65,31 @@ process.dependsOnThingToBeDropped1 = cms.EDProducer("ThingWithMergeProducer",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        10001,   10002,  10003,  # * begin run
-        10001,   10002,  10003,  # * events
-        10001,   10002,  10003   # end run
+        10001,   10002,  10003
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin run
-        0,           0,      0,  # * events
-        100001, 100002, 100003   # * end run
+        100001, 100002, 100003
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        101,       102,    103,  # * begin lumi
-        101,       102,    103,  # * events
-        101,       102,    103   # end lumi
+        101,       102,    103
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin lumi
-        0,           0,      0,  # * events
-        1001,     1002,   1003   # * end lumi
+        1001,     1002,   1003
     ),
 
     verbose = cms.untracked.bool(False),

--- a/FWCore/Integration/test/testRunMergePROD100_cfg.py
+++ b/FWCore/Integration/test/testRunMergePROD100_cfg.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(60)
+)
+
+# This will generate:
+#   run 41 lumis 1-10 events 1-30
+#   run 42 lumis 1-10 events 1-30
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(41),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(3),
+    numberEventsInRun = cms.untracked.uint32(30)
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMerge100.root')
+)
+
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.e = cms.EndPath(process.out, process.task)

--- a/FWCore/Integration/test/testRunMergePROD101_cfg.py
+++ b/FWCore/Integration/test/testRunMergePROD101_cfg.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(60)
+)
+
+# This will generate:
+#   run 41 lumis 11-20 events 1-30
+#   run 42 lumis 11-20 events 1-30
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(41),
+    firstLuminosityBlock = cms.untracked.uint32(11),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(3),
+    numberEventsInRun = cms.untracked.uint32(30)
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMerge101.root')
+)
+
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.e = cms.EndPath(process.out, process.task)

--- a/FWCore/Integration/test/testRunMergePROD102_cfg.py
+++ b/FWCore/Integration/test/testRunMergePROD102_cfg.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(60)
+)
+
+# This will generate:
+#   run 41 lumis 21-30 events 1-30
+#   run 42 lumis 21-30 events 1-30
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(41),
+    firstLuminosityBlock = cms.untracked.uint32(21),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(3),
+    numberEventsInRun = cms.untracked.uint32(30)
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMerge102.root')
+)
+
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.e = cms.EndPath(process.out, process.task)

--- a/FWCore/Integration/test/testRunMergePROD11_cfg.py
+++ b/FWCore/Integration/test/testRunMergePROD11_cfg.py
@@ -49,50 +49,6 @@ process.dependsOnThingToBeDropped1 = cms.EDProducer("ThingWithMergeProducer",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-    #   expected values listed below come in sets of three
-    #      value expected in Thing
-    #      value expected in ThingWithMerge
-    #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
-    expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        10001,   10002,  10003,  # * begin run
-        10001,   10002,  10003,  # * events
-        10001,   10002,  10003   # end run
-    ),
-
-    expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin run
-        0,           0,      0,  # * events
-        100001, 100002, 100003   # * end run
-    ),
-
-    expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        101,       102,    103,  # * begin lumi
-        101,       102,    103,  # * events
-        101,       102,    103   # end lumi
-    ),
-
-    expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin lumi
-        0,           0,      0,  # * events
-        1001,     1002,   1003   # * end lumi
-    ),
-
     verbose = cms.untracked.bool(False),
 
     expectedParents = cms.untracked.vstring(

--- a/FWCore/Integration/test/testRunMergePROD1_cfg.py
+++ b/FWCore/Integration/test/testRunMergePROD1_cfg.py
@@ -65,48 +65,31 @@ process.dependsOnThingToBeDropped1 = cms.EDProducer("ThingWithMergeProducer",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        10001,   10002,  10003,  # * begin run
-        10001,   10002,  10003,  # * events
-        10001,   10002,  10003   # end run
+        10001,   10002,  10003
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin run
-        0,           0,      0,  # * events
-        100001, 100002, 100003   # * end run
+        100001, 100002, 100003
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        101,       102,    103,  # * begin lumi
-        101,       102,    103,  # * events
-        101,       102,    103   # end lumi
+        101,       102,    103
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin lumi
-        0,           0,      0,  # * events
-        1001,     1002,   1003   # * end lumi
+        1001,     1002,   1003
     ),
 
     verbose = cms.untracked.bool(False),

--- a/FWCore/Integration/test/testRunMergePROD2_cfg.py
+++ b/FWCore/Integration/test/testRunMergePROD2_cfg.py
@@ -65,60 +65,35 @@ process.dependsOnThingToBeDropped1 = cms.EDProducer("ThingWithMergeProducer",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        10001,   10002,  10003,  # * begin run
-        10001,   10002,  10003,  # * events
-        10001,   10002,  10003,  # end run
-        10001,   10002,  10003,  # * begin run
-        10001,   10002,  10003,  # * events
-        10001,   10002,  10003   # end run
+        10001,   10002,  10003,
+        10001,   10002,  10003
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin run
-        0,           0,      0,  # * events
-        100001, 100002, 100003,  # * end run
-        0,           0,      0,  # begin run
-        0,           0,      0,  # * events
-        100001, 100002, 100003   # * end run
+        100001, 100002, 100003,
+        100001, 100002, 100003
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        101,       102,    103,  # * begin lumi
-        101,       102,    103,  # * events
-        101,       102,    103,  # end lumi
-        101,       102,    103,  # * begin lumi
-        101,       102,    103,  # * events
-        101,       102,    103   # end lumi
+        101,       102,    103,
+        101,       102,    103
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin lumi
-        0,           0,      0,  # * events
-        1001,     1002,   1003,  # * end lumi
-        0,           0,      0,  # begin lumi
-        0,           0,      0,  # * events
-        1001,     1002,   1003   # * end lumi
+        1001,     1002,   1003,
+        1001,     1002,   1003
     ),
 
     verbose = cms.untracked.bool(False),

--- a/FWCore/Integration/test/testRunMergePROD3_cfg.py
+++ b/FWCore/Integration/test/testRunMergePROD3_cfg.py
@@ -64,48 +64,31 @@ process.dependsOnThingToBeDropped1 = cms.EDProducer("ThingWithMergeProducer")
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
     expectedBeginRunProd = cms.untracked.vint32(
-        0,          0,       0,  # start
-        0,          0,       0,  # begin file
-        10001,  10002,   10004,  # * begin run
-        10001,  10002,   10004,  # * events
-        10001,  10002,   10004   # end run
+        10001,  10002,   10004
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin run
-        0,           0,      0,  # * events
-        100001, 100002, 100004   # * end run
+        100001, 100002, 100004
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        101,       102,    104,  # * begin lumi
-        101,       102,    104,  # * events
-        101,       102,    104   # end lumi
+        101,       102,    104
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin lumi
-        0,           0,      0,  # events
-        1001,     1002,   1004   # * end lumi
+        1001,     1002,   1004
     ),
 
     verbose = cms.untracked.bool(False),

--- a/FWCore/Integration/test/testRunMergePROD7_cfg.py
+++ b/FWCore/Integration/test/testRunMergePROD7_cfg.py
@@ -65,50 +65,6 @@ process.dependsOnThingToBeDropped1 = cms.EDProducer("ThingWithMergeProducer",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-    #   expected values listed below come in sets of three
-    #      value expected in Thing
-    #      value expected in ThingWithMerge
-    #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
-    expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        10001,   10002,  10003,  # * begin run
-        10001,   10002,  10003,  # * events
-        10001,   10002,  10003   # end run
-    ),
-
-    expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin run
-        0,           0,      0,  # * events
-        100001, 100002, 100003   # * end run
-    ),
-
-    expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        101,       102,    103,  # * begin lumi
-        101,       102,    103,  # * events
-        101,       102,    103   # end lumi
-    ),
-
-    expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file
-        0,           0,      0,  # begin lumi
-        0,           0,      0,  # * events
-        1001,     1002,   1003   # * end lumi
-    ),
-
     verbose = cms.untracked.bool(False),
 
     expectedParents = cms.untracked.vstring('m1'),

--- a/FWCore/Integration/test/testRunMergeSPLIT100_cfg.py
+++ b/FWCore/Integration/test/testRunMergeSPLIT100_cfg.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("SPLIT")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMerge100.root'
+    ),
+    lumisToProcess = cms.untracked.VLuminosityBlockRange('41:6-41:10', '42:6-42:10'),
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeSPLIT100.root')
+)
+
+process.e = cms.EndPath(process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeSPLIT101_cfg.py
+++ b/FWCore/Integration/test/testRunMergeSPLIT101_cfg.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("SPLIT")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMerge101.root'
+    ),
+    lumisToProcess = cms.untracked.VLuminosityBlockRange('41:11-41:15', '42:11-42:15'),
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeSPLIT101.root')
+)
+
+process.e = cms.EndPath(process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeSPLIT102_cfg.py
+++ b/FWCore/Integration/test/testRunMergeSPLIT102_cfg.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("SPLIT")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMerge101.root'
+    ),
+    lumisToProcess = cms.untracked.VLuminosityBlockRange('41:16-41:20', '42:16-42:20'),
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeSPLIT102.root')
+)
+
+process.e = cms.EndPath(process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeSPLIT103_cfg.py
+++ b/FWCore/Integration/test/testRunMergeSPLIT103_cfg.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("SPLIT")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMerge102.root'
+    ),
+    lumisToProcess = cms.untracked.VLuminosityBlockRange('41:21-41:25', '42:21-42:25'),
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeSPLIT103.root')
+)
+
+process.e = cms.EndPath(process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeTEST100_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST100_cfg.py
@@ -1,0 +1,137 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.threshold = 'ERROR'
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMergeMERGE100.root',
+        'file:testRunMergeMERGE101.root',
+        'file:testRunMergeMERGE102.root',
+        'file:testRunMergeMERGE100.root',
+        'file:testRunMergeMERGE101.root',
+        'file:testRunMergeMERGE102.root'
+    ),
+    duplicateCheckMode = cms.untracked.string('noDuplicateCheck')
+)
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+
+    expectedBeginRunProd = cms.untracked.vint32(
+        10001,   40008,  10003,
+        10001,   20004,  10003,
+        10001,   40008,  10003,
+        10001,   20004,  10003
+    ),
+
+    expectedEndRunProd = cms.untracked.vint32(
+        100001,   400008,  100003,
+        100001,   200004,  100003,
+        100001,   400008,  100003,
+        100001,   200004,  100003
+    ),
+
+    expectedEndRunProdImproperlyMerged = cms.untracked.vint32(
+        0,   1,  0,
+        0,   0,  0,
+        0,   1,  0,
+        0,   0,  0
+    ),
+
+    expectedBeginLumiProd = cms.untracked.vint32(
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103
+    ),
+
+    expectedEndLumiProd = cms.untracked.vint32(
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003
+    ),
+
+    expectedEndLumiProdImproperlyMerged = cms.untracked.vint32(
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0
+    ),
+    verbose = cms.untracked.bool(False)
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeTEST100.root')
+)
+
+process.e = cms.EndPath(process.test * process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeTEST101_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST101_cfg.py
@@ -1,0 +1,109 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.threshold = 'ERROR'
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMergeSPLIT101.root',
+        'file:testRunMergeSPLIT102.root',
+        'file:testRunMergeSPLIT103.root',
+        'file:testRunMergeSPLIT101.root',
+        'file:testRunMergeSPLIT102.root',
+        'file:testRunMergeSPLIT103.root'
+    ),
+    lumisToProcess = cms.untracked.VLuminosityBlockRange('41:11-41:20', '42:21-42:25'),
+    duplicateCheckMode = cms.untracked.string('noDuplicateCheck')
+)
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+
+    expectedBeginRunProd = cms.untracked.vint32(
+        10001,   10002,  10003,
+        10001,   10002,  10003,
+        10001,   10002,  10003,
+        10001,   10002,  10003
+    ),
+
+    expectedEndRunProd = cms.untracked.vint32(
+        100001,   100002,  100003,
+        100001,   100002,  100003,
+        100001,   100002,  100003,
+        100001,   100002,  100003
+    ),
+
+    expectedEndRunProdImproperlyMerged = cms.untracked.vint32(
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0
+    ),
+
+    expectedBeginLumiProd = cms.untracked.vint32(
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103,
+        101,       102,    103
+    ),
+
+    expectedEndLumiProd = cms.untracked.vint32(
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003,
+        1001,       1002,    1003
+    ),
+
+    expectedEndLumiProdImproperlyMerged = cms.untracked.vint32(
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0,
+        0,   0,  0
+    ),
+
+    verbose = cms.untracked.bool(False)
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+process.task = cms.Task(process.thingWithMergeProducer)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeTEST101.root')
+)
+
+process.e = cms.EndPath(process.test * process.out, process.task)

--- a/FWCore/Integration/test/testRunMergeTEST1_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST1_cfg.py
@@ -43,236 +43,96 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        10001,   20004,  10003,  # * begin run 1
-        10001,   30006,  10003,  # * events
         10001,   30006,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events
         10001,   10002,  10003,  # end run 2
-        10001,   20004,  10003,  # * begin run 11
-        10001,   20004,  10003,  # * events
-        10001,   20004,  10003,  # begin file 2
         10001,   20004,  10003,  # end run 11
-        10001,   20004,  10003,  # * begin run 1
-        10001,   30006,  10003,  # * events
         10001,   30006,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events
         10001,   10002,  10003,  # end run 2
-        10001,   20004,  10003,  # * begin run 11
-        10001,   20004,  10003,  # * events
         10001,   20004,  10003   # end run 11
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        100001, 200004, 100003,  # begin run 1
-        100001, 300006, 100003,  # * events
-        100001, 300006, 100003,  # * end run 1
-        100001, 100002, 100003,  # begin run 2
-        100001, 100002, 100003,  # * events
-        100001, 100002, 100003,  # * end run 2
-        100001, 200004, 100003,  # begin run 11
-        100001, 200004, 100003,  # * events
-        100001, 200004, 100003,  # begin file 2
-        100001, 200004, 100003,  # * end run 11
-        100001, 200004, 100003,  # begin run 1
-        100001, 300006, 100003,  # * events
-        100001, 300006, 100003,  # * end run 1
-        100001, 100002, 100003,  # begin run 2
-        100001, 100002, 100003,  # * events
-        100001, 100002, 100003,  # * end run 2
-        100001, 200004, 100003,  # * begin run 11
-        100001, 200004, 100003,  # * events
-        100001, 200004, 100003   # * end run 11
+        100001, 300006, 100003,  # end run 1
+        100001, 100002, 100003,  # end run 2
+        100001, 200004, 100003,  # end run 11
+        100001, 300006, 100003,  # end run 1
+        100001, 100002, 100003,  # end run 2
+        100001, 200004, 100003   # end run 11
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        101,       204,    103,  # * begin run 1 lumi 1
-        101,       306,    103,  # * events
         101,       306,    103,  # end run 1 lumi 1
-        101,       102,    103,  # * begin run 2 lumi 1
-        101,       102,    103,  # * events
         101,       102,    103,  # end run 2 lumi 1
-        101,       102,    103,  # * begin run 11 lumi 1
-        101,       102,    103,  # * events
         101,       102,    103,  # end run 11 lumi 1
-        101,       102,    103,  # * begin run 11 lumi 2
-        101,       102,    103,  # * events
-        101,       102,    103,  # begin file 2
         101,       102,    103,  # end run 11 lumi 2
-        101,       204,    103,  # * begin run 1 lumi 1
-        101,       306,    103,  # * events
         101,       306,    103,  # end run 1 lumi 1
-        101,       102,    103,  # * begin run 2 lumi 1
-        101,       102,    103,  # * events
         101,       102,    103,  # end run 2 lumi 1
-        101,       102,    103,  # * begin run 11 lumi 1
-        101,       102,    103,  # * events
         101,       102,    103,  # end run 11 lumi 1
-        101,       102,    103,  # * begin run 11 lumi 2
-        101,       102,    103,  # * events
         101,       102,    103   # end run 11 lumi 2
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        1001,     2004,   1003,  # begin run 1 lumi 1
-        1001,     3006,   1003,  # * events
-        1001,     3006,   1003,  # * end run 1 lumi 1
-        1001,     1002,   1003,  # begin run 2 lumi 1
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # * end run 2 lumi 1
-        1001,     1002,   1003,  # begin run 11 lumi 1
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # * end run 11 lumi 1
-        1001,     1002,   1003,  # begin run 11 lumi 2
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # begin file 2
-        1001,     1002,   1003,  # * end run 11 lumi 2
-        1001,     2004,   1003,  # begin run 1 lumi 1
-        1001,     3006,   1003,  # * events
-        1001,     3006,   1003,  # * end run 1 lumi 1
-        1001,     1002,   1003,  # begin run 2 lumi 1
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # * end run 2 lumi 1
-        1001,     1002,   1003,  # begin run 11 lumi 1
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # * end run 11 lumi 1
-        1001,     1002,   1003,  # begin run 11 lumi 2
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003   # * end run 11 lumi 2
+        1001,     3006,   1003,  # end run 1 lumi 1
+        1001,     1002,   1003,  # end run 2 lumi 1
+        1001,     1002,   1003,  # end run 11 lumi 1
+        1001,     1002,   1003,  # end run 11 lumi 2
+        1001,     3006,   1003,  # end run 1 lumi 1
+        1001,     1002,   1003,  # end run 2 lumi 1
+        1001,     1002,   1003,  # end run 11 lumi 1
+        1001,     1002,   1003   # end run 11 lumi 2
     ),
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        10001,   10002,  10003,  # * begin run 1
-        10001,   20004,  10003,  # * events
         10001,   20004,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events
         10001,   10002,  10003,  # end run 2
-        10001,   10002,  10003,  # * begin run 11
-        10001,   10002,  10003,  # * events
-        10001,   10002,  10003,  # begin file 2
         10001,   10002,  10003,  # end run 11
-        10001,   10002,  10003,  # * begin run 1
-        10001,   20004,  10003,  # * events
         10001,   20004,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events
         10001,   10002,  10003,  # end run 2
-        10001,   10002,  10003,  # * begin run 11
-        10001,   10002,  10003,  # * events
         10001,   10002,  10003   # end run 11
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        100001, 100002, 100003,  # begin run 1
-        100001, 200004, 100003,  # * events
-        100001, 200004, 100003,  # * end run 1
-        100001, 100002, 100003,  # begin run 2
-        100001, 100002, 100003,  # * events
-        100001, 100002, 100003,  # * end run 2
-        100001, 100002, 100003,  # begin run 11
-        100001, 100002, 100003,  # * events
-        100001, 100002, 100003,  # begin file 2
-        100001, 100002, 100003,  # * end run 11
-        100001, 100002, 100003,  # begin run 1
-        100001, 200004, 100003,  # * events
-        100001, 200004, 100003,  # * end run 1
-        100001, 100002, 100003,  # begin run 2
-        100001, 100002, 100003,  # * events
-        100001, 100002, 100003,  # * end run 2
-        100001, 100002, 100003,  # begin run 11
-        100001, 100002, 100003,  # * events
-        100001, 100002, 100003   # * end run 11
+        100001, 200004, 100003,  # end run 1
+        100001, 100002, 100003,  # end run 2
+        100001, 100002, 100003,  # end run 11
+        100001, 200004, 100003,  # end run 1
+        100001, 100002, 100003,  # end run 2
+        100001, 100002, 100003   # end run 11
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        101,       102,    103,  # * begin run 1 lumi 1
-        101,       204,    103,  # * events
         101,       204,    103,  # end run 1 lumi 1
-        101,       102,    103,  # * begin run 2 lumi 1
-        101,       102,    103,  # * events
         101,       102,    103,  # end run 2 lumi 1
-        101,       102,    103,  # * begin run 11 lumi 1
-        101,       102,    103,  # * events
         101,       102,    103,  # end run 11 lumi 1
-        101,       102,    103,  # * begin run 11 lumi 2
-        101,       102,    103,  # * events
-        101,       102,    103,  # begin file 2
         101,       102,    103,  # end run 11 lumi 2
-        101,       102,    103,  # * begin run 1 lumi 1
-        101,       204,    103,  # * events
         101,       204,    103,  # end run 1 lumi 1
-        101,       102,    103,  # * begin run 2 lumi 1
-        101,       102,    103,  # * events
         101,       102,    103,  # end run 2 lumi 1
-        101,       102,    103,  # * begin run 11 lumi 1
-        101,       102,    103,  # * events
         101,       102,    103,  # end run 11 lumi 1
-        101,       102,    103,  # * begin run 11 lumi 2
-        101,       102,    103,  # * events
         101,       102,    103   # end run 11 lumi 2
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        1001,     1002,   1003,  # begin run 1 lumi 1
-        1001,     2004,   1003,  # * events
-        1001,     2004,   1003,  # * end run 1 lumi 1
-        1001,     1002,   1003,  # begin run 2 lumi 1
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # * end run 2 lumi 1
-        1001,     1002,   1003,  # begin run 11 lumi 1
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # * end run 11 lumi 1
-        1001,     1002,   1003,  # begin run 11 lumi 2
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # begin file 2
-        1001,     1002,   1003,  # * end run 11 lumi 2
-        1001,     1002,   1003,  # begin run 1 lumi 1
-        1001,     2004,   1003,  # * events
-        1001,     2004,   1003,  # * end run 1 lumi 1
-        1001,     1002,   1003,  # begin run 2 lumi 1
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # * end run 2 lumi 1
-        1001,     1002,   1003,  # begin run 11 lumi 1
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003,  # * end run 11 lumi 1
-        1001,     1002,   1003,  # begin run 11 lumi 2
-        1001,     1002,   1003,  # * events
-        1001,     1002,   1003   # * end run 11 lumi 2
+        1001,     2004,   1003,  # end run 1 lumi 1
+        1001,     1002,   1003,  # end run 2 lumi 1
+        1001,     1002,   1003,  # end run 11 lumi 1
+        1001,     1002,   1003,  # end run 11 lumi 2
+        1001,     2004,   1003,  # end run 1 lumi 1
+        1001,     1002,   1003,  # end run 2 lumi 1
+        1001,     1002,   1003,  # end run 11 lumi 1
+        1001,     1002,   1003   # end run 11 lumi 2
     ),
 
     expectedDroppedEvent = cms.untracked.vint32(13, 10003, 100003, 103, 1003),

--- a/FWCore/Integration/test/testRunMergeTEST2_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST2_cfg.py
@@ -31,72 +31,36 @@ process.source = cms.Source("PoolSource",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        10001,   10002,  10003,  # * begin run 11
-        10001,   10002,  10003,  # * events
-        10001,   20004,  10003,  # * begin file 2
-        10001,   20004,  10003,  # end run 11
+        10001,   20004,  10003  # end run 11
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        100001,   100002,  100003,  # begin run 11
-        100001,   100002,  100003,  # * events
-        100001,   200004,  100003,  # begin file 2
-        100001,   200004,  100003,  # *end run 11
+        100001,   200004,  100003  #end run 11
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        101,       102,    103,  # * begin run 11 lumi 1
-        101,       102,    103,  # * events
-        101,       102,    103,  # begin file 2
         101,       102,    103,  # end run 11 lumi 1
-        101,       102,    103,  # * begin run 11 lumi 2
-        101,       102,    103,  # * events
         101,       102,    103,  # end run 11 lumi 2
-        101,       102,    103,  # * begin run 11 lumi 3
-        101,       102,    103,  # * events
-        101,       102,    103,  # end run 11 lumi 3
-        101,       102,    103,  # * begin run 11 lumi 4
-        101,       102,    103   # * events
+        101,       102,    103   # end run 11 lumi 3
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-         0,           0,      0,     # start
-         0,           0,      0,     # begin file 1
-         1001,       1002,    1003,  # begin run 11 lumi 1
-         1001,       1002,    1003,  # * events
-         1001,       1002,    1003,  # begin file 2
-         1001,       1002,    1003,  # * end run 11 lumi 1
-         1001,       1002,    1003,  # begin run 11 lumi 2
-         1001,       1002,    1003,  # * events
-         1001,       1002,    1003,  # * end run 11 lumi 2
-         1001,       1002,    1003,  # begin run 11 lumi 3
-         1001,       1002,    1003,  # * events
-         1001,       1002,    1003,  # * end run 11 lumi 3
-         1001,       1002,    1003,  # begin run 11 lumi 4
-         1001,       1002,    1003   # * events
+         1001,       1002,    1003,  # end run 11 lumi 1
+         1001,       1002,    1003,  # end run 11 lumi 2
+         1001,       1002,    1003   # end run 11 lumi 3
     ),
 
     verbose = cms.untracked.bool(False)

--- a/FWCore/Integration/test/testRunMergeTEST3_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST3_cfg.py
@@ -40,328 +40,121 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunProd = cms.untracked.vint32(
-    0,           0,      0,  # start
-    0,           0,      0,  # begin file 1
-    10001,   10002,  10003,  # * begin run 100
-    10001,   10002,  10003,  # * events run 100
     10001,   10002,  10003,  # end run 100
-    10001,   10002,  10003,  # * begin run 1
-    10001,   10002,  10003,  # * events run 1
     10001,   10002,  10003,  # end run 1
-    10001,   10002,  10003,  # * begin run 1
-    10001,   10002,  10003,  # * events run 1
     10001,   10002,  10003,  # end run 1
-    10001,   10002,  10003,  # * begin run 2
-    10001,   10002,  10003,  # * events run 2
     10001,   10002,  10003,  # end run 2
-    10001,   10002,  10004,  # * begin run 1
-    10001,   10002,  10004,  # * events run 1
     10001,   10002,  10004,  # end run 1
-    10001,   20004,  10003,  # * begin run 11
-    10001,   20004,  10003,  # * events run 11
     10001,   20004,  10003,  # end run 11
-
-    10001,   20004,  10003,  # begin file 2
-    10001,   20004,  10003,  # * begin run 1
-    10001,   30006,  10003,  # * events run 1
     10001,   30006,  10003,  # end run 1
-    10001,   10002,  10003,  # * begin run 2
-    10001,   10002,  10003,  # * events run 2
     10001,   10002,  10003,  # end run 2
-    10001,   20004,  10003,  # * begin run 11
-    10001,   20004,  10003,  # * events run 11
     10001,   20004,  10003   # end run 11
-    
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        
-        100001,  100002, 100003,  # begin run 100
-        100001,  100002, 100003,  # * events run 100
-        100001,  100002, 100003,  # * end run 100
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 2
-        100001,  100002, 100003,  # * events run 2
-        100001,  100002, 100003,  # * end run 2
-        100001,  100002, 100004,  # begin run 1
-        100001,  100002, 100004,  # * events run 1
-        100001,  100002, 100004,  # * end run 1
-        100001,  200004, 100003,  # begin run 11
-        100001,  200004, 100003,  # * events run 11
-        100001,  200004, 100003,  # * end run 11
-
-        100001,  200004, 100003,  # begin file 2
-        100001,  200004, 100003,  # begin run 1
-        100001,  300006, 100003,  # * events run 1
-        100001,  300006, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 2
-        100001,  100002, 100003,  # * events run 2
-        100001,  100002, 100003,  # * end run 2
-        100001,  200004, 100003,  # begin run 11
-        100001,  200004, 100003,  # * events run 11
-        100001,  200004, 100003   # * end run 11
-
+        100001,  100002, 100003,  # end run 100
+        100001,  100002, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 2
+        100001,  100002, 100004,  # end run 1
+        100001,  200004, 100003,  # end run 11
+        100001,  300006, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 2
+        100001,  200004, 100003   # end run 11
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,      0,   0,  # start
-        0,      0,   0,  # begin file 1
-        
-        101,  102, 103,  # * begin run 100 lumi 100
-        101,  102, 103,  # * events run 100 lumi 100
         101,  102, 103,  # end run 100 lumi 100
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 2 lumi 1
-        101,  102, 103,  # * events run 2 lumi 1
         101,  102, 103,  # end run 2 lumi 1
-        101,  102, 104,  # * begin run 1 lumi 1
-        101,  102, 104,  # * events run 1 lumi 1
-        101,  102, 104,   # end run 1 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 1
-        101,  102, 103,  # * events run 11 lumi 1
+        101,  102, 104,  # end run 1 lumi 1
         101,  102, 103,  # end run 11 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 2
-        101,  102, 103,  # * events run 11 lumi 2
         101,  102, 103,  # end run 11 lumi 2
-        
-        101,  102, 103,  # begin file 2
-        101,  204, 103,  # * begin run 1 lumi 1
-        101,  306, 103,  # * events run 1 lumi 1
         101,  306, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 2 lumi 1
-        101,  102, 103,  # * events run 2 lumi 1
         101,  102, 103,  # end run 2 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 1
-        101,  102, 103,  # * events run 11 lumi 1
         101,  102, 103,  # end run 11 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 2
-        101,  102, 103,  # * events run 11 lumi 2
         101,  102, 103   # end run 11 lumi 2
         
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,        0,    0,  # start
-        0,        0,    0,  # begin file 1
-        
-        1001,  1002, 1003,  # begin run 100 lumi 100
-        1001,  1002, 1003,  # * events run 100 lumi 100
-        1001,  1002, 1003,  # * end run 100 lumi 100
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 2 lumi 1
-        1001,  1002, 1003,  # * events run 2 lumi 1
-        1001,  1002, 1003,  # * end run 2 lumi 1
-        1001,  1002, 1004,  # begin run 1 lumi 1
-        1001,  1002, 1004,  # * events run 1 lumi 1
-        1001,  1002, 1004, # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 1
-        1001,  1002, 1003,  # * events run 11 lumi 1
-        1001,  1002, 1003,  # * end run 11 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 2
-        1001,  1002, 1003,  # * events run 11 lumi 2
-        1001,  1002, 1003,  # * end run 11 lumi 2
-        
-        1001,  1002, 1003,  # begin file 2
-        1001,  2004, 1003,  # begin run 1 lumi 1
-        1001,  3006, 1003,  # * events run 1 lumi 1
-        1001,  3006, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 2 lumi 1
-        1001,  1002, 1003,  # * events run 2 lumi 1
-        1001,  1002, 1003,  # * end run 2 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 1
-        1001,  1002, 1003,  # * events run 11 lumi 1
-        1001,  1002, 1003,  # * end run 11 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 2
-        1001,  1002, 1003,  # * events run 11 lumi 2
-        1001,  1002, 1003   # * end run 11 lumi 2
-        
+        1001,  1002, 1003,  # end run 100 lumi 100
+        1001,  1002, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 2 lumi 1
+        1001,  1002, 1004,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 2
+        1001,  3006, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 2 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 1
+        1001,  1002, 1003   # end run 11 lumi 2
     ),
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-
-        10001,   10002,  10003,  # * begin run 100
-        10001,   10002,  10003,  # * events run 100
         10001,   10002,  10003,  # end run 100
-        10001,   10002,  10003,  # * begin run 1
-        10001,   10002,  10003,  # * events run 1
         10001,   10002,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 1
-        10001,   10002,  10003,  # * events run 1
         10001,   10002,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events run 2
         10001,   10002,  10003,  # end run 2
-        10001,   10002,  10003,  # * begin run 1
-        10001,   10002,  10003,  # * events run 1
         10001,   10002,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 11
-        10001,   10002,  10003,  # * events run 11
         10001,   10002,  10003,  # end run 11
-
-        10001,   10002,  10003,  # begin file 2
-        10001,   10002,  10003,  # * begin run 1
-        10001,   20004,  10003,  # * events run 1
         10001,   20004,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events run 2
         10001,   10002,  10003,  # end run 2
-        10001,   10002,  10003,  # * begin run 11
-        10001,   10002,  10003,  # * events run 11
         10001,   10002,  10003   # end run 11
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        
-        100001,  100002, 100003,  # begin run 100
-        100001,  100002, 100003,  # * events run 100
-        100001,  100002, 100003,  # * end run 100
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 2
-        100001,  100002, 100003,  # * events run 2
-        100001,  100002, 100003,  # * end run 2
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 11
-        100001,  100002, 100003,  # * events run 11
-        100001,  100002, 100003,  # * end run 11
-
-        100001,  100002, 100003,  # begin file 2
-        100001,  100002, 100003,  # begin run 1
-        100001,  200004, 100003,  # * events run 1
-        100001,  200004, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 2
-        100001,  100002, 100003,  # * events run 2
-        100001,  100002, 100003,  # * end run 2
-        100001,  100002, 100003,  # begin run 11
-        100001,  100002, 100003,  # * events run 11
-        100001,  100002, 100003   # * end run 11
+        100001,  100002, 100003,  # end run 100
+        100001,  100002, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 2
+        100001,  100002, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 11
+        100001,  200004, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 2
+        100001,  100002, 100003   # end run 11
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,      0,   0,  # start
-        0,      0,   0,  # begin file 1
-        
-        101,  102, 103,  # * begin run 100 lumi 100
-        101,  102, 103,  # * events run 100 lumi 100
         101,  102, 103,  # end run 100 lumi 100
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 2 lumi 1
-        101,  102, 103,  # * events run 2 lumi 1
         101,  102, 103,  # end run 2 lumi 1
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 1
-        101,  102, 103,  # * events run 11 lumi 1
         101,  102, 103,  # end run 11 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 2
-        101,  102, 103,  # * events run 11 lumi 2
         101,  102, 103,  # end run 11 lumi 2
-        
-        101,  102, 103,  # begin file 2
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  204, 103,  # * events run 1 lumi 1
         101,  204, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 2 lumi 1
-        101,  102, 103,  # * events run 2 lumi 1
         101,  102, 103,  # end run 2 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 1
-        101,  102, 103,  # * events run 11 lumi 1
         101,  102, 103,  # end run 11 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 2
-        101,  102, 103,  # * events run 11 lumi 2
         101,  102, 103   # end run 11 lumi 2
-        
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,        0,    0,  # start
-        0,        0,    0,  # begin file 1
-        
-        1001,  1002, 1003,  # begin run 100 lumi 100
-        1001,  1002, 1003,  # * events run 100 lumi 100
-        1001,  1002, 1003,  # * end run 100 lumi 100
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 2 lumi 1
-        1001,  1002, 1003,  # * events run 2 lumi 1
-        1001,  1002, 1003,  # * end run 2 lumi 1
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 1
-        1001,  1002, 1003,  # * events run 11 lumi 1
-        1001,  1002, 1003,  # * end run 11 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 2
-        1001,  1002, 1003,  # * events run 11 lumi 2
-        1001,  1002, 1003,  # * end run 11 lumi 2
-
-        1001,  1002, 1003,  # begin file 2
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  2004, 1003,  # * events run 1 lumi 1
-        1001,  2004, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 2 lumi 1
-        1001,  1002, 1003,  # * events run 2 lumi 1
-        1001,  1002, 1003,  # * end run 2 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 1
-        1001,  1002, 1003,  # * events run 11 lumi 1
-        1001,  1002, 1003,  # * end run 11 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 2
-        1001,  1002, 1003,  # * events run 11 lumi 2
-        1001,  1002, 1003   # * end run 11 lumi 2
+        1001,  1002, 1003,  # end run 100 lumi 100
+        1001,  1002, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 2 lumi 1
+        1001,  1002, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 2
+        1001,  2004, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 2 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 1
+        1001,  1002, 1003   # end run 11 lumi 2
     ),
 
     expectedDroppedEvent = cms.untracked.vint32(13, 10003, 100003, 103, 1003),

--- a/FWCore/Integration/test/testRunMergeTEST4_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST4_cfg.py
@@ -29,102 +29,48 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        10001,   20004,  10003,  # * begin run 1
-        10001,   40008,  10003,  # * events run 1
-        # The test has a peculiar behavior if the same lumi continues in the
-        # next file, in this case this line must be commented out
-        #10001,   40008,  10003  # begin file 2
-        10001,   80016,  10003,  # * events run 1
         10001,   80016,  10003   # end run 1
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,       0,  # start
-        0,           0,       0,  # begin file 1
-        100001,  200004, 100003,  # begin run 1
-        100001,  400008, 100003,  # * events run 1
-        #100001,  400008, 100003,  # begin file 2
-        100001,  800016, 100003,  # * events run 1
-        100001,  800016, 100003   # * end run 1
+        100001,  800016, 100003   # end run 1
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,      0,   0,  # start
-        0,      0,   0,  # begin file 1
-        101,  204, 103,  # * begin run 1 lumi 1
-        101,  408, 103,  # * events run 1 lumi 1
-        #101,  408, 103,  # begin file 2
-        101,  816, 103,  # * events run 1 lumi 1
         101,  816, 103  # end run 1 lumi 1
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,        0,    0,  # start
-        0,        0,    0,  # begin file 1
-        1001,  2004, 1003,  # begin run 1 lumi 1
-        1001,  4008, 1003,  # * events run 1 lumi 1
-        #1001,  4008, 1003,  # begin file 2
-        1001,  8016, 1003,  # * events run 1 lumi 1
-        1001,  8016, 1003   # * end run 1 lumi 1
+        1001,  8016, 1003   # end run 1 lumi 1
     ),
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        10001,   10002,  10003,  # * begin run 1
-        10001,   30006,  10003,  # * events run 1
-        #10001,   30006,  10003,  # begin file 2
-        10001,   60012,  10003,  # * events run 1
         10001,   60012,  10003   # end run 1
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        100001,  100002, 100003,  # begin run 1
-        100001,  300006, 100003  # * events run 1
-        #100001,  300006, 100003,  # begin file 2
-        #100001,  600012, 100003,  # * events run 1
-        #100001,  600012, 100003   # * end run 1
+        100001,  600012, 100003   # end run 1
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,      0,   0,  # start
-        0,      0,   0,  # begin file 1
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  306, 103,  # * events run 1 lumi 1
-        #101,  306, 103,  # begin file 2
-        101,  612, 103,  # * events run 1 lumi 1
         101,  612, 103   # end run 1 lumi 1
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,        0,    0,  # start
-        0,        0,    0,  # begin file 1
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  3006, 1003,  # * events run 1 lumi 1
-        #1001,  3006, 1003,  # begin file 2
-        1001,  6012, 1003,  # * events run 1 lumi 1
-        1001,  6012, 1003   # * end run 1 lumi 1
+        1001,  6012, 1003   # end run 1 lumi 1
     ),
 
     verbose = cms.untracked.bool(True)

--- a/FWCore/Integration/test/testRunMergeTEST_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST_cfg.py
@@ -40,308 +40,120 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.test = cms.EDAnalyzer("TestMergeResults",
 
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        10001,   20004,  10003,  # * begin run 1
-        10001,   30006,  10003,  # * events run 1
-        10001,   30006,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events run 2
+        10001,   30006,  10003,  # end run 1, merged run entries within a file
         10001,   10002,  10003,  # end run 2
-        10001,   20004,  10003,  # * begin run 11
-        10001,   20004,  10003,  # * events run 11
-        10001,   20004,  10003,  # begin file 2
         10001,   20004,  10003,  # end run 11
-        10001,   10002,  10003,  # * begin run 1
-        10001,   10002,  10003,  # * events run 1
-        10001,   10002,  10003,  # end run 1
-        10001,   20004,  10003,  # * begin run 11
-        10001,   20004,  10003,  # * events run 11
+        10001,   10002,  10003,  # end run 1, second input file starts here
         10001,   20004,  10003,  # end run 11
-        10001,   10002,  10003,  # * begin run 100
-        10001,   10002,  10003,  # * events run 100
         10001,   10002,  10003,  # end run 100
-        10001,   10002,  10003,  # * begin run 1
-        10001,   10002,  10003,  # * events run 1
-        10001,   10002,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events run 2
+        10001,   10002,  10003,  # end run 1, not merged different ProcessHistoryID
         10001,   10002,  10003,  # end run 2
-        10001,   10002,  10004,  # * begin run 1
-        10001,   10002,  10004,  # * events run 1
         10001,   10002,  10004   # end run 1
     ),
 
     expectedEndRunProd = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        100001,  200004, 100003,  # begin run 1
-        100001,  300006, 100003,  # * events run 1
-        100001,  300006, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 2
-        100001,  100002, 100003,  # * events run 2
-        100001,  100002, 100003,  # * end run 2
-        100001,  200004, 100003,  # begin run 11
-        100001,  200004, 100003,  # * events run 11
-        100001,  200004, 100003,  # begin file 2
-        100001,  200004, 100003,  # * end run 11
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003,  # * end run 1
-        100001,  200004, 100003,  # begin run 11
-        100001,  200004, 100003,  # * events run 11
-        100001,  200004, 100003,  # * end run 11
-        100001,  100002, 100003,  # begin run 100
-        100001,  100002, 100003,  # * events run 100
-        100001,  100002, 100003,  # * end run 100
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 2
-        100001,  100002, 100003,  # * events run 2
-        100001,  100002, 100003,  # * end run 2
-        100001,  100002, 100004,  # begin run 1
-        100001,  100002, 100004,  # * events run 1
-        100001,  100002, 100004   # * end run 1
+        100001,  300006, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 2
+        100001,  200004, 100003,  # end run 11
+        100001,  100002, 100003,  # end run 1
+        100001,  200004, 100003,  # end run 11
+        100001,  100002, 100003,  # end run 100
+        100001,  100002, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 2
+        100001,  100002, 100004   # end run 1
     ),
 
     expectedBeginLumiProd = cms.untracked.vint32(
-        0,      0,   0,  # start
-        0,      0,   0,  # begin file 1
-        101,  204, 103,  # * begin run 1 lumi 1
-        101,  306, 103,  # * events run 1 lumi 1
         101,  306, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 2 lumi 1
-        101,  102, 103,  # * events run 2 lumi 1
         101,  102, 103,  # end run 2 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 1
-        101,  102, 103,  # * events run 11 lumi 1
         101,  102, 103,  # end run 11 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 2
-        101,  102, 103,  # * events run 11 lumi 2
-        101,  102, 103,  # begin file 2
         101,  102, 103,  # end run 11 lumi 2
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 1
-        101,  102, 103,  # * events run 11 lumi 1
         101,  102, 103,  # end run 11 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 2
-        101,  102, 103,  # * events run 11 lumi 2
         101,  102, 103,  # end run 11 lumi 2
-        101,  102, 103,  # * begin run 100 lumi 100
-        101,  102, 103,  # * events run 100 lumi 100
         101,  102, 103,  # end run 100 lumi 100
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 2 lumi 1
-        101,  102, 103,  # * events run 2 lumi 1
         101,  102, 103,  # end run 2 lumi 1
-        101,  102, 104,  # * begin run 1 lumi 1
-        101,  102, 104,  # * events run 1 lumi 1
         101,  102, 104   # end run 1 lumi 1
     ),
 
     expectedEndLumiProd = cms.untracked.vint32(
-        0,        0,    0,  # start
-        0,        0,    0,  # begin file 1
-        1001,  2004, 1003,  # begin run 1 lumi 1
-        1001,  3006, 1003,  # * events run 1 lumi 1
-        1001,  3006, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 2 lumi 1
-        1001,  1002, 1003,  # * events run 2 lumi 1
-        1001,  1002, 1003,  # * end run 2 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 1
-        1001,  1002, 1003,  # * events run 11 lumi 1
-        1001,  1002, 1003,  # * end run 11 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 2
-        1001,  1002, 1003,  # * events run 11 lumi 2
-        1001,  1002, 1003,  # begin file 2
-        1001,  1002, 1003,  # * end run 11 lumi 2
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 1
-        1001,  1002, 1003,  # * events run 11 lumi 1
-        1001,  1002, 1003,  # * end run 11 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 2
-        1001,  1002, 1003,  # * events run 11 lumi 2
-        1001,  1002, 1003,  # * end run 11 lumi 2
-        1001,  1002, 1003,  # begin run 100 lumi 100
-        1001,  1002, 1003,  # * events run 100 lumi 100
-        1001,  1002, 1003,  # * end run 100 lumi 100
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 2 lumi 1
-        1001,  1002, 1003,  # * events run 2 lumi 1
-        1001,  1002, 1003,  # * end run 2 lumi 1
-        1001,  1002, 1004,  # begin run 1 lumi 1
-        1001,  1002, 1004,  # * events run 1 lumi 1
-        1001,  1002, 1004   # * end run 1 lumi 1
+        1001,  3006, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 2 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 2
+        1001,  1002, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 2
+        1001,  1002, 1003,  # end run 100 lumi 100
+        1001,  1002, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 2 lumi 1
+        1001,  1002, 1004   # end run 1 lumi 1
     ),
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        10001,   10002,  10003,  # * begin run 1
-        10001,   20004,  10003,  # * events run 1
         10001,   20004,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events run 2
         10001,   10002,  10003,  # end run 2
-        10001,   10002,  10003,  # * begin run 11
-        10001,   10002,  10003,  # * events run 11
-        10001,   10002,  10003,  # begin file 2
         10001,   10002,  10003,  # end run 11
-        10001,   10002,  10003,  # * begin run 1
-        10001,   10002,  10003,  # * events run 1
         10001,   10002,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 11
-        10001,   10002,  10003,  # * events run 11
         10001,   10002,  10003,  # end run 11
-        10001,   10002,  10003,  # * begin run 100
-        10001,   10002,  10003,  # * events run 100
         10001,   10002,  10003,  # end run 100
-        10001,   10002,  10003,  # * begin run 1
-        10001,   10002,  10003,  # * events run 1
         10001,   10002,  10003,  # end run 1
-        10001,   10002,  10003,  # * begin run 2
-        10001,   10002,  10003,  # * events run 2
         10001,   10002,  10003,  # end run 2
-        10001,   10002,  10003,  # * begin run 1
-        10001,   10002,  10003,  # * events run 1
         10001,   10002,  10003   # end run 1
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,  # start
-        0,           0,      0,  # begin file 1
-        100001,  100002, 100003,  # begin run 1
-        100001,  200004, 100003,  # * events run 1
-        100001,  200004, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 2
-        100001,  100002, 100003,  # * events run 2
-        100001,  100002, 100003,  # * end run 2
-        100001,  100002, 100003,  # begin run 11
-        100001,  100002, 100003,  # * events run 11
-        100001,  100002, 100003,  # begin file 2
-        100001,  100002, 100003,  # * end run 11
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 11
-        100001,  100002, 100003,  # * events run 11
-        100001,  100002, 100003,  # * end run 11
-        100001,  100002, 100003,  # begin run 100
-        100001,  100002, 100003,  # * events run 100
-        100001,  100002, 100003,  # * end run 100
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003,  # * end run 1
-        100001,  100002, 100003,  # begin run 2
-        100001,  100002, 100003,  # * events run 2
-        100001,  100002, 100003,  # * end run 2
-        100001,  100002, 100003,  # begin run 1
-        100001,  100002, 100003,  # * events run 1
-        100001,  100002, 100003   # * end run 1
+        100001,  200004, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 2
+        100001,  100002, 100003,  # end run 11
+        100001,  100002, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 11
+        100001,  100002, 100003,  # end run 100
+        100001,  100002, 100003,  # end run 1
+        100001,  100002, 100003,  # end run 2
+        100001,  100002, 100003   # end run 1
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,      0,   0,  # start
-        0,      0,   0,  # begin file 1
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  204, 103,  # * events run 1 lumi 1
         101,  204, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 2 lumi 1
-        101,  102, 103,  # * events run 2 lumi 1
         101,  102, 103,  # end run 2 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 1
-        101,  102, 103,  # * events run 11 lumi 1
         101,  102, 103,  # end run 11 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 2
-        101,  102, 103,  # * events run 11 lumi 2
-        101,  102, 103,  # begin file 2
         101,  102, 103,  # end run 11 lumi 2
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 1
-        101,  102, 103,  # * events run 11 lumi 1
         101,  102, 103,  # end run 11 lumi 1
-        101,  102, 103,  # * begin run 11 lumi 2
-        101,  102, 103,  # * events run 11 lumi 2
         101,  102, 103,  # end run 11 lumi 2
-        101,  102, 103,  # * begin run 100 lumi 100
-        101,  102, 103,  # * events run 100 lumi 100
         101,  102, 103,  # end run 100 lumi 100
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
-        101,  102, 103,  # * begin run 2 lumi 1
-        101,  102, 103,  # * events run 2 lumi 1
         101,  102, 103,  # end run 2 lumi 1
-        101,  102, 103,  # * begin run 1 lumi 1
-        101,  102, 103,  # * events run 1 lumi 1
         101,  102, 103   # end run 1 lumi 1
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,        0,    0,  # start
-        0,        0,    0,  # begin file 1
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  2004, 1003,  # * events run 1 lumi 1
-        1001,  2004, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 2 lumi 1
-        1001,  1002, 1003,  # * events run 2 lumi 1
-        1001,  1002, 1003,  # * end run 2 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 1
-        1001,  1002, 1003,  # * events run 11 lumi 1
-        1001,  1002, 1003,  # * end run 11 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 2
-        1001,  1002, 1003,  # * events run 11 lumi 2
-        1001,  1002, 1003,  # begin file 2
-        1001,  1002, 1003,  # * end run 11 lumi 2
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 1
-        1001,  1002, 1003,  # * events run 11 lumi 1
-        1001,  1002, 1003,  # * end run 11 lumi 1
-        1001,  1002, 1003,  # begin run 11 lumi 2
-        1001,  1002, 1003,  # * events run 11 lumi 2
-        1001,  1002, 1003,  # * end run 11 lumi 2
-        1001,  1002, 1003,  # begin run 100 lumi 100
-        1001,  1002, 1003,  # * events run 100 lumi 100
-        1001,  1002, 1003,  # * end run 100 lumi 100
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003,  # * end run 1 lumi 1
-        1001,  1002, 1003,  # begin run 2 lumi 1
-        1001,  1002, 1003,  # * events run 2 lumi 1
-        1001,  1002, 1003,  # * end run 2 lumi 1
-        1001,  1002, 1003,  # begin run 1 lumi 1
-        1001,  1002, 1003,  # * events run 1 lumi 1
-        1001,  1002, 1003   # * end run 1 lumi 1
+        1001,  2004, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 2 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 2
+        1001,  1002, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 1
+        1001,  1002, 1003,  # end run 11 lumi 2
+        1001,  1002, 1003,  # end run 100 lumi 100
+        1001,  1002, 1003,  # end run 1 lumi 1
+        1001,  1002, 1003,  # end run 2 lumi 1
+        1001,  1002, 1003   # end run 1 lumi 1
     ),
 
     expectedDroppedEvent = cms.untracked.vint32(13, 10003, 100003, 103, 1003),

--- a/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
@@ -286,6 +286,12 @@ For products only read from previous processes, 'skip current process' is added
   ThingWithMergeProducer/'thingWithMergeProducer'
   TestMergeResults/'testMergeResults' consumes:
     edmtest::Thing 'thingWithMergeProducer' 'event' 'PROD'
+    edmtest::Thing 'thingWithMergeProducer' 'beginRun' 'PROD', run
+    edmtest::ThingWithMerge 'thingWithMergeProducer' 'beginRun' 'PROD', run
+    edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'beginRun' 'PROD', run
+    edmtest::Thing 'thingWithMergeProducer' 'beginRun' '', run
+    edmtest::ThingWithMerge 'thingWithMergeProducer' 'beginRun' '', run
+    edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'beginRun' '', run
     edmtest::Thing 'thingWithMergeProducer' 'endRun' 'PROD', run
     edmtest::ThingWithMerge 'thingWithMergeProducer' 'endRun' 'PROD', run
     edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'endRun' 'PROD', run
@@ -298,6 +304,12 @@ For products only read from previous processes, 'skip current process' is added
     edmtest::Thing 'thingWithMergeProducer' 'endLumi' '', lumi
     edmtest::ThingWithMerge 'thingWithMergeProducer' 'endLumi' '', lumi
     edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'endLumi' '', lumi
+    edmtest::Thing 'thingWithMergeProducer' 'beginLumi' 'PROD', lumi
+    edmtest::ThingWithMerge 'thingWithMergeProducer' 'beginLumi' 'PROD', lumi
+    edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'beginLumi' 'PROD', lumi
+    edmtest::Thing 'thingWithMergeProducer' 'beginLumi' '', lumi
+    edmtest::ThingWithMerge 'thingWithMergeProducer' 'beginLumi' '', lumi
+    edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'beginLumi' '', lumi
   TestFindProduct/'testView1' consumes:
     int 'intVectorProducer' '' 'PROD1', element type
   TestFindProduct/'testView2' consumes:

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -15,6 +15,7 @@
 #include "FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h"
 
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
+#include "DataFormats/Common/interface/setIsMergeable.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
@@ -433,6 +434,7 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
 
   for(auto& prod : m_->reg_->productListUpdator()) {
     prod.second.init();
+    setIsMergeable(prod.second);
   }
 
   // Merge into the registries. For now, we do NOT merge the product registry.

--- a/IOPool/Common/bin/BuildFile.xml
+++ b/IOPool/Common/bin/BuildFile.xml
@@ -1,6 +1,7 @@
 <bin   name="edmProvDump" file="EdmProvDump.cc,">
   <use   name="boost_program_options"/>
   <use   name="rootcore"/>
+  <use   name="DataFormats/Common"/>
   <use   name="DataFormats/Provenance"/>
   <use   name="FWCore/Catalog"/>
   <use   name="FWCore/ParameterSet"/>

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -1,3 +1,4 @@
+#include "DataFormats/Common/interface/setIsMergeable.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "DataFormats/Provenance/interface/History.h"
@@ -894,6 +895,7 @@ ProvenanceDumper::work_() {
       }
       //force it to rebuild the branch name
       product.init();
+      setIsMergeable(product);
 
       if(showDependencies_ || extendedAncestors_ || extendedDescendants_) {
         branchIDToBranchName[product.branchID()] = product.branchName();

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -47,6 +47,7 @@ namespace edm {
   class InputFile;
   class ProvenanceReaderBase;
   class ProvenanceAdaptor;
+  class StoredMergeableRunProductMetadata;
   class RunHelperBase;
   class ThinnedAssociationsHelper;
 
@@ -264,6 +265,7 @@ namespace edm {
     IndexIntoFile::IndexIntoFileItr indexIntoFileBegin_;
     IndexIntoFile::IndexIntoFileItr indexIntoFileEnd_;
     IndexIntoFile::IndexIntoFileItr indexIntoFileIter_;
+    edm::propagate_const<std::unique_ptr<StoredMergeableRunProductMetadata>> storedMergeableRunProductMetadata_;
     std::vector<EventProcessHistoryID> eventProcessHistoryIDs_;  // backward compatibility
     std::vector<EventProcessHistoryID>::const_iterator eventProcessHistoryIter_; // backward compatibility
     edm::propagate_const<std::shared_ptr<RunAuxiliary>> savedRunAuxiliary_;
@@ -298,6 +300,7 @@ namespace edm {
     std::vector<ParentageID> parentageIDLookup_;
     edm::propagate_const<std::unique_ptr<DaqProvenanceHelper>> daqProvenanceHelper_;
     edm::propagate_const<TClass*> edProductClass_;
+    InputType inputType_;
   }; // class RootFile
 
 }

--- a/IOPool/Input/test/test_reduced_ProcessHistory_cfg.py
+++ b/IOPool/Input/test/test_reduced_ProcessHistory_cfg.py
@@ -25,125 +25,57 @@ process.output = cms.OutputModule("PoolOutputModule",
 
 process.testmerge = cms.EDAnalyzer("TestMergeResults",
                             
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        10001,   10002,  10003,   # * begin run 100
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 100
-        10001,   10002,  10003,   # * begin run 1
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 2
-        10001,   10002,  10003,   # * begin run 11
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 11
-        10001,   10002,  10003,   # * begin run 12
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 12
-        10001,   10002,  10003,   # * begin run 13
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 13
-        10001,   10002,  10003,   # * begin run 1000
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1000
-        10001,   10002,  10003,   # * begin run 1001
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1001
-        10001,   10002,  10003,   # * begin run 1002
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1002
-        10001,   10002,  10003,   # * begin run 2000
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 2000
-        10001,   10002,  10003,   # * begin run 2001
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 2001
-        10001,   10002,  10003,   # * begin run 2002
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003    # end run 2002
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        100001,   100002,  100003,   # begin run 100
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 100
-        100001,   100002,  100003,   # begin run 1
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1
-        100001,   100002,  100003,   # begin run 1
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1
-        100001,   100002,  100003,   # begin run 2
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 2
-        100001,   100002,  100003,   # begin run 11
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 11
-        100001,   100002,  100003,   # begin run 12
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 12
-        100001,   100002,  100003,   # begin run 13
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 13
-        100001,   100002,  100003,   # begin run 1000
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1000
-        100001,   100002,  100003,   # begin run 1001
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1001
-        100001,   100002,  100003,   # begin run 1002
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1002
-        100001,   100002,  100003,   # begin run 2000
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 2000
-        100001,   100002,  100003,   # begin run 2001
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # *end run 2001
-        100001,   100002,  100003,   # begin run 2002
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003    # * end run 2002
+        100001,   200004,  100003,   # end run 100
+        100001,   200004,  100003,   # end run 1
+        100001,   200004,  100003,   # end run 1
+        100001,   200004,  100003,   # end run 2
+        100001,   200004,  100003,   # end run 11
+        100001,   200004,  100003,   # end run 12
+        100001,   200004,  100003,   # end run 13
+        100001,   200004,  100003,   # end run 1000
+        100001,   200004,  100003,   # end run 1001
+        100001,   200004,  100003,   # end run 1002
+        100001,   200004,  100003,   # end run 2000
+        100001,   200004,  100003,   # end run 2001
+        100001,   200004,  100003    # end run 2002
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        101,       102,    103,   # * begin run 100 lumi 100
-        101,       204,    103,   # * events
         101,       204,    103    # end run 100 lumi 100
 # There are more, but all with the same pattern as the first        
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        1001,     1002,   1003,   # begin run 100 lumi 100
-        1001,     2004,   1003,   # * events
-        1001,     2004,   1003,   # * end run 100 lumi 100
+        1001,     2004,   1003,   # end run 100 lumi 100
     ),
 
     expectedProcessHistoryInRuns = cms.untracked.vstring(

--- a/IOPool/Input/test/test_reduced_ProcessHistory_dup_cfg.py
+++ b/IOPool/Input/test/test_reduced_ProcessHistory_dup_cfg.py
@@ -25,125 +25,57 @@ process.output = cms.OutputModule("PoolOutputModule",
 
 process.testmerge = cms.EDAnalyzer("TestMergeResults",
                             
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        10001,   10002,  10003,   # * begin run 100
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 100
-        10001,   10002,  10003,   # * begin run 1
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 2
-        10001,   10002,  10003,   # * begin run 11
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 11
-        10001,   10002,  10003,   # * begin run 12
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 12
-        10001,   10002,  10003,   # * begin run 13
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 13
-        10001,   10002,  10003,   # * begin run 1000
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1000
-        10001,   10002,  10003,   # * begin run 1001
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1001
-        10001,   10002,  10003,   # * begin run 1002
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1002
-        10001,   10002,  10003,   # * begin run 2000
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 2000
-        10001,   10002,  10003,   # * begin run 2001
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 2001
-        10001,   10002,  10003,   # * begin run 2002
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003    # end run 2002
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        100001,   100002,  100003,   # begin run 100
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 100
-        100001,   100002,  100003,   # begin run 1
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1
-        100001,   100002,  100003,   # begin run 1
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1
-        100001,   100002,  100003,   # begin run 2
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 2
-        100001,   100002,  100003,   # begin run 11
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 11
-        100001,   100002,  100003,   # begin run 12
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 12
-        100001,   100002,  100003,   # begin run 13
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 13
-        100001,   100002,  100003,   # begin run 1000
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1000
-        100001,   100002,  100003,   # begin run 1001
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1001
-        100001,   100002,  100003,   # begin run 1002
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1002
-        100001,   100002,  100003,   # begin run 2000
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 2000
-        100001,   100002,  100003,   # begin run 2001
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # *end run 2001
-        100001,   100002,  100003,   # begin run 2002
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003    # * end run 2002
+        100001,   200004,  100003,   # end run 100
+        100001,   200004,  100003,   # end run 1
+        100001,   200004,  100003,   # end run 1
+        100001,   200004,  100003,   # end run 2
+        100001,   200004,  100003,   # end run 11
+        100001,   200004,  100003,   # end run 12
+        100001,   200004,  100003,   # end run 13
+        100001,   200004,  100003,   # end run 1000
+        100001,   200004,  100003,   # end run 1001
+        100001,   200004,  100003,   # end run 1002
+        100001,   200004,  100003,   # end run 2000
+        100001,   200004,  100003,   # end run 2001
+        100001,   200004,  100003    # end run 2002
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        101,       102,    103,   # * begin run 100 lumi 100
-        101,       204,    103,   # * events
         101,       204,    103    # end run 100 lumi 100
 # There are more, but all with the same pattern as the first        
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        1001,     1002,   1003,   # begin run 100 lumi 100
-        1001,     2004,   1003,   # * events
-        1001,     2004,   1003,   # * end run 100 lumi 100
+        1001,     2004,   1003,   # end run 100 lumi 100
     ),
 
     verbose = cms.untracked.bool(True)

--- a/IOPool/Input/test/test_reduced_ProcessHistory_end_cfg.py
+++ b/IOPool/Input/test/test_reduced_ProcessHistory_end_cfg.py
@@ -30,125 +30,57 @@ process.output = cms.OutputModule("PoolOutputModule",
 
 process.testmerge = cms.EDAnalyzer("TestMergeResults",
                             
-    #   These values below are just arbitrary and meaningless
-    #   We are checking to see that the value we get out matches what
-    #   was put in.
-
-    #   expected values listed below come in sets of three
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
     #      value expected in ThingWithMerge
     #      value expected in ThingWithIsEqual
-    #   This set of 3 is repeated below at each point it might change
-    #   The Prod suffix refers to objects from the process named PROD
-    #   The New suffix refers to objects created in the most recent process
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
     #   When the sequence of parameter values is exhausted it stops checking
-    #   0's are just placeholders, if the value is a "0" the check is not made
-    #   and it indicates the product does not exist at that point.
-    #   *'s indicate lines where the checks are actually run by the test module.
+    #   0's are just placeholders, if the value is a "0" the check is not made.
 
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        10001,   10002,  10003,   # * begin run 100
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 100
-        10001,   10002,  10003,   # * begin run 1
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1
-        10001,   10002,  10003,   # * begin run 2
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 2
-        10001,   10002,  10003,   # * begin run 11
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 11
-        10001,   10002,  10003,   # * begin run 12
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 12
-        10001,   10002,  10003,   # * begin run 13
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 13
-        10001,   10002,  10003,   # * begin run 1000
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1000
-        10001,   10002,  10003,   # * begin run 1001
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1001
-        10001,   10002,  10003,   # * begin run 1002
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 1002
-        10001,   10002,  10003,   # * begin run 2000
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 2000
-        10001,   10002,  10003,   # * begin run 2001
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003,   # end run 2001
-        10001,   10002,  10003,   # * begin run 2002
-        10001,   20004,  10003,   # * events
         10001,   20004,  10003    # end run 2002
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        100001,   100002,  100003,   # begin run 100
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 100
-        100001,   100002,  100003,   # begin run 1
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1
-        100001,   100002,  100003,   # begin run 1
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1
-        100001,   100002,  100003,   # begin run 2
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 2
-        100001,   100002,  100003,   # begin run 11
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 11
-        100001,   100002,  100003,   # begin run 12
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 12
-        100001,   100002,  100003,   # begin run 13
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 13
-        100001,   100002,  100003,   # begin run 1000
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1000
-        100001,   100002,  100003,   # begin run 1001
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1001
-        100001,   100002,  100003,   # begin run 1002
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 1002
-        100001,   100002,  100003,   # begin run 2000
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # * end run 2000
-        100001,   100002,  100003,   # begin run 2001
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003,   # *end run 2001
-        100001,   100002,  100003,   # begin run 2002
-        100001,   200004,  100003,   # * events
-        100001,   200004,  100003    # * end run 2002
+        100001,   200004,  100003,   # end run 100
+        100001,   200004,  100003,   # end run 1
+        100001,   200004,  100003,   # end run 1
+        100001,   200004,  100003,   # end run 2
+        100001,   200004,  100003,   # end run 11
+        100001,   200004,  100003,   # end run 12
+        100001,   200004,  100003,   # end run 13
+        100001,   200004,  100003,   # end run 1000
+        100001,   200004,  100003,   # end run 1001
+        100001,   200004,  100003,   # end run 1002
+        100001,   200004,  100003,   # end run 2000
+        100001,   200004,  100003,   # end run 2001
+        100001,   200004,  100003    # end run 2002
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        101,       102,    103,   # * begin run 100 lumi 100
-        101,       204,    103,   # * events
         101,       204,    103    # end run 100 lumi 100
 # There are more, but all with the same pattern as the first        
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        1001,     1002,   1003,   # begin run 100 lumi 100
-        1001,     2004,   1003,   # * events
-        1001,     2004,   1003,   # * end run 100 lumi 100
+        1001,     2004,   1003,   # end run 100 lumi 100
     ),
 
     expectedProcessHistoryInRuns = cms.untracked.vstring(

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -144,6 +144,8 @@ namespace edm {
     void reallyCloseFile() override;
     void beginJob() override;
 
+    void setProcessesWithSelectedMergeableRunProducts(std::set<std::string> const&) override;
+
     typedef std::map<BranchID, std::set<ParentageID> > BranchParents;
     void updateBranchParentsForOneBranch(ProductProvenanceRetriever const* provRetriever,
                                          BranchID const& branchID);
@@ -154,6 +156,7 @@ namespace edm {
     void writeFileFormatVersion();
     void writeFileIdentifier();
     void writeIndexIntoFile();
+    void writeStoredMergeableRunProductMetadata();
     void writeProcessHistoryRegistry();
     void writeParameterSetRegistry();
     void writeProductDescriptionRegistry();
@@ -195,6 +198,7 @@ namespace edm {
     bool overrideInputFileSplitLevels_;
     edm::propagate_const<std::unique_ptr<RootOutputFile>> rootOutputFile_;
     std::string statusFileName_;
+    std::vector<std::string> processesWithSelectedMergeableRunProducts_;
   };
 }
 

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -262,6 +262,10 @@ namespace edm {
     if(rootOutputFile_) rootOutputFile_->respondToCloseInputFile(fb);
   }
 
+  void PoolOutputModule::setProcessesWithSelectedMergeableRunProducts(std::set<std::string> const& processes) {
+    processesWithSelectedMergeableRunProducts_.assign(processes.begin(), processes.end());
+  }
+
   PoolOutputModule::~PoolOutputModule() {
   }
 
@@ -290,6 +294,7 @@ namespace edm {
     writeFileFormatVersion();
     writeFileIdentifier();
     writeIndexIntoFile();
+    writeStoredMergeableRunProductMetadata();
     writeProcessHistoryRegistry();
     writeParameterSetRegistry();
     writeProductDescriptionRegistry();
@@ -310,6 +315,7 @@ namespace edm {
   void PoolOutputModule::writeFileFormatVersion() { rootOutputFile_->writeFileFormatVersion(); }
   void PoolOutputModule::writeFileIdentifier() { rootOutputFile_->writeFileIdentifier(); }
   void PoolOutputModule::writeIndexIntoFile() { rootOutputFile_->writeIndexIntoFile(); }
+  void PoolOutputModule::writeStoredMergeableRunProductMetadata() { rootOutputFile_->writeStoredMergeableRunProductMetadata(); }
   void PoolOutputModule::writeProcessHistoryRegistry() { rootOutputFile_->writeProcessHistoryRegistry(); }
   void PoolOutputModule::writeParameterSetRegistry() { rootOutputFile_->writeParameterSetRegistry(); }
   void PoolOutputModule::writeProductDescriptionRegistry() { rootOutputFile_->writeProductDescriptionRegistry(); }
@@ -358,7 +364,8 @@ namespace edm {
 
   void PoolOutputModule::reallyOpenFile() {
     auto names = physicalAndLogicalNameForNewFile();
-    rootOutputFile_ = std::make_unique<RootOutputFile>(this, names.first, names.second); // propagate_const<T> has no reset() function
+    rootOutputFile_ = std::make_unique<RootOutputFile>(this, names.first, names.second,
+                                                       processesWithSelectedMergeableRunProducts_); // propagate_const<T> has no reset() function
   }
 
   void

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -28,6 +28,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/StoredProductProvenance.h"
+#include "DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 #include "IOPool/Output/interface/PoolOutputModule.h"
@@ -47,7 +48,8 @@ namespace edm {
     typedef PoolOutputModule::OutputItemList OutputItemList;
     typedef std::array<edm::propagate_const<RootOutputTree*>, NumBranchTypes> RootOutputTreePtrArray;
     explicit RootOutputFile(PoolOutputModule* om, std::string const& fileName,
-                            std::string const& logicalFileName);
+                            std::string const& logicalFileName,
+                            std::vector<std::string> const& processesWithSelectedMergeableRunProducts);
     ~RootOutputFile() {}
     void writeOne(EventForOutput const& e);
     //void endFile();
@@ -56,6 +58,7 @@ namespace edm {
     void writeFileFormatVersion();
     void writeFileIdentifier();
     void writeIndexIntoFile();
+    void writeStoredMergeableRunProductMetadata();
     void writeProcessHistoryRegistry();
     void writeParameterSetRegistry();
     void writeProductDescriptionRegistry();
@@ -116,6 +119,7 @@ namespace edm {
     IndexIntoFile::EntryNumber_t lumiEntryNumber_;
     IndexIntoFile::EntryNumber_t runEntryNumber_;
     IndexIntoFile indexIntoFile_;
+    StoredMergeableRunProductMetadata storedMergeableRunProductMetadata_;
     unsigned long nEventsInLumi_;
     edm::propagate_const<TTree*> metaDataTree_;
     edm::propagate_const<TTree*> parameterSetsTree_;

--- a/IOPool/Output/test/PoolOutputTestUnscheduledRead_cfg.py
+++ b/IOPool/Output/test/PoolOutputTestUnscheduledRead_cfg.py
@@ -17,35 +17,19 @@ process.analyzeOther = cms.EDAnalyzer("OtherThingAnalyzer")
 # get called for EDProducers with Unscheduled turned on.
 process.test = cms.EDAnalyzer("TestMergeResults",
     expectedBeginRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        10001,   10002,  10003,   # * begin run 1
-        10001,   10002,  10003,   # * events
         10001,   10002,  10003    # end run 1
     ),
 
     expectedEndRunNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        100001, 100002, 100003,   # begin run 1
-        100001, 100002, 100003,   # * events
-        100001, 100002, 100003    # * end run 1
+        100001, 100002, 100003    # end run 1
     ),
 
     expectedBeginLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        101,       102,    103,   # * begin run 1 lumi 1
-        101,       102,    103,   # * events
         101,       102,    103    # end run 1 lumi 1
     ),
 
     expectedEndLumiNew = cms.untracked.vint32(
-        0,           0,      0,   # start
-        0,           0,      0,   # begin file 1
-        1001,     1002,   1003,   # begin run 1 lumi 1
-        1001,     1002,   1003,   # * events
-        1001,     1002,   1003    # * end run 1 lumi 1
+        1001,     1002,   1003    # end run 1 lumi 1
     )
 )
 

--- a/SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h
@@ -44,7 +44,8 @@ public:
   double filterEfficiencyError(int idwtup=+3) const;
   // merge method. It will be used when merging different jobs populating the same lumi section
   bool mergeProduct(GenFilterInfo const &other);
-  
+  void swap(GenFilterInfo& other);
+
 private:
   
   unsigned int  numPassPositiveEvents_;

--- a/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
@@ -148,6 +148,7 @@ class GenLumiInfoProduct {
 
   // methods used by EDM
   virtual bool mergeProduct(const GenLumiInfoProduct &other);
+  void swap(GenLumiInfoProduct& other);
   virtual bool isProductEqual(const GenLumiInfoProduct &other) const;
  private:
   // cross sections

--- a/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
@@ -121,9 +121,10 @@ class LHERunInfoProduct {
 	{ return !(*this == other); }
 
 	bool mergeProduct(const LHERunInfoProduct &other);
-    	bool isProductEqual(const LHERunInfoProduct &other) const
-    	{ return *this == other; }
-        static bool isTagComparedInMerge(const std::string& tag);
+	void swap(LHERunInfoProduct& other);
+	bool isProductEqual(const LHERunInfoProduct &other) const
+	{ return *this == other; }
+	static bool isTagComparedInMerge(const std::string& tag);
 
     private:
 	lhef::HEPRUP			heprup_;

--- a/SimDataFormats/GeneratorProducts/interface/LHEXMLStringProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEXMLStringProduct.h
@@ -31,7 +31,7 @@ public:
   
   // merge method. It will be used when merging different jobs populating the same lumi section
   bool mergeProduct(LHEXMLStringProduct const &other);
-  
+  void swap(LHEXMLStringProduct& other);
   
 private:
   std::vector<std::string> content_;

--- a/SimDataFormats/GeneratorProducts/interface/LesHouches.h
+++ b/SimDataFormats/GeneratorProducts/interface/LesHouches.h
@@ -67,6 +67,19 @@ class HEPRUP {
 		LPRUP.resize(NPRUP);
 	}
 
+	void swap(HEPRUP& other) {
+		IDBMUP.swap(other.IDBMUP);
+		EBMUP.swap(other.EBMUP);
+		PDFGUP.swap(other.PDFGUP);
+		PDFSUP.swap(other.PDFSUP);
+		std::swap(IDWTUP, other.IDWTUP);
+		std::swap(NPRUP, other.NPRUP);
+		XSECUP.swap(other.XSECUP);
+		XERRUP.swap(other.XERRUP);
+		XMAXUP.swap(other.XMAXUP);
+		LPRUP.swap(other.LPRUP);
+	}
+
 	/**
 	 * PDG id's of beam particles. (first/second is in +/-z direction).
 	 */

--- a/SimDataFormats/GeneratorProducts/src/GenFilterInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenFilterInfo.cc
@@ -1,5 +1,6 @@
 #include <iostream>
-#include <algorithm> 
+#include <algorithm>
+#include <utility>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -77,6 +78,17 @@ bool GenFilterInfo::mergeProduct(GenFilterInfo const &other)
   sumTotalWeights2_       += other.sumTotalWeights2_;
 
   return true;
+}
+
+void GenFilterInfo::swap(GenFilterInfo& other) {
+  std::swap(numPassPositiveEvents_, other.numPassPositiveEvents_);
+  std::swap(numPassNegativeEvents_, other.numPassNegativeEvents_);
+  std::swap(numTotalPositiveEvents_, other.numTotalPositiveEvents_);
+  std::swap(numTotalNegativeEvents_, other.numTotalNegativeEvents_);
+  std::swap(sumPassWeights_, other.sumPassWeights_);
+  std::swap(sumPassWeights2_, other.sumPassWeights2_);
+  std::swap(sumTotalWeights_, other.sumTotalWeights_);
+  std::swap(sumTotalWeights2_, other.sumTotalWeights2_);
 }
 
 double GenFilterInfo::filterEfficiency(int idwtup) const {

--- a/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenLumiInfoProduct.cc
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <algorithm> 
 #include <map>
+#include <utility>
+
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
@@ -132,6 +134,11 @@ bool GenLumiInfoProduct::mergeProduct(GenLumiInfoProduct const &other)
       iter != processes.end(); ++iter, i++) 
 	internalProcesses_[i]=iter->second;
   return true;
+}
+
+void GenLumiInfoProduct::swap(GenLumiInfoProduct& other) {
+  std::swap(hepidwtup_, other.hepidwtup_);
+  internalProcesses_.swap(other.internalProcesses_);
 }
 
 bool GenLumiInfoProduct::isProductEqual(GenLumiInfoProduct const &other) const

--- a/SimDataFormats/GeneratorProducts/src/LHERunInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/LHERunInfoProduct.cc
@@ -214,7 +214,7 @@ bool LHERunInfoProduct::find_if_checklist(const std::string x, std::vector<std::
 }
 
 bool LHERunInfoProduct::isTagComparedInMerge(const std::string& tag) {
-        return !(tag == "" || tag.find("Alpgen") == 0 || tag == "MGGridCard" || tag=="MGRunCard" || tag == "mgruncard" || tag=="MadSpin" || tag=="madspin");
+        return !(tag.empty() || tag.find("Alpgen") == 0 || tag == "MGGridCard" || tag=="MGRunCard" || tag == "mgruncard" || tag=="MadSpin" || tag=="madspin");
 }
 
 bool LHERunInfoProduct::mergeProduct(const LHERunInfoProduct &other)
@@ -306,4 +306,10 @@ bool LHERunInfoProduct::mergeProduct(const LHERunInfoProduct &other)
 
 	// it is exactly the same, so merge
 	return true;
+}
+
+void LHERunInfoProduct::swap(LHERunInfoProduct& other) {
+  heprup_.swap(other.heprup_);
+  headers_.swap(other.headers_);
+  comments_.swap(other.comments_);
 }

--- a/SimDataFormats/GeneratorProducts/src/LHEXMLStringProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/LHEXMLStringProduct.cc
@@ -146,3 +146,7 @@ bool LHEXMLStringProduct::mergeProduct(LHEXMLStringProduct const &other)
   return true;
 }
 
+void LHEXMLStringProduct::swap(LHEXMLStringProduct& other) {
+  content_.swap(other.content_);
+  compressedContent_.swap(other.compressedContent_);
+}


### PR DESCRIPTION
at luminosity block boundaries and then merging them back together.

The only changes outside the core Framework code are related to
adding the swap function to mergeable data formats types and one
fix required by the automatic code checker. This PR adds a new
requirement that mergeable data format types that are stored in Runs
must have a swap function.
 
Note there are significant restrictions on this new ability to split and merge run
products. I am in the process of writing a new section for the Framework
TWIKI area in the Software Guide that addresses the details which are unfortunately
complicated.

Previously the Framework did not support splitting runs and then merging them.
Previously this was simply against the rules and mergeable products were invalid
when it was done. (And the Framework still will not support splitting lumis or
splitting runs at other than lumi boundaries).

I'll give an example if this is unclear. For example, one might create a product
containing a histogram associated with a run by processing all the events in
10 luminosity blocks with the histogram accumulating some quantity from the events
or the luminosity blocks. Then later one might run two separate processes, one to
process the first 5 luminosity blocks and the other to process the other 5 luminosity
blocks. Then in a subsequent process the two files might be merged together into
one.  In the previous version of the code the histogram would be copied to each of
the two output files (it is not possible to split the summed contents, the information
is not available in the histogram). Then when the files would be merged the histogram
copies would be added bin by bin which would incorrectly double the content of each bin.
After the change in this pull request the proper thing will be done to prevent this double
counting in this simple case.

There should be no change in behavior in cases where a sequence of processing
steps did not split runs and no changes to anything in the output other than the
content of mergeable products in Runs.

Backward compatibility is handled as follows. One can read old files with the new
code and vice versa. If the splitting occurred in a processing step with this new code
and every processing step after that also uses this new code, things will be handled
according to the new merging algorithm. Otherwise, run product merging will occur
according to the old rules.
