### PR TITLE
Fixed confusing naming scheme of Pixel template reco (2D vs. 3D)

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -49,7 +49,7 @@ public:
       
       // 2D fit stuff.
       float templProbXY_ ;
-      bool  recommended3D_ ;
+      bool  recommended2D_ ;
       int   ierr2;
    };
    
@@ -70,13 +70,13 @@ private:
    // Helper functions: 
 
    // Call vanilla template reco, then clean-up
-   void callTempReco2D( DetParam const & theDetParam, 
+   void callTempReco1D( DetParam const & theDetParam, 
 			ClusterParamTemplate & theClusterParam, 
 			SiPixelTemplateReco::ClusMatrix & clusterPayload,
 			int ID, LocalPoint & lp ) const;
 
    // Call 2D template reco, then clean-up
-   void callTempReco3D( DetParam const & theDetParam, 
+   void callTempReco2D( DetParam const & theDetParam, 
 			ClusterParamTemplate & theClusterParam, 
 			SiPixelTemplateReco2D::ClusMatrix & clusterPayload,
 			int ID, LocalPoint & lp ) const;
@@ -95,7 +95,7 @@ private:
    int forwardTemplateID_ ;
    std::string templateDir_ ;
 
-   // Configure 3D reco.
+   // Configure 2D reco.
    float minProbY_ ;
    int   maxSizeMismatchInY_ ;
    

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
@@ -80,23 +80,23 @@ namespace SiPixelTemplateReco {
    };
 #endif
    
-   int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
+   int PixelTempReco1D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
                        SiPixelTemplate& templ,
                        float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed, bool deadpix,
                        std::vector<std::pair<int, int> >& zeropix,
                        float& probQ, int& nypix, int& nxpix);
    
-   int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
+   int PixelTempReco1D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
                        SiPixelTemplate& templ,
                        float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed,
                        float& probQ);
 		 
-   int PixelTempReco2D(int id, float cotalpha, float cotbeta, ClusMatrix & cluster,
+   int PixelTempReco1D(int id, float cotalpha, float cotbeta, ClusMatrix & cluster,
                        SiPixelTemplate& templ,
                        float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed,
                        float& probQ);
    
-   int PixelTempReco2D(int id, float cotalpha, float cotbeta, ClusMatrix & cluster,
+   int PixelTempReco1D(int id, float cotalpha, float cotbeta, ClusMatrix & cluster,
                        SiPixelTemplate& templ, 
                        float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed);
 }

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
@@ -45,11 +45,11 @@ namespace SiPixelTemplateReco2D {
    };
 #endif
    
-   int PixelTempReco3D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy, int edgeflagx,
+   int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy, int edgeflagx,
                        ClusMatrix & cluster, SiPixelTemplate2D& templ,
                        float& yrec, float& sigmay, float& xrec, float& sigmax, float& probxy, float& probQ, int& qbin, float& deltay, int& npixel);
    
-   int PixelTempReco3D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy, int edgeflagx,
+   int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy, int edgeflagx,
                        ClusMatrix & cluster, SiPixelTemplate2D& templ,
                        float& yrec, float& sigmay, float& xrec, float& sigmax, float& probxy, float& probQ, int& qbin, float& deltay);
    

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -87,7 +87,7 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
    UseClusterSplitter_ = conf.getParameter<bool>("UseClusterSplitter");   
 
 
-   //--- Configure 3D reco.
+   //--- Configure 2D reco.
    if ( conf.exists("MinProbY") )
      minProbY_ = conf.getParameter<double>("MinProbY");
    else
@@ -241,15 +241,15 @@ PixelCPEClusterRepair::localPosition(DetParam const & theDetParam, ClusterParam 
    if ( theClusterParam.isOnEdge_ ) {
      //--- Call the Template Reco 2d with cluster repair.0
      filled_from_2d = true;
-     callTempReco3D( theDetParam, theClusterParam, clusterPayload2d, ID, lp );
+     callTempReco2D( theDetParam, theClusterParam, clusterPayload2d, ID, lp );
    }
    else {
-     theClusterParam.recommended3D_ = false;
+     theClusterParam.recommended2D_ = false;
      //--- Call the vanilla Template Reco
-     callTempReco2D( theDetParam, theClusterParam, clusterPayload, ID, lp );
+     callTempReco1D( theDetParam, theClusterParam, clusterPayload, ID, lp );
 
      //--- Did we find a cluster which has bad probability and not enough charge?
-     if ( theClusterParam.recommended3D_ ) {
+     if ( theClusterParam.recommended2D_ ) {
        //--- Yes. So run Template Reco 2d with cluster repair.
        
        // //--- Once again (!) copy clust's pixels (calibrated in electrons) into 
@@ -268,7 +268,7 @@ PixelCPEClusterRepair::localPosition(DetParam const & theDetParam, ClusterParam 
        
 
        //--- Call the Template Reco 2d with cluster repair
-       callTempReco3D( theDetParam, theClusterParam, clusterPayload2d, ID, lp );
+       callTempReco2D( theDetParam, theClusterParam, clusterPayload2d, ID, lp );
        filled_from_2d = true;
      }
 
@@ -302,7 +302,7 @@ PixelCPEClusterRepair::localPosition(DetParam const & theDetParam, ClusterParam 
 //  Helper function to aggregate call & handling of Template Reco
 //------------------------------------------------------------------
 void 
-PixelCPEClusterRepair::callTempReco2D( DetParam const & theDetParam, 
+PixelCPEClusterRepair::callTempReco1D( DetParam const & theDetParam, 
 				       ClusterParamTemplate & theClusterParam,
 				       SiPixelTemplateReco::ClusMatrix & clusterPayload,
 				       int ID, LocalPoint & lp ) const
@@ -329,7 +329,7 @@ PixelCPEClusterRepair::callTempReco2D( DetParam const & theDetParam,
    int nypix =0, nxpix = 0;
    //
    theClusterParam.ierr =
-   PixelTempReco2D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
+   PixelTempReco1D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
                    locBz, locBx,
                    clusterPayload,
                    templ,
@@ -352,7 +352,7 @@ PixelCPEClusterRepair::callTempReco2D( DetParam const & theDetParam,
       
       // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
       // In the x case, apply a rough Lorentz drift average correction
-      // To do: call PixelCPEGeneric whenever PixelTempReco2D fails
+      // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
       float lorentz_drift = -999.9;
       if ( ! GeomDetEnumerators::isEndcap(theDetParam.thePart) )
          lorentz_drift = 60.0f; // in microns
@@ -381,7 +381,7 @@ PixelCPEClusterRepair::callTempReco2D( DetParam const & theDetParam,
 
       //--- templ.clsleny() is the expected length of the cluster along y axis.
       if ( (theClusterParam.probabilityY_ < minProbY_ ) && (templ.clsleny() - nypix > 1) ) {
-	theClusterParam.recommended3D_ = true;
+	theClusterParam.recommended2D_ = true;
       }
       
       //--- Go from microns to centimeters
@@ -403,7 +403,7 @@ PixelCPEClusterRepair::callTempReco2D( DetParam const & theDetParam,
 //  Helper function to aggregate call & handling of Template 2D fit
 //------------------------------------------------------------------
 void 
-PixelCPEClusterRepair::callTempReco3D( DetParam const & theDetParam, 
+PixelCPEClusterRepair::callTempReco2D( DetParam const & theDetParam, 
 				       ClusterParamTemplate & theClusterParam,
 				       SiPixelTemplateReco2D::ClusMatrix & clusterPayload,
 				       int ID, LocalPoint & lp ) const
@@ -439,9 +439,9 @@ PixelCPEClusterRepair::callTempReco3D( DetParam const & theDetParam,
    //   npixels - ???     &&& Ask Morris
 
    float edgeTypeY = theClusterParam.edgeTypeY_ ;  // the default, from PixelCPEBase
-   if ( theClusterParam.recommended3D_ ) {
+   if ( theClusterParam.recommended2D_ ) {
      //  Cluster is not on edge, but instead the normal TemplateReco discovered that it is
-     //  shorter than expected.  So let the 3D algorithm try extending it on both sides, in case
+     //  shorter than expected.  So let the 2D algorithm try extending it on both sides, in case
      //  there is a dead double-column on either side.  (We don't know which.)
      edgeTypeY = 3;
    }
@@ -457,7 +457,7 @@ PixelCPEClusterRepair::callTempReco3D( DetParam const & theDetParam,
    }
    else{
        theClusterParam.ierr2 =
-       PixelTempReco3D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
+       PixelTempReco2D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
                        locBz, locBx,
                        edgeTypeY , theClusterParam.edgeTypeX_ ,
                        clusterPayload,
@@ -476,7 +476,7 @@ PixelCPEClusterRepair::callTempReco3D( DetParam const & theDetParam,
    if UNLIKELY( theClusterParam.ierr2 != 0 )
    {
       LogDebug("PixelCPEClusterRepair::localPosition") <<
-      "3D reconstruction failed with error " << theClusterParam.ierr2 << "\n";
+      "2D reconstruction failed with error " << theClusterParam.ierr2 << "\n";
       
       theClusterParam.probabilityX_ = theClusterParam.probabilityY_ = theClusterParam.probabilityQ_ = 0.f;
       theClusterParam.qBin_ = 0;
@@ -555,7 +555,7 @@ PixelCPEClusterRepair::localError(DetParam const & theDetParam,  ClusterParam & 
        }
    }
    // Leave commented for now, until we study the interplay of failure modes
-   // of 1D template reco and edges.  For edge hits we run 3D reco by default!
+   // of 1D template reco and edges.  For edge hits we run 2D reco by default!
    //
    // else if ( theClusterParam.edgeTypeX_ || theClusterParam.edgeTypeY_ )  {
    //   // for edge pixels assign errors according to observed residual RMS

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -156,8 +156,8 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
    int col_offset = theClusterParam.theCluster->minPixelCol();
    
    // Store the coordinates of the center of the (0,0) pixel of the array that
-   // gets passed to PixelTempReco2D
-   // Will add these values to the output of  PixelTempReco2D
+   // gets passed to PixelTempReco1D
+   // Will add these values to the output of  PixelTempReco1D
    float tmp_x = float(row_offset) + 0.5f;
    float tmp_y = float(col_offset) + 0.5f;
    
@@ -243,7 +243,7 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
    float locBx = theDetParam.bx;
    
    theClusterParam.ierr =
-   PixelTempReco2D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
+   PixelTempReco1D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
                    locBz, locBx,
                    clusterPayload,
                    templ,
@@ -264,7 +264,7 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
       
       // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
       // In the x case, apply a rough Lorentz drift average correction
-      // To do: call PixelCPEGeneric whenever PixelTempReco2D fails
+      // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
       float lorentz_drift = -999.9;
       if ( !fpix )
          lorentz_drift = 60.0f; // in microns
@@ -329,7 +329,7 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
          
          // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
          // In the x case, apply a rough Lorentz drift average correction
-         // To do: call PixelCPEGeneric whenever PixelTempReco2D fails
+         // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
          float lorentz_drift = -999.9f;
          if ( !fpix )
             lorentz_drift = 60.0f; // in microns

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -131,7 +131,7 @@ using namespace SiPixelTemplateReco;
 //! \param      nypix - (output) the projected y-size of the cluster
 //! \param      nxpix - (output) the projected x-size of the cluster
 // *************************************************************************************************************************************
-int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
+int SiPixelTemplateReco::PixelTempReco1D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
                                          SiPixelTemplate& templ,
                                          float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed, bool deadpix, std::vector<std::pair<int, int> >& zeropix,
                                          float& probQ, int& nypix, int& nxpix)
@@ -555,7 +555,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
    
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
    if(speed < 0 || speed > 3) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplateReco::PixelTempReco2D called with illegal speed = " << speed << std::endl;
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplateReco::PixelTempReco1D called with illegal speed = " << speed << std::endl;
    }
 #else
    assert(speed >= 0 && speed < 4);
@@ -989,7 +989,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
    }
    
    return 0;
-} // PixelTempReco2D
+} // PixelTempReco1D
 
 // *************************************************************************************************************************************
 //  Overload parameter list for compatibility with older versions
@@ -1025,7 +1025,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 //!                      4       fastest w/ Q prob, searches same range as 1 but at 1/4 density (no big pix) and 1/2 density (big pix in cluster), calculates Q probability
 //! \param      probQ - (output) the Vavilov-distribution-based cluster charge probability
 // *************************************************************************************************************************************
-int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
+int SiPixelTemplateReco::PixelTempReco1D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
                                          SiPixelTemplate& templ,
                                          float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed,
                                          float& probQ)
@@ -1036,10 +1036,10 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
    std::vector<std::pair<int, int> > zeropix;
    int nypix, nxpix;
    
-   return SiPixelTemplateReco::PixelTempReco2D(id, cotalpha, cotbeta, locBz, locBx, cluster, templ,
+   return SiPixelTemplateReco::PixelTempReco1D(id, cotalpha, cotbeta, locBz, locBx, cluster, templ,
                                                yrec, sigmay, proby, xrec, sigmax, probx, qbin, speed, deadpix, zeropix, probQ, nypix, nxpix);
    
-} // PixelTempReco2D
+} // PixelTempReco1D
 
 
 // *************************************************************************************************************************************
@@ -1070,7 +1070,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 //!                      4       fastest w/ Q prob, searches same range as 1 but at 1/4 density (no big pix) and 1/2 density (big pix in cluster), calculates Q probability
 //! \param      probQ - (output) the Vavilov-distribution-based cluster charge probability
 // *************************************************************************************************************************************
-int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, ClusMatrix& cluster,
+int SiPixelTemplateReco::PixelTempReco1D(int id, float cotalpha, float cotbeta, ClusMatrix& cluster,
                                          SiPixelTemplate& templ,
                                          float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed,
                                          float& probQ)
@@ -1086,10 +1086,10 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
    locBz = locBx;
    if(cotalpha < 0.f) {locBz = -locBx;}
    
-   return SiPixelTemplateReco::PixelTempReco2D(id, cotalpha, cotbeta, locBz, locBx, cluster, templ,
+   return SiPixelTemplateReco::PixelTempReco1D(id, cotalpha, cotbeta, locBz, locBx, cluster, templ,
                                                yrec, sigmay, proby, xrec, sigmax, probx, qbin, speed, deadpix, zeropix, probQ, nypix, nxpix);
    
-} // PixelTempReco2D
+} // PixelTempReco1D
 
 
 // *************************************************************************************************************************************
@@ -1117,7 +1117,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
 //!                      2       faster yet, searches same range as 1 but at 1/2 density
 //!                      3       fastest, searches same range as 1 but at 1/4 density (no big pix) and 1/2 density (big pix in cluster)
 // *************************************************************************************************************************************
-int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, ClusMatrix & cluster, 
+int SiPixelTemplateReco::PixelTempReco1D(int id, float cotalpha, float cotbeta, ClusMatrix & cluster, 
                                          SiPixelTemplate& templ, 
                                          float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed)
 
@@ -1135,7 +1135,7 @@ int SiPixelTemplateReco::PixelTempReco2D(int id, float cotalpha, float cotbeta, 
    if(speed < 0) speed = 0;
    if(speed > 3) speed = 3;
    
-   return SiPixelTemplateReco::PixelTempReco2D(id, cotalpha, cotbeta, locBz, locBx, cluster, templ, 
+   return SiPixelTemplateReco::PixelTempReco1D(id, cotalpha, cotbeta, locBz, locBx, cluster, templ, 
                                                yrec, sigmay, proby, xrec, sigmax, probx, qbin, speed, deadpix, zeropix, probQ, nypix, nxpix);
    
-} // PixelTempReco2D
+} // PixelTempReco1D

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
@@ -78,7 +78,7 @@ using namespace SiPixelTemplateReco2D;
 //!                              3 0.85 > Q/Q_avg > min1  [~30% of all hits]
 //! \param     deltay - (output) template y-length - cluster length [when > 0, possibly missing end]
 // *************************************************************************************************************************************
-int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy, int edgeflagx,
+int SiPixelTemplateReco2D::PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy, int edgeflagx,
                                            ClusMatrix & cluster, SiPixelTemplate2D& templ2D,float& yrec, float& sigmay,
                                            float& xrec, float& sigmax, float& probxy, float& probQ, int& qbin, float& deltay, int& npixels)
 
@@ -299,9 +299,9 @@ int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta
          break;
       default:
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-         throw cms::Exception("DataCorrupt") << "PixelTemplateReco3D::illegal edgeflagy = " << edgeflagy << std::endl;
+         throw cms::Exception("DataCorrupt") << "PixelTemplateReco2D::illegal edgeflagy = " << edgeflagy << std::endl;
 #else
-         std::cout << "PixelTemplate:3D:illegal edgeflagy = " << edgeflagy << std::endl;
+         std::cout << "PixelTemplate:2D:illegal edgeflagy = " << edgeflagy << std::endl;
 #endif
    }
    
@@ -318,9 +318,9 @@ int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta
          break;
       default:
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-         throw cms::Exception("DataCorrupt") << "PixelTemplateReco3D::illegal edgeflagx = " << edgeflagx << std::endl;
+         throw cms::Exception("DataCorrupt") << "PixelTemplateReco2D::illegal edgeflagx = " << edgeflagx << std::endl;
 #else
-         std::cout << "PixelTemplate:3D:illegal edgeflagx = " << edgeflagx << std::endl;
+         std::cout << "PixelTemplate:2D:illegal edgeflagx = " << edgeflagx << std::endl;
 #endif
    }
    
@@ -644,13 +644,13 @@ int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta
    return 0;
 } // PixelTempReco2D
 
-int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy,
+int SiPixelTemplateReco2D::PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy,
                                            int edgeflagx, ClusMatrix & cluster, SiPixelTemplate2D& templ2D,float& yrec, float& sigmay, float& xrec, float& sigmax,
                                            float& probxy, float& probQ, int& qbin, float& deltay)
 
 {
    // Local variables
    int npixels;
-   return SiPixelTemplateReco2D::PixelTempReco3D(id, cotalpha, cotbeta, locBz, locBx, edgeflagy, edgeflagx, cluster,
+   return SiPixelTemplateReco2D::PixelTempReco2D(id, cotalpha, cotbeta, locBz, locBx, edgeflagy, edgeflagx, cluster,
                                                  templ2D, yrec, sigmay, xrec, sigmax, probxy, probQ, qbin, deltay, npixels);
 } // PixelTempReco2D


### PR DESCRIPTION
This is the first of a couple planned PR's attempting to cleanup the pixel code. 

This fixes the terrible naming scheme we had where the regular 1D reco was called 2D in the code of certain files and the new 2D reco was called 3D. This also didn't match the filenames which had the correct 1D and 2D names. This change is purely cosmetic, it does not change any functionality. 

The changes have been tested on small local pixeltree jobs to ensure that the output is exactly the same.

@pmaksim1  @perrotta @slava77 @fabiocos @makortel @tvami @tsusa @cmantill @schuetzepaul