### PR TITLE
Switch to emplace to put data products

### DIFF
--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -30,7 +30,7 @@ namespace edm {
     explicit Wrapper(std::unique_ptr<T> ptr);
     
     template<typename... Args>
-    explicit Wrapper( Args&&... );
+    explicit Wrapper( Emplace, Args&&... );
     ~Wrapper() override {}
     T const* product() const {return (present ? &obj : nullptr);}
     T const* operator->() const {return product();}
@@ -93,7 +93,7 @@ private:
 
   template<typename T>
   template<typename... Args>
-  Wrapper<T>::Wrapper(Args&&... args) :
+  Wrapper<T>::Wrapper(Emplace, Args&&... args) :
   WrapperBase(),
   present(true),
   obj(std::forward<Args>(args)...) {

--- a/DataFormats/Common/interface/WrapperBase.h
+++ b/DataFormats/Common/interface/WrapperBase.h
@@ -22,6 +22,9 @@ namespace edm {
   
   class WrapperBase : public ViewTypeChecker {
   public:
+    //used by inheriting classes to force construction via emplace
+    struct Emplace {};
+
     WrapperBase();
     ~WrapperBase() override;
     bool isPresent() const {return isPresent_();}

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -476,7 +476,7 @@ namespace edm {
     
     assert(index < putProducts().size());
     
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::forward<Args>(args)...));
+    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(WrapperBase::Emplace{}, std::forward<Args>(args)...));
 
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -274,7 +274,8 @@ namespace edm {
     
     assert(index < putProducts().size());
     
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::forward<Args>(args)...));
+    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(WrapperBase::Emplace{},
+                                                         std::forward<Args>(args)...));
     
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -285,7 +285,8 @@ namespace edm {
     
     assert(index < putProducts().size());
     
-    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::forward<Args>(args)...));
+    std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(WrapperBase::Emplace{},
+                                                         std::forward<Args>(args)...));
     
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.

--- a/FWCore/Framework/src/EndPathStatusInserter.cc
+++ b/FWCore/Framework/src/EndPathStatusInserter.cc
@@ -8,13 +8,15 @@
 
 namespace edm
 {
-  EndPathStatusInserter::EndPathStatusInserter(unsigned int) {
-    produces<EndPathStatus>();
+  EndPathStatusInserter::EndPathStatusInserter(unsigned int):
+  token_{produces<EndPathStatus>()}
+  {
   }
 
   void
   EndPathStatusInserter::produce(StreamID, edm::Event& event, edm::EventSetup const&) const
   {
-    event.put(std::make_unique<EndPathStatus>());
+    //Puts a default constructed EndPathStatus
+    event.emplace(token_);
   }
 }

--- a/FWCore/Framework/src/EndPathStatusInserter.h
+++ b/FWCore/Framework/src/EndPathStatusInserter.h
@@ -2,12 +2,14 @@
 #define FWCore_Framework_EndPathStatusInserter_h
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
 
 namespace edm {
 
   class Event;
   class EventSetup;
   class StreamID;
+  class EndPathStatus;
 
   class EndPathStatusInserter : public global::EDProducer<> {
   public:
@@ -15,6 +17,8 @@ namespace edm {
     EndPathStatusInserter(unsigned int numberOfStreams);
 
     void produce(StreamID, Event&, EventSetup const&) const final;
+  private:
+    EDPutTokenT<EndPathStatus> token_;
   };
 }
 #endif

--- a/FWCore/Framework/src/EndPathStatusInserter.h
+++ b/FWCore/Framework/src/EndPathStatusInserter.h
@@ -14,7 +14,7 @@ namespace edm {
   class EndPathStatusInserter : public global::EDProducer<> {
   public:
 
-    EndPathStatusInserter(unsigned int numberOfStreams);
+    explicit EndPathStatusInserter(unsigned int numberOfStreams);
 
     void produce(StreamID, Event&, EventSetup const&) const final;
   private:

--- a/FWCore/Framework/src/PathStatusInserter.cc
+++ b/FWCore/Framework/src/PathStatusInserter.cc
@@ -8,9 +8,9 @@
 namespace edm
 {
   PathStatusInserter::PathStatusInserter(unsigned int numberOfStreams) :
-    hltPathStatus_(numberOfStreams)
+    hltPathStatus_(numberOfStreams),
+    token_{produces<HLTPathStatus>()}
   {
-    produces<HLTPathStatus>();
   }
 
   void
@@ -22,6 +22,6 @@ namespace edm
   void
   PathStatusInserter::produce(StreamID streamID, edm::Event& event, edm::EventSetup const&) const
   {
-    event.put(std::make_unique<HLTPathStatus>(hltPathStatus_[streamID.value()]));
+    event.emplace(token_,hltPathStatus_[streamID.value()]);
   }
 }

--- a/FWCore/Framework/src/PathStatusInserter.h
+++ b/FWCore/Framework/src/PathStatusInserter.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "DataFormats/Common/interface/HLTPathStatus.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
 #include <vector>
 
 namespace edm {
@@ -23,6 +24,7 @@ namespace edm {
   private:
 
     std::vector<HLTPathStatus> hltPathStatus_;
+    EDPutTokenT<HLTPathStatus> token_;
   };
 }
 #endif

--- a/FWCore/Framework/src/TriggerResultInserter.cc
+++ b/FWCore/Framework/src/TriggerResultInserter.cc
@@ -10,9 +10,9 @@ namespace edm
 {
   TriggerResultInserter::TriggerResultInserter(const ParameterSet& pset, unsigned int iNStreams) :
   resultsPerStream_(iNStreams),
-  pset_id_(pset.id())
+  pset_id_(pset.id()),
+  token_{produces<TriggerResults>()}
   {
-    produces<TriggerResults>();
   }
 
   void
@@ -22,6 +22,6 @@ namespace edm
 
   void TriggerResultInserter::produce(StreamID id, edm::Event& e, edm::EventSetup const&) const
   {
-    e.put(std::make_unique<TriggerResults>(*resultsPerStream_[id.value()], pset_id_));
+    e.emplace(token_,*resultsPerStream_[id.value()], pset_id_);
   }
 }

--- a/FWCore/Framework/src/TriggerResultInserter.h
+++ b/FWCore/Framework/src/TriggerResultInserter.h
@@ -26,6 +26,7 @@ namespace edm
   class Event;
   class EventSetup;
   class HLTGlobalStatus;
+  class TriggerResults;
 
   class TriggerResultInserter : public edm::global::EDProducer<>
   {
@@ -47,6 +48,7 @@ namespace edm
     std::vector<edm::propagate_const<TrigResPtr>> resultsPerStream_;
 
     ParameterSetID pset_id_;
+    EDPutTokenT<TriggerResults> token_;
   };
 }
 #endif

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -103,22 +103,20 @@ namespace edmtest {
   class IntProducer : public edm::stream::EDProducer<> {
   public:
     explicit IntProducer(edm::ParameterSet const& p) :
+      token_{produces<IntProduct>()},
       value_(p.getParameter<int>("ivalue")) {
-      produces<IntProduct>();
     }
-    explicit IntProducer(int i) : value_(i) {
-      produces<IntProduct>();
-    }
-    virtual void produce(edm::Event& e, edm::EventSetup const& c) override;
+    void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   private:
+    edm::EDPutTokenT<IntProduct> token_;
     int value_;
   };
 
   void
   IntProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
-    e.put(std::make_unique<IntProduct>(value_));
+    e.emplace(token_,value_);
   }
 
   //--------------------------------------------------------------------
@@ -154,15 +152,16 @@ namespace edmtest {
   class BusyWaitIntProducer : public edm::global::EDProducer<> {
   public:
     explicit BusyWaitIntProducer(edm::ParameterSet const& p) :
+    token_{produces<IntProduct>()},
     value_(p.getParameter<int>("ivalue")),
     iterations_(p.getParameter<unsigned int>("iterations")),
     pi_(std::acos(-1)){
-      produces<IntProduct>();
     }
 
     virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
     
   private:
+    const edm::EDPutTokenT<IntProduct> token_;
     const int value_;
     const unsigned int iterations_;
     const double pi_;
@@ -178,7 +177,7 @@ namespace edmtest {
       sum += stepSize*cos(i*stepSize);
     }
     
-    e.put(std::make_unique<IntProduct>(value_+sum));
+    e.emplace(token_,value_+sum);
   }
 
   //--------------------------------------------------------------------
@@ -187,15 +186,16 @@ namespace edmtest {
     explicit BusyWaitIntLimitedProducer(edm::ParameterSet const& p) :
     edm::limited::EDProducerBase(p),
     edm::limited::EDProducer<>(p),
+    token_{produces<IntProduct>()},
     value_(p.getParameter<int>("ivalue")),
     iterations_(p.getParameter<unsigned int>("iterations")),
     pi_(std::acos(-1)){
-      produces<IntProduct>();
     }
     
     virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
     
   private:
+    const edm::EDPutTokenT<IntProduct> token_;
     const int value_;
     const unsigned int iterations_;
     const double pi_;
@@ -217,7 +217,7 @@ namespace edmtest {
       sum += stepSize*cos(i*stepSize);
     }
     
-    e.put(std::make_unique<IntProduct>(value_+sum));
+    e.emplace(token_,value_+sum);
     --reentrancy_;
   }
   
@@ -257,28 +257,22 @@ namespace edmtest {
   class ConsumingIntProducer : public edm::stream::EDProducer<> {
   public:
     explicit ConsumingIntProducer(edm::ParameterSet const& p) :
+      token_{produces<IntProduct>()},
       value_(p.getParameter<int>("ivalue")) {
-      produces<IntProduct>();
       // not used, only exists to test PathAndConsumesOfModules
       consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"));
       consumesMany<edm::TriggerResults>();
     }
-    explicit ConsumingIntProducer(int i) : value_(i) {
-      produces<IntProduct>();
-      // not used, only exists to test PathAndConsumesOfModules
-      consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"));
-      consumesMany<edm::TriggerResults>();
-    }
-    virtual ~ConsumingIntProducer() {}
-    virtual void produce(edm::Event& e, edm::EventSetup const& c) override;
+    void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   private:
-    int value_;
+    const edm::EDPutTokenT<IntProduct> token_;
+    const int value_;
   };
 
   void
   ConsumingIntProducer::produce(edm::Event& e, edm::EventSetup const&) {
-    e.put(std::make_unique<IntProduct>(value_));
+    e.emplace(token_,value_);
   }
 
   //--------------------------------------------------------------------
@@ -288,21 +282,20 @@ namespace edmtest {
   //
   class EventNumberIntProducer : public edm::global::EDProducer<> {
   public:
-    explicit EventNumberIntProducer(edm::ParameterSet const&) {
-      produces<UInt64Product>();
-    }
-    EventNumberIntProducer() {
-      produces<UInt64Product>();
-    }
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    explicit EventNumberIntProducer(edm::ParameterSet const&) :
+    token_{produces<UInt64Product>()}
+    {}
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
 
   private:
+    const edm::EDPutTokenT<UInt64Product> token_;
+
   };
 
   void
   EventNumberIntProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
-    e.put(std::make_unique<UInt64Product>(e.id().event()));
+    e.emplace(token_,e.id().event());
   }
 
 
@@ -313,22 +306,20 @@ namespace edmtest {
   class TransientIntProducer : public edm::global::EDProducer<> {
   public:
     explicit TransientIntProducer(edm::ParameterSet const& p) :
+    token_{produces<TransientIntProduct>()},
       value_(p.getParameter<int>("ivalue")) {
-      produces<TransientIntProduct>();
     }
-    explicit TransientIntProducer(int i) : value_(i) {
-      produces<TransientIntProduct>();
-    }
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
 
   private:
-    int value_;
+    const edm::EDPutTokenT<TransientIntProduct> token_;
+    const int value_;
   };
 
   void
   TransientIntProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
-    e.put(std::make_unique<TransientIntProduct>(value_));
+    e.emplace(token_,value_);
   }
 
   //--------------------------------------------------------------------
@@ -337,26 +328,25 @@ namespace edmtest {
   //
   class IntProducerFromTransient : public edm::global::EDProducer<> {
   public:
-    explicit IntProducerFromTransient(edm::ParameterSet const&) {
-      produces<IntProduct>();
-      consumes<TransientIntProduct>(edm::InputTag{"TransientThing"});
+    explicit IntProducerFromTransient(edm::ParameterSet const&):
+    putToken_{produces<IntProduct>()},
+    getToken_{consumes<TransientIntProduct>(edm::InputTag{"TransientThing"})}
+    {
     }
-    explicit IntProducerFromTransient() {
-      produces<IntProduct>();
-    }
-    virtual ~IntProducerFromTransient() {}
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
 
   private:
+    const edm::EDPutTokenT<IntProduct> putToken_;
+    const edm::EDGetTokenT<TransientIntProduct> getToken_;
   };
 
   void
   IntProducerFromTransient::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
     edm::Handle<TransientIntProduct> result;
-    bool ok = e.getByLabel("TransientThing", result);
+    bool ok = e.getByToken(getToken_, result);
     assert(ok);
-    e.put(std::make_unique<IntProduct>(result.product()->value));
+    e.emplace(putToken_,result.product()->value);
   }
 
   //--------------------------------------------------------------------
@@ -366,22 +356,20 @@ namespace edmtest {
   class Int16_tProducer : public edm::global::EDProducer<> {
   public:
     explicit Int16_tProducer(edm::ParameterSet const& p) :
+      token_{produces<Int16_tProduct>()},
       value_(p.getParameter<int>("ivalue")) {
-      produces<Int16_tProduct>();
     }
-    explicit Int16_tProducer(boost::int16_t i, boost::uint16_t) : value_(i) {
-      produces<Int16_tProduct>();
-    }
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
 
   private:
+    const edm::EDPutTokenT<Int16_tProduct> token_;
     const boost::int16_t value_;
   };
 
   void
   Int16_tProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
-    e.put(std::make_unique<Int16_tProduct>(value_));
+    e.emplace(token_,value_);
   }
 
   //
@@ -391,11 +379,9 @@ namespace edmtest {
   class AddIntsProducer : public edm::global::EDProducer<> {
   public:
     explicit AddIntsProducer(edm::ParameterSet const& p) :
+      putToken_{produces<IntProduct>()},
+      otherPutToken_{produces<IntProduct>("other")},
       onlyGetOnEvent_(p.getUntrackedParameter<unsigned int>("onlyGetOnEvent", 0u)) {
-
-      produces<IntProduct>();
-      produces<IntProduct>("other");
-
       auto const& labels = p.getParameter<std::vector<std::string> >("labels");
       for( auto const& label: labels) {
         tokens_.emplace_back(consumes<IntProduct>(edm::InputTag{label}));
@@ -404,6 +390,8 @@ namespace edmtest {
     virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
   private:
     std::vector<edm::EDGetTokenT<IntProduct>> tokens_;
+    const edm::EDPutTokenT<IntProduct> putToken_;
+    const edm::EDPutTokenT<IntProduct> otherPutToken_;
     unsigned int onlyGetOnEvent_;
   };
 
@@ -419,8 +407,8 @@ namespace edmtest {
         value += anInt->value;
       }
     }
-    e.put(std::make_unique<IntProduct>(value));
-    e.put(std::make_unique<IntProduct>(value), "other");
+    e.emplace(putToken_,value);
+    e.emplace(otherPutToken_,value);
   }
 
 }

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -43,7 +43,7 @@ namespace edmtest {
     explicit FailingProducer(edm::ParameterSet const& /*p*/) {
       produces<IntProduct>();
     }
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
   };
 
   void
@@ -63,7 +63,7 @@ namespace edmtest {
     explicit FailingInRunProducer(edm::ParameterSet const& /*p*/) {
       produces<IntProduct,edm::Transition::BeginRun>();
     }
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
     
     void globalBeginRunProduce( edm::Run&, edm::EventSetup const&) const override;
 
@@ -88,7 +88,7 @@ namespace edmtest {
     explicit NonProducer(edm::ParameterSet const& /*p*/) {
       produces<IntProduct>();
     }
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
   };
 
   void
@@ -132,7 +132,7 @@ namespace edmtest {
     explicit IntLegacyProducer(int i) : value_(i) {
       produces<IntProduct>();
     }
-    virtual void produce(edm::Event& e, edm::EventSetup const& c) override;
+    void produce(edm::Event& e, edm::EventSetup const& c) override;
     
   private:
     int value_;
@@ -158,7 +158,7 @@ namespace edmtest {
     pi_(std::acos(-1)){
     }
 
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
     
   private:
     const edm::EDPutTokenT<IntProduct> token_;
@@ -192,7 +192,7 @@ namespace edmtest {
     pi_(std::acos(-1)){
     }
     
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
     
   private:
     const edm::EDPutTokenT<IntProduct> token_;
@@ -231,7 +231,7 @@ namespace edmtest {
       produces<IntProduct>();
     }
     
-    virtual void produce(edm::Event& e, edm::EventSetup const& c) override;
+    void produce(edm::Event& e, edm::EventSetup const& c) override;
     
   private:
     const int value_;
@@ -387,7 +387,7 @@ namespace edmtest {
         tokens_.emplace_back(consumes<IntProduct>(edm::InputTag{label}));
       }
     }
-    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
   private:
     std::vector<edm::EDGetTokenT<IntProduct>> tokens_;
     const edm::EDPutTokenT<IntProduct> putToken_;

--- a/FWCore/Modules/src/EventAuxiliaryHistoryProducer.cc
+++ b/FWCore/Modules/src/EventAuxiliaryHistoryProducer.cc
@@ -1,18 +1,18 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
 #include <deque>
 
 namespace edm {
 
-  class EventAuxiliaryHistoryProducer : public EDProducer {
+  class EventAuxiliaryHistoryProducer : public one::EDProducer<> {
   public:
     explicit EventAuxiliaryHistoryProducer(ParameterSet const&);
-    ~EventAuxiliaryHistoryProducer() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
     void produce(Event& e, EventSetup const& c) override;
@@ -20,16 +20,15 @@ namespace edm {
 
   private:
     unsigned int depth_;
-    std::deque<EventAuxiliary> history_; 
+    std::deque<EventAuxiliary> history_;
+    EDPutTokenT<std::vector<EventAuxiliary>> token_;
   };
 
   EventAuxiliaryHistoryProducer::EventAuxiliaryHistoryProducer(ParameterSet const& ps):
     depth_(ps.getParameter<unsigned int>("historyDepth")),
-    history_() {
-      produces<std::vector<EventAuxiliary> > ();
-  }
-
-  EventAuxiliaryHistoryProducer::~EventAuxiliaryHistoryProducer() {
+    history_(),
+    token_{produces<std::vector<EventAuxiliary> > ()}
+  {
   }
 
   void EventAuxiliaryHistoryProducer::produce(Event& e, EventSetup const&) {
@@ -43,12 +42,7 @@ namespace edm {
 
     history_.push_back(aux);
 
-    //Serialize into std::vector 
-    auto result = std::make_unique<std::vector<EventAuxiliary>>();
-    for(size_t j = 0; j < history_.size(); ++j) { 
-      result->push_back(history_[j]);
-    }
-    e.put(std::move(result));
+    e.emplace(token_,history_.begin(), history_.end());
   }
 
   void EventAuxiliaryHistoryProducer::endJob() {

--- a/FWCore/Modules/src/TimeStudyModules.cc
+++ b/FWCore/Modules/src/TimeStudyModules.cc
@@ -29,6 +29,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/ServiceRegistry/interface/SystemBounds.h"
@@ -84,17 +85,18 @@ class SleepingProducer : public edm::global::EDProducer<> {
 public:
   explicit SleepingProducer(edm::ParameterSet const& p) :
   value_(p.getParameter<int>("ivalue")),
-  sleeper_(p, consumesCollector())
+  sleeper_(p, consumesCollector()),
+  token_{produces<int>()}
   {
-    produces<int>();
   }
   void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   
 private:
-  int value_;
+  const int value_;
   Sleeper sleeper_;
+  const edm::EDPutTokenT<int> token_;
 };
 
 void
@@ -102,7 +104,7 @@ SleepingProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) 
   // EventSetup is not used.
   sleeper_.getAndSleep(e);
   
-  e.put(std::make_unique<int>(value_));
+  e.emplace(token_,value_);
 }
   
 void
@@ -119,9 +121,9 @@ SleepingProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions
   public:
     explicit OneSleepingProducer(edm::ParameterSet const& p) :
     value_(p.getParameter<int>("ivalue")),
-    sleeper_(p, consumesCollector())
+    sleeper_(p, consumesCollector()),
+    token_{produces<int>()}
     {
-      produces<int>();
       usesResource(p.getParameter<std::string>("resource"));
     }
     void produce( edm::Event& e, edm::EventSetup const& c) override;
@@ -129,8 +131,9 @@ SleepingProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     
   private:
-    int value_;
+    const int value_;
     Sleeper sleeper_;
+    const edm::EDPutTokenT<int> token_;
   };
   
   void
@@ -138,7 +141,7 @@ SleepingProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions
     // EventSetup is not used.
     sleeper_.getAndSleep(e);
     
-    e.put(std::make_unique<int>(value_));
+    e.emplace(token_,value_);
   }
   
   void
@@ -296,7 +299,8 @@ SleepingProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions
   public:
     explicit ExternalWorkSleepingProducer(edm::ParameterSet const& p) :
     value_(p.getParameter<int>("ivalue")),
-    sleeper_(p, consumesCollector())
+    sleeper_(p, consumesCollector()),
+    token_{produces<int>()}
     {
       {
         auto const& tv = p.getParameter<std::vector<double>>("serviceInitTimes");
@@ -321,8 +325,6 @@ SleepingProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions
       }
       assert(finishTimes_.size() == initTimes_.size());
       assert(workTimes_.size() == initTimes_.size());
-
-      produces<int>();
     }
     void acquire(edm::StreamID, edm::Event const & e, edm::EventSetup const& c, edm::WaitingTaskWithArenaHolder holder) const override;
 
@@ -336,6 +338,7 @@ SleepingProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions
     std::vector<long> finishTimes_;
     int value_;
     Sleeper sleeper_;
+    const edm::EDPutTokenT<int> token_;
   };
 
   void
@@ -349,7 +352,7 @@ SleepingProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions
 
   void
   ExternalWorkSleepingProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
-    e.put(std::make_unique<int>(value_));
+    e.emplace(token_,value_);
   }
   
   void

--- a/FWCore/Modules/src/TimeStudyModules.cc
+++ b/FWCore/Modules/src/TimeStudyModules.cc
@@ -166,7 +166,6 @@ SleepingProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     
   private:
-    int value_;
     Sleeper sleeper_;
   };
   
@@ -336,7 +335,7 @@ SleepingProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions
     std::vector<long> initTimes_;
     std::vector<long> workTimes_;
     std::vector<long> finishTimes_;
-    int value_;
+    const int value_;
     Sleeper sleeper_;
     const edm::EDPutTokenT<int> token_;
   };


### PR DESCRIPTION
Changed many of the modules used in the Framework or for tests to use emplace instead of put when putting a data product into the Event, LuminosityBlock or Run.