### PR TITLE
MTD simulation update

### DIFF
--- a/SimFastTiming/FastTimingCommon/BuildFile.xml
+++ b/SimFastTiming/FastTimingCommon/BuildFile.xml
@@ -9,6 +9,7 @@
 <use   name="Geometry/HcalTowerAlgo"/>
 <use   name="hepmc"/>
 <use   name="CLHEP"/>
+<use   name="CommonTools/Utils"/>
 <use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>

--- a/SimFastTiming/FastTimingCommon/interface/BTLDeviceSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/BTLDeviceSim.h
@@ -32,7 +32,6 @@ class BTLDeviceSim {
   
  private:
 
-  const float refSpeed_;  
   const float bxTime_;
   const float LightYield_;
   const float LightCollEff_;

--- a/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
@@ -48,6 +48,7 @@ class BTLElectronicsSim {
 
   const bool debug_;
 
+  const float bxTime_;
   const float ScintillatorRiseTime_;
   const float ScintillatorDecayTime_;
   const float ChannelTimeOffset_;
@@ -74,6 +75,10 @@ class BTLElectronicsSim {
   const float adcLSB_MIP_;
   const float adcThreshold_MIP_;
   const float toaLSB_ns_;
+
+  const float CorrCoeff_;
+  const float cosPhi_;
+  const float sinPhi_;
 
   const float ScintillatorDecayTime2_;
   const float SPTR2_;

--- a/SimFastTiming/FastTimingCommon/interface/ETLElectronicsSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/ETLElectronicsSim.h
@@ -1,6 +1,8 @@
 #ifndef __SimFastTiming_FastTimingCommon_ETLElectronicsSim_h__
 #define __SimFastTiming_FastTimingCommon_ETLElectronicsSim_h__
 
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -39,7 +41,9 @@ class ETLElectronicsSim {
 
  private:
 
-  const bool debug_;
+  const bool  debug_;
+  const float bxTime_;
+  const reco::FormulaEvaluator sigmaEta_;
 
   // adc/tdc bitwidths
   const uint32_t adcNbits_, tdcNbits_; 

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -14,6 +14,7 @@ _barrel_MTDDigitizer = cms.PSet(
         PhotonDetectionEff       = cms.double(0.20),
         ),
     ElectronicsSimulation = cms.PSet(
+        bxTime                     = cms.double(25),    # [ns] 
         ScintillatorRiseTime       = cms.double(1.1),   # [ns]
         ScintillatorDecayTime      = cms.double(40.),   # [ns]
         ChannelTimeOffset          = cms.double(0.),    # [ns]
@@ -26,6 +27,7 @@ _barrel_MTDDigitizer = cms.PSet(
         SinglePhotonTimeResolution = cms.double(0.060), # [ns]
         SigmaElectronicNoise       = cms.double(1.),    # [p.e.]
         SigmaClock                 = cms.double(0.015), # [ns]
+        CorrelationCoefficient     = cms.double(1.),
         Npe_to_pC                  = cms.double(0.016), # [pC] 
         Npe_to_V                   = cms.double(0.0064),# [V] 
 
@@ -53,16 +55,18 @@ _endcap_MTDDigitizer = cms.PSet(
         meVPerMIP         = cms.double(0.085), # from HGCal
         ),
     ElectronicsSimulation = cms.PSet(
+        bxTime             = cms.double(25),
+        etaResolution      = cms.string("0.03+0.0025*x"), # This is just a dummy dependence on eta.
         # n bits for the ADC 
-        adcNbits          = cms.uint32(12),
+        adcNbits           = cms.uint32(12),
         # n bits for the TDC
-        tdcNbits          = cms.uint32(12),
+        tdcNbits           = cms.uint32(12),
         # ADC saturation
         adcSaturation_MIP  = cms.double(102),
         # for different thickness
         adcThreshold_MIP   = cms.double(0.025),
         # LSB for time of arrival estimate from TDC in ns
-        toaLSB_ns         = cms.double(0.005),
+        toaLSB_ns          = cms.double(0.005),
         )
     )
 

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -95,17 +95,12 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
       finalToA2 += smearing_stat_thr1 + smearing_stat_thr2;
 
 
-      // --- Uncertainty due to the SiPM timing resolution:
-      float sigma2_tot_thr1 = SPTR2_/TimeThreshold1_;
-      float sigma2_tot_thr2 = SPTR2_/TimeThreshold2_;
-
-
-      // --- Add in quadrature the uncertainties due to the SiPM DCR, 
+      // --- Add in quadrature the uncertainties due to the SiPM timing resolution, the SiPM DCR,
       //     the electronic noise and the clock distribution:
       float slew2 = ScintillatorDecayTime2_/Npe/Npe;
 
-      sigma2_tot_thr1 += ( (DCRxRiseTime_ + SigmaElectronicNoise2_)*slew2 + SigmaClock2_ );
-      sigma2_tot_thr2 += ( (DCRxRiseTime_ + SigmaElectronicNoise2_)*slew2 + SigmaClock2_ );
+      float sigma2_tot_thr1 = SPTR2_/TimeThreshold1_ + (DCRxRiseTime_ + SigmaElectronicNoise2_)*slew2 + SigmaClock2_;
+      float sigma2_tot_thr2 = SPTR2_/TimeThreshold2_ + (DCRxRiseTime_ + SigmaElectronicNoise2_)*slew2 + SigmaClock2_;
 
 
       // --- Smear the arrival times using the correlated uncertainties:

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -10,6 +10,7 @@ using namespace mtd;
 
 BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset) :
   debug_( pset.getUntrackedParameter<bool>("debug",false) ),
+  bxTime_(pset.getParameter<double>("bxTime") ),
   ScintillatorRiseTime_( pset.getParameter<double>("ScintillatorRiseTime") ),
   ScintillatorDecayTime_( pset.getParameter<double>("ScintillatorDecayTime") ),
   ChannelTimeOffset_( pset.getParameter<double>("ChannelTimeOffset") ),
@@ -30,6 +31,9 @@ BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset) :
   adcLSB_MIP_( adcSaturation_MIP_/std::pow(2.,adcNbits_) ),
   adcThreshold_MIP_( pset.getParameter<double>("adcThreshold_MIP") ),
   toaLSB_ns_( pset.getParameter<double>("toaLSB_ns") ),
+  CorrCoeff_( pset.getParameter<double>("CorrelationCoefficient") ),
+  cosPhi_( 0.5*(sqrt(1.+CorrCoeff_)+sqrt(1.-CorrCoeff_)) ),
+  sinPhi_( 0.5*CorrCoeff_/cosPhi_ ),
   ScintillatorDecayTime2_(ScintillatorDecayTime_*ScintillatorDecayTime_),
   SPTR2_(SinglePhotonTimeResolution_*SinglePhotonTimeResolution_),
   DCRxRiseTime_(DarkCountRate_*ScintillatorRiseTime_),
@@ -82,13 +86,18 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
 
 
       // --- Uncertainty due to the fluctuations of the n-th photon arrival time:
-      float sigma2_tot_thr1 = ScintillatorDecayTime2_*sigma2_pe(TimeThreshold1_,Npe);
-      float sigma2_tot_thr2 = ScintillatorDecayTime2_*sigma2_pe(TimeThreshold2_,Npe);
+      //     the fluctuations due to the first TimeThreshold1_ p.e. are common to both times
+      float smearing_stat_thr1 = CLHEP::RandGaussQ::shoot(hre, 0., 
+				 ScintillatorDecayTime_*sqrt(sigma2_pe(TimeThreshold1_,Npe)));
+      float smearing_stat_thr2 = CLHEP::RandGaussQ::shoot(hre, 0.,
+			         ScintillatorDecayTime_*sqrt(sigma2_pe(TimeThreshold2_-TimeThreshold1_,Npe)));
+      finalToA1 += smearing_stat_thr1;
+      finalToA2 += smearing_stat_thr1 + smearing_stat_thr2;
 
 
-      // --- Add in quadrature the uncertainty due to the SiPM timing resolution:
-      sigma2_tot_thr1 += SPTR2_/TimeThreshold1_;
-      sigma2_tot_thr2 += SPTR2_/TimeThreshold2_;
+      // --- Uncertainty due to the SiPM timing resolution:
+      float sigma2_tot_thr1 = SPTR2_/TimeThreshold1_;
+      float sigma2_tot_thr2 = SPTR2_/TimeThreshold2_;
 
 
       // --- Add in quadrature the uncertainties due to the SiPM DCR, 
@@ -99,21 +108,25 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
       sigma2_tot_thr2 += ( (DCRxRiseTime_ + SigmaElectronicNoise2_)*slew2 + SigmaClock2_ );
 
 
-      // --- Smear the arrival times using the total uncertainty:
-      finalToA1 += CLHEP::RandGaussQ::shoot(hre, 0., sqrt(sigma2_tot_thr1));
-      finalToA2 += CLHEP::RandGaussQ::shoot(hre, 0., sqrt(sigma2_tot_thr2));
+      // --- Smear the arrival times using the correlated uncertainties:
+      float smearing_thr1_uncorr = CLHEP::RandGaussQ::shoot(hre, 0., sqrt(sigma2_tot_thr1));
+      float smearing_thr2_uncorr = CLHEP::RandGaussQ::shoot(hre, 0., sqrt(sigma2_tot_thr2));
+
+      finalToA1 += cosPhi_*smearing_thr1_uncorr + sinPhi_*smearing_thr2_uncorr;
+      finalToA2 += sinPhi_*smearing_thr1_uncorr + cosPhi_*smearing_thr2_uncorr;
 
 
-      while(finalToA1 < 0.f)  finalToA1 += 25.f;
-      while(finalToA1 > 25.f) finalToA1 -= 25.f;
-      toa1[i]=finalToA1;
-
-      while(finalToA2 < 0.f)  finalToA2 += 25.f;
-      while(finalToA2 > 25.f) finalToA2 -= 25.f;
-      toa2[i]=finalToA2;
-
-      chargeColl[i] = Npe*Npe_to_pC_;
+      // --- Fill the time and charge arrays
+      const unsigned int ibucket = std::floor( finalToA1/bxTime_ );
+      if ( (i+ibucket) >= chargeColl.size() ) continue;
       
+      chargeColl[i+ibucket] = Npe*Npe_to_pC_; // the p.e. number is here converted to pC
+      
+      if ( toa1[i+ibucket] == 0. || (finalToA1-ibucket*bxTime_) < toa1[i+ibucket] ){
+	toa1[i+ibucket] = finalToA1 - ibucket*bxTime_;
+	toa2[i+ibucket] = finalToA2 - ibucket*bxTime_;
+      }
+
     }
 
     //run the shaper to create a new data frame

--- a/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
@@ -3,7 +3,6 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/MTDDetId.h"
 
-
 ETLDeviceSim::ETLDeviceSim(const edm::ParameterSet& pset) : 
   MIPPerMeV_( 1.0/pset.getParameter<double>("meVPerMIP") ),
   bxTime_(pset.getParameter<double>("bxTime") ),
@@ -14,11 +13,6 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int,uint32_t,flo
 				   const edm::Handle<edm::PSimHitContainer> &hits,
 				   mtd_digitizer::MTDSimHitDataAccumulator *simHitAccumulator,
 				   CLHEP::HepRandomEngine *hre){
-
-  bool weightToAbyEnergy(false);
-  float tdcOnset(0.f);
-
-  const float refSpeed = 0.1*CLHEP::c_light;
 
   //loop over sorted hits
   const int nchits = hitRefs.size();
@@ -34,53 +28,28 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int,uint32_t,flo
       
     if(id==0) continue; // to be ignored at RECO level
       
-    const float toa    = std::get<2>(hitRefs[i]);
+    const float toa    = std::get<2>(hitRefs[i]) + tofDelay_;
     const PSimHit &hit = hits->at( hitidx );     
     const float charge = 1000.f*hit.energyLoss()*MIPPerMeV_;
 
-    //distance to the center of the detector
-    const float dist2center( 0.1f*hit.entryPoint().mag() );
-      
-    //hit time: [time()]=ns  [centerDist]=cm [refSpeed]=cm/ns + delay by 1ns
-    //accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
-    const float tof = toa-dist2center/refSpeed+tofDelay_ ;
-    const int itime = std::floor( tof/bxTime_ ) + 9;
-
+    // Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
+    const int itime = std::floor( toa/bxTime_ ) + 9;
     if(itime<0 || itime>14) continue;     
       
-    //check if time index is ok and store energy
+    // Check if time index is ok and store energy
     if(itime >= (int)simHitIt->second.hit_info[0].size() ) continue;
-      
+
     (simHitIt->second).hit_info[0][itime] += charge;
-    float accCharge=(simHitIt->second).hit_info[0][itime];
       
-    //time-of-arrival (check how to be used)
-    if(weightToAbyEnergy) (simHitIt->second).hit_info[1][itime] += charge*tof;
-    else if((simHitIt->second).hit_info[1][itime]==0)
-      {	
-	if( accCharge>tdcOnset )
-	  {
-	    //extrapolate linear using previous simhit if it concerns to the same DetId
-	    float fireTDC=tof;
-	    if(i>0)
-	      {
-		uint32_t prev_id = std::get<1>(hitRefs[i-1]);
-		if(prev_id==id)
-		  {
-		    float prev_toa    = std::get<2>(hitRefs[i-1]);
-		    float prev_tof(prev_toa-dist2center/refSpeed+tofDelay_);
-		    float deltaQ2TDCOnset = tdcOnset-((simHitIt->second).hit_info[0][itime]-charge);
-		    float deltaQ          = charge;
-		    float deltaT          = (tof-prev_tof);
-		    fireTDC               = deltaT*(deltaQ2TDCOnset/deltaQ)+prev_tof;
-		  }		  
-	      }
-	      
-	    (simHitIt->second).hit_info[1][itime]=fireTDC;
+    // Store the time of the first SimHit in the right DataFrame bucket
+    const float tof = toa - (itime-9)*bxTime_;
 
-	  }
-      }
+    if( (simHitIt->second).hit_info[1][itime] == 0. ||
+	tof < (simHitIt->second).hit_info[1][itime] ) {
+      (simHitIt->second).hit_info[1][itime] = tof;
+
+    }
+
   }
-
 
 }

--- a/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
@@ -1,17 +1,20 @@
 #include "SimFastTiming/FastTimingCommon/interface/ETLElectronicsSim.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CLHEP/Random/RandGaussQ.h"
 
 using namespace mtd;
 
 ETLElectronicsSim::ETLElectronicsSim(const edm::ParameterSet& pset) :
   debug_( pset.getUntrackedParameter<bool>("debug",false) ),
+  bxTime_(pset.getParameter<double>("bxTime") ),
+  sigmaEta_( pset.getParameter<std::string>("etaResolution") ),
   adcNbits_( pset.getParameter<uint32_t>("adcNbits") ),
   tdcNbits_( pset.getParameter<uint32_t>("tdcNbits") ),
   adcSaturation_MIP_( pset.getParameter<double>("adcSaturation_MIP") ),
   adcLSB_MIP_( adcSaturation_MIP_/std::pow(2.,adcNbits_) ),
   adcThreshold_MIP_( pset.getParameter<double>("adcThreshold_MIP") ),
-  toaLSB_ns_( pset.getParameter<double>("toaLSB_ns")) {    
+  toaLSB_ns_( pset.getParameter<double>("toaLSB_ns") ) {
 }
 
 
@@ -19,26 +22,45 @@ void ETLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
 			    ETLDigiCollection& output,
 			    CLHEP::HepRandomEngine *hre) const {
   
-  MTDSimHitData chargeColl,toa;
+  MTDSimHitData chargeColl, toa;
   
+
+  std::vector<double> emptyV;
+  std::vector<double> eta(1);
+
   for(MTDSimHitDataAccumulator::const_iterator it=input.begin();
       it!=input.end();
       it++) {
     
-    chargeColl.fill(0.f); 
+    chargeColl.fill(0.f);
     toa.fill(0.f);
     for(size_t i=0; i<it->second.hit_info[0].size(); i++) {
-      //time of arrival
+
+      if ( (it->second).hit_info[0][i] < adcThreshold_MIP_ ) continue;
+
+      // time of arrival
       float finalToA = (it->second).hit_info[1][i];
-      while(finalToA < 0.f)  finalToA+=25.f;
-      while(finalToA > 25.f) finalToA-=25.f;
-      toa[i]=finalToA;
+
+      // Gaussian smearing of the time of arrival
+      eta[0] = 2.;  // This is just temporary. Once the RECO geometry is 
+                    // available, the actual module eta will be used.
+      double sigmaToA = sigmaEta_.evaluate(eta, emptyV);
+
+      if ( sigmaToA > 0. )
+	finalToA += CLHEP::RandGaussQ::shoot(hre, 0., sigmaToA);
+
+      // fill the time and charge arrays
+      const unsigned int ibucket = std::floor( finalToA/bxTime_ );
+      if ( (i+ibucket) >= chargeColl.size() ) continue;
       
-      // collected charge (in this case in MIPs)
-      chargeColl[i] = (it->second).hit_info[0][i];      
+      chargeColl[i+ibucket] += (it->second).hit_info[0][i];      
+
+      if ( toa[i+ibucket] == 0. || (finalToA-ibucket*bxTime_) < toa[i+ibucket] )
+	toa[i+ibucket] = finalToA - ibucket*bxTime_;
+      
     }
-    
-    //run the shaper to create a new data frame
+
+    // run the shaper to create a new data frame
     ETLDataFrame rawDataFrame( it->first );    
     runTrivialShaper(rawDataFrame,chargeColl,toa);
     updateOutput(output,rawDataFrame);
@@ -67,6 +89,11 @@ void ETLElectronicsSim::runTrivialShaper(ETLDataFrame &dataFrame,
       ETLSample newSample;
       newSample.set(chargeColl[it] > adcThreshold_MIP_,false,tdc_time,adc);
       dataFrame.setSample(it,newSample);
+
+      //std::cout << it << " " << chargeColl[it] << " " << toa[it] << std::endl;
+      //std::cout << "    " << adc << " " <<  tdc_time << std::endl;
+
+
 
       if(debug) edm::LogVerbatim("ETLElectronicsSim") << adc << " (" << chargeColl[it] << "/" << adcLSB_MIP_ << ") ";
     }

--- a/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
@@ -90,11 +90,6 @@ void ETLElectronicsSim::runTrivialShaper(ETLDataFrame &dataFrame,
       newSample.set(chargeColl[it] > adcThreshold_MIP_,false,tdc_time,adc);
       dataFrame.setSample(it,newSample);
 
-      //std::cout << it << " " << chargeColl[it] << " " << toa[it] << std::endl;
-      //std::cout << "    " << adc << " " <<  tdc_time << std::endl;
-
-
-
       if(debug) edm::LogVerbatim("ETLElectronicsSim") << adc << " (" << chargeColl[it] << "/" << adcLSB_MIP_ << ") ";
     }
 


### PR DESCRIPTION
BTL code:
 - removed the time of flight subtraction;
 - fixed the assignment of the DataFrame buckets;
 - added correlations between the two times that are read out.

ETL code:
 - removed the time of flight subtraction;
 - removed the linear interpolation of times in the same cell;
 - fixed the assignment of the DataFrame buckets;
 - added a time smearing depending on module eta.

The complete workflow has been successfully tested on a SingleMuon and TTbar sample with runTheMatrix.