### PR TITLE
Fix GCC 8 compiler warnings

### DIFF
--- a/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
@@ -262,7 +262,7 @@ LumiProducer::LumiProducer(const edm::ParameterSet& iConfig):m_cachedrun(0),m_is
       endservlet=connectStr.rfind('/',connectStr.length());
     }
     std::string servlet=connectStr.substr(startservlet,endservlet-startservlet);
-    if( (servlet !="")&& (servlet.find_first_of(":/)[]")==std::string::npos)){
+    if( (!servlet.empty())&& (servlet.find_first_of(":/)[]")==std::string::npos)){
       if(servlet=="cms_conditions_data") servlet="";
       
       std::string siteconfpath=iConfig.getUntrackedParameter<std::string>("siteconfpath","");
@@ -725,7 +725,7 @@ LumiProducer::fillLSCache(unsigned int luminum){
 	const void* trgcountblob_StartAddress=trgcountblob.startingAddress();
 	unsigned int* trgcounts=(unsigned int*)::malloc(trgcountblob.size());
 	std::memmove(trgcounts,trgcountblob_StartAddress,trgcountblob.size());
-	for(unsigned int i=0;i<sizeof(trgcounts)/sizeof(unsigned int);++i){
+	for(unsigned int i=0; i < trgcountblob.size()/sizeof(unsigned int); ++i){
 	  L1Data l1tmp;
 	  l1tmp.bitname=m_runcache.TRGBitNames[i];
 	  l1tmp.prescale=prescales[i];
@@ -778,14 +778,14 @@ LumiProducer::fillLSCache(unsigned int luminum){
 	const void* hltacceptblob_StartAddress=hltacceptblob.startingAddress();
 	unsigned int* hltaccepts=(unsigned int*)::malloc(hltacceptblob.size());
 	std::memmove(hltaccepts,hltacceptblob_StartAddress,hltacceptblob.size()); 	
-	unsigned int nhltaccepts = sizeof(hltaccepts)/sizeof(unsigned int);
+	unsigned int nhltaccepts = hltacceptblob.size()/sizeof(unsigned int);
         if(nhltaccepts > 0 && m_runcache.HLTPathNames.empty()){
           edm::LogWarning("CorruptOrMissingHLTData")<<"Got "<<nhltaccepts
 <<" hltaccepts, but the run chache is empty. hltdata will  not be written";
             break;
         }
 
-	for(unsigned int i=0;i<sizeof(hltaccepts)/sizeof(unsigned int);++i){
+	for(unsigned int i=0; i < hltacceptblob.size()/sizeof(unsigned int); ++i){
 	  HLTData hlttmp;
 	  hlttmp.pathname=m_runcache.HLTPathNames[i];
 	  hlttmp.prescale=hltprescales[i];


### PR DESCRIPTION
Fix makes the code perform as it appears was originally
intended. This appears to have been a real bug.

But I don't think this bug had any bad consequences.
I reported it to the lumi hypernews.
Zhen says "This module is no more supported nor it is of
any real use. However, other CMS production people prefer
running it empty."