### PR TITLE
SiStrip 10bit ZS packer bug fix: assume 10bit instead of 8bit-truncated digis

### DIFF
--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -108,6 +108,11 @@ namespace sistrip {
 				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
 				     std::unique_ptr<FEDRawDataCollection>& buffers,
 				     bool zeroSuppressed) {
+    const bool dataIsAlready8BitTruncated = zeroSuppressed && ( ! ( // not for 10bit modes
+             ( ( mode_ == READOUT_MODE_ZERO_SUPPRESSED ) && ( packetCode_ == PACKET_CODE_ZERO_SUPPRESSED10 ) )
+          || ( mode_ == READOUT_MODE_ZERO_SUPPRESSED_LITE10 )
+          || ( mode_ == READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE )
+          ) );
     try {
       
       //set the L1ID to use in the buffers
@@ -224,7 +229,7 @@ namespace sistrip {
           //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
           //zeroSuppressed here means converted to 8 bit...
           if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
-          FEDStripData fedData(zeroSuppressed);
+          FEDStripData fedData(dataIsAlready8BitTruncated);
           
           
           for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {
@@ -335,7 +340,7 @@ namespace sistrip {
           //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
           //zeroSuppressed here means converted to 8 bit...
           if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
-          FEDStripData fedData(zeroSuppressed);
+          FEDStripData fedData(dataIsAlready8BitTruncated);
           
           
           for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -108,8 +108,11 @@ namespace sistrip {
 				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
 				     std::unique_ptr<FEDRawDataCollection>& buffers,
 				     bool zeroSuppressed) {
-    const bool dataIsAlready8BitTruncated = zeroSuppressed && ( ! ( // not for 10bit modes
-             ( ( mode_ == READOUT_MODE_ZERO_SUPPRESSED ) && ( packetCode_ == PACKET_CODE_ZERO_SUPPRESSED10 ) )
+    const bool dataIsAlready8BitTruncated = zeroSuppressed && ( ! (
+          //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
+             ( mode_ == READOUT_MODE_PREMIX_RAW )
+          // the same goes for 10bit ZS modes
+          || ( ( mode_ == READOUT_MODE_ZERO_SUPPRESSED ) && ( packetCode_ == PACKET_CODE_ZERO_SUPPRESSED10 ) )
           || ( mode_ == READOUT_MODE_ZERO_SUPPRESSED_LITE10 )
           || ( mode_ == READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE )
           ) );
@@ -226,9 +229,6 @@ namespace sistrip {
 	  }
           auto conns = cabling->fedConnections(*ifed);
           
-          //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
-          //zeroSuppressed here means converted to 8 bit...
-          if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
           FEDStripData fedData(dataIsAlready8BitTruncated);
           
           
@@ -337,9 +337,6 @@ namespace sistrip {
           
           auto conns = cabling->fedConnections(*ifed);
           
-          //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
-          //zeroSuppressed here means converted to 8 bit...
-          if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
           FEDStripData fedData(dataIsAlready8BitTruncated);
           
           


### PR DESCRIPTION
This change fixes a bug found by @CesarBernardes in https://github.com/cms-sw/cmssw/pull/23417 (which introduced the 10bit zero-suppressed modes in SiStripDigiToRaw): for the 10bit ZS modes the input digis were wrongly assumed to be 8bit-truncated (as is the case for the other ZS modes), which goes wrong in [`sistrip::FEDStripData::ChannelData::get10BitSample`](https://github.com/cms-sw/cmssw/blob/905af02d3369428df677c232537da6fca8982ff3/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h#L250).
No changes to any standard workflows are expected since the 10bit ZS modes are not used yet.

CC: @icali @abaty @mmusich @echabert @boudoul @erikbutz