### PR TITLE
Remove outdated options in the CSC local trigger. 

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -19,11 +19,7 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 
     # Parameters common for all boards
     commonParam = cms.PSet(
-        isTMB07 = cms.bool(True),
-        isMTCC = cms.bool(False),
-
         # Flag for SLHC studies (upgraded ME11, MPC)
-        # (if true, isTMB07 should be true as well)
         isSLHC = cms.bool(False),
 
         # ME1a configuration:

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
@@ -84,7 +84,6 @@ class CSCAnodeLCTProcessor
 
   /** Pre-defined patterns. */
   static const int pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
-  static const int pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
   static const int pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
   static const int pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
   static const int time_weights[CSCConstants::MAX_WIRES_IN_PATTERN];
@@ -120,12 +119,6 @@ class CSCAnodeLCTProcessor
   int quality[CSCConstants::MAX_NUM_WIRES][3];
   std::vector<CSCWireDigi> digiV[CSCConstants::NUM_LAYERS];
   unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES];
-
-  /** Flag for MTCC data (i.e., "open" patterns). */
-  bool isMTCC;
-
-  /** Use TMB07 flag for DAQ-2006 version (implemented in late 2007). */
-  bool isTMB07;
 
   /** Flag for SLHC studies. */
   bool isSLHC;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1730,17 +1730,3 @@ void CSCCathodeLCTProcessor::testLCTs() {
     }
   }
 }
-
-
-int CSCCathodeLCTProcessor::findNumLayersHit(std::vector<int>
-          stripsHit[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
-  int number = 0;
-  for (int layer = 0; layer < CSCConstants::NUM_LAYERS; layer++) {
-    if ((!stripsHit[layer][ 9].empty()) ||
-        (!stripsHit[layer][10].empty()) ||
-	(!stripsHit[layer][11].empty()) ) number++;
-  }
-  return number;
-}
-
-//  LocalWords:  CMSSW pretrig

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -6,7 +6,7 @@
 //     This class simulates the functionality of the cathode LCT card.  It is
 //     run by the MotherBoard and returns up to two CathodeLCTs. It can be
 //     run either in a test mode, where it is passed arrays of halfstrip
-//     and distrip times, or in normal mode where it determines
+//     times, or in normal mode where it determines
 //     the time and comparator information from the comparator digis.
 //
 //     Additional comments by Jason Mumford 01/31/01 (mumford@physics.ucla.edu)
@@ -38,90 +38,6 @@
 //-----------------
 // Static variables
 //-----------------
-
-// This is the strip pattern that we use for pretrigger.
-// pre_hit_pattern[0][i] = layer. pre_hit_pattern[1][i] = key_strip offset.
-const int CSCCathodeLCTProcessor::pre_hit_pattern[2][CSCConstants::MAX_STRIPS_IN_PATTERN] = {
-  { 999,  0,  0,  0,  999,
-    999,  1,  1,  1,  999,
-    999,  2,  2,  2,  999,
-              3,                // layer
-    999,  4,  4,  4,  999,
-    999,  5,  5,  5,  999},
-  //-------------------------------------------
-  { 999, -1,  0,  1,  999,
-    999, -1,  0,  1,  999,
-    999, -1,  0,  1,  999,
-              0,                // offset
-    999, -1,  0,  1,  999,
-    999, -1,  0,  1,  999}
-};
-
-// The old set of half-strip/di-strip patterns used prior to 2007.
-// For the given pattern, set the unused parts of the pattern to 999.
-// Pattern[i][CSCConstants::MAX_STRIPS_IN_PATTERN] contains pt bend value. JM
-// bend of 0 is left/straight and bend of 1 is right bht 21 June 2001
-// note that the left/right-ness of this is exactly opposite of what one would
-// expect naively (at least it was for me). The only way to make sure you've
-// got the patterns you want is to use the printPatterns() method to dump
-// them. BHT 21 June 2001
-const int CSCCathodeLCTProcessor::pattern[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07][CSCConstants::MAX_STRIPS_IN_PATTERN+1] = {
-  { 999, 999, 999, 999, 999,
-    999, 999, 999, 999, 999,
-    999, 999, 999, 999, 999,
-              999,            // dummy (reserved)
-    999, 999, 999, 999, 999,
-    999, 999, 999, 999, 999, 0},
-  //-------------------------------------------------------------
-  { 999, 999, 999,   0, 999,
-    999, 999, 999,   1, 999,
-    999, 999,   2,   2, 999,
-                3,            // right bending pattern (large)
-    999,   4,   4, 999, 999,
-    999,   5, 999, 999, 999, 1},
-  //-------------------------------------------------------------
-  { 999,   0, 999, 999, 999,
-    999,   1, 999, 999, 999,
-    999,   2,   2, 999, 999,
-                3,            // left bending pattern (large)
-    999, 999,   4,   4, 999,
-    999, 999, 999,   5, 999, 0},
-  //-------------------------------------------------------------
-  { 999, 999,   0, 999, 999,
-    999, 999,   1, 999, 999,
-    999, 999,   2, 999, 999,
-                3,            // right bending pattern (medium)
-    999,   4, 999, 999, 999,
-    999,   5, 999, 999, 999, 1},
-  //-------------------------------------------------------------
-  { 999, 999,   0, 999, 999,
-    999, 999,   1, 999, 999,
-    999, 999,   2, 999, 999,
-                3,            // left bending pattern (medium)
-    999, 999, 999,   4, 999,
-    999, 999, 999,   5, 999, 0},
-  //-------------------------------------------------------------
-  { 999, 999, 999,   0, 999,
-    999, 999, 999,   1, 999,
-    999, 999,   2,   2, 999,
-                3,            // right bending pattern (small)
-    999, 999,   4, 999, 999,
-    999, 999,   5, 999, 999, 1},
-  //-------------------------------------------------------------
-  { 999,   0, 999, 999, 999,
-    999,   1, 999, 999, 999,
-    999,   2,   2, 999, 999,
-                3,            // left bending pattern (small)
-    999, 999,   4, 999, 999,
-    999, 999,   5, 999, 999, 0},
-  //-------------------------------------------------------------
-  { 999, 999,   0, 999, 999,
-    999, 999,   1, 999, 999,
-    999, 999,   2, 999, 999,
-                3,            // straight through pattern
-    999, 999,   4, 999, 999,
-    999, 999,   5, 999, 999, 1}
-};
 
 // New set of halfstrip patterns for 2007 version of the algorithm.
 // For the given pattern, set the unused parts of the pattern to 999.
@@ -261,13 +177,6 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
   // Not used yet.
   fifo_pretrig = conf.getParameter<unsigned int>("clctFifoPretrig");
 
-  // Defines pre-2007 version of the CLCT algorithm used in test beams and
-  // MTCC.
-  isMTCC       = comm.getParameter<bool>("isMTCC");
-
-  // TMB07 firmware used since 2007: switch and config. parameters.
-  isTMB07      = comm.getParameter<bool>("isTMB07");
-
   // Flag for SLHC studies
   isSLHC       = comm.getParameter<bool>("isSLHC");
 
@@ -289,14 +198,12 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
     << "+++ SLHC upgrade configuration is used (isSLHC=True) but smartME1aME1b=False!\n"
     << "Only smartME1aME1b algorithm is so far supported for upgrade! +++\n";
 
-  if (isTMB07) {
-    pid_thresh_pretrig =
-      conf.getParameter<unsigned int>("clctPidThreshPretrig");
-    min_separation    =
-      conf.getParameter<unsigned int>("clctMinSeparation");
+  pid_thresh_pretrig =
+    conf.getParameter<unsigned int>("clctPidThreshPretrig");
+  min_separation    =
+    conf.getParameter<unsigned int>("clctMinSeparation");
 
-    start_bx_shift = conf.getParameter<int>("clctStartBxShift");
-  }
+  start_bx_shift = conf.getParameter<int>("clctStartBxShift");
 
   if (smartME1aME1b) {
     // use of localized dead-time zones
@@ -360,8 +267,6 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor() :
   // CLCT configuration parameters.
   setDefaultConfigParameters();
   infoV =  2;
-  isMTCC  = false;
-  isTMB07 = true;
 
   smartME1aME1b = false;
   disableME1a = false;
@@ -393,7 +298,8 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor() :
   thePreTriggerDigis.clear();
 }
 
-void CSCCathodeLCTProcessor::setDefaultConfigParameters() {
+void CSCCathodeLCTProcessor::setDefaultConfigParameters()
+{
   // Set default values for configuration parameters.
   fifo_tbins   = def_fifo_tbins;
   fifo_pretrig = def_fifo_pretrig;
@@ -401,21 +307,14 @@ void CSCCathodeLCTProcessor::setDefaultConfigParameters() {
   drift_delay  = def_drift_delay;
   nplanes_hit_pretrig = def_nplanes_hit_pretrig;
   nplanes_hit_pattern = def_nplanes_hit_pattern;
-
-  isMTCC = false;
-
-  // New TMB07 parameters.
-  isTMB07 = true;
-  if (isTMB07) {
-    pid_thresh_pretrig = def_pid_thresh_pretrig;
-    min_separation     = def_min_separation;
-  }
-
+  pid_thresh_pretrig = def_pid_thresh_pretrig;
+  min_separation     = def_min_separation;
   tmb_l1a_window_size = def_tmb_l1a_window_size;
 }
 
 // Set configuration parameters obtained via EventSetup mechanism.
-void CSCCathodeLCTProcessor::setConfigParameters(const CSCDBL1TPParameters* conf) {
+void CSCCathodeLCTProcessor::setConfigParameters(const CSCDBL1TPParameters* conf)
+{
   static std::atomic<bool> config_dumped{false};
 
   fifo_tbins   = conf->clctFifoTbins();
@@ -424,12 +323,8 @@ void CSCCathodeLCTProcessor::setConfigParameters(const CSCDBL1TPParameters* conf
   drift_delay  = conf->clctDriftDelay();
   nplanes_hit_pretrig = conf->clctNplanesHitPretrig();
   nplanes_hit_pattern = conf->clctNplanesHitPattern();
-
-  // TMB07 parameters.
-  if (isTMB07) {
-    pid_thresh_pretrig = conf->clctPidThreshPretrig();
-    min_separation     = conf->clctMinSeparation();
-  }
+  pid_thresh_pretrig = conf->clctPidThreshPretrig();
+  min_separation     = conf->clctMinSeparation();
 
   // Check and print configuration parameters.
   checkConfigParameters();
@@ -504,23 +399,21 @@ void CSCCathodeLCTProcessor::checkConfigParameters() {
     nplanes_hit_pattern = def_nplanes_hit_pattern;
   }
 
-  if (isTMB07) {
-    if (pid_thresh_pretrig >= max_pid_thresh_pretrig) {
-      if (infoV >= 0) edm::LogError("L1CSCTPEmulatorConfigError")
-	<< "+++ Value of pid_thresh_pretrig, " << pid_thresh_pretrig
-	<< ", exceeds max allowed, " << max_pid_thresh_pretrig-1 << " +++\n"
-	<< "+++ Try to proceed with the default value, pid_thresh_pretrig="
-	<< def_pid_thresh_pretrig << " +++\n";
-      pid_thresh_pretrig = def_pid_thresh_pretrig;
-    }
-    if (min_separation >= max_min_separation) {
-      if (infoV >= 0) edm::LogError("L1CSCTPEmulatorConfigError")
-	<< "+++ Value of min_separation, " << min_separation
-	<< ", exceeds max allowed, " << max_min_separation-1 << " +++\n"
-	<< "+++ Try to proceed with the default value, min_separation="
-	<< def_min_separation << " +++\n";
-      min_separation = def_min_separation;
-    }
+  if (pid_thresh_pretrig >= max_pid_thresh_pretrig) {
+    if (infoV >= 0) edm::LogError("L1CSCTPEmulatorConfigError")
+	    << "+++ Value of pid_thresh_pretrig, " << pid_thresh_pretrig
+	    << ", exceeds max allowed, " << max_pid_thresh_pretrig-1 << " +++\n"
+	    << "+++ Try to proceed with the default value, pid_thresh_pretrig="
+	    << def_pid_thresh_pretrig << " +++\n";
+    pid_thresh_pretrig = def_pid_thresh_pretrig;
+  }
+  if (min_separation >= max_min_separation) {
+    if (infoV >= 0) edm::LogError("L1CSCTPEmulatorConfigError")
+	    << "+++ Value of min_separation, " << min_separation
+      << ", exceeds max allowed, " << max_min_separation-1 << " +++\n"
+      << "+++ Try to proceed with the default value, min_separation="
+      << def_min_separation << " +++\n";
+    min_separation = def_min_separation;
   }
 
   if (tmb_l1a_window_size >= max_tmb_l1a_window_size) {
@@ -641,19 +534,12 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
   bool noDigis = getDigis(compdc);
 
   if (!noDigis) {
-    // Get halfstrip (and possibly distrip) times from comparator digis.
+    // Get halfstrip times from comparator digis.
     std::vector<int>
       halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
-    std::vector<int>
-      distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
-    if (isTMB07) { // TMB07 (latest) version: halfstrips only.
-      readComparatorDigis(halfstrip);
-    }
-    else { // Earlier versions: halfstrips and distrips.
-      readComparatorDigis(halfstrip, distrip);
-    }
+    readComparatorDigis(halfstrip);
 
-    // Pass arrays of halfstrips and distrips on to another run() doing the
+    // Pass arrays of halfstrips on to another run() doing the
     // LCT search.
     // If the number of layers containing digis is smaller than that
     // required to trigger, quit right away.  (If LCT-based digi suppression
@@ -669,7 +555,7 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
     // Run the algorithm only if the probability for the pre-trigger
     // to fire is not null.  (Pre-trigger decisions are used for the
     // strip read-out conditions in DigiToRaw.)
-    if (layersHit >= nplanes_hit_pretrig) run(halfstrip, distrip);
+    if (layersHit >= nplanes_hit_pretrig) run(halfstrip);
   }
 
   // Return vector of CLCTs.
@@ -689,11 +575,10 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
   return tmpV;
 }
 
-void CSCCathodeLCTProcessor::run(
-  const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-  const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
+void CSCCathodeLCTProcessor::run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS])
+{
   // This version of the run() function can either be called in a standalone
-  // test, being passed the halfstrip and distrip times, or called by the
+  // test, being passed the halfstrip times, or called by the
   // run() function above.  It uses the findLCTs() method to find vectors
   // of LCT candidates. These candidates are sorted and the best two per bx
   // are returned.
@@ -714,18 +599,13 @@ void CSCCathodeLCTProcessor::run(
     int bx = plct->getBX();
     if (bx >= CSCConstants::MAX_CLCT_TBINS) {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeCLCT")
-	<< "+++ Bx of CLCT candidate, " << bx << ", exceeds max allowed, "
-	<< CSCConstants::MAX_CLCT_TBINS-1 << "; skipping it... +++\n";
+                       << "+++ Bx of CLCT candidate, " << bx << ", exceeds max allowed, "
+                       << CSCConstants::MAX_CLCT_TBINS-1 << "; skipping it... +++\n";
       continue;
     }
 
     if (!bestCLCT[bx].isValid()) bestCLCT[bx] = *plct;
     else if (!secondCLCT[bx].isValid()) {
-      // Ignore CLCT if it is the same as the best (i.e. if the same
-      // CLCT was found in both half- and di-strip pattern search).
-      // This can never happen in the test beam and MTCC
-      // implementations.
-      if (!isMTCC && !isTMB07 && *plct == bestCLCT[bx]) continue;
       secondCLCT[bx] = *plct;
     }
   }
@@ -734,18 +614,18 @@ void CSCCathodeLCTProcessor::run(
     if (bestCLCT[bx].isValid()) {
       bestCLCT[bx].setTrknmb(1);
       if (infoV > 0) LogDebug("CSCCathodeLCTProcessor")
-	<< bestCLCT[bx] << " found in ME" << ((theEndcap == 1) ? "+" : "-")
-        << theStation << "/" << theRing << "/" << theChamber
-	<< " (sector " << theSector << " subsector " << theSubsector
-	<< " trig id. " << theTrigChamber << ")" << "\n";
+                       << bestCLCT[bx] << " found in ME" << ((theEndcap == 1) ? "+" : "-")
+                       << theStation << "/" << theRing << "/" << theChamber
+                       << " (sector " << theSector << " subsector " << theSubsector
+                       << " trig id. " << theTrigChamber << ")" << "\n";
     }
     if (secondCLCT[bx].isValid()) {
       secondCLCT[bx].setTrknmb(2);
       if (infoV > 0) LogDebug("CSCCathodeLCTProcessor")
-	<< secondCLCT[bx] << " found in ME" << ((theEndcap == 1) ? "+" : "-")
-        << theStation << "/" << theRing << "/" << theChamber
-	<< " (sector " << theSector << " subsector " << theSubsector
-	<< " trig id. " << theTrigChamber << ")" << "\n";
+                       << secondCLCT[bx] << " found in ME" << ((theEndcap == 1) ? "+" : "-")
+                       << theStation << "/" << theRing << "/" << theChamber
+                       << " (sector " << theSector << " subsector " << theSubsector
+                       << " trig id. " << theTrigChamber << ")" << "\n";
     }
   }
   // Now that we have our best CLCTs, they get correlated with the best
@@ -906,8 +786,6 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
 	      << " digi #"           << i_digi+1
 	      << " strip "           << thisStrip
 	      << " halfstrip "       << thisHalfstrip
-	      << " distrip "         << thisStrip/2 + // [0-39]
-			     ((thisStrip%2 == 1 && thisComparator == 1 && stagger[i_layer] == 1) ? 1 : 0)
 	      << " time "            << bx_times[i]
 	      << " comparator "      << thisComparator
 	      << " stagger "         << stagger[i_layer];
@@ -930,224 +808,6 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
   }
 }
 
-void CSCCathodeLCTProcessor::readComparatorDigis(
-  std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-  std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
-  // Two-argument version for pre-TMB07 (halfstrip and distrips) firmware.
-  // Takes the comparator & time info and stuffs it into halfstrip and (and
-  // possibly distrip) vector.
-
-  int time[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_STRIPS_7CFEBS];
-  int comp[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_STRIPS_7CFEBS];
-  int digiNum[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_STRIPS_7CFEBS];
-  for (int i = 0; i < CSCConstants::NUM_LAYERS; i++){
-    for (int j = 0; j < CSCConstants::MAX_NUM_STRIPS_7CFEBS; j++) {
-      time[i][j]    = -999;
-      comp[i][j]    =    0;
-      digiNum[i][j] = -999;
-    }
-  }
-
-  for (int i = 0; i < CSCConstants::NUM_LAYERS; i++) {
-    std::vector <CSCComparatorDigi> layerDigiV = digiV[i];
-    for (unsigned int j = 0; j < layerDigiV.size(); j++) {
-      // Get one digi at a time for the layer.  -Jm
-      CSCComparatorDigi thisDigi = layerDigiV[j];
-
-      // Dump raw digi info
-      if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
-	<< "Comparator digi: comparator = " << thisDigi.getComparator()
-	<< " strip #" << thisDigi.getStrip()
-	<< " time bin = " << thisDigi.getTimeBin();
-
-      // Get comparator: 0/1 for left/right halfstrip for each comparator
-      // that fired.
-      int thisComparator = thisDigi.getComparator();
-      if (thisComparator != 0 && thisComparator != 1) {
-	if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongInput")
-	  << "+++ Comparator digi with wrong comparator value: digi #" << j
-	  << ", comparator = " << thisComparator << "; skipping it... +++\n";
-	continue;
-      }
-
-      // Get strip number.
-      int thisStrip = thisDigi.getStrip() - 1; // count from 0
-      if (thisStrip < 0 || thisStrip >= numStrips) {
-	if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongInput")
-	  << "+++ Comparator digi with wrong strip number: digi #" << j
-	  << ", strip = " << thisStrip
-	  << ", max strips = " << numStrips << "; skipping it... +++\n";
-	continue;
-      }
-
-      // Get Bx of this Digi and check that it is within the bounds
-      int thisDigiBx = thisDigi.getTimeBin();
-
-      // Total number of time bins in DAQ readout is given by fifo_tbins,
-      // which thus determines the maximum length of time interval.
-      if (thisDigiBx >= 0 && thisDigiBx < static_cast<int>(fifo_tbins)) {
-
-	// If there is more than one hit in the same strip, pick one
-	// which occurred earlier.
-	// In reality, the second hit on the same distrip is ignored only
-	// during the number of clocks defined by the "hit_persist"
-	// parameter (i.e., 6 bx's by default).  So if one simulates
-	// a large number of bx's in a crowded environment, this
-	// approximation here may not be sufficiently good.
-	if (time[i][thisStrip] == -999 || time[i][thisStrip] > thisDigiBx) {
-	  digiNum[i][thisStrip] = j;
-	  time[i][thisStrip]    = thisDigiBx;
-	  comp[i][thisStrip]    = thisComparator;
-	  if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
-	    << "Comp digi: layer " << i+1
-	    << " digi #"           << j+1
-	    << " strip "           << thisStrip
-	    << " halfstrip "       << 2*thisStrip + comp[i][thisStrip] + stagger[i]
-	    << " distrip "         << thisStrip/2 + // [0-39]
-	      ((thisStrip%2 == 1 && comp[i][thisStrip] == 1 && stagger[i] == 1) ? 1 : 0)
-	    << " time "            <<    time[i][thisStrip]
-	    << " comparator "      <<    comp[i][thisStrip]
-	    << " stagger "         << stagger[i];
-	}
-      }
-      else {
-	if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
-	  << "+++ Skipping comparator digi: strip = " << thisStrip
-	  << ", layer = " << i+1 << ", bx = " << thisDigiBx << " +++";
-      }
-    }
-  }
-
-  // Take the comparator & time info and stuff it into half- and di-strip
-  // arrays.
-  for (int i = 0; i < CSCConstants::NUM_LAYERS; i++) {
-    // Use the comparator info to setup the halfstrips and distrips.  -BT
-    // This loop is only for halfstrips.
-    for (int j = 0; j < CSCConstants::MAX_NUM_STRIPS_7CFEBS; j++) {
-      if (time[i][j] >= 0) {
-	int i_halfstrip = 2*j + comp[i][j] + stagger[i];
-	// 2*j    : convert strip to 1/2 strip
-	// comp   : comparator output
-	// stagger: stagger for this layer
-	if (i_halfstrip >= 2*numStrips + 1) {
-	  if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongInput")
-	    << "+++ Found wrong halfstrip number = " << i_halfstrip
-	    << "; skipping this digi... +++\n";
-	  continue;
-	}
-	halfstrip[i][i_halfstrip].push_back(time[i][j]);
-      }
-    }
-
-    // There are no di-strips in the 2007 version of the TMB firmware.
-    if (!isTMB07) {
-      // This loop is only for distrips.  We have to separate the routines
-      // because triad and time arrays can be changed by the distripStagger
-      // routine which could mess up the halfstrips.
-      static std::atomic<int> test_iteration{0};
-      for (int j = 0; j < CSCConstants::MAX_NUM_STRIPS; j++){
-	if (time[i][j] >= 0) {
-	  int i_distrip = j/2;
-	  if (j%2 == 1 && comp[i][j] == 1 && stagger[i] == 1) {
-	    // @@ Needs to be checked.
-	    bool stagger_debug = (infoV > 2);
-	    distripStagger(comp[i], time[i], digiNum[i], j, stagger_debug);
-	  }
-	  // comp[i][j] == 1	: hit on right half-strip.
-	  // stagger[i] == 1	: half-strips are shifted by 1.
-	  // if these conditions are met add 1; otherwise add 0.
-	  // So if there is a hit on the far right half-strip, and the
-	  // half-strips have been staggered to the right, then the di-strip
-	  // would actually correspond to the next highest di-strip.  -JM
-	  if (infoV > 2 && test_iteration == 1) {
-	    testDistripStagger();
-	    test_iteration++;
-	  }
-	  if (i_distrip >= numStrips/2 + 1) {
-	    if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongInput")
-	      << "+++ Found wrong distrip number = " << i_distrip
-	      << "; skipping this digi... +++\n";
-	    continue;
-	  }
-	  distrip[i][i_distrip].push_back(time[i][j]);
-	}
-      }
-    }
-  }
-}
-
-void CSCCathodeLCTProcessor::distripStagger(int stag_triad[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
-				   int stag_time[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
-				   int stag_digi[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
-				   int i_strip, bool debug) {
-  // Author: Jason Mumford (mumford@physics.ucla.edu)
-  // This routine takes care of the stagger situation where there is a hit
-  // on the right half-strip of a di-strip.  If there is a stagger, then
-  // we must associate that distrip with the next distrip. The situation
-  // gets more complicated if the next distrip also has a hit on its right
-  // half-strip.  One could imagine a whole chain of these in which case
-  // we need to go into this routine recursively.  The formula is that
-  // while this condition is satisfied, we enquire the next distrip,
-  // until we have a hit on any other halfstrip (or triad!=3).  Then we
-  // must compare the 2 different bx times and take the smallest one.
-  // Afterwards, we must cycle out of the routine assigning the bx times
-  // to the one strip over.
-
-  // Used only for pre-TMB07 firmware.
-
-  if (i_strip >= CSCConstants::MAX_NUM_STRIPS) {
-    if (debug) edm::LogWarning("L1CSCTPEmulatorWrongInput")
-      << "+++ Found wrong strip number = " << i_strip
-      << "; cannot apply distrip staggering... +++\n";
-    return;
-  }
-
-  if (debug)
-    LogDebug("CSCCathodeLCTProcessor")
-      << " Enter distripStagger: i_strip = " << i_strip
-      << " stag_triad[i_strip] = "   << stag_triad[i_strip]
-      << " stag_time[i_strip] =  "   << stag_time[i_strip]
-      << " stag_triad[i_strip+2] = " << stag_triad[i_strip+2]
-      << " stag_time[i_strip+2] = "  << stag_time[i_strip+2];
-
-  // So if the next distrip has a stagger hit, go into the routine again
-  // for the next distrip.
-  if (i_strip+2 < CSCConstants::MAX_NUM_STRIPS && stag_triad[i_strip+2] == 1)
-    distripStagger(stag_triad, stag_time, stag_digi, i_strip+2);
-
-  // When we have reached a distrip that does not have a staggered hit,
-  // if it has a hit, we compare the bx times of the
-  // staggered distrip with the non-staggered distrip and we take the
-  // smallest of the two and assign it to the shifted distrip time.
-  if (stag_time[i_strip+2] >= 0) {
-    if (stag_time[i_strip] < stag_time[i_strip+2]) {
-      stag_time[i_strip+2] = stag_time[i_strip];
-      stag_digi[i_strip+2] = stag_digi[i_strip];
-    }
-  }
-  // If the next distrip did not have a hit, then we merely assign the
-  // shifted time to the time associated with the staggered distrip.
-  else {
-    stag_time[i_strip+2] = stag_time[i_strip];
-    stag_digi[i_strip+2] = stag_digi[i_strip];
-  }
-
-  // Then to prevent previous staggers from being overwritten, we assign
-  // the unshifted time to -999, and then mark the triads that were shifted
-  // so that we don't go into the routine ever again (such as when making
-  // the next loop over strips).
-  stag_time[i_strip]  = -999;
-  stag_triad[i_strip] =    4;
-  stag_digi[i_strip]  = -999;
-
-  if (debug)
-    LogDebug("CSCCathodeLCTProcessor")
-      << " Exit  distripStagger: i_strip = " << i_strip
-      << " stag_triad[i_strip] = "   << stag_triad[i_strip]
-      << " stag_time[i_strip] = "    << stag_time[i_strip]
-      << " stag_triad[i_strip+2] = " << stag_triad[i_strip+2]
-      << " stag_time[i_strip+2] = "  << stag_time[i_strip+2];
-}
 
 // --------------------------------------------------------------------------
 // The code below is a description of the 2007 version of the CLCT
@@ -1282,9 +942,9 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
 	    keystrip_data[ilct][CLCT_STRIP_TYPE] = 1;           // obsolete
 	    keystrip_data[ilct][CLCT_QUALITY]    = nhits[best_hs];
 	    keystrip_data[ilct][CLCT_CFEB]       =
-	      keystrip_data[ilct][CLCT_STRIP]/cfeb_strips[1];
+	      keystrip_data[ilct][CLCT_STRIP]/CSCConstants::NUM_HALF_STRIPS_PER_CFEB;
 	    int halfstrip_in_cfeb = keystrip_data[ilct][CLCT_STRIP] -
-	      cfeb_strips[1]*keystrip_data[ilct][CLCT_CFEB];
+	      CSCConstants::NUM_HALF_STRIPS_PER_CFEB*keystrip_data[ilct][CLCT_CFEB];
 
 	    if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
 	      << " Final selection: ilct " << ilct
@@ -1778,8 +1438,8 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
             keystrip_data[ilct][CLCT_BX] = bx;
             keystrip_data[ilct][CLCT_STRIP_TYPE] = 1; // obsolete
             keystrip_data[ilct][CLCT_QUALITY] = nhits[best_hs];
-            keystrip_data[ilct][CLCT_CFEB] = keystrip_data[ilct][CLCT_STRIP] / cfeb_strips[1];
-            int halfstrip_in_cfeb = keystrip_data[ilct][CLCT_STRIP] - cfeb_strips[1] * keystrip_data[ilct][CLCT_CFEB];
+            keystrip_data[ilct][CLCT_CFEB] = keystrip_data[ilct][CLCT_STRIP] / CSCConstants::NUM_HALF_STRIPS_PER_CFEB;
+            int halfstrip_in_cfeb = keystrip_data[ilct][CLCT_STRIP] - CSCConstants::NUM_HALF_STRIPS_PER_CFEB * keystrip_data[ilct][CLCT_CFEB];
 
             if (infoV > 1)
               LogTrace("CSCCathodeLCTProcessor") << " Final selection: ilct " << ilct << " key halfstrip "
@@ -1887,12 +1547,10 @@ void CSCCathodeLCTProcessor::dumpConfigParams() const {
        << nplanes_hit_pretrig << "\n";
   strm << " nplanes_hit_pattern [min. number of layers hit for trigger] = "
        << nplanes_hit_pattern << "\n";
-  if (isTMB07) {
-    strm << " pid_thresh_pretrig [lower threshold on pattern id] = "
-	 << pid_thresh_pretrig << "\n";
-    strm << " min_separation     [region of busy key strips] = "
-	 << min_separation << "\n";
-  }
+  strm << " pid_thresh_pretrig [lower threshold on pattern id] = "
+       << pid_thresh_pretrig << "\n";
+  strm << " min_separation     [region of busy key strips] = "
+       << min_separation << "\n";
   strm << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";
   LogDebug("CSCCathodeLCTProcessor") << strm.str();
   //std::cerr<<strm.str()<<std::endl;
@@ -2027,57 +1685,6 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::getCLCTs() {
 }
 
 
-// --------------------------------------------------------------------------
-// Test routines.  Mostly for older versions of the algorithm and outdated.
-// --------------------------------------------------------------------------
-void CSCCathodeLCTProcessor::testDistripStagger() {
-  // Author: Jason Mumford (mumford@physics.ucla.edu)
-  // This routine tests the distripStagger routine.
-  // @@
-  bool debug = true;
-  int test_triad[CSCConstants::NUM_DI_STRIPS], test_time[CSCConstants::NUM_DI_STRIPS];
-  int test_digi[CSCConstants::NUM_DI_STRIPS];
-  int distrip = 0;
-  test_triad[distrip] = 3;    //After routine, I expect 4
-  test_triad[distrip+1] = 3;  //                        4
-  test_triad[distrip+2] = 3;  //                        4
-  test_triad[distrip+3] = 3;  //                        4
-  test_triad[distrip+4] = 3;  //                        4
-  test_triad[distrip+5] = 3;  //                        4
-  test_triad[distrip+6] = 3;  //                        4
-  test_triad[distrip+7] = 3;  //                        4
-  test_triad[distrip+8] = 3;  //                        4
-  test_triad[distrip+9] = 3;  //                        4
-  test_triad[distrip+10] = 2;  //                       2
-
-  test_time[distrip] = 4;     //      ""      ""        0
-  test_time[distrip+1] = 10;  //                        4
-  test_time[distrip+2] = 2;   //                        10
-  test_time[distrip+3] = 0;   //                        2
-  test_time[distrip+4] = 6;   //                        2
-  test_time[distrip+5] = 8;   //                        2
-  test_time[distrip+6] = 10;   //                        2
-  test_time[distrip+7] = 1;   //                        2
-  test_time[distrip+8] = 8;   //                        2
-  test_time[distrip+9] = 5;   //                        2
-  test_time[distrip+10] = 6;   //                        2
-
-  std::cout << "\n ------------------------------------------------- \n";
-  std::cout << "!!!!!!Testing distripStagger routine!!!!!!" << std::endl;
-  std::cout << "Values before distripStagger routine:" << std::endl;
-  for (int i=distrip; i<distrip+11; i++){
-    test_digi[i] = 999;
-    std::cout << "test_triad[" << i << "] = " << test_triad[i];
-    std::cout << "   test_time[" << i << "] = " << test_time[i] << std::endl;
-  }
-  distripStagger(test_triad, test_time, test_digi, distrip, debug);
-  std::cout << "Values after distripStagger routine:" << std::endl;
-  for (int i=distrip; i<distrip+11; i++){
-    std::cout << "test_triad[" << i << "] = " << test_triad[i];
-    std::cout << "   test_time[" << i << "] = " << test_time[i] << std::endl;
-  }
-  std::cout << "\n ------------------------------------------------- \n \n";
-}
 
 void CSCCathodeLCTProcessor::testLCTs() {
   // test to make sure what goes into an LCT is what comes out.

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
@@ -5,12 +5,11 @@
  *
  * This class simulates the functionality of the cathode LCT card. It is run by
  * the MotherBoard and returns up to two CathodeLCTs.  It can be run either in
- * a test mode, where it is passed arrays of halfstrip and distrip times,
+ * a test mode, where it is passed arrays of halfstrip times,
  * or in normal mode where it determines the time and comparator
  * information from the comparator digis.
  *
- * The CathodeLCTs come in distrip and halfstrip flavors; they are sorted
- * (from best to worst) as follows: 6/6H, 5/6H, 6/6D, 4/6H, 5/6D, 4/6D.
+ * The CathodeLCTs only come halfstrip flavors
  *
  * \date May 2001  Removed the card boundaries.  Changed the Pretrigger to
  * emulate the hardware electronic logic.  Also changed the keylayer to be
@@ -69,8 +68,7 @@ class CSCCathodeLCTProcessor
 
   /** Called in test mode and by the run(compdc) function; does the actual LCT
       finding. */
-  void run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-	   const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
+  void run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);
@@ -92,20 +90,12 @@ class CSCCathodeLCTProcessor
 
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigis() const {return thePreTriggerDigis; }
 
-  static void distripStagger(int stag_triad[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
-			     int stag_time[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
-			     int stag_digi[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
-			     int i_distrip, bool debug = false);
-
   /** Set ring number
    * Has to be done for upgrade ME1a!
    **/
   void setRing(unsigned r) {theRing = r;}
 
   /** Pre-defined patterns. */
-  static const int pre_hit_pattern[2][CSCConstants::MAX_STRIPS_IN_PATTERN];
-  static const int pattern[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07][CSCConstants::MAX_STRIPS_IN_PATTERN+1];
-
   static const int pattern2007_offset[CSCConstants::MAX_HALFSTRIPS_IN_PATTERN];
   static const int pattern2007[CSCConstants::NUM_CLCT_PATTERNS][CSCConstants::MAX_HALFSTRIPS_IN_PATTERN+2];
 
@@ -147,12 +137,6 @@ class CSCCathodeLCTProcessor
   std::vector<CSCComparatorDigi> digiV[CSCConstants::NUM_LAYERS];
   std::vector<int> thePreTriggerBXs;
   std::vector<CSCCLCTPreTriggerDigi> thePreTriggerDigis;
-
-  /** Flag for "real" - not idealized - version of the algorithm. */
-  bool isMTCC;
-
-  /** Flag for 2007 firmware version. */
-  bool isTMB07;
 
   /** Flag for SLHC studies. */
   bool isSLHC;
@@ -210,34 +194,26 @@ class CSCCathodeLCTProcessor
   static const int cfeb_strips[2];
 
   //---------------- Methods common to all firmware versions ------------------
-  void readComparatorDigis(std::vector<int>halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-			   std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
   void readComparatorDigis(std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
-  void pulseExtension(
- const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
- const int nStrips,
- unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
+  void pulseExtension(const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+                      const int nStrips,
+                      unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
   //--------------- Functions for 2007 version of the firmware ----------------
-  std::vector<CSCCLCTDigi> findLCTs(
- const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
-  bool preTrigger(
-      const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-      const int start_bx, int& first_bx);
-  bool ptnFinding(
-      const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-      const int nStrips, const unsigned int bx_time);
+  std::vector<CSCCLCTDigi> findLCTs(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
+  bool preTrigger(const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+                  const int start_bx, int& first_bx);
+  bool ptnFinding(const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+                  const int nStrips, const unsigned int bx_time);
   void markBusyKeys(const int best_hstrip, const int best_patid,
-		    int quality[CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
+                    int quality[CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
   unsigned int best_pid[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
   unsigned int nhits[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
   int first_bx_corrected[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
   //--------------- Functions for SLHC studies ----------------
-
-  std::vector<CSCCLCTDigi> findLCTsSLHC(
-    const std::vector<int>  halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
+  std::vector<CSCCLCTDigi> findLCTsSLHC(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
   bool ispretrig[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
@@ -245,13 +221,11 @@ class CSCCathodeLCTProcessor
   /** Dump CLCT configuration parameters. */
   void dumpConfigParams() const;
 
-  /** Dump digis on half-strips and di-strips. */
-  void dumpDigis(
-      const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-      const int stripType, const int nStrips) const;
+  /** Dump digis on half-strips */
+  void dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+                 const int stripType, const int nStrips) const;
 
   //--------------------------- Methods for tests -----------------------------
-  void testDistripStagger();
   void testLCTs();
   int findNumLayersHit(std::vector<int> stripsHit[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 };

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
@@ -227,7 +227,6 @@ class CSCCathodeLCTProcessor
 
   //--------------------------- Methods for tests -----------------------------
   void testLCTs();
-  int findNumLayersHit(std::vector<int> stripsHit[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -9,7 +9,7 @@
 //    The output is up to two Correlated LCTs.
 //
 //    It can be run in either a test mode, where the arguments are a collection
-//    of wire times and arrays of halfstrip and distrip times, or
+//    of wire times and arrays of halfstrip times, or
 //    for general use, with with wire digi and comparator digi collections as
 //    arguments.  In the latter mode, the wire & strip info is passed on the
 //    LCTProcessors, where it is decoded and converted into a convenient form.
@@ -60,16 +60,8 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
   // Pass ALCT, CLCT, and common parameters on to ALCT and CLCT processors.
   static std::atomic<bool> config_dumped{false};
 
-  // Some configuration parameters and some details of the emulator
-  // algorithms depend on whether we want to emulate the trigger logic
-  // used in TB/MTCC or its idealized version (the latter was used in MC
-  // studies since early ORCA days until (and including) CMSSW_2_1_X).
-  edm::ParameterSet commonParams =
-    conf.getParameter<edm::ParameterSet>("commonParam");
-  isMTCC = commonParams.getParameter<bool>("isMTCC");
-
-  // Switch for a new (2007) version of the TMB firmware.
-  isTMB07 = commonParams.getParameter<bool>("isTMB07");
+  // Parameters common for all boards
+  edm::ParameterSet commonParams = conf.getParameter<edm::ParameterSet>("commonParam");
 
   // is it (non-upgrade algorithm) run along with upgrade one?
   isSLHC = commonParams.getParameter<bool>("isSLHC");
@@ -156,9 +148,6 @@ CSCMotherboard::CSCMotherboard() :
                    theSubsector(1), theTrigChamber(1) {
   // Constructor used only for testing.  -JM
   static std::atomic<bool> config_dumped{false};
-
-  isMTCC  = false;
-  isTMB07 = true;
 
   early_tbins = 4;
 
@@ -278,8 +267,7 @@ void CSCMotherboard::checkConfigParameters() {
 
 void CSCMotherboard::run(
 			 const std::vector<int> w_times[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES],
-			 const std::vector<int> hs_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-			 const std::vector<int> ds_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
+			 const std::vector<int> hs_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   // Debug version.  -JM
   clear();
 
@@ -288,7 +276,7 @@ void CSCMotherboard::run(
   clct->setCSCGeometry(csc_g);
 
   alct->run(w_times);            // run anode LCT
-  clct->run(hs_times, ds_times); // run cathodeLCT
+  clct->run(hs_times); // run cathodeLCT
 
   int bx_alct_matched = 0;
   for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_TBINS;
@@ -710,136 +698,51 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
 unsigned int CSCMotherboard::encodePattern(const int ptn,
                                            const int stripType) const {
   const int kPatternBitWidth = 4;
-  unsigned int pattern;
 
-  if (!isTMB07) {
-    // Cathode pattern number is a kPatternBitWidth-1 bit word.
-    pattern = (abs(ptn) & ((1<<(kPatternBitWidth-1))-1));
-
-    // The pattern has the MSB (4th bit in the default version) set if it
-    // consists of half-strips.
-    if (stripType) {
-      pattern = pattern | (1<<(kPatternBitWidth-1));
-    }
-  }
-  else {
-    // In the TMB07 firmware, LCT pattern is just a 4-bit CLCT pattern.
-    pattern = (abs(ptn) & ((1<<kPatternBitWidth)-1));
-  }
+  // In the TMB07 firmware, LCT pattern is just a 4-bit CLCT pattern.
+  unsigned int pattern = (abs(ptn) & ((1<<kPatternBitWidth)-1));
 
   return pattern;
 }
 
-// 4-bit LCT quality number.  Definition can be found in
-// http://www.phys.ufl.edu/~acosta/tb/tmb_quality.txt.  Made by TMB lookup
-// tables and used for MPC sorting.
+// 4-bit LCT quality number.
 unsigned int CSCMotherboard::findQuality(const CSCALCTDigi& aLCT,
-                                         const CSCCLCTDigi& cLCT) const {
+                                         const CSCCLCTDigi& cLCT) const
+{
   unsigned int quality = 0;
 
-  if (!isTMB07) {
-    bool isDistrip = (cLCT.getStripType() == 0);
-
-    if (aLCT.isValid() && !(cLCT.isValid())) {    // no CLCT
-      if (aLCT.getAccelerator()) {quality =  1;}
-      else                       {quality =  3;}
-    }
-    else if (!(aLCT.isValid()) && cLCT.isValid()) { // no ALCT
-      if (isDistrip)             {quality =  4;}
-      else                       {quality =  5;}
-    }
-    else if (aLCT.isValid() && cLCT.isValid()) { // both ALCT and CLCT
-      if (aLCT.getAccelerator()) {quality =  2;} // accelerator muon
-      else {                                     // collision muon
-        // CLCT quality is, in fact, the number of layers hit, so subtract 3
-        // to get quality analogous to ALCT one.
-        int sumQual = aLCT.getQuality() + (cLCT.getQuality()-3);
-        if (sumQual < 1 || sumQual > 6) {
-          if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongValues")
-            << "+++ findQuality: sumQual = " << sumQual << "+++ \n";
-        }
-        if (isDistrip) { // distrip pattern
-          if (sumQual == 2)      {quality =  6;}
-          else if (sumQual == 3) {quality =  7;}
-          else if (sumQual == 4) {quality =  8;}
-          else if (sumQual == 5) {quality =  9;}
-          else if (sumQual == 6) {quality = 10;}
-        }
-        else {            // halfstrip pattern
-          if (sumQual == 2)      {quality = 11;}
-          else if (sumQual == 3) {quality = 12;}
-          else if (sumQual == 4) {quality = 13;}
-          else if (sumQual == 5) {quality = 14;}
-          else if (sumQual == 6) {quality = 15;}
-        }
-      }
-    }
+  // 2008 definition.
+  if (!(aLCT.isValid()) || !(cLCT.isValid())) {
+    if (aLCT.isValid() && !(cLCT.isValid()))      quality = 1; // no CLCT
+    else if (!(aLCT.isValid()) && cLCT.isValid()) quality = 2; // no ALCT
+    else quality = 0; // both absent; should never happen.
   }
-#ifdef OLD
   else {
-    // Temporary definition, used until July 2008.
-    // First if statement is fictitious, just to help the CSC TF emulator
-    // handle such cases (one needs to make sure they will be accounted for
-    // in the new quality definition.
-    if (!(aLCT.isValid()) || !(cLCT.isValid())) {
-      if (aLCT.isValid() && !(cLCT.isValid()))      quality = 1; // no CLCT
-      else if (!(aLCT.isValid()) && cLCT.isValid()) quality = 2; // no ALCT
-      else quality = 0; // both absent; should never happen.
-    }
+    int pattern = cLCT.getPattern();
+    if (pattern == 1) quality = 3; // layer-trigger in CLCT
     else {
-      // Sum of ALCT and CLCT quality bits.  CLCT quality is, in fact, the
-      // number of layers hit, so subtract 3 to put it to the same footing as
-      // the ALCT quality.
-      int sumQual = aLCT.getQuality() + (cLCT.getQuality()-3);
-      if (sumQual < 1 || sumQual > 6) {
-        if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongValues")
-          << "+++ findQuality: Unexpected sumQual = " << sumQual << "+++\n";
-      }
-
-      // LCT quality is basically the sum of ALCT and CLCT qualities, but split
-      // in two groups depending on the CLCT pattern id (higher quality for
-      // straighter patterns).
-      int offset = 0;
-      if (cLCT.getPattern() <= 7) offset = 4;
-      else                        offset = 9;
-      quality = offset + sumQual;
-    }
-  }
-#endif
-  else {
-    // 2008 definition.
-    if (!(aLCT.isValid()) || !(cLCT.isValid())) {
-      if (aLCT.isValid() && !(cLCT.isValid()))      quality = 1; // no CLCT
-      else if (!(aLCT.isValid()) && cLCT.isValid()) quality = 2; // no ALCT
-      else quality = 0; // both absent; should never happen.
-    }
-    else {
-      int pattern = cLCT.getPattern();
-      if (pattern == 1) quality = 3; // layer-trigger in CLCT
-      else {
-        // CLCT quality is the number of layers hit minus 3.
-        // CLCT quality is the number of layers hit.
-        bool a4 = (aLCT.getQuality() >= 1);
-        bool c4 = (cLCT.getQuality() >= 4);
-        //              quality = 4; "reserved for low-quality muons in future"
-        if      (!a4 && !c4) quality = 5; // marginal anode and cathode
-        else if ( a4 && !c4) quality = 6; // HQ anode, but marginal cathode
-        else if (!a4 &&  c4) quality = 7; // HQ cathode, but marginal anode
-        else if ( a4 &&  c4) {
-          if (aLCT.getAccelerator()) quality = 8; // HQ muon, but accel ALCT
+      // CLCT quality is the number of layers hit minus 3.
+      // CLCT quality is the number of layers hit.
+      bool a4 = (aLCT.getQuality() >= 1);
+      bool c4 = (cLCT.getQuality() >= 4);
+      //              quality = 4; "reserved for low-quality muons in future"
+      if      (!a4 && !c4) quality = 5; // marginal anode and cathode
+      else if ( a4 && !c4) quality = 6; // HQ anode, but marginal cathode
+      else if (!a4 &&  c4) quality = 7; // HQ cathode, but marginal anode
+      else if ( a4 &&  c4) {
+        if (aLCT.getAccelerator()) quality = 8; // HQ muon, but accel ALCT
+        else {
+          // quality =  9; "reserved for HQ muons with future patterns
+          // quality = 10; "reserved for HQ muons with future patterns
+          if (pattern == 2 || pattern == 3)      quality = 11;
+          else if (pattern == 4 || pattern == 5) quality = 12;
+          else if (pattern == 6 || pattern == 7) quality = 13;
+          else if (pattern == 8 || pattern == 9) quality = 14;
+          else if (pattern == 10)                quality = 15;
           else {
-            // quality =  9; "reserved for HQ muons with future patterns
-            // quality = 10; "reserved for HQ muons with future patterns
-            if (pattern == 2 || pattern == 3)      quality = 11;
-            else if (pattern == 4 || pattern == 5) quality = 12;
-            else if (pattern == 6 || pattern == 7) quality = 13;
-            else if (pattern == 8 || pattern == 9) quality = 14;
-            else if (pattern == 10)                quality = 15;
-            else {
-              if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongValues")
-                << "+++ findQuality: Unexpected CLCT pattern id = "
-                << pattern << "+++\n";
-            }
+            if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongValues")
+                              << "+++ findQuality: Unexpected CLCT pattern id = "
+                              << pattern << "+++\n";
           }
         }
       }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -11,7 +11,7 @@
  * The output is up to two Correlated LCTs.
  *
  * It can be run in either a test mode, where the arguments are a collection
- * of wire times and arrays of halfstrip and distrip times, or
+ * of wire times and arrays of halfstrip times, or
  * for general use, with wire digi and comparator digi collections as
  * arguments.  In the latter mode, the wire & strip info is passed on the
  * LCTProcessors, where it is decoded and converted into a convenient form.
@@ -56,8 +56,7 @@ class CSCMotherboard
 
   /** Test version of run function. */
   void run(const std::vector<int> w_time[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES],
-	   const std::vector<int> hs_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-	   const std::vector<int> ds_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
+           const std::vector<int> hs_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
   /** Run function for normal usage.  Runs cathode and anode LCT processors,
       takes results and correlates into CorrelatedLCT. */
@@ -103,12 +102,6 @@ class CSCMotherboard
   unsigned theRing;
 
   const CSCGeometry* csc_g;
-
-  /** Flag for MTCC data. */
-  bool isMTCC;
-
-  /** Flag for new (2007) version of TMB firmware. */
-  bool isTMB07;
 
   /** Flag for SLHC studies. */
   bool isSLHC;

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCAnodeLCTAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCAnodeLCTAnalyzer.cc
@@ -24,7 +24,6 @@ using namespace std;
 //-----------------
 
 bool CSCAnodeLCTAnalyzer::debug = true;
-bool CSCAnodeLCTAnalyzer::isMTCCMask = true;
 bool CSCAnodeLCTAnalyzer::doME1A = true;
 
 vector<CSCAnodeLayerInfo> CSCAnodeLCTAnalyzer::getSimInfo(
@@ -114,27 +113,22 @@ vector<CSCAnodeLayerInfo> CSCAnodeLCTAnalyzer::lctDigis(
     // Loop over all the wires in a pattern.
     int mask;
     for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN;
-	 i_wire++) {
+         i_wire++) {
       if (CSCAnodeLCTProcessor::pattern_envelope[0][i_wire] == i_layer) {
-	if (!isMTCCMask) {
-	  mask = CSCAnodeLCTProcessor::pattern_mask_slim[alct_pattern][i_wire];
-	}
-	else {
-	  mask = CSCAnodeLCTProcessor::pattern_mask_open[alct_pattern][i_wire];
-	}
-	if (mask == 1) {
-	  int wire = alct_keywire +
-	    CSCAnodeLCTProcessor::pattern_envelope[1+MESelection][i_wire];
-	  if (wire >= 0 && wire < CSCConstants::MAX_NUM_WIRES) {
-	    // Check if there is a "good" Digi on this wire.
-	    if (digiMap.count(wire) > 0) {
-	      tempInfo.setId(layerId); // store the layer of this object
-	      tempInfo.addComponent(digiMap[wire]); // and the RecDigi
-	      if (debug) LogDebug("lctDigis")
-		<< " Digi on ALCT: wire group " << digiMap[wire].getWireGroup();
-	    }
-	  }
-	}
+        mask = CSCAnodeLCTProcessor::pattern_mask_open[alct_pattern][i_wire];
+        if (mask == 1) {
+          int wire = alct_keywire +
+            CSCAnodeLCTProcessor::pattern_envelope[1+MESelection][i_wire];
+          if (wire >= 0 && wire < CSCConstants::MAX_NUM_WIRES) {
+            // Check if there is a "good" Digi on this wire.
+            if (digiMap.count(wire) > 0) {
+              tempInfo.setId(layerId); // store the layer of this object
+              tempInfo.addComponent(digiMap[wire]); // and the RecDigi
+              if (debug) LogDebug("lctDigis")
+                           << " Digi on ALCT: wire group " << digiMap[wire].getWireGroup();
+            }
+          }
+        }
       }
     }
 

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCAnodeLCTAnalyzer.h
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCAnodeLCTAnalyzer.h
@@ -51,7 +51,6 @@ class CSCAnodeLCTAnalyzer
 
  private:
   static bool debug;
-  static bool isMTCCMask;
 
   /** Flag to decide whether to analyze stubs in ME1/A or not. */
   static bool doME1A;
@@ -61,10 +60,10 @@ class CSCAnodeLCTAnalyzer
 
   /* Find the list of WireDigis belonging to this ALCT. */
   std::vector<CSCAnodeLayerInfo> lctDigis(const CSCALCTDigi& alct,
-       const CSCDetId& alctId, const CSCWireDigiCollection* wiredc);
+                                          const CSCDetId& alctId, const CSCWireDigiCollection* wiredc);
   void preselectDigis(const int alct_bx, const CSCDetId& layerId,
-		      const CSCWireDigiCollection* wiredc,
-		      std::map<int, CSCWireDigi>& digiMap);
+                      const CSCWireDigiCollection* wiredc,
+                      std::map<int, CSCWireDigi>& digiMap);
 
   /* Find SimHits closest to each WireDigi on ALCT. */
   void digiSimHitAssociator(CSCAnodeLayerInfo& info,

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCCathodeLCTAnalyzer.h
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCCathodeLCTAnalyzer.h
@@ -51,7 +51,6 @@ class CSCCathodeLCTAnalyzer
 
  private:
   static bool debug;
-  static bool isTMB07;
 
   /** Flag to decide whether to analyze stubs in ME1/A or not. */
   static bool doME1A;
@@ -61,18 +60,17 @@ class CSCCathodeLCTAnalyzer
 
   /* Find the list of ComparatorDigis belonging to this CLCT. */
   std::vector<CSCCathodeLayerInfo> lctDigis(const CSCCLCTDigi& clct,
-       const CSCDetId& clctId, const CSCComparatorDigiCollection* compdc);
+                                            const CSCDetId& clctId, const CSCComparatorDigiCollection* compdc);
   int preselectDigis(const int clct_bx, const CSCDetId& layerId,
-		     const CSCComparatorDigiCollection* compdc,
-		     std::vector<CSCComparatorDigi>& digiMap,
-		     int hfstripDigis[CSCConstants::NUM_HALF_STRIPS],
-		     int distripDigis[CSCConstants::NUM_HALF_STRIPS],
-		     int time[CSCConstants::MAX_NUM_STRIPS],
-		     int comp[CSCConstants::MAX_NUM_STRIPS],
-		     int digiNum[CSCConstants::MAX_NUM_STRIPS]);
+                     const CSCComparatorDigiCollection* compdc,
+                     std::vector<CSCComparatorDigi>& digiMap,
+                     int hfstripDigis[CSCConstants::NUM_HALF_STRIPS],
+                     int time[CSCConstants::MAX_NUM_STRIPS],
+                     int comp[CSCConstants::MAX_NUM_STRIPS],
+                     int digiNum[CSCConstants::MAX_NUM_STRIPS]);
 
   /* Find SimHits closest to each ComparatorDigi on CLCT. */
   void digiSimHitAssociator(CSCCathodeLayerInfo& info,
-			    const edm::PSimHitContainer* allSimHits);
+                            const edm::PSimHitContainer* allSimHits);
 };
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTPEmulator_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTPEmulator_cfg.py
@@ -3,8 +3,9 @@
 # Slava Valuev; October, 2006.
 
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("CSCTPEmulator")
+process = cms.Process("CSCTPEmulator", eras.Run2_2018)
 
 process.maxEvents = cms.untracked.PSet(
   input = cms.untracked.int32(10000)
@@ -15,27 +16,11 @@ import sys, os
 sys.path.insert(0, os.path.join(os.environ['CMSSW_BASE'],
                                 'src/L1Trigger/CSCTriggerPrimitives/test'))
 
-#    source = NewEventStreamFileReader {
-##	string fileName = "file:/tmp/slava/mtcc.00002571.A.testStorageManager_0.0.dat"
-#	untracked vstring fileNames = {
-#	    "file:/tmp/slava/mtcc.00004138.A.testStorageManager_0.0.dat"
-#	}
-#        int32 max_event_size = 7000000
-#        int32 max_queue_depth = 5
-#    }
-
 process.source = cms.Source("PoolSource",
-##     fileNames = cms.untracked.vstring('file:/data0/slava/data/run109562/FE316E49-047F-DE11-AC0C-001D09F231B0.root')
      fileNames = cms.untracked.vstring(
-#         '/store/data/Commissioning12/MinimumBias/RAW/v1/000/189/778/FC9A951F-977A-E111-9385-001D09F2B30B.root'
-#         '/store/data/Run2012C/SingleMu/RAW/v1/000/199/703/6401E77F-05D7-E111-A310-BCAEC518FF41.root'
-         'rfio:/castor/cern.ch/cms/store/data/Run2012C/SingleMu/RAW/v1/000/200/152/F8871A89-F8DC-E111-BAF2-003048F024FA.root'
+         'file:lcts.root'
      )
-##        untracked uint32 debugVebosity = 10
-##        untracked bool   debugFlag     = false
-###	untracked uint32 skipEvents    = 2370
 )
-#process.load("localrun_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
     destinations = cms.untracked.vstring("debug"),
@@ -46,53 +31,28 @@ process.MessageLogger = cms.Service("MessageLogger",
         lineLength = cms.untracked.int32(132),
         noLineBreaks = cms.untracked.bool(True)
     ),
-    # debugModules = cms.untracked.vstring("*")
-    debugModules = cms.untracked.vstring("cscTriggerPrimitiveDigis", 
+    debugModules = cms.untracked.vstring("cscTriggerPrimitiveDigis",
         "lctreader")
 )
 
 # es_source of ideal geometry
 # ===========================
-#process.load("Configuration/StandardSequences/Geometry_cff")
-
-# endcap muon only...
-process.load("Geometry.MuonCommonData.muonEndcapIdealGeometryXML_cfi")
-
-# Needed according to Mike Case's e-mail from 27/03.
-process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
-
-# flags for modelling of CSC geometry
-# ===================================
-process.load("Geometry.CSCGeometry.cscGeometry_cfi")
+process.load("Configuration/StandardSequences/GeometryDB_cff")
 
 process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = 'MC_38Y_V8::All'
 process.GlobalTag.globaltag = 'GR_R_60_V7::All'
-#process.prefer("GlobalTag")
 
 # magnetic field (do I need it?)
 # ==============================
-process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 
 # CSC raw --> digi unpacker
 # =========================
 process.load("EventFilter.CSCRawToDigi.cscUnpacker_cfi")
 process.muonCSCDigis.InputObjects = "rawDataCollector"
-# InputObjects = cms.InputTag("cscpacker","CSCRawData")
-# for run 566 and 2008 data
-# ErrorMask = cms.untracked.uint32(0xDFCFEFFF)
 
 # CSC Trigger Primitives configuration
 # ====================================
-#process.load("L1TriggerConfig.L1CSCTPConfigProducers.L1CSCTriggerPrimitivesConfig_cff")
-#process.load("L1TriggerConfig.L1CSCTPConfigProducers.L1CSCTriggerPrimitivesDBConfig_cff")
-#process.prefer("l1csctpdbconfsrc")
-#process.l1csctpconf.alctParamMTCC2.alctNplanesHitPretrig = 3
-#process.l1csctpconf.alctParamMTCC2.alctNplanesHitAccelPretrig = 3
-#process.l1csctpconf.clctParam.clctNplanesHitPretrig = 3
-#process.l1csctpconf.clctParam.clctHitPersist = 4
-#process.l1csctpconf.alctParamMTCC2.alctDriftDelay = 9
-#process.l1csctpconf.alctParamMTCC2.alctL1aWindowWidth = 9
 
 # CSC Trigger Primitives emulator
 # ===============================
@@ -108,19 +68,11 @@ process.cscTriggerPrimitiveDigis.CSCWireDigiProducer = "muonCSCDigis:MuonCSCWire
 process.load("CSCTriggerPrimitivesReader_cfi")
 process.lctreader.debug = True
 
-# Auxiliary services
-# ==================
-#process.myfilter = cms.EDFilter(
-#  'EventNumberFilter',
-#  runEventNumbers = cms.vuint32(1,4309, 1,4310)
-#)
-
 # Output
 # ======
 process.output = cms.OutputModule("PoolOutputModule",
-    #fileName = cms.untracked.string("/data0/slava/test/lcts_run122909.root"),
-    fileName = cms.untracked.string("lcts_run200152.root"),
-    outputCommands = cms.untracked.vstring("keep *", 
+    fileName = cms.untracked.string("lcts.root"),
+    outputCommands = cms.untracked.vstring("keep *",
         "drop *_DaqSource_*_*")
 )
 
@@ -130,6 +82,4 @@ process.TFileService = cms.Service("TFileService",
 
 # Scheduler path
 # ==============
-#process.p = cms.Path(process.myfilter*process.muonCSCDigis*process.cscTriggerPrimitiveDigis*process.lctreader)
 process.p = cms.Path(process.muonCSCDigis*process.cscTriggerPrimitiveDigis*process.lctreader)
-#process.ep = cms.EndPath(process.output)

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesProducerTest_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesProducerTest_cfg.py
@@ -2,12 +2,12 @@
 # Slava Valuev May-2006.
 
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("MuonCSCTriggerPrimitives")
+process = cms.Process("MuonCSCTriggerPrimitives", eras.Run2_2018)
 
 process.source = cms.Source("PoolSource",
-#    fileNames = cms.untracked.vstring("file:/data0/slava/test/muminus_pt50_CMSSW_3_9_0_pre1.root"),
-    fileNames = cms.untracked.vstring("file:muminus_pt50_CMSSW_6_1_0_pre2.root")
+    fileNames = cms.untracked.vstring("digis.root")
 )
 
 process.maxEvents = cms.untracked.PSet(
@@ -47,24 +47,16 @@ process.MessageLogger = cms.Service("MessageLogger",
 # ===========================
 process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = 'DESIGN_31X_V8::All'
 process.GlobalTag.globaltag = 'MC_61_V1::All'
 
 # magnetic field (do I need it?)
 # ==============================
-process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
 
 # CSC Trigger Primitives configuration
 # ====================================
 #process.load("L1TriggerConfig.L1CSCTPConfigProducers.L1CSCTriggerPrimitivesConfig_cff")
-#process.l1csctpconf.isMTCC = True
-#process.l1csctpconf.isTMB07 = True
-#process.l1csctpconf.alctParamMTCC2.alctNplanesHitPretrig = 3
-#process.l1csctpconf.alctParamMTCC2.alctNplanesHitAccelPretrig = 3
-#process.l1csctpconf.clctParam.clctNplanesHitPretrig = 3
-#process.l1csctpconf.clctParam.clctHitPersist = 4
 #process.load("L1TriggerConfig.L1CSCTPConfigProducers.L1CSCTriggerPrimitivesDBConfig_cff")
-#process.prefer("l1csctpdbconfsrc")
 
 # CSC Trigger Primitives
 # ======================
@@ -73,22 +65,9 @@ process.cscTriggerPrimitiveDigis.alctParam07.verbosity = 2
 process.cscTriggerPrimitiveDigis.clctParam07.verbosity = 2
 process.cscTriggerPrimitiveDigis.tmbParam.verbosity = 2
 
-#- For cosmic data
-# process.cscTriggerPrimitiveDigis.CSCComparatorDigiProducer = "muonCSCDigis:MuonCSCComparatorDigi"
-# process.cscTriggerPrimitiveDigis.CSCWireDigiProducer = "muonCSCDigis:MuonCSCWireDigi"
-# process.cscTriggerPrimitiveDigis.alctParam.alctTrigMode = 2
-
-# Auxiliary services
-# ==================
-# process.Timing = cms.Service("Timing")
-# process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")
-# process.Tracer = cms.Service("Tracer")
-
 process.out = cms.OutputModule("PoolOutputModule",
-    # fileName = cms.untracked.string("lcts.root"),
-    # fileName = cms.untracked.string("/data0/slava/test/lcts_muminus_pt50_emul_CMSSW_3_9_0_pre1.root"),
-    fileName = cms.untracked.string("lcts_muminus_pt50_emul_CMSSW_6_1_0_pre2.root"),
-    outputCommands = cms.untracked.vstring("keep *", 
+    fileName = cms.untracked.string("out_lcts.root"),
+    outputCommands = cms.untracked.vstring("keep *",
         "drop *_DaqSource_*_*")
 )
 

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc
@@ -14,7 +14,7 @@
 
 //-----------------------
 // This Class's Header --
-//----------------------- 
+//-----------------------
 #include "CSCTriggerPrimitivesReader.h"
 
 //-------------------------------
@@ -77,8 +77,6 @@ const int CSCTriggerPrimitivesReader::MAX_WG[CSC_TYPES] = {
    48,  64,  32,  48, 112,  64,  96,  64,  96,  64};//max. number of wiregroups
 const int CSCTriggerPrimitivesReader::MAX_HS[CSC_TYPES] = {
   128, 160, 128,  96, 160, 160, 160, 160, 160, 160}; // max. # of halfstrips
-const int CSCTriggerPrimitivesReader::ptype[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07]= {
-  -999,  3, -3,  2, -2,  1, -1,  0};  // "signed" pattern (== phiBend)
 const int CSCTriggerPrimitivesReader::ptype_TMB07[CSCConstants::NUM_CLCT_PATTERNS]= {
   -999,  -5,  4, -4,  3, -3,  2, -2,  1, -1,  0}; // "signed" pattern (== phiBend)
 
@@ -116,8 +114,6 @@ CSCTriggerPrimitivesReader::CSCTriggerPrimitivesReader(const edm::ParameterSet& 
   printps = conf.getParameter<bool>("printps");
   dataLctsIn_ = conf.getParameter<bool>("dataLctsIn");
   emulLctsIn_ = conf.getParameter<bool>("emulLctsIn");
-  isMTCCData_ = conf.getParameter<bool>("isMTCCData");
-  isTMB07 = true;
   plotME1A = true;
   plotME42 = true;
   lctProducerData_ = conf.getUntrackedParameter<string>("CSCLCTProducerData",
@@ -141,13 +137,13 @@ CSCTriggerPrimitivesReader::CSCTriggerPrimitivesReader(const edm::ParameterSet& 
   clcts_e_token_    = consumes<CSCCLCTDigiCollection>(edm::InputTag(lctProducerEmul_));
   lcts_tmb_e_token_ = consumes<CSCCorrelatedLCTDigiCollection>(edm::InputTag(lctProducerEmul_));
   lcts_mpc_e_token_ = consumes<CSCCorrelatedLCTDigiCollection>(edm::InputTag(lctProducerEmul_, "MPCSORTED"));
- 
+
   consumesMany<edm::HepMCProduct>();
 
   resultsFileNamesPrefix_ = conf.getUntrackedParameter<string>("resultsFileNamesPrefix","");
-  
+
   checkBadChambers_ = conf.getUntrackedParameter<bool>("checkBadChambers",true);
-  
+
   debug = conf.getUntrackedParameter<bool>("debug", false);
 
   dataIsAnotherMC_ = conf.getUntrackedParameter<bool>("dataIsAnotherMC", false);
@@ -173,7 +169,7 @@ CSCTriggerPrimitivesReader::~CSCTriggerPrimitivesReader() {
 }
 
 
-int CSCTriggerPrimitivesReader::maxRing(int station) 
+int CSCTriggerPrimitivesReader::maxRing(int station)
 {
   if (station == 1) {
     if (plotME1A) return 4;
@@ -205,7 +201,7 @@ void CSCTriggerPrimitivesReader::analyze(const edm::Event& ev,
     setup.get<CSCBadChambersRcd>().get(pBad);
     badChambers_ = pBad.product();
   }
-  
+
   // Get the collections of ALCTs, CLCTs, and correlated LCTs from event.
   edm::Handle<CSCALCTDigiCollection> alcts_data;
   edm::Handle<CSCCLCTDigiCollection> clcts_data;
@@ -221,9 +217,9 @@ void CSCTriggerPrimitivesReader::analyze(const edm::Event& ev,
     //    ev.getByLabel(lctProducerData_,  alcts_data);
     //    ev.getByLabel(lctProducerData_,  clcts_data);
     //    ev.getByLabel(lctProducerData_,  lcts_tmb_data);
-    ev.getByToken(alcts_d_token_, alcts_data);  
-    ev.getByToken(clcts_d_token_, clcts_data);  
-    ev.getByToken(lcts_tmb_d_token_, lcts_tmb_data);  
+    ev.getByToken(alcts_d_token_, alcts_data);
+    ev.getByToken(clcts_d_token_, clcts_data);
+    ev.getByToken(lcts_tmb_d_token_, lcts_tmb_data);
 
     if (!alcts_data.isValid()) {
       edm::LogWarning("L1CSCTPEmulatorWrongInput")
@@ -252,10 +248,10 @@ void CSCTriggerPrimitivesReader::analyze(const edm::Event& ev,
     //    ev.getByLabel(lctProducerEmul_,              clcts_emul);
     //    ev.getByLabel(lctProducerEmul_,              lcts_tmb_emul);
     //    ev.getByLabel(lctProducerEmul_, "MPCSORTED", lcts_mpc_emul);
-    ev.getByToken(alcts_e_token_, alcts_emul);  
-    ev.getByToken(clcts_e_token_, clcts_emul);  
-    ev.getByToken(lcts_tmb_e_token_, lcts_tmb_emul);  
-    ev.getByToken(lcts_mpc_e_token_, lcts_mpc_emul);  
+    ev.getByToken(alcts_e_token_, alcts_emul);
+    ev.getByToken(clcts_e_token_, clcts_emul);
+    ev.getByToken(lcts_tmb_e_token_, lcts_tmb_emul);
+    ev.getByToken(lcts_mpc_e_token_, lcts_mpc_emul);
 
     if (!alcts_emul.isValid()) {
       edm::LogWarning("L1CSCTPEmulatorWrongInput")
@@ -319,9 +315,9 @@ void CSCTriggerPrimitivesReader::endJob() {
     if (bookedCLCTHistos)   drawCLCTHistos();
     if (bookedLCTTMBHistos) drawLCTTMBHistos();
     if (bookedLCTMPCHistos) drawLCTMPCHistos();
-    
+
     if (bookedCompHistos)   drawCompHistos();
-    
+
     if (bookedResolHistos)  drawResolHistos();
     if (bookedEfficHistos)  drawEfficHistos();
   }
@@ -374,7 +370,7 @@ void CSCTriggerPrimitivesReader::endJob() {
 	double eff  = 0.;
 	if (simh > 0.) eff = clct/simh;
 	edm::LogInfo("CSCTriggerPrimitivesReader")
-	  << "    " << csc_type[idh] 
+	  << "    " << csc_type[idh]
 	  << ": clct = " << clct << ", simh = " << simh << " eff = " << eff;
 	tot_simh += simh;
 	tot_clct += clct;
@@ -473,7 +469,7 @@ void CSCTriggerPrimitivesReader::bookALCTHistos() {
   hAlctBXN       = fs->make<TH1F>("ALCT_bx", "ALCT bx",             20, -0.5,  19.5);
 
   hAlctKeyGroupME11 = fs->make<TH1F>("hAlctKeyGroupME11", "ALCT key wiregroup ME1/1", 50, -0.5, 49.5);
-  
+
   bookedALCTHistos = true;
 }
 
@@ -565,14 +561,14 @@ void CSCTriggerPrimitivesReader::bookLCTTMBHistos() {
     snprintf(histname, sizeof(histname), "LCT_CSCId, station %d", istat+1);
     hLctTMBChamber[istat] = fs->make<TH1F>("", histname,  10, -0.5, 9.5);
   }
-  
+
   hLctTMBKeyGroupME11  = fs->make<TH1F>("hLctTMBKeyGroupME11", "LCT key wiregroup ME1/1", 50, -0.5, 49.5);
   hLctTMBKeyStripME11  = fs->make<TH1F>("hLctTMBKeyStripME11", "LCT key strip ME1/1",	  161, -0.5, 160.5);
 
   bookedLCTTMBHistos = true;
 }
 
-int CSCTriggerPrimitivesReader::chamberIXi(CSCDetId id) {  
+int CSCTriggerPrimitivesReader::chamberIXi(CSCDetId id) {
   //    1/1 1/2 1/3 2/1 2/2 3/1 3/2 4/1 4/2 -1/1 -1/2 -1/3 -2/1 -2/2 -3/1 -3/2 -4/1 -4/2
   //ix= 0   1   2   3   4   5   6   7   8    9    10   11   12   13   14   15   16   17
   int ix=0;
@@ -581,7 +577,7 @@ int CSCTriggerPrimitivesReader::chamberIXi(CSCDetId id) {
     ix=(id.station()-2)*2+3;
   }
   ix+=id.ring()-1;
-  if(id.endcap()==2) { 
+  if(id.endcap()==2) {
     ix+=9;
   }
   return ix;
@@ -593,8 +589,8 @@ int CSCTriggerPrimitivesReader::chamberIX(CSCDetId id) {
     ix=(id.station()-2)*2+3+1;
   }
   ix+=id.ring()-1;
-  if(id.endcap()==2) { 
-    ix*=-1;    
+  if(id.endcap()==2) {
+    ix*=-1;
   }
   return ix;
 }
@@ -715,7 +711,7 @@ void CSCTriggerPrimitivesReader::bookCompHistos() {
   hAlctCompSameN2i = fs->make<TH2F>("h_ALCT_SameN2i","h_ALCT_SameN2i",18,0,18,36,0.5,36.5);
   hAlctCompMatch2i = fs->make<TH2F>("h_ALCT_match2i","h_ALCT_match2i",18,0,18,36,0.5,36.5);
   hAlctCompTotal2i = fs->make<TH2F>("h_ALCT_total2i","h_ALCT_total2i",18,0,18,36,0.5,36.5);
-  hClctCompFound2i = fs->make<TH2F>("h_CLCT_found2i","h_CLCT_found2i",18,0,18,36,0.5,36.5);  		   
+  hClctCompFound2i = fs->make<TH2F>("h_CLCT_found2i","h_CLCT_found2i",18,0,18,36,0.5,36.5);
   hClctCompSameN2i = fs->make<TH2F>("h_CLCT_SameN2i","h_CLCT_SameN2i",18,0,18,36,0.5,36.5);
   hClctCompMatch2i = fs->make<TH2F>("h_CLCT_match2i","h_CLCT_match2i",18,0,18,36,0.5,36.5);
   hClctCompTotal2i = fs->make<TH2F>("h_CLCT_total2i","h_CLCT_total2i",18,0,18,36,0.5,36.5);
@@ -884,11 +880,9 @@ void CSCTriggerPrimitivesReader::bookResolHistos() {
   }
 
   int max_patterns, phibend;
-  if (!isTMB07) max_patterns = CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07;
-  else          max_patterns = CSCConstants::NUM_CLCT_PATTERNS;
+  max_patterns = CSCConstants::NUM_CLCT_PATTERNS;
   for (int i = 0; i < max_patterns; i++) {
-    if (!isTMB07) phibend = ptype[i];
-    else          phibend = ptype_TMB07[i];
+    phibend = ptype_TMB07[i];
     snprintf(histname, sizeof(histname), "#phi_rec-#phi_sim, bend = %d", phibend);
     hPhiDiffPattern[i] = fs->make<TH1F>("", histname, 100, PDMIN, PDMAX);
   }
@@ -1006,11 +1000,10 @@ void CSCTriggerPrimitivesReader::fillCLCTHistos(const CSCCLCTDigiCollection* clc
 	hClctCsc[id.endcap()-1][csctype]->Fill(id.chamber());
 
 	if (striptype==1 && csctype==0) hClctKeyStripME11->Fill(keystrip);
-	
+
 	int phibend;
 	int pattern = (*digiIt).getPattern();
-	if (!isTMB07) phibend = ptype[pattern];
-	else          phibend = ptype_TMB07[pattern];
+	phibend = ptype_TMB07[pattern];
 	hClctBendCsc[csctype][striptype]->Fill(abs(phibend));
 
 	if (striptype == 0) // distrips
@@ -1063,24 +1056,16 @@ void CSCTriggerPrimitivesReader::fillLCTTMBHistos(const CSCCorrelatedLCTDigiColl
         hLctTMBQuality->Fill(quality);
         hLctTMBBXN->Fill((*digiIt).getBX());
 
-	if (isTMB07) alct_valid = (quality != 0 && quality != 2);
-	else         alct_valid = (quality != 4 && quality != 5);
+	alct_valid = (quality != 0 && quality != 2);
 	if (alct_valid) {
 	  hLctTMBKeyGroup->Fill((*digiIt).getKeyWG());
 	}
 
-	if (isTMB07) clct_valid = (quality != 0 && quality != 1);
-	else         clct_valid = (quality != 1 && quality != 3);
+	clct_valid = (quality != 0 && quality != 1);
 	if (clct_valid) {
 	  hLctTMBKeyStrip->Fill((*digiIt).getStrip());
-	  if (!isTMB07) {
-	    hLctTMBStripType->Fill((*digiIt).getStripType());
-	    hLctTMBPattern->Fill((*digiIt).getCLCTPattern());
-	  }
-	  else {
-	    hLctTMBStripType->Fill(1.);
-	    hLctTMBPattern->Fill((*digiIt).getPattern());
-	  }
+    hLctTMBStripType->Fill(1.);
+    hLctTMBPattern->Fill((*digiIt).getPattern());
 	  hLctTMBBend->Fill((*digiIt).getBend());
 	}
 
@@ -1088,7 +1073,7 @@ void CSCTriggerPrimitivesReader::fillLCTTMBHistos(const CSCCorrelatedLCTDigiColl
 	hLctTMBPerCSC->Fill(csctype);
 	hLctTMBCsc[id.endcap()-1][csctype]->Fill(id.chamber());
 	// Truly correlated LCTs; for DAQ
-	if (alct_valid && clct_valid) hCorrLctTMBPerCSC->Fill(csctype); 
+	if (alct_valid && clct_valid) hCorrLctTMBPerCSC->Fill(csctype);
 
         if (alct_valid && csctype==0) {
           hLctTMBKeyGroupME11->Fill((*digiIt).getKeyWG());
@@ -1143,31 +1128,23 @@ void CSCTriggerPrimitivesReader::fillLCTMPCHistos(const CSCCorrelatedLCTDigiColl
         hLctMPCQuality->Fill(quality);
         hLctMPCBXN->Fill((*digiIt).getBX());
 
-	if (isTMB07) alct_valid = (quality != 0 && quality != 2);
-	else         alct_valid = (quality != 4 && quality != 5);
+	alct_valid = (quality != 0 && quality != 2);
 	if (alct_valid) {
 	  hLctMPCKeyGroup->Fill((*digiIt).getKeyWG());
 	}
 
-	if (isTMB07) clct_valid = (quality != 0 && quality != 1);
-	else         clct_valid = (quality != 1 && quality != 3);
+	clct_valid = (quality != 0 && quality != 1);
 	if (clct_valid) {
 	  hLctMPCKeyStrip->Fill((*digiIt).getStrip());
-	  if (!isTMB07) {
-	    hLctMPCStripType->Fill((*digiIt).getStripType());
-	    hLctMPCPattern->Fill((*digiIt).getCLCTPattern());
-	  }
-	  else {
-	    hLctMPCStripType->Fill(1.);
-	    hLctMPCPattern->Fill((*digiIt).getPattern());
-	  }
+    hLctMPCStripType->Fill(1.);
+    hLctMPCPattern->Fill((*digiIt).getPattern());
 	  hLctMPCBend->Fill((*digiIt).getBend());
 	}
 
 	int csctype = getCSCType(id);
 	hLctMPCPerCSC->Fill(csctype);
 	// Truly correlated LCTs; for DAQ
-	if (alct_valid && clct_valid) hCorrLctMPCPerCSC->Fill(csctype); 
+	if (alct_valid && clct_valid) hCorrLctMPCPerCSC->Fill(csctype);
 
 
   if (alct_valid && csctype==0) {
@@ -1213,13 +1190,8 @@ void CSCTriggerPrimitivesReader::compare(
 
 void CSCTriggerPrimitivesReader::compareALCTs(
                                  const CSCALCTDigiCollection* alcts_data,
-				 const CSCALCTDigiCollection* alcts_emul) {
+                                 const CSCALCTDigiCollection* alcts_emul) {
   int emul_corr_bx;
-
-  // (Empirical) offset between 12-bit fullBX and Tbin0 of raw anode hits.
-  //int tbin_anode_offset = 4; // 2007, starting with run 539.
-  int tbin_anode_offset = 5; // 2007, run 14419.
-  if (isMTCCData_) tbin_anode_offset = 10; // MTCC-II. Why not 6???
 
   // Should be taken from config. parameters.
   int fifo_pretrig     = 10;
@@ -1284,12 +1256,8 @@ void CSCTriggerPrimitivesReader::compareALCTs(
 	      for (pd = alctV_data.begin(); pd != alctV_data.end(); pd++) {
 		if ((*pd).getTrknmb() == (*pe).getTrknmb()) {
 		  int emul_bx = (*pe).getBX();
-		  if (!isTMB07)
-		    emul_corr_bx =
-		      ((*pd).getFullBX() + emul_bx - tbin_anode_offset) & 0x1f;
-		  else
-		    emul_corr_bx =
-		      emul_bx - rawhit_tbin_offset + register_delay;
+      emul_corr_bx =
+        emul_bx - rawhit_tbin_offset + register_delay;
 		  strstrm << " Corr BX = " << emul_corr_bx;
 		  break;
 		}
@@ -1309,7 +1277,7 @@ void CSCTriggerPrimitivesReader::compareALCTs(
 	  //		 detid.station(),detid.ring(),detid.chamber(),ix);
 	  if(detid.station()>1 && detid.ring()==1) {
 	    hAlctCompFound2x->Fill(ix,detid.chamber()*2);
-	  }	   
+	  }
 	  else {
 	    hAlctCompFound2->Fill(ix,detid.chamber());
 	  }
@@ -1327,7 +1295,7 @@ void CSCTriggerPrimitivesReader::compareALCTs(
 	    hAlctCompSameNCsc[endc-1][csctype]->Fill(cham);
 	    if(detid.station()>1 && detid.ring()==1) {
 	      hAlctCompSameN2x->Fill(ix,detid.chamber()*2);
-	    }	   
+	    }
 	    else {
 	      hAlctCompSameN2->Fill(ix,detid.chamber());
 	    }
@@ -1342,7 +1310,6 @@ void CSCTriggerPrimitivesReader::compareALCTs(
 	    int data_collB     = alctV_data[i].getCollisionB();
 	    int data_wiregroup = alctV_data[i].getKeyWG();
 	    int data_bx        = alctV_data[i].getBX();
-	    int fullBX = alctV_data[i].getFullBX(); // full 12-bit BX
 
 	    if (i < nemul) {
 	      if (alctV_emul[i].isValid() == 0) continue;
@@ -1354,53 +1321,50 @@ void CSCTriggerPrimitivesReader::compareALCTs(
 	      int emul_bx        = alctV_emul[i].getBX();
 
 	      // Emulator BX re-calculated for comparison with BX in the data.
-	      if (!isTMB07)
-		emul_corr_bx = (fullBX + emul_bx - tbin_anode_offset) & 0x1f;
-	      else
-		emul_corr_bx = emul_bx - rawhit_tbin_offset + register_delay;
-              if (dataIsAnotherMC_)
-                emul_corr_bx = emul_bx;
+        emul_corr_bx = emul_bx - rawhit_tbin_offset + register_delay;
+        if (dataIsAnotherMC_)
+          emul_corr_bx = emul_bx;
 	      if (ndata == nemul) {
-		hAlctCompTotal->Fill(mychamber);
-		hAlctCompTotalCsc[endc-1][csctype]->Fill(cham);
-		if(detid.station()>1 && detid.ring()==1) {
-		  hAlctCompTotal2x->Fill(ix,detid.chamber()*2);
-		}	   
-		else {
-		  hAlctCompTotal2->Fill(ix,detid.chamber());
-		}
-                hAlctCompTotal2i->Fill(ix2,detid.chamber());
+          hAlctCompTotal->Fill(mychamber);
+          hAlctCompTotalCsc[endc-1][csctype]->Fill(cham);
+          if(detid.station()>1 && detid.ring()==1) {
+            hAlctCompTotal2x->Fill(ix,detid.chamber()*2);
+          }
+          else {
+            hAlctCompTotal2->Fill(ix,detid.chamber());
+          }
+          hAlctCompTotal2i->Fill(ix2,detid.chamber());
 	      }
 	      if (data_trknmb    == emul_trknmb    &&
-		  data_quality   == emul_quality   &&
-		  data_accel     == emul_accel     &&
-		  data_collB     == emul_collB     &&
-		  data_wiregroup == emul_wiregroup &&
-		  data_bx        == emul_corr_bx) {
-		if (ndata == nemul) {
-		  hAlctCompMatchCsc[endc-1][csctype]->Fill(cham);
-		  hAlctCompMatch->Fill(mychamber);
-		  if(detid.station()>1 && detid.ring()==1) {
-		    hAlctCompMatch2x->Fill(ix,detid.chamber()*2);
-		  }	   
-		  else {
+            data_quality   == emul_quality   &&
+            data_accel     == emul_accel     &&
+            data_collB     == emul_collB     &&
+            data_wiregroup == emul_wiregroup &&
+            data_bx        == emul_corr_bx) {
+          if (ndata == nemul) {
+            hAlctCompMatchCsc[endc-1][csctype]->Fill(cham);
+            hAlctCompMatch->Fill(mychamber);
+            if(detid.station()>1 && detid.ring()==1) {
+              hAlctCompMatch2x->Fill(ix,detid.chamber()*2);
+            }
+            else {
 		    hAlctCompMatch2->Fill(ix,detid.chamber());
-		  }
-		  hAlctCompMatch2i->Fill(ix2,detid.chamber());
-		}
-		if (debug) LogTrace("CSCTriggerPrimitivesReader")
-		  << "       Identical ALCTs #" << data_trknmb;
+            }
+            hAlctCompMatch2i->Fill(ix2,detid.chamber());
+          }
+          if (debug) LogTrace("CSCTriggerPrimitivesReader")
+                       << "       Identical ALCTs #" << data_trknmb;
 	      }
 	      else {
-		//LogTrace("CSCTriggerPrimitivesReader")
-    cerr
-		  << "       Different ALCTs #" << data_trknmb << " in ME"
-		  << ((endc == 1) ? "+" : "-") << stat << "/"
-		  << ring << "/" << cham;
+          //LogTrace("CSCTriggerPrimitivesReader")
+          cerr
+            << "       Different ALCTs #" << data_trknmb << " in ME"
+            << ((endc == 1) ? "+" : "-") << stat << "/"
+            << ring << "/" << cham;
 	      }
 	    }
 	  }
-	}
+        }
       }
     }
   }
@@ -1479,7 +1443,7 @@ void CSCTriggerPrimitivesReader::compareCLCTs(
 	  int ix2 = chamberIXi(detid);
 	  if(detid.station()>1 && detid.ring()==1) {
 	    hClctCompFound2x->Fill(ix,detid.chamber()*2);
-	  }	   
+	  }
 	  else {
 	    hClctCompFound2->Fill(ix,detid.chamber());
 	  }
@@ -1496,7 +1460,7 @@ void CSCTriggerPrimitivesReader::compareCLCTs(
 	    hClctCompSameNCsc[endc-1][csctype]->Fill(cham);
 	    if(detid.station()>1 && detid.ring()==1) {
 	      hClctCompSameN2x->Fill(ix,detid.chamber()*2);
-	    }	   
+	    }
 	    else {
 	      hClctCompSameN2->Fill(ix,detid.chamber());
 	    }
@@ -1527,55 +1491,54 @@ void CSCTriggerPrimitivesReader::compareCLCTs(
 	      int emul_bx        = (*pe).getBX();
 
 	      if (data_trknmb == emul_trknmb) {
-		// Emulator BX re-calculated using 12-bit full BX number.
-		// Used for comparison with BX in the data.
-		int emul_corr_bx =
-		  (fullBX + emul_bx - tbin_cathode_offset) & 0x03;
-                if (dataIsAnotherMC_)
-                    emul_corr_bx = emul_bx;
-		if (ndata == nemul) {
-		  hClctCompTotalCsc[endc-1][csctype]->Fill(cham);
-		  if(detid.station()>1 && detid.ring()==1) {
-		    hClctCompTotal2x->Fill(ix,detid.chamber()*2);
-		  }	   
-		  else {
-		    hClctCompTotal2->Fill(ix,detid.chamber());
-		  }
-		  hClctCompTotal2i->Fill(ix2,detid.chamber());
-		}
-		if (data_quality   == emul_quality   &&
-		    data_pattern   == emul_pattern   &&
-		    data_striptype == emul_striptype &&
-		    data_bend      == emul_bend      &&
-		    data_keystrip  == emul_keystrip  &&
-		    data_cfeb      == emul_cfeb      &&
-		    // BX comparison cannot be performed for MTCC data.
-		    (isMTCCData_ || (data_bx == emul_corr_bx))) {
-		  if (ndata == nemul) {
-		    hClctCompMatchCsc[endc-1][csctype]->Fill(cham);
-		    if(detid.station()>1 && detid.ring()==1) {
-		      hClctCompMatch2x->Fill(ix,detid.chamber()*2);
-		    }	   
-		    else {
-		      hClctCompMatch2->Fill(ix,detid.chamber());
-		    }
-		    hClctCompMatch2i->Fill(ix2,detid.chamber());
-		  }
-		  if (debug) LogTrace("CSCTriggerPrimitivesReader")
-		    << "       Identical CLCTs #" << data_trknmb;
-		}
-		else {
-		  //LogTrace("CSCTriggerPrimitivesReader")
-      cerr
-		    << "       Different CLCTs #" << data_trknmb << " in ME"
-		    << ((endc == 1) ? "+" : "-") << stat << "/"
-		    << ring << "/" << cham;
-		}
-		break;
+          // Emulator BX re-calculated using 12-bit full BX number.
+          // Used for comparison with BX in the data.
+          int emul_corr_bx =
+            (fullBX + emul_bx - tbin_cathode_offset) & 0x03;
+          if (dataIsAnotherMC_)
+            emul_corr_bx = emul_bx;
+          if (ndata == nemul) {
+            hClctCompTotalCsc[endc-1][csctype]->Fill(cham);
+            if(detid.station()>1 && detid.ring()==1) {
+              hClctCompTotal2x->Fill(ix,detid.chamber()*2);
+            }
+            else {
+              hClctCompTotal2->Fill(ix,detid.chamber());
+            }
+            hClctCompTotal2i->Fill(ix2,detid.chamber());
+          }
+          if (data_quality   == emul_quality   &&
+              data_pattern   == emul_pattern   &&
+              data_striptype == emul_striptype &&
+              data_bend      == emul_bend      &&
+              data_keystrip  == emul_keystrip  &&
+              data_cfeb      == emul_cfeb      &&
+              data_bx        == emul_corr_bx) {
+            if (ndata == nemul) {
+              hClctCompMatchCsc[endc-1][csctype]->Fill(cham);
+              if(detid.station()>1 && detid.ring()==1) {
+                hClctCompMatch2x->Fill(ix,detid.chamber()*2);
+              }
+              else {
+                hClctCompMatch2->Fill(ix,detid.chamber());
+              }
+              hClctCompMatch2i->Fill(ix2,detid.chamber());
+            }
+            if (debug) LogTrace("CSCTriggerPrimitivesReader")
+                         << "       Identical CLCTs #" << data_trknmb;
+          }
+          else {
+            //LogTrace("CSCTriggerPrimitivesReader")
+            cerr
+              << "       Different CLCTs #" << data_trknmb << " in ME"
+              << ((endc == 1) ? "+" : "-") << stat << "/"
+              << ring << "/" << cham;
+          }
+          break;
 	      }
 	    }
 	  }
-	}
+        }
       }
     }
   }
@@ -1637,11 +1600,9 @@ void CSCTriggerPrimitivesReader::compareLCTs(
 	    for (pe = lctV_emul.begin(); pe != lctV_emul.end(); pe++) {
 	      strstrm << "     " << (*pe);
 	      strstrm << "    corr BX = "
-		      << convertBXofLCT((*pe).getBX(), detid,
-					alcts_data, clcts_data);
-	      if (isTMB07) {
-		strstrm << " LCT pattern = " << (*pe).getPattern();
-	      }
+                << convertBXofLCT((*pe).getBX(), detid,
+                            alcts_data, clcts_data);
+        strstrm << " LCT pattern = " << (*pe).getPattern();
 	      strstrm << "\n";
 
 	    }
@@ -1654,7 +1615,7 @@ void CSCTriggerPrimitivesReader::compareLCTs(
 	  int ix2 = chamberIXi(detid);
 	  if(detid.station()>1 && detid.ring()==1) {
 	    hLCTCompFound2x->Fill(ix,detid.chamber()*2);
-	  }	   
+	  }
 	  else {
 	    hLCTCompFound2->Fill(ix,detid.chamber());
 	  }
@@ -1671,7 +1632,7 @@ void CSCTriggerPrimitivesReader::compareLCTs(
 	    hLctCompSameNCsc[endc-1][csctype]->Fill(cham);
 	    if(detid.station()>1 && detid.ring()==1) {
 	      hLCTCompSameN2x->Fill(ix,detid.chamber()*2);
-	    }	   
+	    }
 	    else {
 	      hLCTCompSameN2->Fill(ix,detid.chamber());
 	    }
@@ -1711,7 +1672,7 @@ void CSCTriggerPrimitivesReader::compareLCTs(
 		  hLctCompTotalCsc[endc-1][csctype]->Fill(cham);
 		  if(detid.station()>1 && detid.ring()==1) {
 		    hLCTCompTotal2x->Fill(ix,detid.chamber()*2);
-		  }	   
+		  }
 		  else {
 		    hLCTCompTotal2->Fill(ix,detid.chamber());
 		  }
@@ -1728,7 +1689,7 @@ void CSCTriggerPrimitivesReader::compareLCTs(
 		    hLctCompMatchCsc[endc-1][csctype]->Fill(cham);
 		    if(detid.station()>1 && detid.ring()==1) {
 		      hLCTCompMatch2x->Fill(ix,detid.chamber()*2);
-		    }	   
+		    }
 		    else {
 		      hLCTCompMatch2->Fill(ix,detid.chamber());
 		    }
@@ -1756,13 +1717,12 @@ void CSCTriggerPrimitivesReader::compareLCTs(
 
 int CSCTriggerPrimitivesReader::convertBXofLCT(
                              const int emul_bx, const CSCDetId& detid,
-			     const CSCALCTDigiCollection* alcts_data,
-			     const CSCCLCTDigiCollection* clcts_data) {
+                             const CSCALCTDigiCollection* alcts_data,
+                             const CSCCLCTDigiCollection* clcts_data) {
   int full_anode_bx = -999;
   //int full_cathode_bx = -999;
   int lct_bx = -999;
   int tbin_anode_offset = 5; // 2007, run 14419.
-  if (isMTCCData_) tbin_anode_offset = 10; // MTCC-II.  Why not 6???
 
   // Extract full 12-bit anode BX word from ALCT collections.
   const CSCALCTDigiCollection::Range& arange = alcts_data->get(detid);
@@ -1809,7 +1769,7 @@ void CSCTriggerPrimitivesReader::HotWires(const edm::Event& iEvent) {
   if (!bookedHotWireHistos) bookHotWireHistos();
   edm::Handle<CSCWireDigiCollection> wires;
   //  iEvent.getByLabel(wireDigiProducer_.label(), wireDigiProducer_.instance(), wires);
-  iEvent.getByToken(wireDigi_token_, wires);  
+  iEvent.getByToken(wireDigi_token_, wires);
 
   int serial_old=-1;
   for (CSCWireDigiCollection::DigiRangeIterator dWDiter=wires->begin(); dWDiter!=wires->end(); dWDiter++) {
@@ -1865,7 +1825,7 @@ void CSCTriggerPrimitivesReader::MCStudies(const edm::Event& ev,
       int id = (*p)->pdg_id();
       double phitmp = (*p)->momentum().phi();
       if (phitmp < 0) phitmp += 2.*M_PI;
-      if (debug) LogDebug("CSCTriggerPrimitivesReader") 
+      if (debug) LogDebug("CSCTriggerPrimitivesReader")
 	<< "MC part #" << ++i << ": id = "  << id
 	<< ", status = " << (*p)->status()
 	<< "\n   pX = " << (*p)->momentum().x()
@@ -1991,8 +1951,7 @@ void CSCTriggerPrimitivesReader::calcResolution(
   }
 
   // CLCT resolution
-  static const int key_layer = isTMB07 ?
-    CSCConstants::KEY_CLCT_LAYER : CSCConstants::KEY_CLCT_LAYER_PRE_TMB07;
+  static const int key_layer = CSCConstants::KEY_CLCT_LAYER;
   CSCCathodeLCTAnalyzer clct_analyzer;
   clct_analyzer.setGeometry(geom_);
   CSCCLCTDigiCollection::DigiRangeIterator cdetUnitIt;
@@ -2424,46 +2383,16 @@ void CSCTriggerPrimitivesReader::drawCLCTHistos() {
   snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
   gStyle->SetOptStat(111110);
   pad[page]->Draw();
-  if (!isTMB07) pad[page]->Divide(2,3);
-  else          pad[page]->Divide(2,4);
+  pad[page]->Divide(2,4);
   pad[page]->cd(1);  hClctValid->Draw();
   pad[page]->cd(2);  hClctQuality->Draw();
   pad[page]->cd(3);  hClctSign->Draw();
-  if (!isTMB07) {
-    TH1F* hClctPatternTot = (TH1F*)hClctPattern[0]->Clone();
-    hClctPatternTot->SetTitle("CLCT pattern #");
-    hClctPatternTot->Add(hClctPattern[0], hClctPattern[1], 1., 1.);
-    pad[page]->cd(4);  hClctPatternTot->Draw(); 
-    hClctPattern[0]->SetLineStyle(2);
-    hClctPattern[1]->SetLineStyle(3);
-  }
-  else {
-    hClctPattern[1]->SetTitle("CLCT pattern #");
-    pad[page]->cd(4);  hClctPattern[1]->Draw(); 
-  }
+  hClctPattern[1]->SetTitle("CLCT pattern #");
+  pad[page]->cd(4);  hClctPattern[1]->Draw();
   pad[page]->cd(5);  hClctCFEB->Draw();
-  if (!isTMB07) { 
-    pad[page]->cd(6);  hClctBXN->Draw();
-  }
-  else {
-    pad[page]->cd(7);  hClctKeyStrip[1]->Draw();
-    pad[page]->cd(8);  hClctBXN->Draw();
-  }
+  pad[page]->cd(7);  hClctKeyStrip[1]->Draw();
+  pad[page]->cd(8);  hClctBXN->Draw();
   page++;  c1->Update();
-
-  if (!isTMB07) {
-    ps->NewPage();
-    c1->Clear();  c1->cd(0);
-    title = new TPaveLabel(0.1, 0.94, 0.9, 0.98, "CLCT quantities");
-    title->SetFillColor(10);  title->Draw();
-    snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
-    pad[page]->Draw();
-    pad[page]->Divide(1,3);
-    pad[page]->cd(1);  hClctStripType->Draw();
-    pad[page]->cd(2);  hClctKeyStrip[0]->Draw();
-    pad[page]->cd(3);  hClctKeyStrip[1]->Draw(); 
-    page++;  c1->Update();
-  }
 
   ps->NewPage();
   c1->Clear();  c1->cd(0);
@@ -2479,46 +2408,10 @@ void CSCTriggerPrimitivesReader::drawCLCTHistos() {
     pad[page]->cd(idh+1);
     hClctBendCsc[idh][1]->GetXaxis()->SetTitle("Pattern bend");
     hClctBendCsc[idh][1]->GetYaxis()->SetTitle("Number of LCTs");
-    hClctBendCsc[idh][1]->Draw();   
+    hClctBendCsc[idh][1]->Draw();
   }
   page++;  c1->Update();
 
-  if (!isTMB07) {
-    ps->NewPage();
-    c1->Clear();  c1->cd(0);
-    title = new TPaveLabel(0.1, 0.94, 0.9, 0.98,
-			   "CLCT bend for various chamber types, distrips");
-    title->SetFillColor(10);  title->Draw();
-    snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
-    pad[page]->Draw();
-    pad[page]->Divide(2,5);
-    for (int idh = 0; idh < max_idh; idh++) {
-      if (!plotME1A && idh == 3) continue;
-      pad[page]->cd(idh+1);
-      hClctBendCsc[idh][0]->GetXaxis()->SetTitle("Pattern bend");
-      hClctBendCsc[idh][0]->GetYaxis()->SetTitle("Number of LCTs");
-      hClctBendCsc[idh][0]->Draw();    
-    }
-    page++;  c1->Update();
-
-    ps->NewPage();
-    c1->Clear();  c1->cd(0);
-    title = new TPaveLabel(0.1, 0.94, 0.9, 0.98,
-			   "CLCT keystrip, distrip patterns only");
-    title->SetFillColor(10);  title->Draw();
-    snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
-    pad[page]->Draw();
-    pad[page]->Divide(2,5);
-    for (int idh = 0; idh < max_idh; idh++) {
-      if (!plotME1A && idh == 3) continue;
-      pad[page]->cd(idh+1);
-      hClctKeyStripCsc[idh]->GetXaxis()->SetTitle("Key distrip");
-      hClctKeyStripCsc[idh]->GetXaxis()->SetTitleOffset(1.2);
-      hClctKeyStripCsc[idh]->GetYaxis()->SetTitle("Number of LCTs");
-      hClctKeyStripCsc[idh]->Draw();    
-    }
-    page++;  c1->Update();
-  }
   ps->Close();
   delete c1;
 }
@@ -2550,7 +2443,7 @@ void CSCTriggerPrimitivesReader::drawLCTTMBHistos() {
   gStyle->SetOptStat(111110);
   pad[page]->Draw();
   pad[page]->Divide(2,2);
-  pad[page]->cd(1);  hLctTMBPerEvent->Draw(); 
+  pad[page]->cd(1);  hLctTMBPerEvent->Draw();
   pad[page]->cd(2);  hLctTMBPerChamber->Draw();
   c1->Update();
   for (int i = 0; i < CSC_TYPES; i++) {
@@ -2558,7 +2451,7 @@ void CSCTriggerPrimitivesReader::drawLCTTMBHistos() {
     hCorrLctTMBPerCSC->GetXaxis()->SetBinLabel(i+1, csc_type[i].c_str());
   }
   // Should be multiplied by 40/nevents to convert to MHz
-  pad[page]->cd(3);  hLctTMBPerCSC->Draw(); 
+  pad[page]->cd(3);  hLctTMBPerCSC->Draw();
   pad[page]->cd(4);  hCorrLctTMBPerCSC->Draw();
   gStyle->SetOptStat(1110);
   page++;  c1->Update();
@@ -2571,12 +2464,12 @@ void CSCTriggerPrimitivesReader::drawLCTTMBHistos() {
   gStyle->SetOptStat(110110);
   pad[page]->Draw();
   pad[page]->Divide(2,4);
-  pad[page]->cd(1);  hLctTMBEndcap->Draw(); 
+  pad[page]->cd(1);  hLctTMBEndcap->Draw();
   pad[page]->cd(2);  hLctTMBStation->Draw();
-  pad[page]->cd(3);  hLctTMBSector->Draw(); 
-  pad[page]->cd(4);  hLctTMBRing->Draw(); 
+  pad[page]->cd(3);  hLctTMBSector->Draw();
+  pad[page]->cd(4);  hLctTMBRing->Draw();
   for (int istat = 0; istat < MAX_STATIONS; istat++) {
-    pad[page]->cd(istat+5);  hLctTMBChamber[istat]->Draw(); 
+    pad[page]->cd(istat+5);  hLctTMBChamber[istat]->Draw();
   }
   page++;  c1->Update();
 
@@ -2606,12 +2499,12 @@ void CSCTriggerPrimitivesReader::drawLCTTMBHistos() {
   gStyle->SetOptStat(110110);
   pad[page]->Draw();
   pad[page]->Divide(2,4);
-  pad[page]->cd(1);  hLctTMBValid->Draw(); 
+  pad[page]->cd(1);  hLctTMBValid->Draw();
   pad[page]->cd(2);  hLctTMBQuality->Draw();
-  pad[page]->cd(3);  hLctTMBKeyGroup->Draw(); 
+  pad[page]->cd(3);  hLctTMBKeyGroup->Draw();
   pad[page]->cd(4);  hLctTMBKeyStrip->Draw();
   pad[page]->cd(5);  hLctTMBStripType->Draw();
-  pad[page]->cd(6);  hLctTMBPattern->Draw(); 
+  pad[page]->cd(6);  hLctTMBPattern->Draw();
   pad[page]->cd(7);  hLctTMBBend->Draw();
   pad[page]->cd(8);  hLctTMBBXN->Draw();
   page++;  c1->Update();
@@ -2645,13 +2538,13 @@ void CSCTriggerPrimitivesReader::drawLCTMPCHistos() {
   gStyle->SetOptStat(111110);
   pad[page]->Draw();
   pad[page]->Divide(1,3);
-  pad[page]->cd(1);  hLctMPCPerEvent->Draw(); 
+  pad[page]->cd(1);  hLctMPCPerEvent->Draw();
   for (int i = 0; i < CSC_TYPES; i++) {
     hLctMPCPerCSC->GetXaxis()->SetBinLabel(i+1, csc_type[i].c_str());
     hCorrLctMPCPerCSC->GetXaxis()->SetBinLabel(i+1, csc_type[i].c_str());
   }
   // Should be multiplied by 40/nevents to convert to MHz
-  pad[page]->cd(2);  hLctMPCPerCSC->Draw(); 
+  pad[page]->cd(2);  hLctMPCPerCSC->Draw();
   pad[page]->cd(3);  hCorrLctMPCPerCSC->Draw();
   page++;  c1->Update();
 
@@ -2666,7 +2559,7 @@ void CSCTriggerPrimitivesReader::drawLCTMPCHistos() {
   pad[page]->cd(1);  hLctMPCEndcap->Draw();
   pad[page]->cd(2);  hLctMPCStation->Draw();
   pad[page]->cd(3);  hLctMPCSector->Draw();
-  pad[page]->cd(4);  hLctMPCRing->Draw(); 
+  pad[page]->cd(4);  hLctMPCRing->Draw();
   for (int istat = 0; istat < MAX_STATIONS; istat++) {
     pad[page]->cd(istat+5);  hLctMPCChamber[istat]->Draw();
   }
@@ -2679,14 +2572,14 @@ void CSCTriggerPrimitivesReader::drawLCTMPCHistos() {
   snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
   pad[page]->Draw();
   pad[page]->Divide(2,4);
-  pad[page]->cd(1);  hLctMPCValid->Draw(); 
+  pad[page]->cd(1);  hLctMPCValid->Draw();
   pad[page]->cd(2);  hLctMPCQuality->Draw();
   pad[page]->cd(3);  hLctMPCKeyGroup->Draw();
   pad[page]->cd(4);  hLctMPCKeyStrip->Draw();
   pad[page]->cd(5);  hLctMPCStripType->Draw();
-  pad[page]->cd(6);  hLctMPCPattern->Draw(); 
-  pad[page]->cd(7);  hLctMPCBend->Draw(); 
-  pad[page]->cd(8);  hLctMPCBXN->Draw(); 
+  pad[page]->cd(6);  hLctMPCPattern->Draw();
+  pad[page]->cd(7);  hLctMPCBend->Draw();
+  pad[page]->cd(8);  hLctMPCBXN->Draw();
   page++;  c1->Update();
 
   ps->Close();
@@ -2807,7 +2700,7 @@ void CSCTriggerPrimitivesReader::drawCompHistos() {
       hAlctMatchEffVsCsc[endc][idh]->GetYaxis()->SetTitleSize(0.07);
       hAlctMatchEffVsCsc[endc][idh]->GetXaxis()->SetTitle("CSC id");
       hAlctMatchEffVsCsc[endc][idh]->GetYaxis()->SetTitle("% of exact match");
-      pad[page]->cd(idh+1);  hAlctMatchEffVsCsc[endc][idh]->Draw("e"); 
+      pad[page]->cd(idh+1);  hAlctMatchEffVsCsc[endc][idh]->Draw("e");
       double numer = hAlctCompMatchCsc[endc][idh]->Integral();
       double denom = hAlctCompTotalCsc[endc][idh]->Integral();
       double ratio = 0.0, error = 0.0;
@@ -2859,7 +2752,7 @@ void CSCTriggerPrimitivesReader::drawCompHistos() {
       hClctFoundEffVsCsc[endc][idh]->GetYaxis()->SetTitleSize(0.07);
       hClctFoundEffVsCsc[endc][idh]->GetXaxis()->SetTitle("CSC id");
       hClctFoundEffVsCsc[endc][idh]->GetYaxis()->SetTitle("% of same number found");
-      pad[page]->cd(idh+1);  hClctFoundEffVsCsc[endc][idh]->Draw("e"); 
+      pad[page]->cd(idh+1);  hClctFoundEffVsCsc[endc][idh]->Draw("e");
       double numer = hClctCompSameNCsc[endc][idh]->Integral();
       double denom = hClctCompFoundCsc[endc][idh]->Integral();
       double ratio = 0.0, error = 0.0;
@@ -2962,7 +2855,7 @@ void CSCTriggerPrimitivesReader::drawCompHistos() {
       hLctFoundEffVsCsc[endc][idh]->GetYaxis()->SetTitleSize(0.07);
       hLctFoundEffVsCsc[endc][idh]->GetXaxis()->SetTitle("CSC id");
       hLctFoundEffVsCsc[endc][idh]->GetYaxis()->SetTitle("% of same number found");
-      pad[page]->cd(idh+1);  hLctFoundEffVsCsc[endc][idh]->Draw("e"); 
+      pad[page]->cd(idh+1);  hLctFoundEffVsCsc[endc][idh]->Draw("e");
       double numer = hLctCompSameNCsc[endc][idh]->Integral();
       double denom = hLctCompFoundCsc[endc][idh]->Integral();
       double ratio = 0.0, error = 0.0;
@@ -3013,7 +2906,7 @@ void CSCTriggerPrimitivesReader::drawCompHistos() {
       hLctMatchEffVsCsc[endc][idh]->GetYaxis()->SetTitleSize(0.07);
       hLctMatchEffVsCsc[endc][idh]->GetXaxis()->SetTitle("CSC id");
       hLctMatchEffVsCsc[endc][idh]->GetYaxis()->SetTitle("% of exact match");
-      pad[page]->cd(idh+1);  hLctMatchEffVsCsc[endc][idh]->Draw("e"); 
+      pad[page]->cd(idh+1);  hLctMatchEffVsCsc[endc][idh]->Draw("e");
       double numer = hLctCompMatchCsc[endc][idh]->Integral();
       double denom = hLctCompTotalCsc[endc][idh]->Integral();
       double ratio = 0.0, error = 0.0;
@@ -3215,7 +3108,7 @@ void CSCTriggerPrimitivesReader::drawResolHistos() {
   page++;  c1->Update();
 
   /* Old histos, separately for halfstrips and distrips */
-  /* 
+  /*
   ps->NewPage();
   c1->Clear();  c1->cd(0);
   title = new TPaveLabel(0.1, 0.94, 0.9, 0.98,
@@ -3339,7 +3232,7 @@ void CSCTriggerPrimitivesReader::drawResolHistos() {
   page++;  c1->Update();
 
   /* Old histos for distrips */
-  /* 
+  /*
   c1->Clear();  c1->cd(0);
   title = new TPaveLabel(0.1, 0.94, 0.9, 0.98,
 			 "#phi_rec-#phi_sim (mrad) vs distrip #");
@@ -3369,14 +3262,8 @@ void CSCTriggerPrimitivesReader::drawResolHistos() {
   pad[page]->Draw();
   pad[page]->Divide(3,3);
   int min_pattern, max_pattern;
-  if (!isTMB07) {
-    min_pattern = 0;
-    max_pattern = CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07;
-  }
-  else {
-    min_pattern = 2;
-    max_pattern = CSCConstants::NUM_CLCT_PATTERNS;
-  }
+  min_pattern = 2;
+  max_pattern = CSCConstants::NUM_CLCT_PATTERNS;
   for (int idh = min_pattern; idh < max_pattern; idh++) {
     hPhiDiffPattern[idh]->GetXaxis()->SetTitle("Halfstrip");
     hPhiDiffPattern[idh]->GetXaxis()->SetTitleOffset(1.2);
@@ -3425,7 +3312,7 @@ void CSCTriggerPrimitivesReader::drawEfficHistos() {
   char pagenum[16];
   TPaveLabel *title;
   char histtitle[60];
-  
+
   gStyle->SetOptDate(0);
   gStyle->SetTitleSize(0.1, "");   // size for pad title; default is 0.02
 

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.h
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.h
@@ -75,11 +75,6 @@ class CSCTriggerPrimitivesReader : public edm::EDAnalyzer
   bool dataLctsIn_;
   bool emulLctsIn_;
 
-  // Flag to indicate MTCC data (used only when dataLctsIn_ = true).
-  bool isMTCCData_;
-
-  bool isTMB07;
-
   // Flag to plot or not plot ME1/A as a separate chamber.
   bool plotME1A;
 
@@ -129,7 +124,6 @@ class CSCTriggerPrimitivesReader : public edm::EDAnalyzer
   static const int NCHAMBERS[CSC_TYPES];
   static const int MAX_WG[CSC_TYPES];
   static const int MAX_HS[CSC_TYPES];
-  static const int ptype[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07];
   static const int ptype_TMB07[CSCConstants::NUM_CLCT_PATTERNS];
 
   // LCT counters

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader_cfg.py
@@ -1,18 +1,16 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 # Hack to add "test" directory to the python path.
 import sys, os
 sys.path.insert(0, os.path.join(os.environ['CMSSW_BASE'],
                                 'src/L1Trigger/CSCTriggerPrimitives/test'))
 
-process = cms.Process("L1CSCTriggerPrimitivesReader")
+process = cms.Process("L1CSCTriggerPrimitivesReader", eras.Run2_2018)
 
 process.source = cms.Source("PoolSource",
-    # fileNames = cms.untracked.vstring("file:lcts.root"),
-    # fileNames = cms.untracked.vstring("file:/data0/slava/test/lcts_muminus_pt50_emul_CMSSW_3_9_0_pre1.root"),
-    fileNames = cms.untracked.vstring("file:lcts_muminus_pt50_emul_CMSSW_6_1_0_pre2.root")
+    fileNames = cms.untracked.vstring("file:lcts.root")
 )
-#process.PoolSource.fileNames = ['/store/relval/CMSSW_3_1_0_pre7/RelValSingleMuPt100/GEN-SIM-DIGI-RAW-HLTDEBUG/IDEAL_31X_v1/0004/EE15A7EC-E641-DE11-A279-001D09F29321.root']
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
@@ -41,10 +39,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = 'DESIGN_31X_V8::All'
 process.GlobalTag.globaltag = 'MC_61_V1::All'
-
-#process.Tracer = cms.Service("Tracer")
 
 process.TFileService = cms.Service("TFileService",
     fileName = cms.string('TPEHists.root')
@@ -52,8 +47,5 @@ process.TFileService = cms.Service("TFileService",
 
 process.load("CSCTriggerPrimitivesReader_cfi")
 process.lctreader.debug = True
-process.lctreader.dataLctsIn = False
-#- For official RelVal samples
-#process.lctreader.CSCLCTProducerEmul = "simCscTriggerPrimitiveDigis"
 
 process.p = cms.Path(process.lctreader)

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader_cfi.py
@@ -10,12 +10,10 @@ lctreader = cms.EDAnalyzer("CSCTriggerPrimitivesReader",
     dataLctsIn = cms.bool(True),
     emulLctsIn = cms.bool(True),
     printps = cms.bool(True),
-    # Flag to indicate MTCC data (used only when dataLctsIn = true).
-    isMTCCData = cms.bool(False),
     # Labels to retrieve LCTs from the event (optional)
-    #                                       produced by unpacker
+    # produced by unpacker
     CSCLCTProducerData = cms.untracked.string("muonCSCDigis"),
-    #                                       produced by emulator
+    # produced by emulator
     CSCLCTProducerEmul = cms.untracked.string("cscTriggerPrimitiveDigis"),
     # Labels to retrieve simHits, comparator and wire digis.
     #  (Used only when emulLctsIn = true.)

--- a/L1Trigger/CSCTriggerPrimitives/test/runL1CSCTPEmulatorConfigAnalyzer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runL1CSCTPEmulatorConfigAnalyzer_cfg.py
@@ -13,14 +13,14 @@ options.parseArguments()
 
 if str(options.type) == "Data": globalTag = 'auto:run2_data'
 elif str(options.type) == "MC": globalTag = 'auto:run2_mc'
-else: 
-    print("Please choose \"Data\" or \"MC\" ") 
+else:
+    print("Please choose \"Data\" or \"MC\" ")
     sys.exit(1)
 
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("TEST",eras.Run2_2016)
+process = cms.Process("TEST",eras.Run2_2018)
 
 process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi')

--- a/L1TriggerConfig/L1CSCTPConfigProducers/python/L1CSCTriggerPrimitivesConfig_cfi.py
+++ b/L1TriggerConfig/L1CSCTPConfigProducers/python/L1CSCTriggerPrimitivesConfig_cfi.py
@@ -2,13 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 l1csctpconf = cms.ESProducer("L1CSCTriggerPrimitivesConfigProducer",
 
-    # Defines the set of parameters used in MTCC.
-    isMTCC = cms.bool(False),
-
-    # Defines the set of parameters used in the minus-endcap slice test with
-    # the new TMB07 firmware.
-    isTMB07 = cms.bool(True),
-
     # Parameters for ALCT processors: default
     alctParam = cms.PSet(
         alctFifoTbins              = cms.uint32(16),
@@ -23,20 +16,6 @@ l1csctpconf = cms.ESProducer("L1CSCTriggerPrimitivesConfigProducer",
         alctL1aWindowWidth         = cms.uint32(5)
     ),
 
-    # Parameters for ALCT processors: MTCC-II and 2007 tests of new firmware
-    alctParamMTCC2 = cms.PSet(
-        alctFifoTbins              = cms.uint32(16),
-        alctFifoPretrig            = cms.uint32(10),
-        alctDriftDelay             = cms.uint32(2),
-        alctNplanesHitPretrig      = cms.uint32(3),
-        alctNplanesHitPattern      = cms.uint32(4),
-        alctNplanesHitAccelPretrig = cms.uint32(3),
-        alctNplanesHitAccelPattern = cms.uint32(4),
-        alctTrigMode               = cms.uint32(2),
-        alctAccelMode              = cms.uint32(0),
-        alctL1aWindowWidth         = cms.uint32(7)
-    ),
-
     # Parameters for CLCT processors: default and 2007 tests of new firmware
     clctParam = cms.PSet(
         clctFifoTbins   = cms.uint32(12),
@@ -45,18 +24,6 @@ l1csctpconf = cms.ESProducer("L1CSCTriggerPrimitivesConfigProducer",
         clctDriftDelay  = cms.uint32(2),
         clctNplanesHitPretrig = cms.uint32(3),
         clctNplanesHitPattern = cms.uint32(4),
-        clctPidThreshPretrig  = cms.uint32(2),
-        clctMinSeparation     = cms.uint32(10)
-    ),
-
-    # Parameters for CLCT processors: MTCC-II
-    clctParamMTCC2 = cms.PSet(
-        clctFifoTbins   = cms.uint32(12),
-        clctFifoPretrig = cms.uint32(7),
-        clctHitPersist  = cms.uint32(6),
-        clctDriftDelay  = cms.uint32(2),
-        clctNplanesHitPretrig = cms.uint32(4),
-        clctNplanesHitPattern = cms.uint32(1),
         clctPidThreshPretrig  = cms.uint32(2),
         clctMinSeparation     = cms.uint32(10)
     ),

--- a/L1TriggerConfig/L1CSCTPConfigProducers/python/L1CSCTriggerPrimitivesDBConfig_cff.py
+++ b/L1TriggerConfig/L1CSCTPConfigProducers/python/L1CSCTriggerPrimitivesDBConfig_cff.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-#from L1TriggerConfig.L1CSCTPConfigProducers.L1CSCTriggerPrimitivesConfig_cfi import *
-
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 # Read constants from DB.

--- a/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.cc
+++ b/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.cc
@@ -2,7 +2,7 @@
 //
 //   Class: L1CSCTriggerPrimitivesConfigProducer
 //
-//   Description: 
+//   Description:
 //
 //   Author: Slava Valuev
 //
@@ -25,20 +25,8 @@ L1CSCTriggerPrimitivesConfigProducer::L1CSCTriggerPrimitivesConfigProducer(const
   // Decide on which of the two sets of parameters will be used.
   // (Temporary substitute for the IOV.)
   std::string alctParamSet, clctParamSet, tmbParamSet;
-  bool isMTCC  = iConfig.getParameter<bool>("isMTCC");
-  bool isTMB07 = iConfig.getParameter<bool>("isTMB07");
-  if (isMTCC) {
-    alctParamSet = "alctParamMTCC2";
-    clctParamSet = "clctParamMTCC2";
-  }
-  else if (isTMB07) {
-    alctParamSet = "alctParamMTCC2";
-    clctParamSet = "clctParam";
-  }
-  else {
-    alctParamSet = "alctParam";
-    clctParamSet = "clctParam";
-  }
+  alctParamSet = "alctParam";
+  clctParamSet = "clctParam";
   tmbParamSet = "tmbParam";
 
   // get ALCT parameters from the config file


### PR DESCRIPTION
This PR removes the parameters `isMTCC` and `isTMB07` in the CSC local trigger.

The parameter `isMTCC` sets the CSC algorithm to the settings used for the Magnet Test and Cosmic Challenge (when the CSC system was partially installed above ground at P5). `isTMB07` sets the CSC algorithm to the default setting - which has been used since the start of physics data taking. The `isMTCC` algorithm still uses distrips. Distrips have not been used since the 2007 version of the firmware was installed. In addition, distrips are not used to trigger the chambers in the 2007 version of the simulation. So the options can be safely removed.

I also removed two outdated LCT quality definitions in the `CSCMotherboard` class.

I compared the output of the trigger primitive reader on 10,000 events in 2018D data before and after the pull request. I see no differences. 

FYI @tahuang1991 @ptcox @lpernie 