### PR TITLE
Fix GCC 8 compiler warnings, CSCRawToDigi

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2006.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2006.h
@@ -2,6 +2,7 @@
 #define CSCRawToDigi_CSCALCTHeader2006_h
 
 #include <vector>
+#include <cstring>
 #include <strings.h>
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 class CSCDMBHeader;
@@ -13,6 +14,10 @@ struct CSCALCTHeader2006 { ///this struct contains all 2006 ALCT Header words ex
   }
 
   explicit CSCALCTHeader2006(int chamberType);
+
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
 
   void init() {
      bzero(this,  sizeInWords()*2); ///size of header w/o LCTs = 8 bytes
@@ -76,6 +81,10 @@ struct CSCALCTHeader2006 { ///this struct contains all 2006 ALCT Header words ex
 struct CSCALCTs2006 {
   CSCALCTs2006() {
     bzero(this, 8); ///size of ALCT = 2bytes
+  }
+
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
   }
 
   short unsigned int sizeInWords() const { ///size of ALCT

--- a/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2007.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2007.h
@@ -17,6 +17,11 @@ class CSCDMBHeader;
 struct CSCALCT {
   CSCALCT();
   CSCALCT(const CSCALCTDigi & alctDigi);
+
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
+
   static short unsigned int sizeInWords() {return 1; }
 
   unsigned valid   : 1;
@@ -31,6 +36,10 @@ struct CSCALCT {
 struct CSCALCTHeader2007 {
   CSCALCTHeader2007();
   explicit CSCALCTHeader2007(int chamberType);
+
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
 
   void setEventInformation(const CSCDMBHeader &);///for packing
 
@@ -80,6 +89,10 @@ struct CSCVirtexID {
     bzero(this,  sizeInWords()*2); ///size of virtex ID bits = 6 bytes
   }
 
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
+
   short unsigned int sizeInWords() const { ///size of VirtexID
     return 3;
   }
@@ -99,6 +112,10 @@ struct CSCVirtexID {
 struct CSCConfigurationRegister {
   CSCConfigurationRegister()  {
     bzero(this, sizeInWords()*2); 
+  }
+
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
   }
 
   short unsigned int sizeInWords() const { ///size of ConfigReg
@@ -128,6 +145,10 @@ struct CSCCollisionMask {
     bzero(this, sizeInWords()*2);
   }
 
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
+
   short unsigned int sizeInWords() const { ///size of one CollMask word
     return 1;
   }
@@ -140,6 +161,10 @@ struct CSCCollisionMask {
 struct CSCHotChannelMask {
   CSCHotChannelMask()  {
     bzero(this, sizeInWords()*2);
+  }
+
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
   }
 
   short unsigned int sizeInWords() const { ///size of one HotChannMask word

--- a/EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h
@@ -14,6 +14,11 @@
 
 struct CSCALCTTrailer2006 {
   CSCALCTTrailer2006();
+
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
+
   void setSize(int size) {frameCount = size;}
   void setCRC(unsigned int crc) {crc0 = crc&0x7FF; crc1 = (crc >> 11) & 0x7FF;}
   short unsigned int sizeInWords() const { ///size of ALCT Header
@@ -27,6 +32,11 @@ struct CSCALCTTrailer2006 {
 
 struct CSCALCTTrailer2007 {
   CSCALCTTrailer2007();
+
+  void setFromBuffer(unsigned short const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
+
   void setSize(int size) {frameCount = size;}
   void setCRC(unsigned int crc) {crc0 = crc&0x7FF; crc1 = (crc >> 11) & 0x7FF;}
   short unsigned int sizeInWords() const { ///size of ALCT Header

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCHeader.h
@@ -5,6 +5,8 @@
 #ifndef CSCDCCHeader_h
 #define CSCDCCHeader_h
 
+#include <cstdint>
+#include <cstring>
 #include <string> //for bzero
 #include "DataFormats/CSCDigi/interface/CSCDCCStatusDigi.h"
 
@@ -14,6 +16,10 @@ class CSCDCCHeader {
   CSCDCCHeader(int bx, int l1a, int sourceId, int version=0);
   CSCDCCHeader();
   CSCDCCHeader(const CSCDCCStatusDigi & digi);
+
+  void setFromBuffer(uint16_t const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
 
   int getCDFEventNumber() const; 
   int getCDFSourceId() const; 

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCTrailer.h
@@ -4,6 +4,7 @@
 #define CSCDCCTrailer_h
 
 #include <iostream>
+#include <cstdint>
 #include <cstring> // bzero
 #include "DataFormats/CSCDigi/interface/CSCDCCStatusDigi.h"
 
@@ -24,6 +25,11 @@ struct CSCDCCTrailer {
   {
     memcpy(this, digi.trailer(), sizeInWords()*2);
   }
+
+  void setFromBuffer(uint16_t const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
+
   /// for reference www.physics.ohio-state.edu/%7Ecms/dcc/outdatafmt.html
   /// dcc_trail1 should be EF
   unsigned fifo_status      : 8;

--- a/EventFilter/CSCRawToDigi/interface/CSCDDUHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUHeader.h
@@ -6,6 +6,7 @@
 #define CSCDDUHeader_h
 #include "DataFormats/CSCDigi/interface/CSCDDUStatusDigi.h"
 #include <cstring>
+#include <cstdint>
 
 class CSCDDUHeader {
 
@@ -16,6 +17,10 @@ class CSCDDUHeader {
     {
       memcpy(this, digi.header(), sizeInWords()*2);
     }
+
+  void setFromBuffer(uint16_t const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
 
   // Getters
   int s_link_status() const { return s_link_status_;}

--- a/EventFilter/CSCRawToDigi/interface/CSCDDUTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUTrailer.h
@@ -2,6 +2,7 @@
 #define CSCDDUTrailer_h
 
 #include <iostream>
+#include <cstdint>
 #include <cstring> // bzero
 #include "DataFormats/CSCDigi/interface/CSCDDUStatusDigi.h"
 
@@ -25,6 +26,10 @@ class CSCDDUTrailer {
       memcpy(this, digi.trailer(), sizeInWords()*2);
     }
   
+  void setFromBuffer(uint16_t const* buf) {
+    memcpy(this, buf, sizeInWords()*2);
+  }
+
   static unsigned sizeInWords() {return 12;}
   
   bool check() const {

--- a/EventFilter/CSCRawToDigi/src/CSCALCTHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCALCTHeader.cc
@@ -70,35 +70,35 @@ CSCALCTHeader::CSCALCTHeader(const unsigned short * buf) {
   switch (firmwareVersion.load()) {
 #endif 
   case 2006:
-    memcpy(&header2006, buf, header2006.sizeInWords()*2);///the header part
+    header2006.setFromBuffer(buf);///the header part
     buf +=header2006.sizeInWords();
-    memcpy(&alcts2006, buf, alcts2006.sizeInWords()*2);///the alct0 and alct1
+    alcts2006.setFromBuffer(buf);///the alct0 and alct1
     buf +=alcts2006.sizeInWords();
     break;
 
   case 2007:
-    memcpy(&header2007, buf, header2007.sizeInWords()*2); ///the fixed sized header part
+    header2007.setFromBuffer(buf); ///the fixed sized header part
     buf +=header2007.sizeInWords();
     sizeInWords2007_ = header2007.sizeInWords();
     ///now come the variable parts
     if (header2007.configPresent==1) {
-      memcpy(&virtexID, buf, virtexID.sizeInWords()*2);
+      virtexID.setFromBuffer(buf);
       buf +=virtexID.sizeInWords();
       sizeInWords2007_ = virtexID.sizeInWords();
-      memcpy(&configRegister, buf, configRegister.sizeInWords()*2);
+      configRegister.setFromBuffer(buf);
       buf +=configRegister.sizeInWords();
       sizeInWords2007_ += configRegister.sizeInWords();
 
       collisionMasks.resize(collisionMaskWordcount[header2007.boardType]);
       for (unsigned int i=0; i<collisionMaskWordcount[header2007.boardType]; ++i){
-	memcpy(&collisionMasks[i], buf, collisionMasks[i].sizeInWords()*2);
+	collisionMasks[i].setFromBuffer(buf);
 	buf += collisionMasks[i].sizeInWords();
 	sizeInWords2007_ += collisionMasks[i].sizeInWords();
       }
 
       hotChannelMasks.resize(hotChannelMaskWordcount[header2007.boardType]);
       for (unsigned int i=0; i<hotChannelMaskWordcount[header2007.boardType]; ++i) {
-	memcpy(&hotChannelMasks[i], buf, hotChannelMasks[i].sizeInWords()*2);
+	hotChannelMasks[i].setFromBuffer(buf);
 	buf += hotChannelMasks[i].sizeInWords();
 	sizeInWords2007_ += hotChannelMasks[i].sizeInWords();
       }
@@ -106,7 +106,7 @@ CSCALCTHeader::CSCALCTHeader(const unsigned short * buf) {
 
     theALCTs.resize(header2007.lctBins*2); ///2007 has LCTbins * 2 alct words
     for (int i=0; i<header2007.lctBins*2; ++i) {
-      memcpy(&theALCTs[i], buf, theALCTs[i].sizeInWords()*2);
+      theALCTs[i].setFromBuffer(buf);
       buf += theALCTs[i].sizeInWords(); 
       sizeInWords2007_ += theALCTs[i].sizeInWords();
     }

--- a/EventFilter/CSCRawToDigi/src/CSCALCTTrailer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCALCTTrailer.cc
@@ -77,10 +77,10 @@ CSCALCTTrailer::CSCALCTTrailer(const unsigned short * buf){
   switch (firmwareVersion.load()) {
 #endif
   case 2006:
-    memcpy(&trailer2006, buf, trailer2006.sizeInWords()*2);
+    trailer2006.setFromBuffer(buf);
     break;
   case 2007:
-    memcpy(&trailer2007, buf, trailer2007.sizeInWords()*2);
+    trailer2007.setFromBuffer(buf);
     break;
   default:
     edm::LogError("CSCALCTTrailer|CSCRawToDigi")

--- a/EventFilter/CSCRawToDigi/src/CSCDCCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCEventData.cc
@@ -52,7 +52,7 @@ void CSCDCCEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner)
   // decode DCC header (128 bits)
   if (debug) 
     LogTrace ("CSCDCCEventData|CSCRawToDigi") << "unpacking dcc header...";
-  memcpy(&theDCCHeader, buf, theDCCHeader.sizeInWords()*2);
+  theDCCHeader.setFromBuffer(buf);
   //theDCCHeader = CSCDCCHeader(buf); // direct unpacking instead of bitfields
   buf += theDCCHeader.sizeInWords();
 
@@ -87,7 +87,7 @@ void CSCDCCEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner)
 	    
   //decode dcc trailer (128 bits)
   if (debug) LogTrace ("CSCDCCEventData|CSCRawToDigi") <<"decoding DCC trailer";
-  memcpy(&theDCCTrailer, buf, theDCCTrailer.sizeInWords()*2);
+  theDCCTrailer.setFromBuffer(buf);
   if (debug) LogTrace("CSCDCCEventData|CSCRawToDigi") << "checking DDU Trailer" << theDCCTrailer.check(); 
  
   // buf += theDCCTrailer.sizeInWords(); /* =VB= Commented out to please static analyzer */ 

--- a/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
@@ -174,7 +174,7 @@ void CSCDDUEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner)
     }
   //std::cout << "DDU Size: " << std::dec << theDDUHeader.sizeInWords() << std::endl;
 
-  memcpy(&theDDUHeader, buf, theDDUHeader.sizeInWords()*2);
+  theDDUHeader.setFromBuffer(buf);
   
   if (debug) {
     LogTrace ("CSCDDUEventData|CSCRawToDigi") << "size of ddu header in words = " << theDDUHeader.sizeInWords();
@@ -248,7 +248,7 @@ void CSCDDUEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner)
 	}
       // std::cout << std::dec << theDDUTrailer.sizeInWords() << std::endl;
       // decode ddu tail
-      memcpy(&theDDUTrailer, inputBuf+dduBufSize, theDDUTrailer.sizeInWords()*2);
+      theDDUTrailer.setFromBuffer(inputBuf+dduBufSize);
       // memcpy(&theDDUTrailer, dduBlock+(dduBufSize-theDDUTrailer.sizeInWords())*2, theDDUTrailer.sizeInWords()*2);
       if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") << theDDUTrailer.check();
       errorstat=theDDUTrailer.errorstat();
@@ -300,7 +300,7 @@ void CSCDDUEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner)
     }
 
     // decode ddu tail
-    memcpy(&theDDUTrailer, buf, theDDUTrailer.sizeInWords()*2);
+    theDDUTrailer.setFromBuffer(buf);
     if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") << theDDUTrailer.check();
     errorstat=theDDUTrailer.errorstat();
     if ((errorstat&errMask) != 0)  


### PR DESCRIPTION
I expect this to cause no change in behavior and
that there is currently no real problem here.

There is an underlying hack in this code which I did not
modify. This code is based on byte wise memory copies
from a 2 byte array to a non-trivial class. It probably
works, probably will always work, and it is fast,
but there is undefined behavior and big vs little endian
issues lurking in this hack and strictly speaking the
standard does not guarantee this will work.

I moved the memcpy into a member function within the
class so that the hack is encapsulated with the data
it is hacking (an improvement). And empirically
(with GCC 810 on cmslpc40.fnal.gov) I find this causes
the compiler warning to no longer occur.