### PR TITLE
Initialize an int with an int, not a double in RegressionHelper

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
@@ -168,7 +168,7 @@ void RegressionHelper::applyCombinationRegression(reco::GsfElectron & ele) const
   float energyError = ele.correctedEcalEnergyError();
   float momentum = ele.trackMomentumAtVtx().R();
   float momentumError = ele.trackMomentumError();
-  int elClass = -.1;
+  int elClass = -1;
   
   switch (ele.classification()) {
   case reco::GsfElectron::GOLDEN:


### PR DESCRIPTION
The clang compiler spotted the initialization of an int with a explicit double constant. The value is always reset in the following swtich statement and therefore was changed to be initialized with
the switch statement's default choice.