### PR TITLE
reduce compression in rawsim to help premix job speed with minimal change in file size

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -201,7 +201,7 @@ RAWSIMEventContent = cms.PSet(
     splitLevel = cms.untracked.int32(0),
     eventAutoFlushCompressedSize=cms.untracked.int32(20*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
-    compressionLevel=cms.untracked.int32(9)
+    compressionLevel=cms.untracked.int32(1)
 )
 #
 #


### PR DESCRIPTION
Comparing an 8 thread premix job of 500 events, this change reduces CPU time significantly. Thanks to Servesh Muralidharan for identifying this as an optimization.

2555.649u 361.876s 10:24.86 466.9%	0+0k 1499704+1882176io 5169pf+0w
871267564 Jul 19 12:17 step2.root

vs

1755.123u 256.876s 6:37.46 506.2%	0+0k 1500440+3014888io 5167pf+0w
936432715 Jul 19 12:25 step2.root