### PR TITLE
[10.3.X] [Change GTs] Update L1T + change 2018MC trackerAl + DynInEff

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -50,9 +50,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '103X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '103X_postLS2_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '102X_dataRun2_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '102X_dataRun2_relval_v4',
+    'run2_data_relval'  :   '103X_dataRun2_relval_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '102X_dataRun2_PromptLike_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
@@ -36,7 +36,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '102X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'   :   '103X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -48,17 +48,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '102X_upgrade2018_design_v6',
+    'phase1_2018_design'       : '103X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v9',
+    'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v8',
+    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '102X_postLS2_design_v5', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '103X_postLS2_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '102X_postLS2_realistic_v5', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '103X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '102X_upgrade2023_realistic_v7'
+    'phase2_realistic'         : '103X_upgrade2023_realistic_v1'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '102X_dataRun2_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '103X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '103X_dataRun2_relval_v2',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '102X_dataRun2_PromptLike_v4',
     # GlobalTag for Run1 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -52,7 +52,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '103X_postLS2_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
###  2018 MC
.   [103X_upgrade2018_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_design_v6/103X_upgrade2018_design_v1)
.  L1T menu
.   [103X_upgrade2018_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_realistic_v9/103X_upgrade2018_realistic_v2)
.  L1T menu
.  Tracker Alignment scenario
.   [103X_upgrade2018cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018cosmics_realistic_deco_v8/103X_upgrade2018cosmics_realistic_deco_v3)
.  L1T menu
.  Tracker Alignment scenario

###  PostLS2 MC
.   [103X_postLS2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_postLS2_design_v5/103X_postLS2_design_v1)
.  L1T menu
.   [103X_postLS2_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_postLS2_realistic_v5/103X_postLS2_realistic_v1)
.  L1T menu

###  2023 MC
.   [103X_upgrade2023_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2023_realistic_v7/103X_upgrade2023_realistic_v1)
.  L1T menu

###  Data
.  [103X_dataRun2_relval_v2](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_relval_v4/103X_dataRun2_relval_v2)
.  L1T menu
.   [103X_dataRun2_HLT_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_HLT_relval_v1/103X_dataRun2_HLT_relval_v1)
.  L1T menu