### PR TITLE
Print function migration for SimCalorimetry_HGCalSimProducers

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/python/customHGCdigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/customHGCdigitizer_cfi.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 """
@@ -7,7 +8,7 @@ def customHGCdigitizer(process, version='simple0', debug=False):
     
     #configure digitizer model
     if version.find('femodel')>=0:
-        print 'Adapting for FE model'
+        print('Adapting for FE model')
         process.mix.digitizers.hgceeDigitizer.digiCfg.feCfg.fwVersion = cms.uint32(1)
         process.mix.digitizers.hgceeDigitizer.digiCfg.feCfg.shaperN = cms.double(8.02)
         process.mix.digitizers.hgceeDigitizer.digiCfg.feCfg.shaperTau = cms.double(3.26)
@@ -30,7 +31,7 @@ def customHGCdigitizer(process, version='simple0', debug=False):
 
     elif version.find('simple')>=0 :
         tau=float(version.replace('simple',''))
-        print 'Adapting simple pulse shape with tau=%f'%tau
+        print('Adapting simple pulse shape with tau=%f'%tau)
         process.mix.digitizers.hgceeDigitizer.digiCfg.feCfg.fwVersion = cms.uint32(0)
         process.mix.digitizers.hgceeDigitizer.digiCfg.feCfg.shaperTau = cms.double(tau)
         process.mix.digitizers.hgchefrontDigitizer.digiCfg.feCfg.fwVersion = cms.uint32(0)

--- a/SimCalorimetry/HGCalSimProducers/test/hgcalInjectTestHit_cfg.py
+++ b/SimCalorimetry/HGCalSimProducers/test/hgcalInjectTestHit_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('DIGI')
@@ -22,7 +23,7 @@ process.mix.theDigitizers = cms.PSet( hgcee      = cms.PSet( hgceeDigitizer),
                                       hgchefront = cms.PSet( hgchefrontDigitizer),
                                       hgcheback  = cms.PSet( hgchebackDigitizer)
                                       )
-print process.mix.theDigitizers
+print(process.mix.theDigitizers)
 
 # input configuration
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import