### PR TITLE
GCC 8 Compiler Warnings, Minor Reco Fixes

### DIFF
--- a/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
+++ b/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc
@@ -82,7 +82,6 @@ private:
 	map<string, string> toadd_;
 	vector<MVAVar> variables_;
 };
-}
 
 class DeepFlavourJetTagsProducer : public edm::stream::EDProducer<edm::GlobalCache<NeuralNetworkAndConstants>> {
 public:
@@ -302,6 +301,7 @@ DeepFlavourJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
+} // end unnamed namespace
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(DeepFlavourJetTagsProducer);

--- a/RecoCTPPS/TotemRPLocal/interface/FastLineRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/FastLineRecognition.h
@@ -38,7 +38,7 @@ class FastLineRecognition
     void getPatterns(const edm::DetSetVector<TotemRPRecHit> &input, double _z0, double threshold,
       edm::DetSet<TotemRPUVPattern> &patterns);
 
-  protected:
+  private:
     /// the uncertainty of 1-hit cluster, in mm
     static const double sigma0;
 

--- a/RecoCTPPS/TotemRPLocal/interface/FastLineRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/FastLineRecognition.h
@@ -83,12 +83,11 @@ class FastLineRecognition
     {
       double Saw, Sbw, Sw, S1;
       double weight;
-      double min_a, max_a, min_b, max_b;
 
       std::vector<const Point *> contents;
-      
+
       Cluster() : Saw(0.), Sbw(0.), Sw(0.), S1(0.), weight(0.) {}
-      
+
       void add(const Point *p1, const Point *p2, double a, double b, double w);
 
       bool operator<(const Cluster &c) const

--- a/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
@@ -47,16 +47,11 @@ void FastLineRecognition::Cluster::add(const Point *p1, const Point *p2, double 
   if (add2)
     contents.push_back(p2);
 
-  // update sums, mins and maxs
+  // update sums
   Saw += a*w;
   Sbw += b*w;
   Sw += w;
   S1 += 1.;
-
-  min_a = min(a, min_a);
-  min_b = min(b, min_b);
-  max_a = max(a, max_a);
-  max_b = max(b, max_b);
 }
 
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Two fixes included here and neither should affect
behavior. One modifies the extent of an unnamed
namespace. It was maybe inconsistent before, but
not a real problem. The other initializes some
uninitialized variables. A real bug, but these
variables are not used anywhere (alternately we
could delete them).