### PR TITLE
Technical fixes to L1T code from 24242

### DIFF
--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloLayer2Comp.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloLayer2Comp.cc
@@ -412,22 +412,20 @@ bool L1TStage2CaloLayer2Comp::compareJets(
 
       //bypass sorting bug
       if(etGood && !posGood){
-	l1t::JetBxCollection::const_iterator emulItCheckSort;
-	l1t::JetBxCollection::const_iterator dataItCheckSort;
-	for(emulItCheckSort = emulCol->begin(currBx),
-	      dataItCheckSort = jets->begin();
-	    emulItCheckSort != emulCol->end(currBx),
-	      dataItCheckSort != jets->end();
-	    ++emulItCheckSort, ++dataItCheckSort){
-
-	  if(dataItCheckSort->hwEta() > 0) ++nPos;
-	  if(dataItCheckSort->hwEta() < 0) ++nNeg;
-
-	  if(dataIt->hwPt() == emulItCheckSort->hwPt()
-	     && dataIt->hwPhi() == emulItCheckSort->hwPhi()
-	     && dataIt->hwEta() == emulItCheckSort->hwEta())
-	    posGood = true;
-	}
+        l1t::JetBxCollection::const_iterator emulItCheckSort;
+        l1t::JetBxCollection::const_iterator dataItCheckSort;
+        for(emulItCheckSort = emulCol->begin(currBx) ; emulItCheckSort != emulCol->end(currBx) ; ++emulItCheckSort) {
+          for (dataItCheckSort = jets->begin(); dataItCheckSort != jets->end(); ++dataItCheckSort){
+            
+            if(dataItCheckSort->hwEta() > 0) ++nPos;
+            if(dataItCheckSort->hwEta() < 0) ++nNeg;
+            
+            if(dataIt->hwPt() == emulItCheckSort->hwPt()
+               && dataIt->hwPhi() == emulItCheckSort->hwPhi()
+               && dataIt->hwEta() == emulItCheckSort->hwEta())
+              posGood = true;
+          }
+        }
       }
 
       if(etGood && dataIt->hwEta() > 0 && ((distance(dataIt, jets->end())-nNeg) < 5))
@@ -531,22 +529,20 @@ bool L1TStage2CaloLayer2Comp::compareEGs(
 
       //bypass sorting bug
       if(etGood && !posGood){
-	l1t::EGammaBxCollection::const_iterator emulItCheckSort;
-	l1t::EGammaBxCollection::const_iterator dataItCheckSort;
-	for(emulItCheckSort = emulCol->begin(currBx),
-	      dataItCheckSort = egs->begin();
-	    emulItCheckSort != emulCol->end(currBx),
-	      dataItCheckSort != egs->end();
-	    ++emulItCheckSort, ++dataItCheckSort){
-
-	  if(dataItCheckSort->hwEta() > 0) ++nPos;
-	  if(dataItCheckSort->hwEta() < 0) ++nNeg;
-
-	  if(dataIt->hwPt() == emulItCheckSort->hwPt()
-	     && dataIt->hwPhi() == emulItCheckSort->hwPhi()
-	     && dataIt->hwEta() == emulItCheckSort->hwEta())
-	    posGood = true;
-	}
+        l1t::EGammaBxCollection::const_iterator emulItCheckSort;
+        l1t::EGammaBxCollection::const_iterator dataItCheckSort;
+        for(emulItCheckSort = emulCol->begin(currBx); emulItCheckSort != emulCol->end(currBx); ++emulItCheckSort) {
+          for (dataItCheckSort = egs->begin(); dataItCheckSort != egs->end(); ++dataItCheckSort){
+            
+            if(dataItCheckSort->hwEta() > 0) ++nPos;
+            if(dataItCheckSort->hwEta() < 0) ++nNeg;
+            
+            if(dataIt->hwPt() == emulItCheckSort->hwPt()
+               && dataIt->hwPhi() == emulItCheckSort->hwPhi()
+               && dataIt->hwEta() == emulItCheckSort->hwEta())
+              posGood = true;
+          }
+        }
       }
 
       if(etGood && dataIt->hwEta() > 0 && ((distance(dataIt, egs->end())-nNeg) < 5))
@@ -650,22 +646,20 @@ bool L1TStage2CaloLayer2Comp::compareTaus(
 
       //bypass sorting bug
       if(etGood && !posGood){
-	l1t::TauBxCollection::const_iterator emulItCheckSort;
-	l1t::TauBxCollection::const_iterator dataItCheckSort;
-	for(emulItCheckSort = emulCol->begin(currBx),
-	      dataItCheckSort = taus->begin();
-	    emulItCheckSort != emulCol->end(currBx),
-	      dataItCheckSort != taus->end();
-	    ++emulItCheckSort, ++dataItCheckSort){
-
-	  if(dataItCheckSort->hwEta() > 0) ++nPos;
-	  if(dataItCheckSort->hwEta() < 0) ++nNeg;
-
-	  if(dataIt->hwPt() == emulItCheckSort->hwPt()
-	     && dataIt->hwPhi() == emulItCheckSort->hwPhi()
-	     && dataIt->hwEta() == emulItCheckSort->hwEta())
-	    posGood = true;
-	}
+        l1t::TauBxCollection::const_iterator emulItCheckSort;
+        l1t::TauBxCollection::const_iterator dataItCheckSort;
+        for(emulItCheckSort = emulCol->begin(currBx); emulItCheckSort != emulCol->end(currBx); ++emulItCheckSort) {
+          for (dataItCheckSort = taus->begin(); dataItCheckSort != taus->end(); ++dataItCheckSort){
+          
+            if(dataItCheckSort->hwEta() > 0) ++nPos;
+            if(dataItCheckSort->hwEta() < 0) ++nNeg;
+            
+            if(dataIt->hwPt() == emulItCheckSort->hwPt()
+               && dataIt->hwPhi() == emulItCheckSort->hwPhi()
+               && dataIt->hwEta() == emulItCheckSort->hwEta())
+              posGood = true;
+          }
+        }
       }
 
       if(etGood && dataIt->hwEta() > 0 && ((distance(dataIt, taus->end())-nNeg) < 5))

--- a/L1Trigger/L1TMuonBarrel/test/kalmanTools/kmtfAnalysis.py
+++ b/L1Trigger/L1TMuonBarrel/test/kalmanTools/kmtfAnalysis.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import ROOT,itertools,math      #
 from array import array         # 
 from DataFormats.FWLite import Events, Handle
@@ -68,7 +69,7 @@ def fetchTP(event,etaMax=0.83):
         return []
     trigger=tH.product()
 #    for f in range(0,trigger.sizeFilters()):
-#        print f,trigger.filterLabel(f)
+#        print(f,trigger.filterLabel(f))
 #    import pdb;pdb.set_trace()    
     obj = trigger.getObjects()
     index = trigger.filterIndex(ROOT.edm.InputTag("hltL3fL1sMu22Or25L1f0L2f10QL3Filtered27Q::HLT"))
@@ -278,28 +279,28 @@ def deltaR2( e1, p1, e2, p2):
 
 
 def log(counter,mystubs,gen,kmtf,bmtf):   
-    print "--------EVENT"+str(counter)+"------------"
-    print "-----------------------------"
-    print "-----------------------------"
-    print 'Stubs:'
+    print("--------EVENT"+str(counter)+"------------")
+    print("-----------------------------")
+    print("-----------------------------")
+    print('Stubs:')
     for stub in mystubs:
-        print 'wheel={w} sector={sc} station={st} high/low={ts} phi={phi} phiB={phiB} qual={qual} BX={BX} eta1={eta1} eta2={eta2}'.format(w=stub.whNum(),sc=stub.scNum(),st=stub.stNum(),ts=stub.tag(),phi=stub.phi(),phiB=8*stub.phiB(),qual=stub.quality(),BX=stub.bxNum(),eta1=stub.eta1(),eta2=stub.eta2())
-    print 'Gen muons:'
+        print('wheel={w} sector={sc} station={st} high/low={ts} phi={phi} phiB={phiB} qual={qual} BX={BX} eta1={eta1} eta2={eta2}'.format(w=stub.whNum(),sc=stub.scNum(),st=stub.stNum(),ts=stub.tag(),phi=stub.phi(),phiB=8*stub.phiB(),qual=stub.quality(),BX=stub.bxNum(),eta1=stub.eta1(),eta2=stub.eta2()))
+    print('Gen muons:')
     for g in gen:
-        print "Generated muon charge={q} pt={pt} eta={eta} phi={phi}".format(q=g.charge(),pt=g.pt(),eta=g.eta(),phi=g.phi())
-    print 'BMTF:'
+        print("Generated muon charge={q} pt={pt} eta={eta} phi={phi}".format(q=g.charge(),pt=g.pt(),eta=g.eta(),phi=g.phi()))
+    print('BMTF:')
     for g in bmtf :
-        print "BMTF charge={q} pt={pt} eta={eta} phi={phi} qual={qual} dxy={dxy} pt2={pt2} hasFineEta={HF}".format(q=g.charge(),pt=g.pt(),eta=g.eta(),phi=g.phi(),qual=g.quality(),dxy=g.dxy(),pt2=g.ptUnconstrained(),HF=g.hasFineEta())
-    print 'KMTF:'
+        print("BMTF charge={q} pt={pt} eta={eta} phi={phi} qual={qual} dxy={dxy} pt2={pt2} hasFineEta={HF}".format(q=g.charge(),pt=g.pt(),eta=g.eta(),phi=g.phi(),qual=g.quality(),dxy=g.dxy(),pt2=g.ptUnconstrained(),HF=g.hasFineEta()))
+    print('KMTF:')
     for g in kmtf :
-        print "KMTF charge={q} pt={pt} eta={eta} phi={phi} qual={qual} dxy={dxy} pt2={pt2} hasFineEta={HF}".format(q=g.charge(),pt=g.pt(),eta=g.eta(),phi=g.phi(),qual=g.quality(),dxy=g.dxy(),pt2=g.ptUnconstrained(),HF=g.hasFineEta())
+        print("KMTF charge={q} pt={pt} eta={eta} phi={phi} qual={qual} dxy={dxy} pt2={pt2} hasFineEta={HF}".format(q=g.charge(),pt=g.pt(),eta=g.eta(),phi=g.phi(),qual=g.quality(),dxy=g.dxy(),pt2=g.ptUnconstrained(),HF=g.hasFineEta()))
 
 
 
 
-    print "-----------------------------"
-    print "-----------------------------"
-    print "c + enter to continue"
+    print("-----------------------------")
+    print("-----------------------------")
+    print("c + enter to continue")
     import pdb;pdb.set_trace()
 
 #########Histograms#############
@@ -395,9 +396,9 @@ for event in events:
 #    if counter==1000:
 #        break;
 
-#    print 'OLD stubs'
+#    print('OLD stubs')
 #    for s in stubsOLD:
-#        print s.bxNum(),s.whNum(),s.scNum(),s.stNum(),s.phi(),s.phiB(),s.code()
+#        print(s.bxNum(),s.whNum(),s.scNum(),s.stNum(),s.phi(),s.phiB(),s.code())
 
 
 #    reco=fetchRECO(event,2.4)
@@ -417,10 +418,10 @@ for event in events:
     bmtf=[]
 
 #    for g in gen:
-#        print 'GEN', g.pt(),g.eta(),g.phi() 
+#        print('GEN', g.pt(),g.eta(),g.phi())
 
 #    for k in kmtf:
-#        print 'L1', k.pt(),k.eta(),k.phi() 
+#        print('L1', k.pt(),k.eta(),k.phi())
 
 
 
@@ -533,7 +534,7 @@ for event in events:
 #                    d=[]
 #                    for i in range(0,7):
 #                        d.append(s.position(i))
-#                    print s.bxNum(),s.scNum(), s.whNum(), s.stNum(),d    
+#                    print(s.bxNum(),s.scNum(), s.whNum(), s.stNum(),d)
 #                log(counter,stubs,gen,kmtf,bmtf)
 
          
@@ -552,18 +553,18 @@ for event in events:
         if bestKMTF==None and bestBMTF!=None and g.pt()<4:
             log(counter,stubs,gen,kmtf,bmtf)
 #        if bestKMTF!=None and bestBMTF!=None and abs(bestKMTF.eta()-g.eta())>abs(bestBMTF.eta()-g.eta()):
-#            print 'Input Theta stubs'
+#            print('Input Theta stubs')
 #            for s in stubsOLDTheta:
 #                if s.bxNum()!=0:
 #                    continue
 #                a=[]
 #                for i in range(0,7):
 #                    a.append(s.position(i))
-#                print s.whNum(),s.scNum(),s.stNum(),':',a
-#            print 'Combined stubs'
+#                print(s.whNum(),s.scNum(),s.stNum(),':',a)
+#            print('Combined stubs')
 #
 #            for s in stubs:
-#                print s.whNum(),s.scNum(),s.stNum(),s.eta1(),s.eta2(),s.qeta1(),s.qeta2()
+#                print(s.whNum(),s.scNum(),s.stNum(),s.eta1(),s.eta2(),s.qeta1(),s.qeta2())
 #            import pdb;pdb.set_trace()
 
 

--- a/L1Trigger/L1TMuonBarrel/test/kalmanTools/makeInitialState.py
+++ b/L1Trigger/L1TMuonBarrel/test/kalmanTools/makeInitialState.py
@@ -1,5 +1,5 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
-
 
 from L1Trigger.L1TMuonBarrel.simKBmtfDigis_cfi import bmtfKalmanTrackingSettings as settings
 
@@ -56,12 +56,12 @@ for i in range(0,4):
             K=-8191
         arr[address]=str(K)    
 #    import pdb;pdb.set_trace()    
-    print '\n\n\n'    
+    print('\n\n\n')
     if i in [0,1]:
         lut = 'ap_int<14> initialK_'+str(i+1)+'[1024] = {'+','.join(arr)+'};'
     if i in [2,3]:
         lut = 'ap_int<14> initialK_'+str(i+1)+'[1024] = {'+','.join(arr)+'};'
-    print lut
+    print(lut)
 
         
 

--- a/L1Trigger/L1TMuonBarrel/test/kalmanTools/makePTPhiLUTs.py
+++ b/L1Trigger/L1TMuonBarrel/test/kalmanTools/makePTPhiLUTs.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 from math import pi
 
 
-print int(((-330+1024)*pi/(6.0*2048.0))/(0.625*pi/180.0))
+print(int(((-330+1024)*pi/(6.0*2048.0))/(0.625*pi/180.0)))
 
 
 
@@ -11,7 +12,7 @@ for i in range(0,2048):
     p = int((i*2*pi/(6.0*2048.0))/(0.625*pi/180.0))
     phi.append(str(p))
 
-print 'const ap_int<8> phiLUT[2047] = {'+','.join(phi)+'};'
+print('const ap_int<8> phiLUT[2047] = {'+','.join(phi)+'};')
 #import pdb;pdb.set_trace()
 pt=[]
 lsb = 1.25/(1<<13)
@@ -31,4 +32,4 @@ for i in range(0,4096):
     pt.append(str(p))
     
  
-print 'const ap_uint<9> ptLUT[4096] = {'+','.join(pt)+'};'
+print('const ap_uint<9> ptLUT[4096] = {'+','.join(pt)+'};')

--- a/L1Trigger/L1TMuonBarrel/test/kalmanTools/makePropToVertexLUTs.py
+++ b/L1Trigger/L1TMuonBarrel/test/kalmanTools/makePropToVertexLUTs.py
@@ -1,4 +1,4 @@
-
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 
@@ -25,8 +25,8 @@ for addr in range(0,2048):
 
 
 
-print 'ap_ufixed<12,12> eLossVertex[2048] = {'+','.join(deltaK)+'};'
-print 'ap_ufixed<12,12> dxyVertex[2048] = {'+','.join(dxy)+'};'
+print('ap_ufixed<12,12> eLossVertex[2048] = {'+','.join(deltaK)+'};')
+print('ap_ufixed<12,12> dxyVertex[2048] = {'+','.join(dxy)+'};')
 
 
 


### PR DESCRIPTION
The integration of #24242 has caused a couple of issues:
1) in some new python scripts the print syntax was not synchronized with the migration to the python3 compatible standard;
2) there was a clang error reported https://github.com/cms-sw/cmssw/pull/24242#issuecomment-412341978

This PR addresses both issues, corresponding fixes should be backported to the version for 10_2_X.