### PR TITLE
Print function migration for PhysicsTools_TagAndProbe

### DIFF
--- a/PhysicsTools/TagAndProbe/python/cropTnPTrees.py
+++ b/PhysicsTools/TagAndProbe/python/cropTnPTrees.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import ROOT
 ROOT.gROOT.SetBatch(True)
 
@@ -17,26 +18,26 @@ try:
     frac = float(args[1])
 except TypeError:
     parser.print_usage()
-    print "fraction must be a floating point number (e.g. 0.5)"
+    print("fraction must be a floating point number (e.g. 0.5)")
     sys.exit(2)
 
 input  = ROOT.TFile(args[0])
 output = ROOT.TFile(args[2], "RECREATE")
 for k in input.GetListOfKeys():
-    print k.GetName(), k.GetClassName()
+    print(k.GetName(), k.GetClassName())
     if k.GetClassName() == "TDirectoryFile":
-        print "  processing directory ",k.GetName()
+        print("  processing directory ",k.GetName())
         din  = input.Get(k.GetName())
         dout = output.mkdir(k.GetName())
         for i in din.GetListOfKeys():
             if i.GetClassName() == "TTree":
                 src = din.Get(i.GetName()) #i.ReadObj(); # ReadObj doesn't work!!!
                 newEntries = int(src.GetEntries()*frac)
-                print "    cropped TTree",i.GetName(),", original entries",src.GetEntries(), ", new entries",newEntries
+                print("    cropped TTree",i.GetName(),", original entries",src.GetEntries(), ", new entries",newEntries)
                 cloned = src.CloneTree(newEntries)
                 dout.WriteTObject(cloned, i.GetName())       
             elif i.GetClassName() != "TDirectory":
                 dout.WriteTObject(i.ReadObj(), i.GetName())
-                print "    copied ",i.GetClassName(),i.GetName()
+                print("    copied ",i.GetClassName(),i.GetName())
 
 

--- a/PhysicsTools/TagAndProbe/test/utilities/dumpPileup.py
+++ b/PhysicsTools/TagAndProbe/test/utilities/dumpPileup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import sys
 import ROOT
 fin=ROOT.TFile.Open(sys.argv[1])
 pu = fin.Get("pileup")
 pileup = map( pu.GetBinContent, xrange(1,pu.GetNbinsX()+1) )
-print ",".join(map(lambda x: "%1.3g"%x, pileup))
+print(",".join(map(lambda x: "%1.3g"%x, pileup)))


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import