### PR TITLE
Change how we calculate GUID

### DIFF
--- a/FWCore/Utilities/src/Guid.cc
+++ b/FWCore/Utilities/src/Guid.cc
@@ -26,7 +26,7 @@ namespace edm {
   /// Initialize a new Guid
   void Guid::init()   {
     uuid_t me_;
-    ::uuid_generate_time(me_);
+    ::uuid_generate_random(me_);
     unsigned int*   d1 = reinterpret_cast<unsigned int*>(me_);
     unsigned short* d2 = reinterpret_cast<unsigned short*>(me_+4);
     unsigned short* d3 = reinterpret_cast<unsigned short*>(me_+6);


### PR DESCRIPTION
Previously, we used uuid_generate_time which used the MAC address of the machine as part of the calculation. This is leading to problems when we run on virtual machines as many of the machines share the same dummy MAC address. This has lead to noticeable GUID collisions in production. By switching to uuid_generate_random, we hope to decrease collisions.