### PR TITLE
Use EMTF data re-emulation config for DQM

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -34,9 +34,7 @@ valOmtfDigis.srcRPC = cms.InputTag('omtfStage2Digis')
 
 # EMTF
 from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *
-valEmtfStage2Digis = simEmtfDigis.clone()
-valEmtfStage2Digis.CSCInput = "emtfStage2Digis"
-valEmtfStage2Digis.RPCInput = "muonRPCDigis"
+valEmtfStage2Digis = simEmtfDigisData.clone()
 
 # uGMT
 from L1Trigger.L1TMuon.simGmtStage2Digis_cfi import *


### PR DESCRIPTION
Forward-port of last commit here, which is already running in online DQM:
https://github.com/cms-sw/cmssw/pull/23919  (10_1_X)
https://github.com/cms-sw/cmssw/pull/24106  (10_2_X)

simEmtfDigisData includes the following changes w.r.t. the MC emulation:
https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py#L121

CSCInput  = cms.InputTag('emtfStage2Digis'),
RPCInput  = cms.InputTag('muonRPCDigis'),
CPPFInput = cms.InputTag('emtfStage2Digis'),
GEMInput  = cms.InputTag('muonGEMPadDigis'),

CPPFEnable = cms.bool(True), # Use CPPF-emulated clustered RPC hits from CPPF as the RPC hits