### PR TITLE
CMSLITDPG-612: Removed data v. emul. comparison bug

### DIFF
--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
@@ -273,10 +273,12 @@ void L1TStage2CaloLayer2::analyze(const edm::Event & e, const edm::EventSetup & 
 	  // stage2CaloLayer2ETTHFRank_->Fill(itEtSum->hwPt());
 	} else if(l1t::EtSum::EtSumType::kMissingHt == itEtSum->getType()){    // MHT
 	  stage2CaloLayer2MHTRank_->Fill(itEtSum->hwPt());
-	  stage2CaloLayer2MHTPhi_->Fill(itEtSum->hwPhi());
+          if (itEtSum->hwPt()>0)
+		  stage2CaloLayer2MHTPhi_->Fill(itEtSum->hwPhi());
 	} else if(l1t::EtSum::EtSumType::kMissingHtHF == itEtSum->getType()){  // MHTHF
 	  stage2CaloLayer2MHTHFRank_->Fill(itEtSum->hwPt());
-	  stage2CaloLayer2MHTHFPhi_->Fill(itEtSum->hwPhi());
+	  if (itEtSum->hwPt()>0)
+	          stage2CaloLayer2MHTHFPhi_->Fill(itEtSum->hwPhi());
 	} else if(l1t::EtSum::EtSumType::kMinBiasHFP0 == itEtSum->getType()){  // MBHFP0
 	  stage2CaloLayer2MinBiasHFP0_->Fill(itEtSum->hwPt());
 	} else if(l1t::EtSum::EtSumType::kMinBiasHFM0 == itEtSum->getType()){  // MBHFM0

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer2.cc
@@ -488,17 +488,6 @@ bool L1TdeStage2CaloLayer2::compareJets(
 	  break;
       }
 
-      while (true) {
-
-	jetEtEmul->Fill(dataIt->hwPt());
-	jetEtaEmul->Fill(dataIt->hwEta());
-	jetPhiEmul->Fill(dataIt->hwPhi());
-         
-	++dataIt;
-
-	if (dataIt == dataCol->end(currBx))
-	  break;
-      }
     }
 
     problemSummary->Fill(JETCOLLSIZE);


### PR DESCRIPTION
Removing the duplicated (bug) code in the data vs emulator DQM comparison code, as well as fixing the MHTPhi plots by removing the peak coming from the default value (by inserting Pt>0 requirement).