### PR TITLE
Avoid double counting CPU usage in ExternalLHEProducer [CMSSW_9_3]

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -58,7 +58,6 @@ Implementation:
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
-#include "FWCore/Utilities/interface/TimingServiceBase.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -450,13 +449,6 @@ ExternalLHEProducer::executeScript()
       break;
     }
   } while (true);
-  edm::Service<edm::TimingServiceBase> ts;
-  if(ts.isAvailable()) {
-    struct rusage ru;
-    getrusage(RUSAGE_CHILDREN,&ru);
-    double time = static_cast<double>(ru.ru_stime.tv_sec) + (static_cast<double>(ru.ru_stime.tv_usec) * 1E-6);
-    ts->addToCPUTime(time);
-  }
   if (rc) {
     throw cms::Exception("ExternalLHEProducer") << "Child failed with exit code " << rc << ".";
   }


### PR DESCRIPTION
The timing service already accounts for time spent in child
processes. Therefore the ExternalLHEProducer should not add
that same time again.