### PR TITLE
Print function migration for CommonTools_ParticleFlow

### DIFF
--- a/CommonTools/ParticleFlow/test/PF2PAT_cfg.py
+++ b/CommonTools/ParticleFlow/test/PF2PAT_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # official example for PF2PAT
 
 import FWCore.ParameterSet.Config as cms
@@ -17,7 +18,7 @@ process.source = cms.Source("PoolSource",
 
 
 
-print process.source
+print(process.source)
 
 # path ---------------------------------------------------------------
 


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import