### PR TITLE
Fix bug in FormulaEvaluator involving parenthesis and precedence order [9_4]

### DIFF
--- a/CommonTools/Utils/interface/FormulaEvaluator.h
+++ b/CommonTools/Utils/interface/FormulaEvaluator.h
@@ -22,6 +22,7 @@
 #include <array>
 #include <vector>
 #include <memory>
+#include <string>
 
 // user include files
 
@@ -84,6 +85,8 @@ namespace reco {
     
     unsigned int numberOfParameters() const { return m_nParameters; }
     unsigned int numberOfVariables() const { return m_nVariables; }
+
+    std::vector<std::string> abstractSyntaxTree() const;
     
   private:
     double evaluate(double const* iVariables, double const* iParameters) const;

--- a/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
+++ b/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
@@ -77,6 +77,25 @@ namespace reco {
         return m_operator(lhs()->evaluate(iVariables,iParameters),rhs()->evaluate(iVariables,iParameters));
       }
 
+      std::vector<std::string> abstractSyntaxTree() const final {
+        std::vector<std::string> ret;
+        if( lhs()) {
+          ret = shiftAST(lhs()->abstractSyntaxTree());
+        } else {
+          ret.emplace_back(".nullptr");
+        }
+        if(rhs() ){
+          auto child = shiftAST(rhs()->abstractSyntaxTree());
+          for(auto& v: child) {
+            ret.emplace_back(std::move(v));
+          }
+        } else {
+          ret.emplace_back(".nullptr");
+        }
+        ret.emplace(ret.begin(), std::string("op ")+std::to_string(precedence()) );
+        return ret;
+      }
+
     private:
       BinaryOperatorEvaluator(const BinaryOperatorEvaluator&) = delete;
       

--- a/CommonTools/Utils/src/formulaConstantEvaluator.cc
+++ b/CommonTools/Utils/src/formulaConstantEvaluator.cc
@@ -21,5 +21,9 @@ namespace reco {
     double ConstantEvaluator::evaluate(double const* /*iVariables*/, double const* /*iParameters*/) const {
       return m_value;
     }
+
+    std::vector<std::string> ConstantEvaluator::abstractSyntaxTree() const {
+      return std::vector<std::string>{1, std::to_string(m_value) };
+    }
   }
 }

--- a/CommonTools/Utils/src/formulaConstantEvaluator.h
+++ b/CommonTools/Utils/src/formulaConstantEvaluator.h
@@ -36,6 +36,7 @@ namespace reco {
 
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final;
+      std::vector<std::string> abstractSyntaxTree() const final ;
       
     private:
       ConstantEvaluator(const ConstantEvaluator&) = delete;

--- a/CommonTools/Utils/src/formulaEvaluatorBase.cc
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <algorithm>
 
 // user include files
 #include "CommonTools/Utils/src/formulaEvaluatorBase.h"
@@ -39,5 +40,13 @@ reco::formula::EvaluatorBase::EvaluatorBase(Precedence iPrec):
 
 reco::formula::EvaluatorBase::~EvaluatorBase()
 {
+}
+
+std::vector<std::string> 
+reco::formula::shiftAST(std::vector<std::string> child) {
+  for(auto& c: child) {
+    c.insert(c.begin(),'.');
+  }
+  return child;
 }
 

--- a/CommonTools/Utils/src/formulaEvaluatorBase.h
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.h
@@ -21,6 +21,8 @@
 //
 
 // system include files
+#include <vector>
+#include <string>
 
 // user include files
 
@@ -28,6 +30,7 @@
 
 namespace reco {
   namespace formula {
+    std::vector<std::string> shiftAST(std::vector<std::string> child);
     class EvaluatorBase
     {
       
@@ -51,6 +54,7 @@ namespace reco {
       //inputs are considered to be 'arrays' which have already been validated to 
       // be of the appropriate length
       virtual double evaluate(double const* iVariables, double const* iParameters) const = 0;
+      virtual std::vector<std::string> abstractSyntaxTree() const = 0;
 
       unsigned int precedence() const { return m_precedence; }
       void setPrecedenceToParenthesis() { m_precedence = static_cast<unsigned int>(Precedence::kParenthesis); }

--- a/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
@@ -42,7 +42,11 @@ namespace reco {
       double evaluate(double const* iVariables, double const* iParameters) const final {
         return m_function( m_arg->evaluate(iVariables,iParameters) );
       }
-
+      std::vector<std::string> abstractSyntaxTree() const final {
+        auto ret = shiftAST(m_arg->abstractSyntaxTree());
+        ret.emplace(ret.begin(), "func 1 arg");
+        return ret;
+      }
     private:
       FunctionOneArgEvaluator(const FunctionOneArgEvaluator&) = delete;
       

--- a/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
@@ -47,6 +47,14 @@ namespace reco {
         return m_function( m_arg1->evaluate(iVariables,iParameters),
                            m_arg2->evaluate(iVariables,iParameters) );
       }
+      std::vector<std::string> abstractSyntaxTree() const final {
+        auto ret = shiftAST(m_arg1->abstractSyntaxTree());
+        for(auto& v: shiftAST(m_arg2->abstractSyntaxTree()) ) {
+          ret.emplace_back(std::move(v));
+        }
+        ret.emplace(ret.begin(), "func 2 args");
+        return ret;
+      }
 
     private:
       FunctionTwoArgsEvaluator(const FunctionTwoArgsEvaluator&) = delete;

--- a/CommonTools/Utils/src/formulaParameterEvaluator.cc
+++ b/CommonTools/Utils/src/formulaParameterEvaluator.cc
@@ -21,5 +21,8 @@ namespace reco {
     double ParameterEvaluator::evaluate(double const* /*iVariables*/, double const* iParameters) const {
       return iParameters[m_index];
     }
+    std::vector<std::string> ParameterEvaluator::abstractSyntaxTree() const {
+      return std::vector<std::string>{1, std::string("par[")+std::to_string(m_index)+"]"};
+    }
   }
 }

--- a/CommonTools/Utils/src/formulaParameterEvaluator.h
+++ b/CommonTools/Utils/src/formulaParameterEvaluator.h
@@ -36,6 +36,7 @@ namespace reco {
 
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final;
+      std::vector<std::string> abstractSyntaxTree() const final;
       
     private:
       ParameterEvaluator(const ParameterEvaluator&) = delete;

--- a/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
+++ b/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
@@ -41,7 +41,11 @@ namespace reco {
       double evaluate(double const* iVariables, double const* iParameters) const final {
         return -1. * m_arg->evaluate(iVariables,iParameters) ;
       }
-
+      std::vector<std::string> abstractSyntaxTree() const final {
+        auto ret = shiftAST(m_arg->abstractSyntaxTree());
+        ret.emplace(ret.begin(), "unary minus");
+        return ret;
+      }
     private:
       UnaryMinusEvaluator(const UnaryMinusEvaluator&) = delete;
       

--- a/CommonTools/Utils/src/formulaVariableEvaluator.cc
+++ b/CommonTools/Utils/src/formulaVariableEvaluator.cc
@@ -21,5 +21,9 @@ namespace reco {
     double VariableEvaluator::evaluate(double const* iVariables, double const* /*iParameters*/) const {
       return iVariables[m_index];
     }
+
+    std::vector<std::string> VariableEvaluator::abstractSyntaxTree() const {
+      return std::vector<std::string>{1, std::string("var[")+std::to_string(m_index)+"]"};
+    }
   }
 }

--- a/CommonTools/Utils/src/formulaVariableEvaluator.h
+++ b/CommonTools/Utils/src/formulaVariableEvaluator.h
@@ -36,6 +36,7 @@ namespace reco {
 
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final;
+      std::vector<std::string> abstractSyntaxTree() const final;
       
     private:
       VariableEvaluator(const VariableEvaluator&) = delete;

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -371,6 +371,22 @@ testFormulaEvaluator::checkFormulaEvaluator() {
   }
 
   {
+    reco::FormulaEvaluator f("2*(3*4*5)/6");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2*(3*4*5)/6 );
+  }
+
+  {
+    reco::FormulaEvaluator f("2*(2.5*3*3.5)*(4*4.5*5)/6");
+    
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2*(2.5*3*3.5)*(4*4.5*5)/6 );
+  }
+
+  {
     reco::FormulaEvaluator f("x");
     
     std::vector<double> emptyV;
@@ -905,6 +921,37 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     auto func = [&v](double x) { return v[0]+v[1]*std::exp(-x/v[2]); };
 
     CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+  }
+
+  {
+    reco::FormulaEvaluator f("max(0.0001,1-y/x*([1]*(z-[0])*(1+[2]*log(x/30.))))");
+
+    std::vector<double> v = { 1.4, 0.453645, -0.015665 };
+    std::vector<double> x = { 157.2, 0.5, 23.2 };
+
+    auto func = [&v](double x, double y, double z ) { return std::max(0.0001,1-y/x*(v[1]*(z-v[0])*(1+v[2]*std::log(x/30.)))); };
+
+    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0],x[1],x[2]) ) );
+  }
+  {
+    reco::FormulaEvaluator f("max(0.0001,1-y*[1]*(z-[0])*(1+[2]*log(x/30.))/x)");
+
+    std::vector<double> v = { 1.4, 0.453645, -0.015665 };
+    std::vector<double> x = { 157.2, 0.5, 23.2 };
+
+    auto func = [&v](double x, double y, double z ) { return std::max(0.0001,1-y/x*(v[1]*(z-v[0])*(1+v[2]*std::log(x/30.)))); };
+
+    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0],x[1],x[2]) ) );
+  }
+  {
+    reco::FormulaEvaluator f("max(0.0001,1-y*([1]*(z-[0])*(1+[2]*log(x/30.)))/x)");
+
+    std::vector<double> v = { 1.4, 0.453645, -0.015665 };
+    std::vector<double> x = { 157.2, 0.5, 23.2 };
+
+    auto func = [&v](double x, double y, double z ) { return std::max(0.0001,1-y*(v[1]*(z-v[0])*(1+v[2]*std::log(x/30.)))/x); };
+
+    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0],x[1],x[2]) ) );
   }
 
   {


### PR DESCRIPTION
A sub-expression involving a parenthesis was not using the top node as the representation for the expression. That mixed with precedence order fixing resulted in part of the expression being lost.