### PR TITLE
CTPPS: updated DQM for 2018 data taking [10_1_X]

### DIFF
--- a/DQM/CTPPS/plugins/BuildFile.xml
+++ b/DQM/CTPPS/plugins/BuildFile.xml
@@ -11,6 +11,7 @@
 	<use name="DataFormats/CTPPSDetId"/>
 	<use name="DataFormats/CTPPSDigi"/>
 	<use name="DataFormats/CTPPSReco"/>
+	<use name="DataFormats/OnlineMetaData"/>
 	
 	<use name="Geometry/Records"/>
 	<use name="Geometry/VeryForwardGeometryBuilder"/>

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -100,7 +100,7 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker)
   events_per_bx = ibooker.book1D("events per BX", "rp;Event.BX", 4002, -1.5, 4000. + 0.5);
   events_per_bx_short = ibooker.book1D("events per BX (short)", "rp;Event.BX", 102, -1.5, 100. + 0.5);
 
-  RPState = ibooker.book2D("ctpps_common_rpstate_vs_lumisection","RP State per Lumisection;Luminosity Section;",MAX_LUMIS, 0, MAX_LUMIS, MAX_VBINS, 0., MAX_VBINS);
+  RPState = ibooker.book2D("rpstate per LS","RP State per Lumisection;Luminosity Section;",MAX_LUMIS, 0, MAX_LUMIS, MAX_VBINS, 0., MAX_VBINS);
   {
     TH2F* hist = RPState->getTH2F();
     hist->SetCanExtend(TH1::kAllAxes);
@@ -261,8 +261,8 @@ void CTPPSCommonDQMSource::analyze(edm::Event const& event, edm::EventSetup cons
      RP name: RP_56_220_NR_TP
      */
 
+  rpstate.clear();
   if(currentLS > endLS){
-    rpstate.clear();
     for (uint8_t i = 0; i < CTPPSRecord::RomanPot::Last; ++i) {
       rpstate.push_back(rp->status(i));
     }

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -201,6 +201,7 @@ CTPPSCommonDQMSource::CTPPSCommonDQMSource(const edm::ParameterSet& ps) :
 
   currentLS = 0;
   endLS = 0;
+  rpstate.clear();
 
 }
 
@@ -261,8 +262,8 @@ void CTPPSCommonDQMSource::analyze(edm::Event const& event, edm::EventSetup cons
      RP name: RP_56_220_NR_TP
      */
 
-  rpstate.clear();
   if(currentLS > endLS){
+    rpstate.clear();
     for (uint8_t i = 0; i < CTPPSRecord::RomanPot::Last; ++i) {
       rpstate.push_back(rp->status(i));
     }
@@ -414,6 +415,7 @@ void CTPPSCommonDQMSource::endLuminosityBlock(const edm::LuminosityBlock& iLumi,
   }
 
   endLS = iLumi.luminosityBlock();
+  rpstate.clear();
 
 }
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -1,15 +1,16 @@
 /****************************************************************************
-*
-* This is a part of TotemDQM and TOTEM offline software.
-* Authors:
-*   Jan Kašpar (jan.kaspar@gmail.com)
-*
-****************************************************************************/
+ *
+ * This is a part of TotemDQM and TOTEM offline software.
+ * Authors:
+ *   Jan Kašpar (jan.kaspar@gmail.com)
+ *
+ ****************************************************************************/
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -18,8 +19,8 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
-
 #include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+#include "DataFormats/OnlineMetaData/interface/CTPPSRecord.h"
 
 #include <string>
 
@@ -36,17 +37,27 @@ class CTPPSCommonDQMSource: public DQMEDAnalyzer
   protected:
 
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-
     void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& c) override;
+    void endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& c) override;
 
   private:
     unsigned int verbosity;
+    const static int MAX_LUMIS = 6000;
+    const static int MAX_VBINS = 18;
 
     edm::EDGetTokenT< std::vector<CTPPSLocalTrackLite> > tokenLocalTrackLite;
+    edm::EDGetTokenT<CTPPSRecord> ctppsRecordToken;
+
+    int currentLS;
+    int endLS;
+
+    std::vector<int> rpstate;
 
     /// plots related to the whole system
     struct GlobalPlots
     {
+      MonitorElement *RPState = nullptr;
       MonitorElement *events_per_bx = nullptr, *events_per_bx_short = nullptr;
       MonitorElement *h_trackCorr_hor = nullptr, *h_trackCorr_vert = nullptr;
 
@@ -77,6 +88,9 @@ class CTPPSCommonDQMSource: public DQMEDAnalyzer
 using namespace std;
 using namespace edm;
 
+const int CTPPSCommonDQMSource::MAX_LUMIS;
+const int CTPPSCommonDQMSource::MAX_VBINS;
+
 //----------------------------------------------------------------------------------------------------
 
 void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker)
@@ -85,6 +99,31 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker)
 
   events_per_bx = ibooker.book1D("events per BX", "rp;Event.BX", 4002, -1.5, 4000. + 0.5);
   events_per_bx_short = ibooker.book1D("events per BX (short)", "rp;Event.BX", 102, -1.5, 100. + 0.5);
+
+  RPState = ibooker.book2D("ctpps_common_rpstate_vs_lumisection","RP State per Lumisection;Luminosity Section;",MAX_LUMIS, 0, MAX_LUMIS, MAX_VBINS, 0., MAX_VBINS);
+  {
+    TH2F* hist = RPState->getTH2F();
+    hist->SetCanExtend(TH1::kAllAxes);
+    TAxis* ya = hist->GetYaxis();
+    ya->SetBinLabel(1, "45, 210, FR-BT");
+    ya->SetBinLabel(2, "45, 210, FR-HR");
+    ya->SetBinLabel(3, "45, 210, FR-TP");
+    ya->SetBinLabel(4, "45, 220, C1");
+    ya->SetBinLabel(5, "45, 220, FR-BT");
+    ya->SetBinLabel(6, "45, 220, FR-HR");
+    ya->SetBinLabel(7, "45, 220, FR-TP");
+    ya->SetBinLabel(8, "45, 220, NR-BP");
+    ya->SetBinLabel(9, "45, 220, NR-TP");
+    ya->SetBinLabel(10, "56, 210, FR-BT");
+    ya->SetBinLabel(11, "56, 210, FR-HR");
+    ya->SetBinLabel(12, "56, 210, FR-TP");
+    ya->SetBinLabel(13, "56, 220, C1");
+    ya->SetBinLabel(14, "56, 220, FR-BT");
+    ya->SetBinLabel(15, "56, 220, FR-HR");
+    ya->SetBinLabel(16, "56, 220, FR-TP");
+    ya->SetBinLabel(17, "56, 220, NR-BP");
+    ya->SetBinLabel(18, "56, 220, NR-TP");
+  }
 
   h_trackCorr_hor = ibooker.book2D("track correlation hor", "ctpps_common_rp_hor", 6, -0.5, 5.5, 6, -0.5, 5.5);
   {
@@ -158,6 +197,11 @@ CTPPSCommonDQMSource::CTPPSCommonDQMSource(const edm::ParameterSet& ps) :
   verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0))
 {
   tokenLocalTrackLite = consumes< vector<CTPPSLocalTrackLite> >(ps.getParameter<edm::InputTag>("tagLocalTrackLite"));
+  ctppsRecordToken = consumes<CTPPSRecord>(ps.getUntrackedParameter<edm::InputTag>("ctppsmetadata"));
+
+  currentLS = 0;
+  endLS = 0;
+
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -184,6 +228,47 @@ void CTPPSCommonDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run c
 
 void CTPPSCommonDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
 {
+
+  // get CTPPS Event Record
+  Handle<CTPPSRecord> rp;
+  event.getByToken(ctppsRecordToken, rp);
+
+  /*
+     RP State (HV & LV & Insertion):
+     0 -> not used
+     1 -> bad
+     2 -> warning
+     3 -> ok
+
+     CTPPSRecord Order:
+     RP name: RP_45_210_FR_BT
+     RP name: RP_45_210_FR_HR
+     RP name: RP_45_210_FR_TP
+     RP name: RP_45_220_C1
+     RP name: RP_45_220_FR_BT
+     RP name: RP_45_220_FR_HR
+     RP name: RP_45_220_FR_TP
+     RP name: RP_45_220_NR_BT
+     RP name: RP_45_220_NR_TP
+     RP name: RP_56_210_FR_BT
+     RP name: RP_56_210_FR_HR
+     RP name: RP_56_210_FR_TP
+     RP name: RP_56_220_C1
+     RP name: RP_56_220_FR_BT
+     RP name: RP_56_220_FR_HR
+     RP name: RP_56_220_FR_TP
+     RP name: RP_56_220_NR_BT
+     RP name: RP_56_220_NR_TP
+     */
+
+  if(currentLS > endLS){
+    rpstate.clear();
+    for (uint8_t i = 0; i < CTPPSRecord::RomanPot::Last; ++i) {
+      rpstate.push_back(rp->status(i));
+    }
+    endLS=currentLS;
+  }  
+
   // get event data
   Handle< vector<CTPPSLocalTrackLite> > tracks;
   event.getByToken(tokenLocalTrackLite, tracks);
@@ -197,7 +282,7 @@ void CTPPSCommonDQMSource::analyze(edm::Event const& event, edm::EventSetup cons
     if (verbosity)
     {
       LogProblem("CTPPSCommonDQMSource")
-        << "    trackLites.isValid = " << tracks.isValid();
+	<< "    trackLites.isValid = " << tracks.isValid();
     }
 
     return;
@@ -223,7 +308,7 @@ void CTPPSCommonDQMSource::analyze(edm::Event const& event, edm::EventSetup cons
       if (stRPNum == 16) idx = 2;
 
       if (idx >= 0)
-        s_rp_idx_global_hor.insert(3*arm + idx);
+	s_rp_idx_global_hor.insert(3*arm + idx);
     }
 
     {
@@ -234,7 +319,7 @@ void CTPPSCommonDQMSource::analyze(edm::Event const& event, edm::EventSetup cons
       if (stRPNum == 25) idx = 3;
 
       if (idx >= 0)
-        s_rp_idx_global_vert.insert(4*arm + idx);
+	s_rp_idx_global_vert.insert(4*arm + idx);
     }
 
     {
@@ -250,7 +335,7 @@ void CTPPSCommonDQMSource::analyze(edm::Event const& event, edm::EventSetup cons
       const signed int hor = ((rpNum == 2) || (rpNum == 3) || (rpNum == 6)) ? 1 : 0;
 
       if (idx >= 0)
-        ms_rp_idx_arm[arm].insert(idx * 10 + hor);
+	ms_rp_idx_arm[arm].insert(idx * 10 + hor);
     }
   }
 
@@ -303,15 +388,34 @@ void CTPPSCommonDQMSource::analyze(edm::Event const& event, edm::EventSetup cons
     {
       for (const auto &idx2 : ap.second)
       {
-        plots.h_trackCorr->Fill(idx1/10, idx2/10);
+	plots.h_trackCorr->Fill(idx1/10, idx2/10);
 
-        if ((idx1 % 10) != (idx2 % 10))
-          plots.h_trackCorr_overlap->Fill(idx1/10, idx2/10);
+	if ((idx1 % 10) != (idx2 % 10))
+	  plots.h_trackCorr_overlap->Fill(idx1/10, idx2/10);
       }
     }
   }
+
+}
+//----------------------------------------------------------------------------------------------------
+
+void CTPPSCommonDQMSource::beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& c) {
+
+  currentLS = iLumi.id().luminosityBlock();
+
 }
 
+//----------------------------------------------------------------------------------------------------
+
+void CTPPSCommonDQMSource::endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& c) {
+
+  for(std::vector<int>::size_type i=0; i<rpstate.size();i++){
+    globalPlots.RPState->setBinContent(currentLS, i+1, rpstate[i]);
+  }
+
+  endLS = iLumi.luminosityBlock();
+
+}
 //----------------------------------------------------------------------------------------------------
 
 DEFINE_FWK_MODULE(CTPPSCommonDQMSource);

--- a/DQM/CTPPS/python/ctppsCommonDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsCommonDQMSource_cfi.py
@@ -4,6 +4,6 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 ctppsCommonDQMSource = DQMEDAnalyzer('CTPPSCommonDQMSource',
     tagLocalTrackLite = cms.InputTag('ctppsLocalTrackLiteProducer'),
-  
+    ctppsmetadata = cms.untracked.InputTag("onlineMetaDataDigis"),
     verbosity = cms.untracked.uint32(0),
 )

--- a/DQM/CTPPS/test/timing_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/timing_dqm_test_cfg.py
@@ -30,14 +30,16 @@ process.dqmSaver.tag = "CTPPS"
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring( *(
-    # '''/store/data/Commissioning2018/ZeroBias/RAW/v1/000/314/816/00000/0062E91C-2245-E811-8DCB-FA163EE59A93.root',
-    # '''/store/data/Commissioning2018/ZeroBias/RAW/v1/000/314/816/00000/007EABA4-5745-E811-8573-FA163EB3E1C0.root',
-# '''/store/data/Commissioning2018/MinimumBias/RAW/v1/000/314/276/00000/B45F5174-6040-E811-BCDA-FA163EB38F53.root',
-'/store/data/Commissioning2018/ZeroBias1/RAW/v1/000/314/277/00000/04F64F14-A53F-E811-A60D-FA163ED486E3.root',
+    # '/store/data/Commissioning2018/ZeroBias/RAW/v1/000/314/816/00000/0062E91C-2245-E811-8DCB-FA163EE59A93.root',
+    # '/store/data/Commissioning2018/ZeroBias/RAW/v1/000/314/816/00000/007EABA4-5745-E811-8573-FA163EB3E1C0.root',
+# '/store/data/Commissioning2018/MinimumBias/RAW/v1/000/314/276/00000/B45F5174-6040-E811-BCDA-FA163EB38F53.root',
+#'/store/data/Commissioning2018/ZeroBias1/RAW/v1/000/314/277/00000/04F64F14-A53F-E811-A60D-FA163ED486E3.root',
+      #'root://cms-xrd-global.cern.ch//store/relval/CMSSW_10_2_0_pre4/DoubleEG/RAW-RECO/ZElectron-102X_dataRun2_PromptLike_v1_RelVal_doubEG2017B-v1/20000/2A91DAFF-9161-E811-93F5-0CC47A4D765E.root',
+    #'root://cms-xrd-global.cern.ch//store/data/Run2018B/SingleMuon/RAW/v1/000/317/080/00000/08B75D73-B962-E811-BB99-FA163E07C94D.root',
+     'root://cms-xrd-global.cern.ch//store/data/Run2018A/SingleMuon/RAW-RECO/ZMu-PromptReco-v3/000/316/569/00000/006F7ABE-4A64-E811-99E2-FA163E679A44.root',
     )
     )
 )
-
 
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_relval', '')

--- a/DQM/CTPPS/test/timing_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/timing_dqm_test_cfg.py
@@ -4,7 +4,6 @@ import string
 process = cms.Process('RECODQM')
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
-
 process.verbosity = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 # minimum of logs


### PR DESCRIPTION
Backport of #23577 

This PR updates the DQM:
* Includes new CTPPS Roman Pot (RP) state (with CTPPSRecord collection) in function of LS. Each state corresponds to a combination of (HV & LV & position for physics).
* States are 0 (not used), 1 (bad), 2 (warning) and 3 (ok).

A test python is available at DQM/CTPPS/test/timing_dqm_test_cfg.py

@dfigueiredo @nminafra @fabferro