### PR TITLE
DAQ file broker client (10_3_X)

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -123,7 +123,7 @@ namespace evf{
       void unlockFULocal2();
       void createBoLSFile(const uint32_t lumiSection, bool checkIfExists) const;
       void createLumiSectionFiles(const uint32_t lumiSection, const uint32_t currentLumiSection, bool doCreateBoLS = true) const;
-      int grabNextJsonFile(boost::filesystem::path const& jsonSourcePath, boost::filesystem::path const& rawSourcePath, int64_t& fileSizeFromJson,bool unlock=true);
+      int grabNextJsonFile(boost::filesystem::path const& jsonSourcePath, boost::filesystem::path const& rawSourcePath, int64_t& fileSizeFromJson, bool& fileFound, bool unlock=true);
 
       EvFDaqDirector::FileStatus contactFileService(unsigned int& serverHttpStatus, bool& serverState,
                                                 uint32_t& serverLS, uint32_t& closedServerLS,

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -123,7 +123,7 @@ namespace evf{
       void unlockFULocal2();
       void createBoLSFile(const uint32_t lumiSection, bool checkIfExists) const;
       void createLumiSectionFiles(const uint32_t lumiSection, const uint32_t currentLumiSection, bool doCreateBoLS = true) const;
-      int grabNextJsonFile(boost::filesystem::path const& jsonSourcePath, boost::filesystem::path const& rawSourcePath, int64_t& fileSizeFromJson);
+      int grabNextJsonFile(boost::filesystem::path const& jsonSourcePath, boost::filesystem::path const& rawSourcePath, int64_t& fileSizeFromJson,bool unlock=true);
 
       EvFDaqDirector::FileStatus contactFileService(unsigned int& serverHttpStatus, bool& serverState,
                                                 uint32_t& serverLS, uint32_t& closedServerLS,

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -134,6 +134,7 @@ namespace evf{
       void createRunOpendirMaybe();
       void createProcessingNotificationMaybe() const;
       int readLastLSEntry(std::string const& file);
+      unsigned int getLumisectionToStart() const;
       void setDeleteTracking( std::mutex* fileDeleteLock,std::list<std::pair<int,InputFile*>> *filesToDelete) {
         fileDeleteLockPtr_=fileDeleteLock;
         filesToDeletePtr_ = filesToDelete;
@@ -162,6 +163,7 @@ namespace evf{
       bool useFileService_;
       std::string fileServiceHost_;
       std::string fileServicePort_;
+      unsigned int startFromLS_ = 1;
       bool outputAdler32Recheck_;
       bool requireTSPSet_;
       std::string selectedTransferMode_;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -26,6 +26,7 @@
 #include <cstdio>
 
 #include <tbb/concurrent_hash_map.h>
+#include <boost/filesystem.hpp>
 
 class SystemBounds;
 class GlobalContext;
@@ -41,6 +42,10 @@ namespace edm {
 
 namespace Json{
   class Value;
+}
+
+namespace jsoncollector {
+class DataPointDefinition;
 }
 
 namespace edm {
@@ -72,6 +77,7 @@ namespace evf{
       std::string &baseRunDir(){return run_dir_;}
       std::string &buBaseRunDir(){return bu_run_dir_;}
       std::string &buBaseRunOpenDir(){return bu_run_open_dir_;}
+      bool useFileService() const {return useFileService_;}
 
       std::string findCurrentRunDir(){ return dirManager_.findRunDir(run_);}
       std::string getInputJsonFilePath(const unsigned int ls, const unsigned int index) const;
@@ -97,6 +103,7 @@ namespace evf{
       std::string getBoLSFilePathOnFU(const unsigned int ls) const;
       std::string getEoRFilePath() const;
       std::string getEoRFilePathOnFU() const;
+      std::string getFFFParamsFilePathOnBU() const;
       std::string getRunOpenDirPath() const {return run_dir_ +"/open";}
       bool outputAdler32Recheck() const {return outputAdler32Recheck_;}
       void removeFile(unsigned int ls, unsigned int index);
@@ -113,6 +120,11 @@ namespace evf{
       void unlockFULocal();
       void lockFULocal2();
       void unlockFULocal2();
+      void createBoLSFile(const uint32_t lumiSection, bool checkIfExists) const;
+      void createLumiSectionFiles(const uint32_t lumiSection, const uint32_t currentLumiSection) const;
+      int grabNextJsonFile(boost::filesystem::path const& jsonSourcePath);
+      FileStatus getNextFromFileService(const unsigned int currentLumiSection,unsigned int& ls,std::string& nextFile,
+                                        int& serverEventsInNewFile_,uint32_t& fileSize,uint64_t& thisLockWaitTimeUs);
       void createRunOpendirMaybe();
       void createProcessingNotificationMaybe() const;
       int readLastLSEntry(std::string const& file);
@@ -141,6 +153,7 @@ namespace evf{
       std::string bu_base_dir_;
       bool directorBu_;
       unsigned int run_;
+      bool useFileService_;
       bool outputAdler32Recheck_;
       bool requireTSPSet_;
       std::string selectedTransferMode_;
@@ -199,6 +212,10 @@ namespace evf{
 
       //values initialized in .cc file
       static const std::vector<std::string> MergeTypeNames_;
+
+
+      //json parser
+      jsoncollector::DataPointDefinition *dpd_;
   };
 }
 

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -78,7 +78,7 @@ namespace evf{
       std::string &baseRunDir(){return run_dir_;}
       std::string &buBaseRunDir(){return bu_run_dir_;}
       std::string &buBaseRunOpenDir(){return bu_run_open_dir_;}
-      bool useFileService() const {return useFileService_;}
+      bool useFileBroker() const {return useFileBroker_;}
 
       std::string findCurrentRunDir(){ return dirManager_.findRunDir(run_);}
       std::string getInputJsonFilePath(const unsigned int ls, const unsigned int index) const;
@@ -120,16 +120,17 @@ namespace evf{
       void lockFULocal();
       void unlockFULocal();
       void lockFULocal2();
+      void lockFULocal2_SH();
       void unlockFULocal2();
       void createBoLSFile(const uint32_t lumiSection, bool checkIfExists) const;
-      void createLumiSectionFiles(const uint32_t lumiSection, const uint32_t currentLumiSection, bool doCreateBoLS = true) const;
+      void createLumiSectionFiles(const uint32_t lumiSection, const uint32_t currentLumiSection, bool& exclusiveLocked, bool doCreateBoLS = true);
       int grabNextJsonFile(boost::filesystem::path const& jsonSourcePath, boost::filesystem::path const& rawSourcePath, int64_t& fileSizeFromJson, bool& fileFound, bool unlock=true);
 
-      EvFDaqDirector::FileStatus contactFileService(unsigned int& serverHttpStatus, bool& serverState,
+      EvFDaqDirector::FileStatus contactFileBroker(unsigned int& serverHttpStatus, bool& serverState,
                                                 uint32_t& serverLS, uint32_t& closedServerLS,
                                                 std::string& nextFileJson, std::string& nextFileRaw, int maxLS);
 
-      FileStatus getNextFromFileService(const unsigned int currentLumiSection, unsigned int& ls, std::string& nextFile,
+      FileStatus getNextFromFileBroker(const unsigned int currentLumiSection, unsigned int& ls, std::string& nextFile,
                                         int& serverEventsInNewFile_, int64_t& fileSize, uint64_t& thisLockWaitTimeUs);
       void createRunOpendirMaybe();
       void createProcessingNotificationMaybe() const;
@@ -160,11 +161,11 @@ namespace evf{
       std::string bu_base_dir_;
       bool directorBu_;
       unsigned int run_;
-      bool useFileService_;
-      std::string fileServiceHost_;
-      std::string fileServicePort_;
-      bool fileServiceKeepAlive_;
-      bool fileServiceUseLocalLock_;
+      bool useFileBroker_;
+      std::string fileBrokerHost_;
+      std::string fileBrokerPort_;
+      bool fileBrokerKeepAlive_;
+      bool fileBrokerUseLocalLock_;
       unsigned int startFromLS_ = 1;
       bool outputAdler32Recheck_;
       bool requireTSPSet_;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -123,7 +123,8 @@ namespace evf{
       void unlockFULocal2();
       void createBoLSFile(const uint32_t lumiSection, bool checkIfExists) const;
       void createLumiSectionFiles(const uint32_t lumiSection, const uint32_t currentLumiSection, bool doCreateBoLS = true);
-      int grabNextJsonFile(boost::filesystem::path const& jsonSourcePath, boost::filesystem::path const& rawSourcePath, int64_t& fileSizeFromJson, bool& fileFound, bool unlock=true);
+      int grabNextJsonFile(std::string const& jsonSourcePath, std::string const& rawSourcePath, int64_t& fileSizeFromJson, bool& fileFound);
+      int grabNextJsonFileAndUnlock(boost::filesystem::path const& jsonSourcePath);
 
       EvFDaqDirector::FileStatus contactFileBroker(unsigned int& serverHttpStatus, bool& serverState,
                                                 uint32_t& serverLS, uint32_t& closedServerLS,

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -120,7 +120,6 @@ namespace evf{
       void lockFULocal();
       void unlockFULocal();
       void lockFULocal2();
-      void lockFULocal2_SH();
       void unlockFULocal2();
       void createBoLSFile(const uint32_t lumiSection, bool checkIfExists) const;
       void createLumiSectionFiles(const uint32_t lumiSection, const uint32_t currentLumiSection, bool doCreateBoLS = true);

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -163,6 +163,8 @@ namespace evf{
       bool useFileService_;
       std::string fileServiceHost_;
       std::string fileServicePort_;
+      bool fileServiceKeepAlive_;
+      bool fileServiceUseLocalLock_;
       unsigned int startFromLS_ = 1;
       bool outputAdler32Recheck_;
       bool requireTSPSet_;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -123,7 +123,7 @@ namespace evf{
       void lockFULocal2_SH();
       void unlockFULocal2();
       void createBoLSFile(const uint32_t lumiSection, bool checkIfExists) const;
-      void createLumiSectionFiles(const uint32_t lumiSection, const uint32_t currentLumiSection, bool& exclusiveLocked, bool doCreateBoLS = true);
+      void createLumiSectionFiles(const uint32_t lumiSection, const uint32_t currentLumiSection, bool doCreateBoLS = true);
       int grabNextJsonFile(boost::filesystem::path const& jsonSourcePath, boost::filesystem::path const& rawSourcePath, int64_t& fileSizeFromJson, bool& fileFound, bool unlock=true);
 
       EvFDaqDirector::FileStatus contactFileBroker(unsigned int& serverHttpStatus, bool& serverState,

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -87,6 +87,7 @@ private:
 
   // get LS from filename instead of event header
   const bool getLSFromFilename_;
+  const bool alwaysStartFromFirstLS_;
   const bool verifyAdler32_;
   const bool verifyChecksum_;
   const bool useL1EventID_;
@@ -203,7 +204,7 @@ struct InputFile {
   evf::EvFDaqDirector::FileStatus status_;
   unsigned int lumi_;
   std::string fileName_;
-  uint32_t fileSize_;
+  uint64_t fileSize_;
   uint32_t nChunks_;
   int nEvents_;
   unsigned int nProcessed_;
@@ -215,7 +216,7 @@ struct InputFile {
   unsigned int currentChunk_ = 0;
 
   InputFile(evf::EvFDaqDirector::FileStatus status, unsigned int lumi = 0, std::string const& name = std::string(),
-      uint32_t fileSize =0, uint32_t nChunks=0, int nEvents=0, FedRawDataInputSource *parent = nullptr):
+      uint64_t fileSize =0, uint32_t nChunks=0, int nEvents=0, FedRawDataInputSource *parent = nullptr):
     parent_(parent),
     status_(status),
     lumi_(lumi),

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -33,11 +33,6 @@ namespace evf {
 class FastMonitoringService;
 }
 
-namespace jsoncollector {
-class DataPointDefinition;
-}
-
-
 class FedRawDataInputSource: public edm::RawInputSource {
 
 friend struct InputFile;
@@ -57,12 +52,10 @@ private:
   void rewind_() override;
 
   void maybeOpenNewLumiSection(const uint32_t lumiSection);
-  void createBoLSFile(const uint32_t lumiSection,bool checkIfExists);
   evf::EvFDaqDirector::FileStatus nextEvent();
   evf::EvFDaqDirector::FileStatus getNextEvent();
   edm::Timestamp fillFEDRawDataCollection(FEDRawDataCollection&);
   void deleteFile(std::string const&);
-  int grabNextJsonFile(boost::filesystem::path const&);
 
   void readSupervisor();
   void readWorker(unsigned int tid);
@@ -98,6 +91,7 @@ private:
   const bool verifyChecksum_;
   const bool useL1EventID_;
   std::vector<std::string> fileNames_;
+  bool useFileService_;
   //std::vector<std::string> fileNamesSorted_;
 
   const bool fileListMode_;
@@ -122,8 +116,6 @@ private:
   unsigned char *tcds_pointer_;
   unsigned int eventsThisLumi_;
   unsigned long eventsThisRun_ = 0;
-
-  jsoncollector::DataPointDefinition *dpd_;
 
   /*
    *

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -92,7 +92,7 @@ private:
   const bool verifyChecksum_;
   const bool useL1EventID_;
   std::vector<std::string> fileNames_;
-  bool useFileService_;
+  bool useFileBroker_;
   //std::vector<std::string> fileNamesSorted_;
 
   const bool fileListMode_;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -1412,21 +1412,7 @@ namespace evf {
       return noFile;
     }
 
-    bool fileFound=true;
-
-    if (fileStatus == newFile)
-      serverEventsInNewFile = grabNextJsonFile(nextFileJson,nextFileRaw,fileSizeFromJson,fileFound,false);
-
-    if (!fileFound) {
-      fileStatus = noFile;
-      struct stat buf;
-      if (stat(bu_run_dir_.c_str(),&buf)!=0) {
-        edm::LogWarning("EvFDaqDirector") << "BU run directory not found:" << bu_run_dir_;
-        fileStatus=runEnded;
-      }
-    }
-
-    //first execution, allowed to skip to last reported LS (create BoLS file only)
+    //handle creation of EoLS and BoLS files if lumisection has changed
     bool excl_locked=false;
     if (currentLumiSection==0) {
         if (fileStatus == runEnded) {
@@ -1441,6 +1427,21 @@ namespace evf {
           for (uint32_t i=std::max(currentLumiSection,1U);i<=closedServerLS;i++) 
             createLumiSectionFiles(i+1,i,excl_locked);
           }
+    }
+
+    bool fileFound=true;
+
+    if (fileStatus == newFile)
+      serverEventsInNewFile = grabNextJsonFile(nextFileJson,nextFileRaw,fileSizeFromJson,fileFound,false);
+
+    if (!fileFound) {
+      //possible if directory gets deleted
+      fileStatus = noFile;
+      struct stat buf;
+      if (stat(bu_run_dir_.c_str(),&buf)!=0) {
+        edm::LogWarning("EvFDaqDirector") << "BU run directory not found:" << bu_run_dir_;
+        fileStatus=runEnded;
+      }
     }
 
     //can unlock because all files have been created locally

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -1086,7 +1086,7 @@ namespace evf {
         boost::asio::streambuf request;
         std::ostream request_stream(&request);
         std::string path = "/popfile?runnumber="+run_nstring_;
-        if (maxLS>0) {
+        if (maxLS>=0) {
           std::stringstream spath;
           spath << path << "&stopls=" << maxLS;
           path = spath.str();

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -928,12 +928,6 @@ namespace evf {
     flock(fulocal_rwlock_fd2_,LOCK_EX);
   }
 
-  void EvFDaqDirector::lockFULocal2_SH() {
-    //fcntl(fulocal_rwlock_fd2_, F_SETLKW, &fulocal_rw_flk2);
-    flock(fulocal_rwlock_fd2_,LOCK_SH);
-  }
-
-
   void EvFDaqDirector::unlockFULocal2() {
     //fcntl(fulocal_rwlock_fd2_, F_SETLKW, &fulocal_rw_fulk2);
     flock(fulocal_rwlock_fd2_,LOCK_UN);

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -1090,6 +1090,7 @@ namespace evf {
           std::stringstream spath;
           spath << path << "&stopls=" << maxLS;
           path = spath.str();
+          edm::LogWarning("EvFDaqDirector") << "Stop LS requested " << maxLS;
         }
         request_stream << "GET " << path << " HTTP/1.0\r\n";
         request_stream << "Host: " << fileServiceHost_ << "\r\n";
@@ -1257,7 +1258,7 @@ namespace evf {
       serverError= true;
     }
 
-    if (socket_->is_open()) {    
+    if (socket_->is_open()) {
       socket_->shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
       if (ec) {
         edm::LogWarning("EvFDaqDirector") << "socket shutdown error -:" << ec;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -1126,7 +1126,7 @@ namespace evf {
           path = spath.str();
           edm::LogWarning("EvFDaqDirector") << "Stop LS requested " << maxLS;
         }
-        request_stream << "GET " << path << " HTTP/1.0\r\n";
+        request_stream << "GET " << path << " HTTP/1.1\r\n";
         request_stream << "Host: " << fileBrokerHost_ << "\r\n";
         request_stream << "Accept: */*\r\n";
         request_stream << "Connection: close\r\n\r\n";

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -136,6 +136,8 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
     cms::Exception("FedRawDataInputSource") << "EvFDaqDirector not found";
 
   useFileService_ = daqDirector_->useFileService();
+  if (useFileService_)
+    edm::LogInfo("FedRawDataInputSource") << "EvFDaqDirector/Source configured to use file service";
   //set DaqDirector to delete files in preGlobalEndLumi callback
   daqDirector_->setDeleteTracking(&fileDeleteLock_,&filesToDelete_);
   if (fms_) {
@@ -962,7 +964,7 @@ void FedRawDataInputSource::readSupervisor()
       if (useFileService_) rawFile = nextFile;
       else {
         boost::filesystem::path rawFilePath(nextFile);
-        std::string rawFile = rawFilePath.replace_extension(".raw").string();
+        rawFile = rawFilePath.replace_extension(".raw").string();
       }
 
       struct stat st;

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -146,7 +146,6 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
    fms_->setInState(evf::FastMonitoringThread::inInit);
    fms_->setInStateSup(evf::FastMonitoringThread::inInit);
   }
-
   //should delete chunks when run stops
   for (unsigned int i=0;i<numBuffers_;i++) {
     freeChunks_.push(new InputChunk(i,eventChunkSize_));
@@ -856,7 +855,6 @@ void FedRawDataInputSource::readSupervisor()
 	break;
       }
 
-
       uint64_t thisLockWaitTimeUs=0.;
       if (fileListMode_) {
         //return LS if LS not set, otherwise return file
@@ -958,7 +956,7 @@ void FedRawDataInputSource::readSupervisor()
           backoff_exp = std::min(4,backoff_exp); // max 1.6 seconds
           //backoff_exp=0; // disabled!
           int sleeptime  = (int) (100000. * pow(2,backoff_exp));
-	  usleep(sleeptime);
+          usleep(sleeptime);
           backoff_exp++;
 	}
       }

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -998,8 +998,9 @@ void FedRawDataInputSource::readSupervisor()
       }
       else {
         std::string empty;
+        bool fileFound;
         if (!useFileService_)
-          eventsInNewFile = daqDirector_->grabNextJsonFile(nextFile,nextFile,fileSizeFromJson);
+          eventsInNewFile = daqDirector_->grabNextJsonFile(nextFile,nextFile,fileSizeFromJson,fileFound);
         else
           eventsInNewFile = serverEventsInNewFile_;
         assert( eventsInNewFile>=0 );

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -996,9 +996,8 @@ void FedRawDataInputSource::readSupervisor()
       }
       else {
         std::string empty;
-        bool fileFound;
         if (!useFileBroker_)
-          eventsInNewFile = daqDirector_->grabNextJsonFile(nextFile,nextFile,fileSizeFromJson,fileFound);
+          eventsInNewFile = daqDirector_->grabNextJsonFileAndUnlock(nextFile);
         else
           eventsInNewFile = serverEventsInNewFile_;
         assert( eventsInNewFile>=0 );

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -51,12 +51,10 @@
 
 #include <boost/lexical_cast.hpp>
 
-using namespace jsoncollector;
-
 FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
                                              edm::InputSourceDescription const& desc) :
   edm::RawInputSource(pset, desc),
-  defPath_(pset.getUntrackedParameter<std::string> ("buDefPath", std::string(getenv("CMSSW_BASE"))+"/src/EventFilter/Utilities/plugins/budef.jsd")),
+  defPath_(pset.getUntrackedParameter<std::string> ("buDefPath", "")),
   eventChunkSize_(pset.getUntrackedParameter<unsigned int> ("eventChunkSize",32)*1048576),
   eventChunkBlock_(pset.getUntrackedParameter<unsigned int> ("eventChunkBlock",32)*1048576),
   numBuffers_(pset.getUntrackedParameter<unsigned int> ("numBuffers",2)),
@@ -69,14 +67,12 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
   fileListMode_(pset.getUntrackedParameter<bool> ("fileListMode", false)),
   fileListLoopMode_(pset.getUntrackedParameter<bool> ("fileListLoopMode", false)),
   runNumber_(edm::Service<evf::EvFDaqDirector>()->getRunNumber()),
-  fuOutputDir_(std::string()),
   daqProvenanceHelper_(edm::TypeID(typeid(FEDRawDataCollection))),
   eventID_(),
   processHistoryID_(),
   currentLumiSection_(0),
   tcds_pointer_(nullptr),
-  eventsThisLumi_(0),
-  dpd_(nullptr)
+  eventsThisLumi_(0)
 {
   char thishost[256];
   gethostname(thishost, 255);
@@ -101,20 +97,6 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
   //todo:autodetect from file name (assert if names differ)
   setRunAuxiliary(new edm::RunAuxiliary(runNumber_, edm::Timestamp::beginOfTime(),
 					edm::Timestamp::invalidTimestamp()));
-
-  std::string defPathSuffix = "src/EventFilter/Utilities/plugins/budef.jsd";
-  defPath_ = std::string(getenv("CMSSW_BASE")) + "/" + defPathSuffix;
-  struct stat statbuf;
-  if (stat(defPath_.c_str(), &statbuf)) {
-    defPath_ = std::string(getenv("CMSSW_RELEASE_BASE")) + "/" + defPathSuffix;
-    if (stat(defPath_.c_str(), &statbuf)) {
-      defPath_ = defPathSuffix;
-    }
-  }
-
-  dpd_ = new DataPointDefinition();
-  std::string defLabel = "data";
-  DataPointDefinition::getDataPointDefinitionFor(defPath_, dpd_,&defLabel);
 
   //make sure that chunk size is N * block size
   assert(eventChunkSize_>=eventChunkBlock_);
@@ -152,6 +134,7 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
   if (!daqDirector_)
     cms::Exception("FedRawDataInputSource") << "EvFDaqDirector not found";
 
+  useFileService_ = daqDirector_->useFileService();
   //set DaqDirector to delete files in preGlobalEndLumi callback
   daqDirector_->setDeleteTracking(&fileDeleteLock_,&filesToDelete_);
   if (fms_) {
@@ -160,6 +143,7 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
    fms_->setInState(evf::FastMonitoringThread::inInit);
    fms_->setInStateSup(evf::FastMonitoringThread::inInit);
   }
+
   //should delete chunks when run stops
   for (unsigned int i=0;i<numBuffers_;i++) {
     freeChunks_.push(new InputChunk(i,eventChunkSize_));
@@ -237,9 +221,6 @@ bool FedRawDataInputSource::checkNextEvent()
 {
   if (!startedSupervisorThread_)
   {
-    //late init of directory variable
-    fuOutputDir_=edm::Service<evf::EvFDaqDirector>()->baseRunDir();
-
     //this thread opens new files and dispatches reading to worker readers
     //threadInit_.store(false,std::memory_order_release);
     std::unique_lock<std::mutex> lk(startupLock_);
@@ -310,36 +291,27 @@ bool FedRawDataInputSource::checkNextEvent()
   }
 }
 
-void FedRawDataInputSource::createBoLSFile(const uint32_t lumiSection, bool checkIfExists)
-{
-  //used for backpressure mechanisms and monitoring
-  const std::string fuBoLS = daqDirector_->getBoLSFilePathOnFU(lumiSection);
-  struct stat buf;
-  if (checkIfExists==false || stat(fuBoLS.c_str(), &buf) != 0) {
-    int bol_fd = open(fuBoLS.c_str(), O_RDWR|O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
-    close(bol_fd);
-  }
-}
-
 void FedRawDataInputSource::maybeOpenNewLumiSection(const uint32_t lumiSection)
 {
   if (!luminosityBlockAuxiliary()
     || luminosityBlockAuxiliary()->luminosityBlock() != lumiSection) {
 
-    if ( currentLumiSection_ > 0) {
-      const std::string fuEoLS =
-        daqDirector_->getEoLSFilePathOnFU(currentLumiSection_);
-      struct stat buf;
-      bool found = (stat(fuEoLS.c_str(), &buf) == 0);
-      if ( !found ) {
-        daqDirector_->lockFULocal2();
-        int eol_fd = open(fuEoLS.c_str(), O_RDWR|O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
-        close(eol_fd);
-        createBoLSFile(lumiSection,false);
-        daqDirector_->unlockFULocal2();
+    if (!useFileService_) {
+      if ( currentLumiSection_ > 0) {
+        const std::string fuEoLS =
+          daqDirector_->getEoLSFilePathOnFU(currentLumiSection_);
+        struct stat buf;
+        bool found = (stat(fuEoLS.c_str(), &buf) == 0);
+        if ( !found ) {
+          daqDirector_->lockFULocal2();
+          int eol_fd = open(fuEoLS.c_str(), O_RDWR|O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
+          close(eol_fd);
+          daqDirector_->createBoLSFile(lumiSection,false);
+          daqDirector_->unlockFULocal2();
+        }
       }
+      else daqDirector_->createBoLSFile(lumiSection,true);//needed for initial lumisection
     }
-    else createBoLSFile(lumiSection,true);//needed for initial lumisection
 
     currentLumiSection_ = lumiSection;
 
@@ -798,112 +770,6 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollect
   return tstamp;
 }
 
-int FedRawDataInputSource::grabNextJsonFile(boost::filesystem::path const& jsonSourcePath)
-{
-  std::string data;
-  try {
-    // assemble json destination path
-    boost::filesystem::path jsonDestPath(fuOutputDir_);
-
-    //TODO:should be ported to use fffnaming
-    std::ostringstream fileNameWithPID;
-    fileNameWithPID << jsonSourcePath.stem().string() << "_pid"
-                    << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
-    jsonDestPath /= fileNameWithPID.str();
-
-    LogDebug("FedRawDataInputSource") << "JSON rename -: " << jsonSourcePath << " to "
-                                          << jsonDestPath;
-    try {
-      boost::filesystem::copy(jsonSourcePath,jsonDestPath);
-    }
-    catch (const boost::filesystem::filesystem_error& ex)
-    {
-      // Input dir gone?
-      edm::LogError("FedRawDataInputSource") << "grabNextFile BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what();
-      //                                     << " Maybe the file is not yet visible by FU. Trying again in one second";
-      sleep(1);
-      boost::filesystem::copy(jsonSourcePath,jsonDestPath);
-    }
-    daqDirector_->unlockFULocal();
-
-    try {
-      //sometimes this fails but file gets deleted
-      boost::filesystem::remove(jsonSourcePath);
-    }
-    catch (const boost::filesystem::filesystem_error& ex)
-    {
-      // Input dir gone?
-      edm::LogError("FedRawDataInputSource") << "grabNextFile BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what();
-    }
-    catch (std::exception& ex)
-    {
-      // Input dir gone?
-      edm::LogError("FedRawDataInputSource") << "grabNextFile std::exception CAUGHT -: " << ex.what();
-    }
-
-    boost::filesystem::ifstream ij(jsonDestPath);
-    Json::Value deserializeRoot;
-    Json::Reader reader;
-
-    std::stringstream ss;
-    ss << ij.rdbuf();
-    if (!reader.parse(ss.str(), deserializeRoot)) {
-      edm::LogError("FedRawDataInputSource") << "Failed to deserialize JSON file -: " << jsonDestPath
-                                               << "\nERROR:\n" << reader.getFormatedErrorMessages()
-                                               << "CONTENT:\n" << ss.str()<<".";
-      throw std::runtime_error("Cannot deserialize input JSON file");
-    }
-
-    //read BU JSON
-    std::string data;
-    DataPoint dp;
-    dp.deserialize(deserializeRoot);
-    bool success = false;
-    for (unsigned int i=0;i<dpd_->getNames().size();i++) {
-      if (dpd_->getNames().at(i)=="NEvents")
-	if (i<dp.getData().size()) {
-	  data = dp.getData()[i];
-	  success=true;
-	}
-    }
-    if (!success) {
-      if (!dp.getData().empty())
-	data = dp.getData()[0];
-      else
-	throw cms::Exception("FedRawDataInputSource::grabNextJsonFile") <<
-	  " error reading number of events from BU JSON -: No input value " << data;
-    }
-    return boost::lexical_cast<int>(data);
-
-  }
-  catch (const boost::filesystem::filesystem_error& ex)
-  {
-    // Input dir gone?
-    daqDirector_->unlockFULocal();
-    edm::LogError("FedRawDataInputSource") << "grabNextJsonFile - BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what();
-  }
-  catch (std::runtime_error e)
-  {
-    // Another process grabbed the file and NFS did not register this
-    daqDirector_->unlockFULocal();
-    edm::LogError("FedRawDataInputSource") << "grabNextJsonFile - runtime Exception -: " << e.what();
-  }
-
-  catch( boost::bad_lexical_cast const& ) {
-    edm::LogError("FedRawDataInputSource") << "grabNextJsonFile - error parsing number of events from BU JSON. "
-                                           << "Input value is -: " << data;
-  }
-
-  catch (std::exception e)
-  {
-    // BU run directory disappeared?
-    daqDirector_->unlockFULocal();
-    edm::LogError("FedRawDataInputSource") << "grabNextFile - SOME OTHER EXCEPTION OCCURED!!!! -: " << e.what();
-  }
-
-  return -1;
-}
-
 void FedRawDataInputSource::rewind_()
 {}
 
@@ -975,22 +841,29 @@ void FedRawDataInputSource::readSupervisor()
 
     evf::EvFDaqDirector::FileStatus status =  evf::EvFDaqDirector::noFile;
 
+    int serverEventsInNewFile_=-1;
+
     while (status == evf::EvFDaqDirector::noFile) {
       if (quit_threads_.load(std::memory_order_relaxed) || edm::shutdown_flag.load(std::memory_order_relaxed)) {
 	stop=true;
 	break;
       }
 
+
       uint64_t thisLockWaitTimeUs=0.;
       if (fileListMode_) {
         //return LS if LS not set, otherwise return file
         status = getFile(ls,nextFile,fileSize,thisLockWaitTimeUs);
       }
-      else
+      else if (!useFileService_)
         status = daqDirector_->updateFuLock(ls,nextFile,fileSize,thisLockWaitTimeUs);
+      else {
+        status = daqDirector_->getNextFromFileService(currentLumiSection,ls,nextFile,serverEventsInNewFile_,fileSize,thisLockWaitTimeUs);
+      }
 
       if (fms_) fms_->setInStateSup(evf::FastMonitoringThread::inSupBusy);
 
+      //cycle through all remaining LS even if no files get assigned
       if (currentLumiSection!=ls && status==evf::EvFDaqDirector::runEnded) status=evf::EvFDaqDirector::noFile;
 
       //monitoring of lock wait time
@@ -1006,7 +879,7 @@ void FedRawDataInputSource::readSupervisor()
       }
 
       //check again for any remaining index/EoLS files after EoR file is seen
-      if ( status == evf::EvFDaqDirector::runEnded && !fileListMode_) {
+      if ( status == evf::EvFDaqDirector::runEnded && !fileListMode_ && !useFileService_) {
         if (fms_) fms_->setInStateSup(evf::FastMonitoringThread::inRunEnd);
         usleep(100000);
         //now all files should have appeared in ramdisk, check again if any raw files were left behind
@@ -1027,17 +900,28 @@ void FedRawDataInputSource::readSupervisor()
         break;
       }
       //queue new lumisection
-      if( getLSFromFilename_ && ls > currentLumiSection) {
-        //fms_->setInStateSup(evf::FastMonitoringThread::inSupNewLumi);
-	currentLumiSection = ls;
-	fileQueue_.push(new InputFile(evf::EvFDaqDirector::newLumi, currentLumiSection));
-      }
-
-      if( getLSFromFilename_ && currentLumiSection>0 && ls < currentLumiSection) {
+      if( getLSFromFilename_) {
+        if (ls > currentLumiSection) {
+          if (!useFileService_ || currentLumiSection==0) {
+            //fms_->setInStateSup(evf::FastMonitoringThread::inSupNewLumi);
+	    currentLumiSection = ls;
+	    fileQueue_.push(new InputFile(evf::EvFDaqDirector::newLumi, currentLumiSection));
+          }
+          else {
+            //queue all lumisections after last one seen to avoid gaps
+            for (unsigned int nextLS=currentLumiSection+1;nextLS<=ls;nextLS++) {
+	      fileQueue_.push(new InputFile(evf::EvFDaqDirector::newLumi, nextLS));
+            }
+	    currentLumiSection = ls;
+          }
+        }
+        //else
+        if( currentLumiSection>0 && ls < currentLumiSection) {
           edm::LogError("FedRawDataInputSource") << "Got old LS ("<<ls<<") file from EvFDAQDirector! Expected LS:" << currentLumiSection<<". Aborting execution."<<std::endl;
 	  fileQueue_.push(new InputFile(evf::EvFDaqDirector::runAbort, 0));
 	  stop=true;
 	  break;
+        }
       }
 
       int dbgcount=0;
@@ -1076,7 +960,10 @@ void FedRawDataInputSource::readSupervisor()
         else eventsInNewFile=-1;
       }
       else {
-        eventsInNewFile = grabNextJsonFile(nextFile);
+        if (!useFileService_)
+          eventsInNewFile = daqDirector_->grabNextJsonFile(nextFile);
+        else
+          eventsInNewFile = serverEventsInNewFile_;
         assert( eventsInNewFile>=0 );
         assert((eventsInNewFile>0) == (fileSize>0));//file without events must be empty
       }

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -41,9 +41,6 @@ process.maxEvents = cms.untracked.PSet(
 process.options = cms.untracked.PSet(
     numberOfThreads = cms.untracked.uint32(options.numThreads),
     numberOfStreams = cms.untracked.uint32(options.numThreads),
-    multiProcesses = cms.untracked.PSet(
-    maxChildProcesses = cms.untracked.int32(0)
-    )
 )
 process.MessageLogger = cms.Service("MessageLogger",
     cout = cms.untracked.PSet(threshold = cms.untracked.string( "INFO" )),
@@ -57,6 +54,8 @@ process.FastMonitoringService = cms.Service("FastMonitoringService",
     slowName = cms.untracked.string( 'slowmoni' ))
 
 process.EvFDaqDirector = cms.Service("EvFDaqDirector",
+    useFileService = cms.untracked.bool(False),
+    fileServiceHost = cms.untracked.string("htcp40.cern.ch"),
     runNumber = cms.untracked.uint32(options.runNumber),
     baseDir = cms.untracked.string(options.fuBaseDir),
     buBaseDir = cms.untracked.string(options.buBaseDir),


### PR DESCRIPTION
Support for obtaining files from DAQ File Broker in the HLT filter farm.
NFS locking mechanism is supported with a configuration parameter.

This will subsequently be pushed to 10_2_X and 10_1_X (patches are identical).