### PR TITLE
L1T DQM - Disable ugmt muon spectrum quality tests for eta and pt

### DIFF
--- a/DQM/L1TMonitorClient/data/L1TStage2MuonQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2MuonQualityTests.xml
@@ -26,12 +26,12 @@
 
   <LINK name="*/L1TStage2uGMT/ugmtMuonEta">
       <TestName activate="true">muon_etaMeanAt0</TestName>
-      <TestName activate="true">muon_etaSpectrum</TestName>
+      <TestName activate="false">muon_etaSpectrum</TestName>
   </LINK>
 
   <LINK name="*/L1TStage2uGMT/ugmtMuonEtaAtVtx">
       <TestName activate="true">muon_etaMeanAt0</TestName>
-      <TestName activate="true">muon_etaSpectrum</TestName>
+      <TestName activate="false">muon_etaSpectrum</TestName>
   </LINK>
 
   <!-- phi and phi at vertex-->
@@ -70,7 +70,7 @@
 
   <LINK name="*/L1TStage2uGMT/ugmtMuonPt">
       <TestName activate="true">muon_PtRange</TestName>
-      <TestName activate="true">muon_PtSpectrum</TestName>
+      <TestName activate="false">muon_PtSpectrum</TestName>
   </LINK>
 
 

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -429,21 +429,21 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonEta"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
-                            cms.PSet(
-                                QualityTestName = cms.string("muon_etaSpectrum"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonEta"),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
+                            #cms.PSet(
+                            #    QualityTestName = cms.string("muon_etaSpectrum"),
+                            #    QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonEta"),
+                            #    QualityTestSummaryEnabled = cms.uint32(0)
+                            #    ),
                             cms.PSet(
                                 QualityTestName = cms.string("muon_etaMeanAt0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonEtaAtVtx"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
-                            cms.PSet(
-                                QualityTestName = cms.string("muon_etaSpectrum"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonEtaAtVtx"),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
+                            #cms.PSet(
+                            #    QualityTestName = cms.string("muon_etaSpectrum"),
+                            #    QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonEtaAtVtx"),
+                            #    QualityTestSummaryEnabled = cms.uint32(0)
+                            #    ),
                             cms.PSet(
                                 QualityTestName = cms.string("muon_phiMeanAt0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPhi"),
@@ -469,11 +469,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
-                            cms.PSet(
-                                QualityTestName = cms.string("muon_PtSpectrum"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
+                            #cms.PSet(
+                            #    QualityTestName = cms.string("muon_PtSpectrum"),
+                            #    QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
+                            #    QualityTestSummaryEnabled = cms.uint32(0)
+                            #    ),
                             ),
                         ),
                     ),


### PR DESCRIPTION
L1T DQM - Disable ugmt muon spectrum quality tests for eta and pt since they had too many false positives.