### PR TITLE
Print function migration for CondFormats_SiStripObjects

### DIFF
--- a/CondFormats/SiStripObjects/test/SiStripBadChannelInspector.py
+++ b/CondFormats/SiStripObjects/test/SiStripBadChannelInspector.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import DLFCN, sys, os
 sys.setdlopenflags(DLFCN.RTLD_GLOBAL+DLFCN.RTLD_LAZY)
 import pluginCondDBPyInterface as condDB
@@ -16,7 +17,7 @@ payload = Plug.Object(db)
 listOfIovElem= [iovElem for iovElem in iov.elements]
 
 if len(sys.argv) < 2:
-    print "Please specify the IOV (run number)"
+    print("Please specify the IOV (run number)")
     sys.exit()
 
 runNumber = int(sys.argv[1])
@@ -26,9 +27,9 @@ for elem in iov.elements:
     # print elem.till()
     if runNumber >= elem.since() and runNumber <= elem.till():
         theIOV = payload.load(elem)
-        print "since =", elem.since(), ", till =", elem.till()
+        print("since =", elem.since(), ", till =", elem.till())
         if theIOV:
             # print payload.summary()
-            print payload.summary()
-            print payload.dump()
+            print(payload.summary())
+            print(payload.dump())
 db.commitTransaction()

--- a/CondFormats/SiStripObjects/test/SiStripConfObjectInspector.py
+++ b/CondFormats/SiStripObjects/test/SiStripConfObjectInspector.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import DLFCN, sys, os
 sys.setdlopenflags(DLFCN.RTLD_GLOBAL+DLFCN.RTLD_LAZY)
 import pluginCondDBPyInterface as condDB
@@ -23,11 +24,11 @@ if len(sys.argv) >= 2:
 for elem in iov.elements:
     if runNumber==0 or (runNumber >= elem.since() and runNumber <= elem.till()):
         theIOV = payload.load(elem)
-        print "since =", elem.since(), ", till =", elem.till()
+        print("since =", elem.since(), ", till =", elem.till())
         if theIOV:
-            print payload.summary()
-            print payload.dump()
+            print(payload.summary())
+            print(payload.dump())
         else:
-            print "error in retriving payload"
+            print("error in retriving payload")
             
 db.commitTransaction()

--- a/CondFormats/SiStripObjects/test/SiStripLatencyInspector.py
+++ b/CondFormats/SiStripObjects/test/SiStripLatencyInspector.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import DLFCN, sys, os
 sys.setdlopenflags(DLFCN.RTLD_GLOBAL+DLFCN.RTLD_LAZY)
 import pluginCondDBPyInterface as condDB
@@ -26,12 +27,12 @@ for elem in iov.elements:
         if theIOV:
             payload.dumpXML("dump_"+str(elem.since())+".xml")
             if payload.summary().find("PEAK") != -1:
-                print "since =", elem.since(), ", till =", elem.till(), "--> peak mode"
+                print("since =", elem.since(), ", till =", elem.till(), "--> peak mode")
             elif payload.summary().find("DECO") != -1:
-                print "since =", elem.since(), ", till =", elem.till(), "--> deco mode"
+                print("since =", elem.since(), ", till =", elem.till(), "--> deco mode")
             else:
-                print "since =", elem.since(), ", till =", elem.till(), "--> mixed mode"
+                print("since =", elem.since(), ", till =", elem.till(), "--> mixed mode")
         else:
-            print "error in retriving payload"
+            print("error in retriving payload")
             
 db.commitTransaction()


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import