### PR TITLE
Print function migration for FWCore_Modules

### DIFF
--- a/FWCore/Modules/python/customiseCheckEventSetup.py
+++ b/FWCore/Modules/python/customiseCheckEventSetup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import six
 
@@ -15,8 +16,8 @@ def customise(process):
         process.schedule_().append(process.esout)
 
     for name, module in six.iteritems(process.es_sources_()):
-        print "ESModules> provider:%s '%s'" % (name, module.type_())
+        print("ESModules> provider:%s '%s'" % (name, module.type_()))
     for name, module in six.iteritems(process.es_producers_()):
-        print "ESModules> provider:%s '%s'" % (name, module.type_())
+        print("ESModules> provider:%s '%s'" % (name, module.type_()))
 
     return process


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import