### PR TITLE
Minor updates to tracking MC validation scripts

### DIFF
--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1223,6 +1223,12 @@ _seedingBuildingPlots = _simBasedPlots + [
   + _makeMVAPlots(3) \
   + _makeMVAPlots(3, hp=True)
 # add more if needed
+_buildingExtendedPlots = [
+    _pulls,
+    _resolutionsEta,
+    _resolutionsPt,
+    _tuning,
+]
 _extendedPlots = [
     _extDistPtEtaPhi,
     _extDistDxyDzBS,
@@ -1279,7 +1285,7 @@ _packedCandidatePlots = [
 ]
 plotter = Plotter()
 plotterExt = Plotter()
-def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, onlyForElectron=False, onlyForConversion=False, onlyForBHadron=False, seeding=False, rawSummary=False, highPuritySummary=True):
+def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, onlyForElectron=False, onlyForConversion=False, onlyForBHadron=False, seeding=False, building=False, rawSummary=False, highPuritySummary=True):
     folders = _trackingFolders(lastDirName)
     # to keep backward compatibility, this set of plots has empty name
     limiters = dict(onlyForPileup=onlyForPileup, onlyForElectron=onlyForElectron, onlyForConversion=onlyForConversion, onlyForBHadron=onlyForBHadron)
@@ -1290,7 +1296,11 @@ def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, only
         _trackingSubFoldersFallbackSLHC_Phase1PU140,
         _trackingSubFoldersFallbackFromPV, _trackingSubFoldersFallbackConversion])
     plotter.append(name, folders, TrackingPlotFolder(*algoPlots, **commonForTPF), **common)
-    plotterExt.append(name, folders, TrackingPlotFolder(*_extendedPlots, **commonForTPF), **common)
+    extendedPlots = []
+    if building:
+        extendedPlots.extend(_buildingExtendedPlots)
+    extendedPlots.extend(_extendedPlots)
+    plotterExt.append(name, folders, TrackingPlotFolder(*extendedPlots, **commonForTPF), **common)
 
     summaryName = ""
     if name != "":
@@ -1330,7 +1340,7 @@ _appendTrackingPlots("TrackFromPV", "fromPV", _simBasedPlots+_recoBasedPlots, on
 _appendTrackingPlots("TrackFromPVAllTP", "fromPVAllTP", _simBasedPlots+_recoBasedPlots, onlyForPileup=True)
 _appendTrackingPlots("TrackFromPVAllTP2", "fromPVAllTP2", _simBasedPlots+_recoBasedPlots, onlyForPileup=True)
 _appendTrackingPlots("TrackSeeding", "seeding", _seedingBuildingPlots, seeding=True)
-_appendTrackingPlots("TrackBuilding", "building", _seedingBuildingPlots)
+_appendTrackingPlots("TrackBuilding", "building", _seedingBuildingPlots, building=True)
 _appendTrackingPlots("TrackConversion", "conversion", _simBasedPlots+_recoBasedPlots, onlyForConversion=True, rawSummary=True, highPuritySummary=False)
 _appendTrackingPlots("TrackGsf", "gsf", _simBasedPlots+_recoBasedPlots, onlyForElectron=True, rawSummary=True, highPuritySummary=False)
 _appendTrackingPlots("TrackBHadron", "bhadron", _simBasedPlots+_recoBasedPlots, onlyForBHadron=True)

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -78,7 +78,7 @@ def main(opts):
         print "Plots and HTML report created into directory '%s'. You can just move it to some www area and access the pages via web browser" % opts.outputDir
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Create standard set of tracking validation plots from one or more DQM files.")
+    parser = argparse.ArgumentParser(description="Create standard set of tracking validation plots from one or more DQM files.\nNote that for timing plots you have to include FastTimerService (typically it gets included via DQM/VALIDATION), and set\nprocess.FastTimerService.enableDQMbyPath = True")
     parser.add_argument("files", metavar="file", type=str, nargs="+",
                         help="DQM file to plot the validation plots from")
     parser.add_argument("-o", "--outputDir", type=str, default="plots",


### PR DESCRIPTION
This PR suggests two small updates to tracking MC validation scripts
* Include pulls, resolutions, and chi2 to the extended plots of "built tracks"
  * They have always been part of the standard plots of "general tracks", but have not been included for "built tracks" because there was no interest on them before
* Add help to `makeTrackValidationPlots.py` what needs to be done on the CMSSW configuration side to get the timing plots with `FastTimerService`

Tested in CMSSW_10_2_0, no changes expected in standard workflows.

@hajohajo @VinInn @mtosi @JanFSchulte 