### PR TITLE
Bugfix (typo) on PixelPhase1 Online client (same as #24139 for master)

### DIFF
--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -61,7 +61,7 @@ from DQM.SiPixelPhase1Common.SiPixelPhase1Clusters_cfi import *
 
 # Raw data errors
 from DQM.SiPixelPhase1Common.SiPixelPhase1RawData_cfi import *
-from DQM.SiPixelPhase1COmmon.SiPixelPhase1DeadFEDChannels_cfi import *
+from DQM.SiPixelPhase1Common.SiPixelPhase1DeadFEDChannels_cfi import *
 
 from DQM.SiPixelPhase1Common.SiPixelPhase1GeometryDebug_cfi import *
 


### PR DESCRIPTION
Corrected a typo on SiPixelPhase1OnlineDQM_cff.py which prevent the client to run correctly
(same as #24139 for master)