### PR TITLE
Print function migration for IOMC_EventVertexGenerators

### DIFF
--- a/IOMC/EventVertexGenerators/test/calculate_beamwidth.py
+++ b/IOMC/EventVertexGenerators/test/calculate_beamwidth.py
@@ -13,6 +13,7 @@ given beta-star and beam energy estimate: gamma, emittance, and beam width
 at Z = 0
 
 """
+from __future__ import print_function
 
 import math
 
@@ -26,6 +27,6 @@ emittance = normemittance/(gamma*math.sqrt(1.-1/(gamma*gamma)))
 
 width = math.sqrt(emittance*betastar)
 
-print " emittance in m: " + str(emittance)
-print " beam width in m: " + str(width)
+print(" emittance in m: " + str(emittance))
+print(" beam width in m: " + str(width))
 

--- a/RecoParticleFlow/PFProducer/python/tools/pfClusteringCustoms.py
+++ b/RecoParticleFlow/PFProducer/python/tools/pfClusteringCustoms.py
@@ -1,11 +1,12 @@
+from __future__ import print_function
 
 import FWCore.ParameterSet.Config as cms
 
 
 
 def usePFWithMethodOne(process):
-    print '-------------PF with method I -------------'
-    print 'Assumes that HCAL reco is tuned to method I '
+    print('-------------PF with method I -------------')
+    print('Assumes that HCAL reco is tuned to method I ')
     process.particleFlowRecHitHBHE.navigator = cms.PSet(
         name = cms.string("PFRecHitHCALNavigator")
     )
@@ -14,8 +15,8 @@ def usePFWithMethodOne(process):
 
 
 def usePFWithMethodOnePointFive(process):
-    print '-------------PF with method I.5-------------'
-    print 'Independent of which HCAL reco was used since it reads the time samples from the rechit '
+    print('-------------PF with method I.5-------------')
+    print('Independent of which HCAL reco was used since it reads the time samples from the rechit ')
 
 
     from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHEMaxSampleTimeSelected_cfi import particleFlowClusterHBHETimeSelected as timeSelector


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import