### PR TITLE
Fix GCC8 compiler warnings, catch exceptions by reference not value

### DIFF
--- a/CalibMuon/DTCalibration/src/DTMeanTimerFitter.cc
+++ b/CalibMuon/DTCalibration/src/DTMeanTimerFitter.cc
@@ -141,7 +141,7 @@ vector<float> DTMeanTimerFitter::evaluateVDriftAndReso (const TString& N) {
 	ith != hT0.end(); ++ith) {
       try{
         (*ith)->Fit("gaus");
-      } catch(std::exception){
+      } catch(std::exception const&){
         edm::LogError("DTMeanTimerFitter") << "Exception when fitting T0..histogram " << (*ith)->GetName();    
         // return empty or -1 filled vector?
         vector<float> defvec(6,-1);
@@ -207,7 +207,7 @@ TF1* DTMeanTimerFitter::fitTMax(TH1F* histo){
       rGaus->SetMarkerSize();// just silence gcc complainining about unused var
       try{	
         histo->Fit("rGaus","R");
-      } catch(std::exception){
+      } catch(std::exception const&){
 	edm::LogError("DTMeanTimerFitter") << "Exception when fitting TMax..histogram " << histo->GetName()
 	     << "   setting return function pointer to zero";   
 	return nullptr;

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
@@ -146,7 +146,7 @@ offset_slope(const std::vector<LA_Filler_Fitter::EnsembleSummary>& ensembles) {
     
     return std::make_pair( std::make_pair(fit->GetParameter(0), fit->GetParError(0)),
 			   std::make_pair(fit->GetParameter(1), fit->GetParError(1)) );
-  } catch(edm::Exception e) { 
+  } catch(edm::Exception const& e) {
     std::cerr << "Fitting Line Failed " << std::endl << e << std::endl;
     return std::make_pair( std::make_pair(0,0), std::make_pair(0,0));
   }

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -91,7 +91,7 @@ namespace {
         info.nextParseIndex = endIndex;
         info.evaluator = std::make_shared<reco::formula::ConstantEvaluator>(value);
         info.top = info.evaluator;
-      } catch ( std::invalid_argument ) {}
+      } catch ( std::invalid_argument const& ) {}
 
       return info;
 
@@ -130,7 +130,7 @@ namespace {
         info.maxNumParameters = value+1;
         info.evaluator = std::make_shared<reco::formula::ParameterEvaluator>(value);
         info.top = info.evaluator;
-      } catch ( std::invalid_argument ) {}
+      } catch ( std::invalid_argument const& ) {}
       
       return info;
 

--- a/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
+++ b/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
@@ -105,7 +105,7 @@ void testJetCorrectorParameters::setupCorrector(bool is3D) {
        edm::FileInPath strFIP(to_try);
        filename = strFIP.fullPath();
     }
-    catch (edm::Exception ex) {
+    catch (edm::Exception const& ex) {
        throw ex;
     }
 

--- a/CondFormats/L1TObjects/src/L1CaloEtScale.cc
+++ b/CondFormats/L1TObjects/src/L1CaloEtScale.cc
@@ -94,7 +94,7 @@ double L1CaloEtScale::et(const uint16_t rank) const {
   try {
     return m_thresholds.at(rank);
   }
-  catch(std::out_of_range) {
+  catch(std::out_of_range const&) {
     throw cms::Exception("OutOfRange") << "Index out of range in L1CaloEtScale::et(rank)" << std::endl;
   }
 

--- a/CondTools/DT/src/DTKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTKeyedConfigHandler.cc
@@ -552,7 +552,7 @@ void DTKeyedConfigHandler::chkConfigList() {
       if ( brickCheck.get() ) brickFound =
                              ( brickCheck->getId() == brickConfigId );
     }
-    catch ( std::exception e ) {
+    catch ( std::exception const& ) {
     }
     if ( !brickFound ) {
       std::cout << "brick " << brickConfigId << " missing, copy request"

--- a/CondTools/DT/src/DTUserKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTUserKeyedConfigHandler.cc
@@ -370,7 +370,7 @@ void DTUserKeyedConfigHandler::chkConfigList(
 	brickFound = ( brickCheck->getId() == brickConfigId );
       }
     }
-    catch ( std::exception e ) {
+    catch ( std::exception const& ) {
     }
     if ( !brickFound ) {
       std::cout << "brick " << brickConfigId << " missing, copy request"

--- a/DPGAnalysis/Skims/src/TriggerMatchProducer.icc
+++ b/DPGAnalysis/Skims/src/TriggerMatchProducer.icc
@@ -154,7 +154,7 @@ void TriggerMatchProducer<object>::produce(edm::Event &event, const edm::EventSe
 	 filters = hltConfig.moduleLabels( iMyHLT->first );
 	 triggerIndex = hltConfig.triggerIndex(iMyHLT->first);
        }
-       catch (std::exception ex) { cout << "bad trigger\n"; }
+       catch (std::exception const&) { cout << "bad trigger\n"; }
        // Results from TriggerResults product
        if ( triggerIndex==-1 ||
 	   !(pTrgResults->wasrun(triggerIndex)) ||

--- a/DQM/EcalMonitorDbModule/src/MonitorElementsDb.cc
+++ b/DQM/EcalMonitorDbModule/src/MonitorElementsDb.cc
@@ -46,7 +46,7 @@ MonitorElementsDb::MonitorElementsDb( const edm::ParameterSet& ps, std::string& 
     parser_ = new MonitorXMLParser( xmlFile_ );
     try {
       parser_->load();
-    } catch( const std::runtime_error e ) {
+    } catch( std::runtime_error const& e ) {
       delete parser_;
       parser_ = nullptr;
       std::cerr << "Error loading parser: " << e.what() << std::endl;

--- a/DQM/SiStripCommissioningSources/src/NoiseTask.cc
+++ b/DQM/SiStripCommissioningSources/src/NoiseTask.cc
@@ -229,7 +229,7 @@ void NoiseTask::book()
         << ( out << pedestals 
 	<< "   Noises: " << noises, out.str());
       */
-    } catch( std::out_of_range) {
+    } catch( std::out_of_range const& ) {
       // Hmm, didn't find appropriate Apv :((( -> VERY, VERY BAD
       LogTrace( mlDqmSource_)
         << "[NoiseTask::" << __func__ << "] "

--- a/ElectroWeakAnalysis/WENu/src/GenPurposeSkimmerData.cc
+++ b/ElectroWeakAnalysis/WENu/src/GenPurposeSkimmerData.cc
@@ -146,7 +146,7 @@ GenPurposeSkimmerData::analyze(const edm::Event& evt, const edm::EventSetup& es)
   try{
     evt.getByToken(ElectronCollectionToken_, pElectrons);
   }
-  catch (cms::Exception)
+  catch (cms::Exception const&)
     {
       edm::LogError("")<< "Error! Can't get ElectronCollection by label. ";
     }

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -137,7 +137,7 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
   if (fileListMode_) {
     try {
       fms_ = static_cast<evf::FastMonitoringService *> (edm::Service<evf::MicroStateService>().operator->());
-    } catch(cms::Exception e) {
+    } catch(cms::Exception const&) {
         edm::LogInfo("FedRawDataInputSource") << "No FastMonitoringService found in the configuration";
     }
   }
@@ -882,7 +882,7 @@ int FedRawDataInputSource::grabNextJsonFile(boost::filesystem::path const& jsonS
     daqDirector_->unlockFULocal();
     edm::LogError("FedRawDataInputSource") << "grabNextJsonFile - BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what();
   }
-  catch (std::runtime_error e)
+  catch (std::runtime_error const& e)
   {
     // Another process grabbed the file and NFS did not register this
     daqDirector_->unlockFULocal();
@@ -894,7 +894,7 @@ int FedRawDataInputSource::grabNextJsonFile(boost::filesystem::path const& jsonS
                                            << "Input value is -: " << data;
   }
 
-  catch (std::exception e)
+  catch (std::exception const& e)
   {
     // BU run directory disappeared?
     daqDirector_->unlockFULocal();

--- a/Fireworks/FWInterface/src/FWPathsPopup.cc
+++ b/Fireworks/FWInterface/src/FWPathsPopup.cc
@@ -251,7 +251,7 @@ FWPathsPopup::scheduleReloadEvent()
       m_apply->SetEnabled(false);
       gSystem->ExitLoop();
    }
-   catch (boost::python::error_already_set)
+   catch (boost::python::error_already_set const&)
    {
       edm::pythonToCppException("Configuration");
       Py_Finalize();

--- a/HeavyFlavorAnalysis/RecoDecay/interface/BPHTrackReference.h
+++ b/HeavyFlavorAnalysis/RecoDecay/interface/BPHTrackReference.h
@@ -98,7 +98,7 @@ class BPHTrackReference {
       const reco::TrackRef& tkr = rc.get<reco::TrackRef>();
       if ( tkr.isNonnull() && tkr.isAvailable() ) return tkr.get();
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -111,7 +111,7 @@ class BPHTrackReference {
       const reco::TrackRef& tkr = pf->trackRef();
       if ( tkr.isNonnull() && tkr.isAvailable() ) return tkr.get();
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -124,7 +124,7 @@ class BPHTrackReference {
       const reco::TrackRef& tkr = gp->track();
       if ( tkr.isNonnull() && tkr.isAvailable() ) return tkr.get();
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -134,7 +134,7 @@ class BPHTrackReference {
       const reco::Track* trk = rc.bestTrack();
       return trk;
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -147,7 +147,7 @@ class BPHTrackReference {
       const reco::Track* trk = &pp->pseudoTrack();
       return trk;
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -165,7 +165,7 @@ class BPHTrackReference {
         if ( tkr.isNonnull() && tkr.isAvailable() ) return tkr.get();
       }
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -180,7 +180,7 @@ class BPHTrackReference {
       const reco::TrackRef& tkr = mu->muonBestTrack();
       if ( tkr.isNonnull() && tkr.isAvailable() ) return tkr.get();
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -196,7 +196,7 @@ class BPHTrackReference {
       const reco::TrackRef& mit = mu->innerTrack();
       if ( mit.isNonnull() && mit.isAvailable() ) return mit.get();
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -212,7 +212,7 @@ class BPHTrackReference {
       const reco::TrackRef& mgt = mu->globalTrack();
       if ( mgt.isNonnull() && mgt.isAvailable() ) return mgt.get();
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -228,7 +228,7 @@ class BPHTrackReference {
       const reco::TrackRef& msa = mu->standAloneMuon();
       if ( msa.isNonnull() && msa.isAvailable() ) return msa.get();
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }
@@ -246,7 +246,7 @@ class BPHTrackReference {
         if ( tkr.isNonnull() && tkr.isAvailable() ) return tkr.get();
       }
     }
-    catch ( edm::Exception e ) {
+    catch ( edm::Exception const& ) {
     }
     return nullptr;
   }

--- a/HeavyFlavorAnalysis/RecoDecay/src/BPHKinematicFit.cc
+++ b/HeavyFlavorAnalysis/RecoDecay/src/BPHKinematicFit.cc
@@ -205,7 +205,7 @@ const RefCountedKinematicTree& BPHKinematicFit::kinematicTree(
   if ( allParticles.size() != daughFull().size() ) return kinTree;
   vector<RefCountedKinematicParticle> kComp;
   vector<RefCountedKinematicParticle> kTail;
-  if ( name != "" ) {
+  if ( !name.empty() ) {
     const BPHRecoCandidate* comp = getComp( name ).get();
     if ( comp == nullptr ) {
       edm::LogPrint( "ParticleNotFound" )
@@ -247,7 +247,7 @@ const RefCountedKinematicTree& BPHKinematicFit::kinematicTree(
       kinTree = compTree;
     }
   }
-  catch ( std::exception e ) {
+  catch ( std::exception const& ) {
     edm::LogPrint( "FitFailed" )
                 << "BPHKinematicFit::kinematicTree: "
                 << "kin fit reset";
@@ -265,7 +265,7 @@ const RefCountedKinematicTree& BPHKinematicFit::kinematicTree(
   kinParticles();
   if ( allParticles.size() != daughFull().size() ) return kinTree;
   vector<string> nfull;
-  if ( name != "" ) {
+  if ( !name.empty() ) {
     const BPHRecoCandidate* comp = getComp( name ).get();
     if ( comp == nullptr ) {
       edm::LogPrint( "ParticleNotFound" )
@@ -286,7 +286,7 @@ const RefCountedKinematicTree& BPHKinematicFit::kinematicTree(
     KinematicConstrainedVertexFitter cvf;
     kinTree = cvf.fit( kinParticles( nfull ), kc );
   }
-  catch ( std::exception e ) {
+  catch ( std::exception const& ) {
     edm::LogPrint( "FitFailed" )
                 << "BPHKinematicFit::kinematicTree: "
                 << "kin fit reset";

--- a/JetMETCorrections/Modules/plugins/JetCorrectorDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorDBWriter.cc
@@ -76,7 +76,7 @@ void JetCorrectorDBWriter::beginJob()
       }
       std::cout << "Added record " << i << std::endl;
     }
-    catch(edm::Exception ex) {
+    catch(edm::Exception const&) {
       std::cout << "Did not find JEC file " << inputTxtFile << std::endl;
     }
     

--- a/JetMETCorrections/Modules/plugins/METCorrectorDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/METCorrectorDBWriter.cc
@@ -75,7 +75,7 @@ void METCorrectorDBWriter::beginJob()
       }
       std::cout << "Added record " << ilev << std::endl;
     }
-    catch(edm::Exception ex) {
+    catch(edm::Exception const&) {
       std::cout<<"Have not found METC file: "<<inputTxtFile<<std::endl;
     }
   }

--- a/OnlineDB/CSCCondDB/src/CSCOnlineDB.cc
+++ b/OnlineDB/CSCCondDB/src/CSCOnlineDB.cc
@@ -106,7 +106,7 @@
    curtime.tm_hour, curtime.tm_min, curtime.tm_sec);
    stmt->setDate(4, edate_c);
    if(obj_name!="test") stmt->executeUpdate ();
-   }catch(oracle::occi::SQLException ex)
+   }catch(oracle::occi::SQLException &ex)
    {
     std::cout<<"Exception thrown for insertBind"<<std::endl;
     std::cout<<"Error number: "<<  ex.getErrorCode() << std::endl;

--- a/OnlineDB/EcalCondDB/src/LMFLmrSubIOV.cc
+++ b/OnlineDB/EcalCondDB/src/LMFLmrSubIOV.cc
@@ -214,7 +214,7 @@ std::list<int> LMFLmrSubIOV::getIOVIDsLaterThan(const Tm &tmin, const Tm &tmax,
       stmt->setPrefetchRowCount(0);
       m_conn->terminateStatement(stmt);
     }
-    catch (oracle::occi::SQLException e) {
+    catch (oracle::occi::SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
       throw(std::runtime_error(m_className + "::getLmrSubIOVLaterThan: " +
 			       getOraMessage(&e)));

--- a/OnlineDB/EcalCondDB/src/RunDCSHVDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSHVDat.cc
@@ -77,7 +77,7 @@ ResultSet *RunDCSHVDat::getBarrelRset(const Tm& timeStart) {
 
     rset = m_readStmt->executeQuery();
   }
-  catch (SQLException e) {
+  catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
 #else
@@ -105,7 +105,7 @@ ResultSet *RunDCSHVDat::getEndcapAnodeRset(const Tm& timeStart) {
 
     rset = m_readStmt->executeQuery();
   }
-  catch (SQLException e) {
+  catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
 #else
@@ -133,7 +133,7 @@ ResultSet *RunDCSHVDat::getEndcapDynodeRset(const Tm& timeStart) {
 
     rset = m_readStmt->executeQuery();
   }
-  catch (SQLException e) {
+  catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
 #else
@@ -156,7 +156,7 @@ ResultSet *RunDCSHVDat::getBarrelRset() {
     m_readStmt->setSQL(query);
     rset = m_readStmt->executeQuery();
   }
-  catch (SQLException e) {
+  catch (SQLException &e) {
     throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
   }
   return rset;
@@ -174,7 +174,7 @@ ResultSet *RunDCSHVDat::getBarrelRset() {
     m_readStmt->setSQL(query);
     rset = m_readStmt->executeQuery();
   }
-  catch (SQLException e) {
+  catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
 #else
@@ -195,7 +195,7 @@ ResultSet *RunDCSHVDat::getEndcapAnodeRset() {
     m_readStmt->setSQL(query);
     rset = m_readStmt->executeQuery();
   }
-  catch (SQLException e) {
+  catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error(std::string("RunDCSHVDat::getEndcapAnodeRset():  ") + getOraMessage(&e) + " " + query));
 #else
@@ -216,7 +216,7 @@ ResultSet *RunDCSHVDat::getEndcapDynodeRset() {
     m_readStmt->setSQL(query);
     rset = m_readStmt->executeQuery();
   } 
-  catch (SQLException e) {
+  catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error(std::string("RunDCSHVDat::getEndcapDynodeRset():  ") + getOraMessage(&e) + " " + query));
 #else

--- a/OnlineDB/EcalCondDB/src/RunDCSLVDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSLVDat.cc
@@ -63,7 +63,7 @@ ResultSet *RunDCSLVDat::getBarrelRset() {
     m_readStmt->setSQL(query);
     rset = m_readStmt->executeQuery();
   }
-  catch (SQLException e) {
+  catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error(std::string("RunDCSLVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
 #else
@@ -84,7 +84,7 @@ ResultSet *RunDCSLVDat::getEndcapRset() {
     m_readStmt->setSQL(query);
     rset = m_readStmt->executeQuery();
   }
-  catch (SQLException e) {
+  catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error(std::string("RunDCSLVDat::getEndcapRset():  ") + getOraMessage(&e) + " " + query));
 #else

--- a/OnlineDB/EcalCondDB/src/RunDCSMagnetDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSMagnetDat.cc
@@ -84,7 +84,7 @@ ResultSet *RunDCSMagnetDat::getMagnetRset() {
     m_readStmt->setSQL(query);
     rset = m_readStmt->executeQuery();
   }
-  catch (SQLException e) {
+  catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
     throw(std::runtime_error(std::string("RunDCSMagnetDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
 #else

--- a/PhysicsTools/MVAComputer/bin/mvaConvertTMVAWeights.cpp
+++ b/PhysicsTools/MVAComputer/bin/mvaConvertTMVAWeights.cpp
@@ -69,7 +69,7 @@ getCalibration(const std::string &file, const std::vector<std::string> &names)
 		size += iter->size() + 1;
 	size += (size / 32) + 128;
 
-	char *buffer = 0;
+	char *buffer = nullptr;
 	try {
 		buffer = new char[size];
 		ext::omemstream os(buffer, size);
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 		mva.output = names.size();
 
 		MVAComputer::writeCalibration(argv[2], &mva);
-	} catch(cms::Exception e) {
+	} catch(cms::Exception const& e) {
 		std::cerr << e.what() << std::endl;
 	}
 

--- a/PhysicsTools/MVATrainer/bin/mvaExtractor.cpp
+++ b/PhysicsTools/MVATrainer/bin/mvaExtractor.cpp
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
 		out << "\t</output>" << std::endl;
 
 		out << "</MVATrainer>" << std::endl;
-	} catch(cms::Exception e) {
+	} catch(cms::Exception const& e) {
 		std::cerr << e.what() << std::endl;
 	}
 

--- a/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
+++ b/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
@@ -212,7 +212,7 @@ void ProcMLP::trainBegin()
 					getOutputs().size(), layout));
 			mlp->init(count);
 			row = 0;
-		} catch(cms::Exception e) {
+		} catch(cms::Exception const&) {
 			// MLP probably busy (or layout invalid, aaaack)
 			iteration = ITER_WAIT;
 		}

--- a/PhysicsTools/MVATrainer/test/testMVATrainer.cpp
+++ b/PhysicsTools/MVATrainer/test/testMVATrainer.cpp
@@ -112,7 +112,7 @@ int main()
 {
 	try {
 		test();
-	} catch(cms::Exception e) {
+	} catch(cms::Exception const& e) {
 		std::cerr << e.what() << std::endl;
 	}
 

--- a/PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h
+++ b/PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h
@@ -80,7 +80,7 @@ class PATJetCorrExtractor
 	  edm::LogWarning("PATJetCorrExtractor") << "Negative jet energy scale correction noticed" << ".\n";
 	}
       }
-    } catch( cms::Exception e ) {
+    } catch( cms::Exception const& ) {
       throw cms::Exception("InvalidRequest")
 	<< "The JEC level " << jetCorrLabel << " does not exist !!\n"
 	<< "Available levels = " << format_vstring(jet.availableJECLevels()) << ".\n";

--- a/PhysicsTools/PatUtils/interface/StringParserTools.h
+++ b/PhysicsTools/PatUtils/interface/StringParserTools.h
@@ -39,7 +39,7 @@ private:
     boost::shared_ptr<StringObjectFunction<Obj> > tryGet(const std::string &str) {
         try {
             return boost::shared_ptr<StringObjectFunction<Obj> >(new StringObjectFunction<Obj>(str));
-        } catch (cms::Exception) { 
+        } catch (cms::Exception const&) {
             return boost::shared_ptr<StringObjectFunction<Obj> >();
         }
     }
@@ -83,7 +83,7 @@ private:
     boost::shared_ptr<StringCutObjectSelector<Obj> > tryGet(const std::string &str) {
         try {
             return boost::shared_ptr<StringCutObjectSelector<Obj> >(new StringCutObjectSelector<Obj>(str));
-        } catch (cms::Exception) { 
+        } catch (cms::Exception const&) {
             return boost::shared_ptr<StringCutObjectSelector<Obj> >();
         }
     }

--- a/PhysicsTools/TagAndProbe/src/TriggerCandProducer.icc
+++ b/PhysicsTools/TagAndProbe/src/TriggerCandProducer.icc
@@ -224,7 +224,7 @@ void TriggerCandProducer<object>::produce(edm::Event &event, const edm::EventSet
    else{
      std::vector<std::string> filters;
      try { filters = hltConfig.moduleLabels( theRightHLTTag_.label() ); }
-     catch (std::exception ex) { cout << "bad trigger\n"; }
+     catch (std::exception const&) { cout << "bad trigger\n"; }
      for(std::vector<std::string>::iterator filter =
 	   filters.begin(); filter!= filters.end(); ++filter ) {
 

--- a/RecoJets/JetAssociationProducers/src/JetExtender.cc
+++ b/RecoJets/JetAssociationProducers/src/JetExtender.cc
@@ -47,11 +47,11 @@ void JetExtender::produce(edm::Event& fEvent, const edm::EventSetup& fSetup) {
 	extendedData.mTracksAtVertexNumber = reco::JetTracksAssociation::tracksNumber (*j2tVX_h, jet);
 	extendedData.mTracksAtVertexP4 = reco::JetTracksAssociation::tracksP4 (*j2tVX_h, jet);
       }
-      catch (cms::Exception e) {
+      catch (cms::Exception const&) {
 	edm::LogError ("MismatchedJets") << "Jets in original collection " << mJets 
 				    << " mismatch jets in j2t VX association " << mJet2TracksAtVX
 				    << ". Wrong collections?";
-	throw e;
+	throw;
       }
     }
     if (j2tCALO_h.isValid ()) { // fill tracks@CALO  summary
@@ -59,11 +59,11 @@ void JetExtender::produce(edm::Event& fEvent, const edm::EventSetup& fSetup) {
 	extendedData.mTracksAtCaloNumber = reco::JetTracksAssociation::tracksNumber (*j2tCALO_h, jet);
 	extendedData.mTracksAtCaloP4 = reco::JetTracksAssociation::tracksP4 (*j2tCALO_h, jet);
       }
-      catch (cms::Exception e) {
+      catch (cms::Exception const&) {
 	edm::LogError ("MismatchedJets") << "Jets in original collection " << mJets 
 				    << " mismatch jets in j2t CALO association " << mJet2TracksAtCALO
 				    << ". Wrong collections?";
-	throw e;
+	throw;
       }
     }
     reco::JetExtendedAssociation::setValue (&*jetExtender, jet, extendedData);

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -363,7 +363,7 @@ try { // edmNew::CapacityExaustedException
 	    unpacker++;
             }
 	  */
-	} catch (edmNew::CapacityExaustedException) {
+	} catch (edmNew::CapacityExaustedException const&) {
           throw;
         } catch (const cms::Exception& e) {
 	  if (edm::isDebugEnabled()) {
@@ -388,7 +388,7 @@ try { // edmNew::CapacityExaustedException
 	    unpacker++;
 	    }
 	  */
-	} catch (edmNew::CapacityExaustedException) {
+	} catch (edmNew::CapacityExaustedException const&) {
            throw;
         }catch (const cms::Exception& e) {
 	  if (edm::isDebugEnabled()) {
@@ -474,7 +474,7 @@ try { // edmNew::CapacityExaustedException
   COUT << "filled " << record.size() << std::endl;
   for ( auto const & cl : record ) COUT << cl.firstStrip() << ','<<  cl.amplitudes().size() << std::endl;
   incClus(record.size());
-} catch (edmNew::CapacityExaustedException) {
+} catch (edmNew::CapacityExaustedException const&) {
   edm::LogError(sistrip::mlRawToCluster_) << "too many Sistrip Clusters to fit space allocated for OnDemand";
 }  
 

--- a/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTester.cc
+++ b/RecoLocalTracker/SiStripClusterizer/test/ClusterizerUnitTester.cc
@@ -52,10 +52,10 @@ runTheTest(const PSet& test) {
     assertIdentical(expected, result);
     if(test.getParameter<bool>("InvalidCharge")) throw cms::Exception("Failed") << "Charges are valid, contrary to expectation.\n";
   }
-  catch(StripClusterizerAlgorithm::InvalidChargeException e) {
-    if(!test.getParameter<bool>("InvalidCharge")) throw e;
+  catch(StripClusterizerAlgorithm::InvalidChargeException const&) {
+    if(!test.getParameter<bool>("InvalidCharge")) throw;
   }
-  catch(cms::Exception e) {
+  catch(cms::Exception& e) {
     std::cout << ( e << "Input:\n" << printDigis(digiset));
   }
 }

--- a/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.cc
+++ b/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.cc
@@ -183,7 +183,7 @@ NuclearTrackCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
         try{
                 reco::TrackRef  PrimaryTrackRef     = m_TrajToTrackCollection->operator[]( InTrajRef );
 	        Output_tracktrackmap->insert(TrackRef,PrimaryTrackRef);
-        }catch(edm::Exception event){}
+        }catch(edm::Exception const&){}
 	
   }
   iEvent.put(std::move(Output_trajmap));

--- a/RecoVertex/KalmanVertexFit/src/VertexFitterResult.cc
+++ b/RecoVertex/KalmanVertexFit/src/VertexFitterResult.cc
@@ -133,7 +133,7 @@ void VertexFitterResult::fill(const TransientVertex & recVertex,
 //       if (recSimColl!=0) simFound = (*recSimColl)[recTrack->persistentTrackRef()];
 //      if (recSimColl!=0) simFound = (*recSimColl)[recTrack];
 
-    } catch (cms::Exception e) {
+    } catch (cms::Exception const& e) {
 //       LogDebug("TrackValidator") << "reco::Track #" << rT << " with pt=" << track->pt() 
 // 				 << " NOT associated to any TrackingParticle" << "\n";
 //       edm::LogError("TrackValidator") << e.what() << "\n";

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
@@ -43,7 +43,7 @@ EcalSelectiveReadoutProducer::EcalSelectiveReadoutProducer(const edm::ParameterS
     if(params.getParameter<bool>("configFromCondDB")){
       useCondDb_ = true;
     }
-  } catch(cms::Exception){
+  } catch(cms::Exception const&){
     /* pameter not found */
     edm::LogWarning("EcalSelectiveReadout") << "Parameter configFromCondDB of EcalSelectiveReadout module not found. "
       "Selective readout configuration will be read from python file.";

--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -604,7 +604,7 @@ void FullModelHadronicProcess::CalculateMomenta(
 							   targetHasChanged, leadFlag,
 							   leadingStrangeParticle );
 	}
-      catch(G4HadReentrentException aC)
+      catch(G4HadReentrentException &aC)
 	{
 	  aC.Report(G4cout);
 	  throw G4HadReentrentException(__FILE__, __LINE__, "Failing to calculate momenta");

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -38,7 +38,7 @@ void createWatchers(const edm::ParameterSet& iP, SimActivityRegistry& iReg,
     using namespace edm;
     std::vector<ParameterSet> watchers;
     try { watchers = iP.getParameter<vector<ParameterSet> >("Watchers"); } 
-    catch(edm::Exception) {}
+    catch(edm::Exception const&) {}
   
     for(std::vector<ParameterSet>::iterator itWatcher = watchers.begin();
 	itWatcher != watchers.end(); ++itWatcher) 

--- a/SimTracker/TrackAssociation/test/testTrackAssociator.cc
+++ b/SimTracker/TrackAssociation/test/testTrackAssociator.cc
@@ -78,7 +78,7 @@ void testTrackAssociator::analyze(const edm::Event& event, const edm::EventSetup
 	  cout << "\t\tMCTrack " << setw(2) << tpr.index() << " pT: " << setw(6) << tpr->pt() << 
 	    " NShared: " << assocChi2 << endl;
 	}
-    } catch (Exception event) {
+    } catch (Exception const&) {
       cout << "->   Track pT: " 
 	   << setprecision(2) << setw(6) << track->pt() 
 	   <<  " matched to 0  MC Tracks" << endl;
@@ -99,7 +99,7 @@ void testTrackAssociator::analyze(const edm::Event& event, const edm::EventSetup
 	cout << "\t\tMCTrack " << setw(2) << tpr.index() << " pT: " << setw(6) << tpr->pt() << 
 	  " chi2: " << assocChi2 << endl;
       }
-    } catch (Exception event) {
+    } catch (Exception const&) {
       cout << "->   Track pT: " 
 	   << setprecision(2) << setw(6) << track->pt() 
 	   <<  " matched to 0  MC Tracks" << endl;
@@ -122,7 +122,7 @@ void testTrackAssociator::analyze(const edm::Event& event, const edm::EventSetup
 	  cout << "\t\treco::Track pT: " << setw(6) << tr->pt() << 
 	    " NShared: " << assocChi2 << endl;
 	}
-    } catch (Exception event) {
+    } catch (Exception const&) {
       cout << "->   TrackingParticle " << setw(2) << tp.index() << " pT: " 
 	   <<setprecision(2)<<setw(6)<<tp->pt() 
 	   <<  " matched to 0  reco::Tracks" << endl;
@@ -142,7 +142,7 @@ void testTrackAssociator::analyze(const edm::Event& event, const edm::EventSetup
 	cout << "\t\treco::Track pT: " << setw(6) << tr->pt() << 
 	  " chi2: " << assocChi2 << endl;
       }
-    } catch (Exception event) {
+    } catch (Exception const&) {
       cout << "->   TrackingParticle " << setw(2) << tp.index() << " pT: " 
 	   <<setprecision(2)<<setw(6)<<tp->pt() 
 	   <<  " matched to 0  reco::Tracks" << endl;

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -212,7 +212,7 @@ void TrackClassifier::reconstructionInformation(reco::TrackBaseRef const & track
         flags_[Bad] = (dxyPull > badPull_ || dzPull > badPull_);
 
     }
-    catch (cms::Exception exception)
+    catch (cms::Exception const&)
     {
         flags_[Bad] = true;
     }

--- a/Validation/RecoEgamma/plugins/TkConvValidator.cc
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.cc
@@ -1096,7 +1096,7 @@ void TkConvValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 	  myAss.insert( std::make_pair (tr1.get(),theConvTP_[tp_1] ) );
 	  myAss.insert( std::make_pair (tr2.get(),theConvTP_[tp_2]) );
 
-	//} catch (Exception event) {
+	//} catch (Exception const& event) {
 	  //cout << "continue: " << event.what()  << endl;
 	//  continue;
 	//}
@@ -1562,7 +1562,7 @@ void TkConvValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
                   }
                 }
               }
-            } catch (Exception event) {
+            } catch (Exception const& event) {
               //cout << "do not continue: " << event.what()  << endl;
               //continue;
             }


### PR DESCRIPTION
Where possible catch by const reference. There are also a couple
changes the 'scram b code-checks' added in. I expect nothing is
here that would change results of anything.