### PR TITLE
gcc 8 compiler warnings, change strncpy to memcpy

### DIFF
--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingAlpgen.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingAlpgen.cc
@@ -179,7 +179,7 @@ int JetMatchingAlpgen::match( const lhef::LHEEvent* partonLevel, const std::vect
 
 void alshcd_(char csho[3])
 {
-	std::strncpy(csho, "PYT", 3);	// or "HER"
+	std::memcpy(csho, "PYT", 3);	// or "HER"
 }
 
 void alshen_()

--- a/Utilities/StorageFactory/src/LocalFileSystem.cc
+++ b/Utilities/StorageFactory/src/LocalFileSystem.cc
@@ -185,10 +185,10 @@ LocalFileSystem::initFSInfo(void *arg)
   size_t totlen = infolen + fslen + dirlen + typelen + originlen;
   FSInfo *i = (FSInfo *) malloc(totlen);
   char *p = (char *) i;
-  i->fsname = strncpy(p += infolen, m->mnt_fsname, fslen);
-  i->type = strncpy(p += fslen, m->mnt_type, typelen);
-  i->dir = strncpy(p += typelen, m->mnt_dir, dirlen);
-  i->origin = strncpy(p += dirlen, m->mnt_fsname, originlen);
+  i->fsname = static_cast<char*>(memcpy(p += infolen, m->mnt_fsname, fslen));
+  i->type = static_cast<char*>(memcpy(p += fslen, m->mnt_type, typelen));
+  i->dir = static_cast<char*>(memcpy(p += typelen, m->mnt_dir, dirlen));
+  i->origin = static_cast<char*>(memcpy(p += dirlen, m->mnt_fsname, originlen));
   i->dev = -1;
   i->fstype = -1;
   i->freespc = 0;


### PR DESCRIPTION
These are not real problems. Should result in identical
behavior. Destination in both cases is not really a
C string so memcpy is probably a better choice. The
compiler is trying to steer away from dangerous C
string operations. In these cases, one destination is
a FORTRAN array and the other a buffer containing
multiple C strings and a structure.