### PR TITLE
global chi2/ndf cut removed from isLooseTriggerMuon

### DIFF
--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -846,9 +846,8 @@ bool muon::isLooseTriggerMuon(const reco::Muon& muon){
   if ( not tk_id ) return false;
   bool layer_requirements = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
     muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0;
-  bool global_requirements = (not muon.isGlobalMuon()) or muon.globalTrack()->normalizedChi2()<20;
   bool match_requirements = (muon.expectedNnumberOfMatchedStations()<2) or (muon.numberOfMatchedStations()>1) or (muon.pt()<8);
-  return layer_requirements and global_requirements and match_requirements;
+  return layer_requirements and match_requirements;
 }
 
 bool muon::isTightMuon(const reco::Muon& muon, const reco::Vertex& vtx){


### PR DESCRIPTION
The chi2/ndf cut at HLT is found causing a drop in trigger efficiency in the endcaps for high-pt muons. The big is fixed by removing this cut completely from HLT. More details: https://indico.cern.ch/event/742890/contributions/3074437/attachments/1689747/2718508/20180718_PPDGenMeeting_1020pre4problem_schhibra.pdf

The muon selector, isLooseTrigeerMuon, is modified accordingly to be consistent with the changes.