### PR TITLE
EMTF fix track address for low-quality tracks

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -198,7 +198,7 @@ namespace l1t {
 	else Track_.set_track_num( 0 );
 
 	// For single-LCT tracks, "Track_num" = 2 (last in collection)
-	if (SP_.Quality_GMT() < 4) Track_.set_track_num( 2 );
+	if (SP_.Quality_GMT() == 0) Track_.set_track_num( 2 );
 	
 	mu_.setHwSign      ( SP_.C() );
 	mu_.setHwSignValid ( SP_.VC() );


### PR DESCRIPTION
Single-LCT tracks in cosmic mode always have quality = 0 : https://tinyurl.com/y9nejzvp
This line causing EMTF output vs. uGMT input mismatches for tracks with 1 <= quality < 4 : https://tinyurl.com/yacqb3nm
In particular, mismatch in track address 8 (kTrkNum, track_num) : https://tinyurl.com/y7buhfk7, https://tinyurl.com/ycpesl34
Fix should significantly reduce track address disagreement : https://tinyurl.com/ybmblbdz