### PR TITLE
DeepFlavour deltaR calculation fix

### DIFF
--- a/RecoBTag/TensorFlow/plugins/DeepFlavourTagInfoProducer.cc
+++ b/RecoBTag/TensorFlow/plugins/DeepFlavourTagInfoProducer.cc
@@ -218,7 +218,7 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
               { return btagbtvdeep::sv_vertex_comparator(sva, svb, pv); });
     // fill features from secondary vertices
     for (const auto & sv : svs_sorted) {
-      if (reco::deltaR2(sv.position() - pv.position(), flip_ ? -jet_dir : jet_dir) > (jet_radius_*jet_radius_)) continue;
+      if (reco::deltaR2(sv, jet_dir) > (jet_radius_*jet_radius_)) continue;
       else {
         features.sv_features.emplace_back();
         // in C++17 could just get from emplace_back output

--- a/RecoBTag/TensorFlow/src/SecondaryVertexConverter.cc
+++ b/RecoBTag/TensorFlow/src/SecondaryVertexConverter.cc
@@ -17,7 +17,7 @@ namespace btagbtvdeep {
     
     math::XYZVector jet_dir = jet.momentum().Unit();
     sv_features.pt = sv.pt();
-    sv_features.deltaR = catch_infs_and_bound(std::fabs(reco::deltaR(sv.position() - pv.position(), flip ? -jet_dir : jet_dir))-0.5,
+    sv_features.deltaR = catch_infs_and_bound(std::fabs(reco::deltaR(sv, jet_dir))-0.5,
 					      0,-2,0);
     sv_features.mass = sv.mass();
     sv_features.ntracks = sv.numberOfDaughters();


### PR DESCRIPTION
In DeepFlavour deltaR between the vertex and jet should be calculated using the sv momentum instead of the sv flight direction. This also means that its not necessary to do any special treatment of deltaR in the negative tagger, so no flip is performed.