### PR TITLE
Print function migration for DQM_SiStripMonitorHardware

### DIFF
--- a/DQM/SiStripMonitorHardware/test/makeInputlist.py
+++ b/DQM/SiStripMonitorHardware/test/makeInputlist.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 import os,sys, glob
 
 spyInput = '/eos/cms/store/group/dpg_tracker_strip/tracker/Online/store/streamer/SiStripSpy/Commissioning11/'
 spyRun   = '234824/'
 
 for path in glob.glob(spyInput+spyRun+'*.root'):
-    print "'file:"+path+"',"
+    print("'file:"+path+"',")


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import