### PR TITLE
Print function migration for Calibration_TkAlCaRecoProducers

### DIFF
--- a/Calibration/TkAlCaRecoProducers/test/convertSiStripRootDQMFileToEDM_cfg.py
+++ b/Calibration/TkAlCaRecoProducers/test/convertSiStripRootDQMFileToEDM_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 """ This python cfg converts a plain DQM root file in a EDM file that can be used to run the SiStrip bad channel calibration as done @ Tier0"""
@@ -24,7 +25,7 @@ process.maxEvents = cms.untracked.PSet(
 
 
 runNumber = int(process.fileReader.RootFileName.value().split('/')[-1].split('_')[2].lstrip("R"))
-print "Run number extracted from file name:",runNumber
+print("Run number extracted from file name:",runNumber)
 
 process.source = cms.Source("EmptySource",
                             firstRun = cms.untracked.uint32(runNumber),


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import