### PR TITLE
Avoid seg fault if Herwig7Hadronizer only sees Run transitions

### DIFF
--- a/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
+++ b/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
@@ -106,9 +106,11 @@ bool Herwig7Hadronizer::declareStableParticles(const std::vector<int> &pdgIds)
 
 void Herwig7Hadronizer::statistics()
 {
+  if(eg_) {
 	runInfo().setInternalXSec(GenRunInfoProduct::XSec(
 		eg_->integratedXSec() / ThePEG::picobarn,
 		eg_->integratedXSecErr() / ThePEG::picobarn));
+  }
 }
 
 bool Herwig7Hadronizer::generatePartonsAndHadronize()


### PR DESCRIPTION
Protect against the case where eg_ is not set because only
beginRun/endRun transitions have been seen.