### PR TITLE
Protection against lumiScale empty collection

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/src/AlCaHOCalibProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/src/AlCaHOCalibProducer.cc
@@ -330,7 +330,11 @@ AlCaHOCalibProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       iEvent.getByToken(tok_lumi_, lumiScale);
 
       if (lumiScale.isValid()) {
-	tmpHOCalib.inslumi=lumiScale->begin()->pileup();
+        if ( lumiScale->empty() ) {
+          edm::LogError("HOCalib") << "lumiScale collection is empty";
+        } else {
+          tmpHOCalib.inslumi=lumiScale->begin()->pileup();
+        }
       }
     }
   }


### PR DESCRIPTION
Backport of #24259, addressing the Prompt Reco failure reported in https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1964.html