### PR TITLE
MTD DetId: add methods to BTLDetId (hashed index, phi-eta geometric indexes)

### DIFF
--- a/DataFormats/ForwardDetId/interface/BTLDetId.h
+++ b/DataFormats/ForwardDetId/interface/BTLDetId.h
@@ -48,7 +48,7 @@ class BTLDetId : public MTDDetId {
   static constexpr int MAX_HASH =  2*MAX_IPHI_TILE*MAX_IETA_TILE-1; // the total amount is invariant per tile or bar)
   static constexpr int kSizeForDenseIndexing = MAX_HASH + 1 ;
 
-  enum kCrysLayout { tile = 1 , bar = 2 } ;
+  enum class CrysLayout { tile = 1 , bar = 2 } ;
 
  public:
   
@@ -89,20 +89,20 @@ class BTLDetId : public MTDDetId {
   inline int crystal() const { return ((id_>>kBTLCrystalOffset)&kBTLCrystalMask) + 1; }
 
   /** Returns BTL iphi index for crystal according to type tile or bar */
-  int iphi( kCrysLayout lay ) const ;
+  int iphi( CrysLayout lay ) const ;
 
   /** Returns BTL ieta index for crystal according to type tile or bar */
-  int ietaAbs( kCrysLayout lay ) const ;
+  int ietaAbs( CrysLayout lay ) const ;
 
-  int ieta( kCrysLayout lay ) const { return zside()*ietaAbs( lay ); }
+  int ieta( CrysLayout lay ) const { return zside()*ietaAbs( lay ); }
 
   /** define a dense index fo arrays from a DetId */
-  int hashedIndex( kCrysLayout lay ) const ;
+  int hashedIndex( CrysLayout lay ) const ;
 
   static bool validHashedIndex( uint32_t din ) { return ( din < kSizeForDenseIndexing ) ; }
 
   /** get a DetId from a compact index for arrays */
-  BTLDetId getUnhashedIndex( int hi, kCrysLayout lay ) const ;
+  BTLDetId getUnhashedIndex( int hi, CrysLayout lay ) const ;
 
 };
 

--- a/DataFormats/ForwardDetId/interface/BTLDetId.h
+++ b/DataFormats/ForwardDetId/interface/BTLDetId.h
@@ -29,12 +29,12 @@ class BTLDetId : public MTDDetId {
 
   /// range constants, need two sets for the time being (one for tiles and one for bars)
   static constexpr int kModulesPerROD = 54;
-  static constexpr int kTypeBoundaries[4] = { 0, 18, 36, 54 };;
+  static constexpr int kTypeBoundaries[4] = { 0, 18, 36, 54 };
   static constexpr int kCrystalsInPhiTile = 16; // per module and ROD
   static constexpr int kCrystalsInEtaTile = 4; // per module
   static constexpr int kCrystalsInPhiBar = 4; // per module and ROD
   static constexpr int kCrystalsInEtaBar = 16; // per module
-  static constexpr int kCrystalsPerROD = 3456; // 64 crystals per module x 54 modules per rod
+  static constexpr int kCrystalsPerROD = kModulesPerROD*kCrystalsInPhiTile*kCrystalsInEtaTile; // 64 crystals per module x 54 modules per rod, independent on geometry scenario Tile or Bar
   static constexpr int MIN_ROD = 1;
   static constexpr int MAX_ROD = 72;
   static constexpr int HALF_ROD = 36;
@@ -96,7 +96,7 @@ class BTLDetId : public MTDDetId {
 
   int ieta( CrysLayout lay ) const { return zside()*ietaAbs( lay ); }
 
-  /** define a dense index fo arrays from a DetId */
+  /** define a dense index of arrays from a DetId */
   int hashedIndex( CrysLayout lay ) const ;
 
   static bool validHashedIndex( uint32_t din ) { return ( din < kSizeForDenseIndexing ) ; }

--- a/DataFormats/ForwardDetId/interface/BTLDetId.h
+++ b/DataFormats/ForwardDetId/interface/BTLDetId.h
@@ -18,12 +18,37 @@ class BTLDetId : public MTDDetId {
   
  private:
   
-  static const uint32_t kBTLmoduleOffset           = 10;
-  static const uint32_t kBTLmoduleMask             = 0x3F;
-  static const uint32_t kBTLmodTypeOffset          = 8;
-  static const uint32_t kBTLmodTypeMask            = 0x3;
-  static const uint32_t kBTLCrystalOffset          = 0;
-  static const uint32_t kBTLCrystalMask            = 0x3F;
+  static constexpr uint32_t kBTLmoduleOffset           = 10;
+  static constexpr uint32_t kBTLmoduleMask             = 0x3F;
+  static constexpr uint32_t kBTLmodTypeOffset          = 8;
+  static constexpr uint32_t kBTLmodTypeMask            = 0x3;
+  static constexpr uint32_t kBTLCrystalOffset          = 0;
+  static constexpr uint32_t kBTLCrystalMask            = 0x3F;
+
+ public:
+
+  /// range constants, need two sets for the time being (one for tiles and one for bars)
+  static constexpr int kModulesPerROD = 54;
+  static constexpr int kTypeBoundaries[4] = { 0, 18, 36, 54 };;
+  static constexpr int kCrystalsInPhiTile = 16; // per module and ROD
+  static constexpr int kCrystalsInEtaTile = 4; // per module
+  static constexpr int kCrystalsInPhiBar = 4; // per module and ROD
+  static constexpr int kCrystalsInEtaBar = 16; // per module
+  static constexpr int kCrystalsPerROD = 3456; // 64 crystals per module x 54 modules per rod
+  static constexpr int MIN_ROD = 1;
+  static constexpr int MAX_ROD = 36;
+  static constexpr int HALF_ROD = 18;
+  static constexpr int MIN_IETA = 1;
+  static constexpr int MIN_IPHI = 1;
+  static constexpr int MAX_IETA_TILE = kCrystalsInEtaTile*kModulesPerROD;
+  static constexpr int MAX_IPHI_TILE = kCrystalsInPhiTile*HALF_ROD;
+  static constexpr int MAX_IETA_BAR = kCrystalsInEtaBar*kModulesPerROD;
+  static constexpr int MAX_IPHI_BAR = kCrystalsInPhiBar*HALF_ROD;
+  static constexpr int MIN_HASH =  0; // always 0 ...
+  static constexpr int MAX_HASH =  2*MAX_IPHI_TILE*MAX_IETA_TILE-1; // the total amount is invariant per tile or bar)
+  static constexpr int kSizeForDenseIndexing = MAX_HASH + 1 ;
+
+  enum kCrysLayout { tile = 1 , bar = 2 } ;
 
  public:
   
@@ -31,7 +56,7 @@ class BTLDetId : public MTDDetId {
   
   /** Construct a null id */
  BTLDetId() : MTDDetId( DetId::Forward, ForwardSubdetector::FastTime ) { id_ |= ( MTDType::BTL& kMTDsubdMask ) << kMTDsubdOffset ;}
-
+  
   /** Construct from a raw value */
  BTLDetId( const uint32_t& raw_id ) : MTDDetId( raw_id ) {;}
   
@@ -50,18 +75,33 @@ class BTLDetId : public MTDDetId {
       ( module& kBTLmoduleMask ) << kBTLmoduleOffset |
       ( modtyp& kBTLmodTypeMask ) << kBTLmodTypeOffset |
       ( (crystal-1)& kBTLCrystalMask ) << kBTLCrystalOffset ; 
-}
+  }
+  
+  // ---------- Common methods ----------
+  
+  /** Returns BTL module number. */
+  inline int module() const { return (id_>>kBTLmoduleOffset)&kBTLmoduleMask; }
+  
+  /** Returns BTL crystal type number. */
+  inline int modType() const { return (id_>>kBTLmodTypeOffset)&kBTLmodTypeMask; }
+  
+  /** Returns BTL crystal number. */
+  inline int crystal() const { return ((id_>>kBTLCrystalOffset)&kBTLCrystalMask) + 1; }
 
-// ---------- Common methods ----------
+  /** Returns BTL iphi index for crystal according to type tile or bar */
+  int iphi( kCrysLayout lay ) const ;
 
-/** Returns BTL module number. */
-inline int module() const { return (id_>>kBTLmoduleOffset)&kBTLmoduleMask; }
+  /** Returns BTL ieta index for crystal according to type tile or bar */
+  int ietaAbs( kCrysLayout lay ) const ;
 
-/** Returns BTL crystal type number. */
-inline int modType() const { return (id_>>kBTLmodTypeOffset)&kBTLmodTypeMask; }
+  int ieta( kCrysLayout lay ) const { return zside()*ietaAbs( lay ); }
 
-/** Returns BTL crystal number. */
- inline int crystal() const { return ((id_>>kBTLCrystalOffset)&kBTLCrystalMask) + 1; }
+  int hashedIndex( kCrysLayout lay ) const ;
+
+  static bool validHashedIndex( uint32_t din ) { return ( din < kSizeForDenseIndexing ) ; }
+
+  /** get a DetId from a compact index for arrays */
+  // void getUnhashedIndex( int hi, BTLDetId id, kCrysLayout lay ) const ;
 
 };
 

--- a/DataFormats/ForwardDetId/interface/BTLDetId.h
+++ b/DataFormats/ForwardDetId/interface/BTLDetId.h
@@ -36,8 +36,8 @@ class BTLDetId : public MTDDetId {
   static constexpr int kCrystalsInEtaBar = 16; // per module
   static constexpr int kCrystalsPerROD = 3456; // 64 crystals per module x 54 modules per rod
   static constexpr int MIN_ROD = 1;
-  static constexpr int MAX_ROD = 36;
-  static constexpr int HALF_ROD = 18;
+  static constexpr int MAX_ROD = 72;
+  static constexpr int HALF_ROD = 36;
   static constexpr int MIN_IETA = 1;
   static constexpr int MIN_IPHI = 1;
   static constexpr int MAX_IETA_TILE = kCrystalsInEtaTile*kModulesPerROD;
@@ -96,12 +96,13 @@ class BTLDetId : public MTDDetId {
 
   int ieta( kCrysLayout lay ) const { return zside()*ietaAbs( lay ); }
 
+  /** define a dense index fo arrays from a DetId */
   int hashedIndex( kCrysLayout lay ) const ;
 
   static bool validHashedIndex( uint32_t din ) { return ( din < kSizeForDenseIndexing ) ; }
 
   /** get a DetId from a compact index for arrays */
-  // void getUnhashedIndex( int hi, BTLDetId id, kCrysLayout lay ) const ;
+  BTLDetId getUnhashedIndex( int hi, kCrysLayout lay ) const ;
 
 };
 

--- a/DataFormats/ForwardDetId/interface/MTDDetId.h
+++ b/DataFormats/ForwardDetId/interface/MTDDetId.h
@@ -59,10 +59,10 @@ class MTDDetId : public DetId {
   /** Returns enumerated type specifying MTD sub-detector, i.e. BTL or ETL. */
   inline int mtdSubDetector() const { return (id_>>kMTDsubdOffset)&kMTDsubdMask; }
 
-  /** Returns MTD side, i.e. Z-=1 or Z+=0. */
+  /** Returns MTD side, i.e. Z-=0 or Z+=1. */
   inline int mtdSide() const { return (id_>>kZsideOffset)&kZsideMask; }
-  /** Return MTD side, i.e. Z-=-1 or Z+-1. */
-  inline int zside() const { return (id_>>kZsideOffset)&kZsideMask ? (1):(-1) ; }
+  /** Return MTD side, i.e. Z-=-1 or Z+=1. */
+  inline int zside() const { return (mtdSide()==1 ? (1):(-1)) ; }
   
   /** Returns MTD rod/ring number. */
   inline int mtdRR() const { return (id_>>kRodRingOffset)&kRodRingMask; }

--- a/DataFormats/ForwardDetId/interface/MTDDetId.h
+++ b/DataFormats/ForwardDetId/interface/MTDDetId.h
@@ -59,8 +59,10 @@ class MTDDetId : public DetId {
   /** Returns enumerated type specifying MTD sub-detector, i.e. BTL or ETL. */
   inline int mtdSubDetector() const { return (id_>>kMTDsubdOffset)&kMTDsubdMask; }
 
-  /** Returns MTD side, i.e. Z-=1 or Z+=2. */
+  /** Returns MTD side, i.e. Z-=1 or Z+=0. */
   inline int mtdSide() const { return (id_>>kZsideOffset)&kZsideMask; }
+  /** Return MTD side, i.e. Z-=-1 or Z+-1. */
+  inline int zside() const { return (id_>>kZsideOffset)&kZsideMask ? (1):(-1) ; }
   
   /** Returns MTD rod/ring number. */
   inline int mtdRR() const { return (id_>>kRodRingOffset)&kRodRingMask; }

--- a/DataFormats/ForwardDetId/src/BTLDetId.cc
+++ b/DataFormats/ForwardDetId/src/BTLDetId.cc
@@ -1,4 +1,52 @@
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+
+/** Returns BTL iphi index for crystal according to type tile or bar */
+int BTLDetId::iphi( kCrysLayout lay ) const {
+  int res = 2*MAX_HASH; 
+  int kCrystalsInPhi = 1;
+  switch ( lay ) {
+  case tile : kCrystalsInPhi = kCrystalsInPhiTile ; break ;
+  case bar  : kCrystalsInPhi = kCrystalsInPhiBar ; break ;
+  default: break ;  
+  }
+  return res = kCrystalsInPhi * ( ( mtdRR()%HALF_ROD > 0 ? mtdRR()%HALF_ROD : HALF_ROD ) -1 ) 
+    + ( crystal()%kCrystalsInPhi > 0 ? crystal()%kCrystalsInPhi : kCrystalsInPhi ) ;
+}
+
+/** Returns BTL ieta index for crystal according to type tile or bar */
+int BTLDetId::ietaAbs( kCrysLayout lay ) const {
+  int res = 2*MAX_HASH;
+  int kCrystalsInEta = 1, kCrystalsInPhi = 1;
+  switch ( lay ) {
+  case tile : kCrystalsInEta = kCrystalsInEtaTile; kCrystalsInPhi = kCrystalsInPhiTile; break ;
+  case bar  : kCrystalsInEta = kCrystalsInEtaBar ; kCrystalsInPhi = kCrystalsInPhiBar ; break ;
+  default: break ;  
+  }
+  return res = kCrystalsInEta * ( module() -1 ) 
+    + kCrystalsInEta * kTypeBoundaries[(modType() -1)] 
+    + ( (crystal()-1)/kCrystalsInPhi + 1 ) ; 
+}
+
+int BTLDetId::hashedIndex( kCrysLayout lay ) const { 
+  int max_iphi = 1, max_ieta = 1;
+  switch ( lay ) {
+  case tile : max_iphi = MAX_IPHI_TILE; max_ieta = MAX_IETA_TILE; break ;
+  case bar : max_iphi = MAX_IPHI_BAR; max_ieta = MAX_IETA_BAR; break ;
+  default: break ;  
+  }
+  return (max_ieta + ( zside() > 0 ? ietaAbs( lay ) - 1 : -ietaAbs( lay ) ) )*max_iphi+ iphi( lay ) - 1;
+}
+
+/** get a DetId from a compact index for arrays */
+/* void BTLDetId::getUnhashedIndex( int hi, BTLDetId id, kCrysLayout lay ) const { */
+/*   int max_iphi,max_ieta; */
+/*   switch ( lay ) { */
+/*   case tile : max_iphi = MAX_IPHI_TILE; max_ieta = MAX_IETA_TILE; break ; */
+/*   case bar : max_iphi = MAX_IPHI_BAR; max_ieta = MAX_IETA_BAR; break ; */
+/*   default: break ;   */
+/*   } */
+/* } */
+
 #include <iomanip>
 
 std::ostream& operator<< ( std::ostream& os, const BTLDetId& id ) {

--- a/DataFormats/ForwardDetId/src/BTLDetId.cc
+++ b/DataFormats/ForwardDetId/src/BTLDetId.cc
@@ -38,14 +38,26 @@ int BTLDetId::hashedIndex( kCrysLayout lay ) const {
 }
 
 /** get a DetId from a compact index for arrays */
-/* void BTLDetId::getUnhashedIndex( int hi, BTLDetId id, kCrysLayout lay ) const { */
-/*   int max_iphi,max_ieta; */
-/*   switch ( lay ) { */
-/*   case tile : max_iphi = MAX_IPHI_TILE; max_ieta = MAX_IETA_TILE; break ; */
-/*   case bar : max_iphi = MAX_IPHI_BAR; max_ieta = MAX_IETA_BAR; break ; */
-/*   default: break ;   */
-/*   } */
-/* } */
+
+BTLDetId BTLDetId::getUnhashedIndex( int hi, kCrysLayout lay ) const {
+  int max_iphi =1 ,max_ieta = 1, nphi = 0, keta = 0, tmphi = hi + 1;
+  switch ( lay ) {
+  case tile : max_iphi = MAX_IPHI_TILE; max_ieta = MAX_IETA_TILE; nphi = kCrystalsInPhiTile; keta = kCrystalsInEtaTile; break ;
+  case bar : max_iphi = MAX_IPHI_BAR; max_ieta = MAX_IETA_BAR; nphi = kCrystalsInPhiBar; keta = kCrystalsInEtaBar; break ;
+  default: break ;
+  }
+  uint32_t zside = 0, rod = 0, module = 0, modtype = 1, crystal = 0;
+  if ( tmphi > max_ieta*max_iphi ) { zside = 1; }
+  int ip = (tmphi-1)%max_iphi+1;
+  int ie = (tmphi-1)/max_iphi - max_ieta;
+  ie = ( zside == 1 ? ie + 1 : -ie ) ; 
+  rod = (ip-1)/nphi+1;
+  module = (ie-1)/keta+1 ; 
+  if ( module > kTypeBoundaries[1] ) { module > kTypeBoundaries[2] ? modtype = 3  :  modtype = 2 ;  }
+  if ( modtype > 1 ) { module = module - kTypeBoundaries[modtype-1]; }
+  crystal = ((ip-1)%nphi+1)+((ie-1)%keta)*nphi;
+  return  BTLDetId( zside, rod, module, modtype, crystal);
+}
 
 #include <iomanip>
 

--- a/DataFormats/ForwardDetId/src/BTLDetId.cc
+++ b/DataFormats/ForwardDetId/src/BTLDetId.cc
@@ -93,7 +93,7 @@ BTLDetId BTLDetId::getUnhashedIndex( int hi, CrysLayout lay ) const {
   ie = ( zside == 1 ? ie + 1 : -ie ) ; 
   rod = (ip-1)/nphi+1;
   module = (ie-1)/keta+1 ; 
-  if ( module > kTypeBoundaries[1] ) { module > kTypeBoundaries[2] ? modtype = 3  :  modtype = 2 ;  }
+  if ( module > kTypeBoundaries[1] ) { modtype = (module > kTypeBoundaries[2] ? 3 : 2 ) ;  }
   if ( modtype > 1 ) { module = module - kTypeBoundaries[modtype-1]; }
   crystal = ((ip-1)%nphi+1)+((ie-1)%keta)*nphi;
   return  BTLDetId( zside, rod, module, modtype, crystal);

--- a/DataFormats/ForwardDetId/src/BTLDetId.cc
+++ b/DataFormats/ForwardDetId/src/BTLDetId.cc
@@ -1,50 +1,90 @@
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 
 /** Returns BTL iphi index for crystal according to type tile or bar */
-int BTLDetId::iphi( kCrysLayout lay ) const {
-  int res = 2*MAX_HASH; 
+int BTLDetId::iphi( CrysLayout lay ) const {
   int kCrystalsInPhi = 1;
   switch ( lay ) {
-  case tile : kCrystalsInPhi = kCrystalsInPhiTile ; break ;
-  case bar  : kCrystalsInPhi = kCrystalsInPhiBar ; break ;
-  default: break ;  
+    case CrysLayout::tile : {
+      kCrystalsInPhi = kCrystalsInPhiTile ;
+      break ;
+    }
+    case CrysLayout::bar  : {
+      kCrystalsInPhi = kCrystalsInPhiBar ;
+      break ;
+    }
+    default: {
+      break ;
+    }
   }
-  return res = kCrystalsInPhi * ( ( mtdRR()%HALF_ROD > 0 ? mtdRR()%HALF_ROD : HALF_ROD ) -1 ) 
+  return kCrystalsInPhi * ( ( mtdRR()%HALF_ROD > 0 ? mtdRR()%HALF_ROD : HALF_ROD ) -1 ) 
     + ( crystal()%kCrystalsInPhi > 0 ? crystal()%kCrystalsInPhi : kCrystalsInPhi ) ;
 }
 
 /** Returns BTL ieta index for crystal according to type tile or bar */
-int BTLDetId::ietaAbs( kCrysLayout lay ) const {
-  int res = 2*MAX_HASH;
+int BTLDetId::ietaAbs( CrysLayout lay ) const {
   int kCrystalsInEta = 1, kCrystalsInPhi = 1;
   switch ( lay ) {
-  case tile : kCrystalsInEta = kCrystalsInEtaTile; kCrystalsInPhi = kCrystalsInPhiTile; break ;
-  case bar  : kCrystalsInEta = kCrystalsInEtaBar ; kCrystalsInPhi = kCrystalsInPhiBar ; break ;
-  default: break ;  
+    case CrysLayout::tile : {
+      kCrystalsInEta = kCrystalsInEtaTile;
+      kCrystalsInPhi = kCrystalsInPhiTile;
+      break ;
+    }
+    case CrysLayout::bar  : {
+      kCrystalsInEta = kCrystalsInEtaBar ;
+      kCrystalsInPhi = kCrystalsInPhiBar ;
+      break ;
+    }
+    default: {
+      break ;
+    }
   }
-  return res = kCrystalsInEta * ( module() -1 ) 
+  return kCrystalsInEta * ( module() -1 ) 
     + kCrystalsInEta * kTypeBoundaries[(modType() -1)] 
     + ( (crystal()-1)/kCrystalsInPhi + 1 ) ; 
 }
 
-int BTLDetId::hashedIndex( kCrysLayout lay ) const { 
+int BTLDetId::hashedIndex( CrysLayout lay ) const { 
   int max_iphi = 1, max_ieta = 1;
   switch ( lay ) {
-  case tile : max_iphi = MAX_IPHI_TILE; max_ieta = MAX_IETA_TILE; break ;
-  case bar : max_iphi = MAX_IPHI_BAR; max_ieta = MAX_IETA_BAR; break ;
-  default: break ;  
+    case CrysLayout::tile : {
+      max_iphi = MAX_IPHI_TILE;
+      max_ieta = MAX_IETA_TILE;
+      break ;
+    }
+    case CrysLayout::bar : {
+      max_iphi = MAX_IPHI_BAR;
+      max_ieta = MAX_IETA_BAR;
+      break ;
+    }
+    default: {
+      break ;
+    }
   }
   return (max_ieta + ( zside() > 0 ? ietaAbs( lay ) - 1 : -ietaAbs( lay ) ) )*max_iphi+ iphi( lay ) - 1;
 }
 
 /** get a DetId from a compact index for arrays */
 
-BTLDetId BTLDetId::getUnhashedIndex( int hi, kCrysLayout lay ) const {
+BTLDetId BTLDetId::getUnhashedIndex( int hi, CrysLayout lay ) const {
   int max_iphi =1 ,max_ieta = 1, nphi = 0, keta = 0, tmphi = hi + 1;
   switch ( lay ) {
-  case tile : max_iphi = MAX_IPHI_TILE; max_ieta = MAX_IETA_TILE; nphi = kCrystalsInPhiTile; keta = kCrystalsInEtaTile; break ;
-  case bar : max_iphi = MAX_IPHI_BAR; max_ieta = MAX_IETA_BAR; nphi = kCrystalsInPhiBar; keta = kCrystalsInEtaBar; break ;
-  default: break ;
+    case CrysLayout::tile : {
+      max_iphi = MAX_IPHI_TILE;
+      max_ieta = MAX_IETA_TILE;
+      nphi = kCrystalsInPhiTile;
+      keta = kCrystalsInEtaTile;
+      break ;
+    }
+    case CrysLayout::bar : {
+      max_iphi = MAX_IPHI_BAR;
+      max_ieta = MAX_IETA_BAR;
+      nphi = kCrystalsInPhiBar;
+      keta = kCrystalsInEtaBar;
+      break ;
+    }
+    default: {
+      break ;
+    }
   }
   uint32_t zside = 0, rod = 0, module = 0, modtype = 1, crystal = 0;
   if ( tmphi > max_ieta*max_iphi ) { zside = 1; }

--- a/Geometry/MTDCommonData/test/TestMTDNumbering.cc
+++ b/Geometry/MTDCommonData/test/TestMTDNumbering.cc
@@ -169,12 +169,12 @@ void TestMTDNumbering::checkMTD ( const DDCompactView& cpv, std::string fname, i
         theBaseNumber( epv.geoHistory() );
 
         if ( isBarrel ) { 
-          BTLDetId::kCrysLayout lay = static_cast< BTLDetId::kCrysLayout >(theLayout_);
+          BTLDetId::CrysLayout lay = static_cast< BTLDetId::CrysLayout >(theLayout_);
           BTLDetId theId(btlNS_.getUnitID(thisN_)); 
           int hIndex = theId.hashedIndex( lay );
           BTLDetId theNewId( theId.getUnhashedIndex( hIndex ,  lay ) );
           dump << theId; 
-          dump << "\n layout type = " << lay;
+          dump << "\n layout type = " << static_cast< int >(lay);
           dump << "\n ieta        = " << theId.ieta( lay );
           dump << "\n iphi        = " << theId.iphi( lay );
           dump << "\n hashedIndex = " << theId.hashedIndex( lay );

--- a/Geometry/MTDCommonData/test/TestMTDNumbering.cc
+++ b/Geometry/MTDCommonData/test/TestMTDNumbering.cc
@@ -166,7 +166,15 @@ void TestMTDNumbering::checkMTD ( const DDCompactView& cpv, std::string fname, i
 
         theBaseNumber( epv.geoHistory() );
 
-        if ( isBarrel ) { BTLDetId theId(btlNS_.getUnitID(thisN_)); dump << theId; }
+        if ( isBarrel ) { 
+          BTLDetId theId(btlNS_.getUnitID(thisN_)); dump << theId; 
+          dump << "\n Tile ieta        = " << theId.ieta( BTLDetId::tile );
+          dump << "\n Tile iphi        = " << theId.iphi( BTLDetId::tile );
+          dump << "\n Tile hashedIndex = " << theId.hashedIndex( BTLDetId::tile );
+          dump << "\n Bar ieta         = " << theId.ieta( BTLDetId::bar );
+          dump << "\n Bar iphi         = " << theId.iphi( BTLDetId::bar );
+          dump << "\n Bar hashedIndex  = " << theId.hashedIndex( BTLDetId::bar );
+        }
         else { ETLDetId theId(etlNS_.getUnitID(thisN_)); dump << theId; }
         dump << "\n";
 

--- a/Geometry/MTDCommonData/test/TestMTDNumbering.cc
+++ b/Geometry/MTDCommonData/test/TestMTDNumbering.cc
@@ -52,6 +52,7 @@ private:
   std::string fname_;
   int nNodes_;
   std::string ddTopNodeName_;
+  uint32_t theLayout_;
 
   MTDBaseNumber thisN_;
   BTLNumberingScheme btlNS_;
@@ -65,6 +66,7 @@ TestMTDNumbering::TestMTDNumbering( const edm::ParameterSet& iConfig ) :
   fname_(iConfig.getUntrackedParameter<std::string>("outFileName", "GeoHistory")),
   nNodes_(iConfig.getUntrackedParameter<uint32_t>("numNodesToDump", 0)),
   ddTopNodeName_(iConfig.getUntrackedParameter<std::string>("ddTopNodeName", "btl:BarrelTimingLayer")),
+  theLayout_(iConfig.getUntrackedParameter<uint32_t>("theLayout", 1)),
   thisN_(),btlNS_(),etlNS_()
 {
   if ( isMagField_ ) {
@@ -167,13 +169,22 @@ void TestMTDNumbering::checkMTD ( const DDCompactView& cpv, std::string fname, i
         theBaseNumber( epv.geoHistory() );
 
         if ( isBarrel ) { 
-          BTLDetId theId(btlNS_.getUnitID(thisN_)); dump << theId; 
-          dump << "\n Tile ieta        = " << theId.ieta( BTLDetId::tile );
-          dump << "\n Tile iphi        = " << theId.iphi( BTLDetId::tile );
-          dump << "\n Tile hashedIndex = " << theId.hashedIndex( BTLDetId::tile );
-          dump << "\n Bar ieta         = " << theId.ieta( BTLDetId::bar );
-          dump << "\n Bar iphi         = " << theId.iphi( BTLDetId::bar );
-          dump << "\n Bar hashedIndex  = " << theId.hashedIndex( BTLDetId::bar );
+          BTLDetId::kCrysLayout lay = static_cast< BTLDetId::kCrysLayout >(theLayout_);
+          BTLDetId theId(btlNS_.getUnitID(thisN_)); 
+          int hIndex = theId.hashedIndex( lay );
+          BTLDetId theNewId( theId.getUnhashedIndex( hIndex ,  lay ) );
+          dump << theId; 
+          dump << "\n layout type = " << lay;
+          dump << "\n ieta        = " << theId.ieta( lay );
+          dump << "\n iphi        = " << theId.iphi( lay );
+          dump << "\n hashedIndex = " << theId.hashedIndex( lay );
+          dump << "\n BTLDetId hI = " << theNewId;
+          if ( theId.mtdSide() != theNewId.mtdSide() ) { dump << "\n DIFFERENCE IN SIDE"; }
+          if ( theId.mtdRR() != theNewId.mtdRR() ) { dump << "\n DIFFERENCE IN ROD"; }
+          if ( theId.module() != theNewId.module() ) { dump << "\n DIFFERENCE IN MODULE"; }
+          if ( theId.modType() != theNewId.modType() ) { dump << "\n DIFFERENCE IN MODTYPE"; }
+          if ( theId.crystal() != theNewId.crystal() ) { dump << "\n DIFFERENCE IN CRYSTAL"; }
+          dump << "\n";
         }
         else { ETLDetId theId(etlNS_.getUnitID(thisN_)); dump << theId; }
         dump << "\n";

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -21,7 +21,8 @@ process.testBTL = cms.EDAnalyzer("TestMTDNumbering",
                                isMagField = cms.untracked.bool(False),
                                outFileName = cms.untracked.string('BTL'),
                                numNodesToDump = cms.untracked.uint32(0),
-                               ddTopNodeName = cms.untracked.string('btl:BarrelTimingLayer')
+                               ddTopNodeName = cms.untracked.string('btl:BarrelTimingLayer'),
+                               theLayout = cms.untracked.uint32(1)
                                )
 
 process.testETL = cms.EDAnalyzer("TestMTDNumbering",


### PR DESCRIPTION
This PR adds methods to BTLDetId to identify crystals according to a phi-eta map, to define an hashed index useful for arrays, and to build back a BTLDetId from an hashed index. The code is inspired to the corresponding functionalities in the ECAL Barrel EBDetId, which is conceptually very similar.

The test code in Geometry/MTDCommonData has been updated to as to dump the new information and test the consistency of a BTLDetId built from the hashed index with the original one (verified both for scenario D24 and D25).

The code is at present function of a layout parameter that allows it to work for both scenarios. It will be cleaned as soon as the choice of the scenario is finally made.

No change is expected on the existing functionalities.