### PR TITLE
EMTF fix track address for low-quality tracks, back-port to 10_2_1

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -198,7 +198,7 @@ namespace l1t {
 	else Track_.set_track_num( 0 );
 
 	// For single-LCT tracks, "Track_num" = 2 (last in collection)
-	if (SP_.Quality_GMT() < 4) Track_.set_track_num( 2 );
+	if (SP_.Quality_GMT() == 0) Track_.set_track_num( 2 );
 	
 	mu_.setHwSign      ( SP_.C() );
 	mu_.setHwSignValid ( SP_.VC() );


### PR DESCRIPTION
Back-port of https://github.com/cms-sw/cmssw/pull/24234