### PR TITLE
Make L1TMuonOverlapTrackProducer a one module

### DIFF
--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.h
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.h
@@ -10,7 +10,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
@@ -38,7 +38,7 @@ namespace XERCES_CPP_NAMESPACE{
 }
 
 
-class L1TMuonOverlapTrackProducer : public edm::EDProducer {
+class L1TMuonOverlapTrackProducer : public edm::one::EDProducer<edm::one::WatchRuns> {
  public:
   L1TMuonOverlapTrackProducer(const edm::ParameterSet&);
 
@@ -49,7 +49,8 @@ class L1TMuonOverlapTrackProducer : public edm::EDProducer {
   void endJob() override;
 
   void beginRun(edm::Run const& run, edm::EventSetup const& iSetup) override;
-  
+  void endRun(edm::Run const&, edm::EventSetup const&) override {}
+
   void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:

--- a/L1Trigger/L1TMuonOverlap/src/OMTFReconstruction.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFReconstruction.cc
@@ -6,7 +6,6 @@
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
 
-#include "L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFProcessor.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFinput.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFReconstruction.h"


### PR DESCRIPTION
The L1TMuonOverlapTrackProducer is showing up as stalling during DIGI workflows.

The module could not be made into a stream module since it has a mode where it can write out an XML file. I highly recommend that this mode be removed so a more thread efficient module type can be used.