### PR TITLE
Change premixing library format from RAW to DIGI

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -18,7 +18,7 @@ import FWCore.ParameterSet.Config as cms
 #    slimmed-down version of RAWSIM for small transient disk size during MC production, contains Gen+Rawdata
 #
 #  PREMIX
-#    extension of GENRAW with special Digi collection(s) for pre-mixing minbias events for pileup simulation
+#    contains special Digi collection(s) for pre-mixing minbias events for pileup simulation
 #    Raw2Digi step is done on this file.
 #
 #  PREMIXRAW
@@ -527,19 +527,35 @@ GENRAWEventContent.outputCommands.extend(IOMCRAW.outputCommands)
 GENRAWEventContent.outputCommands.extend(DigiToRawFEVT.outputCommands)
 GENRAWEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 
-PREMIXEventContent.outputCommands.extend(RAWEventContent.outputCommands)
-PREMIXEventContent.outputCommands.extend(GeneratorInterfaceRECO.outputCommands)
-PREMIXEventContent.outputCommands.extend(SimG4CoreRECO.outputCommands)
-PREMIXEventContent.outputCommands.extend(SimTrackerRAW.outputCommands)
 PREMIXEventContent.outputCommands.extend(SimGeneralRAW.outputCommands)
-PREMIXEventContent.outputCommands.extend(RecoGenMETFEVT.outputCommands)
-PREMIXEventContent.outputCommands.extend(RecoGenJetsFEVT.outputCommands)
-PREMIXEventContent.outputCommands.extend(MEtoEDMConverterFEVT.outputCommands)
 PREMIXEventContent.outputCommands.extend(IOMCRAW.outputCommands)
-PREMIXEventContent.outputCommands.extend(DigiToRawFEVT.outputCommands)
 PREMIXEventContent.outputCommands.extend(CommonEventContent.outputCommands)
+
+PREMIXEventContent.outputCommands.extend([
+        # Tracker
+        'keep *_simSiPixelDigis_*_*', # covers digis and digiSimLinks
+        'keep *_simSiStripDigis_ZeroSuppressed_*',
+        'keep *_mix_AffectedAPVList_*',
+        # ECAL
+        'keep EBDigiCollection_simEcalDigis_*_*',
+        'keep EEDigiCollection_simEcalDigis_*_*',
+        'keep ESDigiCollection_simEcalUnsuppressedDigis_*_*',
+        # HCAL
+        'keep *_simHcalDigis_*_*',
+        'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
+        # DT
+        'keep *_simMuonDTDigis_*_*',
+        # CSC
+        'keep *_simMuonCSCDigis_*_*',
+        'keep *_simMuonCscTriggerPrimitiveDigis_*_*',
+        # RPC
+        'keep *_simMuonRPCDigis_*_*',
+        # GEM
+        'keep *_simMuonGEMDigis_*_*',
+        'keep *_*_GEMDigiSimLink_*',
+        'keep *_*_GEMStripDigiSimLink_*',
+])
 PREMIXEventContent.outputCommands.append('keep RPCDetIdRPCDigiMuonDigiCollection_simMuonRPCDigis_*_*')
-PREMIXEventContent.outputCommands.append('keep *_mix_MergedTrackTruth_*')
 PREMIXEventContent.outputCommands.append('keep StripDigiSimLinkedmDetSetVector_simSiStripDigis_*_*')
 PREMIXEventContent.outputCommands.append('keep PixelDigiSimLinkedmDetSetVector_simSiPixelDigis_*_*')
 PREMIXEventContent.outputCommands.append('keep StripDigiSimLinkedmDetSetVector_simMuonCSCDigis_*_*')

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -530,37 +530,9 @@ GENRAWEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 PREMIXEventContent.outputCommands.extend(SimGeneralRAW.outputCommands)
 PREMIXEventContent.outputCommands.extend(IOMCRAW.outputCommands)
 PREMIXEventContent.outputCommands.extend(CommonEventContent.outputCommands)
-
-PREMIXEventContent.outputCommands.extend([
-        # Tracker
-        'keep *_simSiPixelDigis_*_*', # covers digis and digiSimLinks
-        'keep *_simSiStripDigis_ZeroSuppressed_*',
-        'keep *_mix_AffectedAPVList_*',
-        # ECAL
-        'keep EBDigiCollection_simEcalDigis_*_*',
-        'keep EEDigiCollection_simEcalDigis_*_*',
-        'keep ESDigiCollection_simEcalUnsuppressedDigis_*_*',
-        # HCAL
-        'keep *_simHcalDigis_*_*',
-        'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
-        # DT
-        'keep *_simMuonDTDigis_*_*',
-        # CSC
-        'keep *_simMuonCSCDigis_*_*',
-        'keep *_simMuonCscTriggerPrimitiveDigis_*_*',
-        # RPC
-        'keep *_simMuonRPCDigis_*_*',
-        # GEM
-        'keep *_simMuonGEMDigis_*_*',
-        'keep *_*_GEMDigiSimLink_*',
-        'keep *_*_GEMStripDigiSimLink_*',
-])
-PREMIXEventContent.outputCommands.append('keep RPCDetIdRPCDigiMuonDigiCollection_simMuonRPCDigis_*_*')
-PREMIXEventContent.outputCommands.append('keep StripDigiSimLinkedmDetSetVector_simSiStripDigis_*_*')
-PREMIXEventContent.outputCommands.append('keep PixelDigiSimLinkedmDetSetVector_simSiPixelDigis_*_*')
-PREMIXEventContent.outputCommands.append('keep StripDigiSimLinkedmDetSetVector_simMuonCSCDigis_*_*')
-PREMIXEventContent.outputCommands.append('keep RPCDigiSimLinkedmDetSetVector_*_*_*')
-PREMIXEventContent.outputCommands.append('keep DTLayerIdDTDigiSimLinkMuonDigiCollection_*_*_*')
+PREMIXEventContent.outputCommands.extend(SimTrackerPREMIX.outputCommands)
+PREMIXEventContent.outputCommands.extend(SimCalorimetryPREMIX.outputCommands)
+PREMIXEventContent.outputCommands.extend(SimMuonPREMIX.outputCommands)
 fastSim.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.outputCommands+fastSimEC.extraPremixContent)
 # Phase2 essentially extends the content to DIGI
 # We could split this by subdetector-eras, but let's start with simple
@@ -601,12 +573,6 @@ phase2_common.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.o
         # CaloParticles
         'keep *_mix_MergedCaloTruth_*',
 ])
-
-
-from Configuration.Eras.Modifier_hcalSkipPacker_cff import hcalSkipPacker
-hcalSkipPacker.toModify(PREMIXEventContent.outputCommands,
-    func=lambda outputCommands: outputCommands.append('keep *_simHcalDigis_*_*')
-)
 
 PREMIXRAWEventContent.outputCommands.extend(RAWSIMEventContent.outputCommands)
 PREMIXRAWEventContent.outputCommands.append('keep CrossingFramePlaybackInfoNew_*_*_*')

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -533,46 +533,8 @@ PREMIXEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 PREMIXEventContent.outputCommands.extend(SimTrackerPREMIX.outputCommands)
 PREMIXEventContent.outputCommands.extend(SimCalorimetryPREMIX.outputCommands)
 PREMIXEventContent.outputCommands.extend(SimMuonPREMIX.outputCommands)
+PREMIXEventContent.outputCommands.extend(SimGeneralPREMIX.outputCommands)
 fastSim.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.outputCommands+fastSimEC.extraPremixContent)
-# Phase2 essentially extends the content to DIGI
-# We could split this by subdetector-eras, but let's start with simple
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.outputCommands+[
-        # Tracker
-        'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
-        'keep *_*_Phase2OTDigiSimLink_*',
-        'keep *_simSiPixelDigis_*_*', # covers digis and digiSimLinks
-        # MTD
-        # ???
-        # ECAL
-        'keep *_simEcalDigis_ebDigis_*',
-        'keep ESDigiCollection_simEcalUnsuppressedDigis_*_*',
-        # HCAL
-        'keep *_simHcalDigis_*_*',
-        'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
-        # HGCAL
-        'keep *_simHGCalUnsuppressedDigis_EE_*',
-        'keep *_simHGCalUnsuppressedDigis_HEfront_*',
-        'keep *_simHGCalUnsuppressedDigis_HEback_*',
-        # DT
-        'keep *_simMuonDTDigis_*_*',
-        # CSC
-        'keep *_simMuonCSCDigis_*_*',
-        'keep *_simMuonCscTriggerPrimitiveDigis_*_*',
-        # RPC
-        'keep *_simMuonRPCDigis_*_*',
-        # GEM
-        'keep *_simMuonGEMDigis_*_*',
-        'keep *_*_GEMDigiSimLink_*',
-        'keep *_*_GEMStripDigiSimLink_*',
-        # ME0
-        'keep *_simMuonME0Digis_*_*',
-        'keep *_mix_g4SimHitsMuonME0Hits_*',
-        'keep *_*_ME0DigiSimLink_*',
-        'keep *_*_ME0StripDigiSimLink_*',
-        # CaloParticles
-        'keep *_mix_MergedCaloTruth_*',
-])
 
 PREMIXRAWEventContent.outputCommands.extend(RAWSIMEventContent.outputCommands)
 PREMIXRAWEventContent.outputCommands.append('keep CrossingFramePlaybackInfoNew_*_*_*')

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -998,7 +998,7 @@ steps["FS_PREMIXUP15_PU25"] = merge([
         {"cfg":"SingleNuE10_cfi",
          "--fast":"",
          "--conditions":"auto:run2_mc",
-         "-s":"GEN,SIM,RECOBEFMIX,DIGI,DIGI2RAW",
+         "-s":"GEN,SIM,RECOBEFMIX,DIGI",
          "--eventcontent":"PREMIX",
          "--datatier":"GEN-SIM-DIGI-RAW",
          "--procModifiers":"premix_stage1",
@@ -1358,7 +1358,7 @@ steps['DIGIPPREF2017']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake2'}, 
 # PRE-MIXING : https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideSimulation#Pre_Mixing_Instructions
 premixUp2015Defaults = {
     '--evt_type'    : 'SingleNuE10_cfi',
-    '-s'            : 'GEN,SIM,DIGI:pdigi_valid,DIGI2RAW',
+    '-s'            : 'GEN,SIM,DIGI:pdigi_valid',
     '-n'            : '10',
     '--conditions'  : 'auto:run2_mc', # 25ns GT; dedicated dict for 50ns
     '--datatier'    : 'GEN-SIM-DIGI-RAW',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -998,7 +998,7 @@ steps["FS_PREMIXUP15_PU25"] = merge([
         {"cfg":"SingleNuE10_cfi",
          "--fast":"",
          "--conditions":"auto:run2_mc",
-         "-s":"GEN,SIM,RECOBEFMIX,DIGI,L1,DIGI2RAW",
+         "-s":"GEN,SIM,RECOBEFMIX,DIGI,DIGI2RAW",
          "--eventcontent":"PREMIX",
          "--datatier":"GEN-SIM-DIGI-RAW",
          "--procModifiers":"premix_stage1",
@@ -1358,7 +1358,7 @@ steps['DIGIPPREF2017']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake2'}, 
 # PRE-MIXING : https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideSimulation#Pre_Mixing_Instructions
 premixUp2015Defaults = {
     '--evt_type'    : 'SingleNuE10_cfi',
-    '-s'            : 'GEN,SIM,DIGI:pdigi_valid,L1,DIGI2RAW',
+    '-s'            : 'GEN,SIM,DIGI:pdigi_valid,DIGI2RAW',
     '-n'            : '10',
     '--conditions'  : 'auto:run2_mc', # 25ns GT; dedicated dict for 50ns
     '--datatier'    : 'GEN-SIM-DIGI-RAW',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1000,7 +1000,7 @@ steps["FS_PREMIXUP15_PU25"] = merge([
          "--conditions":"auto:run2_mc",
          "-s":"GEN,SIM,RECOBEFMIX,DIGI",
          "--eventcontent":"PREMIX",
-         "--datatier":"GEN-SIM-DIGI-RAW",
+         "--datatier":"PREMIX",
          "--procModifiers":"premix_stage1",
          "--era":"Run2_2016",
          },
@@ -1361,7 +1361,7 @@ premixUp2015Defaults = {
     '-s'            : 'GEN,SIM,DIGI:pdigi_valid',
     '-n'            : '10',
     '--conditions'  : 'auto:run2_mc', # 25ns GT; dedicated dict for 50ns
-    '--datatier'    : 'GEN-SIM-DIGI-RAW',
+    '--datatier'    : 'PREMIX',
     '--eventcontent': 'PREMIX',
     '--procModifiers':'premix_stage1',
     '--era'         : 'Run2_2016' # temporary replacement for premix; to be brought back to customisePostLS1 *EDIT - This comment possibly no longer relevant with switch to eras

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1012,7 +1012,7 @@ FS_PREMIXUP15_PU25_OVERLAY = merge([
         {"-s" : "GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,DATAMIX,L1,DIGI2RAW,L1Reco,RECO,VALIDATION",
          "--datamix" : "PreMix",
          "--procModifiers": "premix_stage2",
-         "--pileup_input" : "dbs:/RelValFS_PREMIXUP15_PU25/%s/GEN-SIM-DIGI-RAW"%(baseDataSetRelease[8],),
+         "--pileup_input" : "dbs:/RelValFS_PREMIXUP15_PU25/%s/PREMIX"%(baseDataSetRelease[8],),
          },
         Kby(100,500),step1FastUpg2015Defaults])
 
@@ -1386,7 +1386,7 @@ steps['PREMIXUP18_PU25']=merge([PU25UP18,Kby(100,100),premixUp2018Defaults])
 digiPremixUp2015Defaults25ns = {
     '--conditions'   : 'auto:run2_mc',
     '-s'             : 'DIGI:pdigi_valid,DATAMIX,L1,DIGI2RAW,HLT:@relval2016',
-    '--pileup_input'  :  'das:/RelValPREMIXUP15_PU25/%s/GEN-SIM-DIGI-RAW'%baseDataSetRelease[5],
+    '--pileup_input'  :  'das:/RelValPREMIXUP15_PU25/%s/PREMIX'%baseDataSetRelease[5],
     '--eventcontent' : 'FEVTDEBUGHLT',
     '--datatier'     : 'GEN-SIM-DIGI-RAW-HLTDEBUG',
     '--datamix'      : 'PreMix',
@@ -1407,14 +1407,14 @@ digiPremixLocalPileupUp2015Defaults25ns = merge([digiPremixLocalPileup,
                                                  digiPremixUp2015Defaults25ns])
 digiPremixUp2015Defaults50ns=merge([{'-s':'DIGI:pdigi_valid,DATAMIX,L1,DIGI2RAW,HLT:@relval50ns'},
                                     {'--conditions':'auto:run2_mc_50ns'},
-                                    {'--pileup_input' : 'das:/RelValPREMIXUP15_PU50/%s/GEN-SIM-DIGI-RAW'%baseDataSetRelease[6]},
+                                    {'--pileup_input' : 'das:/RelValPREMIXUP15_PU50/%s/PREMIX'%baseDataSetRelease[6]},
                                     {'--era'            : 'Run2_50ns'},
                                     digiPremixUp2015Defaults25ns])
 
 digiPremixUp2017Defaults25ns = {
     '--conditions'   : 'auto:phase1_2017_realistic',
     '-s'             : 'DIGI:pdigi_valid,DATAMIX,L1,DIGI2RAW,HLT:@relval2017',
-    '--pileup_input'  :  'das:/RelValPREMIXUP17_PU25/%s/GEN-SIM-DIGI-RAW'%baseDataSetRelease[14],
+    '--pileup_input'  :  'das:/RelValPREMIXUP17_PU25/%s/PREMIX'%baseDataSetRelease[14],
     '--eventcontent' : 'FEVTDEBUGHLT',
     '--datatier'     : 'GEN-SIM-DIGI-RAW-HLTDEBUG',
     '--datamix'      : 'PreMix',
@@ -1428,7 +1428,7 @@ digiPremixLocalPileupUp2017Defaults25ns = merge([digiPremixLocalPileup,
 digiPremixUp2018Defaults25ns = {
     '--conditions'   : 'auto:phase1_2018_realistic',
     '-s'             : 'DIGI:pdigi_valid,DATAMIX,L1,DIGI2RAW,HLT:@relval2018',
-    '--pileup_input'  :  'das:/RelValPREMIXUP18_PU25/%s/GEN-SIM-DIGI-RAW'%baseDataSetRelease[15],
+    '--pileup_input'  :  'das:/RelValPREMIXUP18_PU25/%s/PREMIX'%baseDataSetRelease[15],
     '--eventcontent' : 'FEVTDEBUGHLT',
     '--datatier'     : 'GEN-SIM-DIGI-RAW-HLTDEBUG',
     '--datamix'      : 'PreMix',

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -18,19 +18,14 @@ from EventFilter.CastorRawToDigi.CastorDigiToRaw_cfi import *
 from EventFilter.RawDataCollector.rawDataCollector_cfi import *
 from L1Trigger.Configuration.L1TDigiToRaw_cff import *
 
-from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
-
 #DigiToRaw = cms.Sequence(L1TDigiToRaw*siPixelRawData*SiStripDigiToRaw*ecalPacker*esDigiToRaw*hcalRawData*cscpacker*dtpacker*rpcpacker*rawDataCollector)
 DigiToRaw = cms.Sequence(L1TDigiToRaw*siPixelRawData*SiStripDigiToRaw*ecalPacker*esDigiToRaw*hcalRawData*cscpacker*dtpacker*rpcpacker*castorRawData*rawDataCollector)
-# no L1 DigiToRaw in first PreMixing step
-premix_stage1.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([L1TDigiToRaw]))
 
 ecalPacker.Label = 'simEcalDigis'
 ecalPacker.InstanceEB = 'ebDigis'
 ecalPacker.InstanceEE = 'eeDigis'
 ecalPacker.labelEBSRFlags = "simEcalDigis:ebSrFlags"
 ecalPacker.labelEESRFlags = "simEcalDigis:eeSrFlags"
-premix_stage1.toModify(hcalRawDatauHTR, premix = True)
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([castorRawData]))

--- a/EventFilter/ESDigiToRaw/python/esDigiToRaw_cfi.py
+++ b/EventFilter/ESDigiToRaw/python/esDigiToRaw_cfi.py
@@ -6,8 +6,3 @@ esDigiToRaw = cms.EDProducer("ESDigiToRaw",
     Label = cms.string('simEcalPreshowerDigis'),
     LookupTable = cms.untracked.FileInPath('EventFilter/ESDigiToRaw/data/ES_lookup_table.dat')
 )
-
-# bypass zero suppression
-from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
-premix_stage1.toModify(esDigiToRaw, Label = 'mix')
-

--- a/EventFilter/SiStripRawToDigi/python/SiStripDigiToRaw_cfi.py
+++ b/EventFilter/SiStripRawToDigi/python/SiStripDigiToRaw_cfi.py
@@ -10,6 +10,3 @@ SiStripDigiToRaw = cms.EDProducer(
     CopyBufferHeader = cms.bool(False),
     RawDataTag = cms.InputTag('rawDataCollector')
     )
-
-from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
-premix_stage1.toModify(SiStripDigiToRaw, FedReadoutMode = 'PREMIX_RAW', PacketCode="")

--- a/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
+++ b/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
@@ -20,10 +20,6 @@ stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list
 stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("gmtStage2Raw")) )
 stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("gtStage2Raw")) )
 
-# no L1 DigiToRaw in first PreMixing step
-from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
-premix_stage1.toModify(rawDataCollector, RawCollectionList = _RawCollectionListOrig)
-
 #
 # Legacy Trigger:
 #

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -64,12 +64,3 @@ _phase2_siml1emulator += hgcalTriggerPrimitives
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 (phase2_hgcal & ~phase2_hgcalV9).toReplaceWith( SimL1Emulator , _phase2_siml1emulator )
-
-# If PreMixing, don't run these modules during first step
-# TODO: Do we actually need anything from here run in stage1?
-from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
-premix_stage1.toReplaceWith(SimL1Emulator, SimL1Emulator.copyAndExclude([
-    SimL1TCalorimeter,
-    SimL1TechnicalTriggers,
-    SimL1TGlobal
-]))

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -58,3 +58,7 @@ phase2_timing.toModify(SimCalorimetryRAW.outputCommands, func=lambda outputComma
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simEcalUnsuppressedDigis_*_*') )
 phase2_common.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simEcalUnsuppressedDigis_*_*') )
+
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+# TODO: Also the ES digi collection could be removed?
+phase2_hgcal.toModify( SimCalorimetryPREMIX.outputCommands, func=lambda outputCommands: outputCommands.append('drop EEDigiCollection_simEcalDigis_*_*') )

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -57,8 +57,7 @@ phase2_timing.toModify(SimCalorimetryRAW.outputCommands, func=lambda outputComma
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simEcalUnsuppressedDigis_*_*') )
 phase2_common.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simEcalUnsuppressedDigis_*_*') )
+phase2_common.toModify( SimCalorimetryPREMIX.outputCommands, func=lambda outputCommands: outputCommands.append('drop ESDigiCollection_simEcalUnsuppressedDigis_*_*') )
 
-from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
-phase2_ecal.toModify( SimCalorimetryPREMIX.outputCommands, func=lambda outputCommands: outputCommands.append('drop ESDigiCollection_simEcalUnsuppressedDigis_*_*') )
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( SimCalorimetryPREMIX.outputCommands, func=lambda outputCommands: outputCommands.append('drop EEDigiCollection_simEcalDigis_*_*') )

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -28,6 +28,15 @@ SimCalorimetryRECO = cms.PSet(
 SimCalorimetryAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
+SimCalorimetryPREMIX = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep EBDigiCollection_simEcalDigis_*_*',
+        'keep EEDigiCollection_simEcalDigis_*_*',
+        'keep ESDigiCollection_simEcalUnsuppressedDigis_*_*',
+        'keep *_simHcalDigis_*_*',
+        'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
+    )
+)
 
 #
 # Add extra event content if running in Run 2

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -34,7 +34,6 @@ SimCalorimetryPREMIX = cms.PSet(
         'keep EEDigiCollection_simEcalDigis_*_*',
         'keep ESDigiCollection_simEcalUnsuppressedDigis_*_*',
         'keep *_simHcalDigis_*_*',
-        'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
     )
 )
 
@@ -59,6 +58,7 @@ from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simEcalUnsuppressedDigis_*_*') )
 phase2_common.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simEcalUnsuppressedDigis_*_*') )
 
+from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
+phase2_ecal.toModify( SimCalorimetryPREMIX.outputCommands, func=lambda outputCommands: outputCommands.append('drop ESDigiCollection_simEcalUnsuppressedDigis_*_*') )
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-# TODO: Also the ES digi collection could be removed?
 phase2_hgcal.toModify( SimCalorimetryPREMIX.outputCommands, func=lambda outputCommands: outputCommands.append('drop EEDigiCollection_simEcalDigis_*_*') )

--- a/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
+++ b/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
@@ -28,8 +28,12 @@ SimGeneralAOD = cms.PSet(
                                            'keep int_*_bunchSpacing_*',
                                            'keep *_genPUProtons_*_*') 
 )
+# Event content for premixing library
+SimGeneralPREMIX = cms.PSet(
+    outputCommands = cms.untracked.vstring()
+)
 
-# mods for HGCAL
+# mods for HGCAL; should these be moved under SimCalorimetry?
 _phase2_hgc_extraCommands = cms.PSet( # using PSet in order to customize with Modifier
     v = cms.vstring('keep *_simHGCalUnsuppressedDigis_EE_*', 'keep *_simHGCalUnsuppressedDigis_HEfront_*', 'keep *_simHGCalUnsuppressedDigis_HEback_*', 'keep *_mix_MergedCaloTruth_*'),
 )
@@ -42,6 +46,7 @@ from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( SimGeneralRAW, outputCommands = SimGeneralRAW.outputCommands + _phase2_hgc_extraCommands.v )
 phase2_hgcal.toModify( SimGeneralFEVTDEBUG, outputCommands = SimGeneralFEVTDEBUG.outputCommands + _phase2_hgc_extraCommands.v )
 phase2_hgcal.toModify( SimGeneralRECO, outputCommands = SimGeneralRECO.outputCommands + _phase2_hgc_extraCommands.v )
+phase2_hgcal.toModify( SimGeneralPREMIX, outputCommands = SimGeneralPREMIX.outputCommands + _phase2_hgc_extraCommands.v )
 
 _phase2_timing_extraCommands = [ 'keep *_mix_FTLBarrel_*','keep *_mix_FTLEndcap_*','keep *_mix_InitialVertices_*' ]
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -14,52 +14,11 @@ from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2Tracke
 from SimGeneral.MixingModule.ecalDigitizer_cfi import ecalDigitizer
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer, hfnoseDigitizer
 
-import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
-import EventFilter.ESRawToDigi.esRawToDigi_cfi
-import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
-import EventFilter.DTRawToDigi.dtunpacker_cfi
-import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
-import EventFilter.CSCRawToDigi.cscUnpacker_cfi
-import EventFilter.SiStripRawToDigi.SiStripDigis_cfi
-import EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi
-
-# content from Configuration/StandardSequences/DigiToRaw_cff.py
-
-ecalDigis = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone()
-
-ecalPreshowerDigis = EventFilter.ESRawToDigi.esRawToDigi_cfi.esRawToDigi.clone()
-
-hcalDigis = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone()
-
-muonCSCDigis = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone()
-
-muonDTDigis = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone()
-
-siStripDigis = EventFilter.SiStripRawToDigi.SiStripDigis_cfi.siStripDigis.clone()
-
-siPixelDigis = EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi.siPixelDigis.clone()
-
-siPixelDigis.InputLabel = 'rawDataCollector'
-ecalDigis.InputLabel = 'rawDataCollector'
-ecalPreshowerDigis.sourceTag = 'rawDataCollector'
-hcalDigis.InputLabel = 'rawDataCollector'
-muonCSCDigis.InputObjects = 'rawDataCollector'
-muonDTDigis.inputLabel = 'rawDataCollector'
-
-hcalDigis.FilterDataQuality = cms.bool(False)
 hcalSimBlock.HcalPreMixStage2 = cms.bool(True)
 
 mixData = cms.EDProducer("PreMixingModule",
     input = cms.SecSource("EmbeddedRootSource",
-        producers = cms.VPSet(cms.convertToVPSet(
-                ecalDigis = ecalDigis,
-                ecalPreshowerDigis = ecalPreshowerDigis,
-                hcalDigis = hcalDigis,
-                muonDTDigis = muonDTDigis,
-                muonCSCDigis = muonCSCDigis,
-                siStripDigis = siStripDigis,
-                siPixelDigis = siPixelDigis,
-        )),
+        producers = cms.VPSet(),
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),
@@ -93,7 +52,7 @@ mixData = cms.EDProducer("PreMixingModule",
             ),
             workerType = cms.string("PreMixingSiPixelWorker"),
             pixeldigiCollectionSig = cms.InputTag("simSiPixelDigis"),
-            pixeldigiCollectionPile = cms.InputTag("siPixelDigis","","@MIXING"),
+            pixeldigiCollectionPile = cms.InputTag("simSiPixelDigis"),
             PixelDigiCollectionDM = cms.string('siPixelDigisDM'),                   
         ),
         strip = cms.PSet(
@@ -101,7 +60,7 @@ mixData = cms.EDProducer("PreMixingModule",
             workerType = cms.string("PreMixingSiStripWorker"),
 
             SistripLabelSig = cms.InputTag("simSiStripDigis","ZeroSuppressed"),
-            SiStripPileInputTag = cms.InputTag("siStripDigis","ZeroSuppressed","@MIXING"),
+            SiStripPileInputTag = cms.InputTag("simSiStripDigis","ZeroSuppressed"),
             # Dead APV Vector
             SistripAPVPileInputTag = cms.InputTag("mix","AffectedAPVList"),
             SistripAPVLabelSig = cms.InputTag("mix","AffectedAPVList"),
@@ -117,9 +76,9 @@ mixData = cms.EDProducer("PreMixingModule",
             EEdigiProducerSig = cms.InputTag("simEcalUnsuppressedDigis"),
             ESdigiProducerSig = cms.InputTag("simEcalPreshowerDigis"),
 
-            EBPileInputTag = cms.InputTag("ecalDigis","ebDigis","@MIXING"),
-            EEPileInputTag = cms.InputTag("ecalDigis","eeDigis","@MIXING"),
-            ESPileInputTag = cms.InputTag("ecalPreshowerDigis","","@MIXING"),
+            EBPileInputTag = cms.InputTag("simEcalDigis", "ebDigis"),
+            EEPileInputTag = cms.InputTag("simEcalDigis", "eeDigis"),
+            ESPileInputTag = cms.InputTag("simEcalUnsuppressedDigis"),
 
             EBDigiCollectionDM   = cms.string(''),
             EEDigiCollectionDM   = cms.string(''),
@@ -136,11 +95,11 @@ mixData = cms.EDProducer("PreMixingModule",
             QIE11digiCollectionSig = cms.InputTag("simHcalUnsuppressedDigis"),
             ZDCdigiCollectionSig   = cms.InputTag("simHcalUnsuppressedDigis"),
 
-            HBHEPileInputTag = cms.InputTag("hcalDigis","","@MIXING"),
-            HOPileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
-            HFPileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
-            QIE10PileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
-            QIE11PileInputTag   = cms.InputTag("hcalDigis","","@MIXING"),
+            HBHEPileInputTag = cms.InputTag("simHcalDigis"),
+            HOPileInputTag   = cms.InputTag("simHcalDigis"),
+            HFPileInputTag   = cms.InputTag("simHcalDigis"),
+            QIE10PileInputTag   = cms.InputTag("simHcalDigis", "HFQIE10DigiCollection"),
+            QIE11PileInputTag   = cms.InputTag("simHcalDigis", "HBHEQIE11DigiCollection"),
             ZDCPileInputTag  = cms.InputTag(""),
 
             HBHEDigiCollectionDM = cms.string(''),
@@ -153,30 +112,30 @@ mixData = cms.EDProducer("PreMixingModule",
         dt = cms.PSet(
             workerType = cms.string("PreMixingDTWorker"),
             digiTagSig = cms.InputTag("simMuonDTDigis"),
-            pileInputTag = cms.InputTag("muonDTDigis","","@MIXING"),
+            pileInputTag = cms.InputTag("simMuonDTDigis"),
             collectionDM = cms.string(''),
         ),
         rpc = cms.PSet(
             workerType = cms.string("PreMixingRPCWorker"),
             digiTagSig = cms.InputTag("simMuonRPCDigis"),                   
-            pileInputTag = cms.InputTag("simMuonRPCDigis",""),
+            pileInputTag = cms.InputTag("simMuonRPCDigis"),
             collectionDM = cms.string(''),
         ),
         csc = cms.PSet(
             workerType = cms.string("PreMixingCSCWorker"),
             strip = cms.PSet(
                 digiTagSig = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigi"),
-                pileInputTag = cms.InputTag("muonCSCDigis","MuonCSCStripDigi","@MIXING"),
+                pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigi"),
                 collectionDM = cms.string('MuonCSCStripDigisDM'),
             ),
             wire = cms.PSet(
                 digiTagSig = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigi"),
-                pileInputTag = cms.InputTag("muonCSCDigis","MuonCSCWireDigi","@MIXING"),
+                pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigi"),
                 collectionDM = cms.string('MuonCSCWireDigisDM'),
             ),
             comparator = cms.PSet(
                 digiTagSig = cms.InputTag("simMuonCSCDigis","MuonCSCComparatorDigi"),
-                pileInputTag = cms.InputTag("muonCSCDigis","MuonCSCComparatorDigi","@MIXING"),
+                pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCComparatorDigi"),
                 collectionDM = cms.string('MuonCSCComparatorDigisDM'),
             ),
         ),

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -243,26 +243,13 @@ phase2_tracker.toModify(mixData,
 )
 
 # ECAL
-phase2_ecal.toModify(mixData,
-    workers = dict(
-        ecal = dict(
-            doES = False,
-            EBPileInputTag = "simEcalDigis:ebDigis",
-            EEPileInputTag = "simEcalDigis:eeDigis",
-        )
-    )
-)
+phase2_ecal.toModify (mixData, workers=dict(ecal=dict(doES=False)))
 phase2_hgcal.toModify(mixData, workers=dict(ecal=dict(doEE=False)))
 
 # HCAL
 phase2_hcal.toModify(mixData,
     workers = dict(
         hcal = dict(
-            HBHEPileInputTag = "simHcalDigis",
-            HOPileInputTag = "simHcalDigis",
-            HFPileInputTag = "simHcalDigis",
-            QIE10PileInputTag = "simHcalDigis:HFQIE10DigiCollection",
-            QIE11PileInputTag = "simHcalDigis:HBHEQIE11DigiCollection",
             ZDCPileInputTag = "simHcalUnsuppressedDigis",
         )
     )
@@ -312,13 +299,6 @@ phase2_hfnose.toModify(mixData,
 # Muon
 phase2_muon.toModify(mixData,
     workers = dict(
-        dt = dict(pileInputTag = "simMuonDTDigis"),
-        rpc = dict(pileInputTag = "simMuonRPCDigis"),
-        csc = dict(
-            strip = dict(pileInputTag = "simMuonCSCDigis:MuonCSCStripDigi"),
-            wire = dict(pileInputTag = "simMuonCSCDigis:MuonCSCWireDigi"),
-            comparator = dict(pileInputTag = "simMuonCSCDigis:MuonCSCComparatorDigi"),
-        ),
         gem = cms.PSet(
             workerType = cms.string("PreMixingGEMWorker"),
             digiTagSig = cms.InputTag("simMuonGEMDigis"),

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -205,7 +205,6 @@ fastSim.toModify(mixData,
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
@@ -243,7 +242,7 @@ phase2_tracker.toModify(mixData,
 )
 
 # ECAL
-phase2_ecal.toModify (mixData, workers=dict(ecal=dict(doES=False)))
+phase2_common.toModify (mixData, workers=dict(ecal=dict(doES=False)))
 phase2_hgcal.toModify(mixData, workers=dict(ecal=dict(doEE=False)))
 
 # HGCAL

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -246,15 +246,7 @@ phase2_tracker.toModify(mixData,
 phase2_ecal.toModify (mixData, workers=dict(ecal=dict(doES=False)))
 phase2_hgcal.toModify(mixData, workers=dict(ecal=dict(doEE=False)))
 
-# HCAL
-phase2_hcal.toModify(mixData,
-    workers = dict(
-        hcal = dict(
-            ZDCPileInputTag = "simHcalUnsuppressedDigis",
-        )
-    )
-)
-
+# HGCAL
 phase2_hgcal.toModify(mixData,
     workers = dict(
         hgcee = cms.PSet(

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -78,12 +78,25 @@ SimMuonAOD = cms.PSet(
 )
 SimMuonRECO.outputCommands.extend(SimMuonAOD.outputCommands)
 
+# Event content for premixing library
+SimMuonPREMIX = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_simMuonDTDigis_*_*',
+        'keep *_simMuonCSCDigis_*_*',
+        'keep *_simMuonCscTriggerPrimitiveDigis_*_*',
+        'keep *_simMuonRPCDigis_*_*',
+    )
+)
+
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonGEMDigis_*_*',
                                                                                               'keep *_simMuonGEMPadDigis_*_*',
                                                                                               'keep *_simMuonGEMPadDigiClusters_*_*'] )
 run2_GEM_2017.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 run2_GEM_2017.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+run2_GEM_2017.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_simMuonGEMDigis_*_*',
+                                                                                        'keep *_*_GEMDigiSimLink_*',
+                                                                                        'keep *_*_GEMStripDigiSimLink_*'] )
 
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
@@ -92,6 +105,9 @@ run3_GEM.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCom
                                                                                          'keep *_simMuonGEMPadDigiClusters_*_*'] )
 run3_GEM.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 run3_GEM.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+run3_GEM.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_simMuonGEMDigis_*_*',
+                                                                                   'keep *_*_GEMDigiSimLink_*',
+                                                                                   'keep *_*_GEMStripDigiSimLink_*'] )
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonME0PseudoDigis_*_*',

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -117,6 +117,11 @@ phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.output
                                                                                             'keep *_simMuonME0PadDigiClusters_*_*'] )
 phase2_muon.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
 phase2_muon.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
+phase2_muon.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_simMuonME0Digis_*_*',
+                                                                                      'keep *_mix_g4SimHitsMuonME0Hits_*',
+                                                                                      'keep *_*_ME0DigiSimLink_*',
+                                                                                      'keep *_*_ME0StripDigiSimLink_*'] )
+
 
 # For phase2 premixing switch the sim digi collections to the ones including pileup
 (premix_stage2 & phase2_muon).toModify(SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + [

--- a/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
@@ -48,4 +48,12 @@ SimTrackerAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_allTrackMCMatch_*_*')
 )
 
-
+# Event content for premixing library
+SimTrackerPREMIX = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_simSiPixelDigis_*_*', # covers digis and digiSimLinks
+        'keep *_simSiStripDigis_ZeroSuppressed_*',
+        'keep StripDigiSimLinkedmDetSetVector_simSiStripDigis_*_*',
+        'keep *_mix_AffectedAPVList_*',
+    )
+)

--- a/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
@@ -57,3 +57,8 @@ SimTrackerPREMIX = cms.PSet(
         'keep *_mix_AffectedAPVList_*',
     )
 )
+phase2_tracker.toModify(SimTrackerPREMIX, outputCommands = [
+        'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
+        'keep *_*_Phase2OTDigiSimLink_*',
+        'keep *_simSiPixelDigis_*_*', # covers digis and digiSimLinks
+])


### PR DESCRIPTION
The premixing for phase2 is already using (sim) DIGI as the premixing library format, because it allows simplicity (no need to pack+unpack) with only tiny cost in the file size. As outlined in the spring O&C week
https://indico.cern.ch/event/711343/contributions/2964389/attachments/1631761/2601778/slides_premix_20180412.pdf
this PR does the same for the run2 premixing. In addition
* L1 is removed as unnecessary from the stage1 workflow (=produces the premixing library)
* PREMIX event content definitions are distributed to the corresponding packages
  * I hope this to be yet another step for others to become better aware of what happens in premixing

Since the packing+unpacking are (or can be) lossy, there will be small changes in run2 FullSim and FastSim. However, the changes should be towards the classical mixing (as the workflow becomes more similar), and this is what I see e.g. for CSC digis.

Here are links (to my private DQM GUI; black is the release and blue this PR) to 100-event comparison of 250202.181 (2018 ttbar+PU FullSim)
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_2_0-PU50_2018_premixing_100ev_orig_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_2_0-PU50_2018_premixing_100ev_dev_v1-v1/DQMIO%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;

10-event for 250202.171 (2017)
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_2_0-PU35_2017_premixing_10ev_orig_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_2_0-PU35_2017_premixing_10ev_dev_v1-v1/DQMIO%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;

250202.1 (2016)
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_2_0-PU35_2016_premixing_10ev_orig_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_2_0-PU35_2016_premixing_10ev_dev_v1-v1/DQMIO%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;

and 250402.1 (2016 FastSim, added in #24149)
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_2_0-PU35_FS2016_premixing_10ev_orig_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_2_0-PU35_FS2016_premixing_10ev_dev_v1-v1/DQMIO%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;

with the following SSH tunnel recipe
```
ssh -L8081:mkdev.cern.ch:8081 lxplus.cern.ch
http://127.0.0.1:8081/dqm/relval/
```

Tested in 10_2_0 (rebased on top of ~CMSSW_10_3_X_2018-08-29-2300~ CMSSW_10_3_X_2018-09-04-1100), expecting small changes in run2 FullSim and FastSim premixing, but no changes in phase2 (FullSim) premixing. Because the premixing library format changes, this PR breaks all stage2-only premixing workflows.

@kpedro88 @mdhildreth 