### PR TITLE
add hiCentrality and hiClusterCompatibility to pp_on_AA era

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -157,8 +157,7 @@ from RecoHI.HiCentralityAlgos.HiClusterCompatibility_cfi import hiClusterCompati
 _highlevelreco_HI = highlevelreco.copy()
 _highlevelreco_HI += hiCentrality
 _highlevelreco_HI += hiClusterCompatibility
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(highlevelreco, _highlevelreco_HI)
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(highlevelreco, _highlevelreco_HI)
 
 # not commisoned and not relevant in FastSim (?):
 _fastSim_highlevelreco = highlevelreco.copyAndExclude([cosmicDCTracksSeq,muoncosmichighlevelreco])

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -149,14 +149,16 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
                              cosmicDCTracksSeq
                              )
 
-# XeXe data with pp reco
+# AA data with pp reco
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoHI.HiCentralityAlgos.HiCentrality_cfi import hiCentrality
 from RecoHI.HiCentralityAlgos.HiClusterCompatibility_cfi import hiClusterCompatibility
 _highlevelreco_HI = highlevelreco.copy()
 _highlevelreco_HI += hiCentrality
 _highlevelreco_HI += hiClusterCompatibility
-pp_on_XeXe_2017.toReplaceWith(highlevelreco, _highlevelreco_HI)
+for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
+    e.toReplaceWith(highlevelreco, _highlevelreco_HI)
 
 # not commisoned and not relevant in FastSim (?):
 _fastSim_highlevelreco = highlevelreco.copyAndExclude([cosmicDCTracksSeq,muoncosmichighlevelreco])


### PR DESCRIPTION
Processing of AA events requires the addition of these two collections.  This was done for the XeXe era (pp_on_XeXe_2017), but somehow when creating a new era for this year's PbPb run (pp_on_AA_2018), I accidentally dropped this.   

Only a very tiny change to CPU and data volume are expected, which can be tested with wf 158.

As with other HI PR's these days, there is no impact on pp workflows, so we request a 10_2 backport. 