### PR TITLE
Avoid const_cast in operator<<(cms::Exception, ...)

### DIFF
--- a/FWCore/Utilities/interface/Exception.h
+++ b/FWCore/Utilities/interface/Exception.h
@@ -147,34 +147,19 @@ namespace cms {
 
     template <typename E, typename T>
     friend
-    typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type &
-    operator<<(E& e, T const& stuff);
-
-    template <typename E, typename T>
-    friend
-    typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type const&
-    operator<<(E const& e, T const& stuff);
+    typename detail::Desired<E, detail::is_derived_or_same<Exception,std::remove_reference_t<E>>::value>::type &
+    operator<<(E&& e, T const& stuff);
 
     template <typename E>
     friend
-    typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type &
-    operator<<(E& e, std::ostream&(*f)(std::ostream&));
-
-    template <typename E>
-    friend
-    typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type const&
-    operator<<(E const& e, std::ostream&(*f)(std::ostream&));
+    typename detail::Desired<E, detail::is_derived_or_same<Exception,std::remove_reference_t<E>>::value>::type &
+    operator<<(E&& e, std::ostream&(*f)(std::ostream&));
 
   
     template <typename E>
     friend
-    typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type &
-    operator<<(E& e, std::ios_base&(*f)(std::ios_base&));
-
-    template <typename E>
-    friend
-    typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type const&
-    operator<<(E const& e, std::ios_base&(*f)(std::ios_base&));
+    typename detail::Desired<E, detail::is_derived_or_same<Exception,std::remove_reference_t<E>>::value>::type &
+    operator<<(E&& e, std::ios_base&(*f)(std::ios_base&));
 
     // The following two function templates should be included, to help
     // reduce the number of function templates instantiated. However,
@@ -224,61 +209,31 @@ namespace cms {
 
   template <typename E, typename T>
   inline
-  typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type &
-  operator<<(E& e, T const& stuff)
+  typename detail::Desired<E, detail::is_derived_or_same<Exception,std::remove_reference_t<E>>::value>::type &
+  operator<<(E&& e, T const& stuff)
   {
     e.ost_ << stuff;
     return e;
   }
 
-  template <typename E, typename T>
-  inline
-  typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type const&
-  operator<<(E const& e, T const& stuff)
-  {
-    E& ref = const_cast<E&>(e);
-    ref.ost_ << stuff;
-    return e;
-  }
-
   template <typename E>
   inline 
-  typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type &
-  operator<<(E& e, std::ostream&(*f)(std::ostream&))
+  typename detail::Desired<E, detail::is_derived_or_same<Exception,std::remove_reference_t<E>>::value>::type &
+  operator<<(E&& e, std::ostream&(*f)(std::ostream&))
   {
     f(e.ost_);
     return e;
   }
 
   template <typename E>
-  inline 
-  typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type const&
-  operator<<(E const& e, std::ostream&(*f)(std::ostream&))
-  {
-    E& ref = const_cast<E&>(e);
-    f(ref.ost_);
-    return e;
-  }
-  
-  template <typename E>
   inline
-  typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type & 
-  operator<<(E& e, std::ios_base&(*f)(std::ios_base&))
+  typename detail::Desired<E, detail::is_derived_or_same<Exception,std::remove_reference_t<E>>::value>::type &
+  operator<<(E&& e, std::ios_base&(*f)(std::ios_base&))
   {
     f(e.ost_);
     return e;
   }
 
-
-  template <typename E>
-  inline
-  typename detail::Desired<E, detail::is_derived_or_same<Exception,E>::value>::type const& 
-  operator<<(E const& e, std::ios_base&(*f)(std::ios_base&))
-  {
-    E& ref = const_cast<E&>(e);
-    f(ref.ost_);
-    return e;
-  }
 
   // The following four function templates should be included, to help
   // reduce the number of function templates instantiated. However,


### PR DESCRIPTION
While looking at the static analyzer warnings of some code that I recently modified, I noticed that there are quite some from calling `operator<<` with a temporary `cms::Exception`. This picks the by-const-ref overload, which casts the const away (causing the warning) and calls the non-const version - I guess it is actually there only because the non-const version cannot be used on a temporary `cms::Exception`.
Using a universal reference instead should work for both (non-const) lvalue and rvalue references, I think, hence this PR, but please someone more expert on C++ check if the changes make sense.