### PR TITLE
[10_2_X] SiStrip 10bit ZS packer bug fix: assume 10bit instead of 8bit-truncated digis

### DIFF
--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -108,6 +108,11 @@ namespace sistrip {
 				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
 				     std::unique_ptr<FEDRawDataCollection>& buffers,
 				     bool zeroSuppressed) {
+    const bool dataIsAlready8BitTruncated = zeroSuppressed && ( ! ( // not for 10bit modes
+             ( ( mode_ == READOUT_MODE_ZERO_SUPPRESSED ) && ( packetCode_ == PACKET_CODE_ZERO_SUPPRESSED10 ) )
+          || ( mode_ == READOUT_MODE_ZERO_SUPPRESSED_LITE10 )
+          || ( mode_ == READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE )
+          ) );
     try {
       
       //set the L1ID to use in the buffers
@@ -224,7 +229,7 @@ namespace sistrip {
           //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
           //zeroSuppressed here means converted to 8 bit...
           if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
-          FEDStripData fedData(zeroSuppressed);
+          FEDStripData fedData(dataIsAlready8BitTruncated);
           
           
           for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {
@@ -335,7 +340,7 @@ namespace sistrip {
           //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
           //zeroSuppressed here means converted to 8 bit...
           if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
-          FEDStripData fedData(zeroSuppressed);
+          FEDStripData fedData(dataIsAlready8BitTruncated);
           
           
           for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -108,8 +108,11 @@ namespace sistrip {
 				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
 				     std::unique_ptr<FEDRawDataCollection>& buffers,
 				     bool zeroSuppressed) {
-    const bool dataIsAlready8BitTruncated = zeroSuppressed && ( ! ( // not for 10bit modes
-             ( ( mode_ == READOUT_MODE_ZERO_SUPPRESSED ) && ( packetCode_ == PACKET_CODE_ZERO_SUPPRESSED10 ) )
+    const bool dataIsAlready8BitTruncated = zeroSuppressed && ( ! (
+          //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
+             ( mode_ == READOUT_MODE_PREMIX_RAW )
+          // the same goes for 10bit ZS modes
+          || ( ( mode_ == READOUT_MODE_ZERO_SUPPRESSED ) && ( packetCode_ == PACKET_CODE_ZERO_SUPPRESSED10 ) )
           || ( mode_ == READOUT_MODE_ZERO_SUPPRESSED_LITE10 )
           || ( mode_ == READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE )
           ) );
@@ -226,9 +229,6 @@ namespace sistrip {
 	  }
           auto conns = cabling->fedConnections(*ifed);
           
-          //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
-          //zeroSuppressed here means converted to 8 bit...
-          if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
           FEDStripData fedData(dataIsAlready8BitTruncated);
           
           
@@ -337,9 +337,6 @@ namespace sistrip {
           
           auto conns = cabling->fedConnections(*ifed);
           
-          //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
-          //zeroSuppressed here means converted to 8 bit...
-          if (mode_ == READOUT_MODE_PREMIX_RAW) zeroSuppressed=false;
           FEDStripData fedData(dataIsAlready8BitTruncated);
           
           


### PR DESCRIPTION
Backport of #23811
This will be needed in an upcoming 10_2 release for testing the full HI reconstruction chain (see [this talk](https://indico.cern.ch/event/688869/?showDate=all&showSession=all#53-status-of-strip-software-fo) for more information).
No changes to any standard workflows are expected since the 10bit ZS modes are not used yet.

CC: @CesarBernardes @icali @abaty @mmusich @echabert @boudoul @erikbutz