### PR TITLE
Fix hidden overloaded member function clang warning

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h
@@ -173,7 +173,7 @@ class FastTrackerRecHit : public BaseTrackerRecHit
 
     protected:
 
-    FastTrackerRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+    FastTrackerRecHit * clone_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
 	return this->clone();
     }
   

--- a/DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h
@@ -37,10 +37,10 @@ public:
 
 private:
   // double dispatch
-  Phase2TrackerRecHit1D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  Phase2TrackerRecHit1D * clone_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
-   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  RecHitPointer cloneSH_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 };

--- a/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
@@ -73,11 +73,11 @@ public:
 
 private:
   // double dispatch
-  ProjectedSiStripRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  ProjectedSiStripRecHit2D * clone_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-   ConstRecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+   ConstRecHitPointer cloneSH_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -57,11 +57,11 @@ public:
   bool canImproveWithTrack() const override {return true;}
 private:
   // double dispatch
-  SiPixelRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  SiPixelRecHit * clone_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+   RecHitPointer cloneSH_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif  

--- a/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
@@ -63,11 +63,11 @@ class SiStripMatchedRecHit2D final : public BaseTrackerRecHit {
   bool canImproveWithTrack() const override {return true;}
 private:
   // double dispatch
-  SiStripMatchedRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  SiStripMatchedRecHit2D * clone_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+   RecHitPointer cloneSH_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif 

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
@@ -39,11 +39,11 @@ public:
   bool canImproveWithTrack() const override {return true;}
 private:
   // double dispatch
-  SiStripRecHit1D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  SiStripRecHit1D * clone_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+   RecHitPointer cloneSH_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif 

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
@@ -40,11 +40,11 @@ public:
   bool canImproveWithTrack() const override {return true;}
 private:
   // double dispatch
-  SiStripRecHit2D* clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  SiStripRecHit2D* clone_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+   RecHitPointer cloneSH_(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif 

--- a/DataFormats/TrackerRecHit2D/interface/TkCloner.h
+++ b/DataFormats/TrackerRecHit2D/interface/TkCloner.h
@@ -15,13 +15,13 @@ class Phase2TrackerRecHit1D;
 class TkCloner {
 public:
   TrackingRecHit * operator() CMS_THREAD_SAFE (TrackingRecHit const & hit, TrajectoryStateOnSurface const& tsos) const {
-    return hit.clone(*this, tsos);
+    return hit.clone_(*this, tsos);
   }
 
  virtual ~TkCloner() {}
 #ifndef __GCCXML__
   TrackingRecHit::ConstRecHitPointer makeShared(TrackingRecHit::ConstRecHitPointer const & hit, TrajectoryStateOnSurface const& tsos) const {
-    return hit->canImproveWithTrack() ?  hit->cloneSH(*this, tsos) : hit;
+    return hit->canImproveWithTrack() ?  hit->cloneSH_(*this, tsos) : hit;
     // return  hit->cloneSH(*this, tsos);
   }
 #endif

--- a/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
@@ -167,12 +167,12 @@ public:
 private:
   friend class  TkCloner;
   // double dispatch
-  virtual TrackingRecHit * clone(TkCloner const&, TrajectoryStateOnSurface const&) const {
+  virtual TrackingRecHit * clone_(TkCloner const&, TrajectoryStateOnSurface const&) const {
     assert("clone"==nullptr);
     return clone(); // default
   }
 #ifndef __GCCXML__
-  virtual  RecHitPointer cloneSH(TkCloner const&, TrajectoryStateOnSurface const&) const {
+  virtual  RecHitPointer cloneSH_(TkCloner const&, TrajectoryStateOnSurface const&) const {
     assert("cloneSH"==nullptr);
     return cloneSH(); // default
   }


### PR DESCRIPTION
The clang compiler was issuing warnings about the clone and cloneSH
member functions being hidden when inheriting classes only overrode
one of the clone methods. On inspection, the hidden method was only
supposed to be called by TkCloner so the easiest solution was to
rename the functions with a trailing underscore and keep all of
those functions private.