### PR TITLE
Fix parameters for testing online DQM

### DIFF
--- a/DQM/Integration/python/config/environment_cfi.py
+++ b/DQM/Integration/python/config/environment_cfi.py
@@ -22,7 +22,7 @@ dqmRunConfigDefaults = {
     'userarea': cms.PSet(
         type = cms.untracked.string("userarea"),
         collectorPort = cms.untracked.int32(9190),
-        collectorHost = cms.untracked.string('dqm-c2d07-29.cms'),
+        collectorHost = cms.untracked.string('127.0.0.1'),
     ),
     'playback': cms.PSet(
         type = cms.untracked.string("playback"),

--- a/DQM/Integration/python/config/fileinputsource_cfi.py
+++ b/DQM/Integration/python/config/fileinputsource_cfi.py
@@ -90,7 +90,7 @@ print "Selected %d files and %d LS." % (len(readFiles), len(lumirange))
 
 source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles, lumisToProcess = lumirange)
 maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(100)
+    input = cms.untracked.int32(-1)
 )
 
 # Fix to allow scram to compile


### PR DESCRIPTION
This small PR configures online DQM for a locally running DQMGUI when not running in production, and un-limits the number of events processed from files. That makes testing online DQM a bit easier, less files to be adapted by hand...