### PR TITLE
Print function migration for Validation_CaloTowers

### DIFF
--- a/Validation/CaloTowers/test/client_cfg.py
+++ b/Validation/CaloTowers/test/client_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 import os
@@ -12,7 +13,7 @@ for argument in sys.argv[2:]:
       fileToRead = "file:"+argument
       readFiles.append(fileToRead)
 
-print "readFiles : \n", readFiles
+print("readFiles : \n", readFiles)
 
 process = cms.Process("CONV")
 process.load("Configuration.StandardSequences.Reconstruction_cff")


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import