### PR TITLE
Print function migration for RecoTracker_TkSeedGenerator

### DIFF
--- a/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromTripletsWithVertices_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/GlobalSeedsFromTripletsWithVertices_cff.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-print
-print "in file GlobalSeedsFromTripletsWithVertices_cff.py"
-print "The name of this file is mis-leading. Please use GlobalSeedsFromTriplets_cff.py instead"
-print "if you meant to use global triplt with vertex constraint"
-print
+print()
+print("in file GlobalSeedsFromTripletsWithVertices_cff.py")
+print("The name of this file is mis-leading. Please use GlobalSeedsFromTriplets_cff.py instead")
+print("if you meant to use global triplt with vertex constraint")
+print()
 
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
 globalSeedsFromTripletsWithVertices = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone()


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import