### PR TITLE
Print function migration for DQMServices_StreamerIO

### DIFF
--- a/DQMServices/StreamerIO/scripts/personalPlayback.py
+++ b/DQMServices/StreamerIO/scripts/personalPlayback.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
 import sys
 import argparse
@@ -491,9 +492,9 @@ if __name__ == "__main__":
 
         root_log.info("Using directory: %s", path)
 
-    print "*"*80
-    print args
-    print "*"*80
+    print("*"*80)
+    print(args)
+    print("*"*80)
 
     applets = []
 

--- a/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest_cfg.py
+++ b/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import sys
 
@@ -24,9 +25,9 @@ process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(read),
     secondaryFileNames = cms.untracked.vstring(sec),
 )
-print "Selected %d files.", process.source
+print("Selected %d files.", process.source)
 
 process.poolOutput = cms.OutputModule('DQMStreamerOutputRepackerTest')
 process.output = cms.EndPath(process.poolOutput)
 
-print process.source 
+print(process.source) 


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import