### PR TITLE
GCC 8 Compiler Warning Fixes, remove unused function

### DIFF
--- a/IORawData/DTCommissioning/plugins/DTSpyHelper.cc
+++ b/IORawData/DTCommissioning/plugins/DTSpyHelper.cc
@@ -174,26 +174,6 @@ DTCtcp::Connect(const char *host,int toport)
 }
 
 int
-DTCtcp::WaitData(int timeout)
-{
-//    return  read (sock, buffer,size) ;
-     fd_set rfds;
-     struct timeval tv;
-   
-    FD_ZERO(&rfds);
-    FD_SET(sock,&rfds);
-
-    tv.tv_sec = timeout;
-    tv.tv_usec = 0;
- 
-     int retva = select (1,&rfds,nullptr,&rfds,&tv);
-     if (retva)
-         if (FD_ISSET(0,&rfds)) return 1;
-         else return -1;
-     else return 0; 
-}
-
-int
 DTCtcp::Receive(char *buffer,int size)
 {
 //    return  read (sock, buffer,size) ;

--- a/IORawData/DTCommissioning/plugins/DTSpyHelper.h
+++ b/IORawData/DTCommissioning/plugins/DTSpyHelper.h
@@ -45,7 +45,6 @@ class DTCtcp
     unsigned long addr();
     int Send(char * buffer,int size); 
     int Receive(char *buffer,int size);
-    int WaitData(int timeout);
 
 };
 


### PR DESCRIPTION
This function has erroneous code that is causing the warning.
It also contains other code that appears to be nonsense.
The file descriptors passed to FD_SET and FD_ISSET don't
match. Not only does nothing in the repository call this,
the function as written could not work properly.