### PR TITLE
Print function migration for DPGAnalysis_SiStripTools

### DIFF
--- a/DPGAnalysis/SiStripTools/test/MultiplicityMonitor_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/MultiplicityMonitor_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 
@@ -205,4 +206,4 @@ process.TFileService = cms.Service('TFileService',
                                    fileName = cms.string('MultiplicityMonitor.root')
                                    )
 
-print process.dumpPython()
+print(process.dumpPython())


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import