### PR TITLE
Print function migration for EventFilter_Utilities

### DIFF
--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 import os
@@ -66,7 +67,7 @@ process.EvFDaqDirector = cms.Service("EvFDaqDirector",
 try:
   os.makedirs(options.fuBaseDir+"/run"+str(options.runNumber).zfill(6))
 except Exception as ex:
-  print str(ex)
+  print(str(ex))
   pass
 
 process.PrescaleService = cms.Service( "PrescaleService",


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import