### PR TITLE
TRK@HLT DQM: add SIP plots for final tracks collection

### DIFF
--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -90,9 +90,9 @@ iterHLTTracksMonitoringHLT.doEffFromHitPatternVsPU   = True
 iterHLTTracksMonitoringHLT.doEffFromHitPatternVsBX   = True
 iterHLTTracksMonitoringHLT.doEffFromHitPatternVsLUMI = True
 iterHLTTracksMonitoringHLT.doDCAPlots                = True
-iterHLTTracksMonitoringHLT.doPVPlots                 = True
-iterHLTTracksMonitoringHLT.doBSPlots                 = True
-iterHLTTracksMonitoringHLT.doSIPPlots                = True
+iterHLTTracksMonitoringHLT.doPVPlots                 = cms.bool(True)
+iterHLTTracksMonitoringHLT.doBSPlots                 = cms.bool(True)
+iterHLTTracksMonitoringHLT.doSIPPlots                = cms.bool(True)
 
 iter3TracksMonitoringHLT = trackingMonHLT.clone()
 iter3TracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter3Merged'

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -89,6 +89,10 @@ iterHLTTracksMonitoringHLT.allTrackProducer = 'hltMergedTracks'
 iterHLTTracksMonitoringHLT.doEffFromHitPatternVsPU   = True
 iterHLTTracksMonitoringHLT.doEffFromHitPatternVsBX   = True
 iterHLTTracksMonitoringHLT.doEffFromHitPatternVsLUMI = True
+iterHLTTracksMonitoringHLT.doDCAPlots                = True
+iterHLTTracksMonitoringHLT.doPVPlots                 = True
+iterHLTTracksMonitoringHLT.doBSPlots                 = True
+iterHLTTracksMonitoringHLT.doSIPPlots                = True
 
 iter3TracksMonitoringHLT = trackingMonHLT.clone()
 iter3TracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter3Merged'


### PR DESCRIPTION
checking w/ BTV@HLT conveners (@defranchis @mastrolorenzo ) the possible source of the discrepancy they see in the 10_2_0 validation, 
I realized we are missing the important SIP plots in the monitoring of tracks @HLT 
=> I'm enabling them for the final tracks collection @HLT used by PF reconstruction

