### PR TITLE
Print function migration for DQM_DTMonitorModule

### DIFF
--- a/DQM/DTMonitorModule/python/test/dt_dqm_sourceclient-live_GlobalRun_cfg.py
+++ b/DQM/DTMonitorModule/python/test/dt_dqm_sourceclient-live_GlobalRun_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("DTDQM")
@@ -69,4 +70,4 @@ process.dtDQMPathPhys = cms.Path(process.unpackers + process.dqmmodules + proces
 
 process.dtDQMPathCalib = cms.Path(process.unpackers + process.dqmmodules + process.calibrationEventsFilter * process.dtDQMCalib)
 
-print process.source.sourceURL
+print(process.source.sourceURL)


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import