### PR TITLE
Print function migration for PhysicsTools_PatExamples

### DIFF
--- a/PhysicsTools/PatExamples/bin/PatBasicFWLiteAnalyzer.py
+++ b/PhysicsTools/PatExamples/bin/PatBasicFWLiteAnalyzer.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 import ROOT
 import sys
 from DataFormats.FWLite import Events, Handle
@@ -23,7 +24,7 @@ muonPhi = ROOT.TH1F("muonPhi","phi",   100, -5.,  5.)
 i = 0
 for event in events:
     i = i + 1
-    print  i
+    print(i)
     # use getByLabel, just like in cmsRun
     event.getByLabel (label, handle)
     # get the product


### PR DESCRIPTION
Using futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import