### PR TITLE
Print function migration for RecoLocalTracker_SiStripClusterizer

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/test/shotTest_withReClustering_cfg.py
+++ b/RecoLocalTracker/SiStripClusterizer/test/shotTest_withReClustering_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('CALIB')
@@ -56,8 +57,8 @@ process.SiStripMonitorClusterNew = process.SiStripMonitorCluster.clone()
 process.SiStripMonitorClusterNew.TopFolderName = "ClusterToDigi"
 process.SiStripMonitorClusterNew.ClusterProducerStrip = 'siStripClustersNew'
 
-print process.SiStripMonitorClusterNew.ClusterProducerStrip
-print process.SiStripMonitorCluster.ClusterProducerStrip
+print(process.SiStripMonitorClusterNew.ClusterProducerStrip)
+print(process.SiStripMonitorCluster.ClusterProducerStrip)
 
 process.SiStripMonitorCluster.TH1ClusterWidth.Nbinx          = cms.int32(129)
 process.SiStripMonitorCluster.TH1ClusterWidth.xmax           = cms.double(128.5)


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import