### PR TITLE
Add warning for NaN values in DeepFlavourJetTagsProducer for DeepCSV

### DIFF
--- a/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
+++ b/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
@@ -246,6 +246,12 @@ DeepFlavourJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 				else {
 					inputs_[var.name] = vars.get(var.id, var.default_value);
 				}
+
+				//warn if the input is nan
+				if(std::isnan(inputs_[var.name])) {
+					edm::LogWarning("ValueError") 	<< "The required output, " 
+													<< var.name << ", encountered an nan value during TagInfo processing." << endl;
+				}
 			}
 
 			//compute NN output(s)
@@ -254,6 +260,13 @@ DeepFlavourJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 			//merge outputs
 			for(auto const& entry : toadd) {
 				nnout[entry.second] += nnout[entry.first];
+			}
+
+			//warn if the input is nan
+			for(auto entry : nnout) {
+				if(std::isnan(entry.second)) {
+					edm::LogWarning("ValueError") << "The NN output is nan for an event." << endl;
+				}
 			}
 		}
 

--- a/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
+++ b/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
@@ -250,7 +250,7 @@ DeepFlavourJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 				//warn if the input is nan
 				if(std::isnan(inputs_[var.name])) {
 					edm::LogWarning("ValueError") 	<< "The required output, " 
-													<< var.name << ", encountered an nan value during TagInfo processing." << endl;
+									<< var.name << ", encountered an nan value during TagInfo processing";
 				}
 			}
 
@@ -265,7 +265,7 @@ DeepFlavourJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 			//warn if the input is nan
 			for(auto entry : nnout) {
 				if(std::isnan(entry.second)) {
-					edm::LogWarning("ValueError") << "The NN output is nan for an event." << endl;
+					edm::LogWarning("ValueError") << "The NN output is nan for an event.";
 				}
 			}
 		}

--- a/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
+++ b/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
@@ -226,6 +226,9 @@ DeepFlavourJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 		}
 	}
 
+	int naninput = 0;
+	int nanoutput = 0;
+
 	// loop over TagInfos
 	for(auto& info : *(taginfos)) {
 		//convert the taginfo into the value map in the appropriate way
@@ -247,10 +250,9 @@ DeepFlavourJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 					inputs_[var.name] = vars.get(var.id, var.default_value);
 				}
 
-				//warn if the input is nan
+				//count if the input is nan
 				if(std::isnan(inputs_[var.name])) {
-					edm::LogWarning("ValueError") 	<< "The required output, " 
-									<< var.name << ", encountered an nan value during TagInfo processing";
+					naninput++;
 				}
 			}
 
@@ -262,10 +264,10 @@ DeepFlavourJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 				nnout[entry.second] += nnout[entry.first];
 			}
 
-			//warn if the input is nan
+			//count if the output is nan
 			for(auto entry : nnout) {
 				if(std::isnan(entry.second)) {
-					edm::LogWarning("ValueError") << "The NN output is nan for an event.";
+					nanoutput++;
 				}
 			}
 		}
@@ -277,6 +279,10 @@ DeepFlavourJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 		for(size_t i = 0; i < outputs.size(); ++i) {
 			(*output_tags[i])[key] = (defaulted) ? -1 : nnout[outputs[i]];
 		}
+	}
+
+	if( naninput + nanoutput > 0 ) {
+		edm::LogWarning("ValueError") << "The NN encountered " << naninput << " nan input TagInfo values and produced " << nanoutput << " nan output values";
 	}
 
 	// put the output in the event

--- a/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
+++ b/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
@@ -265,7 +265,7 @@ DeepFlavourJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 			}
 
 			//count if the output is nan
-			for(auto entry : nnout) {
+			for(const auto& entry : nnout) {
 				if(std::isnan(entry.second)) {
 					nanoutput++;
 				}


### PR DESCRIPTION
backport of #23640

[copy-paste from 23618]
- Add a warning in the DeepFlavourJetTagsProducer which is triggered when one of the DeepCSV inputs is NaN
- Add a warning which is triggered when the DeepCSV output is NaN

Relevant contacts: @mverzett @emilbols @emanueleusa