### PR TITLE
Ape parallel features: Backport of #24192

### DIFF
--- a/Alignment/APEEstimation/macros/DrawPlot.C
+++ b/Alignment/APEEstimation/macros/DrawPlot.C
@@ -64,7 +64,7 @@ thesisMode_(false)
   if(!baselineTreeX_)std::cout<<"Baseline tree for x coordinate not found, cannot draw baselines!\n";
   if(!baselineTreeY_)std::cout<<"Baseline tree for y coordinate not found, cannot draw baselines!\n";
   
-  baseLineTreeX_->SetDirectory(nullptr);
+  baselineTreeX_->SetDirectory(nullptr);
   baselineTreeY_->SetDirectory(nullptr);
   
   delete inpath;

--- a/Alignment/APEEstimation/python/AlignmentTrackSelector_cff.py
+++ b/Alignment/APEEstimation/python/AlignmentTrackSelector_cff.py
@@ -43,7 +43,6 @@ MuSkimSelector = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.Al
     applyBasicCuts = True,
     filter = True,
     src = 'ALCARECOTkAlMuonIsolated',
-    #~ src = 'ALCARECOTkAlZMuMu',
     ptMin = 17.,
     pMin = 17.,
     etaMin = -2.5,
@@ -56,16 +55,32 @@ MuSkimSelector = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.Al
     nHitMin2D = 0,
 )
 
+DoubleMuSkimSelector = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
+    applyBasicCuts = True,
+    filter = True,
+    src = 'ALCARECOTkAlZMuMu',
+    ptMin = 17.,
+    pMin = 17.,
+    etaMin = -2.5,
+    etaMax = 2.5,
+    d0Min = -2.,
+    d0Max = 2.,
+    dzMin = -25.,
+    dzMax = 25.,
+    nHitMin = 6,
+    nHitMin2D = 0,
+)
 
-#MuSkimSelector = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
-#    #filter = True, ##do not store empty events
-#    applyBasicCuts = True,
-#    src = 'ALCARECOTkAlMuonIsolated',
-#    ptMin = 2.0, ##GeV 
-#    etaMin = -3.5,
-#    etaMax = 3.5,
-#    nHitMin = 1,
-#)
+CosmicsSkimSelector = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
+    applyBasicCuts = True,
+    filter = True,
+    src = 'ALCARECOTkAlCosmicsCTF0T',
+    etaMin = -2.5,
+    etaMax = 2.5,
+    nHitMin = 6,
+    nHitMin2D = 0,
+)
+
 
 
 

--- a/Alignment/APEEstimation/python/samples/Data_TkAlMinBias_Run2018C_PromptReco_v3_cff.py
+++ b/Alignment/APEEstimation/python/samples/Data_TkAlMinBias_Run2018C_PromptReco_v3_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring() 
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+
+
+readFiles.extend( [
+       "/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/826/00000/E23F3B37-8C8B-E811-9E54-FA163EAD4CB1.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/827/00000/884C3F8F-8C8B-E811-8B4F-02163E019F19.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/829/00000/488AF044-8C8B-E811-B07B-FA163EF05F9D.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/830/00000/7E0F6EC0-918B-E811-85ED-02163E019F09.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/831/00000/A0614791-968B-E811-A59D-FA163E7750CB.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/833/00000/F0580EF1-968B-E811-8FB6-FA163E9C118B.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/835/00000/B0823EE4-9D8B-E811-A96B-FA163E7750CB.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/838/00000/04D2AA3F-A68B-E811-84B1-02163E0152A4.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/840/00000/06074A5B-E18B-E811-A5A5-FA163E53A37E.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/840/00000/1252EF18-098C-E811-9258-FA163EBF76CA.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/840/00000/5881721E-E38B-E811-AF87-02163E00BA55.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/840/00000/78CBC170-EB8B-E811-BEC2-FA163E23196D.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/840/00000/7C74081A-EA8B-E811-A6F8-02163E017F89.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/840/00000/BE7978CE-EC8B-E811-97AD-FA163EF5922E.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/841/00000/080B1B2D-ED8B-E811-99FA-FA163EB165D3.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/841/00000/9CD23BA8-F58B-E811-8F50-FA163E2C6343.root", 
+       #"/store/data/Run2018C/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v3/000/319/841/00000/F417EAAE-FD8B-E811-8132-FA163EA194D3.root", 
+       ] );
+
+
+
+secFiles.extend( [
+               ] )
+

--- a/Alignment/APEEstimation/scripts/initialise.bash
+++ b/Alignment/APEEstimation/scripts/initialise.bash
@@ -7,9 +7,10 @@ mkdir $CMSSW_BASE/src/Alignment/TrackerAlignment/hists/
 
 
 mkdir $DIRBASE/hists/
-mkdir $DIRBASE/hists/apeObjects/
 mkdir $DIRBASE/hists/workingArea/
+mkdir $DIRBASE/hists/workingArea/apeObjects/
 mkdir $DIRBASE/test/batch/workingArea/
+mkdir $DIRBASE/test/autoSubmitter/workingArea/
 mkdir $DIRBASE/test/cfgTemplateDesign/workingArea/
 mkdir $DIRBASE/test/cfgTemplateMc/workingArea/
 mkdir $DIRBASE/test/cfgTemplateData/workingArea/

--- a/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
+++ b/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
@@ -1,5 +1,5 @@
+from __future__ import print_function
 import os
-
 import FWCore.ParameterSet.Config as cms
 
 
@@ -14,17 +14,11 @@ options.register('useTrackList', False, VarParsing.VarParsing.multiplicity.singl
 options.register('isTest', False, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.bool, "Test run")
 
 # get and parse the command line arguments
-if( hasattr(sys, "argv") ):
-    for args in sys.argv :
-        arg = args.split(',')
-        for val in arg:
-            val = val.split('=')
-            if(len(val)==2):
-                setattr(options,val[0], val[1])
+options.parseArguments()
 
-print "Input sample: ", options.sample
-print "Use list of preselected tracks: ", options.useTrackList
-print "Test run: ", options.isTest
+print("Input sample: ", options.sample)
+print("Use list of preselected tracks: ", options.useTrackList)
+print("Test run: ", options.isTest)
 
 
 ##
@@ -57,9 +51,13 @@ process.options = cms.untracked.PSet(
 
 
 isData1 = isData2 = isData3 = isData4 = False
+isMultiIOV = False
 isData = False
 isQcd = isWlnu = isZmumu = isZtautau = isZmumu10 = isZmumu20 =  isZmumu50 = False
 isMc = False
+if "iov" in  options.sample:
+    isMultiIOV = True
+    isData = True
 if options.sample == 'data1':
     isData1 = True
     isData = True
@@ -95,33 +93,99 @@ elif options.sample == 'zmumu50':
     isMc = True
 
 else:
-    print 'ERROR --- incorrect data sammple: ', options.sample
+    print('ERROR --- incorrect data sammple: ', options.sample)
     exit(8888)
 
 
 
 ##
-## Input Files
+## Start of Configuration
 ##
 
+maxEvents = -1
+outputName = "defaultOutputName.root"
+outputPath = None
+outputFileSize = 350000
 
-if isData1: process.load("Alignment.APEEstimation.samples.Data_TkAlMuonIsolated_Run2015B_PromptReco_v1_cff")
-if isData2: process.load("Alignment.APEEstimation.samples.Data_TkAlMuonIsolated_22Jan2013B_v1_cff")
-if isData3: process.load("Alignment.APEEstimation.samples.Data_TkAlMuonIsolated_22Jan2013C_v1_cff")
-if isData4: process.load("Alignment.APEEstimation.samples.Data_TkAlMuonIsolated_22Jan2013D_v1_cff")
-if isQcd: process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_Summer12_qcd_cff")
-if isWlnu: process.load("Alignment.APEEstimation.samples.Mc_WJetsToLNu_74XTest_cff")
-if isZmumu10: process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_Summer12_zmumu10_cff")
-if isZmumu20: process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_Summer12_zmumu20_cff")
-if isZmumu50: process.load("Alignment.APEEstimation.samples.DYToMuMu_M-50_Tune4C_13TeV-pythia8_Spring14dr-TkAlMuonIsolated-castor_PU_S14_POSTLS170_V6-v1_ALCARECO_cff")
+##
+## TrackSelection can be SingleMu, DoubleMu, MinBias, Cosmics
+## The choice affects which AlignmentTrackSelector is used.
+## Currently, DoubleMu means ZToMuMu, so if there is the need 
+## for UpsilonToMuMu or JPsiToMuMu, these have to be added first
+##
+trackSelection = "SingleMu"
 
+if isMultiIOV:
+    ## Configure here for campaigns with many different datasets (such as multi-IOV)
+    iovNo = int(options.sample.split("iov")[1])
+    process.load("Alignment.APEEstimation.samples.")
+    outputName = ".root"
+    outputPath = None # can also be specified. If that is done, files are copied to this path afterwards
+    trackSelection = "SingleMu"
+if isData1: 
+    process.load("Alignment.APEEstimation.samples.Data_TkAlMinBias_Run2018C_PromptReco_v3_cff")
+    outputName = 'MinBias.root'
+    #outputPath = "workingArea"
+    trackSelection = "MinBias"
+if isData2: 
+    process.load("Alignment.APEEstimation.samples.Data_TkAlMinBias_Run2018C_PromptReco_v3_cff")
+    outputName = 'MinBias1.root'
+    #outputPath = "workingArea"
+    trackSelection = "MinBias"
+if isData3: 
+    process.load("Alignment.APEEstimation.samples.Data_TkAlMuonIsolated_22Jan2013C_v1_cff")
+    outputName = 'Data_TkAlMuonIsolated_22Jan2013C.root'
+    trackSelection = "SingleMu"
+if isData4: 
+    process.load("Alignment.APEEstimation.samples.Data_TkAlMuonIsolated_22Jan2013D_v1_cff")
+    outputName = 'Data_TkAlMuonIsolated_22Jan2013D.root'
+    trackSelection = "SingleMu"
+# The following options are used for MC samples
+if isQcd: 
+    process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_Summer12_qcd_cff")
+    outputName = 'Mc_TkAlMuonIsolated_Summer12_qcd.root'
+    trackSelection = "MinBias"
+if isWlnu: 
+    process.load("Alignment.APEEstimation.samples.Mc_WJetsToLNu_74XTest_cff")
+    outputName = 'Mc_WJetsToLNu_74XTest.root'
+    trackSelection = "SingleMu"
+if isZmumu: 
+    process.load("")
+    outputName = ''
+    trackSelection = "DoubleMu"
+if isZmumu10: 
+    process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_Summer12_zmumu10_cff")
+    outputName = 'Mc_TkAlMuonIsolated_Summer12_zmumu10.root'
+    trackSelection = "DoubleMu"
+if isZmumu20: 
+    process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_Summer12_zmumu20_cff")
+    outputName = 'Mc_TkAlMuonIsolated_Summer12_zmumu20.root'
+    trackSelection = "DoubleMu"
+if isZmumu50: 
+    process.load("Alignment.APEEstimation.samples.DYToMuMu_M-50_Tune4C_13TeV-pythia8_Spring14dr-TkAlMuonIsolated-castor_PU_S14_POSTLS170_V6-v1_ALCARECO_cff")
+    outputName = 'Mc_DYToMuMu_M-50_Tune4C_13TeV-pythia8_Spring14dr-TkAlMuonIsolated-castor_PU_S14_POSTLS170_V6-v1.root'
+    trackSelection = "DoubleMu"
+
+
+print("Using output name %s"%(outputName))
+if outputPath:
+    print("Using output path %s"%(outputPath))
+
+##
+## Choice of GlobalTag
+##
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_design', '')
 
-print "Using global tag "+process.GlobalTag.globaltag._value
+if isData:
+    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+    #process.GlobalTag = GlobalTag(process.GlobalTag, '101X_dataRun2_Prompt_v11', '')
+elif isMc:
+    #process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic', '')
+    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_design', '')
+
+print("Using global tag "+process.GlobalTag.globaltag._value)
 
 process.load("Configuration.StandardSequences.Services_cff")
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
@@ -131,17 +195,33 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ##
 ## Number of Events (should be after input file)
 ##
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(maxEvents) )
 if options.isTest: process.maxEvents.input = 1001
 
 
 ##
 ## Skim tracks
 ##
-import Alignment.APEEstimation.AlignmentTrackSelector_cff
-process.MuSkim = Alignment.APEEstimation.AlignmentTrackSelector_cff.MuSkimSelector
 
 
+
+import Alignment.APEEstimation.AlignmentTrackSelector_cff as AlignmentTrackSelector
+
+
+# Determination of which AlignmentTrackSelector to use
+if trackSelection == "SingleMu":
+    trackSelector = AlignmentTrackSelector.MuSkimSelector
+elif trackSelection == "DoubleMu":
+    trackSelector = AlignmentTrackSelector.DoubleMuSkimSelector
+elif trackSelection == "MinBias":
+    trackSelector = AlignmentTrackSelector.MinBiasSkimSelector
+elif trackSelection == "Cosmics":
+    trackSelector = AlignmentTrackSelector.CosmicsSkimSelector
+else: # Extend list here with custom track selectors
+    print("Unknown trackSelection %s, exiting"%(trackSelection))
+    exit(1)
+
+process.MuSkim = trackSelector
 
 ##
 ## If preselected track list is used
@@ -151,8 +231,8 @@ if options.useTrackList:
     process.TriggerSelectionSequence *= process.TrackList
 
 import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
-process.seqTrackselRefit = trackselRefit.getSequence(process, 'ALCARECOTkAlMuonIsolated')
-#~ process.seqTrackselRefit = trackselRefit.getSequence(process, 'ALCARECOTkAlZMuMu')
+process.seqTrackselRefit = trackselRefit.getSequence(process, trackSelector.src.getModuleLabel())
+
 
 ##
 ## Path
@@ -162,8 +242,6 @@ process.path = cms.Path(
     process.seqTrackselRefit*
     process.MuSkim
 )
-
-
 
 ##
 ## Define event selection from path
@@ -175,32 +253,15 @@ EventSelection = cms.PSet(
 )
 
 
-
 ##
 ## configure output module
 ##
 process.out = cms.OutputModule("PoolOutputModule",
     ## Parameters directly for PoolOutputModule
-    fileName = cms.untracked.string('Data_TkAlMuonIsolated_DoubleMuon_Run2015B_PromptReco1.root'),
-    #logicalFileName = cms.untracked.string(''),
-    #catalog = cms.untracked.string(''),
-    # Maximus size per file before a new one is created
-    maxSize = cms.untracked.int32(700000),
-    #compressionLevel = cms.untracked.int32(0),
-    #basketSize = cms.untracked.int32(0),
-    #splitLevel = cms.untracked.int32(0),
-    #sortBaskets = cms.untracked.string(''),
-    #treeMaxVirtualSize =  cms.untracked.int32(0),
-    #fastCloning = cms.untracked.bool(False),
-    #overrideInputFileSplitLevels = cms.untracked.bool(True),
+    fileName = cms.untracked.string(outputName),
+    # Maximum size per file before a new one is created
+    maxSize = cms.untracked.int32(outputFileSize),
     dropMetaData = cms.untracked.string("DROPPED"),
-    #dataset = cms.untracked.PSet(
-    #    filterName = cms.untracked.string('TkAlMuonIsolated'),
-    #    dataTier = cms.untracked.string('ALCARECO'),
-    #),
-    # Not yet implemented
-    #eventAutoFlushCompressedSize = cms.untracked.int32(5*1024*1024),
-    
     ## Parameters for inherited OutputModule
     SelectEvents = EventSelection.SelectEvents,
     outputCommands = cms.untracked.vstring(
@@ -213,9 +274,6 @@ process.out.outputCommands.extend(process.ApeSkimEventContent.outputCommands)
 
 if options.isTest:
   process.out.fileName = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/test_apeSkim.root'
-
-
-
 
 
 ##

--- a/Alignment/APEEstimation/test/autoSubmitter/autoSubmitter.py
+++ b/Alignment/APEEstimation/test/autoSubmitter/autoSubmitter.py
@@ -1,0 +1,411 @@
+from __future__ import print_function
+import ConfigParser
+import argparse
+import pickle
+import sys
+import os
+import subprocess
+import shutil
+import time
+
+
+pickle_name = "dump.pkl" # contains all the measurement objects in a list
+clock_interval = 10 # in seconds
+STATE_NONE = -1
+STATE_ITERATION_START=0
+STATE_BJOBS_WAITING=1
+STATE_BJOBS_DONE=2
+STATE_BJOBS_FAILED=12
+STATE_MERGE_WAITING=3
+STATE_MERGE_DONE=4
+STATE_MERGE_FAILED=14
+STATE_SUMMARY_WAITING=5
+STATE_SUMMARY_DONE=6
+STATE_SUMMARY_FAILED=16
+STATE_LOCAL_WAITING=7
+STATE_LOCAL_DONE=8
+STATE_LOCAL_FAILED=18
+STATE_FINISHED=9
+
+status_map = {}
+status_map = {}
+status_map = {}
+status_map[STATE_NONE] = "STATE_NONE"
+status_map[STATE_ITERATION_START] = "STATE_ITERATION_START"
+status_map[STATE_BJOBS_WAITING] = "STATE_BJOBS_WAITING"
+status_map[STATE_BJOBS_DONE] = "STATE_BJOBS_DONE"
+status_map[STATE_BJOBS_FAILED] = "STATE_BJOBS_FAILED"
+status_map[STATE_MERGE_WAITING] = "STATE_MERGE_WAITING"
+status_map[STATE_MERGE_DONE] = "STATE_MERGE_DONE"
+status_map[STATE_MERGE_FAILED] = "STATE_MERGE_FAILED"
+status_map[STATE_SUMMARY_WAITING] = "STATE_SUMMARY_WAITING"
+status_map[STATE_SUMMARY_DONE] = "STATE_SUMMARY_DONE"
+status_map[STATE_SUMMARY_FAILED] = "STATE_SUMMARY_FAILED"
+status_map[STATE_LOCAL_WAITING] = "STATE_LOCAL_WAITING"
+status_map[STATE_LOCAL_DONE] = "STATE_LOCAL_DONE"
+status_map[STATE_LOCAL_FAILED] = "STATE_LOCAL_FAILED"
+status_map[STATE_FINISHED] = "STATE_FINISHED"
+base = ""
+
+
+def ensurePathExists(path):
+    import os
+    import errno
+    try:
+        os.makedirs(path)
+    except OSError as exception:
+        if exception.errno != errno.EEXIST:
+            raise
+
+def save(measurements):
+    with open(pickle_name, "w") as saveFile: 
+        pickle.dump(measurements, saveFile)
+
+class Dataset:
+    name = ""
+    nFiles = 0
+    maxEvents = -1
+    baseDirectory = ""
+    baseFileName = ""
+    sampleType = "data1"
+    fileList = []
+    def __init__(self, config, name):
+        dsDict = dict(config.items("dataset:%s"%(name)))
+        self.name = name
+        self.nFiles = int(dsDict["nFiles"])
+        self.baseDirectory = dsDict["baseDirectory"]
+        self.baseFileName = dsDict["baseFileName"]
+        if dsDict.has_key("maxEvents"):
+            self.maxEvents = dsDict["maxEvents"]
+        if dsDict.has_key("isMC"):
+            if dsDict["isMC"] == "True":
+                self.sampleType = "MC"
+            else:
+                self.sampleType ="data1"
+        self.fileList = []
+        for i in range(self.nFiles):
+            self.fileList.append("%s/%s_%d.root"%(self.baseDirectory, self.baseFileName, i+1))
+        
+
+class Alignment:
+    name = ""
+    alignmentName = ""
+    baselineDir = "Design"
+    globalTag = "None"
+    isDesign = False
+    maxIterations = 15
+    
+    def __init__(self, config, name):
+        alDict = dict(config.items("alignment:%s"%(name)))
+        self.name = name
+        self.alignmentName = alDict["alignmentName"]
+        if alDict.has_key("globalTag"):
+            self.globalTag = alDict["globalTag"]
+        if alDict.has_key("baselineDir"):
+            self.baselineDir= alDict["baselineDir"]
+        if alDict.has_key("isDesign"):
+            self.isDesign= (alDict["isDesign"] == "True")
+        if alDict.has_key("maxIterations"):
+            self.maxIterations = int(alDict["maxIterations"])
+        if self.isDesign:
+            self.maxIterations = 0 # stop immediately after finishing first iteration
+            
+class ApeMeasurement:
+    name = "workingArea"
+    curIteration = 0
+    maxIteration = 15
+    status = STATE_NONE
+    dataset = None
+    alignment = None
+    runningJobs  = None
+    failedJobs      = None
+    error = False
+    done = False
+    startTime = ""
+    finishTime = ""
+    
+    def __init__(self, name, dataset, alignment):
+        self.name = name
+        self.alignment = alignment
+        self.dataset = dataset
+        self.curIteration = 0
+        self.status = STATE_ITERATION_START
+        self.runningJobs = []
+        self.failedJobs = []
+        self.startTime = subprocess.check_output(["date"]).strip()
+        self.maxIteration = self.alignment.maxIterations
+        if self.alignment.isDesign and self.dataset.sampleType != "MC":
+            # For now, this won't immediately shut down the program
+            print("APE Measurement %s is scheduled to to an APE baseline measurement with a dataset that is not marked as isMC=True. Is this intended?"%(self.name))
+        ensurePathExists('%s/hists/%s'%(base, self.name))
+        if not self.alignment.isDesign:
+            ensurePathExists('%s/hists/%s/apeObjects'%(base, self.name))
+        
+    def get_status(self):
+        return status_map[self.status]
+    
+    def print_status(self):
+        print("APE Measurement %s in iteration %d is now in status %s"%(self.name, self.curIteration, self.get_status()))
+    
+    def submit_jobs(self):
+        toSubmit = []
+        for i in range(self.dataset.nFiles):
+            inputFile = self.dataset.fileList[i]
+            lastIter = (self.curIteration==self.maxIteration)
+            inputCommands = "sample=%s fileNumber=%s iterNumber=%d lastIter=%r alignRcd=%s maxEvents=%s globalTag=%s measurementName=%s"%(self.dataset.sampleType,i+1,self.curIteration,lastIter,self.alignment.alignmentName, self.dataset.maxEvents, self.alignment.globalTag, self.name)
+            fiName = "%s/test/autoSubmitter/workingArea/batchscript_%s_iter%d_%d"%(base, self.name,self.curIteration,i+1)
+            with open(fiName+".tcsh", "w") as jobFile:
+                from autoSubmitterTemplates import bjobTemplate
+                jobFile.write(bjobTemplate.format(inputFile = inputFile, inputCommands=inputCommands))
+            toSubmit.append(fiName)
+            
+        submitName = "%s/test/autoSubmitter/workingArea/submit_%s_jobs_iter%d.sh"%(base, self.name, self.curIteration)
+        with open(submitName,"w") as submitFile:
+            for sub in toSubmit:
+                from autoSubmitterTemplates import submitJobTemplate
+                errorFile = sub+"_error.txt"
+                outputFile = sub+"_output.txt"
+                jobFile = sub+".tcsh"
+                date = subprocess.check_output(["date", "+%m_%d_%H_%M_%S"]).strip()
+                jobName = sub.split("/")[-1]+"_"+date
+                self.runningJobs.append(jobName)
+                submitFile.write(submitJobTemplate.format(errorFile=errorFile, outputFile=outputFile, jobFile=jobFile, jobName=jobName))
+            submitFile.write("rm -- $0")
+        
+        subOut = subprocess.check_output("bash %s"%(submitName), shell=True).strip()
+        if len(subOut) == 0:
+                print("Running on environment that does not know bsub command or ssh session is timed out (ongoing for longer than 24h?), exiting")
+                sys.exit()
+        self.status = STATE_BJOBS_WAITING
+        self.print_status()
+    
+    def check_jobs(self):
+        lastStatus = self.status
+        stillRunningJobs = []
+        for job in self.runningJobs:
+            from autoSubmitterTemplates import checkJobTemplate
+            checkString = checkJobTemplate.format(jobName=job)
+            jobState = subprocess.check_output(checkString, shell=True).rstrip()
+            if "DONE" in jobState:
+                print("Job %s in iteration %d of APE measurement %s has just finished"%(job, self.curIteration, self.name))
+            elif "EXIT" in jobState:
+                print("Job %s in iteration %d of APE measurement %s has failed"%(job, self.curIteration, self.name))
+                self.failedJobs.append(job)
+            elif "RUN" in jobState or "PEND" in jobState:
+                stillRunningJobs.append(job)
+            elif "Job <%s> is not found" in jobState:
+                print("Job %s of APE measurement was not found in queue, so it is assumed that it successfully finished long ago."%(job, self.name))
+            elif len(jobState) == 0:
+                print("Running on environment that does not know bjobs command or ssh session is timed out (ongoing for longer than 24h?), exiting")
+                sys.exit()
+            else:
+                print("Unknown state %s, marking job %s of APE measurement %s as failed"%(jobState, job, self.name))
+                self.failedJobs.append(job)
+        self.runningJobs = stillRunningJobs
+        
+        if len(self.failedJobs) > 0:
+            self.status = STATE_BJOBS_FAILED
+        elif len(self.runningJobs) == 0:
+            self.status = STATE_BJOBS_DONE
+            print("All batch jobs of APE measurement %s in iteration %d are done"%(self.name, self.curIteration))
+        if lastStatus != self.status:
+            self.print_status() 
+        
+    def do_merge(self):
+        self.status = STATE_MERGE_WAITING
+        if self.alignment.isDesign:
+            folderName = '%s/hists/%s/baseline'%(base, self.name)
+        else:
+            folderName = '%s/hists/%s/iter%d'%(base, self.name, self.curIteration)
+        if os.path.isdir(folderName):
+            if os.path.isdir(folderName+"_old"):
+                shutil.rmtree("%s_old"%(folderName))
+            os.rename(folderName, folderName+"_old")
+        os.makedirs(folderName)
+        
+        if self.curIteration > 0 and not self.alignment.isDesign: # don't have to check for isDesign here because it always ends after iteration 0...
+            shutil.copyfile('%s/hists/%s/iter%d/allData_iterationApe.root'%(base, self.name, self.curIteration-1),folderName+"/allData_iterationApe.root")
+        fileNames = ['%s/hists/%s/%s%s.root'%(base, self.name, self.dataset.sampleType, str(i)) for i in range(1, self.dataset.nFiles+1)]
+        fileString = " ".join(fileNames)
+        
+        from autoSubmitterTemplates import mergeTemplate
+        merge_result = subprocess.call(mergeTemplate.format(path=folderName, inputFiles=fileString), shell=True) # returns exit code (0 if no error occured)
+        for name in fileNames:
+            os.remove(name)
+            
+        if os.path.isfile("%s/allData.root"%(folderName)) and merge_result == 0:
+            self.status = STATE_MERGE_DONE
+        else:
+            self.status = STATE_MERGE_FAILED
+        self.print_status()
+    
+    def do_summary(self):
+        self.status = STATE_SUMMARY_WAITING        
+        from autoSubmitterTemplates import summaryTemplate
+        if self.alignment.isDesign:
+            inputCommands = "iterNumber=%d setBaseline=%r measurementName=%s baselineName=%s"%(self.curIteration,self.alignment.isDesign,self.name, self.name)
+        else:
+            inputCommands = "iterNumber=%d setBaseline=%r measurementName=%s baselineName=%s"%(self.curIteration,self.alignment.isDesign,self.name, self.alignment.baselineDir)
+        
+        summary_result = subprocess.call(summaryTemplate.format(inputCommands=inputCommands), shell=True) # returns exit code (0 if no error occured)
+        if summary_result == 0:
+            self.status = STATE_SUMMARY_DONE
+        else:
+            self.status = STATE_SUMMARY_FAILED
+        self.print_status()
+    def do_local_setting(self):
+        self.status = STATE_LOCAL_WAITING       
+        from autoSubmitterTemplates import localSettingTemplate
+        inputCommands = "iterNumber=%d setBaseline=%r measurementName=%s"%(self.curIteration,self.alignment.isDesign,self.name)
+
+        local_setting_result = subprocess.call(localSettingTemplate.format(inputCommands=inputCommands), shell=True) # returns exit code (0 if no error occured)
+        if local_setting_result == 0:
+            self.status = STATE_LOCAL_DONE
+        else:
+            self.status = STATE_LOCAL_FAILED
+        self.print_status()
+    def kill(self):
+        from autoSubmitterTemplates import killJobTemplate
+        for job in self.runningJobs:
+            subprocess.call(killJobTemplate.format(jobName=job), shell=True)
+        self.runningJobs = []
+        self.status = STATE_NONE
+    def purge(self):
+        self.kill()
+        folderName = '%s/hists/%s'%(base, self.name)
+        shutil.rmtree(folderName)
+
+        
+def main():    
+    parser = argparse.ArgumentParser(description="Automatically run APE measurements")
+    parser.add_argument("-c", "--config", action="append", dest="configs", default=[],
+                          help="Config file that has list of measurements")
+    parser.add_argument("-k", "--kill", action="append", dest="kill", default=[],
+                          help="List of measurement names to kill (=remove from list and kill all bjobs)")
+    parser.add_argument("-p", "--purge", action="append", dest="purge", default=[],
+                          help="List of measurement names to purge (=kill and remove folder)")
+    parser.add_argument("-r", "--resume", action="store_true", dest="resume", default=False,
+                          help="Resume interrupted APE measurements which are stored in pickle")
+    parser.add_argument("-o", "--one", action="store_true", dest="one_iteration", default=False,
+                          help="Do only one loop iteration and then quit")
+    args = parser.parse_args()
+    
+    global base
+    global clock_interval
+    try:
+        base = os.environ['CMSSW_BASE']+"/src/Alignment/APEEstimation"
+    except KeyError:
+        print("No CMSSW environment was set, exiting")
+        sys.exit()
+    
+    
+    measurements = []
+    
+    if args.resume:
+        try:
+            with open(pickle_name, "r") as saveFile: 
+                resumed = pickle.load(saveFile)
+                for res in resumed:
+                    measurements.append(res)
+                    print("Measurement %s in state %s in iteration %d was resumed"%(res.name, res.get_status(), res.curIteration))
+                    # Killing and purging is done here, because it doesn't make 
+                    # sense to kill or purge a measurement that was just started
+                    for to_kill in args.kill:
+                        if res.name == to_kill:
+                            res.kill()
+                    for to_purge in args.purge:
+                        if res.name == to_purge:
+                            res.purge()
+        except IOError:
+            print("Could not resume because %s could not be opened, exiting"%(pickle_name))
+            sys.exit()
+            
+    # read out from config file
+    if args.configs != []:
+        config = ConfigParser.RawConfigParser()
+        config.optionxform = str 
+        config.read(args.configs)
+    
+        for name, opts in config.items("measurements"):
+            if name in map(lambda x: x.name ,measurements):
+                print("Error: APE Measurement with name %s already exists, skipping"%(name))
+                continue
+                
+            datasetID, alignmentID = opts.split(" ")
+
+            dataset = Dataset(config, datasetID)
+            alignment = Alignment(config, alignmentID)
+            
+            measurement = ApeMeasurement(name, dataset, alignment)
+            
+            measurements.append(measurement)
+            
+            print("APE Measurement %s was started"%(measurement.name))
+            
+    
+    while True:
+        measurements = [measurement for measurement in measurements if not measurement.status==STATE_NONE]
+        save(measurements)
+        
+        if len(measurements) == 0:
+            print("No APE measurements are active, exiting")
+            break
+        for measurement in measurements:
+            if measurement.status == STATE_ITERATION_START:
+                # start bjobs
+                print("APE Measurement %s just started iteration %d"%(measurement.name, measurement.curIteration))
+                measurement.submit_jobs()
+                save(measurements)
+            if measurement.status == STATE_BJOBS_WAITING:
+                # check if bjobs are finished
+                measurement.check_jobs()
+                save(measurements)
+            if measurement.status == STATE_BJOBS_DONE:
+                # merge files
+                measurement.do_merge()
+                save(measurements)
+            if measurement.status == STATE_MERGE_DONE:
+                # start summary
+                measurement.do_summary()
+                save(measurements)
+            if measurement.status == STATE_SUMMARY_DONE:
+                # start local setting (only if not a baseline measurement)
+                if measurement.alignment.isDesign:
+                    measurement.status = STATE_LOCAL_DONE
+                else:
+                    measurement.do_local_setting()
+                save(measurements)
+            if measurement.status == STATE_LOCAL_DONE:
+                print("APE Measurement %s just finished iteration %d"%(measurement.name, measurement.curIteration))
+                if measurement.curIteration < measurement.maxIteration:
+                    measurement.curIteration += 1
+                    measurement.status = STATE_ITERATION_START
+                else:
+                    measurement.status = STATE_FINISHED
+                    measurement.finishTime = subprocess.check_output(["date"]).strip()
+                    print("APE Measurement %s, which was started at %s was finished after %d iterations, at %s"%(measurement.name, measurement.startTime, measurement.curIteration, measurement.finishTime))
+                save(measurements)
+                # go to next iteration or finish measurement
+            if measurement.status == STATE_BJOBS_FAILED or \
+                measurement.status == STATE_MERGE_FAILED or \
+                measurement.status == STATE_SUMMARY_FAILED or \
+                measurement.status == STATE_LOCAL_FAILED or \
+                measurement.status == STATE_FINISHED:
+                    # might want to do something different. for now, this is the solution
+                    measurement.status = STATE_NONE
+                    save(measurements)
+        if args.one_iteration:
+            break
+            
+        
+        
+        time_remaining = clock_interval
+        while time_remaining > 0:
+            print("Sleeping for %s seconds, you can safely [CTRL+C] now"%(time_remaining))
+            time.sleep(1)
+            time_remaining -= 1
+            sys.stdout.write("\033[F")
+            sys.stdout.write("\033[K")
+            
+if __name__ == "__main__":
+    main()

--- a/Alignment/APEEstimation/test/autoSubmitter/autoSubmitterTemplates.py
+++ b/Alignment/APEEstimation/test/autoSubmitter/autoSubmitterTemplates.py
@@ -1,0 +1,29 @@
+bjobTemplate="""#!/bin/tcsh
+
+cd $CMSSW_BASE/src
+
+eval `scramv1 runtime -csh`
+
+source /afs/cern.ch/cms/caf/setup.csh
+cd -
+
+xrdcp {inputFile} reco.root
+
+cmsRun $CMSSW_BASE/src/Alignment/APEEstimation/test/cfgTemplate/apeEstimator_cfg.py {inputCommands}
+
+rm -- "$0"
+"""
+
+submitJobTemplate="""
+bsub -J {jobName} -e {errorFile} -o {outputFile} -q cmscaf1nd -R "rusage[pool=3000]" tcsh {jobFile}
+"""
+
+checkJobTemplate="bjobs -noheader -a -J {jobName}"
+
+killJobTemplate="bkill -J {jobName}"
+
+summaryTemplate="cmsRun $CMSSW_BASE/src/Alignment/APEEstimation/test/cfgTemplate/apeEstimatorSummary_cfg.py {inputCommands}"
+
+mergeTemplate="hadd {path}/allData.root {inputFiles}"
+
+localSettingTemplate="cmsRun $CMSSW_BASE/src/Alignment/APEEstimation/test/cfgTemplate/apeLocalSetting_cfg.py {inputCommands}"

--- a/Alignment/APEEstimation/test/autoSubmitter/config.ini
+++ b/Alignment/APEEstimation/test/autoSubmitter/config.ini
@@ -1,0 +1,37 @@
+# define data sets like this
+[dataset:exampleDataset]
+# directory where to look, probably starting with /eos/cms/store/caf/user/<username>
+baseDirectory=/some/directory
+# without _ or .root at the end
+baseFileName=filename 
+# number of files in base directory
+nFiles=6
+# optional, events per file, not total maxEvents
+maxEvents=-1
+# set to True for MC samples, False by default
+isMC=False
+
+#define alignments like this
+[alignment:alignmentObject]
+# if you want to use a custom GT you can add it here or simply define it 
+# in apeEstimation_cfg.py. If it is not defined or None, it will not overwrite
+# anything defined in apeEstimation_cfg.py
+globalTag=None
+# name as defined in apeEstimation_cfg.py
+alignmentName=alignmentObjectName
+# name of baseline folder. Only used if isDesign is False, elsewise the 
+# name of the APE measurement is used, Design by default
+baselineDir=Design
+# is this a baseline measurement? False by default
+isDesign=False
+# normally, 15 iterations are done for a measurement. If isDesign is True, 
+# this will be automatically set to 0 as only one iteration needs to be run
+# 15 by default
+maxIterations=15
+
+# define measurements like this
+[measurements]
+# name: dataset alignment
+# unique names are important as this name will be used as a folder name
+# where all relevant files are stored
+exampleName: exampleDataset alignmentObjectName

--- a/Alignment/APEEstimation/test/batch/startSkim.py
+++ b/Alignment/APEEstimation/test/batch/startSkim.py
@@ -1,0 +1,114 @@
+from __future__ import print_function
+import sys
+sys.path.append("../SkimProducer")
+import os
+import subprocess
+import signal
+import time
+import argparse
+import multiprocessing as mp
+
+def doSkim(sample):
+    base = os.environ['CMSSW_BASE']    
+    
+    execString = "cmsRun {base}/src/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py isTest=False useTrackList=False sample={sample}".format(sample=sample, base=base)
+    print(execString)
+    toExec = execString.split(" ")
+    
+    outFileName = None
+    outFilePath = None
+    
+    # start cmsRun
+    proc = subprocess.Popen(toExec, stdout=subprocess.PIPE)
+    
+    def get_output(proc):
+        while True:
+            line = proc.stdout.readline().rstrip()
+            if not line:
+                break
+            yield line
+    
+    # print output in shell while program runs, also extract output filename
+    try:
+        for line in get_output(proc):
+            if "Using output name" in line:
+                outFileName = line.split("output name ")[1].split(".root")[0]
+            if "Using output path" in line:
+                outFilePath = line.split("output path ")[1]
+            print(line)
+    except KeyboardInterrupt:
+        #this way, the current file is closed and the skimming is finished in a way that the last opened file is actually usable
+        
+        print("Interrupted")
+        proc.send_signal(signal.SIGINT)
+        proc.wait()
+        
+    
+    time.sleep(1)    
+    print("Finished with %s, renaming files now"%(sample))
+
+    ## Rename output files to match _n.root naming scheme    
+    targetFiles = []
+    if outFileName:
+        for fi in os.listdir("."):
+            if fi.split(".root")[0].startswith(outFileName):
+                if fi.split(".root")[0] == outFileName:
+                    newFileName = "%s_1.root"%(outFileName)
+                    os.rename(fi, newFileName)
+                    targetFiles.append(newFileName)
+                else:
+                    fileNoString = fi.split(".root")[0].split(outFileName)[1]
+                    try:
+                        fileNo = int(fileNoString)
+                        # For (most) weird naming conventions to not mess up renaming
+                        if len(fileNoString) != 3 or fileNo == 1:
+                            continue
+                        
+                        newFileName = "%s_%d.root"%(outFileName, fileNo+1)
+                        os.rename(fi, newFileName)
+                        targetFiles.append(newFileName)
+                    except ValueError: 
+                        # Catching files from previous skim with same name that were already renamed and not removed before next skim
+                        # and files with longer names but identical parts
+                        continue
+    
+    for fi in targetFiles:
+        print(fi)
+
+    if outFilePath:
+        print("Copying files to desired path")
+        if not os.path.isdir(outFilePath):
+            os.makedirs(outFilePath)
+        for fi in targetFiles:
+            subprocess.call("xrdcp %s %s/"%(fi, outFilePath), shell=True)
+
+def main(argv):
+    if not 'CMSSW_BASE' in os.environ:
+        print("CMSSW evironment is not set up, do that first")
+        exit(1)
+    
+    parser = argparse.ArgumentParser(description='Define which samples to skim')
+    parser.add_argument("-s", "--sample", action="append", dest="samples", default=[],
+                          help="Name of sample as defined in skimProducer_cfg.py. Multiple inputs possible")
+    parser.add_argument("-c", "--consecutive", action="store_true", dest="consecutive", default=False,
+                          help="Do consecutive instead of parallel skims")
+    
+    args = parser.parse_args()
+    
+    if len(args.samples) == 0:
+        print("Usage: python startSkim.py -s <sample>")
+        sys.exit()
+    
+    if len(args.samples) == 1 or args.consecutive:
+        for sample in args.samples:
+            doSkim(sample) 
+    else:
+        try:
+            pool = mp.Pool(len(args.samples))
+            pool.map_async(doSkim, args.samples)
+            pool.close()
+            pool.join()
+        except KeyboardInterrupt:
+            pass # The keyboard interrupt will be forwarded to the subprocesses anyway, stopping them without terminating them immediately
+if __name__ == "__main__":
+    main(sys.argv)

--- a/Alignment/APEEstimation/test/cfgTemplate/apeEstimatorSummary_cfg.py
+++ b/Alignment/APEEstimation/test/cfgTemplate/apeEstimatorSummary_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 
 import FWCore.ParameterSet.Config as cms
@@ -12,20 +13,14 @@ import sys
 options = VarParsing.VarParsing ('standard')
 options.register('iterNumber', 0, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Iteration number")
 options.register('setBaseline', False, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.bool, "Set baseline")
-
-
+options.register('measurementName', "workingArea", VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Folder in which to store results")
+options.register('baselineName', "Design", VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Folder in which baseline-trees are found or stored")
 
 # get and parse the command line arguments
-if( hasattr(sys, "argv") ):
-    for args in sys.argv :
-        arg = args.split(',')
-        for val in arg:
-            val = val.split('=')
-            if(len(val)==2):
-                setattr(options,val[0], val[1])
+options.parseArguments()
 
-print "Iteration number: ", options.iterNumber
-print "Set baseline: ", options.setBaseline
+print("Iteration number: ", options.iterNumber)
+print("Set baseline: ", options.setBaseline)
 
 
 
@@ -61,9 +56,9 @@ process.options = cms.untracked.PSet(
 ## Input Files
 ##
 process.source = cms.Source("EmptySource",
-					numberEventsInRun = cms.untracked.uint32(1),
-					firstRun = cms.untracked.uint32(246994)
-					)
+                    numberEventsInRun = cms.untracked.uint32(1),
+                    firstRun = cms.untracked.uint32(246994)
+                    )
 
 
 
@@ -77,18 +72,20 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
 from CondCore.CondDB.CondDB_cfi import *
 
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_design', '')
 
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_design', '')
+
+# Load a certain APE payload to write into allData_defaultApe.root 
 CondDBAlignmentError = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
 process.myTrackerAlignmentErr = cms.ESSource("PoolDBESSource",
-	CondDBAlignmentError,
-	timetype = cms.string("runnumber"),
-	toGet = cms.VPSet(
-		cms.PSet(
-			record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-			tag = cms.string('TrackerAlignmentExtendedErr_2009_v2_express_IOVs')
-		)
-	)
+    CondDBAlignmentError,
+    timetype = cms.string("runnumber"),
+    toGet = cms.VPSet(
+        cms.PSet(
+            record = cms.string('TrackerAlignmentErrorExtendedRcd'),
+            tag = cms.string('TrackerAlignmentExtendedErr_2009_v2_express_IOVs')
+        )
+    )
 )
 process.es_prefer_trackerAlignmentErr = cms.ESPrefer("PoolDBESSource","myTrackerAlignmentErr")
 
@@ -101,33 +98,33 @@ process.ApeEstimatorSummarySequence = cms.Sequence()
 if options.setBaseline:
   process.ApeEstimatorSummary1 = ApeEstimatorSummaryBaseline.clone(
     # baseline will be set
-    BaselineFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData_baselineApe.root',
-    DefaultFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData_defaultApe.root',
-    InputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData.root',
-    ResultsFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData_resultsFile.root',
+    BaselineFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData_baselineApe.root',
+    DefaultFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData_defaultApe.root',
+    InputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData.root',
+    ResultsFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData_resultsFile.root',
   )
   process.ApeEstimatorSummary2 = ApeEstimatorSummaryIter.clone(
-    BaselineFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData_baselineApe.root',
-    InputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData.root',
-    ResultsFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData_resultsFile.root',
+    BaselineFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData_baselineApe.root',
+    InputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData.root',
+    ResultsFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData_resultsFile.root',
     # files are not in use in baseline mode
-    IterationFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData_iterationApe.root',
-    DefaultFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData_defaultApe.root',
-    ApeOutputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData_apeOutput.txt',
+    IterationFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData_iterationApe.root',
+    DefaultFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData_defaultApe.root',
+    ApeOutputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData_apeOutput.txt',
   )
   process.ApeEstimatorSummarySequence *= process.ApeEstimatorSummary1
   process.ApeEstimatorSummarySequence *= process.ApeEstimatorSummary2
 else:
   process.ApeEstimatorSummary1 = ApeEstimatorSummaryIter.clone(
     # keep the same for all jobs
-    BaselineFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/Design/baseline/allData_baselineApe.root',
+    BaselineFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.baselineName+'/baseline/allData_baselineApe.root',
     # keep the first one on misaligned geometry for iterations on same geometry (or better use copy of it)
-    IterationFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/workingArea/iter'+str(options.iterNumber)+'/allData_iterationApe.root',
+    IterationFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.measurementName+'/iter'+str(options.iterNumber)+'/allData_iterationApe.root',
     # change iteration number for these
-    InputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/workingArea/iter'+str(options.iterNumber)+'/allData.root',
-    ResultsFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/workingArea/iter'+str(options.iterNumber)+'/allData_resultsFile.root',
-    ApeOutputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/workingArea/iter'+str(options.iterNumber)+'/allData_apeOutput.txt',
-    DefaultFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/workingArea/iter'+str(options.iterNumber)+'/allData_defaultApe.root',
+    InputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.measurementName+'/iter'+str(options.iterNumber)+'/allData.root',
+    ResultsFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.measurementName+'/iter'+str(options.iterNumber)+'/allData_resultsFile.root',
+    ApeOutputFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.measurementName+'/iter'+str(options.iterNumber)+'/allData_apeOutput.txt',
+    DefaultFile = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.measurementName+'/iter'+str(options.iterNumber)+'/allData_defaultApe.root',
   )
   process.ApeEstimatorSummarySequence *= process.ApeEstimatorSummary1
 

--- a/Alignment/APEEstimation/test/cfgTemplate/apeEstimator_cfg.py
+++ b/Alignment/APEEstimation/test/cfgTemplate/apeEstimator_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 
 import FWCore.ParameterSet.Config as cms
@@ -12,27 +13,21 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 import sys
 options = VarParsing.VarParsing ('standard')
 options.register('sample', 'data1', VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Input sample")
+options.register('globalTag', "None", VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Custom global tag")
+options.register('measurementName', "workingArea", VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Folder in which to store results")
 options.register('fileNumber', 1, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.int, "Input file number")
 options.register('iterNumber', 0, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.int, "Iteration number")
 options.register('lastIter', False, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.bool, "Last iteration")
 options.register('alignRcd','', VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "AlignmentRcd")
 
-
-
 # get and parse the command line arguments
-if( hasattr(sys, "argv") ):
-    for args in sys.argv :
-        arg = args.split(',')
-        for val in arg:
-            val = val.split('=')
-            if(len(val)==2):
-                setattr(options,val[0], val[1])
+options.parseArguments()   
 
-print "Input sample: ", options.sample
-print "Input file number", options.fileNumber
-print "Iteration number: ", options.iterNumber
-print "Last iteration: ", options.lastIter
-print "AlignmentRcd: ", options.alignRcd
+print("Input sample: ", options.sample)
+print("Input file number", options.fileNumber)
+print("Iteration number: ", options.iterNumber)
+print("Last iteration: ", options.lastIter)
+print("AlignmentRcd: ", options.alignRcd)
 
 
 
@@ -114,9 +109,9 @@ elif options.sample == 'zmumu50':
     isMc = True
 elif "MC" in options.sample:
     isMc = True
-    print options.sample
+    print(options.sample)
 else:
-    print 'ERROR --- incorrect data sammple: ', options.sample
+    print('ERROR --- incorrect data sammple: ', options.sample)
     exit(8888)
 
 
@@ -136,7 +131,7 @@ readFiles.extend( [
 ##
 ## Number of Events (should be after input file)
 ##
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) ) # maxEvents is included in options by default
 
 
 
@@ -152,14 +147,13 @@ process.source.duplicateCheckMode = cms.untracked.string("checkEachRealDataFile"
 ##
 process.load("Alignment.APEEstimation.TrackRefitter_38T_cff")
 
-if isParticleGun:
+if options.globalTag != "None":
+    process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+elif isParticleGun:
     process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_design', '')
 elif isMc:
-    #~ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_design', '')
-    #~ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_design', '')
-    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
-    
-
+    #~ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_design', '')
+    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic', '')
 elif isData:
     process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 
@@ -198,8 +192,8 @@ elif options.alignRcd == 'misalTest':
     )
     process.es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource","myTrackerAlignment")
   
-elif options.alignRcd == 'mp1799':
-    CondDBAlignment = CondDB.clone(connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/mp1799/jobData/jobm/alignments_MP.db'))
+elif options.alignRcd == 'mp2705':
+    CondDBAlignment = CondDB.clone(connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/mp2705/jobData/jobm/alignments_MP.db'))
     process.myTrackerAlignment = cms.ESSource("PoolDBESSource",
         CondDBAlignment,
         timetype = cms.string("runnumber"),
@@ -235,19 +229,19 @@ elif options.alignRcd == 'useStartGlobalTagForAllConditions':
 elif options.alignRcd == '':
   pass
 else:
-  print 'ERROR --- incorrect alignment: ', options.alignRcd
+  print('ERROR --- incorrect alignment: ', options.alignRcd)
   exit(8888)
 
 ## APE
 if options.iterNumber!=0:
-    CondDBAlignmentError = CondDB.clone(connect = cms.string('sqlite_file:'+os.environ['CMSSW_BASE']+'/src/Alignment/APEEstimation/hists/apeObjects/apeIter'+str(options.iterNumber-1)+'.db'))
+    CondDBAlignmentError = CondDB.clone(connect = cms.string('sqlite_file:'+os.environ['CMSSW_BASE']+'/src/Alignment/APEEstimation/hists/'+options.measurementName+'/apeObjects/apeIter'+str(options.iterNumber-1)+'.db'))
     process.myTrackerAlignmentErr = cms.ESSource("PoolDBESSource",
         CondDBAlignmentError,
         timetype = cms.string("runnumber"),
         toGet = cms.VPSet(
             cms.PSet(
                 record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-                tag = cms.string('TrackerAlignmentExtendedErr_2009_v2_express_IOVs')
+                tag = cms.string('APEs')
             )
         )
     )
@@ -302,7 +296,7 @@ elif options.lastIter == True:
 ## Output File Configuration
 ##
 process.TFileService = cms.Service("TFileService",
-    fileName = cms.string(os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/workingArea/'+options.sample+str(options.fileNumber)+'.root'),
+    fileName = cms.string(os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/'+options.measurementName+'/'+options.sample+str(options.fileNumber)+'.root'),
     closeFileFast = cms.untracked.bool(True)
 )
 
@@ -312,7 +306,7 @@ process.TFileService = cms.Service("TFileService",
 ## Path
 ##
 process.p = cms.Path(
-    process.TriggerSelectionSequence*
+    #process.TriggerSelectionSequence* # You want to use this if you want to select for triggers
     process.RefitterHighPuritySequence*
     process.ApeEstimatorSequence
 )

--- a/Alignment/APEEstimation/test/cfgTemplate/apeLocalSetting_cfg.py
+++ b/Alignment/APEEstimation/test/cfgTemplate/apeLocalSetting_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 
 import FWCore.ParameterSet.Config as cms
@@ -13,26 +14,19 @@ import sys
 options = VarParsing.VarParsing ('standard')
 options.register('iterNumber', 0, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Iteration number")
 options.register('setBaseline', False, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.bool, "Set baseline")
-
-
+options.register('measurementName', "workingArea", VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Folder in which to store results")
 
 # get and parse the command line arguments
-if( hasattr(sys, "argv") ):
-    for args in sys.argv :
-        arg = args.split(',')
-        for val in arg:
-            val = val.split('=')
-            if(len(val)==2):
-                setattr(options,val[0], val[1])
+options.parseArguments()
 
-print "Iteration number: ", options.iterNumber
-print "Set baseline: ", options.setBaseline
+print("Iteration number: ", options.iterNumber)
+print("Set baseline: ", options.setBaseline)
 
 
 
 if options.setBaseline:
-    print "Set baseline mode, do not create APE DB-object"
-    exit(1)
+    print("Set baseline mode, do not create APE DB-object")
+    exit(0)
 
 
 ##
@@ -40,8 +34,7 @@ if options.setBaseline:
 ##
 process = cms.Process("APE")
 # we need conditions
-#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = 'IDEAL_V11::All'
+
 #;;;;;;;;;;;;;;;new line;;;;;;;;;;;;;;;
 process.load("Configuration.StandardSequences.Services_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
@@ -51,20 +44,8 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
 
 # process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_design', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_design', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_design', '')
 
-#;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-# include "Configuration/StandardSequences/data/FakeConditions.cff"
-# initialize magnetic field
-#process.load("Configuration.StandardSequences.MagneticField_cff")
-
-# ideal geometry and interface
-#process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
-#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-# for Muon: include "Geometry/MuonNumbering/data/muonNumberingInitialization.cfi"
-
-# track selection for alignment
-#process.load("Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi")
 
 # Alignment producer
 process.load("Alignment.CommonAlignmentProducer.AlignmentProducer_cff")
@@ -75,15 +56,11 @@ process.AlignmentProducer.algoConfig.readApeFromASCII = True
 process.AlignmentProducer.algoConfig.setComposites = False
 process.AlignmentProducer.algoConfig.readLocalNotGlobal = True
 # CAVEAT: Input file name has to start with a Package name...
-process.AlignmentProducer.algoConfig.apeASCIIReadFile = 'Alignment/APEEstimation/hists/workingArea/iter'+str(options.iterNumber)+'/allData_apeOutput.txt'
+process.AlignmentProducer.algoConfig.apeASCIIReadFile = 'Alignment/APEEstimation/hists/'+options.measurementName+'/iter'+str(options.iterNumber)+'/allData_apeOutput.txt'
 process.AlignmentProducer.algoConfig.saveApeToASCII = False
 process.AlignmentProducer.algoConfig.saveComposites = False
 process.AlignmentProducer.algoConfig.apeASCIISaveFile = 'myLocalDump.txt'
         
-# replace AlignmentProducer.doMisalignmentScenario = true
-# replace AlignmentProducer.applyDbAlignment = true # needs other conditions than fake!
-# Track refitter (adapted to alignment needs)
-#process.load("RecoTracker.TrackProducer.RefitterWithMaterial_cff")
 
 # to be refined...
 process.MessageLogger = cms.Service("MessageLogger",
@@ -120,25 +97,18 @@ process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
 from CondCore.CondDB.CondDB_cfi import *
-CondDBAlignmentError = CondDB.clone(connect = cms.string('sqlite_file:'+os.environ['CMSSW_BASE']+'/src/Alignment/APEEstimation/hists/apeObjects/apeIter'+str(options.iterNumber)+'.db'))
+CondDBAlignmentError = CondDB.clone(connect = cms.string('sqlite_file:'+os.environ['CMSSW_BASE']+'/src/Alignment/APEEstimation/hists/'+options.measurementName+'/apeObjects/apeIter'+str(options.iterNumber)+'.db'))
 process.PoolDBOutputService = cms.Service(
     "PoolDBOutputService",
     CondDBAlignmentError,
     timetype = cms.untracked.string('runnumber'),
     toPut = cms.VPSet(
         cms.PSet(
-	    record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-            tag = cms.string('TrackerAlignmentExtendedErr_2009_v2_express_IOVs')
+        record = cms.string('TrackerAlignmentErrorExtendedRcd'),
+            tag = cms.string('APEs')
         )
     )
 )
 
-
-
-# We do not even need a path - producer is called anyway...
-#process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
-#process.p = cms.Path(process.offlineBeamSpot)
-#process.TrackRefitter.src = 'AlignmentTrackSelector'
-#process.TrackRefitter.TrajectoryInEvent = True
 
 


### PR DESCRIPTION
Backport of #24192 

This branch is based on a 10_2_X CMSSW version, but still incorporates the python print migration for changed and added files.

This PR consists of three commits:

b3856d6 fixes a small typo in one of the rarely used macros for validation plots.

33f7b47 consists of an update to the SkimProducer and AlignmentTrackSelector on one hand to ease the configuration of skims. On the other hand, a new python script startSkim.py was created to use alternatively to skimProducer.bash. This new script enables parallel execution of skims as well as automatic renaming of the output files (from *00N.root to *_(N+1).root which is the input name format needed for the APE measurements) and moving of the skimmed files to a target directory.

e43f208 adds additional optional input parameters to the central _cfg.py files used for a measurement. When using the standard workflow, these parameters are unused and nothing changes. However, the commit also includes a new folder autoSubmitter which includes a script to configure and submit multiple measurements at the same time in order to be able to do multiple measurements at once using only one CMSSW-environment.