### PR TITLE
Print function migration for TopQuarkAnalysis_Configuration

### DIFF
--- a/TopQuarkAnalysis/Configuration/test/TestForTTGenEvents.py
+++ b/TopQuarkAnalysis/Configuration/test/TestForTTGenEvents.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 import sys
@@ -31,9 +32,9 @@ if( hasattr(sys, "argv") ):
                 setattr(options,val[0], val[1])
 
 if options.runOnPythia8:
-    print 'Running on Pythia8'
+    print('Running on Pythia8')
 else:
-    print 'Running on Pythia6'
+    print('Running on Pythia6')
 
 ## configure message logger
 process.load("FWCore.MessageLogger.MessageLogger_cfi")

--- a/TopQuarkAnalysis/Configuration/test/patRefSel_muJets_cfg.py
+++ b/TopQuarkAnalysis/Configuration/test/patRefSel_muJets_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # As of 1 Feb 2017:
 # This configuration appears to be already broken in more
 # than one way. It fails to even run only under python.
@@ -38,13 +39,13 @@ options.register( 'addTriggerMatch' , True , VarParsing.VarParsing.multiplicity.
 # parsing command line arguments
 if( hasattr( sys, 'argv' ) ):
   if( len( sys.argv ) > 2 ):
-    print 'Parsing command line arguments:'
+    print('Parsing command line arguments:')
   for args in sys.argv :
     arg = args.split(',')
     for val in arg:
       val = val.split( '=' )
       if( len( val ) == 2 ):
-        print 'Setting "', val[0], '" to:', val[1]
+        print('Setting "', val[0], '" to:', val[1])
         setattr( options, val[0], val[1] )
 
 


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import