### PR TITLE
Exclude taus, IVF and other high-level reco features from Run2_2018_pp_on_AA era

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -158,6 +158,7 @@ _highlevelreco_HI = highlevelreco.copy()
 _highlevelreco_HI += hiCentrality
 _highlevelreco_HI += hiClusterCompatibility
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(highlevelreco, _highlevelreco_HI)
+pp_on_AA_2018.toReplaceWith(highlevelreco,highlevelreco.copyAndExclude([PFTau]))
 
 # not commisoned and not relevant in FastSim (?):
 _fastSim_highlevelreco = highlevelreco.copyAndExclude([cosmicDCTracksSeq,muoncosmichighlevelreco])

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -187,6 +187,8 @@ phase2_hcal.toReplaceWith( PostDQMOfflineMiniAOD, PostDQMOfflineMiniAOD.copyAndE
     pfMetDQMAnalyzerMiniAOD, pfPuppiMetDQMAnalyzerMiniAOD # No hcalnoise yet
 ]))
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith(DQMOffline, DQMOffline.copyAndExclude([pfTauRunDQMValidation]))
 
 from PhysicsTools.NanoAOD.nanoDQM_cff import nanoDQM
 DQMOfflineNanoAOD = cms.Sequence(nanoDQM)

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -357,11 +357,12 @@ def miniAOD_customizeCommon(process):
     run2_miniAOD_94XFall17.toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithRetrainedMVATauID
         )
-    #-- Adding customization for 80X 2016 legacy reMiniAOD
+    #-- Adding customization for 80X 2016 legacy reMiniAOD and 2018 heavy ions
     from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+    from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
     _makePatTausTaskWithTauReReco = process.makePatTausTask.copy()
     _makePatTausTaskWithTauReReco.add(process.PFTauTask)
-    run2_miniAOD_80XLegacy.toReplaceWith(
+    (run2_miniAOD_80XLegacy | pp_on_AA_2018).toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithTauReReco
         )
     

--- a/RecoMET/Configuration/python/RecoPFMET_cff.py
+++ b/RecoMET/Configuration/python/RecoPFMET_cff.py
@@ -8,3 +8,6 @@ from RecoMET.METProducers.pfChMet_cfi import *
 recoPFMET = cms.Sequence(pfMet + particleFlowForChargedMET + pfChMet)
 
 ##____________________________________________________________________________||
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(pfMet,  globalThreshold = 999.)
+pp_on_AA_2018.toModify(pfChMet, globalThreshold = 999.)

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -251,7 +251,7 @@ photonConvTrajSeedFromSingleLeg.primaryVerticesTag = cms.InputTag('firstStepPrim
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 trackingLowPU.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag   = "pixelVertices")
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toModify(photonConvTrajSeedFromSingleLeg.RegionFactoryPSet.RegionPSet, ptMin = 999.)
+pp_on_AA_2018.toModify(photonConvTrajSeedFromSingleLeg, vtxMinDoF = 999999.)
     
 # TRACKER DATA CONTROL
 

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -18,9 +18,6 @@ convClusters = _convClustersBase.clone(
   trackClassifier       = cms.InputTag('tobTecStep',"QualityMasks"),
 )
 
-# turn off conversions for heavy ions without removing collections                                                                  
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toModify(convClusters, maxChi2 = 0.)
 
 #Phase2 : configuring the phase2 track Cluster Remover
 from RecoLocalTracker.SubCollectionProducers.phase2trackClusterRemover_cfi import phase2trackClusterRemover as _phase2trackClusterRemover
@@ -253,7 +250,8 @@ photonConvTrajSeedFromSingleLeg.primaryVerticesTag = cms.InputTag('firstStepPrim
 #photonConvTrajSeedFromQuadruplets.primaryVerticesTag = cms.InputTag('pixelVertices')
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 trackingLowPU.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag   = "pixelVertices")
-
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(photonConvTrajSeedFromSingleLeg.RegionFactoryPSet.RegionPSet, ptMin = 999.)
     
 # TRACKER DATA CONTROL
 

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -18,6 +18,10 @@ convClusters = _convClustersBase.clone(
   trackClassifier       = cms.InputTag('tobTecStep',"QualityMasks"),
 )
 
+# turn off conversions for heavy ions without removing collections                                                                  
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(convClusters, maxChi2 = 0.)
+
 #Phase2 : configuring the phase2 track Cluster Remover
 from RecoLocalTracker.SubCollectionProducers.phase2trackClusterRemover_cfi import phase2trackClusterRemover as _phase2trackClusterRemover
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
@@ -59,7 +59,12 @@ inclusiveCandidateVertexingCvsLTask = cms.Task(inclusiveCandidateVertexFinderCvs
 inclusiveCandidateVertexingCvsL = cms.Sequence(inclusiveCandidateVertexingCvsLTask)
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+pp_on_XeXe_2017.toModify(inclusiveVertexFinder, minHits = 10, minPt = 1.0)
+pp_on_XeXe_2017.toModify(inclusiveCandidateVertexFinder, minHits = 10, minPt = 1.0)
+pp_on_XeXe_2017.toModify(inclusiveCandidateVertexFinderCvsL, minHits = 10, minPt = 1.0)
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toModify(inclusiveVertexFinder, minHits = 10, minPt = 1.0)
-    e.toModify(inclusiveCandidateVertexFinderCvsL, minHits = 10, minPt = 1.0)
+pp_on_AA_2018.toModify(inclusiveVertexFinder, minHits = 999, minPt = 999.0)
+pp_on_AA_2018.toModify(inclusiveCandidateVertexFinder, minHits = 999, minPt = 999.0)
+pp_on_AA_2018.toModify(inclusiveCandidateVertexFinderCvsL, minHits = 999, minPt = 999.0)
+
+

--- a/RecoVertex/V0Producer/python/generalV0Candidates_cff.py
+++ b/RecoVertex/V0Producer/python/generalV0Candidates_cff.py
@@ -9,3 +9,5 @@ import FWCore.ParameterSet.Config as cms
 # ctfV0Producer
 from RecoVertex.V0Producer.generalV0Candidates_cfi import *
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(generalV0Candidates, tkPtCut = 999.)

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -195,3 +195,5 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( globalValidation, _run3_globalValidation )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( globalValidation, _phase2_globalValidation )
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith(globalValidation, globalValidation.copyAndExclude([pfTauRunDQMValidation]))


### PR DESCRIPTION
Remove several components of the reconstruction that will not be used for heavy ion data (era Run2_2018_pp_on_AA):  The tau sequence is removed altogether.  It is re-added in PAT to keep it from crashing, although we will not write mini-AOD.  Inclusive vertexing, PF MET and, V0s and conversions are effectively removed by setting high thresholds.  This strategy keeps from having to fix a lot of crashes in mini-AOD, DQM, and validation that would arise due to missing collections.  These collections are rarely or never used in heavy ions and be created from AOD, which is the main output tier. 

These modifications, which leading to significant timing improvements,  were discussed at RECO/AT:
https://indico.cern.ch/event/711247/contributions/2920696/attachments/1614694/2565613/RecoTiming_180309_MAN.pdf

Tested with workflow 158.  
Will need to be backported to 10_2_X, if we use that for data-taking (there's no effect on pp reco) 