### PR TITLE
HGCal noise and aging cleanup

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -61,9 +61,7 @@ def ageHF(process,turnon):
 
 def agedHGCal(process):
     from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import HGCal_setEndOfLifeNoise
-    for subdet in ['EE','FH','BH']:
-        hgcaldigi = getHGCalDigitizer(process,subdet)
-        if hgcaldigi is not None: HGCal_setEndOfLifeNoise(hgcaldigi, process)
+    process = HGCal_setEndOfLifeNoise(process)
     return process
 
 # needs lumi to set proper ZS thresholds (tbd)

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -211,6 +211,17 @@ def HGCal_setEndOfLifeNoise(digitizer,process):
         values = cms.vdouble([x for x in endOfLifeNoises])
         )
 
+def HGCal_disableNoise(digitizer,process):
+    process.HGCAL_noise_fC = cms.PSet(
+        values = cms.vdouble(0,0,0), #100,200,300 um
+    )
+    process.HGCAL_noise_MIP = cms.PSet(
+        value = cms.double(0)
+    )
+    process.HGCAL_noises = cms.PSet(
+        values = cms.vdouble(0,0,0)
+    )
+
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 
 phase2_hgcalV9.toModify( hgceeDigitizer,

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -190,6 +190,8 @@ hgchebackDigitizer = cms.PSet(
             )
         )
     )
+
+# this bypasses the noise simulation
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 for _m in [hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer]:
     premix_stage1.toModify(_m, premixStage1 = True)

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -197,7 +197,7 @@ for _m in [hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer]:
 #function to set noise to aged HGCal
 endOfLifeCCEs = [0.5, 0.5, 0.7]
 endOfLifeNoises = [2400.0,2250.0,1750.0]
-def HGCal_setEndOfLifeNoise(digitizer,process):
+def HGCal_setEndOfLifeNoise(process):
     process.HGCAL_noise_fC = cms.PSet(
         values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] ), #100,200,300 um
         )
@@ -210,8 +210,9 @@ def HGCal_setEndOfLifeNoise(digitizer,process):
     process.HGCAL_noises = cms.PSet(
         values = cms.vdouble([x for x in endOfLifeNoises])
         )
+    return process
 
-def HGCal_disableNoise(digitizer,process):
+def HGCal_disableNoise(process):
     process.HGCAL_noise_fC = cms.PSet(
         values = cms.vdouble(0,0,0), #100,200,300 um
     )
@@ -221,6 +222,7 @@ def HGCal_disableNoise(digitizer,process):
     process.HGCAL_noises = cms.PSet(
         values = cms.vdouble(0,0,0)
     )
+    return process
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -15,26 +15,19 @@ HGCDigitizerBase<DFr>::HGCDigitizerBase(const edm::ParameterSet& ps) {
 
   if( myCfg_.existsAs<edm::ParameterSet>( "chargeCollectionEfficiencies" ) ) {
     cce_ = myCfg_.getParameter<edm::ParameterSet>("chargeCollectionEfficiencies").template getParameter<std::vector<double>>("values");
-  } else {
-    std::vector<double>().swap(cce_);
   }
 
   if(myCfg_.existsAs<double>("noise_fC")) {
-    noise_fC_.resize(1);
-    noise_fC_[0] = myCfg_.getParameter<double>("noise_fC");
+    noise_fC_.reserve(1);
+    noise_fC_.push_back(myCfg_.getParameter<double>("noise_fC"));
   } else if ( myCfg_.existsAs<std::vector<double> >("noise_fC") ) {
     const auto& noises = myCfg_.getParameter<std::vector<double> >("noise_fC");
-    noise_fC_.resize(0);
-    noise_fC_.reserve(noises.size());
-    for( auto noise : noises ) { noise_fC_.push_back( noise ); }
+    noise_fC_ = std::vector<float>(noises.begin(),noises.end());
   } else if(myCfg_.existsAs<edm::ParameterSet>("noise_fC")) {
     const auto& noises = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<std::vector<double> >("values");
-    noise_fC_.resize(0);
-    noise_fC_.reserve(noises.size());
-    for( auto noise : noises ) { noise_fC_.push_back( noise ); }
+    noise_fC_ = std::vector<float>(noises.begin(),noises.end());
   } else {
-    noise_fC_.resize(1);
-    noise_fC_[0] = 1.f;
+    noise_fC_.resize(1,1.f);
   }
   edm::ParameterSet feCfg = myCfg_.getParameter<edm::ParameterSet>("feCfg");
   myFEelectronics_        = std::unique_ptr<HGCFEElectronics<DFr> >( new HGCFEElectronics<DFr>(feCfg) );

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -87,7 +87,8 @@ void HGCDigitizerBase<DFr>::runSimple(std::unique_ptr<HGCDigitizerBase::DColl> &
       //add noise (in fC)
       //we assume it's randomly distributed and won't impact ToA measurement
       //also assume that it is related to the charge path only and that noise fluctuation for ToA circuit be handled separately
-      totalCharge += std::max( (float)CLHEP::RandGaussQ::shoot(engine,0.0,cell.size*noise_fC_[cell.thickness-1]) , 0.f );
+      if (noise_fC_[cell.thickness-1] != 0)
+        totalCharge += std::max( (float)CLHEP::RandGaussQ::shoot(engine,0.0,cell.size*noise_fC_[cell.thickness-1]) , 0.f );
       if(totalCharge<0.f) totalCharge=0.f;
 
       chargeColl[i]= totalCharge;

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -205,8 +205,9 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
   //to be done properly with realistic ToA shaper and jitter for the moment accounted in the smearing 
   if(toaColl[fireBX] != 0.f){
     timeToA = toaColl[fireBX];
-    if(jitterNoise2_ns_[0] != 0) timeToA = CLHEP::RandGaussQ::shoot(engine, timeToA, getTimeJitter(chargeColl[fireBX], thickness));
-    else timeToA = CLHEP::RandGaussQ::shoot(engine, timeToA, tdcResolutionInNs_);
+    float jitter = getTimeJitter(chargeColl[fireBX], thickness);
+    if(jitter != 0) timeToA = CLHEP::RandGaussQ::shoot(engine, timeToA, jitter);
+    else if(tdcResolutionInNs_ != 0) timeToA = CLHEP::RandGaussQ::shoot(engine, timeToA, tdcResolutionInNs_);
     if(timeToA >= 0.f && timeToA <= 25.f) toaFlags[fireBX] = true;
   }
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -68,7 +68,7 @@ void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::unique_ptr<HGCalDigiCollect
 	  if(xTalk_*x!=1) nPixel=(uint32_t) std::max( nTotalPE_*(1.f-x)/(1.f-xTalk_*x), 0.f );
 
 	  //update signal
-	  nPixel = (uint32_t)std::max( CLHEP::RandGaussQ::shoot(engine,(double)nPixel,sdPixels_), 0. );
+	  if(sdPixels_ != 0) nPixel = (uint32_t)std::max( CLHEP::RandGaussQ::shoot(engine,(double)nPixel,sdPixels_), 0. );
 
 	  //convert to MIP again and saturate
           float totalMIPs(0.f), xtalk = 0.f;
@@ -80,7 +80,8 @@ void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::unique_ptr<HGCalDigiCollect
           }
 
 	  //add noise (in MIPs)
-	  chargeColl[i] = totalMIPs+std::max( CLHEP::RandGaussQ::shoot(engine,0.,noise_MIP_), 0. );
+	  chargeColl[i] = totalMIPs;
+      if(noise_MIP_ != 0) chargeColl[i] += std::max( CLHEP::RandGaussQ::shoot(engine,0.,noise_MIP_), 0. );
 	  if(debug && cell.hit_info[0][i]>0)
 	    std::cout << "[runCaliceLikeDigitizer] xtalk=" << xtalk << " En=" << cell.hit_info[0][i] << " keV -> " << totalIniMIPs << " raw-MIPs -> " << chargeColl[i] << " digi-MIPs" << std::endl;
 	}


### PR DESCRIPTION
* avoid calling random number generation if relevant noise parameter is 0
* add customize function to disable HGCal noise
* clean up customization functions that no longer need the digitizer module
* add comment that noise is already disabled for premixing
* simplify initialization of some vector parameters