### PR TITLE
Fix GCC 8 compiler warnings. Object used after out of scope.

### DIFF
--- a/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
@@ -75,8 +75,7 @@ FWCandidateHGCalLegoProxyBuilder::localModelChanges( const FWModelId &iId, TEveE
    {
       TEveElement *el = (parent)->FirstChild();       // There is only one child
       FWLegoCandidate *candidate = dynamic_cast<FWLegoCandidate*> (el);
-      const FWDisplayProperties &dp = item()->modelInfo( iId.index() ).displayProperties();
-      candidate->SetMarkerColor( dp.color() );
+      candidate->SetMarkerColor( item()->modelInfo( iId.index() ).displayProperties().color() );
       candidate->ElementChanged();
    }
 }

--- a/Fireworks/Candidates/plugins/FWCandidateLegoProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateLegoProxyBuilder.cc
@@ -78,8 +78,7 @@ FWCandidateLegoProxyBuilder::localModelChanges( const FWModelId &iId, TEveElemen
    {
       TEveElement *el = (parent)->FirstChild();       // There is only one child
       FWLegoCandidate *candidate = dynamic_cast<FWLegoCandidate*> (el);
-      const FWDisplayProperties &dp = item()->modelInfo( iId.index() ).displayProperties();
-      candidate->SetMarkerColor( dp.color() );
+      candidate->SetMarkerColor( item()->modelInfo( iId.index() ).displayProperties().color() );
       candidate->ElementChanged();
    }
 }

--- a/Fireworks/Core/src/FWModelContextMenuHandler.cc
+++ b/Fireworks/Core/src/FWModelContextMenuHandler.cc
@@ -125,10 +125,9 @@ FWModelContextMenuHandler::chosenItem(Int_t iChoice)
       case kSetVisibleMO:
       {
          FWModelId id = *(m_selectionManager->selected().begin());
-         const FWDisplayProperties& props = id.item()->modelInfo(id.index()).displayProperties();
          for_each(m_selectionManager->selected().begin(),
                   m_selectionManager->selected().end(), 
-                  change_visibility(!props.isVisible())
+                  change_visibility(!id.item()->modelInfo(id.index()).displayProperties().isVisible())
                   );
          break;
       }
@@ -253,8 +252,7 @@ FWModelContextMenuHandler::showSelectedModelContext(Int_t iX, Int_t iY, FWViewCo
 
    //setup the menu based on this object
    FWModelId id = *(m_selectionManager->selected().begin());
-   const FWDisplayProperties& props = id.item()->modelInfo(id.index()).displayProperties();
-   if(props.isVisible()) {
+   if(id.item()->modelInfo(id.index()).displayProperties().isVisible()) {
       m_modelPopup->CheckEntry(kSetVisibleMO);
    }else {
       m_modelPopup->UnCheckEntry(kSetVisibleMO);

--- a/Fireworks/Core/src/FWProxyBuilderBase.cc
+++ b/Fireworks/Core/src/FWProxyBuilderBase.cc
@@ -495,8 +495,8 @@ FWProxyBuilderBase::increaseComponentTransparency(unsigned int index, TEveElemen
 {
    // Helper function to increse transparency of certain components.
 
-   const FWDisplayProperties& dp = item()->modelInfo(index).displayProperties();
-   Char_t transp = TMath::Min(100, transpOffset + (100 - transpOffset) * dp.transparency() / 100);
+   Char_t transparency = item()->modelInfo(index).displayProperties().transparency();
+   Char_t transp = TMath::Min(100, transpOffset + (100 - transpOffset) * transparency / 100);
    TEveElement::List_t matches;
    holder->FindChildren(matches, name.c_str());
    for (TEveElement::List_i m = matches.begin(); m != matches.end(); ++m)

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidatesLegoProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidatesLegoProxyBuilder.cc
@@ -97,8 +97,7 @@ FWPFCandidatesLegoProxyBuilder::localModelChanges(const FWModelId& iId, TEveElem
    {
       TEveElement* el = (parent)->FirstChild();  // we know there is only one child added in this proxy builder
       FWLegoCandidate *candidate = dynamic_cast<FWLegoCandidate*> (el);
-      const FWDisplayProperties& dp = item()->modelInfo(iId.index()).displayProperties();
-      candidate->SetMarkerColor( dp.color());
+      candidate->SetMarkerColor( item()->modelInfo(iId.index()).displayProperties().color());
       candidate->ElementChanged();
    }  
 }

--- a/Fireworks/ParticleFlow/plugins/FWPFClusterLegoProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFClusterLegoProxyBuilder.cc
@@ -11,8 +11,7 @@ FWPFClusterLegoProxyBuilder::localModelChanges( const FWModelId &iId, TEveElemen
         for( TEveElement::List_i j = parent->BeginChildren(); j != parent->EndChildren(); j++ )
         {
             FWLegoCandidate *cluster = dynamic_cast<FWLegoCandidate*>( *j );
-            const FWDisplayProperties &dp = FWProxyBuilderBase::item()->modelInfo( iId.index() ).displayProperties();
-            cluster->SetMarkerColor( dp.color() );
+            cluster->SetMarkerColor( FWProxyBuilderBase::item()->modelInfo( iId.index() ).displayProperties().color() );
             cluster->ElementChanged();
         }
     }

--- a/Fireworks/ParticleFlow/plugins/FWPFEcalRecHitLegoProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFEcalRecHitLegoProxyBuilder.cc
@@ -30,8 +30,7 @@ FWPFEcalRecHitLegoProxyBuilder::localModelChanges( const FWModelId &iId, TEveEle
          TEveStraightLineSet* line = dynamic_cast<TEveStraightLineSet*>(*i);
          if (line)
          {
-            const FWDisplayProperties &p = item()->modelInfo( iId.index() ).displayProperties();
-            line->SetMarkerColor( p.color() );
+            line->SetMarkerColor( item()->modelInfo( iId.index() ).displayProperties().color() );
          }
       }
    }

--- a/Fireworks/ParticleFlow/plugins/FWPFPatJetLegoProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFPatJetLegoProxyBuilder.cc
@@ -56,8 +56,7 @@ FWPFPatJetLegoProxyBuilder<T>::localModelChanges(const FWModelId& iId, TEveEleme
       for( TEveElement::List_i j = parent->BeginChildren(); j != parent->EndChildren(); ++j )
       {
          FWLegoCandidate *cand = dynamic_cast<FWLegoCandidate*> ( *j );
-         const FWDisplayProperties &dp = FWProxyBuilderBase::item()->modelInfo( iId.index() ).displayProperties();
-         cand->SetMarkerColor( dp.color() );
+         cand->SetMarkerColor( FWProxyBuilderBase::item()->modelInfo( iId.index() ).displayProperties().color() );
          cand->ElementChanged();
       }
    }


### PR DESCRIPTION
This fixes the same bug repeated 10 times in the
Fireworks code. modelInfo returns by value and that
temporary goes out of scope before it is used. It
doesn't help that a const reference to one of its
data members is held. I do not know what effect this
bug had although it appears to be a real bug.