### PR TITLE
Print the message about setting the number of threads and streams if either is set

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -419,7 +419,7 @@ namespace edm {
     if (nStreams == 0) {
       nStreams = nThreads;
     }
-    if(nThreads > 1) {
+    if (nThreads > 1 or nStreams > 1) {
       edm::LogInfo("ThreadStreamSetup") <<"setting # threads "<<nThreads<<"\nsetting # streams "<<nStreams;
     }
     unsigned int nConcurrentRuns = optionsPset.getUntrackedParameter<unsigned int>("numberOfConcurrentRuns");


### PR DESCRIPTION
Print the message about setting the number of threads and streams if either is different from the default value.

Currently, the message is printed only if the number of threads is different.