### PR TITLE
Protecting E/gamma Scale and Smearing from "nan" energies : 94X

### DIFF
--- a/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
@@ -43,7 +43,7 @@ calibrate(reco::GsfElectron &ele, unsigned int runNumber,
   const float scEtaAbs = std::abs(ele.superCluster()->eta());
   const float et = ele.ecalEnergy() / cosh(scEtaAbs);
 
-  if (et < minEt_) {
+  if (et < minEt_ || std::isnan(et) ) {
     std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(ele.energy());
     retVal[EGEnergySysIndex::kScaleValue]  = 1.0;

--- a/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
@@ -3,6 +3,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include <CLHEP/Random/RandGaussQ.h>
 
 const EnergyScaleCorrection::ScaleCorrection ElectronEnergyCalibrator::defaultScaleCorr_;
@@ -43,7 +44,7 @@ calibrate(reco::GsfElectron &ele, unsigned int runNumber,
   const float scEtaAbs = std::abs(ele.superCluster()->eta());
   const float et = ele.ecalEnergy() / cosh(scEtaAbs);
 
-  if (et < minEt_ || std::isnan(et) ) {
+  if (et < minEt_ || edm::isNotFinite(et) ) {
     std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(ele.energy());
     retVal[EGEnergySysIndex::kScaleValue]  = 1.0;

--- a/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
@@ -39,7 +39,7 @@ calibrate(reco::Photon &photon,const unsigned int runNumber,
   const float scEtaAbs = std::abs(photon.superCluster()->eta());
   const float et = photon.getCorrectedEnergy(reco::Photon::P4type::regression2) / cosh(scEtaAbs);
 
-  if (et < minEt_) {
+  if (et < minEt_ || std::isnan(et) ) {
     std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(photon.getCorrectedEnergy(reco::Photon::P4type::regression2));
     retVal[EGEnergySysIndex::kScaleValue]  = 1.0;

--- a/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/PhotonEnergyCalibrator.cc
@@ -3,6 +3,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include <CLHEP/Random/RandGaussQ.h>
 
 const EnergyScaleCorrection::ScaleCorrection PhotonEnergyCalibrator::defaultScaleCorr_;
@@ -39,7 +40,7 @@ calibrate(reco::Photon &photon,const unsigned int runNumber,
   const float scEtaAbs = std::abs(photon.superCluster()->eta());
   const float et = photon.getCorrectedEnergy(reco::Photon::P4type::regression2) / cosh(scEtaAbs);
 
-  if (et < minEt_ || std::isnan(et) ) {
+  if (et < minEt_ || edm::isNotFinite(et) ) {
     std::array<float,EGEnergySysIndex::kNrSysErrs> retVal;
     retVal.fill(photon.getCorrectedEnergy(reco::Photon::P4type::regression2));
     retVal[EGEnergySysIndex::kScaleValue]  = 1.0;


### PR DESCRIPTION
This is the 94X flavour of https://github.com/cms-sw/cmssw/pull/24093

It replaces https://github.com/cms-sw/cmssw/pull/24094