### PR TITLE
Fix cross product for gcc 8

### DIFF
--- a/DataFormats/Math/interface/SSEVec.h
+++ b/DataFormats/Math/interface/SSEVec.h
@@ -60,8 +60,9 @@ namespace mathSSE {
     v4 = _mm_shuffle_ps(v2, v1, _MM_SHUFFLE(3, 1, 0, 1));
     
     v3 = _mm_mul_ps(v3, v4);
-    const  __m128 neg = _mm_set_ps(0.0f,0.0f,-0.0f,0.0f);
-    return _mm_xor_ps(_mm_sub_ps(v5, v3), neg);
+    const __m128i neg = _mm_set_epi32(0,0,0x80000000,0);
+    __m128i ret = __m128i(_mm_sub_ps(v5, v3));
+    return __m128(_mm_xor_si128(ret,neg));
   }
 #endif // CMS_USE_SSE
 

--- a/DataFormats/Math/interface/SSEVec.h
+++ b/DataFormats/Math/interface/SSEVec.h
@@ -95,9 +95,9 @@ namespace mathSSE {
     v4 = _mm256_permute_pd(v4,5);
     
     v3 = _mm256_mul_pd(v3, v4);
-    const  __m256d neg = _mm256_set_pd(0.0,0.0,-0.0,0.0);
-    return _mm256_xor_pd(_mm256_sub_pd(v5, v3), neg);
- 
+     __m256d ret = _mm256_sub_pd(v5, v3);
+    const  __m256i neg = _mm256_set_epi64x(0,0,0x8000000000000000,0);
+    return __m256d(_mm256_xor_si256(__m256i(ret), neg));
   }
 
 #endif //  CMS_USE_AVX
@@ -885,14 +885,14 @@ inline double dot(mathSSE::Vec4D a, mathSSE::Vec4D b) {
 inline mathSSE::Vec4D cross(mathSSE::Vec4D a, mathSSE::Vec4D b) __attribute__((always_inline)) __attribute__ ((pure));
 
 inline mathSSE::Vec4D cross(mathSSE::Vec4D a, mathSSE::Vec4D b) {
-  const __m128d neg = _mm_set_pd ( 0.0 , -0.0 );
+  const __m128i neg = _mm_set_epi64x( 0, 0x8000000000000000 );
   // lh .z * rh .x , lh .z * rh .y
   __m128d l1 = _mm_mul_pd ( _mm_unpacklo_pd ( a.vec[1] , a.vec[1] ), b.vec[0] );
   // rh .z * lh .x , rh .z * lh .y
   __m128d l2 = _mm_mul_pd ( _mm_unpacklo_pd (  b.vec[1],  b.vec[1] ),  a.vec[0] );
   __m128d m1 = _mm_sub_pd ( l1 , l2 ); // l1 - l2
   m1 = _mm_shuffle_pd ( m1 , m1 , 1 ); // switch the elements
-  m1 = _mm_xor_pd ( m1 , neg ); // change the sign of the first element
+  m1 = __m128d(_mm_xor_si128 ( __m128i(m1) , neg )); // change the sign of the first element
   // lh .x * rh .y , lh .y * rh .x
   l1 = _mm_mul_pd (  a.vec[0] , _mm_shuffle_pd (  b.vec[0] ,  b.vec[0] , 1 ) );
   // lh .x * rh .y - lh .y * rh .x

--- a/DataFormats/Math/test/BuildFile.xml
+++ b/DataFormats/Math/test/BuildFile.xml
@@ -34,6 +34,9 @@
 </release>
 <bin   file="SSEVec_t.cpp" name="DataFormatsSSEVec_t">
 </bin>
+<bin   file="crossV4_t.cpp" name="DataFormatscrossV4_t">
+  <flags CXXFLAGS="-Ofast"/>
+</bin>
 <bin   file="sign_t.cpp" name="DataFormatsSign_t">
 </bin>
 <bin   file="eta_t.cpp" name="DataFormatsEta_t">

--- a/DataFormats/Math/test/crossV4_t.cpp
+++ b/DataFormats/Math/test/crossV4_t.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include "DataFormats/Math/interface/SSEVec.h"
+
+int main() {
+
+  mathSSE::Vec4<float> yAxis(-0.0144846,0.932024,-0.362108);
+  mathSSE::Vec4<float> zAxis(-0.204951,0.351689,0.913406);
+    
+  auto xAxis = ::cross(yAxis,zAxis);
+
+  const mathSSE::Vec4<float> correctXAxis(0.978666,0.0874447,0.185925);
+   std::cout <<" x axis "<<xAxis<<std::endl;
+   if ( abs(xAxis.o.theX-correctXAxis.o.theX )> 0.000001 or
+        abs(xAxis.o.theY-correctXAxis.o.theY) > 0.000001 or
+        abs(xAxis.o.theZ-correctXAxis.o.theZ) > 0.000001) {
+     std::cout <<"BAD since not same as "<<correctXAxis<<std::endl;
+     return 1;
+   }
+
+   return 0;
+}
+

--- a/DataFormats/Math/test/crossV4_t.cpp
+++ b/DataFormats/Math/test/crossV4_t.cpp
@@ -2,7 +2,7 @@
 #include "DataFormats/Math/interface/SSEVec.h"
 
 int main() {
-
+{
   mathSSE::Vec4<float> yAxis(-0.0144846,0.932024,-0.362108);
   mathSSE::Vec4<float> zAxis(-0.204951,0.351689,0.913406);
     
@@ -16,6 +16,23 @@ int main() {
      std::cout <<"BAD since not same as "<<correctXAxis<<std::endl;
      return 1;
    }
+}
+{
+  mathSSE::Vec4<double> yAxis(-0.0144846,0.932024,-0.362108);
+  mathSSE::Vec4<double> zAxis(-0.204951,0.351689,0.913406);
+
+  auto xAxis = ::cross(yAxis,zAxis);
+
+  const mathSSE::Vec4<float> correctXAxis(0.978666,0.0874447,0.185925);
+   std::cout <<" x axis "<<xAxis<<std::endl;
+   if ( abs(xAxis.o.theX-correctXAxis.o.theX )> 0.000001 or
+        abs(xAxis.o.theY-correctXAxis.o.theY) > 0.000001 or
+        abs(xAxis.o.theZ-correctXAxis.o.theZ) > 0.000001) {
+     std::cout <<"BAD since not same as "<<correctXAxis<<std::endl;
+     return 1;
+   }
+}
+
 
    return 0;
 }


### PR DESCRIPTION
gcc 8 decided for undefined (weird) behavior when -0.0 is involved in case of fast-math
move to integer (assembler identical!)

see issue #24203 

will force compilation of the universe...