### PR TITLE
Protecting E/gamma Scale and Smearing from "nan" energies : 103X

### DIFF
--- a/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
@@ -42,7 +42,7 @@ calibrate(reco::GsfElectron &ele, unsigned int runNumber,
   const float scEtaAbs = std::abs(ele.superCluster()->eta());
   const float et = ele.ecalEnergy() / cosh(scEtaAbs);
 
-  if (et < minEt_) {
+  if (et < minEt_ || std::isnan(et) ) {
     std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(ele.energy());
     retVal[EGEnergySysIndex::kScaleValue]  = 1.0;

--- a/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
@@ -3,6 +3,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include <CLHEP/Random/RandGaussQ.h>
 
 const EnergyScaleCorrection::ScaleCorrection ElectronEnergyCalibrator::defaultScaleCorr_;
@@ -42,7 +43,7 @@ calibrate(reco::GsfElectron &ele, unsigned int runNumber,
   const float scEtaAbs = std::abs(ele.superCluster()->eta());
   const float et = ele.ecalEnergy() / cosh(scEtaAbs);
 
-  if (et < minEt_ || std::isnan(et) ) {
+  if (et < minEt_ || edm::isNotFinite(et) ) {
     std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(ele.energy());
     retVal[EGEnergySysIndex::kScaleValue]  = 1.0;

--- a/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
@@ -39,7 +39,7 @@ calibrate(reco::Photon &photon,const unsigned int runNumber,
   const float scEtaAbs = std::abs(photon.superCluster()->eta());
   const float et = photon.getCorrectedEnergy(reco::Photon::P4type::regression2) / cosh(scEtaAbs);
 
-  if (et < minEt_) {
+  if (et < minEt_ || std::isnan(et) ) {
     std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(photon.getCorrectedEnergy(reco::Photon::P4type::regression2));
     retVal[EGEnergySysIndex::kScaleValue]  = 1.0;

--- a/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
@@ -3,6 +3,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include <CLHEP/Random/RandGaussQ.h>
 
 const EnergyScaleCorrection::ScaleCorrection PhotonEnergyCalibrator::defaultScaleCorr_;
@@ -39,7 +40,7 @@ calibrate(reco::Photon &photon,const unsigned int runNumber,
   const float scEtaAbs = std::abs(photon.superCluster()->eta());
   const float et = photon.getCorrectedEnergy(reco::Photon::P4type::regression2) / cosh(scEtaAbs);
 
-  if (et < minEt_ || std::isnan(et) ) {
+  if (et < minEt_ || edm::isNotFinite(et) ) {
     std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(photon.getCorrectedEnergy(reco::Photon::P4type::regression2));
     retVal[EGEnergySysIndex::kScaleValue]  = 1.0;


### PR DESCRIPTION
Dear All, 

This protects the E/gamma scale and smearing from electrons and photons that have nan energies. This will cause problems when finding the scale/smear corrections and cause an exception to be thrown as it rightly detected an inconsistency. 

This fix now makes it so the scale and smearing is not run when the energy is nan and default values are returned. This has happened once so far in the AOD. 

Issue reported and discussed here: https://its.cern.ch/jira/browse/CMSCOMPPR-3266