### PR TITLE
Fix GCC 8 compiler warnings, strncpy problem

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalL1TriggerObjects.h
+++ b/CondFormats/HcalObjects/interface/HcalL1TriggerObjects.h
@@ -20,8 +20,6 @@ class HcalL1TriggerObjects: public HcalCondObjectContainer<HcalL1TriggerObject>
 #endif
   HcalL1TriggerObjects(const HcalTopology* topo):HcalCondObjectContainer<HcalL1TriggerObject>(topo) {}
 
-  static constexpr std::size_t charArraySize = 128;
-
   //fill the chars and read them
   void setTagString(std::string const& fTag) {
     std::size_t maxCharacters = charArraySize - 1;
@@ -46,6 +44,8 @@ class HcalL1TriggerObjects: public HcalCondObjectContainer<HcalL1TriggerObject>
   std::string myname() const override { return "HcalL1TriggerObjects"; }
 
  private:
+
+  static constexpr std::size_t charArraySize = 128;
   char mTag[charArraySize];
   char mAlgo[charArraySize];
 

--- a/CondFormats/HcalObjects/interface/HcalL1TriggerObjects.h
+++ b/CondFormats/HcalObjects/interface/HcalL1TriggerObjects.h
@@ -10,6 +10,9 @@
 #include "CondFormats/HcalObjects/interface/HcalL1TriggerObject.h"
 #include "CondFormats/HcalObjects/interface/HcalCondObjectContainer.h"
 
+#include "FWCore/Utilities/interface/Exception.h"
+
+constexpr std::size_t charArraySize = 128;
 
 class HcalL1TriggerObjects: public HcalCondObjectContainer<HcalL1TriggerObject>
 {
@@ -20,17 +23,31 @@ class HcalL1TriggerObjects: public HcalCondObjectContainer<HcalL1TriggerObject>
   HcalL1TriggerObjects(const HcalTopology* topo):HcalCondObjectContainer<HcalL1TriggerObject>(topo) {}
 
   //fill the chars and read them
-  void setTagString(std::string fTag) {strncpy(mTag,fTag.c_str(),128);}
-  void setAlgoString(std::string fAlgo) {strncpy(mAlgo,fAlgo.c_str(),128);}
+  void setTagString(std::string const& fTag) {
+    std::size_t maxCharacters = charArraySize - 1;
+    if (fTag.size() > maxCharacters) {
+      throw cms::Exception("HcalL1TriggerObjects::setTagString: string exceeds array size");
+    }
+    strncpy(mTag, fTag.c_str(), maxCharacters);
+    mTag[maxCharacters] = '\0';
+  }
 
-  std::string getTagString() const {return (std::string)mTag;}
-  std::string getAlgoString() const {return (std::string)mAlgo;}
+  void setAlgoString(std::string const& fAlgo) {
+    std::size_t maxCharacters = charArraySize - 1;
+    if (fAlgo.size() > maxCharacters) {
+      throw cms::Exception("HcalL1TriggerObjects::setAlgoString: string exceeds array size");
+    }
+    strncpy(mAlgo, fAlgo.c_str(), maxCharacters);
+    mAlgo[maxCharacters] = '\0';
+  }
 
-  std::string myname() const override {return (std::string)"HcalL1TriggerObjects";}
+  std::string getTagString() const { return mTag; }
+  std::string getAlgoString() const { return mAlgo; }
+  std::string myname() const override { return "HcalL1TriggerObjects"; }
 
  private:
-  char mTag[128];
-  char mAlgo[128];
+  char mTag[charArraySize];
+  char mAlgo[charArraySize];
 
 
  COND_SERIALIZABLE;

--- a/CondFormats/HcalObjects/interface/HcalL1TriggerObjects.h
+++ b/CondFormats/HcalObjects/interface/HcalL1TriggerObjects.h
@@ -12,8 +12,6 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-constexpr std::size_t charArraySize = 128;
-
 class HcalL1TriggerObjects: public HcalCondObjectContainer<HcalL1TriggerObject>
 {
  public:
@@ -21,6 +19,8 @@ class HcalL1TriggerObjects: public HcalCondObjectContainer<HcalL1TriggerObject>
  HcalL1TriggerObjects():HcalCondObjectContainer<HcalL1TriggerObject>(nullptr) { }
 #endif
   HcalL1TriggerObjects(const HcalTopology* topo):HcalCondObjectContainer<HcalL1TriggerObject>(topo) {}
+
+  static constexpr std::size_t charArraySize = 128;
 
   //fill the chars and read them
   void setTagString(std::string const& fTag) {


### PR DESCRIPTION
If the argument to setTagString or setAlgoString
was ever longer than 127, then this would create
C strings lacking the null terminator and possibly
truncated. And in that case calls to getTagString
or getAlgoString would then cause undefined behavior.
As far as I know this never happened ...

Plus a small amount of cleanup.