### PR TITLE
enabling 2D plots for muon inner track monitoring

### DIFF
--- a/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
@@ -51,9 +51,9 @@ MonitorTrackMuonsInnerTrack.PVMax = 79.5 ## it might need to be adjust if CMS as
 
 MonitorTrackMuonsInnerTrack.doRecHitVsPhiVsEtaPerTrack           = True
 MonitorTrackMuonsInnerTrack.doRecHitVsPtVsEtaPerTrack            = True
-MonitorTrackMuonsInnerTrack.doGoodTrackRecHitVsPhiVsEtaPerTrack  = True
+#MonitorTrackMuonsInnerTrack.doGoodTrackRecHitVsPhiVsEtaPerTrack  = True
 MonitorTrackMuonsInnerTrack.doLayersVsPhiVsEtaPerTrack           = True
-MonitorTrackMuonsInnerTrack.doGoodTrackLayersVsPhiVsEtaPerTrack  = True
+#MonitorTrackMuonsInnerTrack.doGoodTrackLayersVsPhiVsEtaPerTrack  = True
 
 MonitorTrackMuonsInnerTrack.Eta2DBin   = 16
 MonitorTrackMuonsInnerTrack.Phi2DBin   = 16

--- a/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
@@ -49,6 +49,15 @@ MonitorTrackMuonsInnerTrack.PVBin = 40
 MonitorTrackMuonsInnerTrack.PVMin = -0.5
 MonitorTrackMuonsInnerTrack.PVMax = 79.5 ## it might need to be adjust if CMS asks to have lumi levelling at lower values
 
+MonitorTrackMuonsInnerTrack.doRecHitVsPhiVsEtaPerTrack           = True
+MonitorTrackMuonsInnerTrack.doRecHitVsPtVsEtaPerTrack            = True
+MonitorTrackMuonsInnerTrack.doGoodTrackRecHitVsPhiVsEtaPerTrack  = True
+MonitorTrackMuonsInnerTrack.doLayersVsPhiVsEtaPerTrack           = True
+MonitorTrackMuonsInnerTrack.doGoodTrackLayersVsPhiVsEtaPerTrack  = True
+
+MonitorTrackMuonsInnerTrack.Eta2DBin   = 16
+MonitorTrackMuonsInnerTrack.Phi2DBin   = 16
+MonitorTrackMuonsInnerTrack.TrackPtBin = 50
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -414,6 +414,14 @@ LongDCAMax = cms.double(8.0),
 )
 
 # Overcoming the 255 arguments limit
+# binning for 2D plots (identical to 1D, but in muon tracks)
+# track eta 2D histo
+TrackMon.Eta2DBin = cms.int32(26)
+# track phi 2D histo
+TrackMon.Phi2DBin = cms.int32(32)
+# track pt 2D histo
+TrackMon.TrackPtBin = cms.int32(100)
+
 # TrackingRegion monitoring
 TrackMon.PVBin = cms.int32 ( 40 )
 TrackMon.PVMin = cms.double( -0.5)

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -420,7 +420,7 @@ TrackMon.Eta2DBin = cms.int32(26)
 # track phi 2D histo
 TrackMon.Phi2DBin = cms.int32(32)
 # track pt 2D histo
-TrackMon.TrackPtBin = cms.int32(100)
+TrackMon.TrackPt2DBin = cms.int32(100)
 
 # TrackingRegion monitoring
 TrackMon.PVBin = cms.int32 ( 40 )

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -338,9 +338,13 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
     double EtaMin       = conf_->getParameter<double>("EtaMin");
     double EtaMax       = conf_->getParameter<double>("EtaMax");
 
-    int    PtBin = conf_->getParameter<int>(   "TrackPtBin");
-    double PtMin = conf_->getParameter<double>("TrackPtMin");
-    double PtMax = conf_->getParameter<double>("TrackPtMax");
+    int    PtBin        = conf_->getParameter<int>(   "TrackPtBin");
+    double PtMin        = conf_->getParameter<double>("TrackPtMin");
+    double PtMax        = conf_->getParameter<double>("TrackPtMax");
+
+    int    Phi2DBin     = conf_->getParameter<int>(   "Phi2DBin");
+    int    Eta2DBin     = conf_->getParameter<int>(   "Eta2DBin");
+    int    Pt2DBin      = conf_->getParameter<int>(   "TrackPt2DBin");
 
     int    VXBin        = conf_->getParameter<int>(   "VXBin");
     double VXMin        = conf_->getParameter<double>("VXMin");
@@ -401,32 +405,32 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
 	
 	histname = "NumberOfValidRecHitVsPhiVsEtaPerTrack_";
 	NumberOfValidRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName, 
-								    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 40., "");
+								    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 40., "");
 	NumberOfValidRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
 	NumberOfValidRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
 
         histname = "NumberOfLostRecHitVsPhiVsEtaPerTrack_";
         NumberOfLostRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 5., "");
+                                                                    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 5., "");
         NumberOfLostRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
         NumberOfLostRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
 
 
         histname = "NumberMIRecHitVsPhiVsEtaPerTrack_";
         NumberOfMIRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 15., "");
+                                                                    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 15., "");
         NumberOfMIRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
         NumberOfMIRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
 
         histname = "NumberMORecHitVsPhiVsEtaPerTrack_";
         NumberOfMORecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 15., "");
+                                                                    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 15., "");
         NumberOfMORecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
         NumberOfMORecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
 
         histname = "ValidFractionVsPhiVsEtaPerTrack_";
         ValidFractionVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 2., "");
+                                                                    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 2., "");
         ValidFractionVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
         ValidFractionVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
 
@@ -436,26 +440,26 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
 	
 	histname = "NumberOfValidRecHitVsPtVsEtaPerTrack_";
 	NumberOfValidRecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName, 
-								    EtaBin, EtaMin, EtaMax, PtBin, PtMin, PtMax, 0, 40., "");
+								    Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 40., "");
 	NumberOfValidRecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
 	NumberOfValidRecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
 
         histname = "NumberOfLostRecHitVsPtVsEtaPerTrack_";
         NumberOfLostRecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    EtaBin, EtaMin, EtaMax, PtBin, PtMin, PtMax, 0, 5., "");
+                                                                    Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 5., "");
         NumberOfLostRecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
         NumberOfLostRecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
 
 
         histname = "NumberMIRecHitVsPtVsEtaPerTrack_";
         NumberOfMIRecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    EtaBin, EtaMin, EtaMax, PtBin, PtMin, PtMax, 0, 15., "");
+                                                                    Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 15., "");
         NumberOfMIRecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
         NumberOfMIRecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
 
         histname = "NumberMORecHitVsPtVsEtaPerTrack_";
         NumberOfMORecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    EtaBin, EtaMin, EtaMax, PtBin, PtMin, PtMax, 0, 15., "");
+                                                                    Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 15., "");
         NumberOfMORecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
         NumberOfMORecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
 
@@ -493,7 +497,7 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
 	for (int i=0; i<5; ++i) {
           histname = "NumberOf"+ layerTypeName[i] + "LayersVsPhiVsEtaPerTrack_";
 	  NumberOfLayersVsPhiVsEtaPerTrack[i] = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName, 
-								    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 40., "");
+								    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 40., "");
 	  NumberOfLayersVsPhiVsEtaPerTrack[i]->setAxisTitle("Track #eta ", 1);
 	  NumberOfLayersVsPhiVsEtaPerTrack[i]->setAxisTitle("Track #phi ", 2);
       }
@@ -1370,6 +1374,9 @@ void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker & ib
     double EtaMin     = conf_->getParameter<double>("EtaMin");
     double EtaMax     = conf_->getParameter<double>("EtaMax");
 
+    int    Phi2DBin     = conf_->getParameter<int>(   "Phi2DBin");
+    int    Eta2DBin     = conf_->getParameter<int>(   "Eta2DBin");
+
     int    ThetaBin   = conf_->getParameter<int>(   "ThetaBin");
     double ThetaMin   = conf_->getParameter<double>("ThetaMin");
     double ThetaMax   = conf_->getParameter<double>("ThetaMax");
@@ -1520,17 +1527,17 @@ void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker & ib
     tkmes.TrackEta->setAxisTitle("Number of Tracks",2);
 
     histname = "TrackEtaPhi_" + histTag;
-    tkmes.TrackEtaPhi = ibooker.book2D(histname, histname, EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax);
+    tkmes.TrackEtaPhi = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
     tkmes.TrackEtaPhi->setAxisTitle("Track #eta", 1);
     tkmes.TrackEtaPhi->setAxisTitle("Track #phi", 2);
 
     histname = "TrackEtaPhiInner_" + histTag;
-    tkmes.TrackEtaPhiInner = ibooker.book2D(histname, histname, EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax);
+    tkmes.TrackEtaPhiInner = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
     tkmes.TrackEtaPhiInner->setAxisTitle("Track #eta", 1);
     tkmes.TrackEtaPhiInner->setAxisTitle("Track #phi", 2);
 
     histname = "TrackEtaPhiOuter_" + histTag;
-    tkmes.TrackEtaPhiOuter = ibooker.book2D(histname, histname, EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax);
+    tkmes.TrackEtaPhiOuter = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
     tkmes.TrackEtaPhiOuter->setAxisTitle("Track #eta", 1);
     tkmes.TrackEtaPhiOuter->setAxisTitle("Track #phi", 2);
 

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -315,7 +315,7 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
     std::string MEBSFolderName = conf_->getParameter<std::string>("BSFolderName"); 
 
     // use the AlgoName and Quality Name 
-    std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
+    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
 
     // get binning from the configuration
     int    TKHitBin     = conf_->getParameter<int>(   "RecHitBin");
@@ -681,7 +681,7 @@ void TrackAnalyzer::bookHistosForLScertification(DQMStore::IBooker & ibooker) {
     std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
 
     // use the AlgoName and Quality Name 
-    std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
+    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
 
 
     // book LS analysis related histograms
@@ -720,7 +720,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
     std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
 
     // use the AlgoName and Quality Name 
-    std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
+    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
 
     // book the Beam Spot related histograms
     // ---------------------------------------------------------------------------------//
@@ -1351,7 +1351,7 @@ void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker & ib
     std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
 
     // use the AlgoName and Quality Name 
-    std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
+    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
 
     // get binning from the configuration
     double Chi2NDFMin = conf_->getParameter<double>("Chi2NDFMin");
@@ -1838,7 +1838,7 @@ void TrackAnalyzer::bookHistosForTrackerSpecific(DQMStore::IBooker & ibooker)
     std::string AlgoName     = conf_->getParameter<std::string>("AlgoName");
 
     // use the AlgoName and Quality Name 
-    std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
+    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
 
     int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
     double PhiMin     = conf_->getParameter<double>("PhiMin");


### PR DESCRIPTION
add 2D plots (eta vs phi) for monitoring the muon inner track

in order to have a reasonable monitoring, even for this category which generally has low stat,
(and to keep as low as possible the #bins)
I introduce new input parameters for handling the binning of 2D plots

by default they assume the same value as the 1D for back-compatibility
and only in the muon inner track configuration they have been set to a factor 1/2 w.r.t. standard