### PR TITLE
Print function migration for RecoBTag_CTagging

### DIFF
--- a/RecoBTag/CTagging/test/test_discriminator_presence.py
+++ b/RecoBTag/CTagging/test/test_discriminator_presence.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import ROOT
 import pprint
 import sys
@@ -22,4 +23,4 @@ for label in jet_labels:
    jet = jets.at(0)
    available = set([i.first for i in jet.getPairDiscri()])
    for test in tested_discriminators:
-      print "%s in %s: %s" % (test, label, test in available)
+      print("%s in %s: %s" % (test, label, test in available))


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import