### PR TITLE
STEAM : (re)enable HLTDQM in the main sequence

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_Client_cff.py
@@ -24,7 +24,8 @@ b2gjetEfficiency = cms.EDProducer("DQMGenericClient",
 )
 
 b2gEfficiency_ElMu = cms.EDProducer("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/B2GHLTOffline/Dileptonic/Dimuon/CrossTriggers"),
+#    subDirs        = cms.untracked.vstring("HLT/B2GHLTOffline/Dileptonic/Dimuon/CrossTriggers"),
+    subDirs        = cms.untracked.vstring("HLT/B2G/Dileptonic/Dimuon/CrossTriggers"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
                                       
     resolution     = cms.vstring(),
@@ -39,7 +40,8 @@ b2gEfficiency_ElMu = cms.EDProducer("DQMGenericClient",
 )
 
 b2gEfficiency_diMu = cms.EDProducer("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/B2GHLTOffline/Dileptonic/Dimuon/"),
+#    subDirs        = cms.untracked.vstring("HLT/B2GHLTOffline/Dileptonic/Dimuon/"),
+    subDirs        = cms.untracked.vstring("HLT/B2G/Dileptonic/Dimuon/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
                                       
     resolution     = cms.vstring(),

--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -143,14 +143,16 @@ AK8PFJet420_TrimMass30_PromptMonitoring.numGenericTriggerEventPSet.hltPaths = cm
 
 
 b2gDileptonHLTOfflineDQM = topDiLeptonHLTOfflineDQM.clone()
-b2gDileptonHLTOfflineDQM.setup.directory = cms.string('HLT/B2GHLTOffline/Dileptonic/CrossTriggers')
+#b2gDileptonHLTOfflineDQM.setup.directory = cms.string('HLT/B2GHLTOffline/Dileptonic/CrossTriggers')
+b2gDileptonHLTOfflineDQM.setup.directory = cms.string('HLT/B2G/Dileptonic/CrossTriggers')
 b2gDileptonHLTOfflineDQM.setup.triggerExtras.pathsELECMU = cms.vstring(['HLT_Mu37_Ele27_CaloIdL_MW_v','HLT_Mu27_Ele37_CaloIdL_MW_v'])
 b2gDileptonHLTOfflineDQM.setup.triggerExtras.pathsDIMUON = cms.vstring([''])
 b2gDileptonHLTOfflineDQM.setup.triggerExtras.pathsDIELEC = cms.vstring([''])
 b2gDileptonHLTOfflineDQM.preselection.trigger.select = cms.vstring(['HLT_Mu37_Ele27_CaloIdL_MW_v','HLT_Mu27_Ele37_CaloIdL_MW_v'])
 
 b2gDimuonHLTOfflineDQM = topDiLeptonHLTOfflineDQM.clone()
-b2gDimuonHLTOfflineDQM.setup.directory = cms.string('HLT/B2GHLTOffline/Dileptonic/Dimuon')
+#b2gDimuonHLTOfflineDQM.setup.directory = cms.string('HLT/B2GHLTOffline/Dileptonic/Dimuon')
+b2gDimuonHLTOfflineDQM.setup.directory = cms.string('HLT/B2G/Dileptonic/Dimuon')
 b2gDimuonHLTOfflineDQM.setup.triggerExtras.pathsELECMU = cms.vstring([''])
 b2gDimuonHLTOfflineDQM.setup.triggerExtras.pathsDIMUON = cms.vstring(['HLT_Mu37_TkMu27_v'])
 b2gDimuonHLTOfflineDQM.setup.triggerExtras.pathsDIELEC = cms.vstring([''])
@@ -159,9 +161,6 @@ b2gDimuonHLTOfflineDQM.preselection.trigger.select = cms.vstring(['HLT_Mu37_TkMu
 
 
 b2gMonitorHLT = cms.Sequence(
-)
-
-b2gHLTDQMSourceExtra = cms.Sequence(
     PFHT1050_Mjjmonitoring +
     PFHT1050_Softdropmonitoring +
 
@@ -194,6 +193,8 @@ b2gHLTDQMSourceExtra = cms.Sequence(
     b2gDileptonHLTOfflineDQM*
     b2gDimuonHLTOfflineDQM,
 
-    cms.Task(B2GegmGsfElectronIDsForDQM)
+    cms.Task(B2GegmGsfElectronIDsForDQM) ## unschedule execution [Use of electron VID requires this module being executed first]
+)
 
+b2gHLTDQMSourceExtra = cms.Sequence(
 )

--- a/DQMOffline/Trigger/python/BTVHLTOfflineSource_cff.py
+++ b/DQMOffline/Trigger/python/BTVHLTOfflineSource_cff.py
@@ -3,17 +3,20 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.BTVHLTOfflineSource_cfi import *
 from DQMOffline.Trigger.BTaggingMonitoring_cff import *
 
-btvHLTDQMSourceExtra = cms.Sequence(
+btagMonitorHLT = cms.Sequence(
     BTagMu_AK4DiJet20_Mu5
     + BTagMu_AK4DiJet40_Mu5
     + BTagMu_AK4DiJet70_Mu5
     + BTagMu_AK4DiJet110_Mu5    
     + BTagMu_AK4DiJet170_Mu5
-    + BTagMu_AK4Jet300_Mu5
     + BTagMu_AK8DiJet170_Mu5
-    + BTagMu_AK8Jet300_Mu5
     + BTagMu_AK8Jet170_DoubleMu5
-    + PFJet40
+    + BTagMu_AK4Jet300_Mu5
+    + BTagMu_AK8Jet300_Mu5
+)
+
+btvHLTDQMSourceExtra = cms.Sequence(
+    PFJet40
     + PFJet60
     + PFJet80
     + PFJet140

--- a/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
@@ -42,5 +42,3 @@ BTVHLTOfflineSource = DQMEDAnalyzer(
     )
 )
 
-btvHLTDQMSourceExtra = cms.Sequence(
-)

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
@@ -569,5 +569,3 @@ AK8PFJetFwd500.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,
 AK8PFJetFwd500.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
 
 
-btagMonitorHLT = cms.Sequence(
-)

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -2,25 +2,30 @@ import FWCore.ParameterSet.Config as cms
 
 # online trigger objects monitoring
 from DQM.HLTEvF.HLTObjectsMonitor_cfi import *
+# HLT path monitoring (per PD)
+from DQMOffline.Trigger.HLTGeneralOffline_cfi import *
 
 # lumi
 from DQMOffline.Trigger.DQMOffline_LumiMontiroring_cff import *
+
 # Egamma
-from DQMOffline.Trigger.HLTGeneralOffline_cfi import *
-# Egamma
-from DQMOffline.Trigger.EgHLTOfflineSource_cfi import *
+from DQMOffline.Trigger.EgHLTOfflineSource_cff import *
 from DQMOffline.Trigger.EgammaMonitoring_cff import * # tag-n-probe (egammaMonitorHLT + egmHLTDQMSourceExtra)
 # Muon
 from DQMOffline.Trigger.MuonOffline_Trigger_cff import *
-# Top
+# TOP
+from DQMOffline.Trigger.topHLTOfflineDQM_cff import *
+from DQMOffline.Trigger.TopMonitoring_cff import *
 #from DQMOffline.Trigger.QuadJetAna_cfi import *
 # Tau
 from DQMOffline.Trigger.HLTTauDQMOffline_cff import *
 # JetMET
 from DQMOffline.Trigger.JetMETHLTOfflineAnalyzer_cff import *
+from DQMOffline.Trigger.JetMETPromptMonitor_cff import *
 
 # BTV
 from DQMOffline.Trigger.BTVHLTOfflineSource_cff import *
+from DQMOffline.Trigger.BTaggingMonitoring_cff import *
 
 from DQMOffline.Trigger.FSQHLTOfflineSource_cff import *
 from DQMOffline.Trigger.HILowLumiHLTOfflineSource_cfi import *
@@ -47,7 +52,7 @@ from DQMOffline.Trigger.SiStrip_OfflineMonitoring_cff import *
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_cff import *
 
 # photon jet
-from DQMOffline.Trigger.HigPhotonJetHLTOfflineSource_cfi import * 
+from DQMOffline.Trigger.HigPhotonJetHLTOfflineSource_cfi import *  # ?!?!?!
 
 ##hotline 
 #from DQMOffline.Trigger.hotlineDQM_cfi import * # ORPHAN
@@ -72,99 +77,141 @@ from DQMOffline.Trigger.B2GMonitoring_cff import *
 from DQMOffline.Trigger.HiggsMonitoring_cff import *
 # SMP
 from DQMOffline.Trigger.StandardModelMonitoring_cff import *
-# TOP
-from DQMOffline.Trigger.TopMonitoring_cff import *
-# BTV
-from DQMOffline.Trigger.BTaggingMonitoring_cff import *
 # BPH
 from DQMOffline.Trigger.BPHMonitor_cff import *
-# remove quadJetAna
-from DQMOffline.Trigger.topHLTOfflineDQM_cff import *
-from DQMOffline.Trigger.JetMETPromptMonitor_cff import *
 
-# offline DQM for running also on AOD (w/o the need of the RECO step on-the-fly)
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+dqmInfoHLTMon = DQMEDAnalyzer('DQMEventInfo',
+    subSystemFolder = cms.untracked.string('HLT')
+)
+###################################################################################################
+#### SEQUENCES TO BE RUN depending on the input DATAFORMAT
+## on MiniAOD
+## ADD here sequences/modules which rely ONLY on collections stored in the MiniAOD format
+offlineHLTSourceOnMiniAOD = cms.Sequence(
+)
+
+## on AOD (w/o the need of the RECO step on-the-fly)
 ## ADD here sequences/modules which rely ONLY on collections stored in the AOD format
-
-egHLTOffDQMSource_HEP17 = egHLTOffDQMSource.clone()
-egHLTOffDQMSource_HEP17.subDQMDirName=cms.string('HEP17')
-egHLTOffDQMSource_HEP17.doHEP =cms.bool(True)
-
 offlineHLTSourceOnAOD = cms.Sequence(
-    hltResults *
-    lumiMonitorHLTsequence *
-    muonFullOfflineDQM *
-    HLTTauDQMOffline *
-    hltInclusiveVBFSource *
-    higPhotonJetHLTOfflineSource* # plots are filled, but I'm not sure who is really looking at them and what you can get from them ... good candidates to be moved in offlineHLTSourceOnAODextra
-    dqmEnvHLT *
-    topHLTriggerOfflineDQM * # plots are filled, but I'm not sure who is really looking at them and what you can get from them ... good candidates to be moved in offlineHLTSourceOnAODextra
+    dqmEnvHLT
+    * hltResults
+    * lumiMonitorHLTsequence
+    * muonFullOfflineDQM
+    * HLTTauDQMOffline
+    * hltInclusiveVBFSource
+    * higPhotonJetHLTOfflineSource # plots are filled, but I'm not sure who is really looking at them and what you can get from them ... good candidates to be moved in offlineHLTSourceOnAODextra
+    * topHLTriggerOfflineDQM # plots are filled, but I'm not sure who is really looking at them and what you can get from them ... good candidates to be moved in offlineHLTSourceOnAODextra
 #    eventshapeDQMSequence * ## OBSOLETE !!!! (looks for HLT_HIQ2Top005_Centrality1030_v, HLT_HIQ2Bottom005_Centrality1030_v, etc)
 #    HeavyIonUCCDQMSequence * ## OBSOLETE !!!! (looks for HLT_HIUCC100_v and HLT_HIUCC020_v)
 #    hotlineDQMSequence * ## ORPHAN !!!!
-    egammaMonitorHLT * 
-    exoticaMonitorHLT *
-    susyMonitorHLT *
-    b2gMonitorHLT *
-    higgsMonitorHLT *
-    smpMonitorHLT *
-    topMonitorHLT *
-    btagMonitorHLT *
-    bphMonitorHLT *
-    hltObjectsMonitor * # as online DQM, requested/suggested by TSG coordinators
-    jetmetMonitorHLT
+    * egammaMonitorHLT 
+    * exoticaMonitorHLT
+    * susyMonitorHLT
+    * b2gMonitorHLT
+    * higgsMonitorHLT
+    * smpMonitorHLT
+    * topMonitorHLT
+    * btagMonitorHLT 
+    * bphMonitorHLT
+    * hltObjectsMonitor # as online DQM, requested/suggested by TSG coordinators
+    * jetmetMonitorHLT
 )
 
+## w/ the RECO step on-the-fly (to be added to offlineHLTSourceOnAOD which should run anyhow)
 offlineHLTSourceWithRECO = cms.Sequence(
-    jetMETHLTOfflineAnalyzer
+    hltResults
+    * egHLTOffDQMSource       ## NEEDED in VALIDATION, not really in MONITORING
+    * egHLTOffDQMSource_HEP17 ## NEEDED in VALIDATION, not really in MONITORING
+    * jetMETHLTOfflineAnalyzer
 )
-
-# offline DQM for running in the standard RECO,DQM (in PromptReco, ReReco, relval, etc)
-## THIS IS THE SEQUENCE TO BE RUN AT TIER0
-## ADD here only sequences/modules which rely on transient collections produced by the RECO step
-## and not stored in the AOD format
-offlineHLTSource = cms.Sequence(
-    offlineHLTSourceWithRECO *
-    offlineHLTSourceOnAOD
-)
-
-## sequence for HI, FSQ and LowLumi
-offlineHLTSourceOnAOD4LowLumi = cms.Sequence(
-    offlineHLTSourceOnAOD *
-    fsqHLTOfflineSourceSequence * 
-    HILowLumiHLTOfflineSourceSequence
-)
-
-offlineHLTSource4LowLumi = cms.Sequence(
-    offlineHLTSourceWithRECO *
-    offlineHLTSourceOnAOD4LowLumi
-)
-
+####################################################################################################
 # offline DQM to be run on AOD (w/o the need of the RECO step on-the-fly) only in the VALIDATION of the HLT menu based on data
 # it is needed in order to have the DQM code in the release, w/o the issue of crashing the tier0
 # asa the new modules in the sequence offlineHLTSourceOnAODextra are tested,
 # these have to be migrated in the main offlineHLTSourceOnAOD sequence
 offlineHLTSourceOnAODextra = cms.Sequence(
-    egHLTOffDQMSource * ## NEEDED in VALIDATION, not really in MONITORING
-    egHLTOffDQMSource_HEP17 * ## NEEDED in VALIDATION, not really in MONITORING
 ### POG
     btvHLTDQMSourceExtra
-    * egmHLTDQMSourceExtra
-    * jmeHLTDQMSourceExtra
-    * muoHLTDQMSourceExtra
-    * tauHLTDQMSourceExtra
-    * trkHLTDQMSourceExtra
+    * egmHLTDQMSourceExtra # empty in 10_2_0
+    * jmeHLTDQMSourceExtra 
+    * muoHLTDQMSourceExtra # empty in 10_2_0
+    * tauHLTDQMSourceExtra # empty in 10_2_0
+    * trkHLTDQMSourceExtra # empty in 10_2_0
 ### PAG
     * b2gHLTDQMSourceExtra
-    * bphHLTDQMSourceExtra
+    * bphHLTDQMSourceExtra # empty in 10_2_0
     * exoHLTDQMSourceExtra
     * higHLTDQMSourceExtra
-    * smpHLTDQMSourceExtra
+    * smpHLTDQMSourceExtra # empty in 10_2_0
     * susHLTDQMSourceExtra
     * topHLTDQMSourceExtra
-    * fsqHLTDQMSourceExtra
+    * fsqHLTDQMSourceExtra # empty in 10_2_0
 #    * hinHLTDQMSourceExtra
 )
+####################################################################################################
+#### SEQUENCES TO BE RUN @Tier0 ####
+### Express : not really needed
+### HLTMonitor : special collections allow to monitor tracks, strip and pixel clusters, b-tagging discriminator, etc --> OfflineHLTMonitoring
+### Physics PDs : monitoring vs offline collection (typically, turnON)
 
+## DQM step on Express
+offlineHLTSource4ExpressPD = cms.Sequence(
+)
+
+## DQM step on HLTMonitor
+## ADD here only sequences/modules which rely on HLT collections which are stored in the HLTMonitoring stream
+## and are not available in the standard RAW format
+offlineHLTSource4HLTMonitorPD = cms.Sequence(
+    dqmInfoHLTMon *
+    lumiMonitorHLTsequence *          # lumi
+    sistripMonitorHLTsequence *       # strip
+    sipixelMonitorHLTsequence *       # pixel
+    BTVHLTOfflineSource *             # BTV
+    trackingMonitorHLT *              # tracking
+    trackingMonitorHLTDisplacedJet*   # EXO : DisplacedJet Tracking 
+    egmTrackingMonitorHLT *           # EGM tracking
+    vertexingMonitorHLT               # vertexing
+)
+
+# sequences run @tier0 on HLTMonitor PD
+OfflineHLTMonitoring = cms.Sequence(
+    offlineHLTSource4HLTMonitorPD
+)
+
+# sequences run @tier0 on HLTMonitor PD w/ HI (PbPb, XeXe), pPb, ppRef
+OfflineHLTMonitoringPA = cms.Sequence(
+    dqmInfoHLTMon *
+    trackingMonitorHLT *
+    PAtrackingMonitorHLT  
+)
+
+## DQM step on physics PDs
+## transient collections produced by the RECO step are allowed ;)
+offlineHLTSource4physicsPD = cms.Sequence(
+    offlineHLTSourceOnAOD
+    * offlineHLTSourceWithRECO
+)
+
+## DQM step on special physics PDs (HI, FSQ and LowLumi, etc)
+## transient collections produced by the RECO step are allowed ;)
+offlineHLTSource4specialPhysicsPD = cms.Sequence(
+    offlineHLTSourceOnAOD 
+    * offlineHLTSourceWithRECO
+    * fsqHLTOfflineSourceSequence
+    * HILowLumiHLTOfflineSourceSequence
+)
+
+## DQM step on relval
+offlineHLTSource4relval = cms.Sequence(
+    offlineHLTSourceOnAOD
+    * offlineHLTSourceWithRECO
+    * offlineHLTSource4HLTMonitorPD       ## special collections (tracking, strip, pixel, etc)
+    * fsqHLTOfflineSourceSequence         ## FSQ
+    * HILowLumiHLTOfflineSourceSequence   ## HI
+    * offlineHLTSourceOnAODextra          ## EXTRA
+)
+####################################################################################################
 # offline DQM to be run on AOD (w/o the need of the RECO step on-the-fly) in the VALIDATION of the HLT menu based on data
 # it is needed in order to have the DQM code in the release, w/o the issue of crashing the tier0
 # asa the new modules in the sequence offlineHLTSourceOnAODextra are tested
@@ -173,47 +220,23 @@ offlineValidationHLTSourceOnAOD = cms.Sequence(
     offlineHLTSourceOnAOD 
     + offlineHLTSourceOnAODextra
 )
+####################################################################################################
 
-# offline DQM for the HLTMonitoring stream
-## ADD here only sequences/modules which rely on HLT collections which are stored in the HLTMonitoring stream
-## and are not available in the standard RAW format
-from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-dqmInfoHLTMon = DQMEDAnalyzer('DQMEventInfo',
-    subSystemFolder = cms.untracked.string('HLT')
-    )
 
-# sequences run @tier0 on HLTMonitor PD
-OfflineHLTMonitoring = cms.Sequence(
-    dqmInfoHLTMon *
-    lumiMonitorHLTsequence * # lumi
-    sistripMonitorHLTsequence * # strip
-    sipixelMonitorHLTsequence * # pixel
-    BTVHLTOfflineSource *
-    trackingMonitorHLT * # tracking
-    trackingMonitorHLTDisplacedJet* #DisplacedJet Tracking 
-    egmTrackingMonitorHLT * # egm tracking
-    vertexingMonitorHLT # vertexing
-    )
-
-# sequences run @tier0 on HLTMonitor PD w/ HI (PbPb, XeXe), pPb, ppRef
-OfflineHLTMonitoringPA = cms.Sequence(
-    dqmInfoHLTMon *
-    trackingMonitorHLT *
-    PAtrackingMonitorHLT  
-    )
+## old sequence, it should be dropped asa we are confident it is no longer used
+offlineHLTSource = cms.Sequence(
+    offlineHLTSource4physicsPD
+)
 
 ### sequence run @tier0 (called by main DQM sequences in DQMOffline/Configuration/python/DQMOffline_cff.py) on all PDs, but HLTMonitor one
 triggerOfflineDQMSource =  cms.Sequence(
     offlineHLTSource
 )
 
-triggerOfflineDQMSource4LowLumi =  cms.Sequence(
-    offlineHLTSource4LowLumi
-)
- 
 # this sequence can be used by AlCa for the validation of conditions,
 # because it is like offlineHLTSource (run @tier0) + offlineHLTSourceOnAODextra (meant to validate new features)
 offlineValidationHLTSource = cms.Sequence(
     offlineHLTSource
     + offlineHLTSourceOnAODextra
 )
+

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -101,7 +101,6 @@ offlineHLTSourceOnAOD = cms.Sequence(
     * HLTTauDQMOffline
     * hltInclusiveVBFSource
     * higPhotonJetHLTOfflineSource # plots are filled, but I'm not sure who is really looking at them and what you can get from them ... good candidates to be moved in offlineHLTSourceOnAODextra
-    * topHLTriggerOfflineDQM # plots are filled, but I'm not sure who is really looking at them and what you can get from them ... good candidates to be moved in offlineHLTSourceOnAODextra
 #    eventshapeDQMSequence * ## OBSOLETE !!!! (looks for HLT_HIQ2Top005_Centrality1030_v, HLT_HIQ2Bottom005_Centrality1030_v, etc)
 #    HeavyIonUCCDQMSequence * ## OBSOLETE !!!! (looks for HLT_HIUCC100_v and HLT_HIUCC020_v)
 #    hotlineDQMSequence * ## ORPHAN !!!!
@@ -146,6 +145,7 @@ offlineHLTSourceOnAODextra = cms.Sequence(
     * smpHLTDQMSourceExtra # empty in 10_2_0
     * susHLTDQMSourceExtra
     * topHLTDQMSourceExtra
+    * topHLTriggerOfflineDQM # plots are filled, but I'm not sure who is really looking at them and what you can get from them ... good candidates to be moved in offlineHLTSourceOnAODextra
     * fsqHLTDQMSourceExtra # empty in 10_2_0
 #    * hinHLTDQMSourceExtra
 )

--- a/DQMOffline/Trigger/python/DiJetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cff.py
@@ -143,5 +143,20 @@ DiPFjetAve300_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
 DiPFjetAve300_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve300_HFJEC_v*")
 
 HLTDiJetmonitoring = cms.Sequence(
+    DiPFjetAve40_Prommonitoring
+    *DiPFjetAve60_Prommonitoring
+    *DiPFjetAve80_Prommonitoring
+    *DiPFjetAve140_Prommonitoring
+    *DiPFjetAve200_Prommonitoring
+    *DiPFjetAve260_Prommonitoring
+    *DiPFjetAve320_Prommonitoring
+    *DiPFjetAve400_Prommonitoring
+    *DiPFjetAve500_Prommonitoring
+    *DiPFjetAve60_HFJEC_Prommonitoring
+    *DiPFjetAve80_HFJEC_Prommonitoring
+    *DiPFjetAve100_HFJEC_Prommonitoring
+    *DiPFjetAve160_HFJEC_Prommonitoring
+    *DiPFjetAve220_HFJEC_Prommonitoring
+    *DiPFjetAve300_HFJEC_Prommonitoring
 )
 

--- a/DQMOffline/Trigger/python/EgHLTOfflineSource_cff.py
+++ b/DQMOffline/Trigger/python/EgHLTOfflineSource_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+### 
+from DQMOffline.Trigger.EgHLTOfflineSource_cfi import *
+
+egHLTOffDQMSource_HEP17 = egHLTOffDQMSource.clone()
+egHLTOffDQMSource_HEP17.subDQMDirName=cms.string('HEP17')
+egHLTOffDQMSource_HEP17.doHEP =cms.bool(True)
+

--- a/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
@@ -10,8 +10,7 @@ egammaMonitorHLT = cms.Sequence(
     egmMuonIDSequenceForDQM*
     egHLTMuonEleDQMOfflineTnPSource*
     egHLTMuonPhoDQMOfflineTnPSource,
-
-    cms.Task(egmGsfElectronIDsForDQM)
+    cms.Task(egmGsfElectronIDsForDQM) ## unschedule execution [Use of electron VID requires this module being executed first]
 )
 
 egmHLTDQMSourceExtra = cms.Sequence(

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
@@ -23,7 +23,8 @@ photonEfficiency = DQMEDHarvester("DQMGenericClient",
 )
 
 photonVBF_jetMETEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Photon/Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50", "HLT/Photon/Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3"),
+#    subDirs        = cms.untracked.vstring("HLT/Photon/Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50", "HLT/Photon/Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3"),
+    subDirs        = cms.untracked.vstring("HLT/EXO/Photon/Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50", "HLT/EXO/Photon/Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
@@ -13,13 +13,13 @@ exoticaMonitorHLT = cms.Sequence(
     exoHLTMETmonitoring
   + exoHLTNoBPTXmonitoring
   + exoHLTdispStaMuonMonitoring
-)
-
-
-exoHLTDQMSourceExtra = cms.Sequence(
-  exoHLTPhotonmonitoring
+  + exoHLTPhotonmonitoring
   + exoHLTHTmonitoring
 # + exoHLTMETplusTrackMonitoring    # disabled pending the review of METplusTrackMonitor.cc
   + exoHLTMuonmonitoring
   + exoHLTDisplacedJetmonitoring
+)
+
+
+exoHLTDQMSourceExtra = cms.Sequence(
 )

--- a/DQMOffline/Trigger/python/HMesonGammaMonitor_Client_cff.py
+++ b/DQMOffline/Trigger/python/HMesonGammaMonitor_Client_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 hmesongammaEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/HMesonGamma/*"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/HMesonGamma/*"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/HMesonGamma/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(

--- a/DQMOffline/Trigger/python/HMesonGammaMonitor_cff.py
+++ b/DQMOffline/Trigger/python/HMesonGammaMonitor_cff.py
@@ -4,7 +4,8 @@ from DQMOffline.Trigger.ObjMonitor_cfi import hltobjmonitoring
 
 # HLT_
 HMesonGammamonitoring = hltobjmonitoring.clone()
-HMesonGammamonitoring.FolderName = cms.string('HLT/Higgs/HMesonGamma/')
+#HMesonGammamonitoring.FolderName = cms.string('HLT/Higgs/HMesonGamma/')
+HMesonGammamonitoring.FolderName = cms.string('HLT/HIG/HMesonGamma/')
 HMesonGammamonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults","","HLT" )
 HMesonGammamonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon35_TwoProngs35_v*")
 #HMesonGammamonitoring.metSelection = cms.string("")

--- a/DQMOffline/Trigger/python/HigPhotonJetHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/HigPhotonJetHLTOfflineSource_cfi.py
@@ -26,7 +26,8 @@ higPhotonJetHLTOfflineSource = DQMEDAnalyzer(
         "HLT_Photon300_NoHE_v",
     ),
     # Location of plots in DQM
-    dirname = cms.untracked.string("HLT/Higgs/PhotonJet"), 
+#    dirname = cms.untracked.string("HLT/Higgs/PhotonJet"), 
+    dirname = cms.untracked.string("HLT/HIG/PhotonJet"), 
     verbose = cms.untracked.bool(False), # default: False
     triggerAccept = cms.untracked.bool(True), # default: True 
     triggerResultsToken = cms.InputTag("TriggerResults","","HLT"),

--- a/DQMOffline/Trigger/python/HiggsMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/HiggsMonitoring_Client_cff.py
@@ -9,7 +9,8 @@ from DQMOffline.Trigger.MssmHbbMonitoring_Client_cfi import *
 from DQMOffline.Trigger.PhotonMonitor_cff import *
 
 metbtagEfficiency_met = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/*"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/*"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -30,7 +31,8 @@ metbtagEfficiency_met = DQMEDHarvester("DQMGenericClient",
 )
 
 metbtagEfficiency_btag = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/*"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/*"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -73,7 +75,8 @@ metbtagEfficiency_btag = DQMEDHarvester("DQMGenericClient",
 
 ###############Same flavour dilepton with dz cuts#######################
 ele23Ele12CaloIdLTrackIdLIsoVL_effdz = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -98,8 +101,10 @@ ele23Ele12CaloIdLTrackIdLIsoVL_effdz = DQMEDHarvester("DQMGenericClient",
 )
 
 ################################MuEG cross triggers###################################
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_effele =  DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg/"),
+muEleDz_effele =  DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg/",
+                                           "HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg/"
+                                          ),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -115,9 +120,46 @@ mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_effele =  DQMEDHarvester("DQMGenericCli
     	"effic_ElectronPt_vs_LS 'Electron p_T efficiency vs LS; LS; Electron p_T efficiency' eleVsLS_numerator eleVsLS_denominator"
     ),
 )
-
+mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_effele =  DQMEDHarvester("DQMGenericClient",
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg/"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_elePt_1       'efficiency vs electron pt; electron pt [GeV]; efficiency' elePt_1_numerator       elePt_1_denominator",
+        "effic_eleEta_1       'efficiency vs electron eta; electron eta ; efficiency' eleEta_1_numerator       eleEta_1_denominator",
+        "effic_elePhi_1       'efficiency vs electron phi; electron phi ; efficiency' elePhi_1_numerator       elePhi_1_denominator",
+        "effic_elePt_1_variableBinning       'efficiency vs electron pt; electron pt [GeV]; efficiency' elePt_1_variableBinning_numerator       elePt_1_variableBinning_denominator",
+        "effic_eleEta_1_variableBinning       'efficiency vs electron eta; electron eta ; efficiency' eleEta_1_variableBinning_numerator       eleEta_1_variableBinning_denominator",
+        "effic_elePtEta_1       'efficiency vs electron pt-#eta; electron pt [GeV]; electron #eta' elePtEta_1_numerator       elePtEta_1_denominator",
+        "effic_eleEtaPhi_1       'efficiency vs electron #eta-#phi; electron #eta ; electron #phi' eleEtaPhi_1_numerator       eleEtaPhi_1_denominator",
+    ),
+    efficiencyProfile = cms.untracked.vstring(
+    	"effic_ElectronPt_vs_LS 'Electron p_T efficiency vs LS; LS; Electron p_T efficiency' eleVsLS_numerator eleVsLS_denominator"
+    ),
+)
+muEleDz_effmu = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg/",
+                                           "HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg/"
+                                          ),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_muPt_1       'efficiency vs muon pt; muon pt [GeV]; efficiency' muPt_1_numerator       muPt_1_denominator",
+        "effic_muEta_1       'efficiency vs muon eta; muon eta ; efficiency' muEta_1_numerator       muEta_1_denominator",
+        "effic_muPhi_1       'efficiency vs muon phi; muon phi ; efficiency' muPhi_1_numerator       muPhi_1_denominator",
+        "effic_muPt_1_variableBinning       'efficiency vs muon pt; muon pt [GeV]; efficiency' muPt_1_variableBinning_numerator       muPt_1_variableBinning_denominator",
+        "effic_muEta_1_variableBinning       'efficiency vs muon eta; muon eta ; efficiency' muEta_1_variableBinning_numerator       muEta_1_variableBinning_denominator",
+        "effic_muPtEta_1       'efficiency vs muon pt-#eta; muon pt [GeV]; muon #eta' muPtEta_1_numerator       muPtEta_1_denominator",
+        "effic_muEtaPhi_1       'efficiency vs muon #eta-#phi; muon #eta ; muon #phi' muEtaPhi_1_numerator       muEtaPhi_1_denominator",
+    ),
+    efficiencyProfile = cms.untracked.vstring(
+        "effic_MuonPt_vs_LS 'Muon p_T efficiency vs LS; LS; Muon p_T efficiency' muVsLS_numerator muVsLS_denominator"
+    ),
+)
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_effmu = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -135,7 +177,8 @@ mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_effmu = DQMEDHarvester("DQMGenericClien
 )
 
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_effele =  DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -153,7 +196,8 @@ mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_effele =  DQMEDHarvester("DQMGenericCli
 )
 
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_effmu = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -172,7 +216,8 @@ mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_effmu = DQMEDHarvester("DQMGenericClien
 
 ##########################Triple Electron################################3##
 ele16ele12ele8caloIdLTrackIdL =  DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -205,7 +250,8 @@ ele16ele12ele8caloIdLTrackIdL =  DQMEDHarvester("DQMGenericClient",
 
 ################################Triple Muon##########################
 triplemu12mu10mu5 = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_TripleMu_12_10_5/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_TripleMu_12_10_5/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/TriLepton/HLT_TripleMu_12_10_5/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -237,7 +283,8 @@ triplemu12mu10mu5 = DQMEDHarvester("DQMGenericClient",
 )
 
 triplemu10mu5mu5DZ = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_TripleM_10_5_5_DZ/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_TripleM_10_5_5_DZ/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/TriLepton/HLT_TripleM_10_5_5_DZ/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -270,7 +317,8 @@ triplemu10mu5mu5DZ = DQMEDHarvester("DQMGenericClient",
 
 #############################Double Mu + Single Ele######################################
 dimu9ele9caloIdLTrackIdLdz_effmu = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -292,7 +340,8 @@ dimu9ele9caloIdLTrackIdLdz_effmu = DQMEDHarvester("DQMGenericClient",
 )
 
 dimu9ele9caloIdLTrackIdLdz_effele = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -307,7 +356,8 @@ dimu9ele9caloIdLTrackIdLdz_effele = DQMEDHarvester("DQMGenericClient",
 )
 
 dimu9ele9caloIdLTrackIdLdz_effdz = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -337,7 +387,8 @@ dimu9ele9caloIdLTrackIdLdz_effdz = DQMEDHarvester("DQMGenericClient",
 
 ######Double Electron + Single Muon######
 mu8diEle12CaloIdLTrackIdL_effele = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -358,7 +409,8 @@ mu8diEle12CaloIdLTrackIdL_effele = DQMEDHarvester("DQMGenericClient",
     ),
 )
 mu8diEle12CaloIdLTrackIdL_effmu = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -373,7 +425,8 @@ mu8diEle12CaloIdLTrackIdL_effmu = DQMEDHarvester("DQMGenericClient",
 )
 
 mu8diEle12CaloIdLTrackIdL_effdz = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon/"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon/"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -400,9 +453,16 @@ mu8diEle12CaloIdLTrackIdL_effdz = DQMEDHarvester("DQMGenericClient",
         "effic_muEtaPhi_1       'efficiency vs muon #eta-#phi; muon #eta ; muon #phi' muEtaPhi_1_numerator       muEtaPhi_1_denominator",
     ),
 )
-
+### mia: FOCA D'OVATTA !
 diphotonEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/photon/HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90_v","HLT/photon/HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v","HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v","HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v","HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v","HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v","HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v","HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v"),
+    subDirs        = cms.untracked.vstring("HLT/photon/HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90_v",
+                                           "HLT/photon/HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v",
+                                           "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v",
+                                           "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v",
+                                           "HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v",
+                                           "HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v",
+                                           "HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v",
+                                           "HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v"),
                                     #subDirs        = cms.untracked.vstring("HLT/Higgs/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
@@ -429,7 +489,8 @@ diphotonEfficiency = DQMEDHarvester("DQMGenericClient",
 )
 
 VBFEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/VBFHbb/*"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/VBFHbb/*"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/VBFHbb/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -498,10 +559,12 @@ higgsClient = cms.Sequence(
   + ele16ele12ele8caloIdLTrackIdL
   + triplemu12mu10mu5
   + triplemu10mu5mu5DZ
-  + mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_effele
-  + mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_effmu
-  + mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_effele
-  + mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_effmu
+  + muEleDz_effmu
+  + muEleDz_effele
+#  + mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_effele
+#  + mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_effmu
+#  + mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_effele
+#  + mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_effmu
   + metbtagEfficiency_met
   + metbtagEfficiency_btag
   + VBFEfficiency

--- a/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
@@ -447,10 +447,7 @@ QuadPFJet111_90_80_15.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Qua
 
 ###############################Higgs Monitor HLT##############################################
 higgsMonitorHLT = cms.Sequence(
-)
-
-
-higHLTDQMSourceExtra = cms.Sequence(
+### THEY WERE IN EXTRA
     higgsinvHLTJetMETmonitoring
   + higgsHLTDiphotonMonitoring
   + higgstautauHLTVBFmonitoring
@@ -492,4 +489,8 @@ higHLTDQMSourceExtra = cms.Sequence(
   + mssmHbbBtagTriggerMonitor 
   + mssmHbbMonitorHLT 
   + HMesonGammamonitoring
+)
+
+
+higHLTDQMSourceExtra = cms.Sequence(
 )

--- a/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
@@ -13,18 +13,21 @@ from DQMOffline.Trigger.BTaggingMonitor_cfi import hltBTVmonitoring
 
 # HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1 MET monitoring
 PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET100_BTag/')
+#PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET100_BTag/')
+PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET100_BTag/')
 PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_v")
 PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
 
 # HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1 MET monitoring
 PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET110_BTag/')
+#PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET110_BTag/')
+PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET110_BTag/')
 PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_v")
 PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
 # HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1 b-tag monitoring
 PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone()
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET110_BTag/')
+#PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET110_BTag/')
+PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/HIG/PFMET110_BTag/')
 # Selection
 PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.leptJetDeltaRmin = cms.double(0.0)
 PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.njets            = cms.uint32(1)
@@ -46,12 +49,14 @@ PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.denGenericTriggerEventPS
 
 # HLT_PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1 MET monitoring
 PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET120_BTag/')
+#PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET120_BTag/')
+PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET120_BTag/')
 PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_v")
 PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
 # HLT_PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1 b-tag monitoring
 PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone()
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET120_BTag/')
+#PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET120_BTag/')
+PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/HIG/PFMET120_BTag/')
 # Selection
 PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.leptJetDeltaRmin = cms.double(0.0)
 PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.njets            = cms.uint32(1)
@@ -73,12 +78,14 @@ PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.denGenericTriggerEventPS
 
 # HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1 MET monitoring
 PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET130_BTag/')
+#PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET130_BTag/')
+PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET130_BTag/')
 PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_v")
 PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
 # HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1 b-tag monitoring
 PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone()
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET130_BTag/')
+#PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET130_BTag/')
+PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/HIG/PFMET130_BTag/')
 # Selection
 PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.leptJetDeltaRmin = cms.double(0.0)
 PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.njets            = cms.uint32(1)
@@ -100,12 +107,14 @@ PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.denGenericTriggerEventPS
 
 # HLT_PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1 MET monitoring
 PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET140_BTag/')
+#PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET140_BTag/')
+PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET140_BTag/')
 PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_v")
 PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
 # HLT_PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1 b-tag monitoring
 PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone()
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET140_BTag/')
+#PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET140_BTag/')
+PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/HIG/PFMET140_BTag/')
 # Selection
 PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.leptJetDeltaRmin = cms.double(0.0)
 PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.njets            = cms.uint32(1)
@@ -127,7 +136,8 @@ PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.denGenericTriggerEventPS
 #######for HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ####
 ele23Ele12CaloIdLTrackIdLIsoVL_dzmon = hltHIGmonitoring.clone()
 ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.nelectrons = cms.uint32(2)
-ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ')
+#ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ')
+ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ')
 ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*")
 ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*")
 
@@ -135,7 +145,8 @@ ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.denGenericTriggerEventPSet.hltPaths = cms.v
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg = hltHIGmonitoring.clone()
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.nmuons = cms.uint32(1)
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.nelectrons = cms.uint32(1)
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
+#mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
+mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*")
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
 	"HLT_Mu20_v*","HLT_TkMu20_v*",
@@ -152,7 +163,8 @@ mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.denGenericTriggerEventPSet.hltPa
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg = hltHIGmonitoring.clone()
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.nmuons = cms.uint32(1)
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.nelectrons = cms.uint32(1)
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
+#mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
+mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*")
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
         "HLT_Ele27_WPTight_Gsf_v*",
@@ -163,7 +175,8 @@ mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.denGenericTriggerEventPSet.hltPat
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg = hltHIGmonitoring.clone()
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.nmuons = cms.uint32(1)
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.nelectrons = cms.uint32(1)
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
+#mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
+mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*") #
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
 	"HLT_Mu20_v*",
@@ -181,7 +194,8 @@ mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.denGenericTriggerEventPSet.hltPa
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg = hltHIGmonitoring.clone()
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.nmuons = cms.uint32(1)
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.nelectrons = cms.uint32(1)
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
+#mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
+mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*")
 mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
         "HLT_Ele27_WPTight_Gsf_v*",
@@ -191,20 +205,23 @@ mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.denGenericTriggerEventPSet.hltPat
 ###############################same flavour trilepton monitor####################################
 ########TripleMuon########
 higgsTrimumon = hltHIGmonitoring.clone()
-higgsTrimumon.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_TripleMu_12_10_5/')
+#higgsTrimumon.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_TripleMu_12_10_5/')
+higgsTrimumon.FolderName = cms.string('HLT/HIG/TriLepton/HLT_TripleMu_12_10_5/')
 higgsTrimumon.nmuons = cms.uint32(3)
 higgsTrimumon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TripleMu_12_10_5_v*") #
 higgsTrimumon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*","HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*")
 
 higgsTrimu10_5_5_dz_mon = hltHIGmonitoring.clone()
-higgsTrimu10_5_5_dz_mon.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_TripleM_10_5_5_DZ/')
+#higgsTrimu10_5_5_dz_mon.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_TripleM_10_5_5_DZ/')
+higgsTrimu10_5_5_dz_mon.FolderName = cms.string('HLT/HIG/TriLepton/HLT_TripleM_10_5_5_DZ/')
 higgsTrimu10_5_5_dz_mon.nmuons = cms.uint32(3)
 higgsTrimu10_5_5_dz_mon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TripleMu_10_5_5_DZ_v*") #
 higgsTrimu10_5_5_dz_mon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*","HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*")
 
 #######TripleElectron####
 higgsTrielemon = hltHIGmonitoring.clone()
-higgsTrielemon.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/')
+#higgsTrielemon.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/')
+higgsTrielemon.FolderName = cms.string('HLT/HIG/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/')
 higgsTrielemon.nelectrons = cms.uint32(3)
 higgsTrielemon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v*") #
 higgsTrielemon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*")
@@ -212,7 +229,8 @@ higgsTrielemon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele23_Ele1
 ###############################cross flavour trilepton monitor####################################
 #########DiMuon+Single Ele Trigger###################
 diMu9Ele9CaloIdLTrackIdL_muleg = hltHIGmonitoring.clone()
-diMu9Ele9CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg')
+#diMu9Ele9CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg')
+diMu9Ele9CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg')
 diMu9Ele9CaloIdLTrackIdL_muleg.nelectrons = cms.uint32(1)
 diMu9Ele9CaloIdLTrackIdL_muleg.nmuons = cms.uint32(2)
 diMu9Ele9CaloIdLTrackIdL_muleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v*")
@@ -222,7 +240,8 @@ diMu9Ele9CaloIdLTrackIdL_muleg.denGenericTriggerEventPSet.hltPaths = cms.vstring
 )
 
 diMu9Ele9CaloIdLTrackIdL_eleleg = hltHIGmonitoring.clone()
-diMu9Ele9CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg')
+#diMu9Ele9CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg')
+diMu9Ele9CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg')
 diMu9Ele9CaloIdLTrackIdL_eleleg.nelectrons = cms.uint32(1)
 diMu9Ele9CaloIdLTrackIdL_eleleg.nmuons = cms.uint32(2)
 diMu9Ele9CaloIdLTrackIdL_eleleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v*")
@@ -237,7 +256,8 @@ diMu9Ele9CaloIdLTrackIdL_eleleg.denGenericTriggerEventPSet.hltPaths = cms.vstrin
 
 ##Eff of the HLT with DZ w.ref to non-DZ one
 diMu9Ele9CaloIdLTrackIdL_dz = hltHIGmonitoring.clone()
-diMu9Ele9CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon')
+#diMu9Ele9CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon')
+diMu9Ele9CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon')
 diMu9Ele9CaloIdLTrackIdL_dz.nelectrons = cms.uint32(1)
 diMu9Ele9CaloIdLTrackIdL_dz.nmuons = cms.uint32(2)
 diMu9Ele9CaloIdLTrackIdL_dz.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_DZ_v*")
@@ -245,7 +265,8 @@ diMu9Ele9CaloIdLTrackIdL_dz.denGenericTriggerEventPSet.hltPaths = cms.vstring("H
 
 #################DiElectron+Single Muon Trigger##################
 mu8diEle12CaloIdLTrackIdL_eleleg = hltHIGmonitoring.clone()
-mu8diEle12CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg')
+#mu8diEle12CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg')
+mu8diEle12CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg')
 mu8diEle12CaloIdLTrackIdL_eleleg.nelectrons = cms.uint32(2)
 mu8diEle12CaloIdLTrackIdL_eleleg.nmuons = cms.uint32(1)
 mu8diEle12CaloIdLTrackIdL_eleleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v*")
@@ -255,7 +276,8 @@ mu8diEle12CaloIdLTrackIdL_eleleg.denGenericTriggerEventPSet.hltPaths = cms.vstri
 )
 
 mu8diEle12CaloIdLTrackIdL_muleg = hltHIGmonitoring.clone()
-mu8diEle12CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg')
+#mu8diEle12CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg')
+mu8diEle12CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg')
 mu8diEle12CaloIdLTrackIdL_muleg.nelectrons = cms.uint32(2)
 mu8diEle12CaloIdLTrackIdL_muleg.nmuons = cms.uint32(1)
 mu8diEle12CaloIdLTrackIdL_muleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v*")
@@ -265,7 +287,8 @@ mu8diEle12CaloIdLTrackIdL_muleg.denGenericTriggerEventPSet.hltPaths = cms.vstrin
 
 ##Eff of the HLT with DZ w.ref to non-DZ one
 mu8diEle12CaloIdLTrackIdL_dz = hltHIGmonitoring.clone()
-mu8diEle12CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon')
+#mu8diEle12CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon')
+mu8diEle12CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon')
 mu8diEle12CaloIdLTrackIdL_dz.nelectrons = cms.uint32(2)
 mu8diEle12CaloIdLTrackIdL_dz.nmuons = cms.uint32(1)
 mu8diEle12CaloIdLTrackIdL_dz.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_DZ_v*")
@@ -273,7 +296,8 @@ mu8diEle12CaloIdLTrackIdL_dz.denGenericTriggerEventPSet.hltPaths = cms.vstring("
 
 ##VBF triggers##
 QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1 = hltTOPmonitoring.clone()
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1_v')
+#QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1_v')
+QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1_v')
 # Selection
 QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.leptJetDeltaRmin = cms.double(0.0)
 QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.njets            = cms.uint32(4)
@@ -317,22 +341,26 @@ QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.histoPSet.ptPSet = cms.PSet(
 
 
 QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1 = QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.clone()
-QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v')
+#QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v')
+QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v')
 QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v*')
 
 
 QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1 = QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.clone()
-QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v')
+#QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v')
+QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v')
 QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v*')
 
 
 QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1 = QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.clone()
-QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v')
+#QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v')
+QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v')
 QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v*')
 
 
 QuadPFJet98_83_71_15_BTagCSV_p013_VBF1 = hltTOPmonitoring.clone()
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2_v')
+#QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2_v')
+QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2_v')
 # Selection
 QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.leptJetDeltaRmin = cms.double(0.0)
 QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.njets            = cms.uint32(4)
@@ -375,21 +403,25 @@ QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.histoPSet.ptPSet = cms.PSet(
 )
 
 QuadPFJet103_88_75_15_BTagCSV_p013_VBF1 = QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.clone()
-QuadPFJet103_88_75_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v')
+#QuadPFJet103_88_75_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v')
+QuadPFJet103_88_75_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v')
 QuadPFJet103_88_75_15_BTagCSV_p013_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v*')
 
 
 QuadPFJet105_88_76_15_BTagCSV_p013_VBF1 = QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.clone()
-QuadPFJet105_88_76_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v')
+#QuadPFJet105_88_76_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v')
+QuadPFJet105_88_76_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v')
 QuadPFJet105_88_76_15_BTagCSV_p013_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v*')
 
 
 QuadPFJet111_90_80_15_BTagCSV_p013_VBF1 = QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.clone()
-QuadPFJet111_90_80_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v')
+#QuadPFJet111_90_80_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v')
+QuadPFJet111_90_80_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v')
 QuadPFJet111_90_80_15_BTagCSV_p013_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v*')
 
 QuadPFJet98_83_71_15 = hltTOPmonitoring.clone()
-QuadPFJet98_83_71_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_v')
+#QuadPFJet98_83_71_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_v')
+QuadPFJet98_83_71_15.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet98_83_71_15_v')
 # Selection
 QuadPFJet98_83_71_15.leptJetDeltaRmin = cms.double(0.0)
 QuadPFJet98_83_71_15.njets            = cms.uint32(4)
@@ -432,17 +464,20 @@ QuadPFJet98_83_71_15.histoPSet.ptPSet = cms.PSet(
 )
 
 QuadPFJet103_88_75_15 = QuadPFJet98_83_71_15.clone()
-QuadPFJet103_88_75_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_v')
+#QuadPFJet103_88_75_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_v')
+QuadPFJet103_88_75_15.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet103_88_75_15_v')
 QuadPFJet103_88_75_15.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet103_88_75_15_v*')
 
 
 QuadPFJet105_88_76_15 = QuadPFJet98_83_71_15.clone()
-QuadPFJet105_88_76_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet105_88_76_15_v')
+#QuadPFJet105_88_76_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet105_88_76_15_v')
+QuadPFJet105_88_76_15.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet105_88_76_15_v')
 QuadPFJet105_88_76_15.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet105_88_76_15_v*')
 
 
 QuadPFJet111_90_80_15 = QuadPFJet98_83_71_15.clone()
-QuadPFJet111_90_80_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_v')
+#QuadPFJet111_90_80_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_v')
+QuadPFJet111_90_80_15.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet111_90_80_15_v')
 QuadPFJet111_90_80_15.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet111_90_80_15_v*')
 
 ###############################Higgs Monitor HLT##############################################

--- a/DQMOffline/Trigger/python/HiggsMonitoring_cfi.py
+++ b/DQMOffline/Trigger/python/HiggsMonitoring_cfi.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.topMonitoring_cfi import topMonitoring
 
 hltHIGmonitoring = topMonitoring.clone()
-hltHIGmonitoring.FolderName = cms.string('HLT/Higgs/default/')
+#hltHIGmonitoring.FolderName = cms.string('HLT/Higgs/default/')
+hltHIGmonitoring.FolderName = cms.string('HLT/HIG/default/')
 hltHIGmonitoring.histoPSet.lsPSet = cms.PSet(
   nbins = cms.uint32 ( 250 ),
   xmin  = cms.double(    0.),

--- a/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
@@ -4,65 +4,10 @@ from DQMOffline.Trigger.JetMonitor_cff import *
 from DQMOffline.Trigger.DiJetMonitor_cff import *
 
 jetmetMonitorHLT = cms.Sequence(
-    HLTJetmonitoring*
-    HLTDiJetmonitoring
+### THEY WERE IN THE EXTRA
+    HLTJetmonitoring
+    * HLTDiJetmonitoring
 )
 
 jmeHLTDQMSourceExtra = cms.Sequence(
-    PFJet40_Prommonitoring    
-    *PFJet60_Prommonitoring    
-    *PFJet80_Prommonitoring    
-    *PFJet140_Prommonitoring    
-    *PFJet200_Prommonitoring    
-    *PFJet260_Prommonitoring    
-    *PFJet320_Prommonitoring    
-    *PFJet400_Prommonitoring
-    *PFJet450_Prommonitoring
-    *PFJet500_Prommonitoring
-    *PFJetFwd40_Prommonitoring    
-    *PFJetFwd60_Prommonitoring    
-    *PFJetFwd80_Prommonitoring    
-    *PFJetFwd140_Prommonitoring    
-    *PFJetFwd200_Prommonitoring    
-    *PFJetFwd260_Prommonitoring    
-    *PFJetFwd320_Prommonitoring    
-    *PFJetFwd400_Prommonitoring    
-    *PFJetFwd450_Prommonitoring
-    *PFJetFwd500_Prommonitoring
-    *AK8PFJet450_Prommonitoring
-    *AK8PFJet40_Prommonitoring    
-    *AK8PFJet60_Prommonitoring    
-    *AK8PFJet80_Prommonitoring    
-    *AK8PFJet140_Prommonitoring    
-    *AK8PFJet200_Prommonitoring    
-    *AK8PFJet260_Prommonitoring    
-    *AK8PFJet320_Prommonitoring    
-    *AK8PFJet400_Prommonitoring    
-    *AK8PFJet500_Prommonitoring
-    *AK8PFJetFwd450_Prommonitoring
-    *AK8PFJetFwd40_Prommonitoring    
-    *AK8PFJetFwd60_Prommonitoring    
-    *AK8PFJetFwd80_Prommonitoring    
-    *AK8PFJetFwd140_Prommonitoring    
-    *AK8PFJetFwd200_Prommonitoring    
-    *AK8PFJetFwd260_Prommonitoring    
-    *AK8PFJetFwd320_Prommonitoring    
-    *AK8PFJetFwd400_Prommonitoring    
-    *AK8PFJetFwd500_Prommonitoring 
-    *CaloJet500_NoJetID_Prommonitoring 
-    *DiPFjetAve40_Prommonitoring
-    *DiPFjetAve60_Prommonitoring
-    *DiPFjetAve80_Prommonitoring
-    *DiPFjetAve140_Prommonitoring
-    *DiPFjetAve200_Prommonitoring
-    *DiPFjetAve260_Prommonitoring
-    *DiPFjetAve320_Prommonitoring
-    *DiPFjetAve400_Prommonitoring
-    *DiPFjetAve500_Prommonitoring
-    *DiPFjetAve60_HFJEC_Prommonitoring
-    *DiPFjetAve80_HFJEC_Prommonitoring
-    *DiPFjetAve100_HFJEC_Prommonitoring
-    *DiPFjetAve160_HFJEC_Prommonitoring
-    *DiPFjetAve220_HFJEC_Prommonitoring
-    *DiPFjetAve300_HFJEC_Prommonitoring
 )

--- a/DQMOffline/Trigger/python/JetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMonitor_cff.py
@@ -482,4 +482,45 @@ CaloJet500_NoJetID_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstr
 
 
 HLTJetmonitoring = cms.Sequence(
+    PFJet40_Prommonitoring    
+    *PFJet60_Prommonitoring    
+    *PFJet80_Prommonitoring    
+    *PFJet140_Prommonitoring    
+    *PFJet200_Prommonitoring    
+    *PFJet260_Prommonitoring    
+    *PFJet320_Prommonitoring    
+    *PFJet400_Prommonitoring
+    *PFJet450_Prommonitoring
+    *PFJet500_Prommonitoring
+    *PFJetFwd40_Prommonitoring    
+    *PFJetFwd60_Prommonitoring    
+    *PFJetFwd80_Prommonitoring    
+    *PFJetFwd140_Prommonitoring    
+    *PFJetFwd200_Prommonitoring    
+    *PFJetFwd260_Prommonitoring    
+    *PFJetFwd320_Prommonitoring    
+    *PFJetFwd400_Prommonitoring    
+    *PFJetFwd450_Prommonitoring
+    *PFJetFwd500_Prommonitoring
+    *AK8PFJet450_Prommonitoring
+    *AK8PFJet40_Prommonitoring    
+    *AK8PFJet60_Prommonitoring    
+    *AK8PFJet80_Prommonitoring    
+    *AK8PFJet140_Prommonitoring    
+    *AK8PFJet200_Prommonitoring    
+    *AK8PFJet260_Prommonitoring    
+    *AK8PFJet320_Prommonitoring    
+    *AK8PFJet400_Prommonitoring    
+    *AK8PFJet500_Prommonitoring
+    *AK8PFJetFwd450_Prommonitoring
+    *AK8PFJetFwd40_Prommonitoring    
+    *AK8PFJetFwd60_Prommonitoring    
+    *AK8PFJetFwd80_Prommonitoring    
+    *AK8PFJetFwd140_Prommonitoring    
+    *AK8PFJetFwd200_Prommonitoring    
+    *AK8PFJetFwd260_Prommonitoring    
+    *AK8PFJetFwd320_Prommonitoring    
+    *AK8PFJetFwd400_Prommonitoring    
+    *AK8PFJetFwd500_Prommonitoring 
+    *CaloJet500_NoJetID_Prommonitoring
 )

--- a/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_Client_cfi.py
+++ b/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_Client_cfi.py
@@ -15,7 +15,7 @@ mssmHbbBtag = DQMEDHarvester("DQMGenericClient",
 )
 
 mssmHbbBtagSL40noMu = mssmHbbBtag.clone()
-mssmHbbBtagSL40noMu..subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon")
+mssmHbbBtagSL40noMu.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon")
 
 mssmHbbBtagSL40 = mssmHbbBtag.clone()
 #mssmHbbBtagSL40.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40/")

--- a/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_Client_cfi.py
+++ b/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_Client_cfi.py
@@ -2,8 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-mssmHbbBtagSL40noMu = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon/"),
+mssmHbbBtag = DQMEDHarvester("DQMGenericClient",
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon/"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -13,36 +14,44 @@ mssmHbbBtagSL40noMu = DQMEDHarvester("DQMGenericClient",
     ),
 )
 
-mssmHbbBtagSL40 = mssmHbbBtagSL40noMu.clone()
-mssmHbbBtagSL40.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40/")
+mssmHbbBtagSL40noMu = mssmHbbBtag.clone()
+mssmHbbBtagSL40noMu..subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon")
 
-mssmHbbBtagSL100 = mssmHbbBtagSL40noMu.clone()
-mssmHbbBtagSL100.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt100/")
+mssmHbbBtagSL40 = mssmHbbBtag.clone()
+#mssmHbbBtagSL40.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40/")
+mssmHbbBtagSL40.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40/")
 
-mssmHbbBtagSL200 = mssmHbbBtagSL40noMu.clone()
-mssmHbbBtagSL200.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt200/")
+mssmHbbBtagSL100 = mssmHbbBtag.clone()
+#mssmHbbBtagSL100.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt100/")
+mssmHbbBtagSL100.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt100/")
 
-mssmHbbBtagSL350 = mssmHbbBtagSL40noMu.clone()
-mssmHbbBtagSL350.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt350/")
+mssmHbbBtagSL200 = mssmHbbBtag.clone()
+#mssmHbbBtagSL200.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt200/")
+mssmHbbBtagSL200.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt200/")
 
-mssmHbbBtagAH100 = mssmHbbBtagSL40noMu.clone()
-mssmHbbBtagAH100.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/fullhadronic/BtagTrigger/pt100/")
+mssmHbbBtagSL350 = mssmHbbBtag.clone()
+#mssmHbbBtagSL350.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt350/")
+mssmHbbBtagSL350.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt350/")
 
-mssmHbbBtagAH200 = mssmHbbBtagSL40noMu.clone()
-mssmHbbBtagAH200.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/fullhadronic/BtagTrigger/pt200/")
+mssmHbbBtagAH100 = mssmHbbBtag.clone()
+mssmHbbBtagAH100.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt100/")
 
-mssmHbbBtagAH350 = mssmHbbBtagSL40noMu.clone()
-mssmHbbBtagAH350.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/fullhadronic/BtagTrigger/pt350/")
+mssmHbbBtagAH200 = mssmHbbBtag.clone()
+mssmHbbBtagAH200.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt200/")
+
+mssmHbbBtagAH350 = mssmHbbBtag.clone()
+mssmHbbBtagAH350.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt350/")
 
 
 
 mssmHbbBtagTriggerEfficiency = cms.Sequence(
-   mssmHbbBtagSL40noMu
- + mssmHbbBtagSL40
- + mssmHbbBtagSL100
- + mssmHbbBtagSL200
- + mssmHbbBtagSL350
- + mssmHbbBtagAH100
- + mssmHbbBtagAH200
- + mssmHbbBtagAH350
+   mssmHbbBtag
+#   mssmHbbBtagSL40noMu
+# + mssmHbbBtagSL40
+# + mssmHbbBtagSL100
+# + mssmHbbBtagSL200
+# + mssmHbbBtagSL350
+# + mssmHbbBtagAH100
+# + mssmHbbBtagAH200
+# + mssmHbbBtagAH350
 )

--- a/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_cfi.py
@@ -17,7 +17,8 @@ triggerFlagPSet = cms.PSet(
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 mssmHbbBtagTriggerMonitor = DQMEDAnalyzer(
     "TagAndProbeBtagTriggerMonitor",
-    dirname = cms.string("HLT/Higgs/MssmHbb/"),
+#    dirname = cms.string("HLT/Higgs/MssmHbb/"),
+    dirname = cms.string("HLT/HIG/MssmHbb/"),
     processname = cms.string("HLT"),
     jetPtMin = cms.double(40),
     jetEtaMax = cms.double(2.2),
@@ -39,56 +40,64 @@ mssmHbbBtagTriggerMonitor = DQMEDAnalyzer(
 # online btagging monitor
 
 mssmHbbBtagTriggerMonitorSL40noMu = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL40noMu.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon")
+#mssmHbbBtagTriggerMonitorSL40noMu.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon")
+mssmHbbBtagTriggerMonitorSL40noMu.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon")
 mssmHbbBtagTriggerMonitorSL40noMu.jetPtMin = cms.double(40)
 mssmHbbBtagTriggerMonitorSL40noMu.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
 mssmHbbBtagTriggerMonitorSL40noMu.histoPSet.jetPt = cms.vdouble(40,45,50,55,60,65,70,75,80,85,90,95,100)
 mssmHbbBtagTriggerMonitorSL40noMu.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets40_CaloBTagDeepCSV_p71_v*')
 
 mssmHbbBtagTriggerMonitorSL40 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL40.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40")
+#mssmHbbBtagTriggerMonitorSL40.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40")
+mssmHbbBtagTriggerMonitorSL40.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40")
 mssmHbbBtagTriggerMonitorSL40.jetPtMin = cms.double(40)
 mssmHbbBtagTriggerMonitorSL40.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
 mssmHbbBtagTriggerMonitorSL40.histoPSet.jetPt = cms.vdouble(40,45,50,55,60,65,70,75,80,85,90,95,100)
 mssmHbbBtagTriggerMonitorSL40.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_DoublePFJets40_CaloBTagDeepCSV_p71_v*')
 
 mssmHbbBtagTriggerMonitorSL100 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL100.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt100")
+#mssmHbbBtagTriggerMonitorSL100.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt100")
+mssmHbbBtagTriggerMonitorSL100.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt100")
 mssmHbbBtagTriggerMonitorSL100.jetPtMin = cms.double(100)
 mssmHbbBtagTriggerMonitorSL100.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
 mssmHbbBtagTriggerMonitorSL100.histoPSet.jetPt = cms.vdouble(100,110,120,130,140,150,160,170,180,190,200)
 mssmHbbBtagTriggerMonitorSL100.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_DoublePFJets100_CaloBTagDeepCSV_p71_v*')
 
 mssmHbbBtagTriggerMonitorSL200 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL200.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt200")
+#mssmHbbBtagTriggerMonitorSL200.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt200")
+mssmHbbBtagTriggerMonitorSL200.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt200")
 mssmHbbBtagTriggerMonitorSL200.jetPtMin = cms.double(200)
 mssmHbbBtagTriggerMonitorSL200.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
 mssmHbbBtagTriggerMonitorSL200.histoPSet.jetPt = cms.vdouble(200,210,220,230,240,250,260,270,280,290,300,310,320,330,340,350)
 mssmHbbBtagTriggerMonitorSL200.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_DoublePFJets200_CaloBTagDeepCSV_p71_v*')
 
 mssmHbbBtagTriggerMonitorSL350 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL350.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt350")
+#mssmHbbBtagTriggerMonitorSL350.dirname = cms.string("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt350")
+mssmHbbBtagTriggerMonitorSL350.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt350")
 mssmHbbBtagTriggerMonitorSL350.jetPtMin = cms.double(350)
 mssmHbbBtagTriggerMonitorSL350.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
 mssmHbbBtagTriggerMonitorSL350.histoPSet.jetPt = cms.vdouble(350,360,370,380,390,400,410,420,430,440,450,460,470,480,490,500,510,520,530,540,550,560,570,580,590,600)
 mssmHbbBtagTriggerMonitorSL350.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_DoublePFJets350_CaloBTagDeepCSV_p71_v*')
 
 mssmHbbBtagTriggerMonitorAH100 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorAH100.dirname = cms.string("HLT/Higgs/MssmHbb/fullhadronic/BtagTrigger/pt100")
+#mssmHbbBtagTriggerMonitorAH100.dirname = cms.string("HLT/Higgs/MssmHbb/fullhadronic/BtagTrigger/pt100")
+mssmHbbBtagTriggerMonitorAH100.dirname = cms.string("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt100")
 mssmHbbBtagTriggerMonitorAH100.jetPtMin = cms.double(100)
 mssmHbbBtagTriggerMonitorAH100.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single6Jets80")
 mssmHbbBtagTriggerMonitorAH100.histoPSet.jetPt = cms.vdouble(100,110,120,130,140,150,160,170,180,190,200)
 mssmHbbBtagTriggerMonitorAH100.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets100_CaloBTagDeepCSV_p71_v*')
 
 mssmHbbBtagTriggerMonitorAH200 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorAH200.dirname = cms.string("HLT/Higgs/MssmHbb/fullhadronic/BtagTrigger/pt200")
+#mssmHbbBtagTriggerMonitorAH200.dirname = cms.string("HLT/Higgs/MssmHbb/fullhadronic/BtagTrigger/pt200")
+mssmHbbBtagTriggerMonitorAH200.dirname = cms.string("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt200")
 mssmHbbBtagTriggerMonitorAH200.jetPtMin = cms.double(200)
 mssmHbbBtagTriggerMonitorAH200.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single6Jets80")
 mssmHbbBtagTriggerMonitorAH200.histoPSet.jetPt = cms.vdouble(200,210,220,230,240,250,260,270,280,290,300,310,320,330,340,350)
 mssmHbbBtagTriggerMonitorAH200.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets200_CaloBTagDeepCSV_p71_v*')
 
 mssmHbbBtagTriggerMonitorAH350 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorAH350.dirname = cms.string("HLT/Higgs/MssmHbb/fullhadronic/BtagTrigger/pt350")
+#mssmHbbBtagTriggerMonitorAH350.dirname = cms.string("HLT/Higgs/MssmHbb/fullhadronic/BtagTrigger/pt350")
+mssmHbbBtagTriggerMonitorAH350.dirname = cms.string("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt350")
 mssmHbbBtagTriggerMonitorAH350.jetPtMin = cms.double(350)
 mssmHbbBtagTriggerMonitorAH350.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single6Jets80")
 mssmHbbBtagTriggerMonitorAH350.histoPSet.jetPt = cms.vdouble(350,360,370,380,390,400,410,420,430,440,450,460,470,480,490,500,510,520,530,540,550,560,570,580,590,600)

--- a/DQMOffline/Trigger/python/MssmHbbMonitoring_Client_cfi.py
+++ b/DQMOffline/Trigger/python/MssmHbbMonitoring_Client_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 MssmHbbHLTEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/MssmHbb/fullhadronic/*"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/MssmHbb/fullhadronic/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -34,7 +34,7 @@ MssmHbbHLTEfficiency = DQMEDHarvester("DQMGenericClient",
 )
 
 MssmHbbmuHLTEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/*"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
@@ -79,7 +79,7 @@ MssmHbbmuHLTEfficiency = DQMEDHarvester("DQMGenericClient",
 )
 
 MssmHbbmuHLTcontrolEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/MssmHbb/control/*"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/MssmHbb/control/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages                                                                                                                                   
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(

--- a/DQMOffline/Trigger/python/MssmHbbMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/MssmHbbMonitoring_cff.py
@@ -11,7 +11,8 @@ hltMssmHbbmonitoring.bJetMuDeltaRmax = cms.double(0.4)   # dR(mu,nbjet) cone; on
 
 # Fully-hadronic MssmHbb
 hltMssmHbbmonitoringAL100 = hltMssmHbbmonitoring.clone()
-hltMssmHbbmonitoringAL100.FolderName = cms.string('HLT/Higgs/MssmHbb/fullhadronic/pt100')
+#hltMssmHbbmonitoringAL100.FolderName = cms.string('HLT/Higgs/MssmHbb/fullhadronic/pt100')
+hltMssmHbbmonitoringAL100.FolderName = cms.string('HLT/HIG/MssmHbb/fullhadronic/pt100')
 hltMssmHbbmonitoringAL100.nmuons = cms.uint32(0)
 hltMssmHbbmonitoringAL100.nbjets = cms.uint32(2)
 hltMssmHbbmonitoringAL100.bjetSelection = cms.string('pt>110 & abs(eta)<2.2')
@@ -19,7 +20,8 @@ hltMssmHbbmonitoringAL100.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT
 hltMssmHbbmonitoringAL100.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
 
 hltMssmHbbmonitoringAL116 = hltMssmHbbmonitoring.clone()
-hltMssmHbbmonitoringAL116.FolderName = cms.string('HLT/Higgs/MssmHbb/fullhadronic/pt116')
+#hltMssmHbbmonitoringAL116.FolderName = cms.string('HLT/Higgs/MssmHbb/fullhadronic/pt116')
+hltMssmHbbmonitoringAL116.FolderName = cms.string('HLT/HIG/MssmHbb/fullhadronic/pt116')
 hltMssmHbbmonitoringAL116.nmuons = cms.uint32(0)
 hltMssmHbbmonitoringAL116.nbjets = cms.uint32(2)
 hltMssmHbbmonitoringAL116.bjetSelection = cms.string('pt>116 & abs(eta)<2.2')
@@ -27,7 +29,8 @@ hltMssmHbbmonitoringAL116.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT
 hltMssmHbbmonitoringAL116.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
 
 hltMssmHbbmonitoringAL128 = hltMssmHbbmonitoring.clone()
-hltMssmHbbmonitoringAL128.FolderName = cms.string('HLT/Higgs/MssmHbb/fullhadronic/pt128')
+#hltMssmHbbmonitoringAL128.FolderName = cms.string('HLT/Higgs/MssmHbb/fullhadronic/pt128')
+hltMssmHbbmonitoringAL128.FolderName = cms.string('HLT/HIG/MssmHbb/fullhadronic/pt128')
 hltMssmHbbmonitoringAL128.nmuons = cms.uint32(0)
 hltMssmHbbmonitoringAL128.nbjets = cms.uint32(2)
 hltMssmHbbmonitoringAL128.bjetSelection = cms.string('pt>128 & abs(eta)<2.2')
@@ -36,7 +39,8 @@ hltMssmHbbmonitoringAL128.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320
 
 # Semi-leptonic MssmHbb(mu)
 hltMssmHbbmonitoringSL40 = hltMssmHbbmonitoring.clone()
-hltMssmHbbmonitoringSL40.FolderName = cms.string('HLT/Higgs/MssmHbb/semileptonic/pt40')
+#hltMssmHbbmonitoringSL40.FolderName = cms.string('HLT/Higgs/MssmHbb/semileptonic/pt40')
+hltMssmHbbmonitoringSL40.FolderName = cms.string('HLT/HIG/MssmHbb/semileptonic/pt40')
 hltMssmHbbmonitoringSL40.nmuons = cms.uint32(1)
 hltMssmHbbmonitoringSL40.nbjets = cms.uint32(2)
 hltMssmHbbmonitoringSL40.muoSelection = cms.string('pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
@@ -45,7 +49,8 @@ hltMssmHbbmonitoringSL40.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_
 hltMssmHbbmonitoringSL40.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
 
 hltMssmHbbmonitoringSL54 = hltMssmHbbmonitoring.clone()
-hltMssmHbbmonitoringSL54.FolderName = cms.string('HLT/Higgs/MssmHbb/semileptonic/pt54')
+#hltMssmHbbmonitoringSL54.FolderName = cms.string('HLT/Higgs/MssmHbb/semileptonic/pt54')
+hltMssmHbbmonitoringSL54.FolderName = cms.string('HLT/HIG/MssmHbb/semileptonic/pt54')
 hltMssmHbbmonitoringSL54.nmuons = cms.uint32(1)
 hltMssmHbbmonitoringSL54.nbjets = cms.uint32(2)
 hltMssmHbbmonitoringSL54.muoSelection = cms.string('pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
@@ -54,7 +59,8 @@ hltMssmHbbmonitoringSL54.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_
 hltMssmHbbmonitoringSL54.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
 
 hltMssmHbbmonitoringSL62 = hltMssmHbbmonitoring.clone()
-hltMssmHbbmonitoringSL62.FolderName = cms.string('HLT/Higgs/MssmHbb/semileptonic/pt62')
+#hltMssmHbbmonitoringSL62.FolderName = cms.string('HLT/Higgs/MssmHbb/semileptonic/pt62')
+hltMssmHbbmonitoringSL62.FolderName = cms.string('HLT/HIG/MssmHbb/semileptonic/pt62')
 hltMssmHbbmonitoringSL62.nmuons = cms.uint32(1)
 hltMssmHbbmonitoringSL62.nbjets = cms.uint32(2)
 hltMssmHbbmonitoringSL62.muoSelection = cms.string('pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
@@ -64,7 +70,8 @@ hltMssmHbbmonitoringSL62.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,
 
 #control b-tagging 
 hltMssmHbbmonitoringControl = hltMssmHbbmonitoring.clone()
-hltMssmHbbmonitoringControl.FolderName = cms.string('HLT/Higgs/MssmHbb/control/mu12_pt30_nobtag')
+#hltMssmHbbmonitoringControl.FolderName = cms.string('HLT/Higgs/MssmHbb/control/mu12_pt30_nobtag')
+hltMssmHbbmonitoringControl.FolderName = cms.string('HLT/HIG/MssmHbb/control/mu12_pt30_nobtag')
 hltMssmHbbmonitoringControl.nmuons = cms.uint32(1)
 hltMssmHbbmonitoringControl.nbjets = cms.uint32(0)
 hltMssmHbbmonitoringControl.njets = cms.uint32(1)

--- a/DQMOffline/Trigger/python/MssmHbbMonitoring_cfi.py
+++ b/DQMOffline/Trigger/python/MssmHbbMonitoring_cfi.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.topMonitoring_cfi import topMonitoring
 
 mssmHbbMonitoring = topMonitoring.clone()
-mssmHbbMonitoring.FolderName = cms.string('HLT/Higgs/default/')
+#mssmHbbMonitoring.FolderName = cms.string('HLT/Higgs/default/')
+mssmHbbMonitoring.FolderName = cms.string('HLT/HIG/default/')
 mssmHbbMonitoring.histoPSet.lsPSet = cms.PSet(
   nbins = cms.uint32 ( 250 ),
   xmin  = cms.double(    0.),

--- a/DQMOffline/Trigger/python/PhotonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/PhotonMonitor_cff.py
@@ -56,7 +56,8 @@ Photon60_DisplacedIdL_PFJet350MinPFJet15_monitoring.numGenericTriggerEventPSet.h
 from DQMOffline.Trigger.ObjMonitor_cfi import hltobjmonitoring
 
 Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50_monitoring = hltobjmonitoring.clone(
-    FolderName = 'HLT/Photon/Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50/',
+#    FolderName = 'HLT/Photon/Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50/',
+    FolderName = 'HLT/EXO/Photon/Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50/',
     denGenericTriggerEventPSet = hltobjmonitoring.numGenericTriggerEventPSet.clone(
         hltPaths = ["HLT_Photon50_R9Id90_HE10_IsoM_v*"]
     ),
@@ -78,7 +79,8 @@ Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50_monitoring.histoPSet.
 )
 
 Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_monitoring = hltobjmonitoring.clone(
-    FolderName = 'HLT/Photon/Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3/',
+#    FolderName = 'HLT/Photon/Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3/',
+    FolderName = 'HLT/EXO/Photon/Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3/',
     denGenericTriggerEventPSet = hltobjmonitoring.numGenericTriggerEventPSet.clone(
         hltPaths = ["HLT_Photon75_R9Id90_HE10_IsoM_v*"]
     ),
@@ -152,14 +154,16 @@ DiphotonMass55EBnoPV_monitoring.photonSelection = cms.string("(pt > 20 && abs(et
 DiphotonMass55EBnoPV_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.)
 
 DiphotonMass55NewAND_monitoring = hltPhotonmonitoring.clone()
-DiphotonMass55NewAND_monitoring.FolderName = cms.string('HLT/Photon/diphotonMass55NewAND/')
+#DiphotonMass55NewAND_monitoring.FolderName = cms.string('HLT/Photon/diphotonMass55NewAND/')
+DiphotonMass55NewAND_monitoring.FolderName = cms.string('HLT/EGM/Photon/diphotonMass55NewAND/')
 DiphotonMass55NewAND_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v*")
 DiphotonMass55NewAND_monitoring.nphotons = cms.uint32(2)
 DiphotonMass55NewAND_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")
 DiphotonMass55NewAND_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.)
 
 DiphotonMass55NewANDnoPV_monitoring = hltPhotonmonitoring.clone()
-DiphotonMass55NewANDnoPV_monitoring.FolderName = cms.string('HLT/Photon/diphotonMass55NewANDnoPV/')
+#DiphotonMass55NewANDnoPV_monitoring.FolderName = cms.string('HLT/Photon/diphotonMass55NewANDnoPV/')
+DiphotonMass55NewANDnoPV_monitoring.FolderName = cms.string('HLT/EGM/Photon/diphotonMass55NewANDnoPV/')
 DiphotonMass55NewANDnoPV_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v*")
 DiphotonMass55NewANDnoPV_monitoring.nphotons = cms.uint32(2)
 DiphotonMass55NewANDnoPV_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")

--- a/DQMOffline/Trigger/python/PhotonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/PhotonMonitor_cff.py
@@ -155,7 +155,7 @@ DiphotonMass55EBnoPV_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,
 
 DiphotonMass55NewAND_monitoring = hltPhotonmonitoring.clone()
 #DiphotonMass55NewAND_monitoring.FolderName = cms.string('HLT/Photon/diphotonMass55NewAND/')
-DiphotonMass55NewAND_monitoring.FolderName = cms.string('HLT/EGM/Photon/diphotonMass55NewAND/')
+DiphotonMass55NewAND_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass55NewAND/')
 DiphotonMass55NewAND_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v*")
 DiphotonMass55NewAND_monitoring.nphotons = cms.uint32(2)
 DiphotonMass55NewAND_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")
@@ -163,7 +163,7 @@ DiphotonMass55NewAND_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,
 
 DiphotonMass55NewANDnoPV_monitoring = hltPhotonmonitoring.clone()
 #DiphotonMass55NewANDnoPV_monitoring.FolderName = cms.string('HLT/Photon/diphotonMass55NewANDnoPV/')
-DiphotonMass55NewANDnoPV_monitoring.FolderName = cms.string('HLT/EGM/Photon/diphotonMass55NewANDnoPV/')
+DiphotonMass55NewANDnoPV_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass55NewANDnoPV/')
 DiphotonMass55NewANDnoPV_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v*")
 DiphotonMass55NewANDnoPV_monitoring.nphotons = cms.uint32(2)
 DiphotonMass55NewANDnoPV_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")

--- a/DQMOffline/Trigger/python/SusyMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_cff.py
@@ -243,10 +243,8 @@ double_soft_muon_dca_metpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HL
 
 susyMonitorHLT = cms.Sequence(
     susyHLTRazorMonitoring
-)
-
-susHLTDQMSourceExtra = cms.Sequence(
-  susyHLTVBFMonitoring
+### THEY WERE IN EXTRA
+  + susyHLTVBFMonitoring
   + LepHTMonitor
   + susyHLTEleCaloJets
   + double_soft_muon_muonpt
@@ -261,4 +259,8 @@ susHLTDQMSourceExtra = cms.Sequence(
   + double_soft_muon_dca_muonpt
   + double_soft_muon_dca_metpt
   + susyHLTSoftMuHardJetMETMonitoring
+
+)
+
+susHLTDQMSourceExtra = cms.Sequence(
 )

--- a/DQMOffline/Trigger/python/TopMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TopMonitoring_cff.py
@@ -216,7 +216,8 @@ topDiMuonHLTMonitor_Mass8.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT
 
 
 topDiMuonHLTMonitor_Mass3p8 = hltTOPmonitoring.clone()
-topDiMuonHLTMonitor_Mass3p8.FolderName = cms.string('HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mass3p8/')
+#topDiMuonHLTMonitor_Mass3p8.FolderName = cms.string('HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mass3p8/')
+topDiMuonHLTMonitor_Mass3p8.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mass3p8/')
 topDiMuonHLTMonitor_Mass3p8.nmuons = cms.uint32(2)
 topDiMuonHLTMonitor_Mass3p8.nelectrons = cms.uint32(0)
 topDiMuonHLTMonitor_Mass3p8.njets = cms.uint32(0)
@@ -226,7 +227,8 @@ topDiMuonHLTMonitor_Mass3p8.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
 topDiMuonHLTMonitor_Mass3p8.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*')
 
 topDiMuonHLTMonitor_Mass8Mon = hltTOPmonitoring.clone()
-topDiMuonHLTMonitor_Mass8Mon.FolderName = cms.string('HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass8Efficiency/')
+#topDiMuonHLTMonitor_Mass8Mon.FolderName = cms.string('HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass8Efficiency/')
+topDiMuonHLTMonitor_Mass8Mon.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Mass8Efficiency/')
 topDiMuonHLTMonitor_Mass8Mon.nmuons = cms.uint32(2)
 topDiMuonHLTMonitor_Mass8Mon.nelectrons = cms.uint32(0)
 topDiMuonHLTMonitor_Mass8Mon.njets = cms.uint32(0)
@@ -237,7 +239,8 @@ topDiMuonHLTMonitor_Mass8Mon.numGenericTriggerEventPSet.hltPaths = cms.vstring('
 topDiMuonHLTMonitor_Mass8Mon.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
 topDiMuonHLTMonitor_Mass3p8Mon = hltTOPmonitoring.clone()
-topDiMuonHLTMonitor_Mass3p8Mon.FolderName = cms.string('HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass3p8Efficiency/')
+#topDiMuonHLTMonitor_Mass3p8Mon.FolderName = cms.string('HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass3p8Efficiency/')
+topDiMuonHLTMonitor_Mass3p8Mon.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Mass3p8Efficiency/')
 topDiMuonHLTMonitor_Mass3p8Mon.nmuons = cms.uint32(2)
 topDiMuonHLTMonitor_Mass3p8Mon.nelectrons = cms.uint32(0)
 topDiMuonHLTMonitor_Mass3p8Mon.njets = cms.uint32(0)
@@ -574,9 +577,6 @@ fullyhadronic_TripleBTag_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring(
 from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM
 
 topMonitorHLT = cms.Sequence(
-    )
-
-topHLTDQMSourceExtra = cms.Sequence(
     topEleJet_ele
     + topEleJet_jet
     + topEleJet_all
@@ -620,4 +620,7 @@ topHLTDQMSourceExtra = cms.Sequence(
     + topElecMuonHLTMonitor_Mu23Ele12_ref
     + topDiMuonHLTMonitor_Dz_Mu17_Mu8,
      cms.Task(egmGsfElectronIDsForDQM) # Use of electron VID requires this module being executed first
+)
+
+topHLTDQMSourceExtra = cms.Sequence(
 )

--- a/DQMOffline/Trigger/python/VBFMETMonitor_Client_cff.py
+++ b/DQMOffline/Trigger/python/VBFMETMonitor_Client_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 vbfmetEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/Higgs/VBFMET/*"),
+#    subDirs        = cms.untracked.vstring("HLT/Higgs/VBFMET/*"),
+    subDirs        = cms.untracked.vstring("HLT/HIG/VBFMET/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(

--- a/DQMOffline/Trigger/python/VBFMETMonitor_cff.py
+++ b/DQMOffline/Trigger/python/VBFMETMonitor_cff.py
@@ -4,7 +4,8 @@ from DQMOffline.Trigger.ObjMonitor_cfi import hltobjmonitoring
 
 # HLT_
 DiJetVBFmonitoring = hltobjmonitoring.clone()
-DiJetVBFmonitoring.FolderName = cms.string('HLT/Higgs/VBFMET/DiJet/')
+#DiJetVBFmonitoring.FolderName = cms.string('HLT/Higgs/VBFMET/DiJet/')
+DiJetVBFmonitoring.FolderName = cms.string('HLT/HIG/VBFMET/DiJet/')
 DiJetVBFmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults","","HLT" )
 DiJetVBFmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiJet110_35_Mjj650_PFMET110_v*","HLT_DiJet110_35_Mjj650_PFMET120_v*","HLT_DiJet110_35_Mjj650_PFMET130_v*")
 #DiJetVBFmonitoring.metSelection = cms.string("")
@@ -14,7 +15,8 @@ DiJetVBFmonitoring.njets = cms.int32(2)
 #DiJetVBFmonitoring.metSelection = cms.string("pt>150")
 
 TripleJetVBFmonitoring = DiJetVBFmonitoring.clone()
-TripleJetVBFmonitoring.FolderName = cms.string('HLT/Higgs/VBFMET/TripleJet/')
+#TripleJetVBFmonitoring.FolderName = cms.string('HLT/Higgs/VBFMET/TripleJet/')
+TripleJetVBFmonitoring.FolderName = cms.string('HLT/HIG/VBFMET/TripleJet/')
 TripleJetVBFmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TripleJet110_35_35_Mjj650_PFMET110_v*","HLT_TripleJet110_35_35_Mjj650_PFMET120_v*","HLT_TripleJet110_35_35_Mjj650_PFMET130_v*")
 
 higgsinvHLTJetMETmonitoring = cms.Sequence(

--- a/DQMOffline/Trigger/python/VBFTauMonitor_Client_cff.py
+++ b/DQMOffline/Trigger/python/VBFTauMonitor_Client_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 vbftauEfficiency = DQMEDHarvester("DQMGenericClient",
-  subDirs        = cms.untracked.vstring("HLT/Higgs/VBFTau/*"),
+#  subDirs        = cms.untracked.vstring("HLT/Higgs/VBFTau/*"),
+  subDirs        = cms.untracked.vstring("HLT/HIG/VBFTau/*"),
   verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
   resolution     = cms.vstring(),
   efficiency     = cms.vstring(

--- a/DQMOffline/Trigger/python/VBFTauMonitor_cff.py
+++ b/DQMOffline/Trigger/python/VBFTauMonitor_cff.py
@@ -5,7 +5,8 @@ from DQMOffline.Trigger.ObjMonitor_cfi import hltobjmonitoring
 # HLT_
 VBFtaumonitoring = hltobjmonitoring.clone()
 
-VBFtaumonitoring.FolderName = cms.string('HLT/Higgs/VBFTau')
+#VBFtaumonitoring.FolderName = cms.string('HLT/Higgs/VBFTau')
+VBFtaumonitoring.FolderName = cms.string('HLT/HIG/VBFTau')
 VBFtaumonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults","","HLT" )
 VBFtaumonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring(
   "HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v*",

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -50,7 +50,7 @@ hltvalidationWithMC    = cms.Sequence(
     HLTMuonVal
     +HLTTauVal
     +egammaValidationSequence
-    +topHLTriggerOfflineDQM
+    +topHLTriggerOfflineDQM ## why is this here ?!?! (it is DQM !)
     +topHLTriggerValidation
     +heavyFlavorValidationSequence
     +HLTJetMETValSeq


### PR DESCRIPTION
as discussed with DQM core,
TSG would need to (re)enable the whole HLTDQM @Tier0,
when the DQM step is run on the physics PDs (SingleMuon, ZeroBias, etc.)

modules which were in the @ExtraHLT are now back in the main sequence

I ran the 136.868 test of the runTheMatrix,
and because it is using DQM:@standardDQM+@ExtraHLT+@miniAODDQM (relval),
I also ran DQM:@standard (standard), DQM (default), DQM:@common (common), DQM:@ExtraHLT (extraHLT)

what I get is the following
relval.memory:Total bytes: 220.97 MiB
TOT 56844333 #histos: 174781
HLT 18221303 ( 32.1 %) #histos: 78773 ( 45.1 %)

standard.memory:Total bytes: 208.91 MiB
TOT 54330445 #histos: 161181
HLT 17014257 ( 31.3 %) #histos: 67378 ( 41.8 %)

default.memory:Total bytes: 210.83 MiB
TOT 54620382 #histos: 169106
HLT 17304194 ( 31.7 %) #histos: 75303 ( 44.5 %)

common.memory: Total bytes: 122.65 MiB
TOT 35190979 #histos: 132342
HLT 11663074 ( 33.1 %) #histos: 70968 ( 53.6 %)

extraHLT.memory:Total bytes: 76.73 MiB
TOT 25188338 #histos: 105527
HLT 12431752 ( 49.4 %) #histos: 73530 ( 69.7 %)

as far as I know / read / understand / discuss about,
Tier0 runs @common in many PDs


ps: I also tried to clean the HLT directory
- B2GHLTOffline --> B2G
- Higgs --> HIG
- Photon --> EXO/Photon or HIG/DiPhoton or EGM/Photon
- TopHLTOffline --> TOP