### PR TITLE
HGCal v9 fixes for egamma

### DIFF
--- a/RecoEcal/EgammaCoreTools/interface/EcalTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalTools.h
@@ -50,6 +50,11 @@ public:
 			    int chStatusThreshold, 
 			    int dx, int dy); 
 
+  /// identify HGCal cells
+  static inline bool isHGCalDet(DetId::Detector thedet){
+    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
+  }
+
 private:
 
   static float recHitE( const DetId id, const EcalRecHitCollection &recHits );

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -9,6 +9,7 @@
 
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 
 #include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
@@ -52,12 +53,6 @@
 using namespace edm ;
 using namespace std ;
 using namespace reco ;
-
-namespace {
-  inline bool isHGCalDet(DetId::Detector thedet){
-    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
-  }
-}
 
 
 //===================================================================
@@ -1395,7 +1390,7 @@ void GsfElectronAlgo::createElectron(const gsfAlgoHelpers::HeavyObjectCache* hoc
     if (EEDetId::isNextToDBoundary(eedetid))
      { fiducialFlags.isEEDeeGap = true ; }
    }
-  else if ( isHGCalDet((DetId::Detector)region) )
+  else if ( EcalTools::isHGCalDet((DetId::Detector)region) )
    {
     fiducialFlags.isEE = true ;
     //HGCalDetId eeDetid(seedXtalId);    
@@ -1418,7 +1413,7 @@ void GsfElectronAlgo::createElectron(const gsfAlgoHelpers::HeavyObjectCache* hoc
 
   reco::GsfElectron::ShowerShape showerShape;
   reco::GsfElectron::ShowerShape full5x5_showerShape;
-  if( !isHGCalDet((DetId::Detector)region) ) {
+  if( !EcalTools::isHGCalDet((DetId::Detector)region) ) {
     calculateShowerShape(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),showerShape) ;    
     calculateShowerShape_full5x5(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),full5x5_showerShape) ;
   }
@@ -1510,7 +1505,7 @@ void GsfElectronAlgo::createElectron(const gsfAlgoHelpers::HeavyObjectCache* hoc
     }
   else  // original implementation
     {
-      if( !isHGCalDet((DetId::Detector)region) ) {
+      if( !EcalTools::isHGCalDet((DetId::Detector)region) ) {
 	if (ele->core()->ecalDrivenSeed())
 	  {
 	    if (generalData_->strategyCfg.ecalDrivenEcalEnergyFromClassBasedParameterization)
@@ -1546,7 +1541,7 @@ void GsfElectronAlgo::createElectron(const gsfAlgoHelpers::HeavyObjectCache* hoc
   dr03.tkSumPt = tkIsol03Calc_.calIsolPt(*ele->gsfTrack(),*eventData_->currentCtfTracks);
   dr04.tkSumPt = tkIsol04Calc_.calIsolPt(*ele->gsfTrack(),*eventData_->currentCtfTracks);
  
-  if( !isHGCalDet((DetId::Detector)region) ) {
+  if( !EcalTools::isHGCalDet((DetId::Detector)region) ) {
     dr03.hcalDepth1TowerSumEt = eventData_->hadDepth1Isolation03->getTowerEtSum(ele) ;
     dr03.hcalDepth2TowerSumEt = eventData_->hadDepth2Isolation03->getTowerEtSum(ele) ;
     dr03.hcalDepth1TowerSumEtBc = eventData_->hadDepth1Isolation03Bc->getTowerEtSum(ele,&(showerShape.hcalTowersBehindClusters)) ;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -53,6 +53,12 @@ using namespace edm ;
 using namespace std ;
 using namespace reco ;
 
+namespace {
+  inline bool isHGCalDet(DetId::Detector thedet){
+    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
+  }
+}
+
 
 //===================================================================
 // GsfElectronAlgo::GeneralData
@@ -1389,7 +1395,7 @@ void GsfElectronAlgo::createElectron(const gsfAlgoHelpers::HeavyObjectCache* hoc
     if (EEDetId::isNextToDBoundary(eedetid))
      { fiducialFlags.isEEDeeGap = true ; }
    }
-  else if ( region==DetId::Forward || region == DetId::Hcal )
+  else if ( isHGCalDet((DetId::Detector)region) )
    {
     fiducialFlags.isEE = true ;
     //HGCalDetId eeDetid(seedXtalId);    
@@ -1412,7 +1418,7 @@ void GsfElectronAlgo::createElectron(const gsfAlgoHelpers::HeavyObjectCache* hoc
 
   reco::GsfElectron::ShowerShape showerShape;
   reco::GsfElectron::ShowerShape full5x5_showerShape;
-  if( !(region==DetId::Forward || region == DetId::Hcal) ) {    
+  if( !isHGCalDet((DetId::Detector)region) ) {
     calculateShowerShape(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),showerShape) ;    
     calculateShowerShape_full5x5(electronData_->superClusterRef,!(electronData_->coreRef->ecalDrivenSeed()),full5x5_showerShape) ;
   }
@@ -1504,7 +1510,7 @@ void GsfElectronAlgo::createElectron(const gsfAlgoHelpers::HeavyObjectCache* hoc
     }
   else  // original implementation
     {
-      if( region!=DetId::Forward && region != DetId::Hcal ) {
+      if( !isHGCalDet((DetId::Detector)region) ) {
 	if (ele->core()->ecalDrivenSeed())
 	  {
 	    if (generalData_->strategyCfg.ecalDrivenEcalEnergyFromClassBasedParameterization)
@@ -1540,7 +1546,7 @@ void GsfElectronAlgo::createElectron(const gsfAlgoHelpers::HeavyObjectCache* hoc
   dr03.tkSumPt = tkIsol03Calc_.calIsolPt(*ele->gsfTrack(),*eventData_->currentCtfTracks);
   dr04.tkSumPt = tkIsol04Calc_.calIsolPt(*ele->gsfTrack(),*eventData_->currentCtfTracks);
  
-  if( !(region==DetId::Forward || region == DetId::Hcal) ) {  
+  if( !isHGCalDet((DetId::Detector)region) ) {
     dr03.hcalDepth1TowerSumEt = eventData_->hadDepth1Isolation03->getTowerEtSum(ele) ;
     dr03.hcalDepth2TowerSumEt = eventData_->hadDepth2Isolation03->getTowerEtSum(ele) ;
     dr03.hcalDepth1TowerSumEtBc = eventData_->hadDepth1Isolation03Bc->getTowerEtSum(ele,&(showerShape.hcalTowersBehindClusters)) ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -51,6 +51,7 @@
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 
 #include <string>
 
@@ -275,7 +276,7 @@ void ElectronSeedProducer::filterClusters
          int detector = scl.seed()->hitsAndFractions()[0].first.subdetId() ;
          if ( detector==EcalBarrel && (had<maxHBarrel_ || had/scle<maxHOverEBarrel_)) HoeVeto=true;
          else if( !allowHGCal_ && detector==EcalEndcap && (had<maxHEndcaps_ || had/scle<maxHOverEEndcaps_) ) HoeVeto=true;
-         else if( allowHGCal_ && (detector==HcalEndcap || det_group == DetId::Forward  || det_group == DetId::HGCalEE || det_group == DetId::HGCalHSi || det_group == DetId::HGCalHSc) ) {
+         else if( allowHGCal_ && EcalTools::isHGCalDet((DetId::Detector)det_group) ) {
            float had_fraction = hgcClusterTools_->getClusterHadronFraction(*(scl.seed()));
            had1 = had_fraction*scl.seed()->energy();
            had2 = 0.;

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -275,7 +275,7 @@ void ElectronSeedProducer::filterClusters
          int detector = scl.seed()->hitsAndFractions()[0].first.subdetId() ;
          if ( detector==EcalBarrel && (had<maxHBarrel_ || had/scle<maxHOverEBarrel_)) HoeVeto=true;
          else if( !allowHGCal_ && detector==EcalEndcap && (had<maxHEndcaps_ || had/scle<maxHOverEEndcaps_) ) HoeVeto=true;
-         else if( allowHGCal_ && (detector==HcalEndcap || det_group == DetId::Forward) ) {
+         else if( allowHGCal_ && (detector==HcalEndcap || det_group == DetId::Forward  || det_group == DetId::HGCalEE || det_group == DetId::HGCalHSi || det_group == DetId::HGCalHSc) ) {
            float had_fraction = hgcClusterTools_->getClusterHadronFraction(*(scl.seed()));
            had1 = had_fraction*scl.seed()->energy();
            had2 = 0.;

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -42,6 +42,7 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h" 
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 
 namespace {
   inline double ptFast( const double energy, 
@@ -49,10 +50,6 @@ namespace {
 			const math::XYZPoint& origin ) {
     const auto v = position - origin;
     return energy*std::sqrt(v.perp2()/v.mag2());
-  }
-
-  inline bool isHGCalDet(DetId::Detector thedet){
-    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
   }
 }
 
@@ -526,7 +523,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
       hits = ecalEndcapHits;
       flags_ = flagsexclEE_;
       severitiesexcl_ = severitiesexclEE_;
-    } else if ( isHGCalDet(thedet) ) {
+    } else if ( EcalTools::isHGCalDet(thedet) ) {
       preselCutValues = preselCutValuesEndcap_;
       hits = nullptr;
       flags_ = flagsexclEE_;
@@ -616,7 +613,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     // Calculate fiducial flags and isolation variable. Blocked are filled from the isolationCalculator
     reco::Photon::FiducialFlags fiducialFlags;
     reco::Photon::IsolationVariables isolVarR03, isolVarR04;
-    if( !isHGCalDet(thedet) ) {
+    if( !EcalTools::isHGCalDet(thedet) ) {
       thePhotonIsolationCalculator_->calculate( &newCandidate,evt,es,fiducialFlags,isolVarR04, isolVarR03);
     }
     newCandidate.setFiducialVolumeFlags( fiducialFlags );
@@ -717,7 +714,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     /// plus values from regressions     and store them in the Photon
     // Photon candidate takes by default (set in photons_cfi.py) 
     // a 4-momentum derived from the ecal photon-specific corrections. 
-    if( !isHGCalDet(thedet) ) {
+    if( !EcalTools::isHGCalDet(thedet) ) {
       thePhotonEnergyCorrector_->calculate(evt, newCandidate, subdet, vertexCollection, es);
       if ( candidateP4type_ == "fromEcalEnergy") {
 	newCandidate.setP4( newCandidate.p4(reco::Photon::ecal_photons) );
@@ -818,7 +815,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
       preselCutValues = preselCutValuesBarrel_;
     } else if (subdet==EcalEndcap)  { 
       preselCutValues = preselCutValuesEndcap_;
-    } else if (isHGCalDet(thedet)) {
+    } else if (EcalTools::isHGCalDet(thedet)) {
       preselCutValues = preselCutValuesEndcap_;
     } else {
       edm::LogWarning("")<<"GEDPhotonProducer: do not know if it is a barrel or endcap SuperCluster" << thedet << ' ' << subdet; 

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
@@ -16,6 +16,10 @@
 
 namespace {
   const edm::InputTag empty_tag;
+
+  inline bool isHGCalDet(DetId::Detector thedet){
+    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
+  }
 }
 
 #include <unordered_map>
@@ -361,7 +365,7 @@ void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
   const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();
 
   // skip HGCAL for now
-  if( theseed->seed().det() == DetId::Forward ) return;
+  if( isHGCalDet(theseed->seed().det()) ) return;
 
   const int numberOfClusters =  the_sc->clusters().size();
   const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
@@ -561,7 +565,7 @@ void EGRegressionModifierV2::modifyObject(reco::Photon& pho) const {
   const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();  
 
   // skip HGCAL for now
-  if( theseed->seed().det() == DetId::Forward ) return;
+  if( isHGCalDet(theseed->seed().det()) ) return;
 
   const int numberOfClusters =  the_sc->clusters().size();
   const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
@@ -11,15 +11,12 @@
 #include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
 #include "CondFormats/EgammaObjects/interface/GBRForestD.h"
 #include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 
 #include <vdt/vdtMath.h>
 
 namespace {
   const edm::InputTag empty_tag;
-
-  inline bool isHGCalDet(DetId::Detector thedet){
-    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
-  }
 }
 
 #include <unordered_map>
@@ -365,7 +362,7 @@ void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {
   const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();
 
   // skip HGCAL for now
-  if( isHGCalDet(theseed->seed().det()) ) return;
+  if( EcalTools::isHGCalDet(theseed->seed().det()) ) return;
 
   const int numberOfClusters =  the_sc->clusters().size();
   const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
@@ -565,7 +562,7 @@ void EGRegressionModifierV2::modifyObject(reco::Photon& pho) const {
   const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();  
 
   // skip HGCAL for now
-  if( isHGCalDet(theseed->seed().det()) ) return;
+  if( EcalTools::isHGCalDet(theseed->seed().det()) ) return;
 
   const int numberOfClusters =  the_sc->clusters().size();
   const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();

--- a/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
+++ b/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
@@ -1,5 +1,6 @@
 #include "RecoEgamma/EgammaTools/interface/EcalRegressionData.h"
 
+#include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
@@ -11,12 +12,6 @@
 
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-
-namespace {
-  inline bool isHGCalDet(DetId::Detector thedet){
-    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
-  }
-}
 
 float EcalRegressionData::seedLeftRightAsym()const
 {
@@ -61,7 +56,7 @@ void EcalRegressionData::fill(const reco::SuperCluster& superClus,
   isEB_ = ( seedid.subdetId()==EcalBarrel );
   
   // skip HGCal
-  if( isHGCalDet(seedid.det()) ) return;
+  if( EcalTools::isHGCalDet(seedid.det()) ) return;
   
   const EcalRecHitCollection* recHits = isEB_ ? ebRecHits : eeRecHits;
 

--- a/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
+++ b/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
@@ -12,6 +12,12 @@
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
+namespace {
+  inline bool isHGCalDet(DetId::Detector thedet){
+    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
+  }
+}
+
 float EcalRegressionData::seedLeftRightAsym()const
 {
   float eLeftRightSum = eLeft()+eRight();
@@ -55,7 +61,7 @@ void EcalRegressionData::fill(const reco::SuperCluster& superClus,
   isEB_ = ( seedid.subdetId()==EcalBarrel );
   
   // skip HGCal
-  if( seedid.det() == DetId::Forward ) return;
+  if( isHGCalDet(seedid.det()) ) return;
   
   const EcalRecHitCollection* recHits = isEB_ ? ebRecHits : eeRecHits;
 

--- a/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
@@ -12,6 +12,12 @@
 
 using namespace reco;
 
+namespace {
+  inline bool isHGCalDet(DetId::Detector thedet){
+    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
+  }
+}
+
 //--------------------------------------------------------------------------------------------------
 SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm() :
 foresteb_(nullptr),
@@ -103,7 +109,7 @@ std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::
   p.second=-1;
 
   // protect against HGCal, don't mod the object
-  if( sc.seed()->seed().det() == DetId::Forward ) return p;
+  if( isHGCalDet(sc.seed()->seed().det()) ) return p;
 
   const reco::CaloCluster &seedCluster = *(sc.seed());
   const bool iseb = seedCluster.hitsAndFractions()[0].first.subdetId() == EcalBarrel;

--- a/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEgamma/EgammaTools/src/SCEnergyCorrectorSemiParm.cc
@@ -4,6 +4,7 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
@@ -11,12 +12,6 @@
 #include <vdt/vdtMath.h>
 
 using namespace reco;
-
-namespace {
-  inline bool isHGCalDet(DetId::Detector thedet){
-    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
-  }
-}
 
 //--------------------------------------------------------------------------------------------------
 SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm() :
@@ -109,7 +104,7 @@ std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::
   p.second=-1;
 
   // protect against HGCal, don't mod the object
-  if( isHGCalDet(sc.seed()->seed().det()) ) return p;
+  if( EcalTools::isHGCalDet(sc.seed()->seed().det()) ) return p;
 
   const reco::CaloCluster &seedCluster = *(sc.seed());
   const bool iseb = seedCluster.hitsAndFractions()[0].first.subdetId() == EcalBarrel;


### PR DESCRIPTION
@hatakeyamak noticed an occasional crash in `RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.cc`. I found that it ultimately occurred because the exclusion of HGCal cells from some parts of the egamma algorithms had not been updated for the new geometry and DetIds. I had previously made a simple function to do this for `GEDPhotonProducer`. I have now moved that function into `EcalTools` and propagated it to every instance I could find.