### PR TITLE
Print function migration for DQM_SiStripMonitorSummary

### DIFF
--- a/DQM/SiStripMonitorSummary/scripts/iov_list_tag.py
+++ b/DQM/SiStripMonitorSummary/scripts/iov_list_tag.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 from optparse import OptionParser, Option, OptionValueError
 import DLFCN
 import sys
@@ -13,7 +14,7 @@ def list_tag( conn_str, tag, auth_path ):
     db.startReadOnlyTransaction()
     iov = db.iov( tag )
     for elem in iov.elements:
-        print elem.since()
+        print(elem.since())
         db.commitTransaction()
         
 if __name__ == "__main__":


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import