### PR TITLE
Adding two by-lumisection plots to ECAL DQM, backport to CMSSW 10_1_X

### DIFF
--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -17,6 +17,7 @@ ecalTrigPrimClient = cms.untracked.PSet(
         EtEmulError = ecalTrigPrimTask.MEs.EtEmulError,
         MatchedIndex = ecalTrigPrimTask.MEs.MatchedIndex,
         TTFlags4 = ecalTrigPrimTask.MEs.TTFlags4,
+        TTFlags4ByLumi = ecalTrigPrimTask.MEs.TTFlags4ByLumi,
         TTMaskMapAll = ecalTrigPrimTask.MEs.TTMaskMapAll,
         TTFMismatch = ecalTrigPrimTask.MEs.TTFMismatch,
         LHCStatusByLumi = ecalTrigPrimTask.MEs.LHCStatusByLumi,
@@ -56,6 +57,13 @@ ecalTrigPrimClient = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('TriggerTower'),
             description = cms.untracked.string('Summarizes whether a TT was masked in the TPGRecords, or had an instance of TT Flag=4.<br/>GRAY: Masked, no TTF4,<br/>BLACK: Masked, with TTF4,<br/>BLUE: Not Masked, with TTF4.')
+        ),
+        TTF4vMaskByLumi = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT TTF4 vs Masking Status%(suffix)s by lumi'),
+            kind = cms.untracked.string('TH2F'),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('TriggerTower'),
+            description = cms.untracked.string('Summarizes whether a TT was masked in this lumisection in the TPGRecords, or had an instance of TT Flag=4.<br/>GRAY: Masked, no TTF4,<br/>BLACK: Masked, with TTF4,<br/>BLUE: Not Masked, with TTF4.')
         ),
         TrendTTF4Flags = cms.untracked.PSet(
             path = cms.untracked.string('Ecal/Trends/TrigPrimClient %(prefix)s number of TTs with TTF4 set'),

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -93,7 +93,9 @@ namespace ecaldqm
     // NOT an occupancy plot: only tells you if non-zero TTF4 occupancy was seen
     // without giving info about how many were seen
     MESet& meTTF4vMask(MEs_.at("TTF4vMask"));
+    MESet& meTTF4vMaskByLumi(MEs_.at("TTF4vMaskByLumi"));
     MESet const& sTTFlags4(sources_.at("TTFlags4"));
+    MESet const& sTTFlags4ByLumi(sources_.at("TTFlags4ByLumi"));
     MESet const& sTTMaskMapAll(sources_.at("TTMaskMapAll"));
 
     std::vector<float> nWithTTF4(nDCC, 0.); // counters to keep track of number of towers in a DCC that have TTF4 flag set
@@ -105,20 +107,29 @@ namespace ecaldqm
       unsigned iDCC( dccId(ttid)-1 );
       bool isMasked( sTTMaskMapAll.getBinContent(ttid) > 0. );
       bool hasTTF4( sTTFlags4.getBinContent(ttid) > 0. );
-      if (hasTTF4) {
+      bool hasTTF4InThisLumiSection( sTTFlags4ByLumi.getBinContent(ttid) > 0. );
+      if (hasTTF4InThisLumiSection) {
         nWithTTF4[iDCC]++;
         if (ttid.subDet() == EcalBarrel) nWithTTF4_EB++;
         else if (ttid.subDet() == EcalEndcap) nWithTTF4_EE++;
       }
       if ( isMasked ) { 
-        if ( hasTTF4 )
+        if ( hasTTF4 ) {
           meTTF4vMask.setBinContent( ttid,12 ); // Masked, has TTF4
-        else
+        }
+        else {
           meTTF4vMask.setBinContent( ttid,11 ); // Masked, no TTF4
+        }
+        if ( hasTTF4InThisLumiSection ) {
+          meTTF4vMaskByLumi.setBinContent( ttid,12 ); // Masked, has TTF4
+        }
+        else {
+          meTTF4vMaskByLumi.setBinContent( ttid,11 ); // Masked, no TTF4
+        }
       } else {
-        if ( hasTTF4 )
-          meTTF4vMask.setBinContent( ttid,13 ); // not Masked, has TTF4
-      }   
+        if ( hasTTF4 ) meTTF4vMask.setBinContent( ttid,13 ); // not Masked, has TTF4
+        if ( hasTTF4InThisLumiSection ) meTTF4vMaskByLumi.setBinContent( ttid,13 ); // not Masked, has TTF4
+      }
     } // TT loop
 
     // Fill trend plots for number of TTs with TTF4 flag set

--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -177,6 +177,13 @@ ecalTrigPrimTask = cms.untracked.PSet(
             btype = cms.untracked.string('TriggerTower'),
             description = cms.untracked.string('Occupancy for TP digis with TTF=4.')
         ),
+        TTFlags4ByLumi = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT TTF4 Occupancy%(suffix)s by lumi'),
+            kind = cms.untracked.string('TH2F'),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('TriggerTower'),
+            description = cms.untracked.string('Occupancy for TP digis with TTF=4, by lumisection.')
+        ),
         TTMaskMap = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/TTStatus/%(prefix)sTTT TT Masking Status%(sm)s'),
             kind = cms.untracked.string('TProfile2D'),

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -65,6 +65,7 @@ namespace ecaldqm
   {
     // Reset by LS plots at beginning of every LS
     MEs_.at("EtSummaryByLumi").reset();
+    MEs_.at("TTFlags4ByLumi").reset();
     MEs_.at("LHCStatusByLumi").reset(-1);
 
     // Reset lhcStatusSet_ to false at the beginning of each LS; when LHC status is set in some event this variable will be set to true
@@ -215,6 +216,7 @@ namespace ecaldqm
     MESet& meTTFlags(MEs_.at("TTFlags"));
     MESet& meTTFlagsVsEt(MEs_.at("TTFlagsVsEt"));
     MESet& meTTFlags4( MEs_.at("TTFlags4") );
+    MESet& meTTFlags4ByLumi( MEs_.at("TTFlags4ByLumi") );
     MESet& meTTFMismatch(MEs_.at("TTFMismatch"));
     MESet& meOccVsBx(MEs_.at("OccVsBx"));
 
@@ -263,9 +265,10 @@ namespace ecaldqm
       meTTFlagsVsEt.fill(ttid, et, 1.0*ttF);
       // Monitor occupancy of TTF=4
       // which contains info about TT auto-masking
-      if ( ttF >= 4 )
+      if ( ttF >= 4 ) {
         meTTFlags4.fill( ttid );
-
+        meTTFlags4ByLumi.fill( ttid );
+      }
       if((ttF == 1 || ttF == 3) && towerReadouts_[ttid.rawId()] != getTrigTowerMap()->constituentsOf(ttid).size())
         meTTFMismatch.fill(ttid);
     }


### PR DESCRIPTION
(1) Added new by-lumisection plots to monitor the behavior of TTF4 flags
(2) Fixed the TTF4 trend plots to display number of masked towers only from the current lumisection.

PR for CMSSW master: [23920](https://github.com/cms-sw/cmssw/pull/23920)
Backport to 10_2_X: [23952](https://github.com/cms-sw/cmssw/pull/23952)
PR for DQM deployment: [652](https://github.com/dmwm/deployment/pull/652)
