### PR TITLE
Print function migration for RecoBTag_TensorFlow

### DIFF
--- a/RecoBTag/TensorFlow/test/test_deep_doubleb_cfg_AOD.py
+++ b/RecoBTag/TensorFlow/test/test_deep_doubleb_cfg_AOD.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask
 import six
@@ -113,7 +114,7 @@ process.out.outputCommands.append('keep *_pfBoostedDoubleSVAK8TagInfos*_*_*')
 process.out.outputCommands.append('keep *_pfDeepDoubleBTagInfos*_*_*')
 process.out.outputCommands.append('keep *_updatedPatJets*_*_*')
 
-print process.out.outputCommands
+print(process.out.outputCommands)
 process.out.fileName = 'test_deep_doubleb_AODSIM.root'
 
 #                                         ##


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import