### PR TITLE
do not drop gen information with DIGI:pdigi_hi_nogen option

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1416,7 +1416,7 @@ class ConfigBuilder(object):
         if sequence == 'pdigi_valid' or sequence == 'pdigi_hi':
             self.executeAndRemember("process.mix.digitizers = cms.PSet(process.theDigitizersValid)")
 
-        if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and not self.process.source.type_()=='EmptySource':
+        if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and sequence != 'pdigi_hi_nogen' and not self.process.source.type_()=='EmptySource':
             if self._options.inputEventContent=='':
                 self._options.inputEventContent='REGEN'
             else:

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -38,7 +38,7 @@ pdigi_valid_nogen=cms.Sequence(pdigi_nogen)
 
 from GeneratorInterface.HiGenCommon.HeavyIon_cff import *
 pdigi_hi=cms.Sequence(pdigi+heavyIon)
-pdigi_hi_nogen=cms.Sequence(pdigi_nogen+heavyIon)
+pdigi_hi_nogen=cms.Sequence(pdigi_nogen+genJetMET+heavyIon)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 def _fastSimDigis(process):


### PR DESCRIPTION
in heavy ion workflows, the genParticles collection created at the GEN-SIM step, which contains gen particle information from both the signal and embedded event, is dropped at the DIGI step. when the genParticles collection is re-made at the DIGI step, the gen particle information from the embedded event is 'lost' because the required input (a edm::CrossingFrame<HepMCProduct> collection) is not available.

this PR changes the cmsDriver.py config builder such that the gen information from the GEN-SIM step is not dropped when using the 'DIGI:pdigi_hi_nogen' option. for this option, the genParticles collection is not re-made at the DIGI step, so the output now contains only the genParticles collection from the GEN-SIM step. the effect of the change is to make the gen particle information from the embedded event available in the final output.

please let us know if this workaround is acceptable. if not, could you please advise us on the proper solution so that the gen particle information from the embedded event can be made available.

thanks!

@mandrenguyen @ttrk 