### PR TITLE
L1T muon offline DQM Fix dPhi calculation - 102x

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
@@ -14,6 +14,10 @@ from DQMOffline.L1Trigger.L1TTauDiff_cfi import *
 
 from DQMOffline.L1Trigger.L1TMuonDQMEfficiency_cff import *
 
+# harvesting sequence for all datasets
+DQMHarvestL1TMon = cms.Sequence(
+)
+
 # harvesting sequence for electron dataset
 DQMHarvestL1TEg = cms.Sequence(
     l1tEGammaEfficiency

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -398,7 +398,8 @@ Stage2l1tMuonDqmOffline = cms.Sequence(
 # DQM Offline sequence
 Stage2l1TriggerDqmOfflineClient = cms.Sequence(
                                 l1tStage2EmulatorMonitorClient *
-                                l1tStage2MonitorClient
+                                l1tStage2MonitorClient *
+                                DQMHarvestL1TMon
                                 )
 
 # DQM Offline sequence for modules requiring an electron dataset

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -53,7 +53,7 @@ MuonGmtPair::MuonGmtPair(const MuonGmtPair& muonGmtPair) {
 
 double MuonGmtPair::dR() {
     float dEta = m_regMu ? (m_gmtEta - eta()) : 999.;
-    float dPhi = m_regMu ? (m_gmtPhi - phi()) : 999.;
+    float dPhi = m_regMu ? reco::deltaPhi(m_gmtPhi, phi()) : 999.;
     return sqrt(dEta*dEta + dPhi*dPhi);
 }
 


### PR DESCRIPTION
backport of #24238 

Fix the dPhi calculation in the L1T muon offline DQM tag and probe code to have a proper wrap around.
Also adds a currently empty harvesting sequence to match setup of the currently used special ones for EGamma and SingleMuon datasets.