### PR TITLE
Removed unused variables in Calibration/IsolatedParticles

### DIFF
--- a/Calibration/IsolatedParticles/interface/CaloSimInfo.icc
+++ b/Calibration/IsolatedParticles/interface/CaloSimInfo.icc
@@ -227,9 +227,6 @@ namespace spr{
       unsigned int matchSimTrk = trkInfo->trackId();
       matchedId                = trkInfo->type();         //pdgid
 
-      edm::SimTrackContainer::const_iterator simTrkItr;
-      edm::SimVertexContainer::const_iterator simVtxItr;
-    
       for (unsigned int ihit=0; ihit<hit.size(); ihit++) {
 
 	DetId id_ = (DetId)(hit[ihit]->id());
@@ -245,7 +242,7 @@ namespace spr{
           } else { 
          // trace back the history and check the pdgId of origin SimTrack of SimHit
 	    bool found = false;
-	    for (simTrkItr = SimTk->begin(); simTrkItr!= SimTk->end(); simTrkItr++) {
+	    for (auto simTrkItr = SimTk->begin(); simTrkItr!= SimTk->end(); simTrkItr++) {
 	      if (hit[ihit]->geantTrackId() == (int)simTrkItr->trackId()) {
   	        found = true;
 	        bool match = spr::validSimTrack(matchSimTrk, simTrkItr, SimTk, SimVtx, debug);
@@ -429,9 +426,6 @@ namespace spr{
       unsigned int matchSimTrk = trkInfo->trackId();
       matchedId                = trkInfo->type();         //pdgid
 
-      edm::SimTrackContainer::const_iterator simTrkItr;
-      edm::SimVertexContainer::const_iterator simVtxItr;
-    
       // Loop over hits
       for (unsigned int ihit=0; ihit<hit.size(); ihit++) {
       
@@ -452,7 +446,7 @@ namespace spr{
 	  nMatched++;
 	} else {
 	  bool found = false;
-	  for (simTrkItr = SimTk->begin(); simTrkItr!= SimTk->end(); simTrkItr++) {
+	  for (auto simTrkItr = SimTk->begin(); simTrkItr!= SimTk->end(); simTrkItr++) {
 	    if (hit[ihit]->geantTrackId() == (int)simTrkItr->trackId()) {
 	      found = true;
 	      bool match = spr::validSimTrack(matchSimTrk, simTrkItr, SimTk, SimVtx, debug);

--- a/Calibration/IsolatedParticles/plugins/HcalHBHEMuonSimAnalyzer.cc
+++ b/Calibration/IsolatedParticles/plugins/HcalHBHEMuonSimAnalyzer.cc
@@ -143,7 +143,6 @@ void HcalHBHEMuonSimAnalyzer::analyze(const edm::Event& iEvent,
   //get Handles to SimTracks and SimHits
   edm::Handle<edm::SimTrackContainer> SimTk;
   iEvent.getByToken(tok_SimTk_,SimTk);
-  edm::SimTrackContainer::const_iterator simTrkItr;
   edm::Handle<edm::SimVertexContainer> SimVtx;
   iEvent.getByToken(tok_SimVtx_,SimVtx);
 

--- a/Calibration/IsolatedParticles/plugins/IsoTrackCalib.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrackCalib.cc
@@ -273,7 +273,6 @@ void IsoTrackCalib::analyze(const edm::Event& iEvent,
   //Get track collection
   edm::Handle<reco::TrackCollection> trkCollection;
   iEvent.getByToken(tok_genTrack_, trkCollection);
-  reco::TrackCollection::const_iterator trkItr;
  
   //event weight for FLAT sample
   t_EventWeight = 1.0;
@@ -302,7 +301,6 @@ void IsoTrackCalib::analyze(const edm::Event& iEvent,
   //pf jets 
   edm::Handle<reco::PFJetCollection> pfJets;
   iEvent.getByToken(tok_pfjets_, pfJets);
-  reco::PFJetCollection::const_iterator pfItr;  
 
   //Define the best vertex and the beamspot
   edm::Handle<reco::VertexCollection> recVtxs;

--- a/Calibration/IsolatedParticles/plugins/IsoTrackCalibration.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrackCalibration.cc
@@ -241,7 +241,6 @@ void IsoTrackCalibration::analyze(const edm::Event& iEvent,
   //Get track collection
   edm::Handle<reco::TrackCollection> trkCollection;
   iEvent.getByToken(tok_genTrack_, trkCollection);
-  reco::TrackCollection::const_iterator trkItr;
  
   //event weight for FLAT sample and PU information
   t_EventWeight = 1.0;

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.cc
@@ -548,7 +548,6 @@ void IsolatedTracksCone::analyze(const edm::Event& iEvent,
   //get Handles to SimTracks and SimHits
   edm::Handle<edm::SimTrackContainer> SimTk;
   if (doMC_) iEvent.getByToken(tok_simTk_,SimTk);
-  edm::SimTrackContainer::const_iterator simTrkItr;
 
   edm::Handle<edm::SimVertexContainer> SimVtx;
   if (doMC_) iEvent.getByToken(tok_simVtx_,SimVtx);

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksHcalScale.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksHcalScale.cc
@@ -1,4 +1,4 @@
-// system include files
+// System include files
 #include <cmath>
 #include <string>
 #include <map>
@@ -312,7 +312,6 @@ void IsolatedTracksHcalScale::analyze(const edm::Event& iEvent, const edm::Event
 
   //get Handles to SimTracks and SimHits
   edm::Handle<edm::SimTrackContainer> SimTk;
-  edm::SimTrackContainer::const_iterator simTrkItr;
   edm::Handle<edm::SimVertexContainer> SimVtx;
 
   //get Handles to PCaloHitContainers of eb/ee/hbhe

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
@@ -670,7 +670,6 @@ void IsolatedTracksNxN::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
   edm::Handle<reco::TrackCollection> trkCollection;
   iEvent.getByToken(tok_genTrack_, trkCollection);
-  reco::TrackCollection::const_iterator trkItr;
   if (debugTrks_>1) {
     edm::LogVerbatim("IsoTrack") << "Track Collection: ";
     edm::LogVerbatim("IsoTrack") << "Number of Tracks " 
@@ -988,7 +987,6 @@ void IsolatedTracksNxN::analyze(const edm::Event& iEvent, const edm::EventSetup&
   //get Handles to SimTracks and SimHits
   edm::Handle<edm::SimTrackContainer> SimTk;
   if (doMC_) iEvent.getByToken(tok_simTk_,SimTk);
-  edm::SimTrackContainer::const_iterator simTrkItr;
 
   edm::Handle<edm::SimVertexContainer> SimVtx;
   if (doMC_) iEvent.getByToken(tok_simVtx_,SimVtx);

--- a/Calibration/IsolatedParticles/src/ChargeIsolation.cc
+++ b/Calibration/IsolatedParticles/src/ChargeIsolation.cc
@@ -133,7 +133,6 @@ namespace spr{
     if (debug) std::cout << (HcalDetId) ClosestCell << std::endl;
 #endif
     std::vector<DetId> vdets = spr::matrixHCALIds(dets, topology, ieta, iphi, false, debug);
-    std::vector<DetId>::iterator it;  
   
 #ifdef EDM_ML_DEBUG
     if (debug) {

--- a/Calibration/IsolatedParticles/src/ChargeIsolationExtra.cc
+++ b/Calibration/IsolatedParticles/src/ChargeIsolationExtra.cc
@@ -154,7 +154,6 @@ namespace spr{
     if (debug) std::cout << (HcalDetId) ClosestCell << std::endl;
 #endif
     std::vector<DetId> vdets = spr::matrixHCALIds(dets, topology, ieta, iphi, false, debug);
-    std::vector<DetId>::iterator it;  
   
 #ifdef EDM_ML_DEBUG
     if (debug) {

--- a/Calibration/IsolatedParticles/src/MatchingSimTrack.cc
+++ b/Calibration/IsolatedParticles/src/MatchingSimTrack.cc
@@ -21,9 +21,6 @@ namespace spr{
   
     edm::SimTrackContainer::const_iterator itr = SimTk->end();;
     
-    edm::SimTrackContainer::const_iterator simTrkItr;
-    edm::SimVertexContainer::const_iterator simVtxItr;
- 
     //Get the vector of PsimHits associated to TrackerRecHits and select the 
     //matching SimTrack on the basis of maximum occurance of trackIds
     std::vector<unsigned int> trkId, trkOcc;
@@ -63,7 +60,7 @@ namespace spr{
 	if(trkOcc[j] > maxTrkOcc ) { maxTrkOcc = trkOcc[j]; idxMax = j; }
       }
       matchSimTrk = trkId[idxMax];
-      for (simTrkItr = SimTk->begin(); simTrkItr!= SimTk->end(); simTrkItr++) {
+      for (auto simTrkItr = SimTk->begin(); simTrkItr!= SimTk->end(); simTrkItr++) {
 	if ( simTrkItr->trackId() == matchSimTrk ) {
 #ifdef EDM_ML_DEBUG
 	  matchedId = simTrkItr->type();
@@ -94,8 +91,7 @@ namespace spr{
 #endif  
     std::vector<int> matchTkid;
     if( trkInfo->type() != 0) {
-      edm::SimTrackContainer::const_iterator simTrkItr;
-      for(simTrkItr = SimTk->begin(); simTrkItr!= SimTk->end(); simTrkItr++){
+      for(auto simTrkItr = SimTk->begin(); simTrkItr!= SimTk->end(); simTrkItr++){
 	if (validSimTrack(matchSimTrk, simTrkItr, SimTk, SimVtx, false))
 	  matchTkid.push_back((int)simTrkItr->trackId());
       }


### PR DESCRIPTION
The clang compiler was issuing warnings for these variables