### PR TITLE
Change produce function return type to unique_ptr in CondTools L1Trigger

### DIFF
--- a/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.h
+++ b/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.h
@@ -39,7 +39,7 @@ class L1SubsystemKeysOnlineProd : public edm::ESProducer {
       L1SubsystemKeysOnlineProd(const edm::ParameterSet&);
       ~L1SubsystemKeysOnlineProd() override;
 
-      typedef std::shared_ptr<L1TriggerKey> ReturnType;
+      typedef std::unique_ptr<L1TriggerKey> ReturnType;
 
       ReturnType produce(const L1TriggerKeyRcd&);
    private:

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyListDummyProd.h
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyListDummyProd.h
@@ -37,7 +37,7 @@ class L1TriggerKeyListDummyProd : public edm::ESProducer {
       L1TriggerKeyListDummyProd(const edm::ParameterSet&);
       ~L1TriggerKeyListDummyProd() override;
 
-      typedef std::shared_ptr<L1TriggerKeyList> ReturnType;
+      typedef std::unique_ptr<L1TriggerKeyList> ReturnType;
 
       ReturnType produce(const L1TriggerKeyListRcd&);
    private:

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.h
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.h
@@ -39,7 +39,7 @@ class L1TriggerKeyOnlineProd : public edm::ESProducer {
       L1TriggerKeyOnlineProd(const edm::ParameterSet&);
       ~L1TriggerKeyOnlineProd() override;
 
-      typedef std::shared_ptr<L1TriggerKey> ReturnType;
+      typedef std::unique_ptr<L1TriggerKey> ReturnType;
 
       ReturnType produce(const L1TriggerKeyRcd&);
    private:


### PR DESCRIPTION
looks like this was overlooked in PR #22138, although it should not actually affect anything currently (these changes are in preparation for future concurrent IOV processing)