### PR TITLE
Removed the ability to use bare pointers as output of ESProducers

### DIFF
--- a/FWCore/Framework/interface/es_Label.h
+++ b/FWCore/Framework/interface/es_Label.h
@@ -36,7 +36,8 @@ namespace edm {
          typedef T element_type;
          
          L() : product_() {}
-         explicit L(std::shared_ptr<T> iP) : product_(iP) {}
+         explicit L(std::shared_ptr<T> iP) : product_(std::move(iP)) {}
+         explicit L(std::unique_ptr<T> iP) : product_(std::move(iP)) {}
          explicit L(T* iP) : product_(iP) {}
          
          T& operator*() { return *product_;}

--- a/FWCore/Framework/interface/produce_helpers.h
+++ b/FWCore/Framework/interface/produce_helpers.h
@@ -40,6 +40,7 @@ namespace edm {
      namespace produce { 
          struct Null {};
          template <typename T> struct EndList {
+           static_assert( (not std::is_pointer_v<T>) ,"use std::shared_ptr or std::unique_ptr to hold EventSetup data products, do not use bare pointers");
             typedef T tail_type;
             typedef Null head_type;
          };

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/ESProducts.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "cppunit/extensions/HelperMacros.h"
+#include "FWCore/Utilities/interface/do_nothing_deleter.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 using edm::eventsetup::test::DummyData;
@@ -63,9 +64,9 @@ public:
       data_.value_ = 0;
       setWhatProduced(this);
    }
-   const DummyData* produce(const DummyRecord& /*iRecord*/) {
-      ++data_.value_;
-      return &data_;
+  std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+    ++data_.value_;
+    return std::shared_ptr<DummyData>(&data_,edm::do_nothing_deleter{});
    }
 private:
    DummyData data_;
@@ -77,8 +78,8 @@ public:
       setWhatProduced(this);
       setWhatProduced(this);
    }
-   const DummyData* produce(const DummyRecord& /*iRecord*/) {
-      return &data_;
+   std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+     return std::shared_ptr<DummyData>(&data_, edm::do_nothing_deleter{});
    }
 private:
    DummyData data_;
@@ -114,7 +115,7 @@ private:
 class LabelledProducer : public ESProducer {
 public:
    enum {kFi, kFum};
-   typedef edm::ESProducts< edm::es::L<DummyData,kFi>, edm::es::L<DummyData,kFum> > ReturnProducts;
+  typedef edm::ESProducts< edm::es::L<DummyData,kFi>, edm::es::L<DummyData,kFum> > ReturnProducts;
    LabelledProducer(): ptr_(new DummyData), fi_(new DummyData){
       ptr_->value_ = 0;
       fi_->value_=0;
@@ -132,7 +133,7 @@ public:
       using namespace edm;
       ++fi_->value_;
 
-      L<DummyData,kFum> fum( new DummyData);
+      L<DummyData,kFum> fum( std::make_shared<DummyData>());
       fum->value_ = fi_->value_;
       
       return edm::es::products(fum, es::l<kFi>(fi_) );


### PR DESCRIPTION
We now require the use of `std::unique_ptr` or `std::shared_ptr`. This transition has already been done in CMSSW code, except for two tests in FWCore/Framework.