### PR TITLE
[HCAL] Fix rechit flags for R45 filter 

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
@@ -233,40 +233,6 @@ void HBHEPulseShapeFlagSetter::SetPulseShapeFlags(
 	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS5TS6.
         }
    }
-/*
-   if(mCharge[4] + mCharge[5] > mTS4TS5ChargeThreshold && mTS4TS5ChargeThreshold>0) // silly protection against negative charge values
-   {
-      double TS4TS5 = (mCharge[4] - mCharge[5]) / (mCharge[4] + mCharge[5]);
-      if(CheckPassFilter(mCharge[4] + mCharge[5], TS4TS5, mTS4TS5UpperCut, 1) == false)
-         hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETS4TS5Noise);
-      if(CheckPassFilter(mCharge[4] + mCharge[5], TS4TS5, mTS4TS5LowerCut, -1) == false)
-         hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETS4TS5Noise);
-      
-      if(CheckPassFilter(mCharge[4] + mCharge[5], TS4TS5, mTS4TS5UpperCut, 1) == false            && // TS4TS5 is above envelope
-         mCharge[3] + mCharge[4] > mTS3TS4ChargeThreshold       &&       mTS3TS4ChargeThreshold>0 && // enough charge in 34
-         mCharge[5] + mCharge[6] < mTS5TS6UpperChargeThreshold  &&  mTS5TS6UpperChargeThreshold>0 && // low charge in 56
-      	 fabs( (mCharge[4] - mCharge[5]) / (mCharge[4] + mCharge[5]) - 1.0 ) < mR45PlusOneRange    ) // R45 is around +1
-   	{
-           double TS3TS4 = (mCharge[3] - mCharge[4]) / (mCharge[3] + mCharge[4]);
-           if(CheckPassFilter(mCharge[3] + mCharge[4], TS3TS4, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
-	      CheckPassFilter(mCharge[3] + mCharge[4], TS3TS4, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
-	      TS3TS4>(mR45MinusOneRange-1)                                                   ) // horizontal cut on R34 (R34>-0.8)
-	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS3TS4.
-   	}
-
-      if(CheckPassFilter(mCharge[4] + mCharge[5], TS4TS5, mTS4TS5LowerCut, -1) == false            && // TS4TS5 is below envelope
-         mCharge[3] + mCharge[4] < mTS3TS4UpperChargeThreshold  &&  mTS3TS4UpperChargeThreshold>0  && // low charge in 34
-         mCharge[5] + mCharge[6] > mTS5TS6ChargeThreshold       &&       mTS5TS6ChargeThreshold>0  && // enough charge in 56
-         fabs( (mCharge[4] - mCharge[5]) / (mCharge[4] + mCharge[5]) + 1.0 ) < mR45MinusOneRange    ) // R45 is around -1
-        {
-           double TS5TS6 = (mCharge[5] - mCharge[6]) / (mCharge[5] + mCharge[6]);
-           if(CheckPassFilter(mCharge[5] + mCharge[6], TS5TS6, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
-	      CheckPassFilter(mCharge[5] + mCharge[6], TS5TS6, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
-	      TS5TS6<(1-mR45PlusOneRange)                                                    ) // horizontal cut on R56 (R56<+0.8)
-	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS5TS6.
-        }
-   }
-*/
 }
 
 #endif

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
@@ -199,34 +199,36 @@ void HBHEPulseShapeFlagSetter::SetPulseShapeFlags(
        }
    }
 
-   if(mCharge[3] + mCharge[4] > mTS4TS5ChargeThreshold && mTS4TS5ChargeThreshold>0) // silly protection against negative charge values
+   int soi = digi.presamples();
+
+   if(mCharge[soi] + mCharge[soi+1] > mTS4TS5ChargeThreshold && mTS4TS5ChargeThreshold>0) // silly protection against negative charge values
    {
-      double TS4TS5 = (mCharge[3] - mCharge[4]) / (mCharge[3] + mCharge[4]);
-      if(CheckPassFilter(mCharge[3] + mCharge[4], TS4TS5, mTS4TS5UpperCut, 1) == false)
+      double TS4TS5 = (mCharge[soi] - mCharge[soi+1]) / (mCharge[soi] + mCharge[soi+1]);
+      if(CheckPassFilter(mCharge[soi] + mCharge[soi+1], TS4TS5, mTS4TS5UpperCut, 1) == false)
          hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETS4TS5Noise);
-      if(CheckPassFilter(mCharge[3] + mCharge[4], TS4TS5, mTS4TS5LowerCut, -1) == false)
+      if(CheckPassFilter(mCharge[soi] + mCharge[soi+1], TS4TS5, mTS4TS5LowerCut, -1) == false)
          hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETS4TS5Noise);
       
-      if(CheckPassFilter(mCharge[3] + mCharge[4], TS4TS5, mTS4TS5UpperCut, 1) == false            && // TS4TS5 is above envelope
-         mCharge[2] + mCharge[3] > mTS3TS4ChargeThreshold       &&       mTS3TS4ChargeThreshold>0 && // enough charge in 34
-         mCharge[4] + mCharge[5] < mTS5TS6UpperChargeThreshold  &&  mTS5TS6UpperChargeThreshold>0 && // low charge in 56
-      	 fabs( (mCharge[3] - mCharge[4]) / (mCharge[3] + mCharge[4]) - 1.0 ) < mR45PlusOneRange    ) // R45 is around +1
+      if(CheckPassFilter(mCharge[soi] + mCharge[soi+1], TS4TS5, mTS4TS5UpperCut, 1) == false            && // TS4TS5 is above envelope
+         mCharge[soi-1] + mCharge[soi] > mTS3TS4ChargeThreshold       &&       mTS3TS4ChargeThreshold>0 && // enough charge in 34
+         mCharge[soi+1] + mCharge[soi+2] < mTS5TS6UpperChargeThreshold  &&  mTS5TS6UpperChargeThreshold>0 && // low charge in 56
+      	 fabs( (mCharge[soi] - mCharge[soi+1]) / (mCharge[soi] + mCharge[soi+1]) - 1.0 ) < mR45PlusOneRange    ) // R45 is around +1
    	{
-           double TS3TS4 = (mCharge[2] - mCharge[3]) / (mCharge[2] + mCharge[3]);
-           if(CheckPassFilter(mCharge[2] + mCharge[3], TS3TS4, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
-	      CheckPassFilter(mCharge[2] + mCharge[3], TS3TS4, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
+           double TS3TS4 = (mCharge[soi-1] - mCharge[soi]) / (mCharge[soi-1] + mCharge[soi]);
+           if(CheckPassFilter(mCharge[soi-1] + mCharge[soi], TS3TS4, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
+	      CheckPassFilter(mCharge[soi-1] + mCharge[soi], TS3TS4, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
 	      TS3TS4>(mR45MinusOneRange-1)                                                   ) // horizontal cut on R34 (R34>-0.8)
 	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS3TS4.
    	}
 
-      if(CheckPassFilter(mCharge[3] + mCharge[4], TS4TS5, mTS4TS5LowerCut, -1) == false            && // TS4TS5 is below envelope
-         mCharge[2] + mCharge[3] < mTS3TS4UpperChargeThreshold  &&  mTS3TS4UpperChargeThreshold>0  && // low charge in 34
-         mCharge[4] + mCharge[5] > mTS5TS6ChargeThreshold       &&       mTS5TS6ChargeThreshold>0  && // enough charge in 56
-         fabs( (mCharge[3] - mCharge[4]) / (mCharge[3] + mCharge[4]) + 1.0 ) < mR45MinusOneRange    ) // R45 is around -1
+      if(CheckPassFilter(mCharge[soi] + mCharge[soi+1], TS4TS5, mTS4TS5LowerCut, -1) == false            && // TS4TS5 is below envelope
+         mCharge[soi-1] + mCharge[soi] < mTS3TS4UpperChargeThreshold  &&  mTS3TS4UpperChargeThreshold>0  && // low charge in 34
+         mCharge[soi+1] + mCharge[soi+2] > mTS5TS6ChargeThreshold       &&       mTS5TS6ChargeThreshold>0  && // enough charge in 56
+         fabs( (mCharge[soi] - mCharge[soi+1]) / (mCharge[soi] + mCharge[soi+1]) + 1.0 ) < mR45MinusOneRange    ) // R45 is around -1
         {
-           double TS5TS6 = (mCharge[4] - mCharge[5]) / (mCharge[4] + mCharge[5]);
-           if(CheckPassFilter(mCharge[4] + mCharge[5], TS5TS6, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
-	      CheckPassFilter(mCharge[4] + mCharge[5], TS5TS6, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
+           double TS5TS6 = (mCharge[soi+1] - mCharge[soi+2]) / (mCharge[soi+1] + mCharge[soi+2]);
+           if(CheckPassFilter(mCharge[soi+1] + mCharge[soi+2], TS5TS6, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
+	      CheckPassFilter(mCharge[soi+1] + mCharge[soi+2], TS5TS6, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
 	      TS5TS6<(1-mR45PlusOneRange)                                                    ) // horizontal cut on R56 (R56<+0.8)
 	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS5TS6.
         }

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h
@@ -199,6 +199,39 @@ void HBHEPulseShapeFlagSetter::SetPulseShapeFlags(
        }
    }
 
+   if(mCharge[3] + mCharge[4] > mTS4TS5ChargeThreshold && mTS4TS5ChargeThreshold>0) // silly protection against negative charge values
+   {
+      double TS4TS5 = (mCharge[3] - mCharge[4]) / (mCharge[3] + mCharge[4]);
+      if(CheckPassFilter(mCharge[3] + mCharge[4], TS4TS5, mTS4TS5UpperCut, 1) == false)
+         hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETS4TS5Noise);
+      if(CheckPassFilter(mCharge[3] + mCharge[4], TS4TS5, mTS4TS5LowerCut, -1) == false)
+         hbhe.setFlagField(1, HcalCaloFlagLabels::HBHETS4TS5Noise);
+      
+      if(CheckPassFilter(mCharge[3] + mCharge[4], TS4TS5, mTS4TS5UpperCut, 1) == false            && // TS4TS5 is above envelope
+         mCharge[2] + mCharge[3] > mTS3TS4ChargeThreshold       &&       mTS3TS4ChargeThreshold>0 && // enough charge in 34
+         mCharge[4] + mCharge[5] < mTS5TS6UpperChargeThreshold  &&  mTS5TS6UpperChargeThreshold>0 && // low charge in 56
+      	 fabs( (mCharge[3] - mCharge[4]) / (mCharge[3] + mCharge[4]) - 1.0 ) < mR45PlusOneRange    ) // R45 is around +1
+   	{
+           double TS3TS4 = (mCharge[2] - mCharge[3]) / (mCharge[2] + mCharge[3]);
+           if(CheckPassFilter(mCharge[2] + mCharge[3], TS3TS4, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
+	      CheckPassFilter(mCharge[2] + mCharge[3], TS3TS4, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
+	      TS3TS4>(mR45MinusOneRange-1)                                                   ) // horizontal cut on R34 (R34>-0.8)
+	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS3TS4.
+   	}
+
+      if(CheckPassFilter(mCharge[3] + mCharge[4], TS4TS5, mTS4TS5LowerCut, -1) == false            && // TS4TS5 is below envelope
+         mCharge[2] + mCharge[3] < mTS3TS4UpperChargeThreshold  &&  mTS3TS4UpperChargeThreshold>0  && // low charge in 34
+         mCharge[4] + mCharge[5] > mTS5TS6ChargeThreshold       &&       mTS5TS6ChargeThreshold>0  && // enough charge in 56
+         fabs( (mCharge[3] - mCharge[4]) / (mCharge[3] + mCharge[4]) + 1.0 ) < mR45MinusOneRange    ) // R45 is around -1
+        {
+           double TS5TS6 = (mCharge[4] - mCharge[5]) / (mCharge[4] + mCharge[5]);
+           if(CheckPassFilter(mCharge[4] + mCharge[5], TS5TS6, mTS4TS5UpperCut,  1) == true && // use the same envelope as TS4TS5
+	      CheckPassFilter(mCharge[4] + mCharge[5], TS5TS6, mTS4TS5LowerCut, -1) == true && // use the same envelope as TS4TS5
+	      TS5TS6<(1-mR45PlusOneRange)                                                    ) // horizontal cut on R56 (R56<+0.8)
+	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS5TS6.
+        }
+   }
+/*
    if(mCharge[4] + mCharge[5] > mTS4TS5ChargeThreshold && mTS4TS5ChargeThreshold>0) // silly protection against negative charge values
    {
       double TS4TS5 = (mCharge[4] - mCharge[5]) / (mCharge[4] + mCharge[5]);
@@ -231,6 +264,7 @@ void HBHEPulseShapeFlagSetter::SetPulseShapeFlags(
 	       hbhe.setFlagField(1, HcalCaloFlagLabels::HBHEOOTPU); // set to 1 if there is a pulse-shape-wise good OOTPU in TS5TS6.
         }
    }
+*/
 }
 
 #endif


### PR DESCRIPTION
The HCAL R45 filter algorithm uses two flags: "HBHETS4TS5Noise" and "HBHEOOTPU". Both are set by https://github.com/cms-sw/cmssw/blob/master/RecoLocalCalo/HcalRecAlgos/interface/HBHEPulseShapeFlag.h and it still assumes that SOI is 4. 

This PR fixes this issue by getting the SOI from HBHEDataFrame::presamples().

Small changes (increase in rejection rate) are expected in both data and MC in the R45 filter decision.

Following is the rate changes for MET+X triggers measured in JetHT sample (13k events) before and after the fix:  

passedFIX/passedBUG		HLTPath
0.964613		HLT_CaloMET70_HBHECleaned_v4
0.959184		HLT_CaloMET80_HBHECleaned_v4
0.952408		HLT_CaloMET90_HBHECleaned_v4
0.944777		HLT_CaloMET100_HBHECleaned_v4
0.509202		HLT_CaloMET250_HBHECleaned_v4
0.367521		HLT_CaloMET300_HBHECleaned_v4
0.311828		HLT_CaloMET350_HBHECleaned_v4
0.708633		HLT_PFMET200_HBHECleaned_v9
0.589474		HLT_PFMET250_HBHECleaned_v9
0.513889		HLT_PFMET300_HBHECleaned_v9
0.703557		HLT_PFMET200_HBHE_BeamHaloCleaned_v9
0.763975		HLT_PFMETTypeOne200_HBHE_BeamHaloCleaned_v9
0.998347		HLT_DiJet110_35_Mjj650_PFMET110_v9
0.997959		HLT_DiJet110_35_Mjj650_PFMET120_v9
0.997436		HLT_DiJet110_35_Mjj650_PFMET130_v9
0.810345		HLT_Rsq0p35_v15
0.710526		HLT_Rsq0p40_v15
0.988839		HLT_RsqMR300_Rsq0p09_MR200_v15
0.982788		HLT_RsqMR320_Rsq0p09_MR200_v15
0.992908		HLT_RsqMR300_Rsq0p09_MR200_4jet_v15
0.989583		HLT_RsqMR320_Rsq0p09_MR200_4jet_v15
 