### PR TITLE
[10.2.X change GT] Change HBHENegativeEFilter in 2018, 23, LS2 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,17 +48,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '102X_upgrade2018_design_v5',
+    'phase1_2018_design'       : '102X_upgrade2018_design_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v7',
+    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '102X_postLS2_design_v4', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '102X_postLS2_design_v5', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '102X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '102X_postLS2_realistic_v5', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '102X_upgrade2023_realistic_v5'
+    'phase2_realistic'         : '102X_upgrade2023_realistic_v6'
 }
 
 aliases = {


### PR DESCRIPTION
#  Using HBHENegativeEFilter_2018v01_mc condition for 2018, 23, LS2 MC GTs.

##  LS2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_postLS2_design_v4/102X_postLS2_design_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_postLS2_realistic_v4/102X_postLS2_realistic_v5
##  2023
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2023_realistic_v5/102X_upgrade2023_realistic_v6
##  2018
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018cosmics_realistic_deco_v6/102X_upgrade2018cosmics_realistic_deco_v7
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_realistic_v7/102X_upgrade2018_realistic_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_design_v5/102X_upgrade2018_design_v6