### PR TITLE
whitespace and print fixes towards compiling with python3

### DIFF
--- a/Alignment/CommonAlignmentProducer/scripts/AlCaHLTBitMon_ParallelJobs.py
+++ b/Alignment/CommonAlignmentProducer/scripts/AlCaHLTBitMon_ParallelJobs.py
@@ -45,7 +45,7 @@ def parallelJobs(hltkeylistfile,jsonDir,globalTag,templateName,queue,cafsetup):
         templateFile = getConfigTemplateFilename()
     else:
         templateFile = os.path.abspath(os.path.expandvars(templateName))
-        
+
     tfile = open(templateFile, 'r')
     template = tfile.read()
     tfile.close()
@@ -54,13 +54,13 @@ def parallelJobs(hltkeylistfile,jsonDir,globalTag,templateName,queue,cafsetup):
     keylistlist = mkHLTKeyListList(hltkeylistfile)
     index = 0
     for keylist in keylistlist:
-        
+
         configName = 'AlCaHLTBitMon_%d_cfg.py'%index
         jobName = 'AlCaHLTBitMon_%d_job.csh'%index
         jsonFile = os.path.abspath('%(dir)s/%(index)d.json' % {'dir' : jsonDir, 'index' : index})
         dataFile = os.path.abspath('%(dir)s/%(index)d.data' % {'dir' : jsonDir, 'index' : index})
         logFile = 'AlCaHLTBitMon_%d'%index
-        
+
         dfile = open(dataFile, 'r')
         data = dfile.read()
         dfile.close()
@@ -79,7 +79,7 @@ def parallelJobs(hltkeylistfile,jsonDir,globalTag,templateName,queue,cafsetup):
         jfile.write('#!/bin/tcsh\n\n')
         if cafsetup == True:
             jfile.write('source /afs/cern.ch/cms/caf/setup.csh\n\n')
-            
+
         jfile.write('cd $1\n\n')
         jfile.write('eval `scramv1 run -csh`\n\n')
         jfile.write('cmsRun %s\n\n'%configName)
@@ -88,7 +88,7 @@ def parallelJobs(hltkeylistfile,jsonDir,globalTag,templateName,queue,cafsetup):
 
         if os.path.exists('./%s'%keylist) == False:
             os.system('mkdir ./%s'%keylist)
-            
+
         os.system('chmod u+x %s'%jobName)
         #print('bsub -q %(queue)s %(jobname)s %(pwd)s %(pwd)s/%(outdir)s' % {'queue' : queue, 'jobname' : jobName, 'pwd' : PWD, 'outdir' : keylist})
         os.system('bsub -q %(queue)s %(jobname)s %(pwd)s %(pwd)s/%(outdir)s' % {'queue' : queue, 'jobname' : jobName, 'pwd' : PWD, 'outdir' : keylist})
@@ -97,7 +97,7 @@ def parallelJobs(hltkeylistfile,jsonDir,globalTag,templateName,queue,cafsetup):
 
 def defineOptions():
     parser = OptionParser()
-    
+
     parser.add_option("-k", "--keylist",
                       dest="hltKeyListFile",
                       default="lista_key.txt",
@@ -106,7 +106,7 @@ def defineOptions():
     parser.add_option("-j", "--json",
                       dest="jsonDir",
                       help="directory with the corresponding json files")
-    
+
     parser.add_option("-g", "--globalTag",
                       dest="globalTag",
                       help="the global tag to use in the config files")
@@ -125,11 +125,11 @@ def defineOptions():
                       dest="cafsetup",
                       default=False,
                       help="wether the caf setup is sourced in the scripts")
-   
+
     (options, args) = parser.parse_args()
 
     if len(sys.argv) == 1:
-	print("\nUsage: %s --help"%sys.argv[0])
+        print("\nUsage: %s --help"%sys.argv[0])
         sys.exit(0)
 
     if str(options.hltKeyListFile) == 'None':
@@ -143,7 +143,7 @@ def defineOptions():
     if str(options.globalTag) == 'None':
         print("Please provide a global tag")
         sys.exit(0)
-    
+
     return options
 
 

--- a/Alignment/CommonAlignmentProducer/scripts/AlCaHLTBitMon_QueryRunRegistry.py
+++ b/Alignment/CommonAlignmentProducer/scripts/AlCaHLTBitMon_QueryRunRegistry.py
@@ -41,7 +41,7 @@ def filesize1(n):
     info = os.stat(n)
     sz = info[stat.ST_SIZE]
     return sz
-            
+
 ### lumiCalc
 def printLumi(file,namefile):
     if(filesize1(file) != 0):
@@ -87,16 +87,16 @@ def makecff(file_list,namefile):
     stringS  = stringS + "secFiles = cms.untracked.vstring()\n"
     stringS  = stringS + "\n"
     file1.write(stringS)
-    
+
     filecount = 0
     extendOpen = 0
     for filename in file_list:
-        
+
         if extendOpen == 0:
             stringS  = "readFiles.extend([\n"
             file1.write(stringS)
             extendOpen = 1
-            
+
         stringS  =           "     '"
         stringS  = stringS + str(filename)
         stringS  = stringS + "',\n"
@@ -111,7 +111,7 @@ def makecff(file_list,namefile):
     if extendOpen == 1:
         stringS  =           "])\n\n"
         file1.write(stringS)
-    
+
     stringS  =           "process.source = cms.Source(\"PoolSource\",\n"
     stringS  = stringS + "         fileNames = readFiles,\n"
     stringS  = stringS + "         secondaryFileNames = secFiles\n"
@@ -137,7 +137,7 @@ def defineOptions():
                       dest="dataset", \
                       default="/MinimumBias/Run2010A-TkAlMinBias-Dec22ReReco_v1/ALCARECO",
                       help="For example : --datasetPath /MinimumBias/Run2010A-TkAlMinBias-Dec22ReReco_v1/ALCARECO")
-    
+
     parser.add_option("-s", "--site",
                       dest="site",
                       default="T2_CH_CAF",
@@ -148,15 +148,15 @@ def defineOptions():
                       dest="info",
                       default=False,
                       help="printout the column names on which it's possible to cut")
-    
+
     (options, args) = parser.parse_args()
     if len(sys.argv) == 1:
-	print("\nUsage: %s --help"%sys.argv[0])
+        print("\nUsage: %s --help"%sys.argv[0])
         sys.exit(0)
-    
+
     return options
 
-    
+
 def serverQuery(workspaceName,regexp):
 
     # get handler to RR XML-RPC server
@@ -190,7 +190,7 @@ def getData(doc,options,dataset,site):
     txtLongData=""
     txtkey=""
     lista=[]
-    
+
     sep="\t"
 
     for run in runs:
@@ -251,7 +251,7 @@ def getData(doc,options,dataset,site):
                         print("LUMI ZERO")
                     else:
                         file1.write(lumirun)
-               
+
         file1.close()
         string=""
         string="sed -i 's/}{/, /g'"
@@ -265,7 +265,7 @@ def getData(doc,options,dataset,site):
             if not (rootLSF in listaDBS2):
                 listaDBS2.append(rootLSF)
         makecff(listaDBS2,nameDBS)
-          
+
     return txtLongData
 
 #---------------------------------------------

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
@@ -74,7 +74,7 @@ for i in xrange(len(lib.JOBID)):
         if os.access(stdOut+'.gz', os.R_OK):
             os.system('gunzip '+stdOut+'.gz')
 
-	try:
+        try:
             with open(stdOut, "r") as STDFILE:
                 # scan records in input file.
                 # use regular expression to search. re.compile needed for options re.M and re.I
@@ -366,9 +366,9 @@ for i in xrange(len(lib.JOBID)):
             print(lib.JOBDIR[i],lib.JOBID[i],'did not reach end of file')
             okStatus = 'ABEND'
         if quotaspace == 1:
-             print(lib.JOBDIR[i],lib.JOBID[i],'had quota space problem')
-             okStatus = 'FAIL'
-             remark = 'eos quota space problem'
+            print(lib.JOBDIR[i],lib.JOBID[i],'had quota space problem')
+            okStatus = 'FAIL'
+            remark = 'eos quota space problem'
         if ioprob == 1:
             print(lib.JOBDIR[i],lib.JOBID[i],'had I/O problem')
             okStatus = 'FAIL'

--- a/Alignment/MuonAlignment/python/geometryDiffVisualization.py
+++ b/Alignment/MuonAlignment/python/geometryDiffVisualization.py
@@ -12,9 +12,9 @@ def csc_colors(endcap, station, ring, chamber):
 
 def draw_station(geom1, geom2, station, filename, length_factor=100., angle_factor=100., colors=dt_colors, template_dir='./'):
     if station == 4: 
-      station_template = load_svg(template_dir + "station4_template.svg")
+        station_template = load_svg(template_dir + "station4_template.svg")
     else: 
-      station_template = load_svg(template_dir + "station_template.svg")
+        station_template = load_svg(template_dir + "station_template.svg")
 
     if station == 1: x_scale_factor = 1/6.
     if station == 2: x_scale_factor = 1/7.
@@ -57,7 +57,7 @@ def draw_station(geom1, geom2, station, filename, length_factor=100., angle_fact
             newBox["style"] = "fill:%s;fill-opacity:0.5;stroke:#000000;stroke-width:1.0;stroke-opacity:1;stroke-dasharray:none" % colors(wheel, station, sector)
 
             new_boxes.append(newBox)
-            
+
     for treeindex, svgitem in station_template:
         if isinstance(svgitem, SVG) and svgitem.t == "g" and "id" in svgitem.attr and svgitem["id"] == "chambers":
             svgitem.append(new_boxes)
@@ -85,15 +85,15 @@ def draw_wheel(geom1, geom2, wheel, filename, length_factor=100., angle_factor=1
             zdiff = length_factor * (geom1.dt[wheel, station, sector].z - geom2.dt[wheel, station, sector].z) * signConventions["DT", wheel, station, sector][2]
             phiydiff = -angle_factor * (geom1.dt[wheel, station, sector].phiy - geom2.dt[wheel, station, sector].phiy) * signConventions["DT", wheel, station, sector][1]
 
-	    m = re.search("translate\(([0-9\.\-\+eE]+),\s([0-9\.\-\+eE]+)\)\srotate\(([0-9\.\-\+eE]+)\)",svgitem["transform"])
+            m = re.search("translate\(([0-9\.\-\+eE]+),\s([0-9\.\-\+eE]+)\)\srotate\(([0-9\.\-\+eE]+)\)",svgitem["transform"])
 
-	    tx = float(m.group(1))
-	    ty = float(m.group(2))
-	    tr = float(m.group(3))
+            tx = float(m.group(1))
+            ty = float(m.group(2))
+            tr = float(m.group(3))
 
             newBox = svgitem.clone()
 
-	    svgitem["style"] = "fill:#e1e1e1;fill-opacity:1;stroke:#000000;stroke-width:5.0;stroke-dasharray:1, 1;stroke-dashoffset:0"
+            svgitem["style"] = "fill:#e1e1e1;fill-opacity:1;stroke:#000000;stroke-width:5.0;stroke-dasharray:1, 1;stroke-dashoffset:0"
             newBox["style"] = "fill:%s;fill-opacity:0.5;stroke:#000000;stroke-width:5.0;stroke-opacity:1;stroke-dasharray:none" % colors(wheel, station, sector)
             newBox["id"] = newBox["id"] + "_moved"
 
@@ -114,16 +114,16 @@ def draw_wheel(geom1, geom2, wheel, filename, length_factor=100., angle_factor=1
 
 def draw_disk(geom1, geom2, endcap, station, filename, length_factor=1., angle_factor=100., colors=csc_colors, template_dir='./'):
     if station == 1: 
-      disk_template = load_svg(template_dir + "disk1_template.svg")
+        disk_template = load_svg(template_dir + "disk1_template.svg")
     if station in (2, 3): 
-      disk_template = load_svg(template_dir + "disk23_template.svg")
+        disk_template = load_svg(template_dir + "disk23_template.svg")
     if endcap == 1 and station == 4: 
-      disk_template = load_svg(template_dir + "diskp4_template.svg")
+        disk_template = load_svg(template_dir + "diskp4_template.svg")
     if endcap == 2 and station == 4: 
-      disk_template = load_svg(template_dir + "diskm4_template.svg")
+        disk_template = load_svg(template_dir + "diskm4_template.svg")
 
     scale_factor = 0.233
-    
+
     new_boxes = SVG("g")
 
     for treeindex, svgitem in disk_template:

--- a/Alignment/MuonAlignmentAlgorithms/scripts/alignmentValidation.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/alignmentValidation.py
@@ -145,10 +145,10 @@ parser.add_option("-v", "--verbose",
 options,args=parser.parse_args()
 
 if options.runLabel=='' or options.inputDir=='' or options.i1=='' or options.iN=='':
-  print("\nOne or more of REQUIRED options is missing!\n")
-  parser.print_help()
-  # See \n"+sys.argv[0]+" --help"
-  sys.exit()
+    print("\nOne or more of REQUIRED options is missing!\n")
+    parser.print_help()
+    # See \n"+sys.argv[0]+" --help"
+    sys.exit()
 
 outdir = options.outputDir
 if outdir=='': outdir = options.inputDir
@@ -160,20 +160,20 @@ iNprefix = options.iNprefix
 if iNprefix=='' : iNprefix = options.iN
 
 if not os.access(outdir,os.F_OK):
-  print("\noutDir = "+outdir+"\ndoes not exist! Exiting...")
-  sys.exit()
+    print("\noutDir = "+outdir+"\ndoes not exist! Exiting...")
+    sys.exit()
 
 # If neither --dt or --csc is present, plots for both systems will be created
 DO_DT  = False
 DO_CSC = False
 if options.dt or not ( options.dt or options.csc):
-  DO_DT = True
+    DO_DT = True
 if options.csc or not ( options.dt or options.csc):
-  DO_CSC = True
+    DO_CSC = True
 
 if not (options.all or options.map or options.curvature or options.segdiff or options.fit or options.median or options.diagnostic):
-  print("\nOptions must include either -a or any of the following: --map, --segdiff, --fit, --median, --diagnostic. Exiting...")
-  sys.exit()
+    print("\nOptions must include either -a or any of the following: --map, --segdiff, --fit, --median, --diagnostic. Exiting...")
+    sys.exit()
 
 SINGLE_ITERATION = False
 if i1prefix == iNprefix: SINGLE_ITERATION = True
@@ -184,15 +184,15 @@ DO_CURVATURE = False
 DO_FIT = False
 DO_MEDIAN = False
 if options.map or options.all:
-  DO_MAP = True
+    DO_MAP = True
 if options.segdiff or options.all:
-  DO_SEGDIFF = True
+    DO_SEGDIFF = True
 if options.curvature or options.all:
-  DO_CURVATURE = True
+    DO_CURVATURE = True
 if options.fit or options.all:
-  DO_FIT = True
+    DO_FIT = True
 if options.median or options.all:
-  DO_MEDIAN = True
+    DO_MEDIAN = True
 
 DO_DIAGNOSTIC = options.diagnostic
 
@@ -278,372 +278,372 @@ CANVASES_LIST_TEMPLATE = [
 
 
 def isFileUnderDir(dir_name, file_name):
-  '''Recursively looks for file named file_name under dir_name directory
-  '''
-  if not DO_DT and dir_name.find("MB")>-1:
+    '''Recursively looks for file named file_name under dir_name directory
+    '''
+    if not DO_DT and dir_name.find("MB")>-1:
+        return False
+    if not DO_CSC and dir_name.find("ME")>-1:
+        return False
+
+    for f in os.listdir(dir_name):
+        dirfile = os.path.join(dir_name, f)
+        if os.path.isfile(dirfile) and f==file_name:
+            return True
+        # recursively access file names in subdirectories
+        elif os.path.isdir(dirfile):
+            #print "Accessing directory:", dirfile
+            if isFileUnderDir(dirfile, file_name): return True
     return False
-  if not DO_CSC and dir_name.find("ME")>-1:
-    return False
-  
-  for f in os.listdir(dir_name):
-    dirfile = os.path.join(dir_name, f)
-    if os.path.isfile(dirfile) and f==file_name:
-      return True
-    # recursively access file names in subdirectories
-    elif os.path.isdir(dirfile):
-      #print "Accessing directory:", dirfile
-      if isFileUnderDir(dirfile, file_name): return True
-  return False
 
 
 # to time saving of plots
 def saveAs(nm): 
-  t1 = time.time()
-  ddt[15] += 1
-  c1.SaveAs(nm)
-  tn = time.time()
-  ddt[16] = 1./ddt[15]*((ddt[15]-1)*ddt[16] + tn-t1)
+    t1 = time.time()
+    ddt[15] += 1
+    c1.SaveAs(nm)
+    tn = time.time()
+    ddt[16] = 1./ddt[15]*((ddt[15]-1)*ddt[16] + tn-t1)
 
 
 def createDirectoryStructure(iteration_name):
-  
-  if not os.access(iteration_name,os.F_OK):
-    os.mkdir(iteration_name)
 
-  csc_basedir = iteration_name+'/'
-  for endcap in CSC_TYPES:
-    #print csc_basedir+endcap[0]
-    shutil.rmtree(csc_basedir+endcap[0],True)
-    os.mkdir(csc_basedir+endcap[0])
-    for station in endcap[2]:
-      #print csc_basedir+endcap[0]+'/'+station[1]
-      os.mkdir(csc_basedir+endcap[0]+'/'+station[1])
-      for ring in station[2]:
-        #print csc_basedir+endcap[0]+'/'+station[1]+'/'+ring[1]
-        os.mkdir(csc_basedir+endcap[0]+'/'+station[1]+'/'+ring[1])
-        for chamber in range(1,ring[2]+1):
-          schamber = "%02d" % chamber
-          #print csc_basedir+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'+schamber
-          os.mkdir(csc_basedir+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'+schamber)
+    if not os.access(iteration_name,os.F_OK):
+        os.mkdir(iteration_name)
 
-  dt_basedir = iteration_name+'/MB/'
-  #print dt_basedir
-  shutil.rmtree(dt_basedir,True)
-  os.mkdir(dt_basedir)
-  for wheel in DT_TYPES:
-    #print dt_basedir+wheel[0]
-    os.mkdir(dt_basedir+wheel[0])
-    for station in wheel[2]:
-      #print dt_basedir+wheel[0]+'/'+station[1]
-      os.mkdir(dt_basedir+wheel[0]+'/'+station[1])
-      for sector in range(1,station[2]+1):
-        ssector = "%02d" % sector
-        #print dt_basedir+wheel[0]+'/'+station[1]+'/'+ssector
-        os.mkdir(dt_basedir+wheel[0]+'/'+station[1]+'/'+ssector)
+    csc_basedir = iteration_name+'/'
+    for endcap in CSC_TYPES:
+        #print csc_basedir+endcap[0]
+        shutil.rmtree(csc_basedir+endcap[0],True)
+        os.mkdir(csc_basedir+endcap[0])
+        for station in endcap[2]:
+            #print csc_basedir+endcap[0]+'/'+station[1]
+            os.mkdir(csc_basedir+endcap[0]+'/'+station[1])
+            for ring in station[2]:
+                #print csc_basedir+endcap[0]+'/'+station[1]+'/'+ring[1]
+                os.mkdir(csc_basedir+endcap[0]+'/'+station[1]+'/'+ring[1])
+                for chamber in range(1,ring[2]+1):
+                    schamber = "%02d" % chamber
+                    #print csc_basedir+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'+schamber
+                    os.mkdir(csc_basedir+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'+schamber)
 
-  print(os.getcwd())
+    dt_basedir = iteration_name+'/MB/'
+    #print dt_basedir
+    shutil.rmtree(dt_basedir,True)
+    os.mkdir(dt_basedir)
+    for wheel in DT_TYPES:
+        #print dt_basedir+wheel[0]
+        os.mkdir(dt_basedir+wheel[0])
+        for station in wheel[2]:
+            #print dt_basedir+wheel[0]+'/'+station[1]
+            os.mkdir(dt_basedir+wheel[0]+'/'+station[1])
+            for sector in range(1,station[2]+1):
+                ssector = "%02d" % sector
+                #print dt_basedir+wheel[0]+'/'+station[1]+'/'+ssector
+                os.mkdir(dt_basedir+wheel[0]+'/'+station[1]+'/'+ssector)
+
+    print(os.getcwd())
 
 ######################################################
 
 def doMapPlotsDT(dt_basedir, tfiles_plotting):
-  """write DT map plots
+    """write DT map plots
 
- "DTvsphi_st%dwh%s" % (station, wheelletter):
+   "DTvsphi_st%dwh%s" % (station, wheelletter):
 
-  plots "integrated" over ALL SECTORS:
-  of x, y, dxdz, dydz vs. phi (y and dydz only for stations 1-3)
-  made for all (station,wheel) combinations
+    plots "integrated" over ALL SECTORS:
+    of x, y, dxdz, dydz vs. phi (y and dydz only for stations 1-3)
+    made for all (station,wheel) combinations
 
-  Access interface may be arranged into station(1 .. 4) vs. wheel(-2 .. +2) map.
-  It could be incorporated into a general DT chambers map (column1: wheel, column2: station,
-  columns3-16 correspond to sector #) by making station numbers in column 2 clickable.
-  
-
- "DTvsz_st%dsec%02d" % (station, sector)
-
-  plots "integrated" over ALL WHEELS:
-  of x, y, dxdz, dydz vs. z (y and dydz only for stations 1-3)
-  made for all (station,sector) combinations
-
-  Interface: may be arranged into station(1 .. 4) vs. sector(1 .. 14) map with sector range
-  (1 .. 12) for stations 1-3.
-  It could be incorporated into an EXTENDED general DT chambers map (extended by adding an
-  identifier "ALL" in column1 for wheel number).
+    Access interface may be arranged into station(1 .. 4) vs. wheel(-2 .. +2) map.
+    It could be incorporated into a general DT chambers map (column1: wheel, column2: station,
+    columns3-16 correspond to sector #) by making station numbers in column 2 clickable.
 
 
- "DTvsz_st%dsecALL" % (station)
+   "DTvsz_st%dsec%02d" % (station, sector)
 
-  plots spanning in z over ALL WHEELS and "integrated" over all sectors:
-  of x, y, dxdz, dydz vs. z (y and dydz only for stations 1-3)
-  made for all stations
+    plots "integrated" over ALL WHEELS:
+    of x, y, dxdz, dydz vs. z (y and dydz only for stations 1-3)
+    made for all (station,sector) combinations
 
-  Interface: may be arranged into station(1 .. 4) map 
-  It could be incorporated into an EXTENDED general DT chambers map (extended by adding an
-  identifier "ALL" in column1 for wheel number)."""
-  
-  
-  for wheel in DT_TYPES:
-    if wheel[1]=="ALL": continue
-    for station in wheel[2]:
-      pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'
-      label = "DTvsphi_st%dwh%s" % (int(station[1]), wheelLetter(int(wheel[1])))
-      htitle = "wheel %+d, station %s" % (int(wheel[1]), station[1])
-      #mapplot(tfiles_plotting, label, "x", window=25., title=htitle, fitsawteeth=True,fitsine=True)
-      mapplot(tfiles_plotting, label, "x", window=10., title=htitle, fitsine=True,fitpeaks=True,peaksbins=2)
-      c1.SaveAs(pdir+'map_DTvsphi_x.png')
-      #mapplot(tfiles_plotting, label, "dxdz", window=25., title=htitle, fitsawteeth=True,fitsine=True)
-      mapplot(tfiles_plotting, label, "dxdz", window=10., title=htitle,peaksbins=2)
-      c1.SaveAs(pdir+'map_DTvsphi_dxdz.png')
+    Interface: may be arranged into station(1 .. 4) vs. sector(1 .. 14) map with sector range
+    (1 .. 12) for stations 1-3.
+    It could be incorporated into an EXTENDED general DT chambers map (extended by adding an
+    identifier "ALL" in column1 for wheel number).
 
-      if station[1]=='4': continue
-      #mapplot(tfiles_plotting, label, "y", window=25., title=htitle, fitsawteeth=True,fitsine=True)
-      mapplot(tfiles_plotting, label, "y", window=10., title=htitle,peaksbins=2)
-      c1.SaveAs(pdir+'map_DTvsphi_y.png')
-      #mapplot(tfiles_plotting, label, "dydz", window=25., title=htitle, fitsawteeth=True,fitsine=True)
-      mapplot(tfiles_plotting, label, "dydz", window=10., title=htitle,peaksbins=2)
-      c1.SaveAs(pdir+'map_DTvsphi_dydz.png')
 
-  
-  qcount=0
-  for wheel in DT_TYPES:
-    if wheel[1]!="ALL": continue
-    for station in wheel[2]:
-      for sector in range(1,station[2]+1):
-        if qcount>QUICKTESTN: break
-        qcount += 1
-        ssector = "%02d" % sector
-        pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'+ssector+'/'
-        label = "DTvsz_st%ssec%s" % (station[1], ssector)
-        htitle = "station %s, sector %d" % (station[1], sector)
-        mapplot(tfiles_plotting, label, "x", window=10., title=htitle, peaksbins=2)
-        c1.SaveAs(pdir+'map_DTvsz_x.png')
-        mapplot(tfiles_plotting, label, "dxdz", window=10., title=htitle, peaksbins=2)
-        c1.SaveAs(pdir+'map_DTvsz_dxdz.png')
-        
-        if station[1]=='4': continue
-	mapplot(tfiles_plotting, label, "y", window=10., title=htitle, peaksbins=2)
-        c1.SaveAs(pdir+'map_DTvsz_y.png')
-        mapplot(tfiles_plotting, label, "dydz", window=10., title=htitle, peaksbins=2)
-        c1.SaveAs(pdir+'map_DTvsz_dydz.png')
-  
-  qcount=0
-  for wheel in DT_TYPES:
-    if wheel[1]!="ALL": continue
-    for station in wheel[2]:
-      if qcount>QUICKTESTN: break
-      qcount += 1
-      pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'
-      label = "DTvsz_st%ssecALL" % (station[1])
-      htitle = "station %s" % (station[1])
-      
-      print(label, end=' ') 
-      mapplot(tfiles_plotting, label, "x", window=10., title=htitle, peaksbins=2)
-      c1.SaveAs(pdir+'map_DTvsz_all_x.png')
-      mapplot(tfiles_plotting, label, "dxdz", window=10., title=htitle, peaksbins=2)
-      c1.SaveAs(pdir+'map_DTvsz_all_dxdz.png')
-      
-      if station[1]=='4': continue
-      mapplot(tfiles_plotting, label, "y", window=10., title=htitle, peaksbins=2)
-      c1.SaveAs(pdir+'map_DTvsz_all_y.png')
-      mapplot(tfiles_plotting, label, "dydz", window=10., title=htitle, peaksbins=2)
-      c1.SaveAs(pdir+'map_DTvsz_all_dydz.png')
+   "DTvsz_st%dsecALL" % (station)
 
-  saveTestResultsMap(options.runLabel)
+    plots spanning in z over ALL WHEELS and "integrated" over all sectors:
+    of x, y, dxdz, dydz vs. z (y and dydz only for stations 1-3)
+    made for all stations
+
+    Interface: may be arranged into station(1 .. 4) map 
+    It could be incorporated into an EXTENDED general DT chambers map (extended by adding an
+    identifier "ALL" in column1 for wheel number)."""
+
+
+    for wheel in DT_TYPES:
+        if wheel[1]=="ALL": continue
+        for station in wheel[2]:
+            pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'
+            label = "DTvsphi_st%dwh%s" % (int(station[1]), wheelLetter(int(wheel[1])))
+            htitle = "wheel %+d, station %s" % (int(wheel[1]), station[1])
+            #mapplot(tfiles_plotting, label, "x", window=25., title=htitle, fitsawteeth=True,fitsine=True)
+            mapplot(tfiles_plotting, label, "x", window=10., title=htitle, fitsine=True,fitpeaks=True,peaksbins=2)
+            c1.SaveAs(pdir+'map_DTvsphi_x.png')
+            #mapplot(tfiles_plotting, label, "dxdz", window=25., title=htitle, fitsawteeth=True,fitsine=True)
+            mapplot(tfiles_plotting, label, "dxdz", window=10., title=htitle,peaksbins=2)
+            c1.SaveAs(pdir+'map_DTvsphi_dxdz.png')
+
+            if station[1]=='4': continue
+            #mapplot(tfiles_plotting, label, "y", window=25., title=htitle, fitsawteeth=True,fitsine=True)
+            mapplot(tfiles_plotting, label, "y", window=10., title=htitle,peaksbins=2)
+            c1.SaveAs(pdir+'map_DTvsphi_y.png')
+            #mapplot(tfiles_plotting, label, "dydz", window=25., title=htitle, fitsawteeth=True,fitsine=True)
+            mapplot(tfiles_plotting, label, "dydz", window=10., title=htitle,peaksbins=2)
+            c1.SaveAs(pdir+'map_DTvsphi_dydz.png')
+
+
+    qcount=0
+    for wheel in DT_TYPES:
+        if wheel[1]!="ALL": continue
+        for station in wheel[2]:
+            for sector in range(1,station[2]+1):
+                if qcount>QUICKTESTN: break
+                qcount += 1
+                ssector = "%02d" % sector
+                pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'+ssector+'/'
+                label = "DTvsz_st%ssec%s" % (station[1], ssector)
+                htitle = "station %s, sector %d" % (station[1], sector)
+                mapplot(tfiles_plotting, label, "x", window=10., title=htitle, peaksbins=2)
+                c1.SaveAs(pdir+'map_DTvsz_x.png')
+                mapplot(tfiles_plotting, label, "dxdz", window=10., title=htitle, peaksbins=2)
+                c1.SaveAs(pdir+'map_DTvsz_dxdz.png')
+
+                if station[1]=='4': continue
+                mapplot(tfiles_plotting, label, "y", window=10., title=htitle, peaksbins=2)
+                c1.SaveAs(pdir+'map_DTvsz_y.png')
+                mapplot(tfiles_plotting, label, "dydz", window=10., title=htitle, peaksbins=2)
+                c1.SaveAs(pdir+'map_DTvsz_dydz.png')
+
+    qcount=0
+    for wheel in DT_TYPES:
+        if wheel[1]!="ALL": continue
+        for station in wheel[2]:
+            if qcount>QUICKTESTN: break
+            qcount += 1
+            pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'
+            label = "DTvsz_st%ssecALL" % (station[1])
+            htitle = "station %s" % (station[1])
+
+            print(label, end=' ') 
+            mapplot(tfiles_plotting, label, "x", window=10., title=htitle, peaksbins=2)
+            c1.SaveAs(pdir+'map_DTvsz_all_x.png')
+            mapplot(tfiles_plotting, label, "dxdz", window=10., title=htitle, peaksbins=2)
+            c1.SaveAs(pdir+'map_DTvsz_all_dxdz.png')
+
+            if station[1]=='4': continue
+            mapplot(tfiles_plotting, label, "y", window=10., title=htitle, peaksbins=2)
+            c1.SaveAs(pdir+'map_DTvsz_all_y.png')
+            mapplot(tfiles_plotting, label, "dydz", window=10., title=htitle, peaksbins=2)
+            c1.SaveAs(pdir+'map_DTvsz_all_dydz.png')
+
+    saveTestResultsMap(options.runLabel)
 
 
 def doMapPlotsCSC(csc_basedir, tfiles_plotting):
-  """write CSC map plots
+    """write CSC map plots
 
- "CSCvsphi_me%s%d%d" % (endcap, station, ring)
+   "CSCvsphi_me%s%d%d" % (endcap, station, ring)
 
-  plots "integrated" over ALL SECTORS:
-  of rphi, drphi/dz vs. phi
-  made for all (endcap,station,ring) combinations
+    plots "integrated" over ALL SECTORS:
+    of rphi, drphi/dz vs. phi
+    made for all (endcap,station,ring) combinations
 
-  Interface: may be arranged into two station(1 .. 4) vs. R(1 .. 4) maps for both endcaps
-  with R range (1 .. 4) for stations 2-4
- It could be incorporated into a general CSC chambers map (column1: endcap, column2: station,
-  column3: ring, columns4-40 correspond to chamber #) by making ring numbers in column 3
-  clickable.
+    Interface: may be arranged into two station(1 .. 4) vs. R(1 .. 4) maps for both endcaps
+    with R range (1 .. 4) for stations 2-4
+   It could be incorporated into a general CSC chambers map (column1: endcap, column2: station,
+    column3: ring, columns4-40 correspond to chamber #) by making ring numbers in column 3
+    clickable.
 
 
- "CSCvsr_me%s%dch%02d" % (endcap, station, chamberNumber)
+   "CSCvsr_me%s%dch%02d" % (endcap, station, chamberNumber)
 
-  plots "integrated" over ALL RINGS:
-  of rphi, drphi/dz vs. z
-  made for all (endcap,station,chamber) combinations
+    plots "integrated" over ALL RINGS:
+    of rphi, drphi/dz vs. z
+    made for all (endcap,station,chamber) combinations
 
-  Interface: may be arranged into two station(1 .. 4) vs. chamber(1 .. 36) maps for both endcaps
-  It could be incorporated into an EXTENDED general CSC chambers map (extended by adding an
-  identifier "ALL" in column3 for ring number).
-  
- "CSCvsr_me%s%dchALL" % (endcap, station)
+    Interface: may be arranged into two station(1 .. 4) vs. chamber(1 .. 36) maps for both endcaps
+    It could be incorporated into an EXTENDED general CSC chambers map (extended by adding an
+    identifier "ALL" in column3 for ring number).
 
-  plots spanning over ALL RINGS along r and integrated over all SECTORS:
-  of rphi, drphi/dz vs. z
-  made for all (endcap,station) combinations
+   "CSCvsr_me%s%dchALL" % (endcap, station)
 
-  Interface: may be arranged into two station(1 .. 4) maps for both endcaps
-  It could be incorporated into an EXTENDED general CSC chambers map (extended by adding an
-  identifier "ALL" in column3 for ring number)."""
+    plots spanning over ALL RINGS along r and integrated over all SECTORS:
+    of rphi, drphi/dz vs. z
+    made for all (endcap,station) combinations
 
-  for endcap in CSC_TYPES:
-    for station in endcap[2]:
-      for ring in station[2]:
-        if ring[1]=="ALL": continue
-        pdir = csc_basedir+'/'+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'
-        label = "CSCvsphi_me%s%s%s" % (endcap[1], station[1], ring[1])
-        htitle = "%s%s/%s" % (endcap[0], station[1],ring[1])
-        mapplot(tfiles_plotting, label, "x", window=15., title=htitle, fitsine=True,fitpeaks=True, peaksbins=2)
-        #mapplot(tfiles_plotting, label, "x", window=15., title=htitle, fitsine=True)
-        c1.SaveAs(pdir+'map_CSCvsphi_x.png')
-        mapplot(tfiles_plotting, label, "dxdz", window=15., title=htitle, peaksbins=2)
-        c1.SaveAs(pdir+'map_CSCvsphi_dxdz.png')
+    Interface: may be arranged into two station(1 .. 4) maps for both endcaps
+    It could be incorporated into an EXTENDED general CSC chambers map (extended by adding an
+    identifier "ALL" in column3 for ring number)."""
 
-  saveTestResultsMap(options.runLabel)
+    for endcap in CSC_TYPES:
+        for station in endcap[2]:
+            for ring in station[2]:
+                if ring[1]=="ALL": continue
+                pdir = csc_basedir+'/'+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'
+                label = "CSCvsphi_me%s%s%s" % (endcap[1], station[1], ring[1])
+                htitle = "%s%s/%s" % (endcap[0], station[1],ring[1])
+                mapplot(tfiles_plotting, label, "x", window=15., title=htitle, fitsine=True,fitpeaks=True, peaksbins=2)
+                #mapplot(tfiles_plotting, label, "x", window=15., title=htitle, fitsine=True)
+                c1.SaveAs(pdir+'map_CSCvsphi_x.png')
+                mapplot(tfiles_plotting, label, "dxdz", window=15., title=htitle, peaksbins=2)
+                c1.SaveAs(pdir+'map_CSCvsphi_dxdz.png')
 
-  qcount = 0
-  for endcap in CSC_TYPES:
-    for station in endcap[2]:
-      for ring in station[2]:
-        if ring[1]!="ALL": continue
-        for chamber in range(1,ring[2]+1):
-          if qcount>QUICKTESTN: break
-          qcount += 1
-          schamber = "%02d" % chamber
-          pdir = csc_basedir+'/'+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'+schamber+'/'
-          label = "CSCvsr_me%s%sch%s" % (endcap[1], station[1], schamber)
-          htitle = "%s%s/ALL/%d" % (endcap[0], station[1],chamber)
-          mapplot(tfiles_plotting, label, "x", window=15., title=htitle, peaksbins=2)
-          c1.SaveAs(pdir+'map_CSCvsr_x.png')
-          mapplot(tfiles_plotting, label, "dxdz", window=15., title=htitle, peaksbins=2)
-          c1.SaveAs(pdir+'map_CSCvsr_dxdz.png')
+    saveTestResultsMap(options.runLabel)
 
-  qcount = 0
-  for endcap in CSC_TYPES:
-    for station in endcap[2]:
-      for ring in station[2]:
-        if ring[1]!="ALL": continue
-        if qcount>QUICKTESTN: break
-        qcount += 1
-        schamber = "%02d" % chamber
-        pdir = csc_basedir+'/'+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'
-        label = "CSCvsr_me%s%schALL" % (endcap[1], station[1])
-        htitle = "%s%s" % (endcap[0], station[1])
-        mapplot(tfiles_plotting, label, "x", window=10., title=htitle, peaksbins=2)
-        c1.SaveAs(pdir+'map_CSCvsr_all_x.png')
-        mapplot(tfiles_plotting, label, "dxdz", window=10., title=htitle, peaksbins=2)
-        c1.SaveAs(pdir+'map_CSCvsr_all_dxdz.png')
+    qcount = 0
+    for endcap in CSC_TYPES:
+        for station in endcap[2]:
+            for ring in station[2]:
+                if ring[1]!="ALL": continue
+                for chamber in range(1,ring[2]+1):
+                    if qcount>QUICKTESTN: break
+                    qcount += 1
+                    schamber = "%02d" % chamber
+                    pdir = csc_basedir+'/'+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'+schamber+'/'
+                    label = "CSCvsr_me%s%sch%s" % (endcap[1], station[1], schamber)
+                    htitle = "%s%s/ALL/%d" % (endcap[0], station[1],chamber)
+                    mapplot(tfiles_plotting, label, "x", window=15., title=htitle, peaksbins=2)
+                    c1.SaveAs(pdir+'map_CSCvsr_x.png')
+                    mapplot(tfiles_plotting, label, "dxdz", window=15., title=htitle, peaksbins=2)
+                    c1.SaveAs(pdir+'map_CSCvsr_dxdz.png')
+
+    qcount = 0
+    for endcap in CSC_TYPES:
+        for station in endcap[2]:
+            for ring in station[2]:
+                if ring[1]!="ALL": continue
+                if qcount>QUICKTESTN: break
+                qcount += 1
+                schamber = "%02d" % chamber
+                pdir = csc_basedir+'/'+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'
+                label = "CSCvsr_me%s%schALL" % (endcap[1], station[1])
+                htitle = "%s%s" % (endcap[0], station[1])
+                mapplot(tfiles_plotting, label, "x", window=10., title=htitle, peaksbins=2)
+                c1.SaveAs(pdir+'map_CSCvsr_all_x.png')
+                mapplot(tfiles_plotting, label, "dxdz", window=10., title=htitle, peaksbins=2)
+                c1.SaveAs(pdir+'map_CSCvsr_all_dxdz.png')
 
 
 
 def doCurvaturePlotsDT(dt_basedir, tfiles_plotting):
-  """write DT curvature plots
+    """write DT curvature plots
 
-  "wheel%s_sector%s" % (wheel, sector)
+    "wheel%s_sector%s" % (wheel, sector)
 
-  wheel in "m2", "m1", "z", "p1", "p2"
-  station 1 only!
-  sector in "01", ..., "12"
+    wheel in "m2", "m1", "z", "p1", "p2"
+    station 1 only!
+    sector in "01", ..., "12"
 
-  "param" may be one of 
-    "deltax" (Delta x position residuals),
-    "deltadxdz" (Delta (dx/dz) angular residuals),
-    "curverr" (Delta x * d(Delta q/pT)/d(Delta x) = Delta q/pT in the absence of misalignment) - not necessary
+    "param" may be one of 
+      "deltax" (Delta x position residuals),
+      "deltadxdz" (Delta (dx/dz) angular residuals),
+      "curverr" (Delta x * d(Delta q/pT)/d(Delta x) = Delta q/pT in the absence of misalignment) - not necessary
 
-  made for all (wheel,station=1,sector) combinations
+    made for all (wheel,station=1,sector) combinations
 
-  Interface: could be accesses through a general DT chambers map for station=1 chambers."""
-  
-  w_dict = {'-2':'m2', '-1':'m1', '0':'z', '1':'p1', '2':'p2'}
-  qcount = 0
-  for wheel in DT_TYPES:
-    if wheel[1]=="ALL": continue
-    #station = 1
-    #station = wheel[2][0]
-    for station in wheel[2]:
-      print("curv in ", wheel[0]+'/'+station[1])
-      for sector in range(1,station[2]+1):
-        #if sector>12: break
-        if qcount>QUICKTESTN: break
-        qcount += 1
-        ssector = "%02d" % sector
-        pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'+ssector+'/'
-        label = "wheel%s_st%s_sector%s" % (w_dict[wheel[1]], station[1], ssector)
-        thetitle ="Wheel %s, station %s, sector %s" % (wheel[1], station[1], ssector)
-        curvatureplot(tfiles_plotting, label, "deltax", title=thetitle, window=10., fitline=True)
-        saveAs(pdir+'dt_curvature_deltax.png')
-        curvatureplot(tfiles_plotting, label, "deltadxdz", title=thetitle, window=10., fitline=True)
-        saveAs(pdir+'dt_curvature_deltadxdz.png')
+    Interface: could be accesses through a general DT chambers map for station=1 chambers."""
+
+    w_dict = {'-2':'m2', '-1':'m1', '0':'z', '1':'p1', '2':'p2'}
+    qcount = 0
+    for wheel in DT_TYPES:
+        if wheel[1]=="ALL": continue
+        #station = 1
+        #station = wheel[2][0]
+        for station in wheel[2]:
+            print("curv in ", wheel[0]+'/'+station[1])
+            for sector in range(1,station[2]+1):
+                #if sector>12: break
+                if qcount>QUICKTESTN: break
+                qcount += 1
+                ssector = "%02d" % sector
+                pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'+ssector+'/'
+                label = "wheel%s_st%s_sector%s" % (w_dict[wheel[1]], station[1], ssector)
+                thetitle ="Wheel %s, station %s, sector %s" % (wheel[1], station[1], ssector)
+                curvatureplot(tfiles_plotting, label, "deltax", title=thetitle, window=10., fitline=True)
+                saveAs(pdir+'dt_curvature_deltax.png')
+                curvatureplot(tfiles_plotting, label, "deltadxdz", title=thetitle, window=10., fitline=True)
+                saveAs(pdir+'dt_curvature_deltadxdz.png')
 
 
 
 def doSegDiffPlotsDT(dt_basedir, tfiles_plotting, iter_reports):
-  """write segment-difference plots for DT
+    """write segment-difference plots for DT
 
- segdiff "dt13_resid" and "dt13_slope"
+   segdiff "dt13_resid" and "dt13_slope"
 
-  set of plots of
-  x vs qpt, x for positive, x for negative ("dt13_resid")
-  dxdz vs qpt, dxdz for positive, dxdz for negative ("dt13_slope")
-  done for MB1-MB2, MB2-MB3, and MB3-MB4 stations combinations with all possible (wheel, sector)
+    set of plots of
+    x vs qpt, x for positive, x for negative ("dt13_resid")
+    dxdz vs qpt, dxdz for positive, dxdz for negative ("dt13_slope")
+    done for MB1-MB2, MB2-MB3, and MB3-MB4 stations combinations with all possible (wheel, sector)
 
-  Interface: could be accessed through a general DT chambers map, but only for chambers in
-  stations 2-4 (e.g., station 2 would provide MB1-MB2 plots).
+    Interface: could be accessed through a general DT chambers map, but only for chambers in
+    stations 2-4 (e.g., station 2 would provide MB1-MB2 plots).
 
- segdiff "dt2_resid" and "dt2_slope"
+   segdiff "dt2_resid" and "dt2_slope"
 
-  set of plots of
-  y vs q/pt, y for positive, y for negative ("dt2_resid")
-  dydz vs q/pt, dydz for positive, dydz for negative ("dt2_slope")
-  done for MB1-MB2, MB2-MB3 stations combinations with all possible (wheel, sector)
+    set of plots of
+    y vs q/pt, y for positive, y for negative ("dt2_resid")
+    dydz vs q/pt, dydz for positive, dydz for negative ("dt2_slope")
+    done for MB1-MB2, MB2-MB3 stations combinations with all possible (wheel, sector)
 
-  Interface: then the interface would still be a general DT map,
-  but the info only available from station 2 & 3 chambers."""
+    Interface: then the interface would still be a general DT map,
+    but the info only available from station 2 & 3 chambers."""
 
-  qcount = 0
-  for iwheel in DT_TYPES:
-    if iwheel[1]=="ALL": continue
-    for istation in iwheel[2]:
-      if istation[1]=="1": continue
-      dstations = (int(istation[1])-1)*10 + int(istation[1])
-      #print dstations
-      for isector in range(1, istation[2] + 1):
-        if isector > 12: continue
-        if qcount>QUICKTESTN: break
-        qcount += 1
-        ssector = "%02d" % isector
-        pdir = dt_basedir + '/' + iwheel[0] + '/' + istation[1] + '/' + ssector + '/'
-        
-        segdiff(tfiles_plotting, "dt13_resid", dstations, wheel=int(iwheel[1]), sector=isector, window=15.)
-        c1.SaveAs(pdir + 'segdif_dt13_resid.png')
-        segdiff(tfiles_plotting, "dt13_slope", dstations, wheel=int(iwheel[1]), sector=isector, window=15.)
-        c1.SaveAs(pdir + 'segdif_dt13_slope.png')
-        
-        if istation[1] != '4':
-          segdiff(tfiles_plotting, "dt2_resid", dstations, wheel=int(iwheel[1]), sector=isector, window=15.)
-          c1.SaveAs(pdir + 'segdif_dt2_resid.png')
-          segdiff(tfiles_plotting, "dt2_slope", dstations, wheel=int(iwheel[1]), sector=isector, window=15.)
-          c1.SaveAs(pdir + 'segdif_dt2_slope.png')
-        
-  qcount = 0
-  for iwheel in DT_TYPES:
-    if iwheel[1]=="ALL": continue
-    if abs(int(iwheel[1])) != 2: continue
-    for istation in iwheel[2]:
-      if istation[1]=="3": continue
-      #print dstations
-      for isector in range(1, istation[2] + 1):
-        ssector = "%02d" % isector
-        pdir = dt_basedir + '/' + iwheel[0] + '/' + istation[1] + '/' + ssector + '/'
-        if istation[1]=="1":
-          segdiff_xalign(tfiles_plotting, "x_dt1_csc", wheel=int(iwheel[1]), sector=isector, cscstations = "12")
-          c1.SaveAs(pdir + 'segdif_x_dt_csc_resid.png')
-        if istation[1]=="2":
-          segdiff_xalign(tfiles_plotting, "x_dt2_csc", wheel=int(iwheel[1]), sector=isector, cscstations = "1")
-          c1.SaveAs(pdir + 'segdif_x_dt_csc_resid.png')
+    qcount = 0
+    for iwheel in DT_TYPES:
+        if iwheel[1]=="ALL": continue
+        for istation in iwheel[2]:
+            if istation[1]=="1": continue
+            dstations = (int(istation[1])-1)*10 + int(istation[1])
+            #print dstations
+            for isector in range(1, istation[2] + 1):
+                if isector > 12: continue
+                if qcount>QUICKTESTN: break
+                qcount += 1
+                ssector = "%02d" % isector
+                pdir = dt_basedir + '/' + iwheel[0] + '/' + istation[1] + '/' + ssector + '/'
 
-  """segdiffvsphi "dt13_resid" and "dt13_slope"
+                segdiff(tfiles_plotting, "dt13_resid", dstations, wheel=int(iwheel[1]), sector=isector, window=15.)
+                c1.SaveAs(pdir + 'segdif_dt13_resid.png')
+                segdiff(tfiles_plotting, "dt13_slope", dstations, wheel=int(iwheel[1]), sector=isector, window=15.)
+                c1.SaveAs(pdir + 'segdif_dt13_slope.png')
+
+                if istation[1] != '4':
+                    segdiff(tfiles_plotting, "dt2_resid", dstations, wheel=int(iwheel[1]), sector=isector, window=15.)
+                    c1.SaveAs(pdir + 'segdif_dt2_resid.png')
+                    segdiff(tfiles_plotting, "dt2_slope", dstations, wheel=int(iwheel[1]), sector=isector, window=15.)
+                    c1.SaveAs(pdir + 'segdif_dt2_slope.png')
+
+    qcount = 0
+    for iwheel in DT_TYPES:
+        if iwheel[1]=="ALL": continue
+        if abs(int(iwheel[1])) != 2: continue
+        for istation in iwheel[2]:
+            if istation[1]=="3": continue
+            #print dstations
+            for isector in range(1, istation[2] + 1):
+                ssector = "%02d" % isector
+                pdir = dt_basedir + '/' + iwheel[0] + '/' + istation[1] + '/' + ssector + '/'
+                if istation[1]=="1":
+                    segdiff_xalign(tfiles_plotting, "x_dt1_csc", wheel=int(iwheel[1]), sector=isector, cscstations = "12")
+                    c1.SaveAs(pdir + 'segdif_x_dt_csc_resid.png')
+                if istation[1]=="2":
+                    segdiff_xalign(tfiles_plotting, "x_dt2_csc", wheel=int(iwheel[1]), sector=isector, cscstations = "1")
+                    c1.SaveAs(pdir + 'segdif_x_dt_csc_resid.png')
+
+    """segdiffvsphi "dt13_resid" and "dt13_slope"
 
   plot for a specific wheel #:
   x vs phi of pair ("dt13_resid")
@@ -665,66 +665,66 @@ def doSegDiffPlotsDT(dt_basedir, tfiles_plotting, iter_reports):
   Interface: could be accessed by clicking on wheel number under the "wheel" column
   in a general DT map"""
 
-  if len(iter_reports)==0: return
-  
-  for iwheel in DT_TYPES:
-    if iwheel[1]=="ALL": continue
-    pdir = dt_basedir + '/' + iwheel[0] + '/'
-    segdiffvsphi(tfiles_plotting, iter_reports, "dt13_resid", int(iwheel[1]), window=10.)#, excludesectors=(1,7))
-    c1.SaveAs(pdir + 'segdifphi_dt13_resid.png')
-    segdiffvsphi(tfiles_plotting, iter_reports, "dt13_slope", int(iwheel[1]), window=10.)#, excludesectors=(1,7))
-    c1.SaveAs(pdir + 'segdifphi_dt13_slope.png')
-    segdiffvsphi(tfiles_plotting, iter_reports, "dt2_resid", int(iwheel[1]), window=10.)#, excludesectors=(1,7))
-    c1.SaveAs(pdir + 'segdifphi_dt2_resid.png')
-    segdiffvsphi(tfiles_plotting, iter_reports, "dt2_slope", int(iwheel[1]), window=15.)#, excludesectors=(1,7))
-    c1.SaveAs(pdir + 'segdifphi_dt2_slope.png')
+    if len(iter_reports)==0: return
 
-  for iwheel in DT_TYPES:
-    if iwheel[1]=="ALL": continue
-    if abs(int(iwheel[1])) != 2: continue
-    pdir = dt_basedir + '/' + iwheel[0] + '/'
-    segdiffvsphi_xalign(tfiles_plotting, int(iwheel[1]), window=10.)
-    c1.SaveAs(pdir + 'segdifphi_x_dt_csc_resid.png')
+    for iwheel in DT_TYPES:
+        if iwheel[1]=="ALL": continue
+        pdir = dt_basedir + '/' + iwheel[0] + '/'
+        segdiffvsphi(tfiles_plotting, iter_reports, "dt13_resid", int(iwheel[1]), window=10.)#, excludesectors=(1,7))
+        c1.SaveAs(pdir + 'segdifphi_dt13_resid.png')
+        segdiffvsphi(tfiles_plotting, iter_reports, "dt13_slope", int(iwheel[1]), window=10.)#, excludesectors=(1,7))
+        c1.SaveAs(pdir + 'segdifphi_dt13_slope.png')
+        segdiffvsphi(tfiles_plotting, iter_reports, "dt2_resid", int(iwheel[1]), window=10.)#, excludesectors=(1,7))
+        c1.SaveAs(pdir + 'segdifphi_dt2_resid.png')
+        segdiffvsphi(tfiles_plotting, iter_reports, "dt2_slope", int(iwheel[1]), window=15.)#, excludesectors=(1,7))
+        c1.SaveAs(pdir + 'segdifphi_dt2_slope.png')
+
+    for iwheel in DT_TYPES:
+        if iwheel[1]=="ALL": continue
+        if abs(int(iwheel[1])) != 2: continue
+        pdir = dt_basedir + '/' + iwheel[0] + '/'
+        segdiffvsphi_xalign(tfiles_plotting, int(iwheel[1]), window=10.)
+        c1.SaveAs(pdir + 'segdifphi_x_dt_csc_resid.png')
 
 
 def doSegDiffPlotsCSC(csc_basedir, tfiles_plotting, iter_reports):
-  """write segment-difference plots for CSC
- 
- segdiff "csc_resid" and "csc_slope"
+    """write segment-difference plots for CSC
 
-  set of plots of
-  rphi vs qpt, rphi for positive, rphi for negative ("csc_resid")
-  drphidz vs qpt, drphidz for positive, drphidz for negative ("csc_slope")
-  done for ME1-ME2, ME2-ME3, and ME3-ME4 stations combinations with
-    endcap "m" or "p" 
-    ring 1 or 2
-    chamber 1-18 (r1) or 1-36 (r2)
-  note: there's no ME3-ME4 plots for R2
-  
-  Interface: could be accessed through a general CSC chambers map, but only for chambers in
-  stations 2-4 (e.g., station 2 would provide ME1-ME2 plots)."""
+   segdiff "csc_resid" and "csc_slope"
 
-  qcount = 0
-  for iendcap in CSC_TYPES:
-    for istation in iendcap[2]:
-      if istation[1]=="1": continue
-      dstations = (int(istation[1])-1)*10 + int(istation[1])
-      for iring in istation[2]:
-        if iring[1]=="ALL": continue
-        if istation[1]=="4" and iring[1]=="2": continue
-        for ichamber in range(1,iring[2]+1):
-          if qcount>QUICKTESTN: break
-          qcount += 1
-          schamber = "%02d" % ichamber
-          pdir = csc_basedir+'/'+iendcap[0]+'/'+istation[1]+'/'+iring[1]+'/'+schamber+'/'
-          segdiff(tfiles_plotting, "csc_resid", dstations, 
-                  endcap=iendcap[1], ring=int(iring[1]), chamber=ichamber, window=15.)
-          c1.SaveAs(pdir + 'segdif_csc_resid.png')
-          segdiff(tfiles_plotting, "csc_slope", dstations, 
-                  endcap=iendcap[1], ring=int(iring[1]), chamber=ichamber, window=15.)
-          c1.SaveAs(pdir + 'segdif_csc_slope.png')
+    set of plots of
+    rphi vs qpt, rphi for positive, rphi for negative ("csc_resid")
+    drphidz vs qpt, drphidz for positive, drphidz for negative ("csc_slope")
+    done for ME1-ME2, ME2-ME3, and ME3-ME4 stations combinations with
+      endcap "m" or "p" 
+      ring 1 or 2
+      chamber 1-18 (r1) or 1-36 (r2)
+    note: there's no ME3-ME4 plots for R2
 
-  """segdiffvsphicsc "csc_resid" and "csc_slope"
+    Interface: could be accessed through a general CSC chambers map, but only for chambers in
+    stations 2-4 (e.g., station 2 would provide ME1-ME2 plots)."""
+
+    qcount = 0
+    for iendcap in CSC_TYPES:
+        for istation in iendcap[2]:
+            if istation[1]=="1": continue
+            dstations = (int(istation[1])-1)*10 + int(istation[1])
+            for iring in istation[2]:
+                if iring[1]=="ALL": continue
+                if istation[1]=="4" and iring[1]=="2": continue
+                for ichamber in range(1,iring[2]+1):
+                    if qcount>QUICKTESTN: break
+                    qcount += 1
+                    schamber = "%02d" % ichamber
+                    pdir = csc_basedir+'/'+iendcap[0]+'/'+istation[1]+'/'+iring[1]+'/'+schamber+'/'
+                    segdiff(tfiles_plotting, "csc_resid", dstations, 
+                            endcap=iendcap[1], ring=int(iring[1]), chamber=ichamber, window=15.)
+                    c1.SaveAs(pdir + 'segdif_csc_resid.png')
+                    segdiff(tfiles_plotting, "csc_slope", dstations, 
+                            endcap=iendcap[1], ring=int(iring[1]), chamber=ichamber, window=15.)
+                    c1.SaveAs(pdir + 'segdif_csc_slope.png')
+
+    """segdiffvsphicsc "csc_resid" and "csc_slope"
 
   plot for a specific deltaME station differences:
   rphi vs phi of pair ("csc_resid")
@@ -736,208 +736,208 @@ def doSegDiffPlotsCSC(csc_basedir, tfiles_plotting, iter_reports):
   Interface: could be accessed by clicking on ME station boxes, but only for stations 2-4 
   (e.g., station 2 would provide ME1-ME2 plots)."""
 
-  qcount = 0
-  for iendcap in CSC_TYPES:
-    for istation in iendcap[2]:
-      if istation[1]=="1": continue
-      dstations = (int(istation[1])-1)*10 + int(istation[1])
-      if qcount>QUICKTESTN: break
-      qcount += 1
-      pdir = csc_basedir+'/'+iendcap[0]+'/'+istation[1]+'/'
-      segdiffvsphicsc(tfiles_plotting, "csc_resid", dstations, window=10., endcap=iendcap[1])
-      c1.SaveAs(pdir + 'segdifphi_csc_resid.png')
-      segdiffvsphicsc(tfiles_plotting, "csc_slope", dstations, window=10., endcap=iendcap[1])
-      c1.SaveAs(pdir + 'segdifphi_csc_slope.png')
+    qcount = 0
+    for iendcap in CSC_TYPES:
+        for istation in iendcap[2]:
+            if istation[1]=="1": continue
+            dstations = (int(istation[1])-1)*10 + int(istation[1])
+            if qcount>QUICKTESTN: break
+            qcount += 1
+            pdir = csc_basedir+'/'+iendcap[0]+'/'+istation[1]+'/'
+            segdiffvsphicsc(tfiles_plotting, "csc_resid", dstations, window=10., endcap=iendcap[1])
+            c1.SaveAs(pdir + 'segdifphi_csc_resid.png')
+            segdiffvsphicsc(tfiles_plotting, "csc_slope", dstations, window=10., endcap=iendcap[1])
+            c1.SaveAs(pdir + 'segdifphi_csc_slope.png')
 
 
 def doFitFunctionsPlotsDT(dt_basedir, iter_tfile, iter_reports):
-  """write fit functions plots for DT
+    """write fit functions plots for DT
 
- DT bellcurves and polynomials
+   DT bellcurves and polynomials
 
-  set of plots of bellcurves
-    x, dxdz, x vs. dxdz (for all 4 stations)
-    y, dydz, x vs. dxdz (only for stations 1-3?)
+    set of plots of bellcurves
+      x, dxdz, x vs. dxdz (for all 4 stations)
+      y, dydz, x vs. dxdz (only for stations 1-3?)
 
-  set of plots of polynomials -- for stations 1-3 only??
-    x vs. xpos,    x vs ypos,    x vs dxdz angle,    x vs dydz angle
-    y vs. xpos,    y vs ypos,    y vs dxdz angle,    y vs dydz angle
-    dxdz vs. xpos, dxdz vs ypos, dxdz vs dxdz angle, dxdz vs dydz angle
-    dydz vs. xpos, dydz vs ypos, dydz vs dxdz angle, dydz vs dydz angle
+    set of plots of polynomials -- for stations 1-3 only??
+      x vs. xpos,    x vs ypos,    x vs dxdz angle,    x vs dydz angle
+      y vs. xpos,    y vs ypos,    y vs dxdz angle,    y vs dydz angle
+      dxdz vs. xpos, dxdz vs ypos, dxdz vs dxdz angle, dxdz vs dydz angle
+      dydz vs. xpos, dydz vs ypos, dydz vs dxdz angle, dydz vs dydz angle
 
-  set of plots of polynomials -- for station 4 only??
-    x vs. xpos,    x vs dxdz angle
-    dxdz vs. xpos, dxdz vs dxdz angle
+    set of plots of polynomials -- for station 4 only??
+      x vs. xpos,    x vs dxdz angle
+      dxdz vs. xpos, dxdz vs dxdz angle
 
-  made for all (wheel,station,sector) combinations
+    made for all (wheel,station,sector) combinations
 
-  Interface: could be accesses through a general DT chambers map."""
+    Interface: could be accesses through a general DT chambers map."""
 
-  qcount = 0
-  clearDDT()
-  for wheel in DT_TYPES:
-    if wheel[1]=="ALL": continue
-    for station in wheel[2]:
-      print(wheel[0]+'/'+station[1])
-      for sector in range(1,station[2]+1):
-        if qcount>QUICKTESTN: break
-        qcount += 1
-        ssector = "%02d" % sector
-        pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'+ssector+'/'
-        label = "MBwh%sst%ssec%s" % (wheelLetter(int(wheel[1])),station[1],ssector)
-        bellcurves(iter_tfile, iter_reports, label, False)
-        #c1.SaveAs(pdir+'dt_bellcurves.png')
-        saveAs(pdir+'dt_bellcurves.png')
-        polynomials(iter_tfile, iter_reports, label, False)
-        #c1.SaveAs(pdir+'dt_polynomials.png')
-        saveAs(pdir+'dt_polynomials.png')
-  #printDeltaTs()
+    qcount = 0
+    clearDDT()
+    for wheel in DT_TYPES:
+        if wheel[1]=="ALL": continue
+        for station in wheel[2]:
+            print(wheel[0]+'/'+station[1])
+            for sector in range(1,station[2]+1):
+                if qcount>QUICKTESTN: break
+                qcount += 1
+                ssector = "%02d" % sector
+                pdir = dt_basedir+'/'+wheel[0]+'/'+station[1]+'/'+ssector+'/'
+                label = "MBwh%sst%ssec%s" % (wheelLetter(int(wheel[1])),station[1],ssector)
+                bellcurves(iter_tfile, iter_reports, label, False)
+                #c1.SaveAs(pdir+'dt_bellcurves.png')
+                saveAs(pdir+'dt_bellcurves.png')
+                polynomials(iter_tfile, iter_reports, label, False)
+                #c1.SaveAs(pdir+'dt_polynomials.png')
+                saveAs(pdir+'dt_polynomials.png')
+    #printDeltaTs()
 
 
 def doFitFunctionsPlotsCSC(csc_basedir, iter_tfile, iter_reports):
-  """write fit functions plots for CSC
+    """write fit functions plots for CSC
 
- CSC bellcurves and polynomials
+   CSC bellcurves and polynomials
 
-  set of plots of bellcurves
-    rphi, drphidz, rphi vs. drphidz
+    set of plots of bellcurves
+      rphi, drphidz, rphi vs. drphidz
 
-  set of plots of polynomials
-    rphi vs. rphi pos,    rphi vs drphidz angle
-    drphidz vs. rphi pos, drphidz vs drphidz angle
+    set of plots of polynomials
+      rphi vs. rphi pos,    rphi vs drphidz angle
+      drphidz vs. rphi pos, drphidz vs drphidz angle
 
-  made for all (endcap,station,ring,chamber) combinations
+    made for all (endcap,station,ring,chamber) combinations
 
-  Interface: could be accesses through a general CSC chambers map."""
+    Interface: could be accesses through a general CSC chambers map."""
 
-  qcount = 0
-  clearDDT()
-  for endcap in CSC_TYPES:
-    for station in endcap[2]:
-      for ring in station[2]:
-        if ring[1]=="ALL": continue
-        print(endcap[0]+'/'+station[1]+'/'+ring[1])
-        for chamber in range(1,ring[2]+1):
-          if qcount>QUICKTESTN: break
-          qcount += 1
-          schamber = "%02d" % chamber
-          pdir = csc_basedir+'/'+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'+schamber+'/'
-          label = "ME%s%s%s_%s" % (endcap[1], station[1], ring[1], schamber)
-          bellcurves(iter_tfile, iter_reports, label, False)
-          #c1.SaveAs(pdir+'csc_bellcurves.png')
-          saveAs(pdir+'csc_bellcurves.png')
-          polynomials(iter_tfile, iter_reports, label, False)
-          #c1.SaveAs(pdir+'csc_polynomials.png')
-          saveAs(pdir+'csc_polynomials.png')
-  #printDeltaTs()
+    qcount = 0
+    clearDDT()
+    for endcap in CSC_TYPES:
+        for station in endcap[2]:
+            for ring in station[2]:
+                if ring[1]=="ALL": continue
+                print(endcap[0]+'/'+station[1]+'/'+ring[1])
+                for chamber in range(1,ring[2]+1):
+                    if qcount>QUICKTESTN: break
+                    qcount += 1
+                    schamber = "%02d" % chamber
+                    pdir = csc_basedir+'/'+endcap[0]+'/'+station[1]+'/'+ring[1]+'/'+schamber+'/'
+                    label = "ME%s%s%s_%s" % (endcap[1], station[1], ring[1], schamber)
+                    bellcurves(iter_tfile, iter_reports, label, False)
+                    #c1.SaveAs(pdir+'csc_bellcurves.png')
+                    saveAs(pdir+'csc_bellcurves.png')
+                    polynomials(iter_tfile, iter_reports, label, False)
+                    #c1.SaveAs(pdir+'csc_polynomials.png')
+                    saveAs(pdir+'csc_polynomials.png')
+    #printDeltaTs()
 
 
 
 def doIterationPlots(iteration_directory, tfiles_plotting, iter_tfile, iter_reports):
-  dt_basedir = iteration_directory+'/'+'MB'
-  csc_basedir = iteration_directory+'/'
+    dt_basedir = iteration_directory+'/'+'MB'
+    csc_basedir = iteration_directory+'/'
 
-  if DO_DT and DO_MAP:
-    doMapPlotsDT(dt_basedir, tfiles_plotting)
-  if DO_CSC and DO_MAP:
-    doMapPlotsCSC(csc_basedir, tfiles_plotting)
+    if DO_DT and DO_MAP:
+        doMapPlotsDT(dt_basedir, tfiles_plotting)
+    if DO_CSC and DO_MAP:
+        doMapPlotsCSC(csc_basedir, tfiles_plotting)
 
-  if DO_DT and DO_CURVATURE:
-    doCurvaturePlotsDT(dt_basedir, tfiles_plotting)
-  #if DO_CSC and DO_CURVATURE:
-  #  doCurvaturePlotsCSC(csc_basedir, tfiles_plotting)
+    if DO_DT and DO_CURVATURE:
+        doCurvaturePlotsDT(dt_basedir, tfiles_plotting)
+    #if DO_CSC and DO_CURVATURE:
+    #  doCurvaturePlotsCSC(csc_basedir, tfiles_plotting)
 
-  if DO_DT and DO_SEGDIFF:
-    doSegDiffPlotsDT(dt_basedir, tfiles_plotting, iter_reports)
-  if DO_CSC and DO_SEGDIFF:
-    doSegDiffPlotsCSC(csc_basedir, tfiles_plotting, iter_reports)
+    if DO_DT and DO_SEGDIFF:
+        doSegDiffPlotsDT(dt_basedir, tfiles_plotting, iter_reports)
+    if DO_CSC and DO_SEGDIFF:
+        doSegDiffPlotsCSC(csc_basedir, tfiles_plotting, iter_reports)
 
-  if DO_DT and DO_FIT:
-    doFitFunctionsPlotsDT(dt_basedir, iter_tfile, iter_reports)
-  if DO_CSC and DO_FIT:
-    doFitFunctionsPlotsCSC(csc_basedir, iter_tfile, iter_reports)
+    if DO_DT and DO_FIT:
+        doFitFunctionsPlotsDT(dt_basedir, iter_tfile, iter_reports)
+    if DO_CSC and DO_FIT:
+        doFitFunctionsPlotsCSC(csc_basedir, iter_tfile, iter_reports)
 
 
 def createCanvasesList(fname="canvases_list.js"):
-  '''Use CANVASES_LIST_TEMPLATE as a template to create a canvases list include for the browser.
-     Write out only those canvases which have existing filename.png plots.
-  '''
-  CANVASES_LIST = []
-  for scope in CANVASES_LIST_TEMPLATE:
-    scope_entry = []
-    if len(scope)>2:
-      scope_entry = [scope[0],scope[1]]
-      for canvas_entry in scope[2:]:
-        if isFileUnderDir("./",canvas_entry[1]):
-          scope_entry.append(canvas_entry)
-    CANVASES_LIST.append(scope_entry)
+    '''Use CANVASES_LIST_TEMPLATE as a template to create a canvases list include for the browser.
+       Write out only those canvases which have existing filename.png plots.
+    '''
+    CANVASES_LIST = []
+    for scope in CANVASES_LIST_TEMPLATE:
+        scope_entry = []
+        if len(scope)>2:
+            scope_entry = [scope[0],scope[1]]
+            for canvas_entry in scope[2:]:
+                if isFileUnderDir("./",canvas_entry[1]):
+                    scope_entry.append(canvas_entry)
+        CANVASES_LIST.append(scope_entry)
 
-  ff = open(fname,mode="w")
-  print("var CANVASES_LIST = ", file=ff)
-  json.dump(CANVASES_LIST,ff)
-  ff.close()
+    ff = open(fname,mode="w")
+    print("var CANVASES_LIST = ", file=ff)
+    json.dump(CANVASES_LIST,ff)
+    ff.close()
 
 
 def createCanvasToIDList(fname="canvas2id_list.js"):
-  '''Writes out a canvas-2-ids list include for the browser.
-     Write out only those canvases which have existing filename.png plots.
-     Returns: list of unique IDs that have existing filename.png plots.
-  '''
-  CANVAS2ID_LIST = []
-  ID_LIST = []
-  for scope in CANVASES_LIST_TEMPLATE:
-    if len(scope)>2:
-      for canvas_entry in scope[2:]:
-        ids = idsForFile("./",canvas_entry[1])
-        #  scope_entry.append(canvas_entry)
-        # uniquify:
-        set_ids = set(ids)
-        uids = list(set_ids)
-        ID_LIST.extend(uids)
-        print(canvas_entry, ":", len(uids), "ids")
-        if (len(uids)>0):
-          CANVAS2ID_LIST.append( (canvas_entry[1],uids) )
-  #print CANVAS2ID_LIST
-  CANVAS2ID_LIST_DICT = dict(CANVAS2ID_LIST)
-  #print CANVAS2ID_LIST_DICT
-  ff = open(fname,mode="w")
-  print("var CANVAS2ID_LIST = ", file=ff)
-  json.dump(CANVAS2ID_LIST_DICT,ff)
-  ff.close()
-  set_ids = set(ID_LIST)
-  return list(set_ids)
+    '''Writes out a canvas-2-ids list include for the browser.
+       Write out only those canvases which have existing filename.png plots.
+       Returns: list of unique IDs that have existing filename.png plots.
+    '''
+    CANVAS2ID_LIST = []
+    ID_LIST = []
+    for scope in CANVASES_LIST_TEMPLATE:
+        if len(scope)>2:
+            for canvas_entry in scope[2:]:
+                ids = idsForFile("./",canvas_entry[1])
+                #  scope_entry.append(canvas_entry)
+                # uniquify:
+                set_ids = set(ids)
+                uids = list(set_ids)
+                ID_LIST.extend(uids)
+                print(canvas_entry, ":", len(uids), "ids")
+                if (len(uids)>0):
+                    CANVAS2ID_LIST.append( (canvas_entry[1],uids) )
+    #print CANVAS2ID_LIST
+    CANVAS2ID_LIST_DICT = dict(CANVAS2ID_LIST)
+    #print CANVAS2ID_LIST_DICT
+    ff = open(fname,mode="w")
+    print("var CANVAS2ID_LIST = ", file=ff)
+    json.dump(CANVAS2ID_LIST_DICT,ff)
+    ff.close()
+    set_ids = set(ID_LIST)
+    return list(set_ids)
 
 def idsForFile(dir_name, file_name):
-  '''Recursively looks for file named file_name under dir_name directory
-  and fill the list with dir names converted to IDs 
-  '''
-  id_list = []
-  for f in os.listdir(dir_name):
-    dirfile = os.path.join(dir_name, f)
-    if os.path.isfile(dirfile) and f==file_name:
-      if file_name[-4:]=='.php': id_list.append(dir_name+'/'+file_name)
-      else:    id_list.append(dirToID(dir_name))
-    # recursively access file names in subdirectories
-    elif os.path.isdir(dirfile):
-      #print "Accessing directory:", dirfile
-      ids = idsForFile(dirfile, file_name)
-      if (len(ids)>0): 
-        id_list.extend(ids)
-  return id_list
+    '''Recursively looks for file named file_name under dir_name directory
+    and fill the list with dir names converted to IDs 
+    '''
+    id_list = []
+    for f in os.listdir(dir_name):
+        dirfile = os.path.join(dir_name, f)
+        if os.path.isfile(dirfile) and f==file_name:
+            if file_name[-4:]=='.php': id_list.append(dir_name+'/'+file_name)
+            else:    id_list.append(dirToID(dir_name))
+        # recursively access file names in subdirectories
+        elif os.path.isdir(dirfile):
+            #print "Accessing directory:", dirfile
+            ids = idsForFile(dirfile, file_name)
+            if (len(ids)>0): 
+                id_list.extend(ids)
+    return id_list
 
 
 def dirToID(d):
-  if d[-1]!='/': d += '/'
-  dtn = d.find("/MB/")
-  if dtn!=-1:
-    return d[dtn+4:-1]
-  cscn = d.find("/ME-/")
-  if cscn!=-1:
-    return 'ME-'+d[cscn+5:-1]
-  cscn = d.find("/ME+/")
-  if cscn!=-1:
-    return 'ME+'+d[cscn+5:-1]
-  return ''
+    if d[-1]!='/': d += '/'
+    dtn = d.find("/MB/")
+    if dtn!=-1:
+        return d[dtn+4:-1]
+    cscn = d.find("/ME-/")
+    if cscn!=-1:
+        return 'ME-'+d[cscn+5:-1]
+    cscn = d.find("/ME+/")
+    if cscn!=-1:
+        return 'ME+'+d[cscn+5:-1]
+    return ''
 
 
 ############################################################################################################
@@ -960,45 +960,45 @@ tfiles1_plotting = []
 iter1_tfile = None
 iter1_reports = []
 if not SINGLE_ITERATION:
-  if (DO_MAP or DO_SEGDIFF or DO_CURVATURE) and not os.access(fname+"_plotting.root",os.F_OK):
-    print("no file "+fname+"_plotting.root")
-    sys.exit()
-  if DO_FIT and not os.access(fname+".root",os.F_OK):
-    print("no file "+fname+".root")
-    sys.exit()
-  if DO_MEDIAN and not os.access(fname+"_report.py",os.F_OK):
-    print("no file "+fname+"_report.py")
-    sys.exit()
-  if DO_MAP or DO_SEGDIFF or DO_CURVATURE: tfiles1_plotting.append(ROOT.TFile(fname+"_plotting.root"))
-  if os.access(fname+".root",os.F_OK):
-    iter1_tfile = ROOT.TFile(fname+".root")
-  if os.access(fname+"_report.py",os.F_OK):
-    execfile(fname+"_report.py")
-    iter1_reports = reports
+    if (DO_MAP or DO_SEGDIFF or DO_CURVATURE) and not os.access(fname+"_plotting.root",os.F_OK):
+        print("no file "+fname+"_plotting.root")
+        sys.exit()
+    if DO_FIT and not os.access(fname+".root",os.F_OK):
+        print("no file "+fname+".root")
+        sys.exit()
+    if DO_MEDIAN and not os.access(fname+"_report.py",os.F_OK):
+        print("no file "+fname+"_report.py")
+        sys.exit()
+    if DO_MAP or DO_SEGDIFF or DO_CURVATURE: tfiles1_plotting.append(ROOT.TFile(fname+"_plotting.root"))
+    if os.access(fname+".root",os.F_OK):
+        iter1_tfile = ROOT.TFile(fname+".root")
+    if os.access(fname+"_report.py",os.F_OK):
+        execfile(fname+"_report.py")
+        iter1_reports = reports
 
 fname = options.inputDir+'/'+options.iN+'/'+iNprefix
 tfilesN_plotting = []
 iterN_tfile = None
 iterN_reports = []
 if (DO_MAP or DO_SEGDIFF or DO_CURVATURE) and not os.access(fname+"_plotting.root",os.F_OK):
-  print("no file "+fname+"_plotting.root")
-  sys.exit()
+    print("no file "+fname+"_plotting.root")
+    sys.exit()
 if DO_FIT and not os.access(fname+".root",os.F_OK):
-  print("no file "+fname+".root")
-  sys.exit()
+    print("no file "+fname+".root")
+    sys.exit()
 if DO_MEDIAN and not os.access(fname+"_report.py",os.F_OK):
-  print("no file "+fname+"_report.py")
-  sys.exit()
+    print("no file "+fname+"_report.py")
+    sys.exit()
 if DO_MAP or DO_SEGDIFF or DO_CURVATURE: tfilesN_plotting.append(ROOT.TFile(fname+"_plotting.root"))
 if os.access(fname+".root",os.F_OK):
-  iterN_tfile = ROOT.TFile(fname+".root")
+    iterN_tfile = ROOT.TFile(fname+".root")
 if os.access(fname+"_report.py",os.F_OK):
-  execfile(fname+"_report.py")
-  iterN_reports = reports
+    execfile(fname+"_report.py")
+    iterN_reports = reports
 
 if DO_MAP:
-  os.chdir(options.inputDir)
-  phiedges2c()
+    os.chdir(options.inputDir)
+    phiedges2c()
 
 ######################################################
 # setup output:
@@ -1012,11 +1012,11 @@ iterationN = "iterN"
 
 # create directory structure
 if options.createDirSructure:
-  print("WARNING: all existing results in "+options.outputDir+" will be deleted!")
-  if not SINGLE_ITERATION: createDirectoryStructure(iteration1)
-  createDirectoryStructure(iterationN)
-  if not os.access(comdir,os.F_OK):
-    os.mkdir(comdir)
+    print("WARNING: all existing results in "+options.outputDir+" will be deleted!")
+    if not SINGLE_ITERATION: createDirectoryStructure(iteration1)
+    createDirectoryStructure(iterationN)
+    if not os.access(comdir,os.F_OK):
+        os.mkdir(comdir)
 
 ######################################################
 # do drawing
@@ -1035,13 +1035,13 @@ if CPP_LOADED: ROOT.cleanUpHeap()
 # write distributions of medians plots
 
 if DO_MEDIAN:
-  #plotmedians(iter1_reports, iterN_reports)
-  plotmedians(iter1_reports, iterN_reports,binsx=100, windowx=10., binsy=100, windowy=10., binsdxdz=100, windowdxdz=10., binsdydz=100, windowdydz=10.)
-  c1.SaveAs(comdir+'medians.png')
+    #plotmedians(iter1_reports, iterN_reports)
+    plotmedians(iter1_reports, iterN_reports,binsx=100, windowx=10., binsy=100, windowy=10., binsdxdz=100, windowdxdz=10., binsdydz=100, windowdydz=10.)
+    c1.SaveAs(comdir+'medians.png')
 
 # perform diagnostic
 if DO_DIAGNOSTIC:
-  #if not SINGLE_ITERATION: doTests(iter1_reports,"mu_list_1.js","dqm_report_1.js",options.runLabel)
-  createCanvasesList("canvases_list.js")
-  pic_ids = createCanvasToIDList("canvas2id_list.js")
-  doTests(iterN_reports, pic_ids, "mu_list.js","dqm_report.js",options.runLabel)
+    #if not SINGLE_ITERATION: doTests(iter1_reports,"mu_list_1.js","dqm_report_1.js",options.runLabel)
+    createCanvasesList("canvases_list.js")
+    pic_ids = createCanvasToIDList("canvas2id_list.js")
+    doTests(iterN_reports, pic_ids, "mu_list.js","dqm_report.js",options.runLabel)

--- a/Alignment/MuonAlignmentAlgorithms/scripts/createBeamHaloJobs.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/createBeamHaloJobs.py
@@ -195,10 +195,10 @@ fileNamesBlocks=[]
 execfile(INPUTFILES)
 njobs = options.subjobs
 if (options.inputInBlocks):
-  njobs = len(fileNamesBlocks)
-  if njobs==0:
-    print("while --inputInBlocks is specified, the INPUTFILES has no blocks!")
-    sys.exit()
+    njobs = len(fileNamesBlocks)
+    if njobs==0:
+        print("while --inputInBlocks is specified, the INPUTFILES has no blocks!")
+        sys.exit()
 
 stepsize = int(math.ceil(1.*len(fileNames)/options.subjobs))
 pwd = str(os.getcwd())
@@ -275,9 +275,9 @@ python $ALIGNMENT_AFSDIR/Alignment/MuonAlignmentAlgorithms/scripts/relativeConst
     for jobnumber in range(njobs):
         gather_fileName = "%sgather%03d.sh" % (directory, jobnumber)
         if not options.inputInBlocks:
-          inputfiles = " ".join(fileNames[jobnumber*stepsize:(jobnumber+1)*stepsize])
+            inputfiles = " ".join(fileNames[jobnumber*stepsize:(jobnumber+1)*stepsize])
         else:
-          inputfiles = " ".join(fileNamesBlocks[jobnumber])
+            inputfiles = " ".join(fileNamesBlocks[jobnumber])
 
         if len(inputfiles) > 0:
             file(gather_fileName, "w").write("""#/bin/sh
@@ -341,10 +341,10 @@ cp -f *.tmp *.root $ALIGNMENT_AFSDIR/%(directory)s
             else: waiter = "-w \"ended(%s)\"" % last_align
             if options.big: queue = "cmscaf1nd"
             else: queue = "cmscaf1nh"
-            
-	    if user_mail: bsubfile.append("bsub -R \"type==SLC5_64\" -q %s -J \"%s_gather%03d\" -u %s %s gather%03d.sh" % (queue, director, jobnumber, user_mail, waiter, jobnumber))
+
+            if user_mail: bsubfile.append("bsub -R \"type==SLC5_64\" -q %s -J \"%s_gather%03d\" -u %s %s gather%03d.sh" % (queue, director, jobnumber, user_mail, waiter, jobnumber))
             else: bsubfile.append("bsub -R \"type==SLC5_64\" -q %s -J \"%s_gather%03d\" %s gather%03d.sh" % (queue, director, jobnumber, waiter, jobnumber))
-	    
+
             bsubnames.append("ended(%s_gather%03d)" % (director, jobnumber))
 
     file("%sconvert-db-to-xml_cfg.py" % directory, "w").write("""from Alignment.MuonAlignment.convertSQLitetoXML_cfg import *
@@ -435,10 +435,10 @@ fi
     os.system("chmod +x %salign.sh" % directory)
 
     bsubfile.append("echo %salign.sh" % directory)
-    
+
     if user_mail: bsubfile.append("bsub -R \"type==SLC5_64\" -q cmscaf1nd -J \"%s_align\" -u %s -w \"%s\" align.sh" % (director, user_mail, " && ".join(bsubnames)))
     else: bsubfile.append("bsub -R \"type==SLC5_64\" -q cmscaf1nd -J \"%s_align\" -w \"%s\" align.sh" % (director, " && ".join(bsubnames)))
-    
+
     bsubfile.append("cd ..")
     bsubnames = []
     last_align = "%s_align" % director

--- a/Alignment/MuonAlignmentAlgorithms/scripts/createJobs.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/createJobs.py
@@ -328,8 +328,8 @@ if options.noCSC: doCSC = False
 doDT = True
 if options.noDT: doDT = False
 if options.noCSC and options.noDT:
-  print("cannot do --noCSC and --noDT at the same time!")
-  sys.exit()
+    print("cannot do --noCSC and --noDT at the same time!")
+    sys.exit()
 
 json_file = options.json
 
@@ -338,10 +338,10 @@ fileNamesBlocks=[]
 execfile(INPUTFILES)
 njobs = options.subjobs
 if (options.inputInBlocks):
-  njobs = len(fileNamesBlocks)
-  if njobs==0:
-    print("while --inputInBlocks is specified, the INPUTFILES has no blocks!")
-    sys.exit()
+    njobs = len(fileNamesBlocks)
+    if njobs==0:
+        print("while --inputInBlocks is specified, the INPUTFILES has no blocks!")
+        sys.exit()
 
 stepsize = int(math.ceil(1.*len(fileNames)/options.subjobs))
 
@@ -358,13 +358,13 @@ if gprcdconnect[0:12] == "sqlite_file:": copytrackerdb += "%s " % gprcdconnect[1
 # step 0: convert initial geometry to xml
 INITIALXML = INITIALGEOM + '.xml'
 if INITIALGEOM[-3:]=='.db':
-  INITIALXML = INITIALGEOM[:-3] + '.xml'
+    INITIALXML = INITIALGEOM[:-3] + '.xml'
 print("Converting",INITIALGEOM,"to",INITIALXML," ...will be done in several seconds...")
 print("./Alignment/MuonAlignmentAlgorithms/scripts/convertSQLiteXML.py  %s %s --gprcdconnect %s --gprcd %s" % (INITIALGEOM,INITIALXML,gprcdconnect,gprcd))
 exit_code = os.system("./Alignment/MuonAlignmentAlgorithms/scripts/convertSQLiteXML.py  %s %s --gprcdconnect %s --gprcd %s" % (INITIALGEOM,INITIALXML,gprcdconnect,gprcd))
 if exit_code>0:
-  print("problem: conversion exited with code:", exit_code)
-  sys.exit()
+    print("problem: conversion exited with code:", exit_code)
+    sys.exit()
 
 #####################################################################
 
@@ -669,7 +669,7 @@ for iteration in range(1, ITERATIONS+1):
 
     dir_no_ = DIRNAME
     if DIRNAME[-1]=='_': dir_no_ = DIRNAME[:-1]
- 
+
     os.system("rm -rf %s; mkdir %s" % (directory, directory))
     os.system("cp Alignment/MuonAlignmentAlgorithms/python/gather_cfg.py %s" % directory)
     os.system("cp Alignment/MuonAlignmentAlgorithms/python/align_cfg.py %s" % directory)
@@ -686,10 +686,10 @@ for iteration in range(1, ITERATIONS+1):
     ### gather.sh runners for njobs
     for jobnumber in range(njobs):
         if not options.inputInBlocks:
-          inputfiles = " ".join(fileNames[jobnumber*stepsize:(jobnumber+1)*stepsize])
+            inputfiles = " ".join(fileNames[jobnumber*stepsize:(jobnumber+1)*stepsize])
         else:
-          inputfiles = " ".join(fileNamesBlocks[jobnumber])
-        
+            inputfiles = " ".join(fileNamesBlocks[jobnumber])
+
         if mapplots or segdiffplots or curvatureplots: copyplots = "plotting*.root"
         else: copyplots = ""
 
@@ -723,18 +723,18 @@ for iteration in range(1, ITERATIONS+1):
             station123params, station123params, useResiduals = tmp
     else:
         writeAlignCfg("%salign.sh" % directory, vars())
-    
+
     os.system("chmod +x %salign.sh" % directory)
 
     bsubfile.append("echo %salign.sh" % directory)
     if user_mail: bsubfile.append("bsub -R \"type==SLC6_64\" -q cmscaf1nd -J \"%s_align\" -u %s -w \"%s\" align.sh" % (director, user_mail, " && ".join(bsubnames)))
     else: bsubfile.append("bsub -R \"type==SLC6_64\" -q cmscaf1nd -J \"%s_align\" -w \"%s\" align.sh" % (director, " && ".join(bsubnames)))
-    
+
     #bsubfile.append("cd ..")
     bsubnames = []
     last_align = "%s_align" % director
-    
-    
+
+
     ### after the last iteration (optionally) do diagnostics run
     if len(validationLabel) and iteration == ITERATIONS:
         # do we have plotting files created?
@@ -743,10 +743,10 @@ for iteration in range(1, ITERATIONS+1):
 
         writeValidationCfg("%svalidation.sh" % directory, vars())
         os.system("chmod +x %svalidation.sh" % directory)
-        
+
         bsubfile.append("echo %svalidation.sh" % directory)
         if user_mail: bsubfile.append("bsub -R \"type==SLC6_64\" -q cmscaf1nd -J \"%s_validation\" -u %s -w \"ended(%s)\" validation.sh" % (director, user_mail, last_align))
-	else: bsubfile.append("bsub -R \"type==SLC6_64\" -q cmscaf1nd -J \"%s_validation\" -w \"ended(%s)\" validation.sh" % (director, last_align))
+        else: bsubfile.append("bsub -R \"type==SLC6_64\" -q cmscaf1nd -J \"%s_validation\" -w \"ended(%s)\" validation.sh" % (director, last_align))
 
     bsubfile.append("cd ..")
     bsubfile.append("")

--- a/Alignment/MuonAlignmentAlgorithms/scripts/groupFilesInBlocks.py
+++ b/Alignment/MuonAlignmentAlgorithms/scripts/groupFilesInBlocks.py
@@ -43,42 +43,42 @@ OUTFILE = sys.argv[3]
 
 
 def makeJobBlock(mylist, evtn):
-  n = mylist[0][0]
-  block = [mylist[0]]
-  choosen = [0]
-  while n<evtn:
+    n = mylist[0][0]
+    block = [mylist[0]]
+    choosen = [0]
+    while n<evtn:
     #print "n,evtn=",n,evtn
     # find the biggest unused #evt that would give n<evtn
-    for i in range(len(mylist)):
-      # get last not choosen i
-      last_i=len(mylist)-1
-      while last_i in choosen: last_i += -1
-      if i==last_i:
+        for i in range(len(mylist)):
+            # get last not choosen i
+            last_i=len(mylist)-1
+            while last_i in choosen: last_i += -1
+            if i==last_i:
         #print i,"last element reached"
-        n += mylist[i][0]
-        #print "   new last append: ",i, mylist[i][0], n
-        block.append(mylist[i])
-        choosen.append(i)
-        break
-      if i in choosen:
-        #print i,"  in choosen, continue..."
-        continue
-      if n+mylist[i][0]<evtn:
-        n += mylist[i][0]
-        #print "   new append: ",i, mylist[i][0], n
-	block.append(mylist[i])
-	choosen.append(i)
-	break
-    if len(choosen)==len(mylist):
-      #print " got everything"
-      break
-  # pick up unused elements
-  newlist = []
-  for i in range(len(mylist)):
-    if not i in choosen:
-      newlist.append(mylist[i])
-  print("done makeJobBlock n =",n," len =",len(block))
-  return block, newlist, n
+                n += mylist[i][0]
+                #print "   new last append: ",i, mylist[i][0], n
+                block.append(mylist[i])
+                choosen.append(i)
+                break
+            if i in choosen:
+                #print i,"  in choosen, continue..."
+                continue
+            if n+mylist[i][0]<evtn:
+                n += mylist[i][0]
+                #print "   new append: ",i, mylist[i][0], n
+                block.append(mylist[i])
+                choosen.append(i)
+                break
+        if len(choosen)==len(mylist):
+            #print " got everything"
+            break
+    # pick up unused elements
+    newlist = []
+    for i in range(len(mylist)):
+        if not i in choosen:
+            newlist.append(mylist[i])
+    print("done makeJobBlock n =",n," len =",len(block))
+    return block, newlist, n
 
 
 
@@ -87,8 +87,8 @@ fileLineRE = re.compile (r'^.*\'(.*)\'.+# (\d*).*$')
 #fileLineRE = re.compile (r'^.*\'(.*)\'.+# (\d*),(\d*).*$')
 
 if not os.access(INFILE, os.F_OK): 
-  print("Cannot find input file ", INFILE)
-  sys.exit()
+    print("Cannot find input file ", INFILE)
+    sys.exit()
 
 fin = open(INFILE, "r")
 lines = fin.readlines()
@@ -100,24 +100,24 @@ ntotal = 0
 commentLines=[]
 
 for line in lines:
-  #line = comment1RE.sub ('', line)
-  #line = line.strip()
-  #if not line: continue
-  match = comment1RE.match(line)
-  if match:
-    commentLines.append(line)
-  
-  match = fileLineRE.match(line)
-  if match:
-    #print int(match.group(3)), str(match.group(1))
-    #eventsFiles.append((int(match.group(3)), str(match.group(1)), str(match.group(2))))
-    eventsFiles.append((int(match.group(2)), str(match.group(1))))
-    ntotal += int(match.group(2))
-  #else: print line,
+    #line = comment1RE.sub ('', line)
+    #line = line.strip()
+    #if not line: continue
+    match = comment1RE.match(line)
+    if match:
+        commentLines.append(line)
+
+    match = fileLineRE.match(line)
+    if match:
+        #print int(match.group(3)), str(match.group(1))
+        #eventsFiles.append((int(match.group(3)), str(match.group(1)), str(match.group(2))))
+        eventsFiles.append((int(match.group(2)), str(match.group(1))))
+        ntotal += int(match.group(2))
+    #else: print line,
 
 if len(eventsFiles)==0:
-  print("no file description strings found")
-  sys.exit()
+    print("no file description strings found")
+    sys.exit()
 
 #print "len=", len(eventsFiles), ntotal
 #tmp = set(eventsFiles)
@@ -133,8 +133,8 @@ eventsFiles.sort(reverse=True)
 evtPerJob = int(math.ceil(float(ntotal)/NBLOCKS))
 print("Total = ",ntotal, "  per block =", evtPerJob,"(would give total of ", evtPerJob*NBLOCKS, ")", "  list length =",len(eventsFiles))
 if eventsFiles[0][0] > evtPerJob:
-  print("the biggest #evt is larger then #evt/block:",eventsFiles[0][0],">",evtPerJob)
-  print("consider lowering NBLOCKS")
+    print("the biggest #evt is larger then #evt/block:",eventsFiles[0][0],">",evtPerJob)
+    print("consider lowering NBLOCKS")
 
 
 jobsBlocks=[]
@@ -142,18 +142,18 @@ temp = eventsFiles
 
 tt = 0
 for j in range(NBLOCKS):
-  print(j)
-  if len(temp)==0:
-    print("done!")
-    break
-  block, temp, nn = makeJobBlock(temp,evtPerJob)
-  tt+=nn
-  if len(block)>0:
-    jobsBlocks.append((block,nn))
-    print(block)
-  else:
-    print("empty block!")
-  
+    print(j)
+    if len(temp)==0:
+        print("done!")
+        break
+    block, temp, nn = makeJobBlock(temp,evtPerJob)
+    tt+=nn
+    if len(block)>0:
+        jobsBlocks.append((block,nn))
+        print(block)
+    else:
+        print("empty block!")
+
 print(tt)
 print(commandline)
 
@@ -170,15 +170,15 @@ fout.write("\nfileNamesBlocks = [\n")
 
 commax = ","
 for b in range(len(jobsBlocks)):
-  fout.write('  [ # job '+str(b)+' with nevt='+str(jobsBlocks[b][1])+'\n')
-  comma = ","
-  for i in range(len(jobsBlocks[b][0])):
-    if i==len(jobsBlocks[b][0])-1:
-        comma=""
-    #fout.write("    '"+ jobsBlocks[b][0][i][1] +"'"+comma+" # "+ str(jobsBlocks[b][0][i][2]) +','+ str(jobsBlocks[b][0][i][0]) + "\n")
-    fout.write("    '"+ jobsBlocks[b][0][i][1] +"'"+comma+" # "+ str(jobsBlocks[b][0][i][0]) + "\n")
-  if b==len(jobsBlocks)-1:
-    commax=""
-  fout.write('  ]'+commax+'\n')
+    fout.write('  [ # job '+str(b)+' with nevt='+str(jobsBlocks[b][1])+'\n')
+    comma = ","
+    for i in range(len(jobsBlocks[b][0])):
+        if i==len(jobsBlocks[b][0])-1:
+            comma=""
+        #fout.write("    '"+ jobsBlocks[b][0][i][1] +"'"+comma+" # "+ str(jobsBlocks[b][0][i][2]) +','+ str(jobsBlocks[b][0][i][0]) + "\n")
+        fout.write("    '"+ jobsBlocks[b][0][i][1] +"'"+comma+" # "+ str(jobsBlocks[b][0][i][0]) + "\n")
+    if b==len(jobsBlocks)-1:
+        commax=""
+    fout.write('  ]'+commax+'\n')
 fout.write(']\n')
 fout.close()

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -352,7 +352,7 @@ class Dataset(object):
         return forcerunrangefunction
 
     def __getData( self, dasQuery, dasLimit = 0 ):
-	dasData = das_client.get_data(dasQuery, dasLimit)
+        dasData = das_client.get_data(dasQuery, dasLimit)
         if isinstance(dasData, str):
             jsondict = json.loads( dasData )
         else:
@@ -734,19 +734,19 @@ class Dataset(object):
                     "only work for official datasets, not predefined _cff.py files" )
             raise AllInOneError( msg )
         if self.__predefined and parent:
-                with open(self.__filename) as f:
-                    if "secFiles.extend" not in f.read():
-                        msg = ("The predefined dataset '%s' does not contain secondary files, "
-                               "which your validation requires!") % self.__name
-                        if self.__official:
-                            self.__name = self.__origName
-                            self.__predefined = False
-                            print(msg)
-                            print ("Retreiving the files from DAS.  You will be asked if you want "
-                                   "to overwrite the old dataset.\n"
-                                   "It will still be compatible with validations that don't need secondary files.")
-                        else:
-                            raise AllInOneError(msg)
+            with open(self.__filename) as f:
+                if "secFiles.extend" not in f.read():
+                    msg = ("The predefined dataset '%s' does not contain secondary files, "
+                           "which your validation requires!") % self.__name
+                    if self.__official:
+                        self.__name = self.__origName
+                        self.__predefined = False
+                        print(msg)
+                        print ("Retreiving the files from DAS.  You will be asked if you want "
+                               "to overwrite the old dataset.\n"
+                               "It will still be compatible with validations that don't need secondary files.")
+                    else:
+                        raise AllInOneError(msg)
 
         if self.__predefined:
             snippet = ("process.load(\"Alignment.OfflineValidation.%s_cff\")\n"

--- a/CalibMuon/DTCalibration/python/PlottingTools/plotResidualsPerLayer.py
+++ b/CalibMuon/DTCalibration/python/PlottingTools/plotResidualsPerLayer.py
@@ -64,7 +64,7 @@ def plotResLayer(fileName,sl,layer,
                 histoMean.SetBinError(binHistoNew,fitMeanErr)
                 histoSigma.SetBinContent(binHistoNew,fitSigma*corrFactor)
                 histoSigma.SetBinError(binHistoNew,fitSigmaErr*corrFactor)
-  
+
                 if sec == 1:
                     label = "Wheel %d" % wh
                     if wh == -2: label += " MB%d" % st  
@@ -115,7 +115,7 @@ def plot(fileName,sl,
 
     legend = ROOT.TLegend(0.4,0.7,0.95,0.8)
     for idx in range( len(histos) ):
-	histo = histos[idx]
+        histo = histos[idx]
         label = histo.GetName()
         if len(labels): label = labels[idx]
         legend.AddEntry(histo,label,"LP")
@@ -168,7 +168,7 @@ def plot(fileName,sl,
             histoAverage.SetBinContent(binHistoAve,averages[(st,wh)])
             histoAverage.SetBinError(binHistoAve,averagesErr[(st,wh)])
             print("Station %d, Wheel %d: %.4f +/- %.6f" % (st,wh,averages[(st,wh)],averagesErr[(st,wh)]))
-     
+
     canvasAverage = ROOT.TCanvas("c_" + histoAverage.GetName())
     canvasAverage.SetGridx()
     canvasAverage.SetGridy()
@@ -234,10 +234,10 @@ def plotSigmaAll(fileName,dir='DQMData/Run 1/DT/Run summary/DTCalibValidation',o
             histos[-1].Draw(option + "SAME")
 
         idx += 1
-        
+
     legend = ROOT.TLegend(0.4,0.7,0.95,0.8)
     for idx in range( len(histos) ):
-	histo = histos[idx]
+        histo = histos[idx]
         label = histo.GetName()
         if len(labels): label = labels[idx]
         legend.AddEntry(histo,label,"LP")
@@ -303,9 +303,9 @@ def plotFromFile(fileNames,labels=[]):
             histos_tmp.append( file.Get(var) )
             histos_tmp[-1].SetName( "%s_%d" % (histos_tmp[-1].GetName(),idx) )
             print("Created",histos_tmp[-1].GetName())
-	    histos_tmp[-1].SetLineColor(colors[ idx % len(colors) ]) 
-	    histos_tmp[-1].SetMarkerColor(colors[ idx % len(colors) ]) 
-	    histos_tmp[-1].SetMarkerStyle(markers[ idx % len(markers) ]) 
+            histos_tmp[-1].SetLineColor(colors[ idx % len(colors) ]) 
+            histos_tmp[-1].SetMarkerColor(colors[ idx % len(colors) ]) 
+            histos_tmp[-1].SetMarkerStyle(markers[ idx % len(markers) ]) 
             histos_tmp[-1].SetMarkerSize(1.4)
             idx += 1
         histos.append( histos_tmp )
@@ -320,19 +320,19 @@ def plotFromFile(fileNames,labels=[]):
         #histos.append( (histoData,histoMC) )
         histos[-1][0].Draw()
         for histo in histos[-1][1:]: histo.Draw("SAME")
-            
+
         if len(labels):
             #labelData = labels[0]
             #labelMC = labels[1]
-	    legends.append( ROOT.TLegend(0.4,0.7,0.95,0.8) )
+            legends.append( ROOT.TLegend(0.4,0.7,0.95,0.8) )
             idx = 0
             for histo in histos[-1]:
-		legends[-1].AddEntry(histo,labels[idx],"LP")
+                legends[-1].AddEntry(histo,labels[idx],"LP")
                 idx += 1
 
-	    legends[-1].SetFillColor( canvases[-1].GetFillColor() )
-	    legends[-1].Draw("SAME")
- 
+            legends[-1].SetFillColor( canvases[-1].GetFillColor() )
+            legends[-1].Draw("SAME")
+
         idx_var += 1
 
     if not objects: objects = [legends]

--- a/CalibMuon/DTCalibration/python/PlottingTools/plotT0FromHistos.py
+++ b/CalibMuon/DTCalibration/python/PlottingTools/plotT0FromHistos.py
@@ -7,7 +7,7 @@ def binNumber(station,sl):
     if sl is 2 and station is 4: return None
     start = (station - 1)*3
     return start + sl
- 
+
 def plot(fileName,sl,run,ymin=-5,ymax=5,option="HISTOP",draw=True):
     path = "DQMData/Run "+str(run)+"/DT/Run summary/DtCalib/TTrigDBValidation/"
     slType = sl
@@ -49,7 +49,7 @@ def plot(fileName,sl,run,ymin=-5,ymax=5,option="HISTOP",draw=True):
                 binHistoNew = (st - 1)*60 + (wh + 2)*nSectors + sec
                 if verbose: print("Bin final",binHistoNew,value)
                 histo.SetBinContent(binHistoNew,value) 
-  
+
                 if sec == 1:
                     label = "Wheel %d" % wh
                     if wh == -2: label += " MB%d" % st  
@@ -65,7 +65,7 @@ def SLcompare(fileName,sls,run,ymin=-5,ymax=5,labels=[]):
     option = "HISTOP"
     colors = (2,4,12,44,55,38,27,46)
     markers = (24,25,26,27,28,30,32,5)
-    
+
     idx = 0
     canvas = None
     objects = None
@@ -93,7 +93,7 @@ def SLcompare(fileName,sls,run,ymin=-5,ymax=5,labels=[]):
 
     legend = ROOT.TLegend(0.4,0.7,0.95,0.8)
     for idx in range( len(histos) ):
-	histo = histos[idx]
+        histo = histos[idx]
         label = histo.GetName()
         if len(labels): label = labels[idx]
         legend.AddEntry(histo,label,"LP")
@@ -112,7 +112,7 @@ def compareDiff(fileNames,sl,ymin=-15.,ymax=15.):
     option = "HISTOP"
     colors = (2,4,9,12,38,44,46,55)
     markers = (24,25,26,27,28,30,32,5)
-    
+
     idx = 0
     canvases = [None,None]
     objects = None
@@ -128,7 +128,7 @@ def compareDiff(fileNames,sl,ymin=-15.,ymax=15.):
             histos[-1].Reset()
         else:
             histos[-1].Add(histoRef,-1.) 
-       
+
         draw = False
         if not idx: draw = True
 
@@ -139,7 +139,7 @@ def compareDiff(fileNames,sl,ymin=-15.,ymax=15.):
         if not idx: 
             canvases[0] = objs[0]
             objects = objs[2]
-            
+
         if idx:
             canvases[0].cd()
             histos[-1].SetLineColor(colors[ (idx - 1) % len(colors) ])
@@ -157,8 +157,8 @@ def compareDiff(fileNames,sl,ymin=-15.,ymax=15.):
             histosDist[-1].SetMarkerStyle(markers[ (idx - 1) % len(markers) ])
 
         idx += 1
-    
-    
+
+
     canvases[1] = ROOT.TCanvas("c_tTrigDist")
     canvases[1].SetGridy()
     canvases[1].SetFillColor(0)

--- a/CalibMuon/DTCalibration/python/PlottingTools/plotTTrigFromHistos.py
+++ b/CalibMuon/DTCalibration/python/PlottingTools/plotTTrigFromHistos.py
@@ -5,7 +5,7 @@ from drawHistoAllChambers import drawHisto
 def binNumber(station,sector):
     start = (station - 1)*12
     return start + sector
- 
+
 def plot(fileName,sl,ymin=300,ymax=360,option="HISTOP",draw=True):
 
     slType = sl
@@ -46,7 +46,7 @@ def plot(fileName,sl,ymin=300,ymax=360,option="HISTOP",draw=True):
                 binHistoNew = (st - 1)*60 + (wh + 2)*nSectors + sec
                 if verbose: print("Bin final",binHistoNew)
                 histo.SetBinContent(binHistoNew,value) 
-  
+
                 if sec == 1:
                     label = "Wheel %d" % wh
                     if wh == -2: label += " MB%d" % st  
@@ -62,7 +62,7 @@ def compare(fileNames,sl,ymin=300,ymax=360,labels=[]):
     option = "HISTOP"
     colors = (2,4,12,44,55,38,27,46)
     markers = (24,25,26,27,28,30,32,5)
-    
+
     idx = 0
     canvas = None
     objects = None
@@ -90,7 +90,7 @@ def compare(fileNames,sl,ymin=300,ymax=360,labels=[]):
 
     legend = ROOT.TLegend(0.4,0.7,0.95,0.8)
     for idx in range( len(histos) ):
-	histo = histos[idx]
+        histo = histos[idx]
         label = histo.GetName()
         if len(labels): label = labels[idx]
         legend.AddEntry(histo,label,"LP")
@@ -109,7 +109,7 @@ def compareDiff(fileNames,sl,ymin=-15.,ymax=15.):
     option = "HISTOP"
     colors = (2,4,9,12,38,44,46,55)
     markers = (24,25,26,27,28,30,32,5)
-    
+
     idx = 0
     canvases = [None,None]
     objects = None
@@ -125,7 +125,7 @@ def compareDiff(fileNames,sl,ymin=-15.,ymax=15.):
             histos[-1].Reset()
         else:
             histos[-1].Add(histoRef,-1.) 
-       
+
         draw = False
         if not idx: draw = True
 
@@ -136,7 +136,7 @@ def compareDiff(fileNames,sl,ymin=-15.,ymax=15.):
         if not idx: 
             canvases[0] = objs[0]
             objects = objs[2]
-            
+
         if idx:
             canvases[0].cd()
             histos[-1].SetLineColor(colors[ (idx - 1) % len(colors) ])
@@ -154,8 +154,8 @@ def compareDiff(fileNames,sl,ymin=-15.,ymax=15.):
             histosDist[-1].SetMarkerStyle(markers[ (idx - 1) % len(markers) ])
 
         idx += 1
-    
-    
+
+
     canvases[1] = ROOT.TCanvas("c_tTrigDist")
     canvases[1].SetGridy()
     canvases[1].SetFillColor(0)

--- a/CondCore/Utilities/python/CondDBFW/querying.py
+++ b/CondCore/Utilities/python/CondDBFW/querying.py
@@ -22,436 +22,436 @@ import netrc
 import sys
 
 class connection(object):
-	engine = None
-	connection = None
-	session = None
-	connection_data = None
-	netrc_authenticators = None
-	secrets = None
-	"""
+    engine = None
+    connection = None
+    session = None
+    connection_data = None
+    netrc_authenticators = None
+    secrets = None
+    """
 
 	Given a connection string, parses the connection string and connects.
 
 	"""
-	def __init__(self, connection_data, mode=None, map_blobs=False, secrets=None, pooling=False):
+    def __init__(self, connection_data, mode=None, map_blobs=False, secrets=None, pooling=False):
 
-		self._pooling = pooling
+        self._pooling = pooling
 
-		# add querying utility properties
-		# these must belong to the connection since the way in which their values are handled
-		# depends on the database being connected to.
-		self.range = models.Range
-		self.radius = models.Radius
-		self.regexp = models.RegExp
-		self.regexp.connection_object = self
+        # add querying utility properties
+        # these must belong to the connection since the way in which their values are handled
+        # depends on the database being connected to.
+        self.range = models.Range
+        self.radius = models.Radius
+        self.regexp = models.RegExp
+        self.regexp.connection_object = self
 
-		if type(connection_data) in [str, unicode]:
-			# if we've been given a connection string, process it
-			self.connection_data = new_connection_dictionary(connection_data, secrets=secrets, mode=mode)
-			self.schema = self.connection_data.get("schema") if self.connection_data.get("schema") != None else ""
+        if type(connection_data) in [str, unicode]:
+            # if we've been given a connection string, process it
+            self.connection_data = new_connection_dictionary(connection_data, secrets=secrets, mode=mode)
+            self.schema = self.connection_data.get("schema") if self.connection_data.get("schema") != None else ""
 
-			self.range.database_type = self.connection_data["host"]
-			self.radius.database_type = self.connection_data["host"]
-			self.regexp.database_type = self.connection_data["host"]
-		else:
-			self.connection_data = connection_data
-			# assume we have an engine
-			# we need to take the string representation so we know which type of db we're aiming at
-			engine_string = str(connection_data)
-			db_type = None
-			if "oracle" in engine_string:
-				db_type = "oracle"
-			elif "frontier" in engine_string:
-				db_type = "frontier"
-			elif "sqlite" in engine_string:
-				db_type = "sqlite"
+            self.range.database_type = self.connection_data["host"]
+            self.radius.database_type = self.connection_data["host"]
+            self.regexp.database_type = self.connection_data["host"]
+        else:
+            self.connection_data = connection_data
+            # assume we have an engine
+            # we need to take the string representation so we know which type of db we're aiming at
+            engine_string = str(connection_data)
+            db_type = None
+            if "oracle" in engine_string:
+                db_type = "oracle"
+            elif "frontier" in engine_string:
+                db_type = "frontier"
+            elif "sqlite" in engine_string:
+                db_type = "sqlite"
 
-			self.range.database_type = db_type
-			self.radius.database_type = db_type
-			self.regexp.database_type = db_type
+            self.range.database_type = db_type
+            self.radius.database_type = db_type
+            self.regexp.database_type = db_type
 
-		import models as ms
-		self.models = ms.generate(map_blobs)
-		#self.base = self.models["Base"]
+        import models as ms
+        self.models = ms.generate(map_blobs)
+        #self.base = self.models["Base"]
 
-	def setup(self):
-		"""
-		Setup engine with given credentials from netrc file, and make a session maker.
-		"""
+    def setup(self):
+        """
+        Setup engine with given credentials from netrc file, and make a session maker.
+        """
 
-		if isinstance(self.connection_data, dict):
-			self.engine = engine_from_dictionary(self.connection_data, pooling=self._pooling)
-		else:
-			# we've been given an engine by the user
-			# use it as the engine
-			self.engine = self.connection_data
+        if isinstance(self.connection_data, dict):
+            self.engine = engine_from_dictionary(self.connection_data, pooling=self._pooling)
+        else:
+            # we've been given an engine by the user
+            # use it as the engine
+            self.engine = self.connection_data
 
-		self.sessionmaker = sessionmaker(bind=self.engine)
-		self.session = self.sessionmaker()
-		self.factory = factory(self)
+        self.sessionmaker = sessionmaker(bind=self.engine)
+        self.session = self.sessionmaker()
+        self.factory = factory(self)
 
-		# assign correct schema for database name to each model
-		tmp_models_dict = {}
-		for key in self.models:
-			if self.models[key].__class__ == sqlalchemy.ext.declarative.api.DeclarativeMeta\
-			   and str(self.models[key].__name__) != "Base":
+        # assign correct schema for database name to each model
+        tmp_models_dict = {}
+        for key in self.models:
+            if self.models[key].__class__ == sqlalchemy.ext.declarative.api.DeclarativeMeta\
+               and str(self.models[key].__name__) != "Base":
 
-			   	if isinstance(self.connection_data, dict):
-			   		# we can only extract the secrets and schema individuall
-			   		# if we were given a dictionary...  if we were given an engine
-			   		# we can't do this without parsing the connection string from the engine
-			   		# - a wide range of which it will be difficult to support!
-					self.models[key].__table__.schema = self.connection_data["schema"]
-					self.models[key].secrets = self.connection_data["secrets"]
+                if isinstance(self.connection_data, dict):
+                    # we can only extract the secrets and schema individuall
+                    # if we were given a dictionary...  if we were given an engine
+                    # we can't do this without parsing the connection string from the engine
+                    # - a wide range of which it will be difficult to support!
+                    self.models[key].__table__.schema = self.connection_data["schema"]
+                    self.models[key].secrets = self.connection_data["secrets"]
 
-				self.models[key].session = self.session
-				# isn't used anywhere - comment it out for now
-				#self.models[key].authentication = self.netrc_authenticators
-				self.models[key].connection = self
-				tmp_models_dict[key.lower()] = self.models[key]
-				tmp_models_dict[key.lower()].empty = False
+                self.models[key].session = self.session
+                # isn't used anywhere - comment it out for now
+                #self.models[key].authentication = self.netrc_authenticators
+                self.models[key].connection = self
+                tmp_models_dict[key.lower()] = self.models[key]
+                tmp_models_dict[key.lower()].empty = False
 
-		self.models = tmp_models_dict
+        self.models = tmp_models_dict
 
-		return self
+        return self
 
-	@staticmethod
-	def _get_CMS_frontier_connection_string(database):
-		try:
-		    import subprocess
-		    return subprocess.Popen(['cmsGetFnConnect', 'frontier://%s' % database], stdout = subprocess.PIPE).communicate()[0].strip()
-		except:
-			raise Exception("Frontier connections can only be constructed when inside a CMSSW environment.")
+    @staticmethod
+    def _get_CMS_frontier_connection_string(database):
+        try:
+            import subprocess
+            return subprocess.Popen(['cmsGetFnConnect', 'frontier://%s' % database], stdout = subprocess.PIPE).communicate()[0].strip()
+        except:
+            raise Exception("Frontier connections can only be constructed when inside a CMSSW environment.")
 
-	@staticmethod
-	def _cms_frontier_string(database, schema="cms_conditions"):
-		"""
-		Get database string for frontier.
-		"""
-		import urllib
-		return 'oracle+frontier://@%s/%s' % (urllib.quote_plus(connection._get_CMS_frontier_connection_string(database)), schema)
+    @staticmethod
+    def _cms_frontier_string(database, schema="cms_conditions"):
+        """
+        Get database string for frontier.
+        """
+        import urllib
+        return 'oracle+frontier://@%s/%s' % (urllib.quote_plus(connection._get_CMS_frontier_connection_string(database)), schema)
 
-	@staticmethod
-	def _cms_oracle_string(user, pwd, db_name):
-		"""
-		Get database string for oracle.
-		"""
-		return 'oracle://%s:%s@%s' % (user, pwd, db_name)
+    @staticmethod
+    def _cms_oracle_string(user, pwd, db_name):
+        """
+        Get database string for oracle.
+        """
+        return 'oracle://%s:%s@%s' % (user, pwd, db_name)
 
-	@staticmethod
-	def build_oracle_url(user, pwd, db_name):
-		"""
-		Build the connection url, and get credentials from self.secrets dictionary.
-		"""
+    @staticmethod
+    def build_oracle_url(user, pwd, db_name):
+        """
+        Build the connection url, and get credentials from self.secrets dictionary.
+        """
 
-		database_url = connection._cms_oracle_string(user, pwd, db_name)
+        database_url = connection._cms_oracle_string(user, pwd, db_name)
 
-		try:
-			url = sqlalchemy.engine.url.make_url(database_url)
-			if url.password is None:
-				url.password = pwd
-		except sqlalchemy.exc.ArgumentError:
-			url = sqlalchemy.engine.url.make_url('sqlite:///%s' % db_name)
-		return url
+        try:
+            url = sqlalchemy.engine.url.make_url(database_url)
+            if url.password is None:
+                url.password = pwd
+        except sqlalchemy.exc.ArgumentError:
+            url = sqlalchemy.engine.url.make_url('sqlite:///%s' % db_name)
+        return url
 
-	@staticmethod
-	def build_frontier_url(db_name, schema):
-		database_url = connection._cms_frontier_string(db_name, schema)
+    @staticmethod
+    def build_frontier_url(db_name, schema):
+        database_url = connection._cms_frontier_string(db_name, schema)
 
-		try:
-			url = sqlalchemy.engine.url.make_url(database_url)
-		except sqlalchemy.exc.ArgumentError:
-			"""
-			Is this needed for a use case?
-			"""
-			url = sqlalchemy.engine.url.make_url('sqlite:///%s' % db_name)
-		return url
+        try:
+            url = sqlalchemy.engine.url.make_url(database_url)
+        except sqlalchemy.exc.ArgumentError:
+            """
+            Is this needed for a use case?
+            """
+            url = sqlalchemy.engine.url.make_url('sqlite:///%s' % db_name)
+        return url
 
-	# currently just commits and closes the current session (ends transaction, closes connection)
-	# may do other things later
-	def tear_down(self):
-		try:
-			self.session.commit()
-			self.close_session()
-		except:
-			return "Couldn't tear down connection on engine %s." % str(self.engine)
+    # currently just commits and closes the current session (ends transaction, closes connection)
+    # may do other things later
+    def tear_down(self):
+        try:
+            self.session.commit()
+            self.close_session()
+        except:
+            return "Couldn't tear down connection on engine %s." % str(self.engine)
 
-	def close_session(self):
-		self.session.close()
-		return True
+    def close_session(self):
+        self.session.close()
+        return True
 
-	def hard_close(self):
-		self.engine.dispose()
-		return True
+    def hard_close(self):
+        self.engine.dispose()
+        return True
 
-	# get model based on given model name
-	def model(self, model_name):
-		if model_name.__class__ == sqlalchemy.ext.declarative.api.DeclarativeMeta:
-			model_name = model_name.__name__
-		model_name = model_name.replace("_", "")
-		return self.models[model_name]
+    # get model based on given model name
+    def model(self, model_name):
+        if model_name.__class__ == sqlalchemy.ext.declarative.api.DeclarativeMeta:
+            model_name = model_name.__name__
+        model_name = model_name.replace("_", "")
+        return self.models[model_name]
 
-	# model should be the class the developer wants to be instantiated
-	# pk_to_value maps primary keys to values
-	def object(self, model, pk_to_value):
-		if self.session == None:
-			return None
-		model_data = self.session.query(model)
-		for pk in pk_to_value:
-			model_data = model_data.filter(model.__dict__[pk] == pk_to_value[pk])
-		return model_data.first()
+    # model should be the class the developer wants to be instantiated
+    # pk_to_value maps primary keys to values
+    def object(self, model, pk_to_value):
+        if self.session == None:
+            return None
+        model_data = self.session.query(model)
+        for pk in pk_to_value:
+            model_data = model_data.filter(model.__dict__[pk] == pk_to_value[pk])
+        return model_data.first()
 
-	def global_tag(self, **pkargs):
-		return self.factory.object("globaltag", **pkargs)
+    def global_tag(self, **pkargs):
+        return self.factory.object("globaltag", **pkargs)
 
-	def global_tag_map(self, **pkargs):
-		return self.factory.object("globaltagmap", **pkargs)
+    def global_tag_map(self, **pkargs):
+        return self.factory.object("globaltagmap", **pkargs)
 
-	"""def global_tag_map_request(self, **pkargs):
+    """def global_tag_map_request(self, **pkargs):
 		return self.factory.object("globaltagmaprequest", **pkargs)"""
 
-	def tag(self, **pkargs):
-		return self.factory.object("tag", **pkargs)
+    def tag(self, **pkargs):
+        return self.factory.object("tag", **pkargs)
 
-	def iov(self, **pkargs):
-		return self.factory.object("iov", **pkargs)
+    def iov(self, **pkargs):
+        return self.factory.object("iov", **pkargs)
 
-	def payload(self, **pkargs):
-		return self.factory.object("payload", **pkargs)
+    def payload(self, **pkargs):
+        return self.factory.object("payload", **pkargs)
 
-	"""def record(self, **pkargs):
+    """def record(self, **pkargs):
 		return self.factory.object("record", **pkargs)"""
 
-	# adds %% at the beginning and end so LIKE in SQL searches all of the string
-	def _oracle_match_format(self, string):
-		return "%%%s%%" % string
+    # adds %% at the beginning and end so LIKE in SQL searches all of the string
+    def _oracle_match_format(self, string):
+        return "%%%s%%" % string
 
-	# returns dictionary mapping object type to a list of all objects found in the search
-	def search_everything(self, string, amount=10):
-		string = self._oracle_match_format(string)
+    # returns dictionary mapping object type to a list of all objects found in the search
+    def search_everything(self, string, amount=10):
+        string = self._oracle_match_format(string)
 
-		gt = self.model("globaltag")
-		global_tags = self.session.query(gt).filter(or_(
-														gt.name.ilike(string),
-														gt.description.ilike(string),
-														gt.release.ilike(string)
-													)).limit(amount)
-		tag = self.model("tag")
-		tags = self.session.query(tag).filter(or_(
-													tag.name.ilike(string),
-													tag.object_type.ilike(string),
-													tag.description.ilike(string))
-												).limit(amount)
-		iov = self.model("iov")
-		iovs = self.session.query(iov).filter(or_(
-													iov.tag_name.ilike(string),
-													iov.since.ilike(string),
-													iov.payload_hash.ilike(string),
-													iov.insertion_time.ilike(string)
-												)).limit(amount)
-		payload = self.model("payload")
-		payloads = self.session.query(payload).filter(or_(
-															payload.hash.ilike(string),
-															payload.object_type.ilike(string),
-															payload.insertion_time.ilike(string)
-														)).limit(amount)
+        gt = self.model("globaltag")
+        global_tags = self.session.query(gt).filter(or_(
+                                                                                                        gt.name.ilike(string),
+                                                                                                        gt.description.ilike(string),
+                                                                                                        gt.release.ilike(string)
+                                                                                                )).limit(amount)
+        tag = self.model("tag")
+        tags = self.session.query(tag).filter(or_(
+                                                                                                tag.name.ilike(string),
+                                                                                                tag.object_type.ilike(string),
+                                                                                                tag.description.ilike(string))
+                                                                                        ).limit(amount)
+        iov = self.model("iov")
+        iovs = self.session.query(iov).filter(or_(
+                                                                                                iov.tag_name.ilike(string),
+                                                                                                iov.since.ilike(string),
+                                                                                                iov.payload_hash.ilike(string),
+                                                                                                iov.insertion_time.ilike(string)
+                                                                                        )).limit(amount)
+        payload = self.model("payload")
+        payloads = self.session.query(payload).filter(or_(
+                                                                                                                payload.hash.ilike(string),
+                                                                                                                payload.object_type.ilike(string),
+                                                                                                                payload.insertion_time.ilike(string)
+                                                                                                        )).limit(amount)
 
-		return json_data_node.make({
-			"global_tags" : global_tags.all(),
-			"tags" : tags.all(),
-			"iovs" : iovs.all(),
-			"payloads" : payloads.all()
-		})
+        return json_data_node.make({
+                "global_tags" : global_tags.all(),
+                "tags" : tags.all(),
+                "iovs" : iovs.all(),
+                "payloads" : payloads.all()
+        })
 
-	def write(self, object):
-		new_object = models.session_independent_object(object, schema=self.schema)
-		self.session.add(new_object)
-		return new_object
+    def write(self, object):
+        new_object = models.session_independent_object(object, schema=self.schema)
+        self.session.add(new_object)
+        return new_object
 
-	def commit(self):
-		try:
-			self.session.commit()
-		except:
-			traceback.print_exc()
-			self.session.rollback()
+    def commit(self):
+        try:
+            self.session.commit()
+        except:
+            traceback.print_exc()
+            self.session.rollback()
 
-	def write_and_commit(self, object):
-		if isinstance(object, list):
-			for item in object:
-				self.write_and_commit(item)
-		else:
-			# should be changed to deal with errors - add them to exception handling if they appear
-			self.write(object)
-			self.commit()
+    def write_and_commit(self, object):
+        if isinstance(object, list):
+            for item in object:
+                self.write_and_commit(item)
+        else:
+            # should be changed to deal with errors - add them to exception handling if they appear
+            self.write(object)
+            self.commit()
 
-	def rollback(self):
-		try:
-			self.session.rollback()
-		except:
-			traceback.print_exc()
-			print("Session couldn't be rolled back.")
+    def rollback(self):
+        try:
+            self.session.rollback()
+        except:
+            traceback.print_exc()
+            print("Session couldn't be rolled back.")
 
 class factory():
-	"""
-	Contains methods for creating objects.
-	"""
-	def __init__(self, connection):
-		self.connection = connection
+    """
+    Contains methods for creating objects.
+    """
+    def __init__(self, connection):
+        self.connection = connection
 
-	# class_name is the class name of the model to be used
-	# pkargs is a dictionary of keyword arguments used as primary key values
-	# this dictionary will be used to populate the object of type name class_name
-	def object(self, class_name, **pkargs):
-		from data_sources import json_list
-		from models import apply_filters
-		# get the class that self.connection holds from the class name
-		model = self.connection.model(class_name)
+    # class_name is the class name of the model to be used
+    # pkargs is a dictionary of keyword arguments used as primary key values
+    # this dictionary will be used to populate the object of type name class_name
+    def object(self, class_name, **pkargs):
+        from data_sources import json_list
+        from models import apply_filters
+        # get the class that self.connection holds from the class name
+        model = self.connection.model(class_name)
 
-		if self.connection.session == None:
-			return None
+        if self.connection.session == None:
+            return None
 
-		# query for the ORM object, and return the appropriate object (None, CondDBFW object, or json_list)
-		model_data = self.connection.session.query(model)
-		if len(pkargs.items()) != 0:
-			# apply the filters defined in **kwargs
-			model_data = apply_filters(model_data, model, **pkargs)
-			amount = pkargs["amount"] if "amount" in pkargs.keys() else None
-			model_data = model_data.limit(amount)
-			if model_data.count() > 1:
-				# if we have multiple objects, return a json_list
-				return json_list(model_data.all())
-			elif model_data.count() == 1:
-				# if we have a single object, return that object
-				return model_data.first()
-			else:
-				# if we have no objects returned, return None
-				return None
-		else:
-			# no column arguments were given, so return an empty object
-			new_object = model()
-			new_object.empty = True
-			return new_object
+        # query for the ORM object, and return the appropriate object (None, CondDBFW object, or json_list)
+        model_data = self.connection.session.query(model)
+        if len(pkargs.items()) != 0:
+            # apply the filters defined in **kwargs
+            model_data = apply_filters(model_data, model, **pkargs)
+            amount = pkargs["amount"] if "amount" in pkargs.keys() else None
+            model_data = model_data.limit(amount)
+            if model_data.count() > 1:
+                # if we have multiple objects, return a json_list
+                return json_list(model_data.all())
+            elif model_data.count() == 1:
+                # if we have a single object, return that object
+                return model_data.first()
+            else:
+                # if we have no objects returned, return None
+                return None
+        else:
+            # no column arguments were given, so return an empty object
+            new_object = model()
+            new_object.empty = True
+            return new_object
 
 def _get_netrc_data(netrc_file, key):
-	"""
-	Returns a dictionary {login : ..., account : ..., password : ...}
-	"""
-	try:
-		headers = ["login", "account", "password"]
-		authenticator_tuple = netrc.netrc(netrc_file).authenticators(key)
-		if authenticator_tuple == None:
-			raise Exception("netrc file must contain key '%s'." % key)
-	except:
-		raise Exception("Couldn't get credentials from netrc file.")
-	return dict(zip(headers, authenticator_tuple))
+    """
+    Returns a dictionary {login : ..., account : ..., password : ...}
+    """
+    try:
+        headers = ["login", "account", "password"]
+        authenticator_tuple = netrc.netrc(netrc_file).authenticators(key)
+        if authenticator_tuple == None:
+            raise Exception("netrc file must contain key '%s'." % key)
+    except:
+        raise Exception("Couldn't get credentials from netrc file.")
+    return dict(zip(headers, authenticator_tuple))
 
 def new_connection_dictionary(connection_data, secrets=None, mode="r"):
-	"""
-	Function used to construct connection data dictionaries - internal to framework.
-	"""
-	frontier_str_length = len("frontier://")
-	sqlite_str_length = len("sqlite://")
-	#sqlite_file_str_length = len("sqlite_file://")
-	oracle_str_length = len("oracle://")
+    """
+    Function used to construct connection data dictionaries - internal to framework.
+    """
+    frontier_str_length = len("frontier://")
+    sqlite_str_length = len("sqlite://")
+    #sqlite_file_str_length = len("sqlite_file://")
+    oracle_str_length = len("oracle://")
 
-	if type(connection_data) in [str, unicode] and connection_data[0:frontier_str_length] == "frontier://":
-		"""
-		frontier://database_name/schema
-		"""
-		db_name = connection_data[frontier_str_length:].split("/")[0]
-		schema = connection_data[frontier_str_length:].split("/")[1]
-		connection_data = {}
-		connection_data["database_name"] = db_name
-		connection_data["schema"] = schema
-		connection_data["host"] = "frontier"
-		connection_data["secrets"] = None
-	elif type(connection_data) in [str, unicode] and connection_data[0:sqlite_str_length] == "sqlite://":
-		"""
-		sqlite://database_file_name
-		"""
-		# for now, just support "sqlite://" format for sqlite connection strings
-		db_name = connection_data[sqlite_str_length:]
-		schema = ""
-		connection_data = {}
-		connection_data["database_name"] = os.path.abspath(db_name)
-		connection_data["schema"] = schema
-		connection_data["host"] = "sqlite"
-		connection_data["secrets"] = None
-	elif type(connection_data) in [str, unicode] and connection_data[0:oracle_str_length] == "oracle://":
-		"""
-		oracle://account:password@database_name
-		or
-		oracle://database_name/schema (requires a separate method of authentication - either dictionary or netrc)
-		"""
-		new_connection_string = connection_data[oracle_str_length:]
+    if type(connection_data) in [str, unicode] and connection_data[0:frontier_str_length] == "frontier://":
+        """
+        frontier://database_name/schema
+        """
+        db_name = connection_data[frontier_str_length:].split("/")[0]
+        schema = connection_data[frontier_str_length:].split("/")[1]
+        connection_data = {}
+        connection_data["database_name"] = db_name
+        connection_data["schema"] = schema
+        connection_data["host"] = "frontier"
+        connection_data["secrets"] = None
+    elif type(connection_data) in [str, unicode] and connection_data[0:sqlite_str_length] == "sqlite://":
+        """
+        sqlite://database_file_name
+        """
+        # for now, just support "sqlite://" format for sqlite connection strings
+        db_name = connection_data[sqlite_str_length:]
+        schema = ""
+        connection_data = {}
+        connection_data["database_name"] = os.path.abspath(db_name)
+        connection_data["schema"] = schema
+        connection_data["host"] = "sqlite"
+        connection_data["secrets"] = None
+    elif type(connection_data) in [str, unicode] and connection_data[0:oracle_str_length] == "oracle://":
+        """
+        oracle://account:password@database_name
+        or
+        oracle://database_name/schema (requires a separate method of authentication - either dictionary or netrc)
+        """
+        new_connection_string = connection_data[oracle_str_length:]
 
-		if ":" in new_connection_string:
-			# the user has given a password - usually in the case of the db upload service
-			database_name = new_connection_string[new_connection_string.index("@")+1:]
-			schema_name = new_connection_string[0:new_connection_string.index(":")]
-			# set username based on connection string
-			username = new_connection_string[0:new_connection_string.index(":")]
-			password = new_connection_string[new_connection_string.index(":")+1:new_connection_string.index("@")]
-		else:
-			mode_to_netrc_key_suffix = {"r" : "read", "w" : "write"}
-			database_name = new_connection_string[0:new_connection_string.index("/")]
-			schema_name = new_connection_string[new_connection_string.index("/")+1:]
-			if secrets == None:
-				username = str(raw_input("Enter the username you want to connect to the schema '%s' with: " % (schema_name)))
-				password = str(raw_input("Enter the password for the user '%s' in database '%s': " % (username, database_name)))
-			else:
-				if isinstance(secrets, str):
-					netrc_key = "%s/%s/%s" % (database_name, schema_name, mode_to_netrc_key_suffix[mode])
-					netrc_data = _get_netrc_data(secrets, key=netrc_key)
-					# take the username from the netrc entry corresponding to the mode the database is opened in
-					# eg, if the user has given mode="read", the database_name/schema_name/read entry will be taken
-					username = netrc_data["login"]
-					password = netrc_data["password"]
-				elif isinstance(secrets, dict):
-					username = secrets["user"]
-					password = secrets["password"]
-				else:
-					raise Exception("Invalid type given for secrets.  Either an str or a dict must be given.")
+        if ":" in new_connection_string:
+            # the user has given a password - usually in the case of the db upload service
+            database_name = new_connection_string[new_connection_string.index("@")+1:]
+            schema_name = new_connection_string[0:new_connection_string.index(":")]
+            # set username based on connection string
+            username = new_connection_string[0:new_connection_string.index(":")]
+            password = new_connection_string[new_connection_string.index(":")+1:new_connection_string.index("@")]
+        else:
+            mode_to_netrc_key_suffix = {"r" : "read", "w" : "write"}
+            database_name = new_connection_string[0:new_connection_string.index("/")]
+            schema_name = new_connection_string[new_connection_string.index("/")+1:]
+            if secrets == None:
+                username = str(raw_input("Enter the username you want to connect to the schema '%s' with: " % (schema_name)))
+                password = str(raw_input("Enter the password for the user '%s' in database '%s': " % (username, database_name)))
+            else:
+                if isinstance(secrets, str):
+                    netrc_key = "%s/%s/%s" % (database_name, schema_name, mode_to_netrc_key_suffix[mode])
+                    netrc_data = _get_netrc_data(secrets, key=netrc_key)
+                    # take the username from the netrc entry corresponding to the mode the database is opened in
+                    # eg, if the user has given mode="read", the database_name/schema_name/read entry will be taken
+                    username = netrc_data["login"]
+                    password = netrc_data["password"]
+                elif isinstance(secrets, dict):
+                    username = secrets["user"]
+                    password = secrets["password"]
+                else:
+                    raise Exception("Invalid type given for secrets.  Either an str or a dict must be given.")
 
-		#print("Connected to database %s, schema %s, with username %s." % (database_name, schema_name, username))
+        #print("Connected to database %s, schema %s, with username %s." % (database_name, schema_name, username))
 
-		connection_data = {}
-		connection_data["database_name"] = database_name
-		connection_data["schema"] = schema_name
-		connection_data["password"] = password
-		connection_data["host"] = "oracle"
-		connection_data["secrets"] = {"login" : username, "password" : password}
+        connection_data = {}
+        connection_data["database_name"] = database_name
+        connection_data["schema"] = schema_name
+        connection_data["password"] = password
+        connection_data["host"] = "oracle"
+        connection_data["secrets"] = {"login" : username, "password" : password}
 
-	return connection_data
+    return connection_data
 
 def engine_from_dictionary(dictionary, pooling=True):
-	if dictionary["host"] != "sqlite":
-		if dictionary["host"] != "frontier":
-			# probably oracle
-			# if not frontier, we have to authenticate
-			user = dictionary["secrets"]["login"]
-			pwd = dictionary["secrets"]["password"]
-			# set max label length for oracle
-			if pooling:
-				return create_engine(connection.build_oracle_url(user, pwd, dictionary["database_name"]), label_length=6)
-			else:
-				return create_engine(connection.build_oracle_url(user, pwd, dictionary["database_name"]), label_length=6, poolclass=NullPool)
-		else:
-			# if frontier, no need to authenticate
-			# set max label length for frontier
-			if pooling:
-				return create_engine(connection.build_frontier_url(dictionary["database_name"], dictionary["schema"]), label_length=6)
-			else:
-				return create_engine(connection.build_frontier_url(dictionary["database_name"], dictionary["schema"]), label_length=6, poolclass=NullPool)
-	else:
-		# if host is sqlite, making the url is easy - no authentication
-		return create_engine("sqlite:///%s" % dictionary["database_name"])
+    if dictionary["host"] != "sqlite":
+        if dictionary["host"] != "frontier":
+            # probably oracle
+            # if not frontier, we have to authenticate
+            user = dictionary["secrets"]["login"]
+            pwd = dictionary["secrets"]["password"]
+            # set max label length for oracle
+            if pooling:
+                return create_engine(connection.build_oracle_url(user, pwd, dictionary["database_name"]), label_length=6)
+            else:
+                return create_engine(connection.build_oracle_url(user, pwd, dictionary["database_name"]), label_length=6, poolclass=NullPool)
+        else:
+            # if frontier, no need to authenticate
+            # set max label length for frontier
+            if pooling:
+                return create_engine(connection.build_frontier_url(dictionary["database_name"], dictionary["schema"]), label_length=6)
+            else:
+                return create_engine(connection.build_frontier_url(dictionary["database_name"], dictionary["schema"]), label_length=6, poolclass=NullPool)
+    else:
+        # if host is sqlite, making the url is easy - no authentication
+        return create_engine("sqlite:///%s" % dictionary["database_name"])
 
 
 def connect(connection_data, mode="r", map_blobs=False, secrets=None, pooling=True):
-	"""
-	Utility method for user - set up a connection object.
-	"""
-	con = connection(connection_data=connection_data, mode=mode, map_blobs=map_blobs, secrets=secrets, pooling=pooling)
-	con = con.setup()
-	return con
+    """
+    Utility method for user - set up a connection object.
+    """
+    con = connection(connection_data=connection_data, mode=mode, map_blobs=map_blobs, secrets=secrets, pooling=pooling)
+    con = con.setup()
+    return con

--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -11,7 +11,7 @@ import subprocess
 
 # as we need to load the shared lib from here, make sure it's in our path:
 if os.path.join( os.environ['CMSSW_BASE'], 'src') not in sys.path:
-   sys.path.append( os.path.join( os.environ['CMSSW_BASE'], 'src') )
+    sys.path.append( os.path.join( os.environ['CMSSW_BASE'], 'src') )
 
 # -------------------------------------------------------------------------------------------------------
 
@@ -45,26 +45,26 @@ def localLibName( payloadType ):
     # required to avoid ( unlikely ) clashes between lib names from templates and lib names from classes
     prefix = ''
     if '<' in payloadType and '>' in payloadType:
-       prefix = 't'
+        prefix = 't'
     return "%s_%spayload2xml" %(sanitize(payloadType),prefix)
 
 class CondXmlProcessor(object):
 
     def __init__(self, condDBIn):
-    	self.conddb = condDBIn
+        self.conddb = condDBIn
 
-	if not os.path.exists( os.path.join( os.environ['CMSSW_BASE'], 'src') ):
-	   raise Exception("Looks like you are not running in a CMSSW developer area, $CMSSW_BASE/src/ does not exist")
+        if not os.path.exists( os.path.join( os.environ['CMSSW_BASE'], 'src') ):
+            raise Exception("Looks like you are not running in a CMSSW developer area, $CMSSW_BASE/src/ does not exist")
 
-	self.fakePkgName = "fakeSubSys4pl/fakePkg4pl"
-	self._pl2xml_tmpDir = os.path.join( os.environ['CMSSW_BASE'], 'src', self.fakePkgName )
+        self.fakePkgName = "fakeSubSys4pl/fakePkg4pl"
+        self._pl2xml_tmpDir = os.path.join( os.environ['CMSSW_BASE'], 'src', self.fakePkgName )
 
-	self.doCleanup = False
+        self.doCleanup = False
 
     def __del__(self):
 
-    	if self.doCleanup: 
-           shutil.rmtree( '/'.join( self._pl2xml_tmpDir.split('/')[:-1] ) )
+        if self.doCleanup: 
+            shutil.rmtree( '/'.join( self._pl2xml_tmpDir.split('/')[:-1] ) )
         return 
 
     def discover(self, payloadType):
@@ -77,85 +77,85 @@ class CondXmlProcessor(object):
         releaseBase = os.environ["CMSSW_RELEASE_BASE"]
         devCheckout = (releaseBase != '')
         if not devCheckout:
-           logging.debug('Looks like the current working environment is a read-only release')
+            logging.debug('Looks like the current working environment is a read-only release')
         if not os.path.exists( libPath ) and devCheckout:
-           # main release ( for dev checkouts )
-           libDir = os.path.join( releaseBase, 'lib', os.environ["SCRAM_ARCH"] )
-           libPath = os.path.join( libDir, libName )
-           if not os.path.exists( libPath ):
-              if "CMSSW_FULL_RELEASE_BASE" in os.environ:
-                 libDir = os.path.join( os.environ["CMSSW_FULL_RELEASE_BASE"], 'lib', os.environ["SCRAM_ARCH"] )
-                 libPath = os.path.join( libDir, libName )
+            # main release ( for dev checkouts )
+            libDir = os.path.join( releaseBase, 'lib', os.environ["SCRAM_ARCH"] )
+            libPath = os.path.join( libDir, libName )
+            if not os.path.exists( libPath ):
+                if "CMSSW_FULL_RELEASE_BASE" in os.environ:
+                    libDir = os.path.join( os.environ["CMSSW_FULL_RELEASE_BASE"], 'lib', os.environ["SCRAM_ARCH"] )
+                    libPath = os.path.join( libDir, libName )
         if not os.path.exists( libPath ):
-           # it should never happen!
-           raise Exception('No built-in library %s found with XML converters.' %libPath)
+            # it should never happen!
+            raise Exception('No built-in library %s found with XML converters.' %libPath)
         logging.debug("Importing built-in library %s" %libPath)
         module = importlib.import_module( libName.replace('.so', '') )
         functors = dir(module)
         funcName = payloadType+'2xml'
         if funcName in functors:
-           logging.info('XML converter for payload class %s found in the built-in library.' %payloadType)
-           return getattr( module, funcName)
+            logging.info('XML converter for payload class %s found in the built-in library.' %payloadType)
+            return getattr( module, funcName)
         if not devCheckout:
-           # give-up if it is a read-only release...
-           raise Exception('No XML converter suitable for payload class %s has been found in the built-in library.')
+            # give-up if it is a read-only release...
+            raise Exception('No XML converter suitable for payload class %s has been found in the built-in library.')
         libName = 'plugin%s.so' %localLibName( payloadType )
         libPath = os.path.join( devLibDir, libName )
         if os.path.exists( libPath ):
-           logging.info('Found local library with XML converter for class %s' %payloadType )
-           module = importlib.import_module( libName.replace('.so', '') )
-           return getattr( module, funcName)
+            logging.info('Found local library with XML converter for class %s' %payloadType )
+            module = importlib.import_module( libName.replace('.so', '') )
+            return getattr( module, funcName)
         logging.warning('No XML converter for payload class %s found in the built-in library.' %payloadType)
         return None
 
     def prepPayload2xml(self, payloadType):
-    
+
         converter = self.discover(payloadType)
-	if converter: return converter
+        if converter: return converter
 
         #otherwise, go for the code generation in the local checkout area.
-    	startTime = time.time()
+        startTime = time.time()
 
         libName = localLibName( payloadType )
         pluginName = 'plugin%s' % libName
         tmpLibName = "Tmp_payload2xml"
         tmpPluginName = 'plugin%s' %tmpLibName
-         
+
         libDir = os.path.join( os.environ["CMSSW_BASE"], 'lib', os.environ["SCRAM_ARCH"] )
         tmpLibFile = os.path.join( libDir,tmpPluginName+'.so' )
         code = payload2xmlCodeTemplate %(pluginName,payloadType) 
-    
+
         tmpSrcFileName = 'Local_2XML.cpp' 
         tmpDir = self._pl2xml_tmpDir
         if ( os.path.exists( tmpDir ) ) :
-           msg = '\nERROR: %s already exists, please remove if you did not create that manually !!' % tmpDir
-	   raise Exception(msg)
+            msg = '\nERROR: %s already exists, please remove if you did not create that manually !!' % tmpDir
+            raise Exception(msg)
 
         logging.debug('Creating temporary package %s' %self._pl2xml_tmpDir)
         os.makedirs( tmpDir+'/plugins' )
-    
+
         buildFileName = "%s/plugins/BuildFile.xml" % (tmpDir,)
         with open(buildFileName, 'w') as buildFile:
-        	 buildFile.write( buildFileTemplate %(tmpSrcFileName,tmpLibName) )
-    	 	 buildFile.close()
-    
+            buildFile.write( buildFileTemplate %(tmpSrcFileName,tmpLibName) )
+            buildFile.close()
+
         tmpSrcFilePath = "%s/plugins/%s" % (tmpDir, tmpSrcFileName,)
         with open(tmpSrcFilePath, 'w') as codeFile:
-        	 codeFile.write(code)
-    	 	 codeFile.close()
-    
-    	cmd = "source $CMS_PATH/cmsset_default.sh;"
-    	cmd += "(cd %s ; scram b 2>&1 >build.log)" %tmpDir
+            codeFile.write(code)
+            codeFile.close()
+
+        cmd = "source $CMS_PATH/cmsset_default.sh;"
+        cmd += "(cd %s ; scram b 2>&1 >build.log)" %tmpDir
         pipe = subprocess.Popen( cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
         out, err = pipe.communicate()
         ret = pipe.returncode
 
-	buildTime = time.time()-startTime
+        buildTime = time.time()-startTime
         logging.info("Building done in %s sec., return code from build: %s" %(buildTime,ret) )
 
-	if (ret != 0):
-           logging.error("Local build for xml dump failed.")
-           return None
+        if (ret != 0):
+            logging.error("Local build for xml dump failed.")
+            return None
 
         libFile = os.path.join(libDir,pluginName + '.so')
         shutil.copyfile(tmpLibFile,libFile)
@@ -165,24 +165,24 @@ class CondXmlProcessor(object):
         functor = getattr( module, funcName ) 
         self.doCleanup = True
         return functor
-    
+
     def payload2xml(self, session, payloadHash, destFile):
-    
+
         Payload = session.get_dbtype(self.conddb.Payload)
         # get payload from DB:
         result = session.query(Payload.data, Payload.object_type).filter(Payload.hash == payloadHash).one()
         data, plType = result
         logging.info('Found payload of type %s' %plType)
-    
+
         convFuncName = sanitize(plType)+'2xml'
         xmlConverter = self.prepPayload2xml(plType)
 
         if xmlConverter is not None:
-           obj = xmlConverter()
-           resultXML = obj.write( str(data) )
-           if destFile is None:
-              print(resultXML)    
-           else:
-              with open(destFile, 'w') as outFile:
-                 outFile.write(resultXML)
-                 outFile.close()
+            obj = xmlConverter()
+            resultXML = obj.write( str(data) )
+            if destFile is None:
+                print(resultXML)    
+            else:
+                with open(destFile, 'w') as outFile:
+                    outFile.write(resultXML)
+                    outFile.close()

--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -240,7 +240,7 @@ def make_dbtype( backendName, schemaName, baseType ):
                 nullable = (True if v[1]==_Col.nullable else False)
                 members[k] = sqlalchemy.Column(v[0],nullable=nullable)
     dbType = type(dbtype_name,(_Base,),members)
-    
+
     if backendName not in db_models.keys():
         db_models[backendName] = {}
     db_models[backendName][baseType.__name__] = dbType
@@ -592,7 +592,7 @@ def _exists(session, primary_key, value):
     ret = None
     try: 
         ret = session.query(primary_key).\
-    	    filter(primary_key == value).\
+            filter(primary_key == value).\
             count() != 0
     except sqlalchemy.exc.OperationalError:
         pass
@@ -619,10 +619,10 @@ def listObject(session, name, snapshot=None):
     if is_tag:
         result['type'] = 'Tag'
         result['name'] = session.query(Tag).get(name).name
-	result['timeType'] = session.query(Tag.time_type).\
-				     filter(Tag.name == name).\
-            			     scalar()
-    
+        result['timeType'] = session.query(Tag.time_type).\
+                                     filter(Tag.name == name).\
+                                     scalar()
+
         result['iovs'] = session.query(IOV.since, IOV.insertion_time, IOV.payload_hash, Payload.object_type).\
                 join(IOV.payload).\
                 filter(
@@ -638,11 +638,11 @@ def listObject(session, name, snapshot=None):
         is_global_tag = _exists(session, GlobalTag.name, name)
         if is_global_tag:
             result['type'] = 'GlobalTag'
-	    result['name'] = session.query(GlobalTag).get(name)
+            result['name'] = session.query(GlobalTag).get(name)
             result['tags'] = session.query(GlobalTagMap.record, GlobalTagMap.label, GlobalTagMap.tag_name).\
                                      filter(GlobalTagMap.global_tag_name == name).\
-                    		     order_by(GlobalTagMap.record, GlobalTagMap.label).\
-                    		     all()
+                                     order_by(GlobalTagMap.record, GlobalTagMap.label).\
+                                     all()
     except sqlalchemy.exc.OperationalError:
         sys.stderr.write("No table for GlobalTags found in DB.\n\n")
 

--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -172,8 +172,8 @@ def get_serializable_classes_members(node, all_template_types=None, namespace=''
             if only_from_path is not None \
                 and child.location.file is not None \
                 and not child.location.file.name.startswith(only_from_path):
-                    logging.debug('Skipping since it is an external of this package: %s', child.spelling)
-                    continue
+                logging.debug('Skipping since it is an external of this package: %s', child.spelling)
+                continue
 
             serializable = is_serializable_class(child)
             if serializable:
@@ -216,8 +216,8 @@ def get_serializable_classes_members(node, all_template_types=None, namespace=''
                 # Template non-type parameters (e.g. <int N>)
                 elif member.kind == clang.cindex.CursorKind.TEMPLATE_NON_TYPE_PARAMETER:
                     type_string = get_type_string(member)
-		    if not type_string: 
-		       type_string = get_basic_type_string(member)
+                    if not type_string: 
+                        type_string = get_basic_type_string(member)
                     logging.info('    Found template non-type parameter: %s %s', type_string, member.spelling)
                     template_types.append((type_string, member.spelling))
 
@@ -449,12 +449,12 @@ class SerializationCodeGenerator(object):
         product_name = '%s%s' % (self.split_path[1], self.split_path[2])
         logging.debug('product_name = %s', product_name)
 
-	if not scramFlags:
-	   cpp_flags = get_flags(product_name, 'CPPFLAGS')
-           cxx_flags = get_flags(product_name, 'CXXFLAGS')
-	else:
-	   cpp_flags = self.cleanFlags( scramFlags )
-	   cxx_flags = []
+        if not scramFlags:
+            cpp_flags = get_flags(product_name, 'CPPFLAGS')
+            cxx_flags = get_flags(product_name, 'CXXFLAGS')
+        else:
+            cpp_flags = self.cleanFlags( scramFlags )
+            cxx_flags = []
 
         # We are using libClang, thus we have to follow Clang include paths
         std_flags = get_default_gcc_search_paths(gcc='clang++')
@@ -516,9 +516,9 @@ class SerializationCodeGenerator(object):
 
     def generate(self, outFileName):
 
-    	filename = outFileName
-	if not filename:  # in case we're not using scram, this may not be set, use the default then, assuming we're in the package dir ...
-	   filename = self._join_package_path('src', 'Serialization.cc')
+        filename = outFileName
+        if not filename:  # in case we're not using scram, this may not be set, use the default then, assuming we're in the package dir ...
+            filename = self._join_package_path('src', 'Serialization.cc')
 
         n_serializable_classes = 0
 
@@ -577,10 +577,10 @@ def main():
 
     logLevel = logging.INFO
     if opts.verbose < 1 and opts.output and opts.package:   # assume we're called by scram and reduce logging - but only if no verbose is requested
-       logLevel = logging.WARNING
+        logLevel = logging.WARNING
 
     if opts.verbose >= 1: 
-       logLevel = logging.DEBUG
+        logLevel = logging.DEBUG
 
     logging.basicConfig(
         format = '[%(asctime)s] %(levelname)s: %(message)s',
@@ -589,13 +589,13 @@ def main():
 
     if opts.package:  # we got a directory name to process, assume it's from scram and remove the last ('/src') dir from the path
         pkgDir = opts.package
-	if pkgDir.endswith('/src') :
-	    pkgDir, srcDir = os.path.split( opts.package )
+        if pkgDir.endswith('/src') :
+            pkgDir, srcDir = os.path.split( opts.package )
         os.chdir( pkgDir )
-	logging.info("Processing package in %s " % pkgDir)
+        logging.info("Processing package in %s " % pkgDir)
 
     if opts.output:
-       logging.info("Writing serialization code to %s " % opts.output)
+        logging.info("Writing serialization code to %s " % opts.output)
 
     SerializationCodeGenerator( scramFlags=args[1:] ).generate( opts.output )
 

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -18,7 +18,7 @@ import collections
 from subprocess import Popen,PIPE
 import FWCore.ParameterSet.DictTypes as DictTypes
 class Options:
-        pass
+    pass
 
 # the canonical defaults
 defaultOptions = Options()
@@ -88,164 +88,164 @@ defaultOptions.nThreads = '1'
 
 # some helper routines
 def dumpPython(process,name):
-        theObject = getattr(process,name)
-        if isinstance(theObject,cms.Path) or isinstance(theObject,cms.EndPath) or isinstance(theObject,cms.Sequence):
-                return "process."+name+" = " + theObject.dumpPython("process")
-        elif isinstance(theObject,_Module) or isinstance(theObject,cms.ESProducer):
-                return "process."+name+" = " + theObject.dumpPython()+"\n"
-        else:
-                return "process."+name+" = " + theObject.dumpPython()+"\n"
+    theObject = getattr(process,name)
+    if isinstance(theObject,cms.Path) or isinstance(theObject,cms.EndPath) or isinstance(theObject,cms.Sequence):
+        return "process."+name+" = " + theObject.dumpPython("process")
+    elif isinstance(theObject,_Module) or isinstance(theObject,cms.ESProducer):
+        return "process."+name+" = " + theObject.dumpPython()+"\n"
+    else:
+        return "process."+name+" = " + theObject.dumpPython()+"\n"
 def filesFromList(fileName,s=None):
-	import os
-	import FWCore.ParameterSet.Config as cms
-	prim=[]
-	sec=[]
-	for line in open(fileName,'r'):
-		if line.count(".root")>=2:
-			#two files solution...
-			entries=line.replace("\n","").split()
-			if not entries[0] in prim:
-				prim.append(entries[0])
-			if not entries[1] in sec:
-				sec.append(entries[1])
-		elif (line.find(".root")!=-1):
-			entry=line.replace("\n","")
-			if not entry in prim:
-				prim.append(entry)
-	if s:
-		if not hasattr(s,"fileNames"):
-			s.fileNames=cms.untracked.vstring(prim)
-		else:
-			s.fileNames.extend(prim)
-		if len(sec)!=0:
-			if not hasattr(s,"secondaryFileNames"):
-				s.secondaryFileNames=cms.untracked.vstring(sec)
-			else:
-				s.secondaryFileNames.extend(sec)
-	print("found files: ",prim)
-	if len(prim)==0:
-		raise Exception("There are not files in input from the file list")
-	if len(sec)!=0:
-		print("found parent files:",sec)
-	return (prim,sec)
-	
+    import os
+    import FWCore.ParameterSet.Config as cms
+    prim=[]
+    sec=[]
+    for line in open(fileName,'r'):
+        if line.count(".root")>=2:
+            #two files solution...
+            entries=line.replace("\n","").split()
+            if not entries[0] in prim:
+                prim.append(entries[0])
+            if not entries[1] in sec:
+                sec.append(entries[1])
+        elif (line.find(".root")!=-1):
+            entry=line.replace("\n","")
+            if not entry in prim:
+                prim.append(entry)
+    if s:
+        if not hasattr(s,"fileNames"):
+            s.fileNames=cms.untracked.vstring(prim)
+        else:
+            s.fileNames.extend(prim)
+        if len(sec)!=0:
+            if not hasattr(s,"secondaryFileNames"):
+                s.secondaryFileNames=cms.untracked.vstring(sec)
+            else:
+                s.secondaryFileNames.extend(sec)
+    print("found files: ",prim)
+    if len(prim)==0:
+        raise Exception("There are not files in input from the file list")
+    if len(sec)!=0:
+        print("found parent files:",sec)
+    return (prim,sec)
+
 def filesFromDASQuery(query,option="",s=None):
-	import os,time
-	import FWCore.ParameterSet.Config as cms
-	prim=[]
-	sec=[]
-	print("the query is",query)
-	eC=5
-	count=0
-	while eC!=0 and count<3:
-		if count!=0:
-			print('Sleeping, then retrying DAS')
-			time.sleep(100)
-		p = Popen('dasgoclient %s --query "%s"'%(option,query), stdout=PIPE,shell=True)
-                pipe=p.stdout.read()
-		tupleP = os.waitpid(p.pid, 0)
-		eC=tupleP[1]
-		count=count+1
-	if eC==0:
-		print("DAS succeeded after",count,"attempts",eC)
-	else:
-		print("DAS failed 3 times- I give up")
-	for line in pipe.split('\n'):
-		if line.count(".root")>=2:
-			#two files solution...
-			entries=line.replace("\n","").split()
-			if not entries[0] in prim:
-				prim.append(entries[0])
-			if not entries[1] in sec:
-				sec.append(entries[1])
-		elif (line.find(".root")!=-1):
-			entry=line.replace("\n","")
-			if not entry in prim:
-				prim.append(entry)
-	if s:
-		if not hasattr(s,"fileNames"):
-			s.fileNames=cms.untracked.vstring(prim)
-		else:
-			s.fileNames.extend(prim)
-		if len(sec)!=0:
-			if not hasattr(s,"secondaryFileNames"):
-				s.secondaryFileNames=cms.untracked.vstring(sec)
-			else:
-				s.secondaryFileNames.extend(sec)
-	print("found files: ",prim)
-	if len(sec)!=0:
-		print("found parent files:",sec)
-	return (prim,sec)
+    import os,time
+    import FWCore.ParameterSet.Config as cms
+    prim=[]
+    sec=[]
+    print("the query is",query)
+    eC=5
+    count=0
+    while eC!=0 and count<3:
+        if count!=0:
+            print('Sleeping, then retrying DAS')
+            time.sleep(100)
+        p = Popen('dasgoclient %s --query "%s"'%(option,query), stdout=PIPE,shell=True)
+        pipe=p.stdout.read()
+        tupleP = os.waitpid(p.pid, 0)
+        eC=tupleP[1]
+        count=count+1
+    if eC==0:
+        print("DAS succeeded after",count,"attempts",eC)
+    else:
+        print("DAS failed 3 times- I give up")
+    for line in pipe.split('\n'):
+        if line.count(".root")>=2:
+            #two files solution...
+            entries=line.replace("\n","").split()
+            if not entries[0] in prim:
+                prim.append(entries[0])
+            if not entries[1] in sec:
+                sec.append(entries[1])
+        elif (line.find(".root")!=-1):
+            entry=line.replace("\n","")
+            if not entry in prim:
+                prim.append(entry)
+    if s:
+        if not hasattr(s,"fileNames"):
+            s.fileNames=cms.untracked.vstring(prim)
+        else:
+            s.fileNames.extend(prim)
+        if len(sec)!=0:
+            if not hasattr(s,"secondaryFileNames"):
+                s.secondaryFileNames=cms.untracked.vstring(sec)
+            else:
+                s.secondaryFileNames.extend(sec)
+    print("found files: ",prim)
+    if len(sec)!=0:
+        print("found parent files:",sec)
+    return (prim,sec)
 
 def anyOf(listOfKeys,dict,opt=None):
-	for k in listOfKeys:
-		if k in dict:
-			toReturn=dict[k]
-			dict.pop(k)
-			return toReturn
-	if opt!=None:
-		return opt
-	else:
-		raise Exception("any of "+','.join(listOfKeys)+" are mandatory entries of --output options")
+    for k in listOfKeys:
+        if k in dict:
+            toReturn=dict[k]
+            dict.pop(k)
+            return toReturn
+    if opt!=None:
+        return opt
+    else:
+        raise Exception("any of "+','.join(listOfKeys)+" are mandatory entries of --output options")
 
 class ConfigBuilder(object):
     """The main building routines """
 
     def __init__(self, options, process = None, with_output = False, with_input = False ):
         """options taken from old cmsDriver and optparse """
-	    
+
         options.outfile_name = options.dirout+options.fileout
 
         self._options = options
 
         if self._options.isData and options.isMC:
-                raise Exception("ERROR: You may specify only --data or --mc, not both")
+            raise Exception("ERROR: You may specify only --data or --mc, not both")
         #if not self._options.conditions:
         #        raise Exception("ERROR: No conditions given!\nPlease specify conditions. E.g. via --conditions=IDEAL_30X::All")
 
-	# check that MEtoEDMConverter (running in ENDJOB) and DQMIO don't run in the same job
-	if 'ENDJOB' in self._options.step:
-		if  (hasattr(self._options,"outputDefinition") and \
-		    self._options.outputDefinition != '' and \
-		    any(anyOf(['t','tier','dataTier'],outdic) == 'DQMIO' for outdic in eval(self._options.outputDefinition))) or \
-		    (hasattr(self._options,"datatier") and \
-		    self._options.datatier and \
-		    'DQMIO' in self._options.datatier):
-			print("removing ENDJOB from steps since not compatible with DQMIO dataTier") 
-			self._options.step=self._options.step.replace(',ENDJOB','')
+        # check that MEtoEDMConverter (running in ENDJOB) and DQMIO don't run in the same job
+        if 'ENDJOB' in self._options.step:
+            if  (hasattr(self._options,"outputDefinition") and \
+                self._options.outputDefinition != '' and \
+                any(anyOf(['t','tier','dataTier'],outdic) == 'DQMIO' for outdic in eval(self._options.outputDefinition))) or \
+                (hasattr(self._options,"datatier") and \
+                self._options.datatier and \
+                'DQMIO' in self._options.datatier):
+                print("removing ENDJOB from steps since not compatible with DQMIO dataTier") 
+                self._options.step=self._options.step.replace(',ENDJOB','')
 
 
-		
+
         # what steps are provided by this class?
         stepList = [re.sub(r'^prepare_', '', methodName) for methodName in ConfigBuilder.__dict__ if methodName.startswith('prepare_')]
         self.stepMap={}
-	self.stepKeys=[]
+        self.stepKeys=[]
         for step in self._options.step.split(","):
-                if step=='': continue
-                stepParts = step.split(":")
-                stepName = stepParts[0]
-                if stepName not in stepList and not stepName.startswith('re'):
-                        raise ValueError("Step "+stepName+" unknown")
-                if len(stepParts)==1:
-                        self.stepMap[stepName]=""
-                elif len(stepParts)==2:
-                        self.stepMap[stepName]=stepParts[1].split('+')
-                elif len(stepParts)==3:
-                        self.stepMap[stepName]=(stepParts[2].split('+'),stepParts[1])
-                else:
-                        raise ValueError("Step definition "+step+" invalid")
-		self.stepKeys.append(stepName)
-		
+            if step=='': continue
+            stepParts = step.split(":")
+            stepName = stepParts[0]
+            if stepName not in stepList and not stepName.startswith('re'):
+                raise ValueError("Step "+stepName+" unknown")
+            if len(stepParts)==1:
+                self.stepMap[stepName]=""
+            elif len(stepParts)==2:
+                self.stepMap[stepName]=stepParts[1].split('+')
+            elif len(stepParts)==3:
+                self.stepMap[stepName]=(stepParts[2].split('+'),stepParts[1])
+            else:
+                raise ValueError("Step definition "+step+" invalid")
+            self.stepKeys.append(stepName)
+
         #print "map of steps is:",self.stepMap
 
         self.with_output = with_output
-	self.process=process
+        self.process=process
 
         if hasattr(self._options,"no_output_flag") and self._options.no_output_flag:
-                self.with_output = False
+            self.with_output = False
         self.with_input = with_input
         self.imports = []
-	self.create_process()
+        self.create_process()
         self.define_Configs()
         self.schedule = list()
 
@@ -261,52 +261,52 @@ class ConfigBuilder(object):
 
         self.productionFilterSequence = None
         self.labelsToAssociate=[]
-	self.nextScheduleIsConditional=False
-	self.conditionalPaths=[]
-	self.excludedPaths=[]
+        self.nextScheduleIsConditional=False
+        self.conditionalPaths=[]
+        self.excludedPaths=[]
 
     def profileOptions(self):
-	    """
-	    addIgProfService
-	    Function to add the igprof profile service so that you can dump in the middle
-	    of the run.
-	    """
-	    profileOpts = self._options.profile.split(':')
-	    profilerStart = 1
-	    profilerInterval = 100
-	    profilerFormat = None
-	    profilerJobFormat = None
-	    
-	    if len(profileOpts):
-		    #type, given as first argument is unused here
-		    profileOpts.pop(0) 
-	    if len(profileOpts):   
-		    startEvent = profileOpts.pop(0)
-		    if not startEvent.isdigit():
-			    raise Exception("%s is not a number" % startEvent)
-		    profilerStart = int(startEvent)
-	    if len(profileOpts):
-		    eventInterval = profileOpts.pop(0)
-		    if not eventInterval.isdigit():
-			    raise Exception("%s is not a number" % eventInterval)
-		    profilerInterval = int(eventInterval)
-	    if len(profileOpts):
-		    profilerFormat = profileOpts.pop(0)
+        """
+        addIgProfService
+        Function to add the igprof profile service so that you can dump in the middle
+        of the run.
+        """
+        profileOpts = self._options.profile.split(':')
+        profilerStart = 1
+        profilerInterval = 100
+        profilerFormat = None
+        profilerJobFormat = None
+
+        if len(profileOpts):
+            #type, given as first argument is unused here
+            profileOpts.pop(0) 
+        if len(profileOpts):   
+            startEvent = profileOpts.pop(0)
+            if not startEvent.isdigit():
+                raise Exception("%s is not a number" % startEvent)
+            profilerStart = int(startEvent)
+        if len(profileOpts):
+            eventInterval = profileOpts.pop(0)
+            if not eventInterval.isdigit():
+                raise Exception("%s is not a number" % eventInterval)
+            profilerInterval = int(eventInterval)
+        if len(profileOpts):
+            profilerFormat = profileOpts.pop(0)
 
 
-	    if not profilerFormat:
-		    profilerFormat = "%s___%s___%s___%s___%s___%s___%%I.gz" % (self._options.evt_type.replace("_cfi", ""),
-									       self._options.step,
-									       self._options.pileup,
-									       self._options.conditions,
-									       self._options.datatier,
-									       self._options.profileTypeLabel)
-	    if not profilerJobFormat and profilerFormat.endswith(".gz"):
-		    profilerJobFormat = profilerFormat.replace(".gz", "_EndOfJob.gz")
-	    elif not profilerJobFormat:
-		    profilerJobFormat = profilerFormat + "_EndOfJob.gz"
+        if not profilerFormat:
+            profilerFormat = "%s___%s___%s___%s___%s___%s___%%I.gz" % (self._options.evt_type.replace("_cfi", ""),
+                                                                       self._options.step,
+                                                                       self._options.pileup,
+                                                                       self._options.conditions,
+                                                                       self._options.datatier,
+                                                                       self._options.profileTypeLabel)
+        if not profilerJobFormat and profilerFormat.endswith(".gz"):
+            profilerJobFormat = profilerFormat.replace(".gz", "_EndOfJob.gz")
+        elif not profilerJobFormat:
+            profilerJobFormat = profilerFormat + "_EndOfJob.gz"
 
-	    return (profilerStart,profilerInterval,profilerFormat,profilerJobFormat)
+        return (profilerStart,profilerInterval,profilerFormat,profilerJobFormat)
 
     def load(self,includeFile):
         includeFile = includeFile.replace('/','.')
@@ -326,354 +326,354 @@ class ConfigBuilder(object):
         """helper routine to remember replace statements"""
         self.additionalCommands.append(command)
         if not command.strip().startswith("#"):
-            # substitute: process.foo = process.bar -> self.process.foo = self.process.bar
+        # substitute: process.foo = process.bar -> self.process.foo = self.process.bar
             import re
             exec(re.sub(r"([^a-zA-Z_0-9]|^)(process)([^a-zA-Z_0-9])",r"\1self.process\3",command))
             #exec(command.replace("process.","self.process."))
 
     def addCommon(self):
-            if 'HARVESTING' in self.stepMap.keys() or 'ALCAHARVEST' in self.stepMap.keys():
-                    self.process.options = cms.untracked.PSet( Rethrow = cms.untracked.vstring('ProductNotFound'),fileMode = cms.untracked.string('FULLMERGE'))
-            else:
-                    self.process.options = cms.untracked.PSet( )
+        if 'HARVESTING' in self.stepMap.keys() or 'ALCAHARVEST' in self.stepMap.keys():
+            self.process.options = cms.untracked.PSet( Rethrow = cms.untracked.vstring('ProductNotFound'),fileMode = cms.untracked.string('FULLMERGE'))
+        else:
+            self.process.options = cms.untracked.PSet( )
 
-            self.addedObjects.append(("","options"))
+        self.addedObjects.append(("","options"))
 
-            if self._options.lazy_download:
-                    self.process.AdaptorConfig = cms.Service("AdaptorConfig",
-                                                             stats = cms.untracked.bool(True),
-                                                             enable = cms.untracked.bool(True),
-                                                             cacheHint = cms.untracked.string("lazy-download"),
-                                                             readHint = cms.untracked.string("read-ahead-buffered")
-                                                             )
-                    self.addedObjects.append(("Setup lazy download","AdaptorConfig"))
+        if self._options.lazy_download:
+            self.process.AdaptorConfig = cms.Service("AdaptorConfig",
+                                                     stats = cms.untracked.bool(True),
+                                                     enable = cms.untracked.bool(True),
+                                                     cacheHint = cms.untracked.string("lazy-download"),
+                                                     readHint = cms.untracked.string("read-ahead-buffered")
+                                                     )
+            self.addedObjects.append(("Setup lazy download","AdaptorConfig"))
 
-            #self.process.cmsDriverCommand = cms.untracked.PSet( command=cms.untracked.string('cmsDriver.py '+self._options.arguments) )
-            #self.addedObjects.append(("what cmsDriver command was used","cmsDriverCommand"))
+        #self.process.cmsDriverCommand = cms.untracked.PSet( command=cms.untracked.string('cmsDriver.py '+self._options.arguments) )
+        #self.addedObjects.append(("what cmsDriver command was used","cmsDriverCommand"))
 
-	    if self._options.profile:
-		    (start, interval, eventFormat, jobFormat)=self.profileOptions()
-		    self.process.IgProfService = cms.Service("IgProfService",
-							     reportFirstEvent            = cms.untracked.int32(start),
-							     reportEventInterval         = cms.untracked.int32(interval),
-							     reportToFileAtPostEvent     = cms.untracked.string("| gzip -c > %s"%(eventFormat)),
-							     reportToFileAtPostEndJob    = cms.untracked.string("| gzip -c > %s"%(jobFormat)))
-		    self.addedObjects.append(("Setup IGProf Service for profiling","IgProfService"))
-							     
+        if self._options.profile:
+            (start, interval, eventFormat, jobFormat)=self.profileOptions()
+            self.process.IgProfService = cms.Service("IgProfService",
+                                                     reportFirstEvent            = cms.untracked.int32(start),
+                                                     reportEventInterval         = cms.untracked.int32(interval),
+                                                     reportToFileAtPostEvent     = cms.untracked.string("| gzip -c > %s"%(eventFormat)),
+                                                     reportToFileAtPostEndJob    = cms.untracked.string("| gzip -c > %s"%(jobFormat)))
+            self.addedObjects.append(("Setup IGProf Service for profiling","IgProfService"))
+
     def addMaxEvents(self):
         """Here we decide how many evts will be processed"""
         self.process.maxEvents=cms.untracked.PSet(input=cms.untracked.int32(int(self._options.number)))
-	if self._options.number_out:
-		self.process.maxEvents.output = cms.untracked.int32(int(self._options.number_out))
+        if self._options.number_out:
+            self.process.maxEvents.output = cms.untracked.int32(int(self._options.number_out))
         self.addedObjects.append(("","maxEvents"))
 
     def addSource(self):
         """Here the source is built. Priority: file, generator"""
         self.addedObjects.append(("Input source","source"))
 
-	def filesFromOption(self):
-		for entry in self._options.filein.split(','):
-			print("entry",entry)
-			if entry.startswith("filelist:"):
-				filesFromList(entry[9:],self.process.source)
-			elif entry.startswith("dbs:") or entry.startswith("das:"):
-				filesFromDASQuery('file dataset = %s'%(entry[4:]),self._options.dasoption,self.process.source)
-			else:
-				self.process.source.fileNames.append(self._options.dirin+entry)
-		if self._options.secondfilein:
-			if not hasattr(self.process.source,"secondaryFileNames"):
-				raise Exception("--secondfilein not compatible with "+self._options.filetype+"input type")
-			for entry in self._options.secondfilein.split(','):
-				print("entry",entry)
-				if entry.startswith("filelist:"):
-					self.process.source.secondaryFileNames.extend((filesFromList(entry[9:]))[0])
-				elif entry.startswith("dbs:") or entry.startswith("das:"):
-					self.process.source.secondaryFileNames.extend((filesFromDASQuery('file dataset = %s'%(entry[4:]),self._options.dasoption))[0])
-				else:
-					self.process.source.secondaryFileNames.append(self._options.dirin+entry)
+        def filesFromOption(self):
+            for entry in self._options.filein.split(','):
+                print("entry",entry)
+                if entry.startswith("filelist:"):
+                    filesFromList(entry[9:],self.process.source)
+                elif entry.startswith("dbs:") or entry.startswith("das:"):
+                    filesFromDASQuery('file dataset = %s'%(entry[4:]),self._options.dasoption,self.process.source)
+                else:
+                    self.process.source.fileNames.append(self._options.dirin+entry)
+            if self._options.secondfilein:
+                if not hasattr(self.process.source,"secondaryFileNames"):
+                    raise Exception("--secondfilein not compatible with "+self._options.filetype+"input type")
+                for entry in self._options.secondfilein.split(','):
+                    print("entry",entry)
+                    if entry.startswith("filelist:"):
+                        self.process.source.secondaryFileNames.extend((filesFromList(entry[9:]))[0])
+                    elif entry.startswith("dbs:") or entry.startswith("das:"):
+                        self.process.source.secondaryFileNames.extend((filesFromDASQuery('file dataset = %s'%(entry[4:]),self._options.dasoption))[0])
+                    else:
+                        self.process.source.secondaryFileNames.append(self._options.dirin+entry)
 
         if self._options.filein or self._options.dasquery:
-	   if self._options.filetype == "EDM":
-		   self.process.source=cms.Source("PoolSource",
-						  fileNames = cms.untracked.vstring(),
-						  secondaryFileNames= cms.untracked.vstring())
-		   filesFromOption(self)
-	   elif self._options.filetype == "DAT":
-		   self.process.source=cms.Source("NewEventStreamFileReader",fileNames = cms.untracked.vstring())
-		   filesFromOption(self)
-           elif self._options.filetype == "LHE":
-		   self.process.source=cms.Source("LHESource", fileNames = cms.untracked.vstring())
-		   if self._options.filein.startswith("lhe:"):
-			   #list the article directory automatically
-			   args=self._options.filein.split(':')
-			   article=args[1]
-			   print('LHE input from article ',article)
-			   location='/store/lhe/'
-			   import os
-			   textOfFiles=os.popen('cmsLHEtoEOSManager.py -l '+article)
-			   for line in textOfFiles:
-				   for fileName in [x for x in line.split() if '.lhe' in x]:
-					   self.process.source.fileNames.append(location+article+'/'+fileName)
-			   #check first if list of LHE files is loaded (not empty)
-			   if len(line)<2:
-				   print('Issue to load LHE files, please check and try again.')
-				   sys.exit(-1)
-			   #Additional check to protect empty fileNames in process.source
-			   if len(self.process.source.fileNames)==0:
-				   print('Issue with empty filename, but can pass line check')
-				   sys.exit(-1)
-			   if len(args)>2:
-				   self.process.source.skipEvents = cms.untracked.uint32(int(args[2]))
-		   else:
-			   filesFromOption(self)
-		   
-	   elif self._options.filetype == "DQM":
-		   self.process.source=cms.Source("DQMRootSource",
-						  fileNames = cms.untracked.vstring())
-		   filesFromOption(self)
+            if self._options.filetype == "EDM":
+                self.process.source=cms.Source("PoolSource",
+                                               fileNames = cms.untracked.vstring(),
+                                               secondaryFileNames= cms.untracked.vstring())
+                filesFromOption(self)
+            elif self._options.filetype == "DAT":
+                self.process.source=cms.Source("NewEventStreamFileReader",fileNames = cms.untracked.vstring())
+                filesFromOption(self)
+            elif self._options.filetype == "LHE":
+                self.process.source=cms.Source("LHESource", fileNames = cms.untracked.vstring())
+                if self._options.filein.startswith("lhe:"):
+                    #list the article directory automatically
+                    args=self._options.filein.split(':')
+                    article=args[1]
+                    print('LHE input from article ',article)
+                    location='/store/lhe/'
+                    import os
+                    textOfFiles=os.popen('cmsLHEtoEOSManager.py -l '+article)
+                    for line in textOfFiles:
+                        for fileName in [x for x in line.split() if '.lhe' in x]:
+                            self.process.source.fileNames.append(location+article+'/'+fileName)
+                    #check first if list of LHE files is loaded (not empty)
+                    if len(line)<2:
+                        print('Issue to load LHE files, please check and try again.')
+                        sys.exit(-1)
+                    #Additional check to protect empty fileNames in process.source
+                    if len(self.process.source.fileNames)==0:
+                        print('Issue with empty filename, but can pass line check')
+                        sys.exit(-1)
+                    if len(args)>2:
+                        self.process.source.skipEvents = cms.untracked.uint32(int(args[2]))
+                else:
+                    filesFromOption(self)
 
-	   elif self._options.filetype == "DQMDAQ":
-		   # FIXME: how to configure it if there are no input files specified?
-		   self.process.source=cms.Source("DQMStreamerReader")
-		   
-			   
-           if ('HARVESTING' in self.stepMap.keys() or 'ALCAHARVEST' in self.stepMap.keys()) and (not self._options.filetype == "DQM"):
-               self.process.source.processingMode = cms.untracked.string("RunsAndLumis")
+            elif self._options.filetype == "DQM":
+                self.process.source=cms.Source("DQMRootSource",
+                                               fileNames = cms.untracked.vstring())
+                filesFromOption(self)
 
-	if self._options.dasquery!='':
-               self.process.source=cms.Source("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
-	       filesFromDASQuery(self._options.dasquery,self._options.dasoption,self.process.source)
-	       
-	       if ('HARVESTING' in self.stepMap.keys() or 'ALCAHARVEST' in self.stepMap.keys()) and (not self._options.filetype == "DQM"):
-		       self.process.source.processingMode = cms.untracked.string("RunsAndLumis")
-		       
-	##drop LHEXMLStringProduct on input to save memory if appropriate
-	if 'GEN' in self.stepMap.keys():
-        	if self._options.inputCommands:
-        		self._options.inputCommands+=',drop LHEXMLStringProduct_*_*_*,'
-		else:
-			self._options.inputCommands='keep *, drop LHEXMLStringProduct_*_*_*,'    
+            elif self._options.filetype == "DQMDAQ":
+                # FIXME: how to configure it if there are no input files specified?
+                self.process.source=cms.Source("DQMStreamerReader")
 
-	if self.process.source and self._options.inputCommands:
-		if not hasattr(self.process.source,'inputCommands'): self.process.source.inputCommands=cms.untracked.vstring()
-		for command in self._options.inputCommands.split(','):
-			# remove whitespace around the keep/drop statements
-			command = command.strip()
-			if command=='': continue
-			self.process.source.inputCommands.append(command)
-		if not self._options.dropDescendant:
-			self.process.source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
 
-	if self._options.lumiToProcess:
-		import FWCore.PythonUtilities.LumiList as LumiList
-		self.process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange( LumiList.LumiList(self._options.lumiToProcess).getCMSSWString().split(',') )
+            if ('HARVESTING' in self.stepMap.keys() or 'ALCAHARVEST' in self.stepMap.keys()) and (not self._options.filetype == "DQM"):
+                self.process.source.processingMode = cms.untracked.string("RunsAndLumis")
+
+        if self._options.dasquery!='':
+            self.process.source=cms.Source("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
+            filesFromDASQuery(self._options.dasquery,self._options.dasoption,self.process.source)
+
+            if ('HARVESTING' in self.stepMap.keys() or 'ALCAHARVEST' in self.stepMap.keys()) and (not self._options.filetype == "DQM"):
+                self.process.source.processingMode = cms.untracked.string("RunsAndLumis")
+
+        ##drop LHEXMLStringProduct on input to save memory if appropriate
+        if 'GEN' in self.stepMap.keys():
+            if self._options.inputCommands:
+                self._options.inputCommands+=',drop LHEXMLStringProduct_*_*_*,'
+            else:
+                self._options.inputCommands='keep *, drop LHEXMLStringProduct_*_*_*,'    
+
+        if self.process.source and self._options.inputCommands:
+            if not hasattr(self.process.source,'inputCommands'): self.process.source.inputCommands=cms.untracked.vstring()
+            for command in self._options.inputCommands.split(','):
+                # remove whitespace around the keep/drop statements
+                command = command.strip()
+                if command=='': continue
+                self.process.source.inputCommands.append(command)
+            if not self._options.dropDescendant:
+                self.process.source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
+
+        if self._options.lumiToProcess:
+            import FWCore.PythonUtilities.LumiList as LumiList
+            self.process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange( LumiList.LumiList(self._options.lumiToProcess).getCMSSWString().split(',') )
 
         if 'GEN' in self.stepMap.keys() or 'LHE' in self.stepMap or (not self._options.filein and hasattr(self._options, "evt_type")):
             if self.process.source is None:
                 self.process.source=cms.Source("EmptySource")
 
-	# modify source in case of run-dependent MC
-	self.runsAndWeights=None
-	if self._options.runsAndWeightsForMC or self._options.runsScenarioForMC :
-		if not self._options.isMC :
-			raise Exception("options --runsAndWeightsForMC and --runsScenarioForMC are only valid for MC")
-		if self._options.runsAndWeightsForMC:
-			self.runsAndWeights = eval(self._options.runsAndWeightsForMC)
-		else:
-			from Configuration.StandardSequences.RunsAndWeights import RunsAndWeights
-			if isinstance(RunsAndWeights[self._options.runsScenarioForMC], str):
-				__import__(RunsAndWeights[self._options.runsScenarioForMC])
-				self.runsAndWeights = sys.modules[RunsAndWeights[self._options.runsScenarioForMC]].runProbabilityDistribution
-			else:
-				self.runsAndWeights = RunsAndWeights[self._options.runsScenarioForMC]
-				
-	if self.runsAndWeights:
-		import SimGeneral.Configuration.ThrowAndSetRandomRun as ThrowAndSetRandomRun
-		ThrowAndSetRandomRun.throwAndSetRandomRun(self.process.source,self.runsAndWeights)
-		self.additionalCommands.append('import SimGeneral.Configuration.ThrowAndSetRandomRun as ThrowAndSetRandomRun')
-		self.additionalCommands.append('ThrowAndSetRandomRun.throwAndSetRandomRun(process.source,%s)'%(self.runsAndWeights))
+        # modify source in case of run-dependent MC
+        self.runsAndWeights=None
+        if self._options.runsAndWeightsForMC or self._options.runsScenarioForMC :
+            if not self._options.isMC :
+                raise Exception("options --runsAndWeightsForMC and --runsScenarioForMC are only valid for MC")
+            if self._options.runsAndWeightsForMC:
+                self.runsAndWeights = eval(self._options.runsAndWeightsForMC)
+            else:
+                from Configuration.StandardSequences.RunsAndWeights import RunsAndWeights
+                if isinstance(RunsAndWeights[self._options.runsScenarioForMC], str):
+                    __import__(RunsAndWeights[self._options.runsScenarioForMC])
+                    self.runsAndWeights = sys.modules[RunsAndWeights[self._options.runsScenarioForMC]].runProbabilityDistribution
+                else:
+                    self.runsAndWeights = RunsAndWeights[self._options.runsScenarioForMC]
+
+        if self.runsAndWeights:
+            import SimGeneral.Configuration.ThrowAndSetRandomRun as ThrowAndSetRandomRun
+            ThrowAndSetRandomRun.throwAndSetRandomRun(self.process.source,self.runsAndWeights)
+            self.additionalCommands.append('import SimGeneral.Configuration.ThrowAndSetRandomRun as ThrowAndSetRandomRun')
+            self.additionalCommands.append('ThrowAndSetRandomRun.throwAndSetRandomRun(process.source,%s)'%(self.runsAndWeights))
 
         return
 
     def addOutput(self):
         """ Add output module to the process """
-	result=""
-	if self._options.outputDefinition:
-		if self._options.datatier:
-			print("--datatier & --eventcontent options ignored")
-							
-		#new output convention with a list of dict
-		outList = eval(self._options.outputDefinition)
-		for (id,outDefDict) in enumerate(outList):
-			outDefDictStr=outDefDict.__str__()
-			if not isinstance(outDefDict,dict):
-				raise Exception("--output needs to be passed a list of dict"+self._options.outputDefinition+" is invalid")
-		        #requires option: tier
-			theTier=anyOf(['t','tier','dataTier'],outDefDict)
-		        #optional option: eventcontent, filtername, selectEvents, moduleLabel, filename
-			## event content
-			theStreamType=anyOf(['e','ec','eventContent','streamType'],outDefDict,theTier)
-			theFilterName=anyOf(['f','ftN','filterName'],outDefDict,'')
-			theSelectEvent=anyOf(['s','sE','selectEvents'],outDefDict,'')
-			theModuleLabel=anyOf(['l','mL','moduleLabel'],outDefDict,'')
-			theExtraOutputCommands=anyOf(['o','oC','outputCommands'],outDefDict,'')
-			# module label has a particular role
-			if not theModuleLabel:
-				tryNames=[theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+'output',
-					  theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+theFilterName+'output',
-					  theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+theFilterName+theSelectEvent.split(',')[0].replace(':','for').replace(' ','')+'output'
-					  ]
-				for name in tryNames:
-					if not hasattr(self.process,name):
-						theModuleLabel=name
-						break
-			if not theModuleLabel:
-				raise Exception("cannot find a module label for specification: "+outDefDictStr)
-			if id==0:
-				defaultFileName=self._options.outfile_name
-			else:
-				defaultFileName=self._options.outfile_name.replace('.root','_in'+theTier+'.root')
-				
-			theFileName=self._options.dirout+anyOf(['fn','fileName'],outDefDict,defaultFileName)
-			if not theFileName.endswith('.root'):
-				theFileName+='.root'
-				
-			if len(outDefDict):
-				raise Exception("unused keys from --output options: "+','.join(outDefDict.keys()))
-			if theStreamType=='DQMIO': theStreamType='DQM'
-			if theStreamType=='ALL':
-				theEventContent = cms.PSet(outputCommands = cms.untracked.vstring('keep *'))
-			else:
-				theEventContent = getattr(self.process, theStreamType+"EventContent")
+        result=""
+        if self._options.outputDefinition:
+            if self._options.datatier:
+                print("--datatier & --eventcontent options ignored")
+
+            #new output convention with a list of dict
+            outList = eval(self._options.outputDefinition)
+            for (id,outDefDict) in enumerate(outList):
+                outDefDictStr=outDefDict.__str__()
+                if not isinstance(outDefDict,dict):
+                    raise Exception("--output needs to be passed a list of dict"+self._options.outputDefinition+" is invalid")
+                #requires option: tier
+                theTier=anyOf(['t','tier','dataTier'],outDefDict)
+                #optional option: eventcontent, filtername, selectEvents, moduleLabel, filename
+                ## event content
+                theStreamType=anyOf(['e','ec','eventContent','streamType'],outDefDict,theTier)
+                theFilterName=anyOf(['f','ftN','filterName'],outDefDict,'')
+                theSelectEvent=anyOf(['s','sE','selectEvents'],outDefDict,'')
+                theModuleLabel=anyOf(['l','mL','moduleLabel'],outDefDict,'')
+                theExtraOutputCommands=anyOf(['o','oC','outputCommands'],outDefDict,'')
+                # module label has a particular role
+                if not theModuleLabel:
+                    tryNames=[theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+'output',
+                              theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+theFilterName+'output',
+                              theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+theFilterName+theSelectEvent.split(',')[0].replace(':','for').replace(' ','')+'output'
+                              ]
+                    for name in tryNames:
+                        if not hasattr(self.process,name):
+                            theModuleLabel=name
+                            break
+                if not theModuleLabel:
+                    raise Exception("cannot find a module label for specification: "+outDefDictStr)
+                if id==0:
+                    defaultFileName=self._options.outfile_name
+                else:
+                    defaultFileName=self._options.outfile_name.replace('.root','_in'+theTier+'.root')
+
+                theFileName=self._options.dirout+anyOf(['fn','fileName'],outDefDict,defaultFileName)
+                if not theFileName.endswith('.root'):
+                    theFileName+='.root'
+
+                if len(outDefDict):
+                    raise Exception("unused keys from --output options: "+','.join(outDefDict.keys()))
+                if theStreamType=='DQMIO': theStreamType='DQM'
+                if theStreamType=='ALL':
+                    theEventContent = cms.PSet(outputCommands = cms.untracked.vstring('keep *'))
+                else:
+                    theEventContent = getattr(self.process, theStreamType+"EventContent")
 
 
-			addAlCaSelects=False
-			if theStreamType=='ALCARECO' and not theFilterName:
-				theFilterName='StreamALCACombined'
-				addAlCaSelects=True
+                addAlCaSelects=False
+                if theStreamType=='ALCARECO' and not theFilterName:
+                    theFilterName='StreamALCACombined'
+                    addAlCaSelects=True
 
-			CppType='PoolOutputModule'
-			if self._options.timeoutOutput:
-				CppType='TimeoutPoolOutputModule'
-			if theStreamType=='DQM' and theTier=='DQMIO': CppType='DQMRootOutputModule'
-			output = cms.OutputModule(CppType,			
-						  theEventContent.clone(),
-						  fileName = cms.untracked.string(theFileName),
-						  dataset = cms.untracked.PSet(
-				                     dataTier = cms.untracked.string(theTier),
-						     filterName = cms.untracked.string(theFilterName))
-						  )
-			if not theSelectEvent and hasattr(self.process,'generation_step') and theStreamType!='LHE':
-				output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('generation_step'))
-			if not theSelectEvent and hasattr(self.process,'filtering_step'):
-				output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('filtering_step'))				
-			if theSelectEvent:
-				output.SelectEvents =cms.untracked.PSet(SelectEvents = cms.vstring(theSelectEvent))
+                CppType='PoolOutputModule'
+                if self._options.timeoutOutput:
+                    CppType='TimeoutPoolOutputModule'
+                if theStreamType=='DQM' and theTier=='DQMIO': CppType='DQMRootOutputModule'
+                output = cms.OutputModule(CppType,			
+                                          theEventContent.clone(),
+                                          fileName = cms.untracked.string(theFileName),
+                                          dataset = cms.untracked.PSet(
+                                             dataTier = cms.untracked.string(theTier),
+                                             filterName = cms.untracked.string(theFilterName))
+                                          )
+                if not theSelectEvent and hasattr(self.process,'generation_step') and theStreamType!='LHE':
+                    output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('generation_step'))
+                if not theSelectEvent and hasattr(self.process,'filtering_step'):
+                    output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('filtering_step'))				
+                if theSelectEvent:
+                    output.SelectEvents =cms.untracked.PSet(SelectEvents = cms.vstring(theSelectEvent))
 
-			if addAlCaSelects:
-				if not hasattr(output,'SelectEvents'):
-					output.SelectEvents=cms.untracked.PSet(SelectEvents=cms.vstring())
-				for alca in self.AlCaPaths:
-					output.SelectEvents.SelectEvents.extend(getattr(self.process,'OutALCARECO'+alca).SelectEvents.SelectEvents)
+                if addAlCaSelects:
+                    if not hasattr(output,'SelectEvents'):
+                        output.SelectEvents=cms.untracked.PSet(SelectEvents=cms.vstring())
+                    for alca in self.AlCaPaths:
+                        output.SelectEvents.SelectEvents.extend(getattr(self.process,'OutALCARECO'+alca).SelectEvents.SelectEvents)
 
-			
-			if hasattr(self.process,theModuleLabel):
-				raise Exception("the current process already has a module "+theModuleLabel+" defined")
-			#print "creating output module ",theModuleLabel
-			setattr(self.process,theModuleLabel,output)
-			outputModule=getattr(self.process,theModuleLabel)
-			setattr(self.process,theModuleLabel+'_step',cms.EndPath(outputModule))
-			path=getattr(self.process,theModuleLabel+'_step')
-			self.schedule.append(path)
 
-			if not self._options.inlineEventContent and hasattr(self.process,theStreamType+"EventContent"):
-				def doNotInlineEventContent(instance,label = "cms.untracked.vstring(process."+theStreamType+"EventContent.outputCommands)"):
-					return label
-				outputModule.outputCommands.__dict__["dumpPython"] = doNotInlineEventContent
-			if theExtraOutputCommands:
-				if not isinstance(theExtraOutputCommands,list):
-					raise Exception("extra ouput command in --option must be a list of strings")
-				if hasattr(self.process,theStreamType+"EventContent"):
-					self.executeAndRemember('process.%s.outputCommands.extend(%s)'%(theModuleLabel,theExtraOutputCommands))
-				else:
-					outputModule.outputCommands.extend(theExtraOutputCommands)
+                if hasattr(self.process,theModuleLabel):
+                    raise Exception("the current process already has a module "+theModuleLabel+" defined")
+                #print "creating output module ",theModuleLabel
+                setattr(self.process,theModuleLabel,output)
+                outputModule=getattr(self.process,theModuleLabel)
+                setattr(self.process,theModuleLabel+'_step',cms.EndPath(outputModule))
+                path=getattr(self.process,theModuleLabel+'_step')
+                self.schedule.append(path)
 
-			result+="\nprocess."+theModuleLabel+" = "+outputModule.dumpPython()
+                if not self._options.inlineEventContent and hasattr(self.process,theStreamType+"EventContent"):
+                    def doNotInlineEventContent(instance,label = "cms.untracked.vstring(process."+theStreamType+"EventContent.outputCommands)"):
+                        return label
+                    outputModule.outputCommands.__dict__["dumpPython"] = doNotInlineEventContent
+                if theExtraOutputCommands:
+                    if not isinstance(theExtraOutputCommands,list):
+                        raise Exception("extra ouput command in --option must be a list of strings")
+                    if hasattr(self.process,theStreamType+"EventContent"):
+                        self.executeAndRemember('process.%s.outputCommands.extend(%s)'%(theModuleLabel,theExtraOutputCommands))
+                    else:
+                        outputModule.outputCommands.extend(theExtraOutputCommands)
 
-		##ends the --output options model
-		return result
+                result+="\nprocess."+theModuleLabel+" = "+outputModule.dumpPython()
 
-	streamTypes=self._options.eventcontent.split(',')
-	tiers=self._options.datatier.split(',')
-	if not self._options.outputDefinition and len(streamTypes)!=len(tiers):
-		raise Exception("number of event content arguments does not match number of datatier arguments")
+            ##ends the --output options model
+            return result
+
+        streamTypes=self._options.eventcontent.split(',')
+        tiers=self._options.datatier.split(',')
+        if not self._options.outputDefinition and len(streamTypes)!=len(tiers):
+            raise Exception("number of event content arguments does not match number of datatier arguments")
 
         # if the only step is alca we don't need to put in an output
         if self._options.step.split(',')[0].split(':')[0] == 'ALCA':
             return "\n"
 
         for i,(streamType,tier) in enumerate(zip(streamTypes,tiers)):
-		if streamType=='': continue
-		if streamType == 'ALCARECO' and not 'ALCAPRODUCER' in self._options.step: continue
-		if streamType=='DQMIO': streamType='DQM'
-		eventContent=streamType
-                ## override streamType to eventContent in case NANOEDM
-		if streamType == "NANOEDMAOD" :
-			eventContent = "NANOAOD"
-		elif streamType == "NANOEDMAODSIM" :
-			eventContent = "NANOAODSIM"
-                theEventContent = getattr(self.process, eventContent+"EventContent")
-                if i==0:
-                        theFileName=self._options.outfile_name
-                        theFilterName=self._options.filtername
-                else:
-                        theFileName=self._options.outfile_name.replace('.root','_in'+streamType+'.root')
-                        theFilterName=self._options.filtername
-		CppType='PoolOutputModule'
-		if self._options.timeoutOutput:
-			CppType='TimeoutPoolOutputModule'
-		if streamType=='DQM' and tier=='DQMIO': CppType='DQMRootOutputModule'
-		if "NANOAOD" in streamType : CppType='NanoAODOutputModule'
-                output = cms.OutputModule(CppType,
-                                          theEventContent,
-                                          fileName = cms.untracked.string(theFileName),
-                                          dataset = cms.untracked.PSet(dataTier = cms.untracked.string(tier),
-                                                                       filterName = cms.untracked.string(theFilterName)
-                                                                       )
-                                          )
-                if hasattr(self.process,"generation_step") and streamType!='LHE':
-                        output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('generation_step'))
-		if hasattr(self.process,"filtering_step"):
-                        output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('filtering_step'))
+            if streamType=='': continue
+            if streamType == 'ALCARECO' and not 'ALCAPRODUCER' in self._options.step: continue
+            if streamType=='DQMIO': streamType='DQM'
+            eventContent=streamType
+            ## override streamType to eventContent in case NANOEDM
+            if streamType == "NANOEDMAOD" :
+                eventContent = "NANOAOD"
+            elif streamType == "NANOEDMAODSIM" :
+                eventContent = "NANOAODSIM"
+            theEventContent = getattr(self.process, eventContent+"EventContent")
+            if i==0:
+                theFileName=self._options.outfile_name
+                theFilterName=self._options.filtername
+            else:
+                theFileName=self._options.outfile_name.replace('.root','_in'+streamType+'.root')
+                theFilterName=self._options.filtername
+            CppType='PoolOutputModule'
+            if self._options.timeoutOutput:
+                CppType='TimeoutPoolOutputModule'
+            if streamType=='DQM' and tier=='DQMIO': CppType='DQMRootOutputModule'
+            if "NANOAOD" in streamType : CppType='NanoAODOutputModule'
+            output = cms.OutputModule(CppType,
+                                      theEventContent,
+                                      fileName = cms.untracked.string(theFileName),
+                                      dataset = cms.untracked.PSet(dataTier = cms.untracked.string(tier),
+                                                                   filterName = cms.untracked.string(theFilterName)
+                                                                   )
+                                      )
+            if hasattr(self.process,"generation_step") and streamType!='LHE':
+                output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('generation_step'))
+            if hasattr(self.process,"filtering_step"):
+                output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('filtering_step'))
 
-                if streamType=='ALCARECO':
-                        output.dataset.filterName = cms.untracked.string('StreamALCACombined')
+            if streamType=='ALCARECO':
+                output.dataset.filterName = cms.untracked.string('StreamALCACombined')
 
-                if "MINIAOD" in streamType:
-                    from PhysicsTools.PatAlgos.slimming.miniAOD_tools import miniAOD_customizeOutput
-                    miniAOD_customizeOutput(output)
+            if "MINIAOD" in streamType:
+                from PhysicsTools.PatAlgos.slimming.miniAOD_tools import miniAOD_customizeOutput
+                miniAOD_customizeOutput(output)
 
-                outputModuleName=streamType+'output'
-                setattr(self.process,outputModuleName,output)
-                outputModule=getattr(self.process,outputModuleName)
-                setattr(self.process,outputModuleName+'_step',cms.EndPath(outputModule))
-                path=getattr(self.process,outputModuleName+'_step')
-                self.schedule.append(path)
+            outputModuleName=streamType+'output'
+            setattr(self.process,outputModuleName,output)
+            outputModule=getattr(self.process,outputModuleName)
+            setattr(self.process,outputModuleName+'_step',cms.EndPath(outputModule))
+            path=getattr(self.process,outputModuleName+'_step')
+            self.schedule.append(path)
 
-		if self._options.outputCommands and streamType!='DQM':
-			for evct in self._options.outputCommands.split(','):
-				if not evct: continue
-				self.executeAndRemember("process.%s.outputCommands.append('%s')"%(outputModuleName,evct.strip()))
-				
-                if not self._options.inlineEventContent:
-			tmpstreamType=streamType
-			if "NANOEDM" in tmpstreamType :
-				tmpstreamType=tmpstreamType.replace("NANOEDM","NANO")
-			def doNotInlineEventContent(instance,label = "process."+tmpstreamType+"EventContent.outputCommands"):
-                                return label
-                        outputModule.outputCommands.__dict__["dumpPython"] = doNotInlineEventContent
+            if self._options.outputCommands and streamType!='DQM':
+                for evct in self._options.outputCommands.split(','):
+                    if not evct: continue
+                    self.executeAndRemember("process.%s.outputCommands.append('%s')"%(outputModuleName,evct.strip()))
 
-                result+="\nprocess."+outputModuleName+" = "+outputModule.dumpPython()
+            if not self._options.inlineEventContent:
+                tmpstreamType=streamType
+                if "NANOEDM" in tmpstreamType :
+                    tmpstreamType=tmpstreamType.replace("NANOEDM","NANO")
+                def doNotInlineEventContent(instance,label = "process."+tmpstreamType+"EventContent.outputCommands"):
+                    return label
+                outputModule.outputCommands.__dict__["dumpPython"] = doNotInlineEventContent
+
+            result+="\nprocess."+outputModuleName+" = "+outputModule.dumpPython()
 
         return result
 
@@ -682,135 +682,135 @@ class ConfigBuilder(object):
         Add selected standard sequences to the process
         """
         # load the pile up file
-	if self._options.pileup:
-		pileupSpec=self._options.pileup.split(',')[0]
+        if self._options.pileup:
+            pileupSpec=self._options.pileup.split(',')[0]
 
-		# Does the requested pile-up scenario exist?
-		from Configuration.StandardSequences.Mixing import Mixing,defineMixing
-		if not pileupSpec in Mixing and '.' not in pileupSpec and 'file:' not in pileupSpec:
-			message = pileupSpec+' is not a know mixing scenario:\n available are: '+'\n'.join(Mixing.keys())
-			raise Exception(message)
+            # Does the requested pile-up scenario exist?
+            from Configuration.StandardSequences.Mixing import Mixing,defineMixing
+            if not pileupSpec in Mixing and '.' not in pileupSpec and 'file:' not in pileupSpec:
+                message = pileupSpec+' is not a know mixing scenario:\n available are: '+'\n'.join(Mixing.keys())
+                raise Exception(message)
 
-		# Put mixing parameters in a dictionary
-		if '.' in pileupSpec:
-			mixingDict={'file':pileupSpec}
-		elif pileupSpec.startswith('file:'):
-			mixingDict={'file':pileupSpec[5:]}
-		else:
-			import copy
-			mixingDict=copy.copy(Mixing[pileupSpec])
-		if len(self._options.pileup.split(','))>1:
-			mixingDict.update(eval(self._options.pileup[self._options.pileup.find(',')+1:]))
+            # Put mixing parameters in a dictionary
+            if '.' in pileupSpec:
+                mixingDict={'file':pileupSpec}
+            elif pileupSpec.startswith('file:'):
+                mixingDict={'file':pileupSpec[5:]}
+            else:
+                import copy
+                mixingDict=copy.copy(Mixing[pileupSpec])
+            if len(self._options.pileup.split(','))>1:
+                mixingDict.update(eval(self._options.pileup[self._options.pileup.find(',')+1:]))
 
-		# Load the pu cfg file corresponding to the requested pu scenario
-		if 'file:' in pileupSpec:
-			#the file is local
-			self.process.load(mixingDict['file'])
-			print("inlining mixing module configuration")
-			self._options.inlineObjets+=',mix'
-		else:
-			self.loadAndRemember(mixingDict['file'])
+            # Load the pu cfg file corresponding to the requested pu scenario
+            if 'file:' in pileupSpec:
+                #the file is local
+                self.process.load(mixingDict['file'])
+                print("inlining mixing module configuration")
+                self._options.inlineObjets+=',mix'
+            else:
+                self.loadAndRemember(mixingDict['file'])
 
-		mixingDict.pop('file')
-		if not "DATAMIX" in self.stepMap.keys(): # when DATAMIX is present, pileup_input refers to pre-mixed GEN-RAW
-			if self._options.pileup_input:
-				if self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:'):
-					mixingDict['F']=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],),self._options.pileup_dasoption)[0]
-				elif self._options.pileup_input.startswith("filelist:"):
-					mixingDict['F']=(filesFromList(self._options.pileup_input[9:]))[0]
-				else:
-					mixingDict['F']=self._options.pileup_input.split(',')
-			specialization=defineMixing(mixingDict)
-			for command in specialization:
-				self.executeAndRemember(command)
-			if len(mixingDict)!=0:
-				raise Exception('unused mixing specification: '+mixingDict.keys().__str__())
+            mixingDict.pop('file')
+            if not "DATAMIX" in self.stepMap.keys(): # when DATAMIX is present, pileup_input refers to pre-mixed GEN-RAW
+                if self._options.pileup_input:
+                    if self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:'):
+                        mixingDict['F']=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],),self._options.pileup_dasoption)[0]
+                    elif self._options.pileup_input.startswith("filelist:"):
+                        mixingDict['F']=(filesFromList(self._options.pileup_input[9:]))[0]
+                    else:
+                        mixingDict['F']=self._options.pileup_input.split(',')
+                specialization=defineMixing(mixingDict)
+                for command in specialization:
+                    self.executeAndRemember(command)
+                if len(mixingDict)!=0:
+                    raise Exception('unused mixing specification: '+mixingDict.keys().__str__())
 
 
         # load the geometry file
         try:
-		if len(self.stepMap):
-			self.loadAndRemember(self.GeometryCFF)
-			if ('SIM' in self.stepMap or 'reSIM' in self.stepMap) and not self._options.fast:
-				self.loadAndRemember(self.SimGeometryCFF)
-				if self.geometryDBLabel:
-					self.executeAndRemember('process.XMLFromDBSource.label = cms.string("%s")'%(self.geometryDBLabel))
+            if len(self.stepMap):
+                self.loadAndRemember(self.GeometryCFF)
+                if ('SIM' in self.stepMap or 'reSIM' in self.stepMap) and not self._options.fast:
+                    self.loadAndRemember(self.SimGeometryCFF)
+                    if self.geometryDBLabel:
+                        self.executeAndRemember('process.XMLFromDBSource.label = cms.string("%s")'%(self.geometryDBLabel))
         except ImportError:
-                print("Geometry option",self._options.geometry,"unknown.")
-                raise
+            print("Geometry option",self._options.geometry,"unknown.")
+            raise
 
-	if len(self.stepMap):
-		self.loadAndRemember(self.magFieldCFF)
+        if len(self.stepMap):
+            self.loadAndRemember(self.magFieldCFF)
 
-	for stepName in self.stepKeys:
-		stepSpec = self.stepMap[stepName]
-		print("Step:", stepName,"Spec:",stepSpec)
-		if stepName.startswith('re'):
-			##add the corresponding input content
-			if stepName[2:] not in self._options.donotDropOnInput:
-				self._options.inputEventContent='%s,%s'%(stepName.upper(),self._options.inputEventContent)
-			stepName=stepName[2:]
-		if stepSpec=="":
-			getattr(self,"prepare_"+stepName)(sequence = getattr(self,stepName+"DefaultSeq"))
-		elif isinstance(stepSpec, list):
-			getattr(self,"prepare_"+stepName)(sequence = '+'.join(stepSpec))
-		elif isinstance(stepSpec, tuple):
-			getattr(self,"prepare_"+stepName)(sequence = ','.join([stepSpec[1],'+'.join(stepSpec[0])]))
-		else:
-			raise ValueError("Invalid step definition")
-		
-	if self._options.restoreRNDSeeds!=False:
-		#it is either True, or a process name
-		if self._options.restoreRNDSeeds==True:
-			self.executeAndRemember('process.RandomNumberGeneratorService.restoreStateLabel=cms.untracked.string("randomEngineStateProducer")')
-		else:
-			self.executeAndRemember('process.RandomNumberGeneratorService.restoreStateTag=cms.untracked.InputTag("randomEngineStateProducer","","%s")'%(self._options.restoreRNDSeeds))
-		if self._options.inputEventContent or self._options.inputCommands:
-			if self._options.inputCommands:
-				self._options.inputCommands+='keep *_randomEngineStateProducer_*_*,'
-			else:
-				self._options.inputCommands='keep *_randomEngineStateProducer_*_*,'
-					
+        for stepName in self.stepKeys:
+            stepSpec = self.stepMap[stepName]
+            print("Step:", stepName,"Spec:",stepSpec)
+            if stepName.startswith('re'):
+                ##add the corresponding input content
+                if stepName[2:] not in self._options.donotDropOnInput:
+                    self._options.inputEventContent='%s,%s'%(stepName.upper(),self._options.inputEventContent)
+                stepName=stepName[2:]
+            if stepSpec=="":
+                getattr(self,"prepare_"+stepName)(sequence = getattr(self,stepName+"DefaultSeq"))
+            elif isinstance(stepSpec, list):
+                getattr(self,"prepare_"+stepName)(sequence = '+'.join(stepSpec))
+            elif isinstance(stepSpec, tuple):
+                getattr(self,"prepare_"+stepName)(sequence = ','.join([stepSpec[1],'+'.join(stepSpec[0])]))
+            else:
+                raise ValueError("Invalid step definition")
+
+        if self._options.restoreRNDSeeds!=False:
+            #it is either True, or a process name
+            if self._options.restoreRNDSeeds==True:
+                self.executeAndRemember('process.RandomNumberGeneratorService.restoreStateLabel=cms.untracked.string("randomEngineStateProducer")')
+            else:
+                self.executeAndRemember('process.RandomNumberGeneratorService.restoreStateTag=cms.untracked.InputTag("randomEngineStateProducer","","%s")'%(self._options.restoreRNDSeeds))
+            if self._options.inputEventContent or self._options.inputCommands:
+                if self._options.inputCommands:
+                    self._options.inputCommands+='keep *_randomEngineStateProducer_*_*,'
+                else:
+                    self._options.inputCommands='keep *_randomEngineStateProducer_*_*,'
+
 
     def completeInputCommand(self):
-	    if self._options.inputEventContent:
-		    import copy
-		    def dropSecondDropStar(iec):
-			    #drop occurence of 'drop *' in the list
-			    count=0
-			    for item in iec:
-				    if item=='drop *':
-					    if count!=0:
-						    iec.remove(item)
-					    count+=1
+        if self._options.inputEventContent:
+            import copy
+            def dropSecondDropStar(iec):
+                #drop occurence of 'drop *' in the list
+                count=0
+                for item in iec:
+                    if item=='drop *':
+                        if count!=0:
+                            iec.remove(item)
+                        count+=1
 
 
-		    ## allow comma separated input eventcontent
-		    if not hasattr(self.process.source,'inputCommands'): self.process.source.inputCommands=cms.untracked.vstring()
-		    for evct in self._options.inputEventContent.split(','):
-			    if evct=='': continue
-			    theEventContent = getattr(self.process, evct+"EventContent")
-			    if hasattr(theEventContent,'outputCommands'):
-				    self.process.source.inputCommands.extend(copy.copy(theEventContent.outputCommands))
-			    if hasattr(theEventContent,'inputCommands'):
-				    self.process.source.inputCommands.extend(copy.copy(theEventContent.inputCommands))
+            ## allow comma separated input eventcontent
+            if not hasattr(self.process.source,'inputCommands'): self.process.source.inputCommands=cms.untracked.vstring()
+            for evct in self._options.inputEventContent.split(','):
+                if evct=='': continue
+                theEventContent = getattr(self.process, evct+"EventContent")
+                if hasattr(theEventContent,'outputCommands'):
+                    self.process.source.inputCommands.extend(copy.copy(theEventContent.outputCommands))
+                if hasattr(theEventContent,'inputCommands'):
+                    self.process.source.inputCommands.extend(copy.copy(theEventContent.inputCommands))
 
-		    dropSecondDropStar(self.process.source.inputCommands)
-		    
-		    if not self._options.dropDescendant:
-			    self.process.source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
+            dropSecondDropStar(self.process.source.inputCommands)
 
-			    
-	    return 
+            if not self._options.dropDescendant:
+                self.process.source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
+
+
+        return 
 
     def addConditions(self):
         """Add conditions to the process"""
-	if not self._options.conditions: return
-	
-	if 'FrontierConditions_GlobalTag' in self._options.conditions:
-		print('using FrontierConditions_GlobalTag in --conditions is not necessary anymore and will be deprecated soon. please update your command line')
-		self._options.conditions = self._options.conditions.replace("FrontierConditions_GlobalTag,",'')
-						
+        if not self._options.conditions: return
+
+        if 'FrontierConditions_GlobalTag' in self._options.conditions:
+            print('using FrontierConditions_GlobalTag in --conditions is not necessary anymore and will be deprecated soon. please update your command line')
+            self._options.conditions = self._options.conditions.replace("FrontierConditions_GlobalTag,",'')
+
         self.loadAndRemember(self.ConditionsDefaultCFF)
         from Configuration.AlCa.GlobalTag import GlobalTag
         self.process.GlobalTag = GlobalTag(self.process.GlobalTag, self._options.conditions, self._options.custom_conditions)
@@ -821,84 +821,84 @@ class ConfigBuilder(object):
     def addCustomise(self,unsch=0):
         """Include the customise code """
 
-	custOpt=[]
-	if unsch==0:
-		for c in self._options.customisation_file:
-			custOpt.extend(c.split(","))
-	else:
-		for c in self._options.customisation_file_unsch:
-			custOpt.extend(c.split(","))
-
-	custMap=DictTypes.SortedKeysDict()
-	for opt in custOpt:
-		if opt=='': continue
-		if opt.count('.')>1:
-			raise Exception("more than . in the specification:"+opt)
-		fileName=opt.split('.')[0]
-		if opt.count('.')==0:	rest='customise'
-		else:
-			rest=opt.split('.')[1]
-			if rest=='py': rest='customise' #catch the case of --customise file.py
-			
-		if fileName in custMap:
-			custMap[fileName].extend(rest.split('+'))
-		else:
-			custMap[fileName]=rest.split('+')
-		
-        if len(custMap)==0:
-                final_snippet='\n'
+        custOpt=[]
+        if unsch==0:
+            for c in self._options.customisation_file:
+                custOpt.extend(c.split(","))
         else:
-                final_snippet='\n# customisation of the process.\n'
+            for c in self._options.customisation_file_unsch:
+                custOpt.extend(c.split(","))
 
-	allFcn=[]
-	for opt in custMap:
-		allFcn.extend(custMap[opt])
-	for fcn in allFcn:
-		if allFcn.count(fcn)!=1:
-			raise Exception("cannot specify twice "+fcn+" as a customisation method") 
+        custMap=DictTypes.SortedKeysDict()
+        for opt in custOpt:
+            if opt=='': continue
+            if opt.count('.')>1:
+                raise Exception("more than . in the specification:"+opt)
+            fileName=opt.split('.')[0]
+            if opt.count('.')==0:	rest='customise'
+            else:
+                rest=opt.split('.')[1]
+                if rest=='py': rest='customise' #catch the case of --customise file.py
 
-	for f in custMap:
-		# let python search for that package and do syntax checking at the same time
-                packageName = f.replace(".py","").replace("/",".")
-                __import__(packageName)
-                package = sys.modules[packageName]
+            if fileName in custMap:
+                custMap[fileName].extend(rest.split('+'))
+            else:
+                custMap[fileName]=rest.split('+')
 
-                # now ask the package for its definition and pick .py instead of .pyc
-                customiseFile = re.sub(r'\.pyc$', '.py', package.__file__)
-		
-                final_snippet+='\n# Automatic addition of the customisation function from '+packageName+'\n'
-		if self._options.inline_custom:
-			for line in file(customiseFile,'r'):
-				if "import FWCore.ParameterSet.Config" in line:
-					continue
-				final_snippet += line
-		else:
-			final_snippet += 'from %s import %s \n'%(packageName,','.join(custMap[f]))
-		for fcn in custMap[f]:
-			print("customising the process with",fcn,"from",f)
-			if not hasattr(package,fcn):
-				#bound to fail at run time
-				raise Exception("config "+f+" has no function "+fcn)
-			#execute the command
-			self.process=getattr(package,fcn)(self.process)
-			#and print it in the configuration
-			final_snippet += "\n#call to customisation function "+fcn+" imported from "+packageName
-			final_snippet += "\nprocess = %s(process)\n"%(fcn,)
+        if len(custMap)==0:
+            final_snippet='\n'
+        else:
+            final_snippet='\n# customisation of the process.\n'
 
-	if len(custMap)!=0:
-		final_snippet += '\n# End of customisation functions\n'
+        allFcn=[]
+        for opt in custMap:
+            allFcn.extend(custMap[opt])
+        for fcn in allFcn:
+            if allFcn.count(fcn)!=1:
+                raise Exception("cannot specify twice "+fcn+" as a customisation method") 
 
-	### now for a useful command
-	return final_snippet
+        for f in custMap:
+            # let python search for that package and do syntax checking at the same time
+            packageName = f.replace(".py","").replace("/",".")
+            __import__(packageName)
+            package = sys.modules[packageName]
+
+            # now ask the package for its definition and pick .py instead of .pyc
+            customiseFile = re.sub(r'\.pyc$', '.py', package.__file__)
+
+            final_snippet+='\n# Automatic addition of the customisation function from '+packageName+'\n'
+            if self._options.inline_custom:
+                for line in file(customiseFile,'r'):
+                    if "import FWCore.ParameterSet.Config" in line:
+                        continue
+                    final_snippet += line
+            else:
+                final_snippet += 'from %s import %s \n'%(packageName,','.join(custMap[f]))
+            for fcn in custMap[f]:
+                print("customising the process with",fcn,"from",f)
+                if not hasattr(package,fcn):
+                    #bound to fail at run time
+                    raise Exception("config "+f+" has no function "+fcn)
+                #execute the command
+                self.process=getattr(package,fcn)(self.process)
+                #and print it in the configuration
+                final_snippet += "\n#call to customisation function "+fcn+" imported from "+packageName
+                final_snippet += "\nprocess = %s(process)\n"%(fcn,)
+
+        if len(custMap)!=0:
+            final_snippet += '\n# End of customisation functions\n'
+
+        ### now for a useful command
+        return final_snippet
 
     def addCustomiseCmdLine(self):
         final_snippet='\n# Customisation from command line\n'
-	if self._options.customise_commands:
-		import string
-		for com in self._options.customise_commands.split('\\n'):
-			com=string.lstrip(com)
-			self.executeAndRemember(com)
-			final_snippet +='\n'+com
+        if self._options.customise_commands:
+            import string
+            for com in self._options.customise_commands.split('\\n'):
+                com=string.lstrip(com)
+                self.executeAndRemember(com)
+                final_snippet +='\n'+com
 
         return final_snippet
 
@@ -908,14 +908,14 @@ class ConfigBuilder(object):
     #----------------------------------------------------------------------------
     def define_Configs(self):
         if len(self.stepMap):
-		self.loadAndRemember('Configuration/StandardSequences/Services_cff')
+            self.loadAndRemember('Configuration/StandardSequences/Services_cff')
         if self._options.particleTable not in defaultOptions.particleTableList:
             print('Invalid particle table provided. Options are:')
             print(defaultOptions.particleTable)
             sys.exit(-1)
         else:
-	    if len(self.stepMap):
-		    self.loadAndRemember('SimGeneral.HepPDTESSource.'+self._options.particleTable+'_cfi')
+            if len(self.stepMap):
+                self.loadAndRemember('SimGeneral.HepPDTESSource.'+self._options.particleTable+'_cfi')
 
         self.loadAndRemember('FWCore/MessageService/MessageLogger_cfi')
 
@@ -934,7 +934,7 @@ class ConfigBuilder(object):
         self.RECOSIMDefaultCFF="Configuration/StandardSequences/RecoSim_cff"
         self.PATDefaultCFF="Configuration/StandardSequences/PAT_cff"
         self.NANODefaultCFF="PhysicsTools/NanoAOD/nano_cff"
-	self.EIDefaultCFF=None
+        self.EIDefaultCFF=None
         self.SKIMDefaultCFF="Configuration/StandardSequences/Skims_cff"
         self.POSTRECODefaultCFF="Configuration/StandardSequences/PostRecoGenerator_cff"
         self.VALIDATIONDefaultCFF="Configuration/StandardSequences/Validation_cff"
@@ -954,7 +954,7 @@ class ConfigBuilder(object):
             self.L1EMDefaultCFF='Configuration/StandardSequences/SimL1EmulatorDM_cff'
 
         self.ALCADefaultSeq=None
-	self.LHEDefaultSeq='externalLHEProducer'
+        self.LHEDefaultSeq='externalLHEProducer'
         self.GENDefaultSeq='pgen'
         self.SIMDefaultSeq='psim'
         self.DIGIDefaultSeq='pdigi'
@@ -970,47 +970,47 @@ class ConfigBuilder(object):
         self.L1RecoDefaultSeq='L1Reco'
         self.L1TrackTriggerDefaultSeq='L1TrackTrigger'
         if self._options.fast or ('RAW2DIGI' in self.stepMap and 'RECO' in self.stepMap):
-                self.RECODefaultSeq='reconstruction'
+            self.RECODefaultSeq='reconstruction'
         else:
-                self.RECODefaultSeq='reconstruction_fromRECO'
+            self.RECODefaultSeq='reconstruction_fromRECO'
         self.RECOSIMDefaultSeq='recosim'
-	self.EIDefaultSeq='top'
+        self.EIDefaultSeq='top'
         self.POSTRECODefaultSeq=None
         self.L1HwValDefaultSeq='L1HwVal'
         self.DQMDefaultSeq='DQMOffline'
         self.VALIDATIONDefaultSeq=''
         self.ENDJOBDefaultSeq='endOfProcess'
         self.REPACKDefaultSeq='DigiToRawRepack'
-	self.PATDefaultSeq='miniAOD'
-	self.PATGENDefaultSeq='miniGEN'
-	self.NANODefaultSeq='nanoSequence'
+        self.PATDefaultSeq='miniAOD'
+        self.PATGENDefaultSeq='miniGEN'
+        self.NANODefaultSeq='nanoSequence'
 
         self.EVTCONTDefaultCFF="Configuration/EventContent/EventContent_cff"
 
-	if not self._options.beamspot:
-		self._options.beamspot=VtxSmearedDefaultKey
-		
+        if not self._options.beamspot:
+            self._options.beamspot=VtxSmearedDefaultKey
+
         # if its MC then change the raw2digi
         if self._options.isMC==True:
-                self.RAW2DIGIDefaultCFF="Configuration/StandardSequences/RawToDigi_cff"
-		self.RECODefaultCFF="Configuration/StandardSequences/Reconstruction_cff"
-		self.PATDefaultCFF="Configuration/StandardSequences/PATMC_cff"
-		self.PATGENDefaultCFF="Configuration/StandardSequences/PATGEN_cff"
-                self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineMC_cff"
-                self.ALCADefaultCFF="Configuration/StandardSequences/AlCaRecoStreamsMC_cff"
-	        self.NANODefaultSeq='nanoSequenceMC'
-	else:
-		self._options.beamspot = None
-	
-	#patch for gen, due to backward incompatibility
-	if 'reGEN' in self.stepMap:
-		self.GENDefaultSeq='fixGenInfo'
+            self.RAW2DIGIDefaultCFF="Configuration/StandardSequences/RawToDigi_cff"
+            self.RECODefaultCFF="Configuration/StandardSequences/Reconstruction_cff"
+            self.PATDefaultCFF="Configuration/StandardSequences/PATMC_cff"
+            self.PATGENDefaultCFF="Configuration/StandardSequences/PATGEN_cff"
+            self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineMC_cff"
+            self.ALCADefaultCFF="Configuration/StandardSequences/AlCaRecoStreamsMC_cff"
+            self.NANODefaultSeq='nanoSequenceMC'
+        else:
+            self._options.beamspot = None
+
+        #patch for gen, due to backward incompatibility
+        if 'reGEN' in self.stepMap:
+            self.GENDefaultSeq='fixGenInfo'
 
         if self._options.scenario=='cosmics':
-	    self._options.pileup='Cosmics'	
+            self._options.pileup='Cosmics'	
             self.DIGIDefaultCFF="Configuration/StandardSequences/DigiCosmics_cff"
             self.RECODefaultCFF="Configuration/StandardSequences/ReconstructionCosmics_cff"
-	    self.SKIMDefaultCFF="Configuration/StandardSequences/SkimsCosmics_cff"
+            self.SKIMDefaultCFF="Configuration/StandardSequences/SkimsCosmics_cff"
             self.EVTCONTDefaultCFF="Configuration/EventContent/EventContentCosmics_cff"
             self.VALIDATIONDefaultCFF="Configuration/StandardSequences/ValidationCosmics_cff"
             self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineCosmics_cff"
@@ -1021,8 +1021,8 @@ class ConfigBuilder(object):
             self.DQMDefaultSeq='DQMOfflineCosmics'
 
         if self._options.scenario=='HeavyIons':
-	    if not self._options.beamspot:
-		    self._options.beamspot=VtxSmearedHIDefaultKey
+            if not self._options.beamspot:
+                self._options.beamspot=VtxSmearedHIDefaultKey
             self.HLTDefaultSeq = 'HIon'
             self.VALIDATIONDefaultCFF="Configuration/StandardSequences/ValidationHeavyIons_cff"
             self.VALIDATIONDefaultSeq=''
@@ -1035,198 +1035,198 @@ class ConfigBuilder(object):
             self.SKIMDefaultCFF="Configuration/StandardSequences/SkimsHeavyIons_cff"
             self.HARVESTINGDefaultCFF="Configuration/StandardSequences/HarvestingHeavyIons_cff"
             if self._options.isMC==True:
-                    self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineHeavyIonsMC_cff"
+                self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineHeavyIonsMC_cff"
 
 
         self.RAW2RECODefaultSeq=','.join([self.RAW2DIGIDefaultSeq,self.RECODefaultSeq])
 
-	self.USERDefaultSeq='user'
-	self.USERDefaultCFF=None
+        self.USERDefaultSeq='user'
+        self.USERDefaultCFF=None
 
         # the magnetic field
-	if self._options.isData:
-		if self._options.magField==defaultOptions.magField:
-			print("magnetic field option forced to: AutoFromDBCurrent")
-		self._options.magField='AutoFromDBCurrent'
+        if self._options.isData:
+            if self._options.magField==defaultOptions.magField:
+                print("magnetic field option forced to: AutoFromDBCurrent")
+            self._options.magField='AutoFromDBCurrent'
         self.magFieldCFF = 'Configuration/StandardSequences/MagneticField_'+self._options.magField.replace('.','')+'_cff'
         self.magFieldCFF = self.magFieldCFF.replace("__",'_')
 
         # the geometry
-	self.GeometryCFF='Configuration/StandardSequences/GeometryRecoDB_cff'
-	self.geometryDBLabel=None
-	simGeometry=''
+        self.GeometryCFF='Configuration/StandardSequences/GeometryRecoDB_cff'
+        self.geometryDBLabel=None
+        simGeometry=''
         if self._options.fast:
-                if 'start' in self._options.conditions.lower():
-                        self.GeometryCFF='FastSimulation/Configuration/Geometries_START_cff'
-                else:
-                        self.GeometryCFF='FastSimulation/Configuration/Geometries_MC_cff'
+            if 'start' in self._options.conditions.lower():
+                self.GeometryCFF='FastSimulation/Configuration/Geometries_START_cff'
+            else:
+                self.GeometryCFF='FastSimulation/Configuration/Geometries_MC_cff'
         else:
-		def inGeometryKeys(opt):
-			from Configuration.StandardSequences.GeometryConf import GeometryConf
-			if opt in GeometryConf:
-				return GeometryConf[opt]
-			else:
-				return opt
+            def inGeometryKeys(opt):
+                from Configuration.StandardSequences.GeometryConf import GeometryConf
+                if opt in GeometryConf:
+                    return GeometryConf[opt]
+                else:
+                    return opt
 
-		geoms=self._options.geometry.split(',')
-		if len(geoms)==1: geoms=inGeometryKeys(geoms[0]).split(',')
-		if len(geoms)==2:
-			#may specify the reco geometry
-			if '/' in geoms[1] or '_cff' in geoms[1]:
-				self.GeometryCFF=geoms[1]
-			else:
-				self.GeometryCFF='Configuration/Geometry/Geometry'+geoms[1]+'_cff'
+            geoms=self._options.geometry.split(',')
+            if len(geoms)==1: geoms=inGeometryKeys(geoms[0]).split(',')
+            if len(geoms)==2:
+                #may specify the reco geometry
+                if '/' in geoms[1] or '_cff' in geoms[1]:
+                    self.GeometryCFF=geoms[1]
+                else:
+                    self.GeometryCFF='Configuration/Geometry/Geometry'+geoms[1]+'_cff'
 
-		if (geoms[0].startswith('DB:')):
-			self.SimGeometryCFF='Configuration/StandardSequences/GeometrySimDB_cff'
-			self.geometryDBLabel=geoms[0][3:]
-			print("with DB:")
-		else:
-			if '/' in geoms[0] or '_cff' in geoms[0]:
-								self.SimGeometryCFF=geoms[0]
-			else:
-				simGeometry=geoms[0]
-				if self._options.gflash==True:
-					self.SimGeometryCFF='Configuration/Geometry/Geometry'+geoms[0]+'GFlash_cff'
-				else:
-					self.SimGeometryCFF='Configuration/Geometry/Geometry'+geoms[0]+'_cff'
+            if (geoms[0].startswith('DB:')):
+                self.SimGeometryCFF='Configuration/StandardSequences/GeometrySimDB_cff'
+                self.geometryDBLabel=geoms[0][3:]
+                print("with DB:")
+            else:
+                if '/' in geoms[0] or '_cff' in geoms[0]:
+                    self.SimGeometryCFF=geoms[0]
+                else:
+                    simGeometry=geoms[0]
+                    if self._options.gflash==True:
+                        self.SimGeometryCFF='Configuration/Geometry/Geometry'+geoms[0]+'GFlash_cff'
+                    else:
+                        self.SimGeometryCFF='Configuration/Geometry/Geometry'+geoms[0]+'_cff'
 
-	# synchronize the geometry configuration and the FullSimulation sequence to be used
+        # synchronize the geometry configuration and the FullSimulation sequence to be used
         if simGeometry not in defaultOptions.geometryExtendedOptions:
-		self.SIMDefaultCFF="Configuration/StandardSequences/SimIdeal_cff"
+            self.SIMDefaultCFF="Configuration/StandardSequences/SimIdeal_cff"
 
-	if self._options.scenario=='nocoll' or self._options.scenario=='cosmics':
+        if self._options.scenario=='nocoll' or self._options.scenario=='cosmics':
             self.SIMDefaultCFF="Configuration/StandardSequences/SimNOBEAM_cff"
             self._options.beamspot='NoSmear'
 
         # fastsim requires some changes to the default cff files and sequences
-	if self._options.fast:
-		self.SIMDefaultCFF = 'FastSimulation.Configuration.SimIdeal_cff'
-		self.RECODefaultCFF= 'FastSimulation.Configuration.Reconstruction_AftMix_cff'
-		self.RECOBEFMIXDefaultCFF = 'FastSimulation.Configuration.Reconstruction_BefMix_cff'
-		self.RECOBEFMIXDefaultSeq = 'reconstruction_befmix'
-                self.DQMOFFLINEDefaultCFF="FastSimulation.Configuration.DQMOfflineMC_cff"
+        if self._options.fast:
+            self.SIMDefaultCFF = 'FastSimulation.Configuration.SimIdeal_cff'
+            self.RECODefaultCFF= 'FastSimulation.Configuration.Reconstruction_AftMix_cff'
+            self.RECOBEFMIXDefaultCFF = 'FastSimulation.Configuration.Reconstruction_BefMix_cff'
+            self.RECOBEFMIXDefaultSeq = 'reconstruction_befmix'
+            self.DQMOFFLINEDefaultCFF="FastSimulation.Configuration.DQMOfflineMC_cff"
 
         # Mixing
-	if self._options.pileup=='default':
-		from Configuration.StandardSequences.Mixing import MixingDefaultKey
-		self._options.pileup=MixingDefaultKey
-		
-
-	#not driven by a default cff anymore
-	if self._options.isData:
-		self._options.pileup=None
+        if self._options.pileup=='default':
+            from Configuration.StandardSequences.Mixing import MixingDefaultKey
+            self._options.pileup=MixingDefaultKey
 
 
-	self.REDIGIDefaultSeq=self.DIGIDefaultSeq
+        #not driven by a default cff anymore
+        if self._options.isData:
+            self._options.pileup=None
+
+
+        self.REDIGIDefaultSeq=self.DIGIDefaultSeq
 
     # for alca, skims, etc
     def addExtraStream(self,name,stream,workflow='full'):
             # define output module and go from there
-            output = cms.OutputModule("PoolOutputModule")
-            if stream.selectEvents.parameters_().__len__()!=0:
-                    output.SelectEvents = stream.selectEvents
+        output = cms.OutputModule("PoolOutputModule")
+        if stream.selectEvents.parameters_().__len__()!=0:
+            output.SelectEvents = stream.selectEvents
+        else:
+            output.SelectEvents = cms.untracked.PSet()
+            output.SelectEvents.SelectEvents=cms.vstring()
+            if isinstance(stream.paths,tuple):
+                for path in stream.paths:
+                    output.SelectEvents.SelectEvents.append(path.label())
             else:
-                    output.SelectEvents = cms.untracked.PSet()
-                    output.SelectEvents.SelectEvents=cms.vstring()
-                    if isinstance(stream.paths,tuple):
-                            for path in stream.paths:
-                                    output.SelectEvents.SelectEvents.append(path.label())
-                    else:
-                            output.SelectEvents.SelectEvents.append(stream.paths.label())
+                output.SelectEvents.SelectEvents.append(stream.paths.label())
 
 
 
-            if isinstance(stream.content,str):
-		    evtPset=getattr(self.process,stream.content)
-		    for p in evtPset.parameters_():
-			    setattr(output,p,getattr(evtPset,p))
-                    if not self._options.inlineEventContent:
-                            def doNotInlineEventContent(instance,label = "process."+stream.content+".outputCommands"):
-                                    return label
-                            output.outputCommands.__dict__["dumpPython"] = doNotInlineEventContent
+        if isinstance(stream.content,str):
+            evtPset=getattr(self.process,stream.content)
+            for p in evtPset.parameters_():
+                setattr(output,p,getattr(evtPset,p))
+            if not self._options.inlineEventContent:
+                def doNotInlineEventContent(instance,label = "process."+stream.content+".outputCommands"):
+                    return label
+                output.outputCommands.__dict__["dumpPython"] = doNotInlineEventContent
+        else:
+            output.outputCommands = stream.content
+
+
+        output.fileName = cms.untracked.string(self._options.dirout+stream.name+'.root')
+
+        output.dataset  = cms.untracked.PSet( dataTier = stream.dataTier,
+                                              filterName = cms.untracked.string(stream.name))
+
+        if self._options.filtername:
+            output.dataset.filterName= cms.untracked.string(self._options.filtername+"_"+stream.name)
+
+        #add an automatic flushing to limit memory consumption
+        output.eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+
+        if workflow in ("producers,full"):
+            if isinstance(stream.paths,tuple):
+                for path in stream.paths:
+                    self.schedule.append(path)
             else:
-                    output.outputCommands = stream.content
+                self.schedule.append(stream.paths)
 
 
-            output.fileName = cms.untracked.string(self._options.dirout+stream.name+'.root')
+        # in case of relvals we don't want to have additional outputs
+        if (not self._options.relval) and workflow in ("full","output"):
+            self.additionalOutputs[name] = output
+            setattr(self.process,name,output)
 
-            output.dataset  = cms.untracked.PSet( dataTier = stream.dataTier,
-                                                  filterName = cms.untracked.string(stream.name))
+        if workflow == 'output':
+            # adjust the select events to the proper trigger results from previous process
+            filterList = output.SelectEvents.SelectEvents
+            for i, filter in enumerate(filterList):
+                filterList[i] = filter+":"+self._options.triggerResultsProcess
 
-            if self._options.filtername:
-                    output.dataset.filterName= cms.untracked.string(self._options.filtername+"_"+stream.name)
+        return output
 
-	    #add an automatic flushing to limit memory consumption
-	    output.eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
-
-            if workflow in ("producers,full"):
-                    if isinstance(stream.paths,tuple):
-                            for path in stream.paths:
-                                    self.schedule.append(path)
-                    else:
-                            self.schedule.append(stream.paths)
-
-
-	    # in case of relvals we don't want to have additional outputs
-            if (not self._options.relval) and workflow in ("full","output"):
-                    self.additionalOutputs[name] = output
-		    setattr(self.process,name,output)
-	    
-            if workflow == 'output':
-                    # adjust the select events to the proper trigger results from previous process
-                    filterList = output.SelectEvents.SelectEvents
-                    for i, filter in enumerate(filterList):
-                            filterList[i] = filter+":"+self._options.triggerResultsProcess
-
-	    return output
-    
     #----------------------------------------------------------------------------
     # here the methods to create the steps. Of course we are doing magic here ;)
     # prepare_STEPNAME modifies self.process and what else's needed.
     #----------------------------------------------------------------------------
 
     def loadDefaultOrSpecifiedCFF(self, sequence,defaultCFF):
-            if ( len(sequence.split('.'))==1 ):
-                    l=self.loadAndRemember(defaultCFF)
-            elif ( len(sequence.split('.'))==2 ):
-                    l=self.loadAndRemember(sequence.split('.')[0])
-                    sequence=sequence.split('.')[1]
-            else:
-                    print("sub sequence configuration must be of the form dir/subdir/cff.a+b+c or cff.a")
-                    print(sequence,"not recognized")
-                    raise
-            return l
+        if ( len(sequence.split('.'))==1 ):
+            l=self.loadAndRemember(defaultCFF)
+        elif ( len(sequence.split('.'))==2 ):
+            l=self.loadAndRemember(sequence.split('.')[0])
+            sequence=sequence.split('.')[1]
+        else:
+            print("sub sequence configuration must be of the form dir/subdir/cff.a+b+c or cff.a")
+            print(sequence,"not recognized")
+            raise
+        return l
 
     def scheduleSequence(self,seq,prefix,what='Path'):
-	    if '*' in seq:
-		    #create only one path with all sequences in it
-		    for i,s in enumerate(seq.split('*')):
-			    if i==0:
-				    setattr(self.process,prefix,getattr(cms,what)( getattr(self.process, s) ))
-			    else:
-				    p=getattr(self.process,prefix)
-				    p+=getattr(self.process, s)
-		    self.schedule.append(getattr(self.process,prefix))
-		    return
-	    else:
-		    #create as many path as many sequences
-		    if not '+' in seq:
-			    if self.nextScheduleIsConditional:
-				    self.conditionalPaths.append(prefix)
-			    setattr(self.process,prefix,getattr(cms,what)( getattr(self.process, seq) ))
-			    self.schedule.append(getattr(self.process,prefix))
-		    else:
-			    for i,s in enumerate(seq.split('+')):
-				    sn=prefix+'%d'%(i)
-				    setattr(self.process,sn,getattr(cms,what)( getattr(self.process, s) ))
-				    self.schedule.append(getattr(self.process,sn))
-		    return
-    
+        if '*' in seq:
+            #create only one path with all sequences in it
+            for i,s in enumerate(seq.split('*')):
+                if i==0:
+                    setattr(self.process,prefix,getattr(cms,what)( getattr(self.process, s) ))
+                else:
+                    p=getattr(self.process,prefix)
+                    p+=getattr(self.process, s)
+            self.schedule.append(getattr(self.process,prefix))
+            return
+        else:
+            #create as many path as many sequences
+            if not '+' in seq:
+                if self.nextScheduleIsConditional:
+                    self.conditionalPaths.append(prefix)
+                setattr(self.process,prefix,getattr(cms,what)( getattr(self.process, seq) ))
+                self.schedule.append(getattr(self.process,prefix))
+            else:
+                for i,s in enumerate(seq.split('+')):
+                    sn=prefix+'%d'%(i)
+                    setattr(self.process,sn,getattr(cms,what)( getattr(self.process, s) ))
+                    self.schedule.append(getattr(self.process,sn))
+            return
+
     def scheduleSequenceAtEnd(self,seq,prefix):
-	    self.scheduleSequence(seq,prefix,what='EndPath')
-	    return
-	    
+        self.scheduleSequence(seq,prefix,what='EndPath')
+        return
+
     def prepare_ALCAPRODUCER(self, sequence = None):
         self.prepare_ALCA(sequence, workflow = "producers")
 
@@ -1240,170 +1240,170 @@ class ConfigBuilder(object):
 
         # decide which ALCA paths to use
         alcaList = sequence.split("+")
-	maxLevel=0
-	from Configuration.AlCa.autoAlca import autoAlca
-	# support @X from autoAlca.py, and recursion support: i.e T0:@Mu+@EG+...
-	self.expandMapping(alcaList,autoAlca)
-	self.AlCaPaths=[]
+        maxLevel=0
+        from Configuration.AlCa.autoAlca import autoAlca
+        # support @X from autoAlca.py, and recursion support: i.e T0:@Mu+@EG+...
+        self.expandMapping(alcaList,autoAlca)
+        self.AlCaPaths=[]
         for name in alcaConfig.__dict__:
             alcastream = getattr(alcaConfig,name)
             shortName = name.replace('ALCARECOStream','')
             if shortName in alcaList and isinstance(alcastream,cms.FilteredStream):
-	        output = self.addExtraStream(name,alcastream, workflow = workflow)
-		self.executeAndRemember('process.ALCARECOEventContent.outputCommands.extend(process.OutALCARECO'+shortName+'_noDrop.outputCommands)')
-		self.AlCaPaths.append(shortName)
-		if 'DQM' in alcaList:
-			if not self._options.inlineEventContent and hasattr(self.process,name):
-				self.executeAndRemember('process.' + name + '.outputCommands.append("keep *_MEtoEDMConverter_*_*")')
-			else:
-				output.outputCommands.append("keep *_MEtoEDMConverter_*_*")
-			
+                output = self.addExtraStream(name,alcastream, workflow = workflow)
+                self.executeAndRemember('process.ALCARECOEventContent.outputCommands.extend(process.OutALCARECO'+shortName+'_noDrop.outputCommands)')
+                self.AlCaPaths.append(shortName)
+                if 'DQM' in alcaList:
+                    if not self._options.inlineEventContent and hasattr(self.process,name):
+                        self.executeAndRemember('process.' + name + '.outputCommands.append("keep *_MEtoEDMConverter_*_*")')
+                    else:
+                        output.outputCommands.append("keep *_MEtoEDMConverter_*_*")
+
                 #rename the HLT process name in the alca modules
                 if self._options.hltProcess or 'HLT' in self.stepMap:
-                        if isinstance(alcastream.paths,tuple):
-                                for path in alcastream.paths:
-                                        self.renameHLTprocessInSequence(path.label())
-                        else:
-                                self.renameHLTprocessInSequence(alcastream.paths.label())
-				
+                    if isinstance(alcastream.paths,tuple):
+                        for path in alcastream.paths:
+                            self.renameHLTprocessInSequence(path.label())
+                    else:
+                        self.renameHLTprocessInSequence(alcastream.paths.label())
+
                 for i in range(alcaList.count(shortName)):
-                        alcaList.remove(shortName)
+                    alcaList.remove(shortName)
 
             # DQM needs a special handling
             elif name == 'pathALCARECODQM' and 'DQM' in alcaList:
-                    path = getattr(alcaConfig,name)
-                    self.schedule.append(path)
-                    alcaList.remove('DQM')
+                path = getattr(alcaConfig,name)
+                self.schedule.append(path)
+                alcaList.remove('DQM')
 
             if isinstance(alcastream,cms.Path):
-                    #black list the alca path so that they do not appear in the cfg
-                    self.blacklist_paths.append(alcastream)
+                #black list the alca path so that they do not appear in the cfg
+                self.blacklist_paths.append(alcastream)
 
 
         if len(alcaList) != 0:
-                available=[]
-                for name in alcaConfig.__dict__:
-                        alcastream = getattr(alcaConfig,name)
-                        if isinstance(alcastream,cms.FilteredStream):
-                                available.append(name.replace('ALCARECOStream',''))
-                print("The following alcas could not be found "+str(alcaList))
-                print("available ",available)
-                #print "verify your configuration, ignoring for now"
-                raise Exception("The following alcas could not be found "+str(alcaList))
+            available=[]
+            for name in alcaConfig.__dict__:
+                alcastream = getattr(alcaConfig,name)
+                if isinstance(alcastream,cms.FilteredStream):
+                    available.append(name.replace('ALCARECOStream',''))
+            print("The following alcas could not be found "+str(alcaList))
+            print("available ",available)
+            #print "verify your configuration, ignoring for now"
+            raise Exception("The following alcas could not be found "+str(alcaList))
 
     def prepare_LHE(self, sequence = None):
-	    #load the fragment
-	    ##make it loadable
-	    loadFragment = self._options.evt_type.replace('.py','',).replace('.','_').replace('python/','').replace('/','.')
-	    print("Loading lhe fragment from",loadFragment)
-	    __import__(loadFragment)
-	    self.process.load(loadFragment)
-	    ##inline the modules
-	    self._options.inlineObjets+=','+sequence
-	    
-	    getattr(self.process,sequence).nEvents = int(self._options.number)
-	    
-	    #schedule it
-	    self.process.lhe_step = cms.Path( getattr( self.process,sequence)  )
-	    self.excludedPaths.append("lhe_step")
-	    self.schedule.append( self.process.lhe_step )
+            #load the fragment
+            ##make it loadable
+        loadFragment = self._options.evt_type.replace('.py','',).replace('.','_').replace('python/','').replace('/','.')
+        print("Loading lhe fragment from",loadFragment)
+        __import__(loadFragment)
+        self.process.load(loadFragment)
+        ##inline the modules
+        self._options.inlineObjets+=','+sequence
+
+        getattr(self.process,sequence).nEvents = int(self._options.number)
+
+        #schedule it
+        self.process.lhe_step = cms.Path( getattr( self.process,sequence)  )
+        self.excludedPaths.append("lhe_step")
+        self.schedule.append( self.process.lhe_step )
 
     def prepare_GEN(self, sequence = None):
         """ load the fragment of generator configuration """
-	loadFailure=False
+        loadFailure=False
         #remove trailing .py
         #support old style .cfi by changing into something.cfi into something_cfi
         #remove python/ from the name
         loadFragment = self._options.evt_type.replace('.py','',).replace('.','_').replace('python/','')
         #standard location of fragments
         if not '/' in loadFragment:
-                loadFragment='Configuration.Generator.'+loadFragment
+            loadFragment='Configuration.Generator.'+loadFragment
         else:
-                loadFragment=loadFragment.replace('/','.')
-	try:
-		print("Loading generator fragment from",loadFragment)
-		__import__(loadFragment)
-	except:
-		loadFailure=True
-		#if self.process.source and self.process.source.type_()=='EmptySource':
-		if not (self._options.filein or self._options.dasquery):
-			raise Exception("Neither gen fragment of input files provided: this is an inconsistent GEN step configuration")
-			
-	if not loadFailure:
-		generatorModule=sys.modules[loadFragment]
-		genModules=generatorModule.__dict__
-		#remove lhe producer module since this should have been
-		#imported instead in the LHE step
-		if self.LHEDefaultSeq in genModules:
-                        del genModules[self.LHEDefaultSeq]
+            loadFragment=loadFragment.replace('/','.')
+        try:
+            print("Loading generator fragment from",loadFragment)
+            __import__(loadFragment)
+        except:
+            loadFailure=True
+            #if self.process.source and self.process.source.type_()=='EmptySource':
+            if not (self._options.filein or self._options.dasquery):
+                raise Exception("Neither gen fragment of input files provided: this is an inconsistent GEN step configuration")
 
-		if self._options.hideGen:
-			self.loadAndRemember(loadFragment)
-		else:
-			self.process.load(loadFragment)
-			# expose the objects from that fragment to the configuration
-			import FWCore.ParameterSet.Modules as cmstypes
-			for name in genModules:
-				theObject = getattr(generatorModule,name)
-				if isinstance(theObject, cmstypes._Module):
-					self._options.inlineObjets=name+','+self._options.inlineObjets
-				elif isinstance(theObject, cms.Sequence) or isinstance(theObject, cmstypes.ESProducer):
-					self._options.inlineObjets+=','+name
+        if not loadFailure:
+            generatorModule=sys.modules[loadFragment]
+            genModules=generatorModule.__dict__
+            #remove lhe producer module since this should have been
+            #imported instead in the LHE step
+            if self.LHEDefaultSeq in genModules:
+                del genModules[self.LHEDefaultSeq]
 
-		if sequence == self.GENDefaultSeq or sequence == 'pgen_genonly':
-			if 'ProductionFilterSequence' in genModules and ('generator' in genModules):
-				self.productionFilterSequence = 'ProductionFilterSequence'
-			elif 'generator' in genModules:
-				self.productionFilterSequence = 'generator'
+            if self._options.hideGen:
+                self.loadAndRemember(loadFragment)
+            else:
+                self.process.load(loadFragment)
+                # expose the objects from that fragment to the configuration
+                import FWCore.ParameterSet.Modules as cmstypes
+                for name in genModules:
+                    theObject = getattr(generatorModule,name)
+                    if isinstance(theObject, cmstypes._Module):
+                        self._options.inlineObjets=name+','+self._options.inlineObjets
+                    elif isinstance(theObject, cms.Sequence) or isinstance(theObject, cmstypes.ESProducer):
+                        self._options.inlineObjets+=','+name
+
+            if sequence == self.GENDefaultSeq or sequence == 'pgen_genonly':
+                if 'ProductionFilterSequence' in genModules and ('generator' in genModules):
+                    self.productionFilterSequence = 'ProductionFilterSequence'
+                elif 'generator' in genModules:
+                    self.productionFilterSequence = 'generator'
 
         """ Enrich the schedule with the rest of the generation step """
         self.loadDefaultOrSpecifiedCFF(sequence,self.GENDefaultCFF)
         genSeqName=sequence.split('.')[-1]
 
-	if True:
-                try:
-			from Configuration.StandardSequences.VtxSmeared import VtxSmeared
-			cffToBeLoaded=VtxSmeared[self._options.beamspot]
-			self.loadAndRemember(cffToBeLoaded)
-                except ImportError:
-                        raise Exception("VertexSmearing type or beamspot "+self._options.beamspot+" unknown.")
+        if True:
+            try:
+                from Configuration.StandardSequences.VtxSmeared import VtxSmeared
+                cffToBeLoaded=VtxSmeared[self._options.beamspot]
+                self.loadAndRemember(cffToBeLoaded)
+            except ImportError:
+                raise Exception("VertexSmearing type or beamspot "+self._options.beamspot+" unknown.")
 
-                if self._options.scenario == 'HeavyIons': 
-			if self._options.pileup=='HiMixGEN':
-				self.loadAndRemember("Configuration/StandardSequences/GeneratorMix_cff")
-			else:
-				self.loadAndRemember("Configuration/StandardSequences/GeneratorHI_cff")
+            if self._options.scenario == 'HeavyIons': 
+                if self._options.pileup=='HiMixGEN':
+                    self.loadAndRemember("Configuration/StandardSequences/GeneratorMix_cff")
+                else:
+                    self.loadAndRemember("Configuration/StandardSequences/GeneratorHI_cff")
 
         self.process.generation_step = cms.Path( getattr(self.process,genSeqName) )
         self.schedule.append(self.process.generation_step)
 
-	#register to the genstepfilter the name of the path (static right now, but might evolve)
-	self.executeAndRemember('process.genstepfilter.triggerConditions=cms.vstring("generation_step")')
-	
-	if 'reGEN' in self.stepMap:
-		#stop here
-		return 
+        #register to the genstepfilter the name of the path (static right now, but might evolve)
+        self.executeAndRemember('process.genstepfilter.triggerConditions=cms.vstring("generation_step")')
+
+        if 'reGEN' in self.stepMap:
+            #stop here
+            return 
 
         """ Enrich the schedule with the summary of the filter step """
         #the gen filter in the endpath
         self.loadAndRemember("GeneratorInterface/Core/genFilterSummary_cff")
-	self.scheduleSequenceAtEnd('genFilterSummary','genfiltersummary_step')
+        self.scheduleSequenceAtEnd('genFilterSummary','genfiltersummary_step')
         return
 
     def prepare_SIM(self, sequence = None):
         """ Enrich the schedule with the simulation step"""
-	self.loadDefaultOrSpecifiedCFF(sequence,self.SIMDefaultCFF)
-	if not self._options.fast:
-		if self._options.gflash==True:
-			self.loadAndRemember("Configuration/StandardSequences/GFlashSIM_cff")
+        self.loadDefaultOrSpecifiedCFF(sequence,self.SIMDefaultCFF)
+        if not self._options.fast:
+            if self._options.gflash==True:
+                self.loadAndRemember("Configuration/StandardSequences/GFlashSIM_cff")
 
-		if self._options.magField=='0T':
-			self.executeAndRemember("process.g4SimHits.UseMagneticField = cms.bool(False)")
-	else:
-		if self._options.magField=='0T':
-			self.executeAndRemember("process.fastSimProducer.detectorDefinition.magneticFieldZ = cms.untracked.double(0.)")
+            if self._options.magField=='0T':
+                self.executeAndRemember("process.g4SimHits.UseMagneticField = cms.bool(False)")
+        else:
+            if self._options.magField=='0T':
+                self.executeAndRemember("process.fastSimProducer.detectorDefinition.magneticFieldZ = cms.untracked.double(0.)")
 
-	self.scheduleSequence(sequence.split('.')[-1],'simulation_step')
+        self.scheduleSequence(sequence.split('.')[-1],'simulation_step')
         return
 
     def prepare_DIGI(self, sequence = None):
@@ -1411,222 +1411,222 @@ class ConfigBuilder(object):
         self.loadDefaultOrSpecifiedCFF(sequence,self.DIGIDefaultCFF)
 
         if self._options.gflash==True:
-                self.loadAndRemember("Configuration/StandardSequences/GFlashDIGI_cff")
+            self.loadAndRemember("Configuration/StandardSequences/GFlashDIGI_cff")
 
         if sequence == 'pdigi_valid' or sequence == 'pdigi_hi':
             self.executeAndRemember("process.mix.digitizers = cms.PSet(process.theDigitizersValid)")
 
-	if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and not self.process.source.type_()=='EmptySource':
-		if self._options.inputEventContent=='':
-			self._options.inputEventContent='REGEN'
-		else:
-			self._options.inputEventContent=self._options.inputEventContent+',REGEN'
+        if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and not self.process.source.type_()=='EmptySource':
+            if self._options.inputEventContent=='':
+                self._options.inputEventContent='REGEN'
+            else:
+                self._options.inputEventContent=self._options.inputEventContent+',REGEN'
 
 
-	self.scheduleSequence(sequence.split('.')[-1],'digitisation_step')
+        self.scheduleSequence(sequence.split('.')[-1],'digitisation_step')
         return
 
     def prepare_CFWRITER(self, sequence = None):
-	    """ Enrich the schedule with the crossing frame writer step"""
-	    self.loadAndRemember(self.CFWRITERDefaultCFF)
-	    self.scheduleSequence('pcfw','cfwriter_step')
-	    return
+        """ Enrich the schedule with the crossing frame writer step"""
+        self.loadAndRemember(self.CFWRITERDefaultCFF)
+        self.scheduleSequence('pcfw','cfwriter_step')
+        return
 
     def prepare_DATAMIX(self, sequence = None):
-	    """ Enrich the schedule with the digitisation step"""
-	    self.loadAndRemember(self.DATAMIXDefaultCFF)
-	    self.scheduleSequence('pdatamix','datamixing_step')
+        """ Enrich the schedule with the digitisation step"""
+        self.loadAndRemember(self.DATAMIXDefaultCFF)
+        self.scheduleSequence('pdatamix','datamixing_step')
 
-	    if self._options.pileup_input:
-		    theFiles=''
-		    if self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:'):
-			    theFiles=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],),self._options.pileup_dasoption)[0]
-		    elif self._options.pileup_input.startswith("filelist:"):
-			    theFiles= (filesFromList(self._options.pileup_input[9:]))[0]
-		    else:
-			    theFiles=self._options.pileup_input.split(',')
-		    #print theFiles
-		    self.executeAndRemember( "process.mixData.input.fileNames = cms.untracked.vstring(%s)"%(  theFiles ) )
+        if self._options.pileup_input:
+            theFiles=''
+            if self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:'):
+                theFiles=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],),self._options.pileup_dasoption)[0]
+            elif self._options.pileup_input.startswith("filelist:"):
+                theFiles= (filesFromList(self._options.pileup_input[9:]))[0]
+            else:
+                theFiles=self._options.pileup_input.split(',')
+            #print theFiles
+            self.executeAndRemember( "process.mixData.input.fileNames = cms.untracked.vstring(%s)"%(  theFiles ) )
 
-	    return
+        return
 
     def prepare_DIGI2RAW(self, sequence = None):
-            self.loadDefaultOrSpecifiedCFF(sequence,self.DIGI2RAWDefaultCFF)
-	    self.scheduleSequence(sequence.split('.')[-1],'digi2raw_step')
-            return
+        self.loadDefaultOrSpecifiedCFF(sequence,self.DIGI2RAWDefaultCFF)
+        self.scheduleSequence(sequence.split('.')[-1],'digi2raw_step')
+        return
 
     def prepare_REPACK(self, sequence = None):
-            self.loadDefaultOrSpecifiedCFF(sequence,self.REPACKDefaultCFF)
-	    self.scheduleSequence(sequence.split('.')[-1],'digi2repack_step')
-            return
+        self.loadDefaultOrSpecifiedCFF(sequence,self.REPACKDefaultCFF)
+        self.scheduleSequence(sequence.split('.')[-1],'digi2repack_step')
+        return
 
     def prepare_L1(self, sequence = None):
-	    """ Enrich the schedule with the L1 simulation step"""
-            assert(sequence == None)
-	    self.loadAndRemember(self.L1EMDefaultCFF)
-	    self.scheduleSequence('SimL1Emulator','L1simulation_step')
-	    return
+        """ Enrich the schedule with the L1 simulation step"""
+        assert(sequence == None)
+        self.loadAndRemember(self.L1EMDefaultCFF)
+        self.scheduleSequence('SimL1Emulator','L1simulation_step')
+        return
 
     def prepare_L1REPACK(self, sequence = None):
-            """ Enrich the schedule with the L1 simulation step, running the L1 emulator on data unpacked from the RAW collection, and repacking the result in a new RAW collection"""
-	    supported = ['GT','GT1','GT2','GCTGT','Full','FullSimTP','FullMC','Full2015Data','uGT','CalouGT']
-            if sequence in supported:
-                self.loadAndRemember('Configuration/StandardSequences/SimL1EmulatorRepack_%s_cff'%sequence)
-		if self._options.scenario == 'HeavyIons':
-			self.renameInputTagsInSequence("SimL1Emulator","rawDataCollector","rawDataRepacker")
-		self.scheduleSequence('SimL1Emulator','L1RePack_step')
-	    else:
-                print("L1REPACK with '",sequence,"' is not supported! Supported choices are: ",supported)
-                raise Exception('unsupported feature')
+        """ Enrich the schedule with the L1 simulation step, running the L1 emulator on data unpacked from the RAW collection, and repacking the result in a new RAW collection"""
+        supported = ['GT','GT1','GT2','GCTGT','Full','FullSimTP','FullMC','Full2015Data','uGT','CalouGT']
+        if sequence in supported:
+            self.loadAndRemember('Configuration/StandardSequences/SimL1EmulatorRepack_%s_cff'%sequence)
+            if self._options.scenario == 'HeavyIons':
+                self.renameInputTagsInSequence("SimL1Emulator","rawDataCollector","rawDataRepacker")
+            self.scheduleSequence('SimL1Emulator','L1RePack_step')
+        else:
+            print("L1REPACK with '",sequence,"' is not supported! Supported choices are: ",supported)
+            raise Exception('unsupported feature')
 
 
     def prepare_HLT(self, sequence = None):
         """ Enrich the schedule with the HLT simulation step"""
         if not sequence:
-                print("no specification of the hlt menu has been given, should never happen")
-                raise  Exception('no HLT sequence provided')
+            print("no specification of the hlt menu has been given, should never happen")
+            raise  Exception('no HLT sequence provided')
 
         if '@' in sequence:
-                # case where HLT:@something was provided
-                from Configuration.HLT.autoHLT import autoHLT
-                key = sequence[1:]
-                if key in autoHLT:
-                  sequence = autoHLT[key]
-                else:
-                  raise ValueError('no HLT mapping key "%s" found in autoHLT' % key)
+            # case where HLT:@something was provided
+            from Configuration.HLT.autoHLT import autoHLT
+            key = sequence[1:]
+            if key in autoHLT:
+                sequence = autoHLT[key]
+            else:
+                raise ValueError('no HLT mapping key "%s" found in autoHLT' % key)
 
         if ',' in sequence:
-                #case where HLT:something:something was provided
-                self.executeAndRemember('import HLTrigger.Configuration.Utilities')
-                optionsForHLT = {}
-                if self._options.scenario == 'HeavyIons':
-                  optionsForHLT['type'] = 'HIon'
+            #case where HLT:something:something was provided
+            self.executeAndRemember('import HLTrigger.Configuration.Utilities')
+            optionsForHLT = {}
+            if self._options.scenario == 'HeavyIons':
+                optionsForHLT['type'] = 'HIon'
+            else:
+                optionsForHLT['type'] = 'GRun'
+            optionsForHLTConfig = ', '.join('%s=%s' % (key, repr(val)) for (key, val) in six.iteritems(optionsForHLT))
+            if sequence == 'run,fromSource':
+                if hasattr(self.process.source,'firstRun'):
+                    self.executeAndRemember('process.loadHltConfiguration("run:%%d"%%(process.source.firstRun.value()),%s)'%(optionsForHLTConfig))
+                elif hasattr(self.process.source,'setRunNumber'):
+                    self.executeAndRemember('process.loadHltConfiguration("run:%%d"%%(process.source.setRunNumber.value()),%s)'%(optionsForHLTConfig))
                 else:
-                  optionsForHLT['type'] = 'GRun'
-                optionsForHLTConfig = ', '.join('%s=%s' % (key, repr(val)) for (key, val) in six.iteritems(optionsForHLT))
-		if sequence == 'run,fromSource':
-			if hasattr(self.process.source,'firstRun'):
-				self.executeAndRemember('process.loadHltConfiguration("run:%%d"%%(process.source.firstRun.value()),%s)'%(optionsForHLTConfig))
-			elif hasattr(self.process.source,'setRunNumber'):
-				self.executeAndRemember('process.loadHltConfiguration("run:%%d"%%(process.source.setRunNumber.value()),%s)'%(optionsForHLTConfig))
-			else:
-				raise Exception('Cannot replace menu to load %s'%(sequence))
-		else:
-			self.executeAndRemember('process.loadHltConfiguration("%s",%s)'%(sequence.replace(',',':'),optionsForHLTConfig))
+                    raise Exception('Cannot replace menu to load %s'%(sequence))
+            else:
+                self.executeAndRemember('process.loadHltConfiguration("%s",%s)'%(sequence.replace(',',':'),optionsForHLTConfig))
         else:
-		self.loadAndRemember('HLTrigger/Configuration/HLT_%s_cff'       % sequence)
+            self.loadAndRemember('HLTrigger/Configuration/HLT_%s_cff'       % sequence)
 
         if self._options.isMC:
-		self._options.customisation_file.append("HLTrigger/Configuration/customizeHLTforMC.customizeHLTforMC")
+            self._options.customisation_file.append("HLTrigger/Configuration/customizeHLTforMC.customizeHLTforMC")
 
-	if self._options.name != 'HLT':
-		self.additionalCommands.append('from HLTrigger.Configuration.CustomConfigs import ProcessName')
-		self.additionalCommands.append('process = ProcessName(process)')
-                self.additionalCommands.append('')
-		from HLTrigger.Configuration.CustomConfigs import ProcessName
-		self.process = ProcessName(self.process)
-		
+        if self._options.name != 'HLT':
+            self.additionalCommands.append('from HLTrigger.Configuration.CustomConfigs import ProcessName')
+            self.additionalCommands.append('process = ProcessName(process)')
+            self.additionalCommands.append('')
+            from HLTrigger.Configuration.CustomConfigs import ProcessName
+            self.process = ProcessName(self.process)
+
         self.schedule.append(self.process.HLTSchedule)
         [self.blacklist_paths.append(path) for path in self.process.HLTSchedule if isinstance(path,(cms.Path,cms.EndPath))]
 
-	#this is a fake, to be removed with fastim migration and HLT menu dump
-	if self._options.fast:
-		if not hasattr(self.process,'HLTEndSequence'):
-			self.executeAndRemember("process.HLTEndSequence = cms.Sequence( process.dummyModule )")
-		
+        #this is a fake, to be removed with fastim migration and HLT menu dump
+        if self._options.fast:
+            if not hasattr(self.process,'HLTEndSequence'):
+                self.executeAndRemember("process.HLTEndSequence = cms.Sequence( process.dummyModule )")
+
 
     def prepare_RAW2RECO(self, sequence = None):
-            if ','in sequence:
-                    seqReco=sequence.split(',')[1]
-                    seqDigi=sequence.split(',')[0]
-            else:
-                    print("RAW2RECO requires two specifications",sequence,"insufficient")
+        if ','in sequence:
+            seqReco=sequence.split(',')[1]
+            seqDigi=sequence.split(',')[0]
+        else:
+            print("RAW2RECO requires two specifications",sequence,"insufficient")
 
-	    self.prepare_RAW2DIGI(seqDigi)
-	    self.prepare_RECO(seqReco)
-            return
+        self.prepare_RAW2DIGI(seqDigi)
+        self.prepare_RECO(seqReco)
+        return
 
     def prepare_RAW2DIGI(self, sequence = "RawToDigi"):
-            self.loadDefaultOrSpecifiedCFF(sequence,self.RAW2DIGIDefaultCFF)
-	    self.scheduleSequence(sequence,'raw2digi_step')
-	    #	    if self._options.isRepacked:
-	    #self.renameInputTagsInSequence(sequence)
-            return
+        self.loadDefaultOrSpecifiedCFF(sequence,self.RAW2DIGIDefaultCFF)
+        self.scheduleSequence(sequence,'raw2digi_step')
+        #	    if self._options.isRepacked:
+        #self.renameInputTagsInSequence(sequence)
+        return
 
     def prepare_PATFILTER(self, sequence=None):
-            self.loadAndRemember("PhysicsTools/PatAlgos/slimming/metFilterPaths_cff")
-	    from PhysicsTools.PatAlgos.slimming.metFilterPaths_cff import allMetFilterPaths
-	    for filt in allMetFilterPaths:
-		    self.schedule.append(getattr(self.process,'Flag_'+filt))
+        self.loadAndRemember("PhysicsTools/PatAlgos/slimming/metFilterPaths_cff")
+        from PhysicsTools.PatAlgos.slimming.metFilterPaths_cff import allMetFilterPaths
+        for filt in allMetFilterPaths:
+            self.schedule.append(getattr(self.process,'Flag_'+filt))
 
     def prepare_L1HwVal(self, sequence = 'L1HwVal'):
         ''' Enrich the schedule with L1 HW validation '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.L1HwValDefaultCFF)
-	#self.scheduleSequence(sequence.split('.')[-1],'l1hwval_step')
-	print('\n\n\n DEPRECATED this has no action \n\n\n')
+        #self.scheduleSequence(sequence.split('.')[-1],'l1hwval_step')
+        print('\n\n\n DEPRECATED this has no action \n\n\n')
         return
 
     def prepare_L1Reco(self, sequence = "L1Reco"):
         ''' Enrich the schedule with L1 reconstruction '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.L1RecoDefaultCFF)
-	self.scheduleSequence(sequence.split('.')[-1],'L1Reco_step')
+        self.scheduleSequence(sequence.split('.')[-1],'L1Reco_step')
         return
 
     def prepare_L1TrackTrigger(self, sequence = "L1TrackTrigger"):
         ''' Enrich the schedule with L1 reconstruction '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.L1TrackTriggerDefaultCFF)
-	self.scheduleSequence(sequence.split('.')[-1],'L1TrackTrigger_step')
+        self.scheduleSequence(sequence.split('.')[-1],'L1TrackTrigger_step')
         return
 
     def prepare_FILTER(self, sequence = None):
         ''' Enrich the schedule with a user defined filter sequence '''
-	## load the relevant part
-	filterConfig=self.load(sequence.split('.')[0])
-	filterSeq=sequence.split('.')[-1]
-	## print it in the configuration
-	class PrintAllModules(object):
-		def __init__(self):
-			self.inliner=''
-			pass
-		def enter(self,visitee):
-			try:
-				label=visitee.label()
-				##needs to be in reverse order
-				self.inliner=label+','+self.inliner
-			except:
-				pass
-		def leave(self,v): pass
+        ## load the relevant part
+        filterConfig=self.load(sequence.split('.')[0])
+        filterSeq=sequence.split('.')[-1]
+        ## print it in the configuration
+        class PrintAllModules(object):
+            def __init__(self):
+                self.inliner=''
+                pass
+            def enter(self,visitee):
+                try:
+                    label=visitee.label()
+                    ##needs to be in reverse order
+                    self.inliner=label+','+self.inliner
+                except:
+                    pass
+            def leave(self,v): pass
 
-	expander=PrintAllModules()
-	getattr(self.process,filterSeq).visit( expander )
-	self._options.inlineObjets+=','+expander.inliner
-	self._options.inlineObjets+=','+filterSeq
-		
-	## put the filtering path in the schedule
-	self.scheduleSequence(filterSeq,'filtering_step')
-	self.nextScheduleIsConditional=True
-	## put it before all the other paths
-	self.productionFilterSequence = filterSeq 
-	
-	return
+        expander=PrintAllModules()
+        getattr(self.process,filterSeq).visit( expander )
+        self._options.inlineObjets+=','+expander.inliner
+        self._options.inlineObjets+=','+filterSeq
+
+        ## put the filtering path in the schedule
+        self.scheduleSequence(filterSeq,'filtering_step')
+        self.nextScheduleIsConditional=True
+        ## put it before all the other paths
+        self.productionFilterSequence = filterSeq 
+
+        return
 
     def prepare_RECO(self, sequence = "reconstruction"):
         ''' Enrich the schedule with reconstruction '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.RECODefaultCFF)
-	self.scheduleSequence(sequence.split('.')[-1],'reconstruction_step')
+        self.scheduleSequence(sequence.split('.')[-1],'reconstruction_step')
         return
 
     def prepare_RECOSIM(self, sequence = "recosim"):
         ''' Enrich the schedule with reconstruction '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.RECOSIMDefaultCFF)
-	self.scheduleSequence(sequence.split('.')[-1],'recosim_step')
+        self.scheduleSequence(sequence.split('.')[-1],'recosim_step')
         return
 
     def prepare_RECOBEFMIX(self, sequence = "reconstruction"):
         ''' Enrich the schedule with the part of reconstruction that is done before mixing in FastSim'''
         if not self._options.fast:
-                print("ERROR: this step is only implemented for FastSim")
-                sys.exit()
+            print("ERROR: this step is only implemented for FastSim")
+            sys.exit()
         self.loadDefaultOrSpecifiedCFF(self.RECOBEFMIXDefaultSeq,self.RECOBEFMIXDefaultCFF)
         self.scheduleSequence(sequence.split('.')[-1],'reconstruction_befmix_step')
         return
@@ -1637,7 +1637,7 @@ class ConfigBuilder(object):
         self.loadDefaultOrSpecifiedCFF(sequence,self.PATDefaultCFF)
         self.labelsToAssociate.append('patTask')
         if not self._options.runUnscheduled:
-               raise Exception("MiniAOD production can only run in unscheduled mode, please run cmsDriver with --runUnscheduled")
+            raise Exception("MiniAOD production can only run in unscheduled mode, please run cmsDriver with --runUnscheduled")
         if self._options.isData:
             self._options.customisation_file_unsch.insert(0,"PhysicsTools/PatAlgos/slimming/miniAOD_tools.miniAOD_customizeAllData")
         else:
@@ -1646,12 +1646,12 @@ class ConfigBuilder(object):
             else:
                 self._options.customisation_file_unsch.insert(0,"PhysicsTools/PatAlgos/slimming/miniAOD_tools.miniAOD_customizeAllMC")
 
-	if self._options.hltProcess:
-	     if len(self._options.customise_commands) > 1:
-		     self._options.customise_commands = self._options.customise_commands + " \n"
-	     self._options.customise_commands = self._options.customise_commands + "process.patTrigger.processName = \""+self._options.hltProcess+"\"\n"
-             self._options.customise_commands = self._options.customise_commands + "process.slimmedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
-             self._options.customise_commands = self._options.customise_commands + "process.patMuons.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
+        if self._options.hltProcess:
+            if len(self._options.customise_commands) > 1:
+                self._options.customise_commands = self._options.customise_commands + " \n"
+            self._options.customise_commands = self._options.customise_commands + "process.patTrigger.processName = \""+self._options.hltProcess+"\"\n"
+            self._options.customise_commands = self._options.customise_commands + "process.slimmedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
+            self._options.customise_commands = self._options.customise_commands + "process.patMuons.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
 
 #            self.renameHLTprocessInSequence(sequence)
 
@@ -1661,8 +1661,8 @@ class ConfigBuilder(object):
         ''' Enrich the schedule with PATGEN '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.PATGENDefaultCFF) #this is unscheduled
         self.labelsToAssociate.append('patGENTask')
-	if not self._options.runUnscheduled:	
-		raise Exception("MiniGEN production can only run in unscheduled mode, please run cmsDriver with --runUnscheduled")
+        if not self._options.runUnscheduled:	
+            raise Exception("MiniGEN production can only run in unscheduled mode, please run cmsDriver with --runUnscheduled")
         if self._options.isData:
             raise Exception("PATGEN step can only run on MC")
         return
@@ -1670,28 +1670,28 @@ class ConfigBuilder(object):
     def prepare_NANO(self, sequence = "nanoAOD"):
         ''' Enrich the schedule with NANO '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.NANODefaultCFF)
-	self.scheduleSequence(sequence.split('.')[-1],'nanoAOD_step')
+        self.scheduleSequence(sequence.split('.')[-1],'nanoAOD_step')
         custom = "nanoAOD_customizeData" if self._options.isData else "nanoAOD_customizeMC"
         if self._options.runUnscheduled:
             self._options.customisation_file_unsch.insert(0,"PhysicsTools/NanoAOD/nano_cff."+custom)
         else:
             self._options.customisation_file.insert(0,"PhysicsTools/NanoAOD/nano_cff."+custom)
-	if self._options.hltProcess:
-	     if len(self._options.customise_commands) > 1:
-		     self._options.customise_commands = self._options.customise_commands + " \n"
-             self._options.customise_commands = self._options.customise_commands + "process.unpackedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
+        if self._options.hltProcess:
+            if len(self._options.customise_commands) > 1:
+                self._options.customise_commands = self._options.customise_commands + " \n"
+            self._options.customise_commands = self._options.customise_commands + "process.unpackedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
 
 
     def prepare_EI(self, sequence = None):
         ''' Enrich the schedule with event interpretation '''
-	from Configuration.StandardSequences.EventInterpretation import EventInterpretation
-	if sequence in EventInterpretation:
-		self.EIDefaultCFF = EventInterpretation[sequence]
-		sequence = 'EIsequence'
-	else:
-		raise Exception('Cannot set %s event interpretation'%( sequence) )
+        from Configuration.StandardSequences.EventInterpretation import EventInterpretation
+        if sequence in EventInterpretation:
+            self.EIDefaultCFF = EventInterpretation[sequence]
+            sequence = 'EIsequence'
+        else:
+            raise Exception('Cannot set %s event interpretation'%( sequence) )
         self.loadDefaultOrSpecifiedCFF(sequence,self.EIDefaultCFF)
-	self.scheduleSequence(sequence.split('.')[-1],'eventinterpretaion_step')
+        self.scheduleSequence(sequence.split('.')[-1],'eventinterpretaion_step')
         return
 
     def prepare_SKIM(self, sequence = "all"):
@@ -1701,265 +1701,265 @@ class ConfigBuilder(object):
 
         skimlist=sequence.split('+')
         ## support @Mu+DiJet+@Electron configuration via autoSkim.py
-	from Configuration.Skimming.autoSkim import autoSkim
-	self.expandMapping(skimlist,autoSkim)
+        from Configuration.Skimming.autoSkim import autoSkim
+        self.expandMapping(skimlist,autoSkim)
 
         #print "dictionnary for skims:",skimConfig.__dict__
         for skim in skimConfig.__dict__:
-                skimstream = getattr(skimConfig,skim)
-                if isinstance(skimstream,cms.Path):
-                    #black list the alca path so that they do not appear in the cfg
-                    self.blacklist_paths.append(skimstream)
-                if (not isinstance(skimstream,cms.FilteredStream)):
-                        continue
-                shortname = skim.replace('SKIMStream','')
-                if (sequence=="all"):
-                        self.addExtraStream(skim,skimstream)
-                elif (shortname in skimlist):
-                        self.addExtraStream(skim,skimstream)
-                        #add a DQM eventcontent for this guy
-			if self._options.datatier=='DQM':
-                                self.process.load(self.EVTCONTDefaultCFF)
-                                skimstreamDQM = cms.FilteredStream(
-                                        responsible = skimstream.responsible,
-                                        name = skimstream.name+'DQM',
-                                        paths = skimstream.paths,
-                                        selectEvents = skimstream.selectEvents,
-                                        content = self._options.datatier+'EventContent',
-                                        dataTier = cms.untracked.string(self._options.datatier)
-                                        )
-                                self.addExtraStream(skim+'DQM',skimstreamDQM)
-                        for i in range(skimlist.count(shortname)):
-                                skimlist.remove(shortname)
+            skimstream = getattr(skimConfig,skim)
+            if isinstance(skimstream,cms.Path):
+            #black list the alca path so that they do not appear in the cfg
+                self.blacklist_paths.append(skimstream)
+            if (not isinstance(skimstream,cms.FilteredStream)):
+                continue
+            shortname = skim.replace('SKIMStream','')
+            if (sequence=="all"):
+                self.addExtraStream(skim,skimstream)
+            elif (shortname in skimlist):
+                self.addExtraStream(skim,skimstream)
+                #add a DQM eventcontent for this guy
+                if self._options.datatier=='DQM':
+                    self.process.load(self.EVTCONTDefaultCFF)
+                    skimstreamDQM = cms.FilteredStream(
+                            responsible = skimstream.responsible,
+                            name = skimstream.name+'DQM',
+                            paths = skimstream.paths,
+                            selectEvents = skimstream.selectEvents,
+                            content = self._options.datatier+'EventContent',
+                            dataTier = cms.untracked.string(self._options.datatier)
+                            )
+                    self.addExtraStream(skim+'DQM',skimstreamDQM)
+                for i in range(skimlist.count(shortname)):
+                    skimlist.remove(shortname)
 
 
 
         if (skimlist.__len__()!=0 and sequence!="all"):
-                print('WARNING, possible typo with SKIM:'+'+'.join(skimlist))
-                raise Exception('WARNING, possible typo with SKIM:'+'+'.join(skimlist))
+            print('WARNING, possible typo with SKIM:'+'+'.join(skimlist))
+            raise Exception('WARNING, possible typo with SKIM:'+'+'.join(skimlist))
 
     def prepare_USER(self, sequence = None):
         ''' Enrich the schedule with a user defined sequence '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.USERDefaultCFF)
-	self.scheduleSequence(sequence.split('.')[-1],'user_step')
+        self.scheduleSequence(sequence.split('.')[-1],'user_step')
         return
 
     def prepare_POSTRECO(self, sequence = None):
         """ Enrich the schedule with the postreco step """
         self.loadAndRemember(self.POSTRECODefaultCFF)
-	self.scheduleSequence('postreco_generator','postreco_step')
+        self.scheduleSequence('postreco_generator','postreco_step')
         return
 
 
     def prepare_VALIDATION(self, sequence = 'validation'):
-	    print(sequence,"in preparing validation")
-            self.loadDefaultOrSpecifiedCFF(sequence,self.VALIDATIONDefaultCFF)
-	    from Validation.Configuration.autoValidation import autoValidation
-            #in case VALIDATION:something:somethingelse -> something,somethingelse
-            sequence=sequence.split('.')[-1]
-            if sequence.find(',')!=-1:
-                    prevalSeqName=sequence.split(',')[0].split('+')
-                    valSeqName=sequence.split(',')[1].split('+')
-		    self.expandMapping(prevalSeqName,autoValidation,index=0)
-		    self.expandMapping(valSeqName,autoValidation,index=1)
+        print(sequence,"in preparing validation")
+        self.loadDefaultOrSpecifiedCFF(sequence,self.VALIDATIONDefaultCFF)
+        from Validation.Configuration.autoValidation import autoValidation
+        #in case VALIDATION:something:somethingelse -> something,somethingelse
+        sequence=sequence.split('.')[-1]
+        if sequence.find(',')!=-1:
+            prevalSeqName=sequence.split(',')[0].split('+')
+            valSeqName=sequence.split(',')[1].split('+')
+            self.expandMapping(prevalSeqName,autoValidation,index=0)
+            self.expandMapping(valSeqName,autoValidation,index=1)
+        else:
+            if '@' in sequence:
+                prevalSeqName=sequence.split('+')
+                valSeqName=sequence.split('+')
+                self.expandMapping(prevalSeqName,autoValidation,index=0)
+                self.expandMapping(valSeqName,autoValidation,index=1)
             else:
-		    if '@' in sequence:
-			    prevalSeqName=sequence.split('+')
-			    valSeqName=sequence.split('+')
-			    self.expandMapping(prevalSeqName,autoValidation,index=0)
-			    self.expandMapping(valSeqName,autoValidation,index=1)
-		    else:
-			    postfix=''
-			    if sequence:
-				    postfix='_'+sequence
-			    prevalSeqName=['prevalidation'+postfix]
-			    valSeqName=['validation'+postfix]
-			    if not hasattr(self.process,valSeqName[0]):
-				    prevalSeqName=['']
-				    valSeqName=[sequence]
+                postfix=''
+                if sequence:
+                    postfix='_'+sequence
+                prevalSeqName=['prevalidation'+postfix]
+                valSeqName=['validation'+postfix]
+                if not hasattr(self.process,valSeqName[0]):
+                    prevalSeqName=['']
+                    valSeqName=[sequence]
 
-	    def NFI(index):
-		    ##name from index, required to keep backward compatibility
-		    if index==0:
-			    return ''
-		    else:
-			    return '%s'%index
+        def NFI(index):
+            ##name from index, required to keep backward compatibility
+            if index==0:
+                return ''
+            else:
+                return '%s'%index
 
 
-            #rename the HLT process in validation steps
-	    if ('HLT' in self.stepMap and not self._options.fast) or self._options.hltProcess:
-		    for s in valSeqName+prevalSeqName:
-			    if s:
-				    self.renameHLTprocessInSequence(s)
-	    for (i,s) in enumerate(prevalSeqName):
-		    if s:
-			    setattr(self.process,'prevalidation_step%s'%NFI(i),  cms.Path( getattr(self.process, s)) )
-			    self.schedule.append(getattr(self.process,'prevalidation_step%s'%NFI(i)))
-			    
-	    for (i,s) in enumerate(valSeqName):
-		    setattr(self.process,'validation_step%s'%NFI(i), cms.EndPath( getattr(self.process, s)))
-		    self.schedule.append(getattr(self.process,'validation_step%s'%NFI(i)))
+        #rename the HLT process in validation steps
+        if ('HLT' in self.stepMap and not self._options.fast) or self._options.hltProcess:
+            for s in valSeqName+prevalSeqName:
+                if s:
+                    self.renameHLTprocessInSequence(s)
+        for (i,s) in enumerate(prevalSeqName):
+            if s:
+                setattr(self.process,'prevalidation_step%s'%NFI(i),  cms.Path( getattr(self.process, s)) )
+                self.schedule.append(getattr(self.process,'prevalidation_step%s'%NFI(i)))
 
-            #needed in case the miniAODValidation sequence is run starting from AODSIM
-	    if 'PAT' in self.stepMap and not 'RECO' in self.stepMap:
-		    return
+        for (i,s) in enumerate(valSeqName):
+            setattr(self.process,'validation_step%s'%NFI(i), cms.EndPath( getattr(self.process, s)))
+            self.schedule.append(getattr(self.process,'validation_step%s'%NFI(i)))
 
-            if not 'DIGI' in self.stepMap and not self._options.fast and not any(map( lambda s : s.startswith('genvalid'), valSeqName)):
-		    if self._options.restoreRNDSeeds==False and not self._options.restoreRNDSeeds==True:
-			    self._options.restoreRNDSeeds=True
-
-	    if not 'DIGI' in self.stepMap and not self._options.fast:
-		    self.executeAndRemember("process.mix.playback = True")
-		    self.executeAndRemember("process.mix.digitizers = cms.PSet()")
-                    self.executeAndRemember("for a in process.aliases: delattr(process, a)")
-                    self._options.customisation_file.append("SimGeneral/MixingModule/fullMixCustomize_cff.setCrossingFrameOn")
-
-	    if hasattr(self.process,"genstepfilter") and len(self.process.genstepfilter.triggerConditions):
-		    #will get in the schedule, smoothly
-		    for (i,s) in enumerate(valSeqName):
-			    getattr(self.process,'validation_step%s'%NFI(i))._seq = self.process.genstepfilter * getattr(self.process,'validation_step%s'%NFI(i))._seq
-
+        #needed in case the miniAODValidation sequence is run starting from AODSIM
+        if 'PAT' in self.stepMap and not 'RECO' in self.stepMap:
             return
+
+        if not 'DIGI' in self.stepMap and not self._options.fast and not any(map( lambda s : s.startswith('genvalid'), valSeqName)):
+            if self._options.restoreRNDSeeds==False and not self._options.restoreRNDSeeds==True:
+                self._options.restoreRNDSeeds=True
+
+        if not 'DIGI' in self.stepMap and not self._options.fast:
+            self.executeAndRemember("process.mix.playback = True")
+            self.executeAndRemember("process.mix.digitizers = cms.PSet()")
+            self.executeAndRemember("for a in process.aliases: delattr(process, a)")
+            self._options.customisation_file.append("SimGeneral/MixingModule/fullMixCustomize_cff.setCrossingFrameOn")
+
+        if hasattr(self.process,"genstepfilter") and len(self.process.genstepfilter.triggerConditions):
+            #will get in the schedule, smoothly
+            for (i,s) in enumerate(valSeqName):
+                getattr(self.process,'validation_step%s'%NFI(i))._seq = self.process.genstepfilter * getattr(self.process,'validation_step%s'%NFI(i))._seq
+
+        return
 
 
     class MassSearchReplaceProcessNameVisitor(object):
-            """Visitor that travels within a cms.Sequence, looks for a parameter and replace its value
-            It will climb down within PSets, VPSets and VInputTags to find its target"""
-            def __init__(self, paramSearch, paramReplace, verbose=False, whitelist=()):
-                    self._paramReplace = paramReplace
-                    self._paramSearch = paramSearch
-                    self._verbose = verbose
-                    self._whitelist = whitelist
+        """Visitor that travels within a cms.Sequence, looks for a parameter and replace its value
+        It will climb down within PSets, VPSets and VInputTags to find its target"""
+        def __init__(self, paramSearch, paramReplace, verbose=False, whitelist=()):
+            self._paramReplace = paramReplace
+            self._paramSearch = paramSearch
+            self._verbose = verbose
+            self._whitelist = whitelist
 
-            def doIt(self,pset,base):
-                    if isinstance(pset, cms._Parameterizable):
-                            for name in pset.parameters_().keys():
-                                    # skip whitelisted parameters
-                                    if name in self._whitelist:
-                                        continue
-                                    # if I use pset.parameters_().items() I get copies of the parameter values
-                                    # so I can't modify the nested pset
-                                    value = getattr(pset,name)
-                                    type = value.pythonTypeName()
-                                    if type in ('cms.PSet', 'cms.untracked.PSet'):
-                                        self.doIt(value,base+"."+name)
-                                    elif type in ('cms.VPSet', 'cms.untracked.VPSet'):
-                                        for (i,ps) in enumerate(value): self.doIt(ps, "%s.%s[%d]"%(base,name,i) )
-                                    elif type in ('cms.string', 'cms.untracked.string'):
-                                        if value.value() == self._paramSearch:
-                                            if self._verbose: print("set string process name %s.%s %s ==> %s"% (base, name, value, self._paramReplace))
-                                            setattr(pset, name,self._paramReplace)
-                                    elif type in ('cms.VInputTag', 'cms.untracked.VInputTag'):
-                                            for (i,n) in enumerate(value):
-                                                    if not isinstance(n, cms.InputTag):
-                                                            n=cms.InputTag(n)
-                                                    if n.processName == self._paramSearch:
-                                                            # VInputTag can be declared as a list of strings, so ensure that n is formatted correctly
-                                                            if self._verbose:print("set process name %s.%s[%d] %s ==> %s " % (base, name, i, n, self._paramReplace))
-                                                            setattr(n,"processName",self._paramReplace)
-                                                            value[i]=n
-				    elif type in ('cms.vstring', 'cms.untracked.vstring'):
-					    for (i,n) in enumerate(value):
-						    if n==self._paramSearch:
-							    getattr(pset,name)[i]=self._paramReplace
-				    elif type in ('cms.InputTag', 'cms.untracked.InputTag'):
-                                            if value.processName == self._paramSearch:
-                                                    if self._verbose: print("set process name %s.%s %s ==> %s " % (base, name, value, self._paramReplace))
-                                                    setattr(getattr(pset, name),"processName",self._paramReplace)
+        def doIt(self,pset,base):
+            if isinstance(pset, cms._Parameterizable):
+                for name in pset.parameters_().keys():
+                    # skip whitelisted parameters
+                    if name in self._whitelist:
+                        continue
+                    # if I use pset.parameters_().items() I get copies of the parameter values
+                    # so I can't modify the nested pset
+                    value = getattr(pset,name)
+                    type = value.pythonTypeName()
+                    if type in ('cms.PSet', 'cms.untracked.PSet'):
+                        self.doIt(value,base+"."+name)
+                    elif type in ('cms.VPSet', 'cms.untracked.VPSet'):
+                        for (i,ps) in enumerate(value): self.doIt(ps, "%s.%s[%d]"%(base,name,i) )
+                    elif type in ('cms.string', 'cms.untracked.string'):
+                        if value.value() == self._paramSearch:
+                            if self._verbose: print("set string process name %s.%s %s ==> %s"% (base, name, value, self._paramReplace))
+                            setattr(pset, name,self._paramReplace)
+                    elif type in ('cms.VInputTag', 'cms.untracked.VInputTag'):
+                        for (i,n) in enumerate(value):
+                            if not isinstance(n, cms.InputTag):
+                                n=cms.InputTag(n)
+                            if n.processName == self._paramSearch:
+                                # VInputTag can be declared as a list of strings, so ensure that n is formatted correctly
+                                if self._verbose:print("set process name %s.%s[%d] %s ==> %s " % (base, name, i, n, self._paramReplace))
+                                setattr(n,"processName",self._paramReplace)
+                                value[i]=n
+                    elif type in ('cms.vstring', 'cms.untracked.vstring'):
+                        for (i,n) in enumerate(value):
+                            if n==self._paramSearch:
+                                getattr(pset,name)[i]=self._paramReplace
+                    elif type in ('cms.InputTag', 'cms.untracked.InputTag'):
+                        if value.processName == self._paramSearch:
+                            if self._verbose: print("set process name %s.%s %s ==> %s " % (base, name, value, self._paramReplace))
+                            setattr(getattr(pset, name),"processName",self._paramReplace)
 
-            def enter(self,visitee):
-                    label = ''
-                    try:
-                            label = visitee.label()
-                    except AttributeError:
-                            label = '<Module not in a Process>'
-                    except:
-                            label = 'other execption'
-                    self.doIt(visitee, label)
+        def enter(self,visitee):
+            label = ''
+            try:
+                label = visitee.label()
+            except AttributeError:
+                label = '<Module not in a Process>'
+            except:
+                label = 'other execption'
+            self.doIt(visitee, label)
 
-            def leave(self,visitee):
-                    pass
+        def leave(self,visitee):
+            pass
 
     #visit a sequence to repalce all input tags
     def renameInputTagsInSequence(self,sequence,oldT="rawDataCollector",newT="rawDataRepacker"):
-	    print("Replacing all InputTag %s => %s"%(oldT,newT))
-	    from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
-	    massSearchReplaceAnyInputTag(getattr(self.process,sequence),oldT,newT)
-	    loadMe='from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag'
-	    if not loadMe in self.additionalCommands:
-		    self.additionalCommands.append(loadMe)
-	    self.additionalCommands.append('massSearchReplaceAnyInputTag(process.%s,"%s","%s",False,True)'%(sequence,oldT,newT))
+        print("Replacing all InputTag %s => %s"%(oldT,newT))
+        from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
+        massSearchReplaceAnyInputTag(getattr(self.process,sequence),oldT,newT)
+        loadMe='from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag'
+        if not loadMe in self.additionalCommands:
+            self.additionalCommands.append(loadMe)
+        self.additionalCommands.append('massSearchReplaceAnyInputTag(process.%s,"%s","%s",False,True)'%(sequence,oldT,newT))
 
     #change the process name used to address HLT results in any sequence
     def renameHLTprocessInSequence(self,sequence,proc=None,HLTprocess='HLT'):
-	    if self._options.hltProcess:
-		    proc=self._options.hltProcess
-	    else:
-		    proc=self.process.name_()
-	    if proc==HLTprocess:    return
-            # look up all module in dqm sequence
-            print("replacing %s process name - sequence %s will use '%s'" % (HLTprocess,sequence, proc))
-            getattr(self.process,sequence).visit(ConfigBuilder.MassSearchReplaceProcessNameVisitor(HLTprocess,proc,whitelist = ("subSystemFolder",)))
-            if 'from Configuration.Applications.ConfigBuilder import ConfigBuilder' not in self.additionalCommands:
-                    self.additionalCommands.append('from Configuration.Applications.ConfigBuilder import ConfigBuilder')
-            self.additionalCommands.append('process.%s.visit(ConfigBuilder.MassSearchReplaceProcessNameVisitor("%s", "%s", whitelist = ("subSystemFolder",)))'% (sequence,HLTprocess, proc))
+        if self._options.hltProcess:
+            proc=self._options.hltProcess
+        else:
+            proc=self.process.name_()
+        if proc==HLTprocess:    return
+        # look up all module in dqm sequence
+        print("replacing %s process name - sequence %s will use '%s'" % (HLTprocess,sequence, proc))
+        getattr(self.process,sequence).visit(ConfigBuilder.MassSearchReplaceProcessNameVisitor(HLTprocess,proc,whitelist = ("subSystemFolder",)))
+        if 'from Configuration.Applications.ConfigBuilder import ConfigBuilder' not in self.additionalCommands:
+            self.additionalCommands.append('from Configuration.Applications.ConfigBuilder import ConfigBuilder')
+        self.additionalCommands.append('process.%s.visit(ConfigBuilder.MassSearchReplaceProcessNameVisitor("%s", "%s", whitelist = ("subSystemFolder",)))'% (sequence,HLTprocess, proc))
 
 
     def expandMapping(self,seqList,mapping,index=None):
-	    maxLevel=20
-	    level=0
-	    while '@' in repr(seqList) and level<maxLevel:
-		    level+=1
-		    for specifiedCommand in seqList:
-			    if specifiedCommand.startswith('@'):
-				    location=specifiedCommand[1:]
-				    if not location in mapping:
-					    raise Exception("Impossible to map "+location+" from "+repr(mapping))
-				    mappedTo=mapping[location]
-				    if index!=None:
-					    mappedTo=mappedTo[index]
-				    seqList.remove(specifiedCommand)
-				    seqList.extend(mappedTo.split('+'))
-				    break;
-	    if level==maxLevel:
-		    raise Exception("Could not fully expand "+repr(seqList)+" from "+repr(mapping))
-	    
+        maxLevel=20
+        level=0
+        while '@' in repr(seqList) and level<maxLevel:
+            level+=1
+            for specifiedCommand in seqList:
+                if specifiedCommand.startswith('@'):
+                    location=specifiedCommand[1:]
+                    if not location in mapping:
+                        raise Exception("Impossible to map "+location+" from "+repr(mapping))
+                    mappedTo=mapping[location]
+                    if index!=None:
+                        mappedTo=mappedTo[index]
+                    seqList.remove(specifiedCommand)
+                    seqList.extend(mappedTo.split('+'))
+                    break;
+        if level==maxLevel:
+            raise Exception("Could not fully expand "+repr(seqList)+" from "+repr(mapping))
+
     def prepare_DQM(self, sequence = 'DQMOffline'):
         # this one needs replacement
 
         self.loadDefaultOrSpecifiedCFF(sequence,self.DQMOFFLINEDefaultCFF)
         sequenceList=sequence.split('.')[-1].split('+')
         postSequenceList=sequence.split('.')[-1].split('+')
-	from DQMOffline.Configuration.autoDQM import autoDQM
-	self.expandMapping(sequenceList,autoDQM,index=0)
-	self.expandMapping(postSequenceList,autoDQM,index=1)
-	
-	if len(set(sequenceList))!=len(sequenceList):
-		sequenceList=list(set(sequenceList))
-		print("Duplicate entries for DQM:, using",sequenceList)
+        from DQMOffline.Configuration.autoDQM import autoDQM
+        self.expandMapping(sequenceList,autoDQM,index=0)
+        self.expandMapping(postSequenceList,autoDQM,index=1)
 
-	pathName='dqmoffline_step'
-	for (i,sequence) in enumerate(sequenceList):
-		if (i!=0):
-			pathName='dqmoffline_%d_step'%(i)
-			
-		if 'HLT' in self.stepMap.keys() or self._options.hltProcess:
-			self.renameHLTprocessInSequence(sequence)
-                
-                setattr(self.process,pathName, cms.EndPath( getattr(self.process,sequence ) ) )
-                self.schedule.append(getattr(self.process,pathName))
+        if len(set(sequenceList))!=len(sequenceList):
+            sequenceList=list(set(sequenceList))
+            print("Duplicate entries for DQM:, using",sequenceList)
 
-                if hasattr(self.process,"genstepfilter") and len(self.process.genstepfilter.triggerConditions):
-                        #will get in the schedule, smoothly
-                        getattr(self.process,pathName).insert(0,self.process.genstepfilter)
+        pathName='dqmoffline_step'
+        for (i,sequence) in enumerate(sequenceList):
+            if (i!=0):
+                pathName='dqmoffline_%d_step'%(i)
 
-	pathName='dqmofflineOnPAT_step'
-	for (i,sequence) in enumerate(postSequenceList):
-                if (i!=0):
-                        pathName='dqmofflineOnPAT_%d_step'%(i)
+            if 'HLT' in self.stepMap.keys() or self._options.hltProcess:
+                self.renameHLTprocessInSequence(sequence)
 
-                setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
-                self.schedule.append(getattr(self.process,pathName))
+            setattr(self.process,pathName, cms.EndPath( getattr(self.process,sequence ) ) )
+            self.schedule.append(getattr(self.process,pathName))
+
+            if hasattr(self.process,"genstepfilter") and len(self.process.genstepfilter.triggerConditions):
+                #will get in the schedule, smoothly
+                getattr(self.process,pathName).insert(0,self.process.genstepfilter)
+
+        pathName='dqmofflineOnPAT_step'
+        for (i,sequence) in enumerate(postSequenceList):
+            if (i!=0):
+                pathName='dqmofflineOnPAT_%d_step'%(i)
+
+            setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
+            self.schedule.append(getattr(self.process,pathName))
 
     def prepare_HARVESTING(self, sequence = None):
         """ Enrich the process with harvesting step """
@@ -1971,31 +1971,31 @@ class ConfigBuilder(object):
 
         # decide which HARVESTING paths to use
         harvestingList = sequence.split("+")
-	from DQMOffline.Configuration.autoDQM import autoDQM
-	from Validation.Configuration.autoValidation import autoValidation
-	import copy
-	combined_mapping = copy.deepcopy( autoDQM )
-	combined_mapping.update( autoValidation )
-	self.expandMapping(harvestingList,combined_mapping,index=-1)
-	
-	if len(set(harvestingList))!=len(harvestingList):
-		harvestingList=list(set(harvestingList))
-		print("Duplicate entries for HARVESTING, using",harvestingList)
+        from DQMOffline.Configuration.autoDQM import autoDQM
+        from Validation.Configuration.autoValidation import autoValidation
+        import copy
+        combined_mapping = copy.deepcopy( autoDQM )
+        combined_mapping.update( autoValidation )
+        self.expandMapping(harvestingList,combined_mapping,index=-1)
 
-	for name in harvestingList:
-		if not name in harvestingConfig.__dict__:
-			print(name,"is not a possible harvesting type. Available are",harvestingConfig.__dict__.keys())
-			continue
-		harvestingstream = getattr(harvestingConfig,name)
-		if isinstance(harvestingstream,cms.Path):
-			self.schedule.append(harvestingstream)
-			self.blacklist_paths.append(harvestingstream)
-		if isinstance(harvestingstream,cms.Sequence):
-			setattr(self.process,name+"_step",cms.Path(harvestingstream))
-			self.schedule.append(getattr(self.process,name+"_step"))
+        if len(set(harvestingList))!=len(harvestingList):
+            harvestingList=list(set(harvestingList))
+            print("Duplicate entries for HARVESTING, using",harvestingList)
+
+        for name in harvestingList:
+            if not name in harvestingConfig.__dict__:
+                print(name,"is not a possible harvesting type. Available are",harvestingConfig.__dict__.keys())
+                continue
+            harvestingstream = getattr(harvestingConfig,name)
+            if isinstance(harvestingstream,cms.Path):
+                self.schedule.append(harvestingstream)
+                self.blacklist_paths.append(harvestingstream)
+            if isinstance(harvestingstream,cms.Sequence):
+                setattr(self.process,name+"_step",cms.Path(harvestingstream))
+                self.schedule.append(getattr(self.process,name+"_step"))
 
         self.scheduleSequence('DQMSaver','dqmsave_step')
-	return
+        return
 
     def prepare_ALCAHARVEST(self, sequence = None):
         """ Enrich the process with AlCaHarvesting step """
@@ -2007,24 +2007,24 @@ class ConfigBuilder(object):
 
 
 
- 	from Configuration.AlCa.autoPCL import autoPCL
- 	self.expandMapping(harvestingList,autoPCL)
+        from Configuration.AlCa.autoPCL import autoPCL
+        self.expandMapping(harvestingList,autoPCL)
 
         for name in harvestingConfig.__dict__:
             harvestingstream = getattr(harvestingConfig,name)
             if name in harvestingList and isinstance(harvestingstream,cms.Path):
-               self.schedule.append(harvestingstream)
-               if isinstance(getattr(harvestingConfig,"ALCAHARVEST" + name + "_dbOutput"), cms.VPSet) and \
-                  isinstance(getattr(harvestingConfig,"ALCAHARVEST" + name + "_metadata"), cms.VPSet):
-                   self.executeAndRemember("process.PoolDBOutputService.toPut.extend(process.ALCAHARVEST" + name + "_dbOutput)")
-                   self.executeAndRemember("process.pclMetadataWriter.recordsToMap.extend(process.ALCAHARVEST" + name + "_metadata)")
-               else:
-                   self.executeAndRemember("process.PoolDBOutputService.toPut.append(process.ALCAHARVEST" + name + "_dbOutput)")
-                   self.executeAndRemember("process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVEST" + name + "_metadata)")
-               harvestingList.remove(name)
-	# append the common part at the end of the sequence
-	lastStep = getattr(harvestingConfig,"ALCAHARVESTDQMSaveAndMetadataWriter")
-	self.schedule.append(lastStep)
+                self.schedule.append(harvestingstream)
+                if isinstance(getattr(harvestingConfig,"ALCAHARVEST" + name + "_dbOutput"), cms.VPSet) and \
+                   isinstance(getattr(harvestingConfig,"ALCAHARVEST" + name + "_metadata"), cms.VPSet):
+                    self.executeAndRemember("process.PoolDBOutputService.toPut.extend(process.ALCAHARVEST" + name + "_dbOutput)")
+                    self.executeAndRemember("process.pclMetadataWriter.recordsToMap.extend(process.ALCAHARVEST" + name + "_metadata)")
+                else:
+                    self.executeAndRemember("process.PoolDBOutputService.toPut.append(process.ALCAHARVEST" + name + "_dbOutput)")
+                    self.executeAndRemember("process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVEST" + name + "_metadata)")
+                harvestingList.remove(name)
+        # append the common part at the end of the sequence
+        lastStep = getattr(harvestingConfig,"ALCAHARVESTDQMSaveAndMetadataWriter")
+        self.schedule.append(lastStep)
 
         if len(harvestingList) != 0 and 'dummyHarvesting' not in harvestingList :
             print("The following harvesting could not be found : ", harvestingList)
@@ -2033,13 +2033,13 @@ class ConfigBuilder(object):
 
 
     def prepare_ENDJOB(self, sequence = 'endOfProcess'):
-	    self.loadDefaultOrSpecifiedCFF(sequence,self.ENDJOBDefaultCFF)
-	    self.scheduleSequenceAtEnd(sequence.split('.')[-1],'endjob_step')
-	    return
+        self.loadDefaultOrSpecifiedCFF(sequence,self.ENDJOBDefaultCFF)
+        self.scheduleSequenceAtEnd(sequence.split('.')[-1],'endjob_step')
+        return
 
     def finalizeFastSimHLT(self):
-            self.process.reconstruction = cms.Path(self.process.reconstructionWithFamos)
-            self.schedule.append(self.process.reconstruction)
+        self.process.reconstruction = cms.Path(self.process.reconstructionWithFamos)
+        self.schedule.append(self.process.reconstruction)
 
 
     def build_production_info(self, evt_type, evtnumber):
@@ -2059,43 +2059,43 @@ class ConfigBuilder(object):
         self.pythonCfgCode += "# with command line options: "+self._options.arguments+'\n'
         self.pythonCfgCode += "import FWCore.ParameterSet.Config as cms\n\n"
 
-	# now set up the modifies
-	modifiers=[]
-	modifierStrings=[]
-	modifierImports=['from Configuration.StandardSequences.Eras import eras']
+        # now set up the modifies
+        modifiers=[]
+        modifierStrings=[]
+        modifierImports=['from Configuration.StandardSequences.Eras import eras']
 
         if hasattr(self._options,"era") and self._options.era :
-            # Multiple eras can be specified in a comma seperated list
+        # Multiple eras can be specified in a comma seperated list
             from Configuration.StandardSequences.Eras import eras
             for requestedEra in self._options.era.split(",") :
-		    modifierStrings.append("eras."+requestedEra)
-		    modifiers.append(getattr(eras,requestedEra))
+                modifierStrings.append("eras."+requestedEra)
+                modifiers.append(getattr(eras,requestedEra))
 
 
-	if hasattr(self._options,"procModifiers") and self._options.procModifiers:
+        if hasattr(self._options,"procModifiers") and self._options.procModifiers:
             import importlib
-	    thingsImported=[]
- 	    for pm in self._options.procModifiers.split(','):
-                   modifierStrings.append(pm)
-		   modifierImports.append('from Configuration.ProcessModifiers.'+pm+'_cff import '+pm)
-                   modifiers.append(getattr(importlib.import_module('Configuration.ProcessModifiers.'+pm+'_cff'),pm))
+            thingsImported=[]
+            for pm in self._options.procModifiers.split(','):
+                modifierStrings.append(pm)
+                modifierImports.append('from Configuration.ProcessModifiers.'+pm+'_cff import '+pm)
+                modifiers.append(getattr(importlib.import_module('Configuration.ProcessModifiers.'+pm+'_cff'),pm))
 
-	self.pythonCfgCode += '\n'.join(modifierImports)+'\n\n'
-	self.pythonCfgCode += "process = cms.Process('"+self._options.name+"'" # Start of the line, finished after the loop
+        self.pythonCfgCode += '\n'.join(modifierImports)+'\n\n'
+        self.pythonCfgCode += "process = cms.Process('"+self._options.name+"'" # Start of the line, finished after the loop
 
 
-	if len(modifierStrings)>0:
-		self.pythonCfgCode+= ','+','.join(modifierStrings)
-	self.pythonCfgCode+=')\n\n'
+        if len(modifierStrings)>0:
+            self.pythonCfgCode+= ','+','.join(modifierStrings)
+        self.pythonCfgCode+=')\n\n'
 
         #yes, the cfg code gets out of sync here if a process is passed in. That could be fixed in the future
         #assuming there is some way for the fwk to get the list of modifiers (and their stringified name)
         if self.process == None:
-	    if len(modifiers)>0:	
-               self.process = cms.Process(self._options.name,*modifiers)
+            if len(modifiers)>0:	
+                self.process = cms.Process(self._options.name,*modifiers)
             else:
-               self.process = cms.Process(self._options.name)
-	
+                self.process = cms.Process(self._options.name)
+
 
 
 
@@ -2105,16 +2105,16 @@ class ConfigBuilder(object):
         self.loadAndRemember(self.EVTCONTDefaultCFF)  #load the event contents regardless
         self.addMaxEvents()
         if self.with_input:
-           self.addSource()
-	self.addStandardSequences()
-	##adding standard sequences might change the inputEventContent option and therefore needs to be finalized after
-	self.completeInputCommand()
+            self.addSource()
+        self.addStandardSequences()
+        ##adding standard sequences might change the inputEventContent option and therefore needs to be finalized after
+        self.completeInputCommand()
         self.addConditions()
 
 
         outputModuleCfgCode=""
         if not 'HARVESTING' in self.stepMap.keys() and not 'ALCAHARVEST' in self.stepMap.keys() and not 'ALCAOUTPUT' in self.stepMap.keys() and self.with_output:
-                outputModuleCfgCode=self.addOutput()
+            outputModuleCfgCode=self.addOutput()
 
         self.addCommon()
 
@@ -2124,16 +2124,16 @@ class ConfigBuilder(object):
 
         # production info
         if not hasattr(self.process,"configurationMetadata"):
-                self.build_production_info(self._options.evt_type, self._options.number)
+            self.build_production_info(self._options.evt_type, self._options.number)
         else:
-                #the PSet was added via a load
-                self.addedObjects.append(("Production Info","configurationMetadata"))
+            #the PSet was added via a load
+            self.addedObjects.append(("Production Info","configurationMetadata"))
 
         self.pythonCfgCode +="\n"
         for comment,object in self.addedObjects:
-                if comment!="":
-                        self.pythonCfgCode += "\n# "+comment+"\n"
-                self.pythonCfgCode += dumpPython(self.process,object)
+            if comment!="":
+                self.pythonCfgCode += "\n# "+comment+"\n"
+            self.pythonCfgCode += dumpPython(self.process,object)
 
         # dump the output definition
         self.pythonCfgCode += "\n# Output definition\n"
@@ -2144,11 +2144,11 @@ class ConfigBuilder(object):
         #I do not understand why the keys are not normally ordered.
         nl=sorted(self.additionalOutputs.keys())
         for name in nl:
-                output = self.additionalOutputs[name]
-                self.pythonCfgCode += "process.%s = %s" %(name, output.dumpPython())
-                tmpOut = cms.EndPath(output)
-                setattr(self.process,name+'OutPath',tmpOut)
-                self.schedule.append(tmpOut)
+            output = self.additionalOutputs[name]
+            self.pythonCfgCode += "process.%s = %s" %(name, output.dumpPython())
+            tmpOut = cms.EndPath(output)
+            setattr(self.process,name+'OutPath',tmpOut)
+            self.schedule.append(tmpOut)
 
         # dump all additional commands
         self.pythonCfgCode += "\n# Other statements\n"
@@ -2157,111 +2157,111 @@ class ConfigBuilder(object):
 
         #comma separated list of objects that deserve to be inlined in the configuration (typically from a modified config deep down)
         for object in self._options.inlineObjets.split(','):
-                if not object:
-                        continue
-                if not hasattr(self.process,object):
-                        print('cannot inline -'+object+'- : not known')
-                else:
-                        self.pythonCfgCode +='\n'
-                        self.pythonCfgCode +=dumpPython(self.process,object)
+            if not object:
+                continue
+            if not hasattr(self.process,object):
+                print('cannot inline -'+object+'- : not known')
+            else:
+                self.pythonCfgCode +='\n'
+                self.pythonCfgCode +=dumpPython(self.process,object)
 
         # dump all paths
         self.pythonCfgCode += "\n# Path and EndPath definitions\n"
         for path in self.process.paths:
             if getattr(self.process,path) not in self.blacklist_paths:
                 self.pythonCfgCode += dumpPython(self.process,path)
-		
+
         for endpath in self.process.endpaths:
             if getattr(self.process,endpath) not in self.blacklist_paths:
                 self.pythonCfgCode += dumpPython(self.process,endpath)
 
         # dump the schedule
-	self.pythonCfgCode += "\n# Schedule definition\n"
-	result = "process.schedule = cms.Schedule("
+        self.pythonCfgCode += "\n# Schedule definition\n"
+        result = "process.schedule = cms.Schedule("
 
         # handling of the schedule
-	self.process.schedule = cms.Schedule()
-	for item in self.schedule:
-		if not isinstance(item, cms.Schedule):
-			self.process.schedule.append(item)
-		else:
-			self.process.schedule.extend(item)
+        self.process.schedule = cms.Schedule()
+        for item in self.schedule:
+            if not isinstance(item, cms.Schedule):
+                self.process.schedule.append(item)
+            else:
+                self.process.schedule.extend(item)
 
-	if hasattr(self.process,"HLTSchedule"):
-		beforeHLT = self.schedule[:self.schedule.index(self.process.HLTSchedule)]
-		afterHLT = self.schedule[self.schedule.index(self.process.HLTSchedule)+1:]
-		pathNames = ['process.'+p.label_() for p in beforeHLT]
-		result += ','.join(pathNames)+')\n'
-		result += 'process.schedule.extend(process.HLTSchedule)\n'
-		pathNames = ['process.'+p.label_() for p in afterHLT]
-		result += 'process.schedule.extend(['+','.join(pathNames)+'])\n'
-	else:
-		pathNames = ['process.'+p.label_() for p in self.schedule]
-		result ='process.schedule = cms.Schedule('+','.join(pathNames)+')\n'
+        if hasattr(self.process,"HLTSchedule"):
+            beforeHLT = self.schedule[:self.schedule.index(self.process.HLTSchedule)]
+            afterHLT = self.schedule[self.schedule.index(self.process.HLTSchedule)+1:]
+            pathNames = ['process.'+p.label_() for p in beforeHLT]
+            result += ','.join(pathNames)+')\n'
+            result += 'process.schedule.extend(process.HLTSchedule)\n'
+            pathNames = ['process.'+p.label_() for p in afterHLT]
+            result += 'process.schedule.extend(['+','.join(pathNames)+'])\n'
+        else:
+            pathNames = ['process.'+p.label_() for p in self.schedule]
+            result ='process.schedule = cms.Schedule('+','.join(pathNames)+')\n'
 
-	self.pythonCfgCode += result
+        self.pythonCfgCode += result
 
         for labelToAssociate in self.labelsToAssociate:
-                self.process.schedule.associate(getattr(self.process, labelToAssociate))
-                self.pythonCfgCode += 'process.schedule.associate(process.' + labelToAssociate + ')\n'
+            self.process.schedule.associate(getattr(self.process, labelToAssociate))
+            self.pythonCfgCode += 'process.schedule.associate(process.' + labelToAssociate + ')\n'
 
         from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
         associatePatAlgosToolsTask(self.process)
         self.pythonCfgCode+="from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask\n"
         self.pythonCfgCode+="associatePatAlgosToolsTask(process)\n"
 
-	if self._options.nThreads is not "1":
-		self.pythonCfgCode +="\n"
-		self.pythonCfgCode +="#Setup FWK for multithreaded\n"
-		self.pythonCfgCode +="process.options.numberOfThreads=cms.untracked.uint32("+self._options.nThreads+")\n"
-		self.pythonCfgCode +="process.options.numberOfStreams=cms.untracked.uint32(0)\n"
-	#repacked version
-	if self._options.isRepacked:
-		self.pythonCfgCode +="\n"
-		self.pythonCfgCode +="from Configuration.Applications.ConfigBuilder import MassReplaceInputTag\n"
-		self.pythonCfgCode +="MassReplaceInputTag(process)\n"
-		MassReplaceInputTag(self.process)
-		
+        if self._options.nThreads is not "1":
+            self.pythonCfgCode +="\n"
+            self.pythonCfgCode +="#Setup FWK for multithreaded\n"
+            self.pythonCfgCode +="process.options.numberOfThreads=cms.untracked.uint32("+self._options.nThreads+")\n"
+            self.pythonCfgCode +="process.options.numberOfStreams=cms.untracked.uint32(0)\n"
+        #repacked version
+        if self._options.isRepacked:
+            self.pythonCfgCode +="\n"
+            self.pythonCfgCode +="from Configuration.Applications.ConfigBuilder import MassReplaceInputTag\n"
+            self.pythonCfgCode +="MassReplaceInputTag(process)\n"
+            MassReplaceInputTag(self.process)
+
         # special treatment in case of production filter sequence 2/2
         if self.productionFilterSequence:
-                self.pythonCfgCode +='# filter all path with the production filter sequence\n'
-                self.pythonCfgCode +='for path in process.paths:\n'
-		if len(self.conditionalPaths):
-			self.pythonCfgCode +='\tif not path in %s: continue\n'%str(self.conditionalPaths)
-                if len(self.excludedPaths):
-                        self.pythonCfgCode +='\tif path in %s: continue\n'%str(self.excludedPaths)			
-                self.pythonCfgCode +='\tgetattr(process,path)._seq = process.%s * getattr(process,path)._seq \n'%(self.productionFilterSequence,)
-		pfs = getattr(self.process,self.productionFilterSequence)
-		for path in self.process.paths:
-			if not path in self.conditionalPaths: continue
-                        if path in self.excludedPaths: continue
-			getattr(self.process,path)._seq = pfs * getattr(self.process,path)._seq
-			
+            self.pythonCfgCode +='# filter all path with the production filter sequence\n'
+            self.pythonCfgCode +='for path in process.paths:\n'
+            if len(self.conditionalPaths):
+                self.pythonCfgCode +='\tif not path in %s: continue\n'%str(self.conditionalPaths)
+            if len(self.excludedPaths):
+                self.pythonCfgCode +='\tif path in %s: continue\n'%str(self.excludedPaths)			
+            self.pythonCfgCode +='\tgetattr(process,path)._seq = process.%s * getattr(process,path)._seq \n'%(self.productionFilterSequence,)
+            pfs = getattr(self.process,self.productionFilterSequence)
+            for path in self.process.paths:
+                if not path in self.conditionalPaths: continue
+                if path in self.excludedPaths: continue
+                getattr(self.process,path)._seq = pfs * getattr(self.process,path)._seq
+
 
         # dump customise fragment
-	self.pythonCfgCode += self.addCustomise()
+        self.pythonCfgCode += self.addCustomise()
 
-	if self._options.runUnscheduled:	
-		# prune and delete paths
-		#this is not supporting the blacklist at this point since I do not understand it
-		self.pythonCfgCode+="#do not add changes to your config after this point (unless you know what you are doing)\n"
-		self.pythonCfgCode+="from FWCore.ParameterSet.Utilities import convertToUnscheduled\n"
-		self.pythonCfgCode+="process=convertToUnscheduled(process)\n"
+        if self._options.runUnscheduled:	
+            # prune and delete paths
+            #this is not supporting the blacklist at this point since I do not understand it
+            self.pythonCfgCode+="#do not add changes to your config after this point (unless you know what you are doing)\n"
+            self.pythonCfgCode+="from FWCore.ParameterSet.Utilities import convertToUnscheduled\n"
+            self.pythonCfgCode+="process=convertToUnscheduled(process)\n"
 
-		from FWCore.ParameterSet.Utilities import convertToUnscheduled
-		self.process=convertToUnscheduled(self.process)
+            from FWCore.ParameterSet.Utilities import convertToUnscheduled
+            self.process=convertToUnscheduled(self.process)
 
-		self.pythonCfgCode += self.addCustomise(1)
+            self.pythonCfgCode += self.addCustomise(1)
 
-	self.pythonCfgCode += self.addCustomiseCmdLine()
+        self.pythonCfgCode += self.addCustomiseCmdLine()
 
         if hasattr(self.process,"logErrorHarvester"):
-                #configure logErrorHarvester to wait for same EDProducers to finish as the OutputModules
-                self.pythonCfgCode +="\n#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule\n"
-                self.pythonCfgCode +="from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands\n"
-                self.pythonCfgCode +="process = customiseLogErrorHarvesterUsingOutputCommands(process)\n"
-                from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
-                self.process = customiseLogErrorHarvesterUsingOutputCommands(self.process)
+            #configure logErrorHarvester to wait for same EDProducers to finish as the OutputModules
+            self.pythonCfgCode +="\n#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule\n"
+            self.pythonCfgCode +="from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands\n"
+            self.pythonCfgCode +="process = customiseLogErrorHarvesterUsingOutputCommands(process)\n"
+            from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+            self.process = customiseLogErrorHarvesterUsingOutputCommands(self.process)
 
         # Temporary hack to put the early delete customization after
         # everything else
@@ -2275,27 +2275,27 @@ class ConfigBuilder(object):
         self.process = customiseEarlyDelete(self.process)
 
 
-	# make the .io file
+        # make the .io file
 
-	if self._options.io:
-		#io=open(self._options.python_filename.replace('.py','.io'),'w')
-		if not self._options.io.endswith('.io'): self._option.io+='.io'
-		io=open(self._options.io,'w')
-		ioJson={}
-		if hasattr(self.process.source,"fileNames"):
-			if len(self.process.source.fileNames.value()):
-				ioJson['primary']=self.process.source.fileNames.value()
-		if hasattr(self.process.source,"secondaryFileNames"):
-			if len(self.process.source.secondaryFileNames.value()):
-				ioJson['secondary']=self.process.source.secondaryFileNames.value()
-		if self._options.pileup_input and (self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:')):
-			ioJson['pileup']=self._options.pileup_input[4:]
-		for (o,om) in self.process.outputModules_().items():
-			ioJson[o]=om.fileName.value()
-		ioJson['GT']=self.process.GlobalTag.globaltag.value()
-		if self.productionFilterSequence:
-			ioJson['filter']=self.productionFilterSequence
-		import json
-		io.write(json.dumps(ioJson))
-	return
+        if self._options.io:
+            #io=open(self._options.python_filename.replace('.py','.io'),'w')
+            if not self._options.io.endswith('.io'): self._option.io+='.io'
+            io=open(self._options.io,'w')
+            ioJson={}
+            if hasattr(self.process.source,"fileNames"):
+                if len(self.process.source.fileNames.value()):
+                    ioJson['primary']=self.process.source.fileNames.value()
+            if hasattr(self.process.source,"secondaryFileNames"):
+                if len(self.process.source.secondaryFileNames.value()):
+                    ioJson['secondary']=self.process.source.secondaryFileNames.value()
+            if self._options.pileup_input and (self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:')):
+                ioJson['pileup']=self._options.pileup_input[4:]
+            for (o,om) in self.process.outputModules_().items():
+                ioJson[o]=om.fileName.value()
+            ioJson['GT']=self.process.GlobalTag.globaltag.value()
+            if self.productionFilterSequence:
+                ioJson['filter']=self.productionFilterSequence
+            import json
+            io.write(json.dumps(ioJson))
+        return
 

--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -27,47 +27,47 @@ class MatrixRunner(object):
 
         return nActive
 
-        
+
     def runTests(self, opt):
 
         testList=opt.testList
         dryRun=opt.dryRun
         cafVeto=opt.cafVeto
-        
+
         startDir = os.getcwd()
 
-    	report=''
+        report=''
         noRun=(self.maxThreads==0)
         if noRun:
             print('Not running the wf, only creating cfgs and logs')
             print('resetting to default number of threads')
             self.maxThreads=4
 
-    	print('Running in %s thread(s)' % self.maxThreads)
+        print('Running in %s thread(s)' % self.maxThreads)
 
-            
+
         for wf in self.workFlows:
 
             if testList and float(wf.numId) not in [float(x) for x in testList]: continue
 
             item = wf.nameId
             if os.path.islink(item) : continue # ignore symlinks
-            
-    	    # make sure we don't run more than the allowed number of threads:
-    	    while self.activeThreads() >= self.maxThreads:
+
+            # make sure we don't run more than the allowed number of threads:
+            while self.activeThreads() >= self.maxThreads:
                 time.sleep(1)
-    	    
-    	    print('\nPreparing to run %s %s' % (wf.numId, item))
+
+            print('\nPreparing to run %s %s' % (wf.numId, item))
             sys.stdout.flush()
             current = WorkFlowRunner(wf,noRun,dryRun,cafVeto, opt.dasOptions, opt.jobReports, opt.nThreads, opt.maxSteps)
-    	    self.threadList.append(current)
-    	    current.start()
+            self.threadList.append(current)
+            current.start()
             if not dryRun:
                 time.sleep(0.5) # try to avoid race cond by sleeping 0.5 sec
 
-    	# wait until all threads are finished
+        # wait until all threads are finished
         while self.activeThreads() > 0:
-    	    time.sleep(0.5)
+            time.sleep(0.5)
 
 
         #wrap up !
@@ -79,7 +79,7 @@ class MatrixRunner(object):
                 collect.append(0)
             for i,c in enumerate(result):
                 collect[i]+=c
-                
+
         for pingle in self.threadList:
             pingle.join()
             try:
@@ -90,7 +90,7 @@ class MatrixRunner(object):
             except Exception as e:
                 msg = "ERROR retrieving info from thread: " + str(e)
                 report += msg
-                
+
         report+=' '.join(map(str,totpassed))+' tests passed, '+' '.join(map(str,totfailed))+' failed\n'
         print(report)
         sys.stdout.flush()
@@ -102,6 +102,6 @@ class MatrixRunner(object):
         os.chdir(startDir)
 
         anyFail=sum(totfailed)
-                                        
+
         return anyFail
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -64,8 +64,8 @@ numWFAll={
 for year in upgradeKeys:
     for i in range(0,len(upgradeKeys[year])):
         numWFtmp = numWFStart[year] if i==0 else (numWFAll[year][i-1] + numWFSkip)
-	for conflict in numWFConflict:
-	    if numWFtmp>=conflict[0] and numWFtmp<conflict[1]:
+        for conflict in numWFConflict:
+            if numWFtmp>=conflict[0] and numWFtmp<conflict[1]:
                 numWFtmp = conflict[1]
                 break
         numWFAll[year].append(numWFtmp)

--- a/DQM/Integration/scripts/XMLcfgfiles/getRunAppsInfo.py
+++ b/DQM/Integration/scripts/XMLcfgfiles/getRunAppsInfo.py
@@ -16,101 +16,101 @@ import ExtractAppInfoFromXML as appinf
 # ssh srv-c2d05-18.cms ps -eo pid,cmd | grep 22101
 ################################################################################
 def getAppPID(srv,port):
-	try:
-		print("Connecting to server: "+srv+" and fetching PID for application running on port: "+port)
-		cf=os.popen('ssh '+srv+' ps -eo pid,cmd | grep '+port)
-		l=cf.readline();
-		if l=="":
-			cf.close()
-			return "App Not Running" 
-		else:
-			pidv=l.split()
-			cf.close();
-			return pidv[0]
-	except:
-		sys.stderr.write(  "Something went really bad\n" )
-        return -1
+    try:
+        print("Connecting to server: "+srv+" and fetching PID for application running on port: "+port)
+        cf=os.popen('ssh '+srv+' ps -eo pid,cmd | grep '+port)
+        l=cf.readline();
+        if l=="":
+            cf.close()
+            return "App Not Running" 
+        else:
+            pidv=l.split()
+            cf.close();
+            return pidv[0]
+    except:
+        sys.stderr.write(  "Something went really bad\n" )
+    return -1
 ################################################################################
 def getAppLogFileName(srv,pid):
 #	try:
-		#pid=getAppPID(srv,port)
-		if pid=="App Not Running":
-			return "No active log file"
-		else:
-			print("Connecting to server: "+srv+" and fetching LogFile for application with PID: "+pid)
-			cf=os.popen('ssh '+srv+' ls -l /tmp | grep '+pid)
-			l=cf.readline();
-			if l=="":
-				cf.close()
-				return "App Not Running???" 
-			else:
-				logfilev=l.split()
-				cf.close();
-				return logfilev[-1]
+        #pid=getAppPID(srv,port)
+    if pid=="App Not Running":
+        return "No active log file"
+    else:
+        print("Connecting to server: "+srv+" and fetching LogFile for application with PID: "+pid)
+        cf=os.popen('ssh '+srv+' ls -l /tmp | grep '+pid)
+        l=cf.readline();
+        if l=="":
+            cf.close()
+            return "App Not Running???" 
+        else:
+            logfilev=l.split()
+            cf.close();
+            return logfilev[-1]
 #	except Exception,e:
 #		sys.stderr.write(  "Something went really bad\n" + e[0])
 #        return -1
 ################################################################################
 def getRunningAppsInfo(filename):
-	(table,grid)=appinf.getAppInfo(filename,2,1,3,4)
-	for apps in grid:
-		apps.insert(3,getAppPID(apps[1],apps[2]))
-		apps.insert(4,getAppLogFileName(apps[1],apps[3]))
-	return grid
+    (table,grid)=appinf.getAppInfo(filename,2,1,3,4)
+    for apps in grid:
+        apps.insert(3,getAppPID(apps[1],apps[2]))
+        apps.insert(4,getAppLogFileName(apps[1],apps[3]))
+    return grid
 ################################################################################
 #Script operation                                                              #
 ################################################################################
 if __name__ == "__main__":             
-	fullinfo=False
-	headers=False
-	try:
-		(args,filename)=gop.getopt(sys.argv[1:],"hf",["help"])
-	except getopt.GetoptError:
-		sys.stderr.write(  "Sintax Error unrecognised option" )
-		sys.stderr.write( __doc__ )
-		sys.exit(2)
-	
-	for item in args:
-		if item[0]=="-h":
-			headers=True
-		elif item[0]=="-f":
-			fullinfo=True
-		elif item[0]=="--help":
-			sys.stdout.write(__doc__)
-			sys.exit(2)
-	if len(filename)==0:
-		sys.stderr.write(  "\nERROR: xdaq XML config file name not present, please specify\n\n" )
-		sys.stdout.write(__doc__)
-	elif len(filename) > 1:
-		sys.stderr.write(  "\nERROR: Too many file names or other arguments, please specify only 1\n\n" )
-		sys.stdout.write(__doc__)
-		sys.exit(2)
-	elif not os.path.exists(filename[0]):
-		sys.stderr.write(  "\nERROR: xdaq XML config file does not exist please verify\n\n" )
-		sys.stdout.write(__doc__)
-		sys.exit(2)
-	grid=getRunningAppsInfo(filename[0])
-	if fullinfo:
-		if headers:
-			grid.insert(0,["Application","Server","Port","PID","LogfileName","App Config File"])
-	else:
-		if headers:
-			i=0;
-			for record in grid:
-			 	newrecord=[record[0],record[3],record[4]]
-			 	grid[i]=newrecord
-			 	del record
-			 	i+=1
-			grid.insert(0,["Application","PID","LogfileName"])
-			
-		else:
-			i=0;
-			for record in grid:
-			 	newrecord=[record[0],record[3],record[4]]
-			 	grid[i]=newrecord
-			 	del record
-			 	i+=1
-	
-	appinf.printGrid(grid)
-		
-	
+    fullinfo=False
+    headers=False
+    try:
+        (args,filename)=gop.getopt(sys.argv[1:],"hf",["help"])
+    except getopt.GetoptError:
+        sys.stderr.write(  "Sintax Error unrecognised option" )
+        sys.stderr.write( __doc__ )
+        sys.exit(2)
+
+    for item in args:
+        if item[0]=="-h":
+            headers=True
+        elif item[0]=="-f":
+            fullinfo=True
+        elif item[0]=="--help":
+            sys.stdout.write(__doc__)
+            sys.exit(2)
+    if len(filename)==0:
+        sys.stderr.write(  "\nERROR: xdaq XML config file name not present, please specify\n\n" )
+        sys.stdout.write(__doc__)
+    elif len(filename) > 1:
+        sys.stderr.write(  "\nERROR: Too many file names or other arguments, please specify only 1\n\n" )
+        sys.stdout.write(__doc__)
+        sys.exit(2)
+    elif not os.path.exists(filename[0]):
+        sys.stderr.write(  "\nERROR: xdaq XML config file does not exist please verify\n\n" )
+        sys.stdout.write(__doc__)
+        sys.exit(2)
+    grid=getRunningAppsInfo(filename[0])
+    if fullinfo:
+        if headers:
+            grid.insert(0,["Application","Server","Port","PID","LogfileName","App Config File"])
+    else:
+        if headers:
+            i=0;
+            for record in grid:
+                newrecord=[record[0],record[3],record[4]]
+                grid[i]=newrecord
+                del record
+                i+=1
+            grid.insert(0,["Application","PID","LogfileName"])
+
+        else:
+            i=0;
+            for record in grid:
+                newrecord=[record[0],record[3],record[4]]
+                grid[i]=newrecord
+                del record
+                i+=1
+
+    appinf.printGrid(grid)
+
+

--- a/DQM/Integration/scripts/fileregistration/dqmPostProcessing_online.py
+++ b/DQM/Integration/scripts/fileregistration/dqmPostProcessing_online.py
@@ -20,129 +20,129 @@ YourMail = "lilopera@cern.ch"
 ServerMail = "dqm@srv-C2D05-19.cms"
 
 def sendmail(EmailAddress,run):
-  s=smtplib.SMTP("localhost")
-  tolist=[EmailAddress, "lat@cern.ch"]
-  body="File merge failed by unknown reason for run"+run
-  msg = MIMEText(body)
-  msg['Subject'] = "File merge failed."
-  msg['From'] = ServerMail
-  msg['To'] = EmailAddress
-  s.sendmail(ServerMail,tolist,msg.as_string())
-  s.quit()
+    s=smtplib.SMTP("localhost")
+    tolist=[EmailAddress, "lat@cern.ch"]
+    body="File merge failed by unknown reason for run"+run
+    msg = MIMEText(body)
+    msg['Subject'] = "File merge failed."
+    msg['From'] = ServerMail
+    msg['To'] = EmailAddress
+    s.sendmail(ServerMail,tolist,msg.as_string())
+    s.quit()
 
 def filecheck(rootfile):
-  f = TFile(rootfile)
-  if (f.IsZombie()):
-      #print "File corrupted"
-      f.Close()
-      return 0
-  else:
-      hist = f.FindObjectAny("reportSummaryContents")
-      #(skip filecheck for HcalTiming files!!)
-      if (hist == None and rootfile.rfind('HcalTiming') == -1):
-          #print "File is incomplete"
-          f.Close()
-          return 0
-      else:
-          #print "File is OK"
-          f.Close()
-          return 1
-      
-while True:
-  #### search new files
-  NRUNS = 0
-  NFOUND = 0
-  NEW = {}
-  for dir, subdirs, files in os.walk(DIR):
-    for f in files:
-      if not f.startswith("DQM_Reference") and re.match(r'^DQM_.*_R[0-9]{9}\.root$', f):
-	runnr = f[-14:-5]
-        donefile = "%s/%s/%s/%s" % (DONEDIR, runnr[0:3], runnr[3:6], f)
-        f = "%s/%s" % (dir, f)
-	if os.path.exists(donefile) and os.stat(donefile).st_size == os.stat(f).st_size:
-	  print("WARNING: %s was already processed but re-appeared" % f)
-	  os.remove(f)
-	  continue
-        NEW.setdefault(runnr, []).append(f)
-        NFOUND += 1
-  
-  if NFOUND:
-    print('%s: found %d new files in %d runs.' % (datetime.now(), NFOUND, len(NEW)))
-
-    newFiles = []
-    allOldFiles = []
-    for run in sorted(NEW.keys())[::-1]:
-      NRUNS += 1
-      if NRUNS > MAX_RUNS:
-        break
-
-      files = NEW[run]
-      runnr = "%09d" % long(run)
-      destdir = "%s/%s/%s" % (FILEDIR, runnr[0:3], runnr[3:6])
-      donedir = "%s/%s/%s" % (DONEDIR, runnr[0:3], runnr[3:6])
-      oldfiles = sorted(glob.glob("%s/DQM_V????_R%s.root" % (destdir, runnr)))[::-1]
-      if len(oldfiles) > 0:
-        version = int(oldfiles[0][-20:-16]) + 1
-        files.append(oldfiles[0])
-      else:
-	version = 1
-
-      if not os.path.exists(destdir):
-        os.makedirs(destdir)
-      if not os.path.exists(donedir):
-        os.makedirs(donedir)
-    
-      destfile = "%s/DQM_V%04d_R%s.root" % (destdir, version, runnr)
-      logfile = "%s.log" % destfile[:-5]
-      tmpdestfile = "%s.tmp" % destfile
-    
-      print('Merging run %s to %s (adding %s to %s)' % (run, destfile, files, oldfiles))
-      LOGFILE = open(logfile, 'a')
-      LOGFILE.write(os.popen('DQMMergeFile %s %s' % (tmpdestfile, " ".join(files))).read())
-      LOGFILE.close()
-      if not os.path.exists(tmpdestfile):
-        print('Failed merging files for run %s. Will try again later.' % run)
-        sendmail(YourMail,run)
-	continue
-    
-      os.rename(tmpdestfile, destfile)
-      for f in files:
-	os.rename(f, "%s/%s" % (donedir, f.rsplit('/', 1)[1]))
-
-      allOldFiles.extend(oldfiles)
-      newFiles.append((long(run), destfile))
-  
-    if os.path.exists(TMPDB):
-      os.remove(TMPDB)
-  
-    if os.path.exists(DB):
-      os.rename(DB, TMPDB)
+    f = TFile(rootfile)
+    if (f.IsZombie()):
+        #print "File corrupted"
+        f.Close()
+        return 0
     else:
-      os.system('set -x; visDQMRegisterFile %s "/Global/Online/ALL" "Global run"' % TMPDB)
-  
-    if len(allOldFiles) > 0:
-      os.system('set -x; visDQMUnregisterFile %s %s' % (TMPDB, " ".join(allOldFiles)))
-  
-    existing = [long(x) for x in os.popen("sqlite3 %s 'select distinct runnr from t_data'" % TMPDB).read().split()]
-    for runnr, file in newFiles:
-      print('Registering %s for run %d' % (file, runnr))
-      older = sorted([x for x in existing if x < runnr])
-      newer = sorted([x for x in existing if x > runnr])
-      if len(newer) > MAX_TOTAL_RUNS:
-	print("Too many newer runs (%d), not registering %s for run %d" % (len(newer), file, runnr))
-	continue
+        hist = f.FindObjectAny("reportSummaryContents")
+        #(skip filecheck for HcalTiming files!!)
+        if (hist == None and rootfile.rfind('HcalTiming') == -1):
+            #print "File is incomplete"
+            f.Close()
+            return 0
+        else:
+            #print "File is OK"
+            f.Close()
+            return 1
 
-      if len(older) > MAX_TOTAL_RUNS:
-	print("Too many older runs (%d), pruning data for oldest run %d" % (len(older), older[0]))
-	os.system(r"set -x; sqlite3 %s 'delete from t_data where runnr = %d'" % (TMPDB, older[0]))
-	os.system(r"set -x; sqlite3 %s 'delete from t_files where name like '\''%%R%09d.root'\'" % (TMPDB, older[0]))
-	os.system(r"set -x; sqlite3 %s 'vacuum'" % TMPDB)
-	existing.remove(older[0])
+while True:
+    #### search new files
+    NRUNS = 0
+    NFOUND = 0
+    NEW = {}
+    for dir, subdirs, files in os.walk(DIR):
+        for f in files:
+            if not f.startswith("DQM_Reference") and re.match(r'^DQM_.*_R[0-9]{9}\.root$', f):
+                runnr = f[-14:-5]
+                donefile = "%s/%s/%s/%s" % (DONEDIR, runnr[0:3], runnr[3:6], f)
+                f = "%s/%s" % (dir, f)
+                if os.path.exists(donefile) and os.stat(donefile).st_size == os.stat(f).st_size:
+                    print("WARNING: %s was already processed but re-appeared" % f)
+                    os.remove(f)
+                    continue
+                NEW.setdefault(runnr, []).append(f)
+                NFOUND += 1
 
-      os.system('set -x; visDQMRegisterFile %s "/Global/Online/ALL" "Global run" %s' % (TMPDB, file))
-      existing.append(runnr)
-  
-    os.rename(TMPDB, DB)
+    if NFOUND:
+        print('%s: found %d new files in %d runs.' % (datetime.now(), NFOUND, len(NEW)))
 
-  if NRUNS <= MAX_RUNS:
-    time.sleep(WAITTIME)
+        newFiles = []
+        allOldFiles = []
+        for run in sorted(NEW.keys())[::-1]:
+            NRUNS += 1
+            if NRUNS > MAX_RUNS:
+                break
+
+            files = NEW[run]
+            runnr = "%09d" % long(run)
+            destdir = "%s/%s/%s" % (FILEDIR, runnr[0:3], runnr[3:6])
+            donedir = "%s/%s/%s" % (DONEDIR, runnr[0:3], runnr[3:6])
+            oldfiles = sorted(glob.glob("%s/DQM_V????_R%s.root" % (destdir, runnr)))[::-1]
+            if len(oldfiles) > 0:
+                version = int(oldfiles[0][-20:-16]) + 1
+                files.append(oldfiles[0])
+            else:
+                version = 1
+
+            if not os.path.exists(destdir):
+                os.makedirs(destdir)
+            if not os.path.exists(donedir):
+                os.makedirs(donedir)
+
+            destfile = "%s/DQM_V%04d_R%s.root" % (destdir, version, runnr)
+            logfile = "%s.log" % destfile[:-5]
+            tmpdestfile = "%s.tmp" % destfile
+
+            print('Merging run %s to %s (adding %s to %s)' % (run, destfile, files, oldfiles))
+            LOGFILE = open(logfile, 'a')
+            LOGFILE.write(os.popen('DQMMergeFile %s %s' % (tmpdestfile, " ".join(files))).read())
+            LOGFILE.close()
+            if not os.path.exists(tmpdestfile):
+                print('Failed merging files for run %s. Will try again later.' % run)
+                sendmail(YourMail,run)
+                continue
+
+            os.rename(tmpdestfile, destfile)
+            for f in files:
+                os.rename(f, "%s/%s" % (donedir, f.rsplit('/', 1)[1]))
+
+            allOldFiles.extend(oldfiles)
+            newFiles.append((long(run), destfile))
+
+        if os.path.exists(TMPDB):
+            os.remove(TMPDB)
+
+        if os.path.exists(DB):
+            os.rename(DB, TMPDB)
+        else:
+            os.system('set -x; visDQMRegisterFile %s "/Global/Online/ALL" "Global run"' % TMPDB)
+
+        if len(allOldFiles) > 0:
+            os.system('set -x; visDQMUnregisterFile %s %s' % (TMPDB, " ".join(allOldFiles)))
+
+        existing = [long(x) for x in os.popen("sqlite3 %s 'select distinct runnr from t_data'" % TMPDB).read().split()]
+        for runnr, file in newFiles:
+            print('Registering %s for run %d' % (file, runnr))
+            older = sorted([x for x in existing if x < runnr])
+            newer = sorted([x for x in existing if x > runnr])
+            if len(newer) > MAX_TOTAL_RUNS:
+                print("Too many newer runs (%d), not registering %s for run %d" % (len(newer), file, runnr))
+                continue
+
+            if len(older) > MAX_TOTAL_RUNS:
+                print("Too many older runs (%d), pruning data for oldest run %d" % (len(older), older[0]))
+                os.system(r"set -x; sqlite3 %s 'delete from t_data where runnr = %d'" % (TMPDB, older[0]))
+                os.system(r"set -x; sqlite3 %s 'delete from t_files where name like '\''%%R%09d.root'\'" % (TMPDB, older[0]))
+                os.system(r"set -x; sqlite3 %s 'vacuum'" % TMPDB)
+                existing.remove(older[0])
+
+            os.system('set -x; visDQMRegisterFile %s "/Global/Online/ALL" "Global run" %s' % (TMPDB, file))
+            existing.append(runnr)
+
+        os.rename(TMPDB, DB)
+
+    if NRUNS <= MAX_RUNS:
+        time.sleep(WAITTIME)

--- a/DQM/Integration/scripts/harvesting_tools/cmsHarvester.py
+++ b/DQM/Integration/scripts/harvesting_tools/cmsHarvester.py
@@ -408,10 +408,10 @@ class CMSHarvester(object):
         self.input_name["runs"]["use"] = None
         self.input_name["runs"]["ignore"] = None
 
-	self.Jsonlumi = False
-	self.Jsonfilename = "YourJSON.txt"
-     	self.Jsonrunfilename = "YourJSON.txt"
-	self.todofile = "YourToDofile.txt"
+        self.Jsonlumi = False
+        self.Jsonfilename = "YourJSON.txt"
+        self.Jsonrunfilename = "YourJSON.txt"
+        self.todofile = "YourToDofile.txt"
 
         # If this is true, we're running in `force mode'. In this case
         # the sanity checks are performed but failure will not halt
@@ -446,12 +446,12 @@ class CMSHarvester(object):
         # the --no-t1access flag can be used. This variable keeps
         # track of that special mode.
         self.non_t1access = False
-	self.caf_access = False
+        self.caf_access = False
         self.saveByLumiSection = False
         self.crab_submission = False
         self.nr_max_sites = 1
 
-	self.preferred_site = "no preference"
+        self.preferred_site = "no preference"
 
         # This will become the list of datasets and runs to consider
         self.datasets_to_use = {}
@@ -817,7 +817,7 @@ class CMSHarvester(object):
         self.logger.warning("Switching off all use of reference histograms")
 
         # End of option_handler_no_ref_hists.
-        
+
      ##########
 
     def option_handler_frontier_connection(self, option, opt_str,
@@ -1097,7 +1097,7 @@ class CMSHarvester(object):
                             "further promises...")
 
         # End of option_handler_no_t1access.
-       
+
     ##########
 
     def option_handler_caf_access(self, option, opt_str, value, parser):
@@ -1113,7 +1113,7 @@ class CMSHarvester(object):
                             "further promises...")
 
         # End of option_handler_caf_access.
-        
+
    ##########
 
     def option_handler_saveByLumiSection(self, option, opt_str, value, parser):
@@ -1130,12 +1130,12 @@ class CMSHarvester(object):
 
     def option_handler_crab_submission(self, option, opt_str, value, parser):
         """Crab jobs are not created and
-	"submitted automatically",
+        "submitted automatically",
         """
         self.crab_submission = True
 
         # End of option_handler_crab_submission.
-       
+
     ##########
 
     def option_handler_sites(self, option, opt_str, value, parser):
@@ -1446,7 +1446,7 @@ class CMSHarvester(object):
         castor_dirs = []
         for (dataset_name, runs) in six.iteritems(self.datasets_to_use):
 
-	    for run in runs:
+            for run in runs:
                 castor_dirs.append(self.datasets_information[dataset_name] \
                                    ["castor_path"][run])
         castor_dirs_unique = sorted(set(castor_dirs))
@@ -1705,14 +1705,14 @@ class CMSHarvester(object):
 
     def pick_a_site(self, sites, cmssw_version):
 
-	# Create list of forbidden sites
+        # Create list of forbidden sites
         sites_forbidden = []
 
-	if (self.preferred_site == "CAF") or (self.preferred_site == "caf.cern.ch"):
-	    self.caf_access = True
+        if (self.preferred_site == "CAF") or (self.preferred_site == "caf.cern.ch"):
+            self.caf_access = True
 
-	if self.caf_access == False:
-	    sites_forbidden.append("caf.cern.ch")
+        if self.caf_access == False:
+            sites_forbidden.append("caf.cern.ch")
 
         # These are the T1 sites. These are only forbidden if we're
         # running in non-T1 mode.
@@ -1733,19 +1733,19 @@ class CMSHarvester(object):
                 "storm-fe-cms.cr.cnaf.infn.it"
                 ]
 
-	country_codes = {
-	      "CAF" : "caf.cern.ch",
-	      "CH" : "srm-cms.cern.ch",
-	      "FR" : "ccsrm.in2p3.fr",
-	      "DE" : "cmssrm-fzk.gridka.de",
-	      "GOV" : "cmssrm.fnal.gov",
-	      "DE2" : "gridka-dCache.fzk.de",
-	      "UK" : "srm-cms.gridpp.rl.ac.uk",
-	      "TW" : "srm.grid.sinica.edu.tw",
-	      "TW2" : "srm2.grid.sinica.edu.tw",
-	      "ES" : "srmcms.pic.es",
-	      "IT" : "storm-fe-cms.cr.cnaf.infn.it"
-	        }
+        country_codes = {
+              "CAF" : "caf.cern.ch",
+              "CH" : "srm-cms.cern.ch",
+              "FR" : "ccsrm.in2p3.fr",
+              "DE" : "cmssrm-fzk.gridka.de",
+              "GOV" : "cmssrm.fnal.gov",
+              "DE2" : "gridka-dCache.fzk.de",
+              "UK" : "srm-cms.gridpp.rl.ac.uk",
+              "TW" : "srm.grid.sinica.edu.tw",
+              "TW2" : "srm2.grid.sinica.edu.tw",
+              "ES" : "srmcms.pic.es",
+              "IT" : "storm-fe-cms.cr.cnaf.infn.it"
+                }
 
         if self.non_t1access: 
             sites_forbidden.extend(all_t1)
@@ -1754,17 +1754,17 @@ class CMSHarvester(object):
             if site in sites:
                 sites.remove(site)
 
-	if self.preferred_site in country_codes:
-	    self.preferred_site = country_codes[self.preferred_site]
+        if self.preferred_site in country_codes:
+            self.preferred_site = country_codes[self.preferred_site]
 
-	if self.preferred_site != "no preference":
-	    if self.preferred_site in sites:
-	        sites = [self.preferred_site]
-	    else:
-		sites= []
+        if self.preferred_site != "no preference":
+            if self.preferred_site in sites:
+                sites = [self.preferred_site]
+            else:
+                sites= []
 
-	#print sites
- 
+        #print sites
+
         # Looks like we have to do some caching here, otherwise things
         # become waaaay toooo sloooooow. So that's what the
         # sites_and_versions_cache does.
@@ -1775,17 +1775,17 @@ class CMSHarvester(object):
         while len(sites) > 0 and \
               site_name is None:
 
-	    # Create list of t1_sites
-	    t1_sites = []
-	    for site in sites:
-	        if site in all_t1:
+            # Create list of t1_sites
+            t1_sites = []
+            for site in sites:
+                if site in all_t1:
                     t1_sites.append(site)
-	        if site == "caf.cern.ch":
+                if site == "caf.cern.ch":
                     t1_sites.append(site)
 
-	    # If avilable pick preferred site
-	    #if self.preferred_site in sites:
-	    #  se_name = self.preferred_site
+            # If avilable pick preferred site
+            #if self.preferred_site in sites:
+            #  se_name = self.preferred_site
             # Else, if available pick t1 site
 
             if len(t1_sites) > 0:
@@ -2049,7 +2049,7 @@ class CMSHarvester(object):
                           metavar="RUNSLISTFILE-IGNORE")
 
         # Option to specify a Jsonfile contaning a list of runs
-	# to be used.
+        # to be used.
         parser.add_option("", "--Jsonrunfile",
                           help="Jsonfile containing dictionary of run/lumisections pairs. " \
                           "All lumisections of runs contained in dictionary are processed.",
@@ -2059,7 +2059,7 @@ class CMSHarvester(object):
                           metavar="JSONRUNFILE")
 
         # Option to specify a Jsonfile contaning a dictionary of run/lumisections pairs
-	# to be used.
+        # to be used.
         parser.add_option("", "--Jsonfile",
                           help="Jsonfile containing dictionary of run/lumisections pairs. " \
                           "Only specified lumisections of runs contained in dictionary are processed.",
@@ -2069,7 +2069,7 @@ class CMSHarvester(object):
                           metavar="JSONFILE")
 
         # Option to specify a ToDo file contaning a list of runs
-	# to be used.
+        # to be used.
         parser.add_option("", "--todo-file",
                           help="Todo file containing a list of runs to process.",
                           action="callback",
@@ -2107,14 +2107,14 @@ class CMSHarvester(object):
                           "without special `t1access' role",
                           action="callback",
                           callback=self.option_handler_no_t1access)
-                        
+
         # Use this to create jobs that may run on CAF
         parser.add_option("", "--caf-access",
                           help="Crab jobs may run " \
                           "on CAF",
                           action="callback",
                           callback=self.option_handler_caf_access)
-                          
+
         # set process.dqmSaver.saveByLumiSection=1 in harvesting cfg file
         parser.add_option("", "--saveByLumiSection",
                           help="set saveByLumiSection=1 in harvesting cfg file",
@@ -2124,7 +2124,7 @@ class CMSHarvester(object):
         # Use this to enable automatic creation and submission of crab jobs
         parser.add_option("", "--automatic-crab-submission",
                           help="Crab jobs are created and " \
-			  "submitted automatically",
+                          "submitted automatically",
                           action="callback",
                           callback=self.option_handler_crab_submission)
 
@@ -3382,7 +3382,7 @@ class CMSHarvester(object):
                              input_name)
             try:
                 listfile = open("/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/harvesting/bin/%s" %input_name, "r")
-		print("open listfile")
+                print("open listfile")
                 for dataset in listfile:
                     # Skip empty lines.
                     dataset_stripped = dataset.strip()
@@ -3511,7 +3511,7 @@ class CMSHarvester(object):
 
         # Remove duplicates, sort and done.
         runs = list(set(runs))
-	
+
         # End of build_runs_list().
         return runs
 
@@ -3661,76 +3661,76 @@ class CMSHarvester(object):
                 runs = runs_tmp
 
             if self.todofile != "YourToDofile.txt":
-		runs_todo = []
+                runs_todo = []
                 print("Reading runs from file /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/harvesting/%s" %self.todofile)
                 cmd="grep %s /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/harvesting/%s | cut -f5 -d' '" %(dataset_name,self.todofile)
                 (status, output)=commands.getstatusoutput(cmd)
-		for run in runs:
-		    run_str="%s" %run
-		    if run_str in output:
-			runs_todo.append(run)
+                for run in runs:
+                    run_str="%s" %run
+                    if run_str in output:
+                        runs_todo.append(run)
                 self.logger.info("Using %d runs " \
                                  "of dataset `%s'" % \
                                  (len(runs_todo),
                                   dataset_name))
-		runs=runs_todo
+                runs=runs_todo
 
-	    Json_runs = []
-	    if self.Jsonfilename != "YourJSON.txt":
-		good_runs = []
-		self.Jsonlumi = True
-		# We were passed a Jsonfile containing a dictionary of
-		# run/lunisection-pairs
-		self.logger.info("Reading runs and lumisections from file `%s'" % \
-				self.Jsonfilename)
-		try:
-		    Jsonfile = open(self.Jsonfilename, "r")
-		    for names in Jsonfile:
-			dictNames= eval(str(names))
-			for key in dictNames:
-			    intkey=int(key)
-			    Json_runs.append(intkey)
-		    Jsonfile.close()
-		except IOError:
-		    msg = "ERROR: Could not open Jsonfile `%s'" % \
-			  input_name
-		    self.logger.fatal(msg)
-		    raise Error(msg)
-		for run in runs:
-		    if run in Json_runs:
-			good_runs.append(run)
-		self.logger.info("Using %d runs " \
-                                 "of dataset `%s'" % \
-                                 (len(good_runs),
-                                  dataset_name))
-		runs=good_runs
-            if (self.Jsonrunfilename != "YourJSON.txt") and (self.Jsonfilename == "YourJSON.txt"):
-		good_runs = []
+            Json_runs = []
+            if self.Jsonfilename != "YourJSON.txt":
+                good_runs = []
+                self.Jsonlumi = True
                 # We were passed a Jsonfile containing a dictionary of
-		# run/lunisection-pairs
-	        self.logger.info("Reading runs from file `%s'" % \
-				self.Jsonrunfilename)
-		try:
-		    Jsonfile = open(self.Jsonrunfilename, "r")
-		    for names in Jsonfile:
-	                dictNames= eval(str(names))
-			for key in dictNames:
-			    intkey=int(key)
-			    Json_runs.append(intkey)
-		    Jsonfile.close()
-		except IOError:
-		    msg = "ERROR: Could not open Jsonfile `%s'" % \
-			  input_name
-		    self.logger.fatal(msg)
-		    raise Error(msg)
-	    	for run in runs:
-	            if run in Json_runs: 
+                # run/lunisection-pairs
+                self.logger.info("Reading runs and lumisections from file `%s'" % \
+                                self.Jsonfilename)
+                try:
+                    Jsonfile = open(self.Jsonfilename, "r")
+                    for names in Jsonfile:
+                        dictNames= eval(str(names))
+                        for key in dictNames:
+                            intkey=int(key)
+                            Json_runs.append(intkey)
+                    Jsonfile.close()
+                except IOError:
+                    msg = "ERROR: Could not open Jsonfile `%s'" % \
+                          input_name
+                    self.logger.fatal(msg)
+                    raise Error(msg)
+                for run in runs:
+                    if run in Json_runs:
                         good_runs.append(run)
                 self.logger.info("Using %d runs " \
                                  "of dataset `%s'" % \
                                  (len(good_runs),
                                   dataset_name))
-		runs=good_runs
+                runs=good_runs
+            if (self.Jsonrunfilename != "YourJSON.txt") and (self.Jsonfilename == "YourJSON.txt"):
+                good_runs = []
+                # We were passed a Jsonfile containing a dictionary of
+                # run/lunisection-pairs
+                self.logger.info("Reading runs from file `%s'" % \
+                                self.Jsonrunfilename)
+                try:
+                    Jsonfile = open(self.Jsonrunfilename, "r")
+                    for names in Jsonfile:
+                        dictNames= eval(str(names))
+                        for key in dictNames:
+                            intkey=int(key)
+                            Json_runs.append(intkey)
+                    Jsonfile.close()
+                except IOError:
+                    msg = "ERROR: Could not open Jsonfile `%s'" % \
+                          input_name
+                    self.logger.fatal(msg)
+                    raise Error(msg)
+                for run in runs:
+                    if run in Json_runs: 
+                        good_runs.append(run)
+                self.logger.info("Using %d runs " \
+                                 "of dataset `%s'" % \
+                                 (len(good_runs),
+                                  dataset_name))
+                runs=good_runs
 
             self.datasets_to_use[dataset_name] = runs
 
@@ -3999,7 +3999,7 @@ class CMSHarvester(object):
                 #self.book_keeping_information[dataset_name] = self.datasets_information \
                 #                                              [dataset_name]["num_events"]
                 continue
-	      
+
             tmp = [i for i in \
                    self.datasets_information[dataset_name] \
                    ["num_events"].items() if i[1] < 1]
@@ -4260,35 +4260,35 @@ class CMSHarvester(object):
         tmp.append(self.config_file_header())
         tmp.append("")
 
-	## CRAB
-	##------
+        ## CRAB
+        ##------
         tmp.append("[CRAB]")
         tmp.append("jobtype = cmssw")
         tmp.append("")
 
-	## GRID
-	##------
+        ## GRID
+        ##------
         tmp.append("[GRID]")
         tmp.append("virtual_organization=cms")
         tmp.append("")
 
-	## USER
-	##------
+        ## USER
+        ##------
         tmp.append("[USER]")
         tmp.append("copy_data = 1")
         tmp.append("")
 
-	## CMSSW
-	##-------
+        ## CMSSW
+        ##-------
         tmp.append("[CMSSW]")
         tmp.append("# This reveals data hosted on T1 sites,")
         tmp.append("# which is normally hidden by CRAB.")
         tmp.append("show_prod = 1")
         tmp.append("number_of_jobs = 1")
-	if self.Jsonlumi == True:
-	    tmp.append("lumi_mask = %s" % self.Jsonfilename)
-	    tmp.append("total_number_of_lumis = -1")
-	else:
+        if self.Jsonlumi == True:
+            tmp.append("lumi_mask = %s" % self.Jsonfilename)
+            tmp.append("total_number_of_lumis = -1")
+        else:
             if self.harvesting_type == "DQMOffline":
                 tmp.append("total_number_of_lumis = -1")
             else:
@@ -4298,8 +4298,8 @@ class CMSHarvester(object):
             tmp.append("no_block_boundary = 1")
         tmp.append("")
 
-	## CAF
-	##-----
+        ## CAF
+        ##-----
         tmp.append("[CAF]")
 
         crab_config = "\n".join(tmp)
@@ -4325,12 +4325,12 @@ class CMSHarvester(object):
 
         """
 
-	cmd="who i am | cut -f1 -d' '"
-	(status, output)=commands.getstatusoutput(cmd)
-	UserName = output
+        cmd="who i am | cut -f1 -d' '"
+        (status, output)=commands.getstatusoutput(cmd)
+        UserName = output
 
-	if self.caf_access == True:
-	    print("Extracting %s as user name" %UserName) 
+        if self.caf_access == True:
+            print("Extracting %s as user name" %UserName) 
 
         number_max_sites = self.nr_max_sites + 1
 
@@ -4407,57 +4407,57 @@ class CMSHarvester(object):
                                     break
 
                             nevents = self.datasets_information[dataset_name]["num_events"][run]
-    
+
                             # The block name.
                             multicrab_block_name = self.create_multicrab_block_name( \
                                 dataset_name, run, index)
                             multicrab_config_lines.append("[%s]" % \
                                                       multicrab_block_name)
 
-			    ## CRAB
-			    ##------
-			    if site_name == "caf.cern.ch":
-				multicrab_config_lines.append("CRAB.use_server=0")
-				multicrab_config_lines.append("CRAB.scheduler=caf")
-			    else:
-				multicrab_config_lines.append("scheduler = glite")
-
-			    ## GRID
-			    ##------
-			    if site_name == "caf.cern.ch":
-			        pass
+                            ## CRAB
+                            ##------
+                            if site_name == "caf.cern.ch":
+                                multicrab_config_lines.append("CRAB.use_server=0")
+                                multicrab_config_lines.append("CRAB.scheduler=caf")
                             else:
-			        multicrab_config_lines.append("GRID.se_white_list = %s" % \
+                                multicrab_config_lines.append("scheduler = glite")
+
+                            ## GRID
+                            ##------
+                            if site_name == "caf.cern.ch":
+                                pass
+                            else:
+                                multicrab_config_lines.append("GRID.se_white_list = %s" % \
                                                       site_name)
-				multicrab_config_lines.append("# This removes the default blacklisting of T1 sites.")
-				multicrab_config_lines.append("GRID.remove_default_blacklist = 1")
-				multicrab_config_lines.append("GRID.rb = CERN")
-				if not self.non_t1access:
-				    multicrab_config_lines.append("GRID.role = t1access")
+                                multicrab_config_lines.append("# This removes the default blacklisting of T1 sites.")
+                                multicrab_config_lines.append("GRID.remove_default_blacklist = 1")
+                                multicrab_config_lines.append("GRID.rb = CERN")
+                                if not self.non_t1access:
+                                    multicrab_config_lines.append("GRID.role = t1access")
 
-			    ## USER
-			    ##------
+                            ## USER
+                            ##------
 
-			    castor_dir = castor_dir.replace(castor_prefix, "")
-			    multicrab_config_lines.append("USER.storage_element=srm-cms.cern.ch")
-			    multicrab_config_lines.append("USER.user_remote_dir = %s" % \
-						      castor_dir)
-			    multicrab_config_lines.append("USER.check_user_remote_dir=0")
+                            castor_dir = castor_dir.replace(castor_prefix, "")
+                            multicrab_config_lines.append("USER.storage_element=srm-cms.cern.ch")
+                            multicrab_config_lines.append("USER.user_remote_dir = %s" % \
+                                                      castor_dir)
+                            multicrab_config_lines.append("USER.check_user_remote_dir=0")
 
-			    if site_name == "caf.cern.ch":
-				multicrab_config_lines.append("USER.storage_path=%s" % castor_prefix)
-			        #multicrab_config_lines.append("USER.storage_element=T2_CH_CAF")
-				#castor_dir = castor_dir.replace("/cms/store/caf/user/%s" %UserName, "")
-				#multicrab_config_lines.append("USER.user_remote_dir = %s" % \
-				#		      castor_dir)
-			    else:
+                            if site_name == "caf.cern.ch":
+                                multicrab_config_lines.append("USER.storage_path=%s" % castor_prefix)
+                                #multicrab_config_lines.append("USER.storage_element=T2_CH_CAF")
+                                #castor_dir = castor_dir.replace("/cms/store/caf/user/%s" %UserName, "")
+                                #multicrab_config_lines.append("USER.user_remote_dir = %s" % \
+                                #		      castor_dir)
+                            else:
                                 multicrab_config_lines.append("USER.storage_path=/srm/managerv2?SFN=%s" % castor_prefix)
-				#multicrab_config_lines.append("USER.user_remote_dir = %s" % \
-				#		      castor_dir)
-				#multicrab_config_lines.append("USER.storage_element=srm-cms.cern.ch")
+                                #multicrab_config_lines.append("USER.user_remote_dir = %s" % \
+                                #		      castor_dir)
+                                #multicrab_config_lines.append("USER.storage_element=srm-cms.cern.ch")
 
-			    ## CMSSW
-			    ##-------
+                            ## CMSSW
+                            ##-------
                             multicrab_config_lines.append("CMSSW.pset = %s" % \
                                                        config_file_name)
                             multicrab_config_lines.append("CMSSW.datasetpath = %s" % \
@@ -4465,9 +4465,9 @@ class CMSHarvester(object):
                             multicrab_config_lines.append("CMSSW.runselection = %d" % \
                                                   run)
 
-			    if self.Jsonlumi == True:
-				pass
-			    else:
+                            if self.Jsonlumi == True:
+                                pass
+                            else:
                                 if self.harvesting_type == "DQMOffline":
                                     pass
                                 else:
@@ -4477,10 +4477,10 @@ class CMSHarvester(object):
                             multicrab_config_lines.append("CMSSW.output_file = %s" % \
                                                       output_file_name)
 
-			    ## CAF
-			    ##-----
-			    if site_name == "caf.cern.ch":
-			        multicrab_config_lines.append("CAF.queue=cmscaf1nd")
+                            ## CAF
+                            ##-----
+                            if site_name == "caf.cern.ch":
+                                multicrab_config_lines.append("CAF.queue=cmscaf1nd")
 
 
                             # End of block.
@@ -4490,7 +4490,7 @@ class CMSHarvester(object):
 
                             self.all_sites_found = True
 
-	multicrab_config = "\n".join(multicrab_config_lines)
+        multicrab_config = "\n".join(multicrab_config_lines)
 
         # End of create_multicrab_config.
         return multicrab_config
@@ -4755,7 +4755,7 @@ class CMSHarvester(object):
         # This seems to be new in CMSSW 3.3.0.pre6, no clue what it
         # does.
         #config_options.himix = "dummy_value"
-	config_options.dbsquery = ""
+        config_options.dbsquery = ""
 
         ###
 
@@ -4833,12 +4833,12 @@ class CMSHarvester(object):
         customisations.append("process.GlobalTag.connect = \"%s\"" % \
                               connect_name)
 
-        
+
         if self.saveByLumiSection == True:
             customisations.append("process.dqmSaver.saveByLumiSection = 1")
         ##
         ##
-        
+
         customisations.append("")
 
         # About the reference histograms... For data there is only one
@@ -5166,7 +5166,7 @@ class CMSHarvester(object):
 
     ##########
 
-    
+
     def ref_hist_mappings_needed(self, dataset_name=None):
         """Check if we need to load and check the reference mappings.
 

--- a/DQM/SiStripMonitorClient/scripts/DeadROCCounter.py
+++ b/DQM/SiStripMonitorClient/scripts/DeadROCCounter.py
@@ -16,8 +16,8 @@ def GetNonZeroOccNumber(histoname):
     nrocs=0
     histo=fin.Get(histoname)
     if not histo:
-	print("null histo")
-	return
+        print("null histo")
+        return
     nx=histo.GetNbinsX()
     ny=histo.GetNbinsY()
     for i in range(1,nx+1):

--- a/DQM/SiStripMonitorClient/scripts/DeadROCCounter_Phase1.py
+++ b/DQM/SiStripMonitorClient/scripts/DeadROCCounter_Phase1.py
@@ -80,14 +80,14 @@ def countBadROCForward(fin, ringNo, os):
     ny = digi2D.GetNbinsY()
     for xbin in range(1,nx+1):
         if xbin >= 25 and xbin <= 32:    continue;#region of cross on x-axis
-	if xbin > 1 and  (xbin-1)%8 == 0:    dcounter += 1; 
-	for ybin in range(1,ny+1):
-	    if (ybin >= 2*nblades_perRing_fpx[ringNo-1] + 1) and (ybin <= 2*nblades_perRing_fpx[ringNo-1] + 4):
-	        continue;#region of cross on y-axis
-	    bentries = digi2D.GetBinContent(xbin,ybin)
-	    if(bentries > 0):
+        if xbin > 1 and  (xbin-1)%8 == 0:    dcounter += 1; 
+        for ybin in range(1,ny+1):
+            if (ybin >= 2*nblades_perRing_fpx[ringNo-1] + 1) and (ybin <= 2*nblades_perRing_fpx[ringNo-1] + 4):
+                continue;#region of cross on y-axis
+            bentries = digi2D.GetBinContent(xbin,ybin)
+            if(bentries > 0):
                 Nrocspopulated[dcounter] += 1
-		totalEntries[dcounter] += bentries
+                totalEntries[dcounter] += bentries
     #Loop to find inefficient modules
     meanEntries = [6] * 6
     for d in range(0,6):
@@ -97,28 +97,28 @@ def countBadROCForward(fin, ringNo, os):
     dcounter = 0;
     for xbin in range(1,nx+1):
         if xbin >= 25 and xbin <= 32:    continue;#region of cross on x-axis
-	if xbin > 1 and  (xbin-1)%8 == 0:    dcounter += 1 
+        if xbin > 1 and  (xbin-1)%8 == 0:    dcounter += 1 
         for ybin in range(1,ny+1):
-	    if (ybin >= 2*nblades_perRing_fpx[ringNo-1] + 1) and (ybin <= 2*nblades_perRing_fpx[ringNo-1] + 4):
+            if (ybin >= 2*nblades_perRing_fpx[ringNo-1] + 1) and (ybin <= 2*nblades_perRing_fpx[ringNo-1] + 4):
                 continue;#region of cross on y-axis
-	    bentries = digi2D.GetBinContent(xbin,ybin)
-	    if(bentries > 0):#//Assume < 25% of MEAN = inefficient 
-	        if bentries > 0 and bentries < meanEntries[dcounter]/4.: 
-		    NineffROC[dcounter] += 1
+            bentries = digi2D.GetBinContent(xbin,ybin)
+            if(bentries > 0):#//Assume < 25% of MEAN = inefficient 
+                if bentries > 0 and bentries < meanEntries[dcounter]/4.: 
+                    NineffROC[dcounter] += 1
 
     print("#Summary for FPix Ring", ringNo, file=os)
     for d in range(0,6):
         disc = 0
-	if d < 3:    disc = "M" + str(3 - d)
-	else:    disc = "P" + str(d - 2)
+        if d < 3:    disc = "M" + str(3 - d)
+        else:    disc = "P" + str(d - 2)
         ##Printing Disc no., #dead ROC, #inefficienct ROC, #mean occupancy of Non-zer roc
-	tmpstr = "FPix R" + str(ringNo) + "D" + str(disc)
+        tmpstr = "FPix R" + str(ringNo) + "D" + str(disc)
         print('{0:10s} {1:4d} {2:4d} {3:4.1f}'.format(tmpstr, NexpectedROC_perRing[ringNo-1] - Nrocspopulated[d], NineffROC[d], round(meanEntries[d],1)), file=os)
         fpix_tot_deadROC += NexpectedROC_perRing[ringNo-1] - Nrocspopulated[d]
         fpix_tot_ineffROC += NineffROC[d]
         fpix_tot_Nrocspopulated += Nrocspopulated[d]
-	fpix_tot_totalentries += float(totalEntries[d])
-	
+        fpix_tot_totalentries += float(totalEntries[d])
+
     return 0;
 ################################################main#######################################
 fname=sys.argv[1]

--- a/DQMOffline/Trigger/python/HILowLumiHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/HILowLumiHLTOfflineSource_cfi.py
@@ -224,7 +224,7 @@ def getFullTrackVPSet():
             combinedObjectDimension = cms.int32(1),
             combinedObjectDrawables =  cms.VPSet()
         )
-	ret.append(hltFullTrackMult)
+        ret.append(hltFullTrackMult)
 
     thresholds4 = [20, 30, 40]
     for t in thresholds4:
@@ -327,7 +327,7 @@ def getPAHighMultHighPtVPSet():
             combinedObjectDimension = cms.int32(1),
             combinedObjectDrawables =  cms.VPSet()
         )
-	ret.append(hltPAFullTracks)
+        ret.append(hltPAFullTracks)
 
     return ret
 
@@ -771,7 +771,7 @@ def getPAMBVPSet():
             cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5)),
             cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
         ),
-	combinedObjectSelection =  cms.string("1==1"),
+        combinedObjectSelection =  cms.string("1==1"),
         combinedObjectSortCriteria = cms.string("at(0).pt"),
         combinedObjectDimension = cms.int32(1),
         combinedObjectDrawables =  cms.VPSet()
@@ -792,7 +792,7 @@ def getPAMBVPSet():
             cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5)),
             cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
         ),
-	combinedObjectSelection =  cms.string("1==1"),
+        combinedObjectSelection =  cms.string("1==1"),
         combinedObjectSortCriteria = cms.string("at(0).pt"),
         combinedObjectDimension = cms.int32(1),
         combinedObjectDrawables =  cms.VPSet()
@@ -813,7 +813,7 @@ def getPAMBVPSet():
             cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5)),
             cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
         ),
-	combinedObjectSelection =  cms.string("1==1"),
+        combinedObjectSelection =  cms.string("1==1"),
         combinedObjectSortCriteria = cms.string("at(0).pt"),
         combinedObjectDimension = cms.int32(1),
         combinedObjectDrawables =  cms.VPSet()

--- a/HLTrigger/Tools/python/PDRates.py
+++ b/HLTrigger/Tools/python/PDRates.py
@@ -29,97 +29,97 @@ parser.add_option("--saveplot",action="store_true",default=False,dest="saveplot"
 
 
 def PrimaryDatasets(Run):
-	# -- List of Primary Datasets:
+    # -- List of Primary Datasets:
 
-	dbs_cmd = """ dbs search --query='find primds.name 
+    dbs_cmd = """ dbs search --query='find primds.name 
           	where run=%d and dataset like */RAW' """ % (Run)
-	rows = commands.getoutput(dbs_cmd)
-	lines = rows.split("\n")
-	j=0
-	print("\nThe primary datasets for this run are: \n")
-	for Line in lines:
-		j=j+1
-		if j <=4:
-			continue
-		print(Line)
-		line=Line.split()
-		Datasets.append(line[0])
-	print(" ")
+    rows = commands.getoutput(dbs_cmd)
+    lines = rows.split("\n")
+    j=0
+    print("\nThe primary datasets for this run are: \n")
+    for Line in lines:
+        j=j+1
+        if j <=4:
+            continue
+        print(Line)
+        line=Line.split()
+        Datasets.append(line[0])
+    print(" ")
 
 
 
 def RateInPD(Run,PrimaryDataset,lsMin,lsMax,printLS=False):
-	dbs_cmd = """ dbs search --query='find file,lumi,file.numevents, file.size
+    dbs_cmd = """ dbs search --query='find file,lumi,file.numevents, file.size
 		where run=%d and dataset like /%s/*/RAW 
 		and lumi >= %d and lumi <= %d
 		and file.status=VALID '""" % (Run, PrimaryDataset,lsMin, lsMax)
-	rows = commands.getoutput(dbs_cmd)
-	lines = rows.split("\n")
-	j=0
-	LumiSections = []
-	Files = []
-	Evts = 0
-	Size = 0
-	LSinFile = {}
-  	NumberOfLSInFile = {}
-	for Line in lines:
-		j=j+1
-		if j <=4:
-			continue
-		line=Line.split()
-		LS = line[1]
-		file = line[0]
-		Nevts = int(line[2])
-		size = int(line[3])
-		LSinFile[LS] = file
-		if LumiSections.count(LS) == 0:
-			LumiSections.append(LS)
-		if Files.count(file) == 0:
-			Files.append(file)
-			Evts += Nevts
-			Size += size
-			NumberOfLSInFile[file] =1
-		else:
-			NumberOfLSInFile[file] = NumberOfLSInFile[file]+1
-		RatePerLS[LS] = Nevts
-			
-	Number_of_LS = len(LumiSections)
- 	LS_Length = 23.3
-	if Run < 125100:
-		LS_Length = 93.3
-	rate = Evts / (Number_of_LS * LS_Length)
-	if Evts > 0:
-		size_per_event = (Size / Evts) / 1000.
-	else:
-		size_per_event=-1
-	print("Rate in \t",PrimaryDataset,"\t is : \t",rate," Hz", " \t size is : \t",size_per_event, "kB / event ")
+    rows = commands.getoutput(dbs_cmd)
+    lines = rows.split("\n")
+    j=0
+    LumiSections = []
+    Files = []
+    Evts = 0
+    Size = 0
+    LSinFile = {}
+    NumberOfLSInFile = {}
+    for Line in lines:
+        j=j+1
+        if j <=4:
+            continue
+        line=Line.split()
+        LS = line[1]
+        file = line[0]
+        Nevts = int(line[2])
+        size = int(line[3])
+        LSinFile[LS] = file
+        if LumiSections.count(LS) == 0:
+            LumiSections.append(LS)
+        if Files.count(file) == 0:
+            Files.append(file)
+            Evts += Nevts
+            Size += size
+            NumberOfLSInFile[file] =1
+        else:
+            NumberOfLSInFile[file] = NumberOfLSInFile[file]+1
+        RatePerLS[LS] = Nevts
 
-	lsmin=9999999
-	lsmax=-1
-	for (LS,file) in six.iteritems(LSinFile):
-		nls = NumberOfLSInFile[file]
-		RatePerLS[LS] = RatePerLS[LS] / nls
-		RatePerLS[LS] = RatePerLS[LS] / LS_Length
-		if int(LS) > lsmax:
-			lsmax=int(LS)
-		if int(LS) < lsmin:
-			lsmin=int(LS)
-	if printLS:
-		print("lsmin lsmax",lsmin,lsmax)
-		for ls in range(lsmin,lsmax):
-			if not repr(ls) in RatePerLS.keys():
-				RatePerLS[LS] = 0
-				print("Missing LS ",ls)
+    Number_of_LS = len(LumiSections)
+    LS_Length = 23.3
+    if Run < 125100:
+        LS_Length = 93.3
+    rate = Evts / (Number_of_LS * LS_Length)
+    if Evts > 0:
+        size_per_event = (Size / Evts) / 1000.
+    else:
+        size_per_event=-1
+    print("Rate in \t",PrimaryDataset,"\t is : \t",rate," Hz", " \t size is : \t",size_per_event, "kB / event ")
+
+    lsmin=9999999
+    lsmax=-1
+    for (LS,file) in six.iteritems(LSinFile):
+        nls = NumberOfLSInFile[file]
+        RatePerLS[LS] = RatePerLS[LS] / nls
+        RatePerLS[LS] = RatePerLS[LS] / LS_Length
+        if int(LS) > lsmax:
+            lsmax=int(LS)
+        if int(LS) < lsmin:
+            lsmin=int(LS)
+    if printLS:
+        print("lsmin lsmax",lsmin,lsmax)
+        for ls in range(lsmin,lsmax):
+            if not repr(ls) in RatePerLS.keys():
+                RatePerLS[LS] = 0
+                print("Missing LS ",ls)
 
 
 if __name__ == "__main__":
 
-  if not options.RunNumber:
-	print("wrong usage")
-	exit(2)
+    if not options.RunNumber:
+        print("wrong usage")
+        exit(2)
 
-  lsMin = -1
-  lsMax = 999999
+    lsMin = -1
+    lsMax = 999999
 
 # -- does not work yet.
 #  if options.lsMin:
@@ -128,59 +128,59 @@ if __name__ == "__main__":
 #	lsMax = options.lsMax
 
 
-  print("\nRun Number: ",options.RunNumber)
-  if options.PrimaryDataset:
-	Run = options.RunNumber
-	PrimaryDataset = options.PrimaryDataset
-	RatePerLS = {}
-	if not options.perLS:
-		RateInPD(Run,PrimaryDataset,lsMin, lsMax, False)
-	if options.perLS:
-		average = 0
-		nLS_within_range = 0
-		RateInPD(Run,PrimaryDataset,lsMin, lsMax, True)
-		RatesTmp = open("rates_tmp.txt","w")
-		#RatesTmpSort = open("rates_tmp_sort.txt","w")
-		for (LS, rate) in six.iteritems(RatePerLS):
-			RatesTmp.write(LS+"\t"+repr(rate)+"\n")
-			#if int(LS) >=  lsMin and int(LS) <= lsMax:
-				#nLS_within_range =nLS_within_range +1
-				#average = average + rate
-		#print "Average rate within ",options.lsMin," and ",options.lsMax," is: ",average/nLS_within_range
-		#if os.path.exists("./rates_tmp_sort.txt"):
-			#os.system("rm rates_tmp_sort.txt")
-		#os.system("sort -n rates_tmp.txt > rates_tmp_sort.txt")
-		RatesTmp.close()
-		
-		TempFile = open("tmp.gnuplot.txt","w")
-		if options.logy:
-			TempFile.write("set logscale y \n")
-		if options.saveplot:
-			TempFile.write("set term postscript eps enhanced \n")
-			TempFile.write("set output \"tmp.eps\" \n")
-		st_title = " \"Rates in PrimaryDataset " + PrimaryDataset+ " in Run " + repr(Run)+ "\" "
-		TempFile.write("set title " + st_title + "\n")
-                TempFile.write(" set pointsize 2. \n")
-                TempFile.write(" set nokey \n")
-		TempFile.write(" set xlabel \"LS number\" \n")
-                TempFile.write(" set ylabel \"Rate (Hz)\" \n")
-		TempFile.write(" plot \"rates_tmp.txt\" using 1:2 title 'Rate per LS' \n")
-		if not options.saveplot:
-                	TempFile.write(" pause -1")
-		else:
-			print("The plot is saved under tmp.eps")
-                TempFile.close()
+    print("\nRun Number: ",options.RunNumber)
+    if options.PrimaryDataset:
+        Run = options.RunNumber
+        PrimaryDataset = options.PrimaryDataset
+        RatePerLS = {}
+        if not options.perLS:
+            RateInPD(Run,PrimaryDataset,lsMin, lsMax, False)
+        if options.perLS:
+            average = 0
+            nLS_within_range = 0
+            RateInPD(Run,PrimaryDataset,lsMin, lsMax, True)
+            RatesTmp = open("rates_tmp.txt","w")
+            #RatesTmpSort = open("rates_tmp_sort.txt","w")
+            for (LS, rate) in six.iteritems(RatePerLS):
+                RatesTmp.write(LS+"\t"+repr(rate)+"\n")
+                #if int(LS) >=  lsMin and int(LS) <= lsMax:
+                #nLS_within_range =nLS_within_range +1
+                #average = average + rate
+            #print "Average rate within ",options.lsMin," and ",options.lsMax," is: ",average/nLS_within_range
+            #if os.path.exists("./rates_tmp_sort.txt"):
+                #os.system("rm rates_tmp_sort.txt")
+            #os.system("sort -n rates_tmp.txt > rates_tmp_sort.txt")
+            RatesTmp.close()
 
-		os.system("gnuplot tmp.gnuplot.txt")
+            TempFile = open("tmp.gnuplot.txt","w")
+            if options.logy:
+                TempFile.write("set logscale y \n")
+            if options.saveplot:
+                TempFile.write("set term postscript eps enhanced \n")
+                TempFile.write("set output \"tmp.eps\" \n")
+            st_title = " \"Rates in PrimaryDataset " + PrimaryDataset+ " in Run " + repr(Run)+ "\" "
+            TempFile.write("set title " + st_title + "\n")
+            TempFile.write(" set pointsize 2. \n")
+            TempFile.write(" set nokey \n")
+            TempFile.write(" set xlabel \"LS number\" \n")
+            TempFile.write(" set ylabel \"Rate (Hz)\" \n")
+            TempFile.write(" plot \"rates_tmp.txt\" using 1:2 title 'Rate per LS' \n")
+            if not options.saveplot:
+                TempFile.write(" pause -1")
+            else:
+                print("The plot is saved under tmp.eps")
+            TempFile.close()
+
+            os.system("gnuplot tmp.gnuplot.txt")
 
 
-  else:
-	Run = options.RunNumber
-	Datasets = []
-	PrimaryDatasets(Run)
-	for PrimaryDataset in Datasets:
-		RatePerLS = {}
-		RateInPD(Run,PrimaryDataset,lsMin,lsMax)
-		
+    else:
+        Run = options.RunNumber
+        Datasets = []
+        PrimaryDatasets(Run)
+        for PrimaryDataset in Datasets:
+            RatePerLS = {}
+            RateInPD(Run,PrimaryDataset,lsMin,lsMax)
 
-	
+
+

--- a/HLTrigger/Tools/python/getHLTPrescaleColumns.py
+++ b/HLTrigger/Tools/python/getHLTPrescaleColumns.py
@@ -26,12 +26,12 @@ def getPrescalesFromKey(key):
     psMap = {}
     aa=""
     if len(res)>0:
-	for uu in range(3,len(res_split)-1):
-		if uu % 2 == 1:
-		   aa = aa + res_split[uu] + "\t"
-	psMap[path] = aa
+        for uu in range(3,len(res_split)-1):
+            if uu % 2 == 1:
+                aa = aa + res_split[uu] + "\t"
+        psMap[path] = aa
     else:
-	psMap[path] = 0
+        psMap[path] = 0
     return psMap
 
 from queryRR import queryRR

--- a/HLTrigger/Tools/python/getHLTkey.py
+++ b/HLTrigger/Tools/python/getHLTkey.py
@@ -25,32 +25,32 @@ runKeys = queryRR(options.firstRun,options.lastRun,options.groupName)
 runs = runKeys.keys(); runs.sort()
 
 if options.perKey:
- 	runsPerKey={}
-	for run in runs:
-		key = runKeys[run]
-		if not key in runsPerKey.keys():
-			tmpruns=[]
-			tmpruns.append(run)
-			runsPerKey[key] = tmpruns
-		else:
-			runsPerKey[key].append(run)
-	theKeys = runsPerKey.keys()
-	for key in theKeys:
-		theruns = runsPerKey[key]
-		topr=""
-		for r in theruns:
-			topr=topr+"\t"+r
-		print(key,topr)
-	exit(1)
-			
+    runsPerKey={}
+    for run in runs:
+        key = runKeys[run]
+        if not key in runsPerKey.keys():
+            tmpruns=[]
+            tmpruns.append(run)
+            runsPerKey[key] = tmpruns
+        else:
+            runsPerKey[key].append(run)
+    theKeys = runsPerKey.keys()
+    for key in theKeys:
+        theruns = runsPerKey[key]
+        topr=""
+        for r in theruns:
+            topr=topr+"\t"+r
+        print(key,topr)
+    exit(1)
+
 if options.HLTkey:
-	HLTkey = options.HLTkey
-	print("List of runs taken with HLT key = ",HLTkey) 
+    HLTkey = options.HLTkey
+    print("List of runs taken with HLT key = ",HLTkey) 
 for run in runs:
     key = runKeys[run]
 
     if not options.HLTkey:
-       print(run,key)	
+        print(run,key)	
     else:
-	if key == options.HLTkey:
-	   print(run)
+        if key == options.HLTkey:
+            print(run)

--- a/HLTrigger/Tools/python/getHLTprescales.py
+++ b/HLTrigger/Tools/python/getHLTprescales.py
@@ -25,28 +25,28 @@ def getPrescalesFromKey(key):
     res_split = res.split()
     psCols = []
     if len(res)>0:
-	for uu in range(3,len(res_split)-1):
-		if uu % 2 == 1:
-		   psCols.append(res_split[uu])
+        for uu in range(3,len(res_split)-1):
+            if uu % 2 == 1:
+                psCols.append(res_split[uu])
     return psCols
 
 from queryRR import queryRR
 
 def readIndex():
-	asciiFile=open("columns.txt","read")
-	mapIndex={}
-	fl="go"
-	while fl:
-	  fl=asciiFile.readline()
-	  if len(fl)>0:
-		ll=fl.split()
-		runnumber=ll[0]
-		pindex=ll[1]
-		mapIndex[runnumber]=pindex
-	asciiFile.close()
-	return mapIndex
+    asciiFile=open("columns.txt","read")
+    mapIndex={}
+    fl="go"
+    while fl:
+        fl=asciiFile.readline()
+        if len(fl)>0:
+            ll=fl.split()
+            runnumber=ll[0]
+            pindex=ll[1]
+            mapIndex[runnumber]=pindex
+    asciiFile.close()
+    return mapIndex
 
-	
+
 MapIndex=readIndex()
 runKeys = queryRR(options.firstRun,options.lastRun,options.groupName)
 prescaleTable = {}
@@ -61,34 +61,34 @@ for run in runs:
     psfactor = 1
     absent=0
     if len(prescaleTable[key]) == 0:
-	psfactor = 0
+        psfactor = 0
     else:
-    	if run in MapIndex:
-		index = int(MapIndex[run])
-		psfactor = prescaleTable[key][index]
-    	else:
-		if int(run) < 138564:
-			index = 0
-			psfactor = prescaleTable[key][index]
-		else:
-			#print "... the run ",run," is not found in columns.txt ... Index is set to zero, need to check independently..."
-			index=0
-			psfactor = prescaleTable[key][index]
-			Absent.append(run)
-			absent=1
+        if run in MapIndex:
+            index = int(MapIndex[run])
+            psfactor = prescaleTable[key][index]
+        else:
+            if int(run) < 138564:
+                index = 0
+                psfactor = prescaleTable[key][index]
+            else:
+                #print "... the run ",run," is not found in columns.txt ... Index is set to zero, need to check independently..."
+                index=0
+                psfactor = prescaleTable[key][index]
+                Absent.append(run)
+                absent=1
     if absent==0:
-    	print("%s\t%s" % (run, psfactor))
+        print("%s\t%s" % (run, psfactor))
     else:
-	print("%s\t%s\t (*)" % (run, psfactor))
+        print("%s\t%s\t (*)" % (run, psfactor))
     jsout[run] = psfactor
 
 if len(Absent)>0:
-	print("")
-	print("(*) The following runs were not found in columns.txt (the run may be too recent, or the prescale index is not in OMDS).")
-     	print("For these runs, the prescale_index was assumed to be zero. You need to check independently.")
-	for r in Absent:
-		print("\t",r)
-	print("")
+    print("")
+    print("(*) The following runs were not found in columns.txt (the run may be too recent, or the prescale index is not in OMDS).")
+    print("For these runs, the prescale_index was assumed to be zero. You need to check independently.")
+    for r in Absent:
+        print("\t",r)
+    print("")
 
 if options.jsonOut:
     stderr.write("Exporting to JSON file %s...\n" % (options.jsonOut))

--- a/HLTrigger/Tools/scripts/timingPdfMaker.py
+++ b/HLTrigger/Tools/scripts/timingPdfMaker.py
@@ -36,443 +36,443 @@ gStyle.SetHistFillColor(kBlue)
 ###############################################################
 def usage():
 ###############################################################
-	print("\nThis is the usage function\n")
-	print('Usage: '+sys.argv[0]+' -i <file1> [option]')
-	print('e.g.:  '+sys.argv[0]+' -i outputTiming.root -t')
-	print('e.g.:  '+sys.argv[0]+' -i outputTiming.root -s HLT_Jet300_v5\n')
+    print("\nThis is the usage function\n")
+    print('Usage: '+sys.argv[0]+' -i <file1> [option]')
+    print('e.g.:  '+sys.argv[0]+' -i outputTiming.root -t')
+    print('e.g.:  '+sys.argv[0]+' -i outputTiming.root -s HLT_Jet300_v5\n')
 
-	print('\n-----Options-----')
-	print(' -i		 	Input File')
-	print(' -o 			Output File (optional)')
-	print(' -t 			For only main time info per event. It will take less than 1 min.')
-	print(' -p			For path time info. It will take approx 25 min.')
-	print(' -m 			For module time info. It will take approx 25 min.')
-	print(' -s Path_Name            (For an specific path). Ti will take less than 1 min.')
-	print('\n For -p or -m option, the process needs like 200 Mb in disk space,')
-	print(' but please dont be afraid. Before the process ends, all the temporal files')
-	print(' will be erased.')
+    print('\n-----Options-----')
+    print(' -i		 	Input File')
+    print(' -o 			Output File (optional)')
+    print(' -t 			For only main time info per event. It will take less than 1 min.')
+    print(' -p			For path time info. It will take approx 25 min.')
+    print(' -m 			For module time info. It will take approx 25 min.')
+    print(' -s Path_Name            (For an specific path). Ti will take less than 1 min.')
+    print('\n For -p or -m option, the process needs like 200 Mb in disk space,')
+    print(' but please dont be afraid. Before the process ends, all the temporal files')
+    print(' will be erased.')
 
 
 ###############################################################
 def maininfo(infile, outfile):
-	''' Creates main info tex file'''
+    ''' Creates main info tex file'''
 ##############################################################
-        texpreamble = ['\documentclass[10pt,a5paper,landscape]{report}\n',
-                        '\usepackage{graphicx}\n',
-                        '\usepackage[a5paper,vmargin={5mm,2mm},hmargin={5mm,5mm}]{geometry}\n',
-                        '\usepackage[linktocpage]{hyperref}\n',
-                        '\hypersetup{backref, colorlinks=true}\n',
-                        '\\title{ \\textbf{\Huge{HLT Timing Summary}} \\footnote{\large{Documentation at \url{https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideHLTTimingSummary}}} \\\\ Main Info }\n',
-                        '\\author{\Large{CMS Experiment}}\n',
-                        '\date{\\today}\n',
-                        '\\begin{document}\n',
-                        '\maketitle\n',
-                        '\\newpage\n',
-			'\clearpage\n'
-                        '\\tableofcontents\n',
-                        '\\newpage\n',
-                        '\\newpage \chapter{Total time for all modules per event} \\newpage \centering \includegraphics[scale=0.6]{totalTimetemp.png}\n']
+    texpreamble = ['\documentclass[10pt,a5paper,landscape]{report}\n',
+                    '\usepackage{graphicx}\n',
+                    '\usepackage[a5paper,vmargin={5mm,2mm},hmargin={5mm,5mm}]{geometry}\n',
+                    '\usepackage[linktocpage]{hyperref}\n',
+                    '\hypersetup{backref, colorlinks=true}\n',
+                    '\\title{ \\textbf{\Huge{HLT Timing Summary}} \\footnote{\large{Documentation at \url{https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideHLTTimingSummary}}} \\\\ Main Info }\n',
+                    '\\author{\Large{CMS Experiment}}\n',
+                    '\date{\\today}\n',
+                    '\\begin{document}\n',
+                    '\maketitle\n',
+                    '\\newpage\n',
+                    '\clearpage\n'
+                    '\\tableofcontents\n',
+                    '\\newpage\n',
+                    '\\newpage \chapter{Total time for all modules per event} \\newpage \centering \includegraphics[scale=0.6]{totalTimetemp.png}\n']
 
-        names1 = {}
-        names4 = {}
-	specific = {}
-        file1 = TFile(infile,'read')
-        for k in file1.GetListOfKeys():
-                allnames = k.ReadObj().GetName()
-                if 'pathTime_' in allnames:
-                        pathname = '_'.join(allnames.split('_')[1:])
-                        if not pathname in names1:
-                                names1[pathname] = k.ReadObj().GetMean()
-		elif 'incPathTime_' in allnames:
-                        pathname = '_'.join(allnames.split('_')[1:])
-                        if not pathname in names4:
-                                names4[pathname] = k.ReadObj().GetMean()
+    names1 = {}
+    names4 = {}
+    specific = {}
+    file1 = TFile(infile,'read')
+    for k in file1.GetListOfKeys():
+        allnames = k.ReadObj().GetName()
+        if 'pathTime_' in allnames:
+            pathname = '_'.join(allnames.split('_')[1:])
+            if not pathname in names1:
+                names1[pathname] = k.ReadObj().GetMean()
+        elif 'incPathTime_' in allnames:
+            pathname = '_'.join(allnames.split('_')[1:])
+            if not pathname in names4:
+                names4[pathname] = k.ReadObj().GetMean()
 
-        names2 = dict(sorted(six.iteritems(names1), key=operator.itemgetter(1),reverse=True)[:10])
-	names3 = sorted(names2, key=names2.get, reverse=True)
-        names5 = dict(sorted(six.iteritems(names4), key=operator.itemgetter(1),reverse=True)[:10])
-	names6 = sorted(names5, key=names5.get, reverse=True)
+    names2 = dict(sorted(six.iteritems(names1), key=operator.itemgetter(1),reverse=True)[:10])
+    names3 = sorted(names2, key=names2.get, reverse=True)
+    names5 = dict(sorted(six.iteritems(names4), key=operator.itemgetter(1),reverse=True)[:10])
+    names6 = sorted(names5, key=names5.get, reverse=True)
 
-        texfile = open(outfile+'-main.tex', 'w')
-        texfile.writelines(texpreamble)
-	if os.path.exists(infile.replace('.root','')+'-summary.txt'):
-                excludefile = open(infile.replace('.root','')+'-summary.txt', 'r')
-                texfile.write('\\newpage \section{Summary} \n \\begin{verbatim} \n')
-                for line in excludefile.readlines():
-                        texfile.write(line+'\n')
-                excludefile.close()
-		texfile.write('\end{verbatim}')
-        texfile.write('\\newpage \\chapter{10 Slowest Paths}\n')
-        texfile.write('\section{Average module (in path) time}\n')
-        for path in names3:
-                texfile.write('\\newpage \subsection{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{moduleInPathTimeSummary'+ path.replace('_','') +'temp.png}\n')
-                get_plot2(infile,'moduleInPathTimeSummary_'+path)
-        texfile.write('\section{Average module (in path) running time}\n')
-        for path in names3:
-                texfile.write('\\newpage \subsection{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{moduleInPathScaledTimeSummary'+ path.replace('_','') +'temp.png}\n')
-                get_plot2(infile,'moduleInPathScaledTimeSummary_'+path)
-        texfile.write('\section{Per event time for path}\n')
-        for path in names3:
-                texfile.write('\\newpage \subsection{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{pathTime'+ path.replace('_','') +'temp.png}\n')
-                get_plot1(infile,'pathTime_'+path)
-        texfile.write('\section{Per event incremental time for path}\n')
-        for path in names6:
-                texfile.write('\\newpage \subsection{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{incPathTime'+ path.replace('_','') +'temp.png}\n')
-                get_plot1(infile,'incPathTime_'+path)
-        texfile.write('\end{document}')
-        texfile.close()
+    texfile = open(outfile+'-main.tex', 'w')
+    texfile.writelines(texpreamble)
+    if os.path.exists(infile.replace('.root','')+'-summary.txt'):
+        excludefile = open(infile.replace('.root','')+'-summary.txt', 'r')
+        texfile.write('\\newpage \section{Summary} \n \\begin{verbatim} \n')
+        for line in excludefile.readlines():
+            texfile.write(line+'\n')
+        excludefile.close()
+        texfile.write('\end{verbatim}')
+    texfile.write('\\newpage \\chapter{10 Slowest Paths}\n')
+    texfile.write('\section{Average module (in path) time}\n')
+    for path in names3:
+        texfile.write('\\newpage \subsection{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{moduleInPathTimeSummary'+ path.replace('_','') +'temp.png}\n')
+        get_plot2(infile,'moduleInPathTimeSummary_'+path)
+    texfile.write('\section{Average module (in path) running time}\n')
+    for path in names3:
+        texfile.write('\\newpage \subsection{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{moduleInPathScaledTimeSummary'+ path.replace('_','') +'temp.png}\n')
+        get_plot2(infile,'moduleInPathScaledTimeSummary_'+path)
+    texfile.write('\section{Per event time for path}\n')
+    for path in names3:
+        texfile.write('\\newpage \subsection{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{pathTime'+ path.replace('_','') +'temp.png}\n')
+        get_plot1(infile,'pathTime_'+path)
+    texfile.write('\section{Per event incremental time for path}\n')
+    for path in names6:
+        texfile.write('\\newpage \subsection{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{incPathTime'+ path.replace('_','') +'temp.png}\n')
+        get_plot1(infile,'incPathTime_'+path)
+    texfile.write('\end{document}')
+    texfile.close()
 
-        texfile.close()
+    texfile.close()
 
-	get_plot1(infile,'totalTime')
+    get_plot1(infile,'totalTime')
 
 
 
 #################################################
 def pathsinfo(infile,outfile):
-	'''Create the paths info tex file'''
+    '''Create the paths info tex file'''
 ################################################
 
-	texpreamble = ['\documentclass[10pt,a5paper,landscape]{book}\n',
-			'\usepackage{graphicx}\n',
-			'\usepackage[a5paper,vmargin={5mm,2mm},hmargin={5mm,5mm}]{geometry}\n',
-			'\usepackage[linktocpage]{hyperref}\n',
-			'\usepackage[titles]{tocloft}\n'
-			'\hypersetup{backref, colorlinks=true}\n',
-                        '\setlength{\cftsecnumwidth}{4em}\n'
-			'\\title{ \\textbf{\Huge{HLT Timing Summary}} \\footnote{\large{Documentation at \url{https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideHLTTimingSummary}}} \\\\ Paths Info }\n',
-			'\\author{\Large{CMS Experiment}}\n',
-			'\date{\\today}\n',
-			'\\begin{document}\n',
-			'\maketitle\n',
-			'\\newpage\n',
-			'\\tableofcontents\n',
-			'\\newpage\n']
+    texpreamble = ['\documentclass[10pt,a5paper,landscape]{book}\n',
+                    '\usepackage{graphicx}\n',
+                    '\usepackage[a5paper,vmargin={5mm,2mm},hmargin={5mm,5mm}]{geometry}\n',
+                    '\usepackage[linktocpage]{hyperref}\n',
+                    '\usepackage[titles]{tocloft}\n'
+                    '\hypersetup{backref, colorlinks=true}\n',
+                    '\setlength{\cftsecnumwidth}{4em}\n'
+                    '\\title{ \\textbf{\Huge{HLT Timing Summary}} \\footnote{\large{Documentation at \url{https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideHLTTimingSummary}}} \\\\ Paths Info }\n',
+                    '\\author{\Large{CMS Experiment}}\n',
+                    '\date{\\today}\n',
+                    '\\begin{document}\n',
+                    '\maketitle\n',
+                    '\\newpage\n',
+                    '\\tableofcontents\n',
+                    '\\newpage\n']
 
-	names1 = {}
-	file = TFile(infile,'read')
-	for k in file.GetListOfKeys():
-		allnames= k.ReadObj().GetName()
-		mean = 1
-		if 'moduleInPathScaledTime_' in allnames:
-			pathname = '_'.join(allnames.split('_')[1:-1])
-			if not pathname in names1:
-				names1[pathname] = mean
-	names = sorted(names1.keys())
+    names1 = {}
+    file = TFile(infile,'read')
+    for k in file.GetListOfKeys():
+        allnames= k.ReadObj().GetName()
+        mean = 1
+        if 'moduleInPathScaledTime_' in allnames:
+            pathname = '_'.join(allnames.split('_')[1:-1])
+            if not pathname in names1:
+                names1[pathname] = mean
+    names = sorted(names1.keys())
 
-        texfile = open(outfile+'-paths.tex', 'w')
-        texfile.writelines(texpreamble)
+    texfile = open(outfile+'-paths.tex', 'w')
+    texfile.writelines(texpreamble)
 
-	texfile.write('\\chapter{Average module (in path) time}\n')
-	for path in names:
-		texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{moduleInPathTimeSummary'+ path.replace('_','') +'temp.png}\n')	
-		get_plot2(infile,'moduleInPathTimeSummary_'+path)
-	texfile.write('\\chapter{Average module (in path) running time}\n')
-	for path in names:
-		texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{moduleInPathScaledTimeSummary'+ path.replace('_','') +'temp.png}\n')	
-		get_plot2(infile,'moduleInPathScaledTimeSummary_'+path)
-	texfile.write('\\chapter{Failing module (by path)}')
-	for path in names:
-		texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{failedModule'+ path.replace('_','') +'temp.png}\n')
-		get_plot2(infile,'failedModule_'+path)
-	texfile.write('\\chapter{Per event time for path}\n')
-	for path in names:
-		texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{pathTime'+ path.replace('_','') +'temp.png}\n')
-		get_plot1(infile,'pathTime_'+path)
-	texfile.write('\\chapter{Per event incremental time for path}\n')
-	for path in names:
-		texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{incPathTime'+ path.replace('_','') +'temp.png}\n')
-		get_plot1(infile,'incPathTime_'+path)
+    texfile.write('\\chapter{Average module (in path) time}\n')
+    for path in names:
+        texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{moduleInPathTimeSummary'+ path.replace('_','') +'temp.png}\n')	
+        get_plot2(infile,'moduleInPathTimeSummary_'+path)
+    texfile.write('\\chapter{Average module (in path) running time}\n')
+    for path in names:
+        texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{moduleInPathScaledTimeSummary'+ path.replace('_','') +'temp.png}\n')	
+        get_plot2(infile,'moduleInPathScaledTimeSummary_'+path)
+    texfile.write('\\chapter{Failing module (by path)}')
+    for path in names:
+        texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.35]{failedModule'+ path.replace('_','') +'temp.png}\n')
+        get_plot2(infile,'failedModule_'+path)
+    texfile.write('\\chapter{Per event time for path}\n')
+    for path in names:
+        texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{pathTime'+ path.replace('_','') +'temp.png}\n')
+        get_plot1(infile,'pathTime_'+path)
+    texfile.write('\\chapter{Per event incremental time for path}\n')
+    for path in names:
+        texfile.write('\\newpage \section{'+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{incPathTime'+ path.replace('_','') +'temp.png}\n')
+        get_plot1(infile,'incPathTime_'+path)
 
-	texfile.write('\end{document}')
-	texfile.close()
+    texfile.write('\end{document}')
+    texfile.close()
 
 
 #################################################
 def moduleinfo(infile,outfile):
-        '''Create the paths info tex file'''
+    '''Create the paths info tex file'''
 ################################################
 
-        texpreamble = ['\documentclass[10pt,a5paper,landscape]{report}\n',
-                        '\usepackage{graphicx}\n',
-                        '\usepackage[a5paper,vmargin={5mm,2mm},hmargin={5mm,5mm}]{geometry}\n',
-                        '\usepackage[linktocpage]{hyperref}\n',
-                        '\hypersetup{backref, colorlinks=true}\n',
-			'\usepackage[titles]{tocloft}\n'
-                        '\setlength{\cftsecnumwidth}{4em}\n'
-                        '\\title{ \\textbf{\Huge{HLT Timing Summary}} \\footnote{\large{Documentation at \url{https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideHLTTimingSummary}}} \\\\ Modules Info }\n',
-                        '\\author{\Large{CMS Experiment}}\n',
-                        '\date{\\today}\n',
-                        '\\begin{document}\n',
-                        '\maketitle\n',
-                        '\\newpage\n',
-                        '\\tableofcontents\n',
-                        '\\newpage\n']
+    texpreamble = ['\documentclass[10pt,a5paper,landscape]{report}\n',
+                    '\usepackage{graphicx}\n',
+                    '\usepackage[a5paper,vmargin={5mm,2mm},hmargin={5mm,5mm}]{geometry}\n',
+                    '\usepackage[linktocpage]{hyperref}\n',
+                    '\hypersetup{backref, colorlinks=true}\n',
+                    '\usepackage[titles]{tocloft}\n'
+                    '\setlength{\cftsecnumwidth}{4em}\n'
+                    '\\title{ \\textbf{\Huge{HLT Timing Summary}} \\footnote{\large{Documentation at \url{https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideHLTTimingSummary}}} \\\\ Modules Info }\n',
+                    '\\author{\Large{CMS Experiment}}\n',
+                    '\date{\\today}\n',
+                    '\\begin{document}\n',
+                    '\maketitle\n',
+                    '\\newpage\n',
+                    '\\tableofcontents\n',
+                    '\\newpage\n']
 
-        names1 = {}
-        file = TFile(infile,'read')
-        for k in file.GetListOfKeys():
-                allnames = k.ReadObj().GetName()
-                mean = 1
-                if 'moduleTime_' in allnames:
-                        modname = ''.join(allnames.split('_')[1:])
-			if not (('!' in modname) or ('-' in modname)): 
-	                        if not modname in names1:
-        	                	names1[modname] = mean
-	names = sorted(names1.keys())
+    names1 = {}
+    file = TFile(infile,'read')
+    for k in file.GetListOfKeys():
+        allnames = k.ReadObj().GetName()
+        mean = 1
+        if 'moduleTime_' in allnames:
+            modname = ''.join(allnames.split('_')[1:])
+            if not (('!' in modname) or ('-' in modname)): 
+                if not modname in names1:
+                    names1[modname] = mean
+    names = sorted(names1.keys())
 
-        texfile1 = open(outfile+'-modules.tex', 'w')
-        texfile1.writelines(texpreamble)
+    texfile1 = open(outfile+'-modules.tex', 'w')
+    texfile1.writelines(texpreamble)
 
-	texfile1.write('\\chapter{Time per event for module} \n \\newpage')
-	for modules in names:
-		texfile1.write('\section{'+modules+'}')
-		texfile1.write('\centering \includegraphics[scale=0.4]{moduleTime'+ modules +'temp.png}\n')
-		get_plot1(infile,'moduleTime_'+modules)
-        texfile1.write('\end{document}')
-        texfile1.close()
+    texfile1.write('\\chapter{Time per event for module} \n \\newpage')
+    for modules in names:
+        texfile1.write('\section{'+modules+'}')
+        texfile1.write('\centering \includegraphics[scale=0.4]{moduleTime'+ modules +'temp.png}\n')
+        get_plot1(infile,'moduleTime_'+modules)
+    texfile1.write('\end{document}')
+    texfile1.close()
 
-        texfile2 = open(outfile+'-runningModules.tex', 'w')
-        texfile2.writelines(texpreamble)
-        texfile2.write('\\chapter{Running Time per event for module} \n \\newpage')
-	for modules in names:
-		texfile2.write('\section{'+modules+'}')
-		texfile2.write('\centering \includegraphics[scale=0.45]{moduleScaledTime'+modules+'temp.png}\n')    
-		get_plot1(infile,'moduleScaledTime_'+ modules)
+    texfile2 = open(outfile+'-runningModules.tex', 'w')
+    texfile2.writelines(texpreamble)
+    texfile2.write('\\chapter{Running Time per event for module} \n \\newpage')
+    for modules in names:
+        texfile2.write('\section{'+modules+'}')
+        texfile2.write('\centering \includegraphics[scale=0.45]{moduleScaledTime'+modules+'temp.png}\n')    
+        get_plot1(infile,'moduleScaledTime_'+ modules)
 
-        texfile2.write('\end{document}')
-        texfile2.close()
+    texfile2.write('\end{document}')
+    texfile2.close()
 
 ###############################################################
 def specificpathinfo(infile, outfile, path):
-        ''' Creates an specific path info tex file'''
+    ''' Creates an specific path info tex file'''
 ##############################################################
-        texpreamble = ['\documentclass[10pt,a5paper,landscape]{report}\n',
-                        '\usepackage{graphicx}\n',
-                        '\usepackage[a5paper,vmargin={5mm,2mm},hmargin={5mm,5mm}]{geometry}\n',
-                        '\usepackage[linktocpage]{hyperref}\n',
-			'\usepackage[titles]{tocloft}\n'
-                        '\hypersetup{backref, colorlinks=true}\n',
-                        '\setlength{\cftsubsecnumwidth}{4em}\n'
-                        '\\title{ \\textbf{\Huge{HLT Timing Summary}} \\footnote{\large{Documentation at \url{https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideHLTTimingSummary}}} \\\\ Main Info + ' + path.replace('_','\_') +' info }\n',
-                        '\\author{\Large{CMS Experiment}}\n',
-                        '\date{\\today}\n',
-                        '\\begin{document}\n',
-                        '\maketitle\n',
-			'\\tableofcontents \n'
-                        '\\newpage\n \\chapter{Main Info} \n',
-                        '\\newpage \centering \section{Total time for all modules per event} \includegraphics[scale=0.6]{totalTimetemp.png}\n']
+    texpreamble = ['\documentclass[10pt,a5paper,landscape]{report}\n',
+                    '\usepackage{graphicx}\n',
+                    '\usepackage[a5paper,vmargin={5mm,2mm},hmargin={5mm,5mm}]{geometry}\n',
+                    '\usepackage[linktocpage]{hyperref}\n',
+                    '\usepackage[titles]{tocloft}\n'
+                    '\hypersetup{backref, colorlinks=true}\n',
+                    '\setlength{\cftsubsecnumwidth}{4em}\n'
+                    '\\title{ \\textbf{\Huge{HLT Timing Summary}} \\footnote{\large{Documentation at \url{https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideHLTTimingSummary}}} \\\\ Main Info + ' + path.replace('_','\_') +' info }\n',
+                    '\\author{\Large{CMS Experiment}}\n',
+                    '\date{\\today}\n',
+                    '\\begin{document}\n',
+                    '\maketitle\n',
+                    '\\tableofcontents \n'
+                    '\\newpage\n \\chapter{Main Info} \n',
+                    '\\newpage \centering \section{Total time for all modules per event} \includegraphics[scale=0.6]{totalTimetemp.png}\n']
 
-        texfile = open(outfile+'-'+path+'.tex', 'w')
-        texfile.writelines(texpreamble)
-        get_plot1(infile,'totalTime')
+    texfile = open(outfile+'-'+path+'.tex', 'w')
+    texfile.writelines(texpreamble)
+    get_plot1(infile,'totalTime')
 
-	names = {}
-	file1 = TFile(infile,'read')
-	for k in file1.GetListOfKeys():
-		allnames = k.ReadObj().GetName()
-		if 'moduleInPathScaledTime_' in allnames:
-			pathname = '_'.join(allnames.split('_')[1:-1])
-			if not pathname in names:
-				names[pathname] = {}
-	for pathnames in names.keys():
-		histo = file1.Get('moduleInPathTimeSummary_'+pathnames)
-		for bin in range(histo.GetNbinsX()):
-			label = histo.GetXaxis().GetBinLabel(bin+1)
-			names[pathnames][bin+1] = label
+    names = {}
+    file1 = TFile(infile,'read')
+    for k in file1.GetListOfKeys():
+        allnames = k.ReadObj().GetName()
+        if 'moduleInPathScaledTime_' in allnames:
+            pathname = '_'.join(allnames.split('_')[1:-1])
+            if not pathname in names:
+                names[pathname] = {}
+    for pathnames in names.keys():
+        histo = file1.Get('moduleInPathTimeSummary_'+pathnames)
+        for bin in range(histo.GetNbinsX()):
+            label = histo.GetXaxis().GetBinLabel(bin+1)
+            names[pathnames][bin+1] = label
 
-	for pathname in names:
-		if path in pathname:
-			texfile.write('\chapter{' + path.replace('_','\_')+ ' Info} \n')
-			texfile.write('\\newpage \section{Average module in '+ path.replace('_','\_') +' time} \centering \includegraphics[scale=0.35]{moduleInPathTimeSummary'+ path.replace('_','') +'temp.png}\n')
-			get_plot2(infile,'moduleInPathTimeSummary_'+path)
-			texfile.write('\\newpage \section{Average module in '+ path.replace('_','\_') +' running time} \centering \includegraphics[scale=0.35]{moduleInPathScaledTimeSummary'+ path.replace('_','') +'temp.png}\n')
-			get_plot2(infile,'moduleInPathScaledTimeSummary_'+path)
-			texfile.write('\\newpage \section{Per event time for '+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{pathTime'+ path.replace('_','') +'temp.png}\n')
-			get_plot1(infile,'pathTime_'+path)
-			texfile.write('\\newpage \section{Per event incremental time for '+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{incPathTime'+ path.replace('_','') +'temp.png}\n')
-			get_plot1(infile,'incPathTime_'+path)
-			texfile.write('\section{Running time per event for '+path.replace('_','\_')+'}')	
-			for modules in names[path].values():
-				texfile.write('\subsection{'+ modules +'} \centering \includegraphics[scale=0.6]{moduleInPathScaledTime'+ path.replace('_','') + modules +'temp.png}\n')
-			        get_plot1(infile,'moduleInPathScaledTime_'+ path +'_'+ modules)
-	texfile.write('\\end{document}')
-	texfile.close()
+    for pathname in names:
+        if path in pathname:
+            texfile.write('\chapter{' + path.replace('_','\_')+ ' Info} \n')
+            texfile.write('\\newpage \section{Average module in '+ path.replace('_','\_') +' time} \centering \includegraphics[scale=0.35]{moduleInPathTimeSummary'+ path.replace('_','') +'temp.png}\n')
+            get_plot2(infile,'moduleInPathTimeSummary_'+path)
+            texfile.write('\\newpage \section{Average module in '+ path.replace('_','\_') +' running time} \centering \includegraphics[scale=0.35]{moduleInPathScaledTimeSummary'+ path.replace('_','') +'temp.png}\n')
+            get_plot2(infile,'moduleInPathScaledTimeSummary_'+path)
+            texfile.write('\\newpage \section{Per event time for '+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{pathTime'+ path.replace('_','') +'temp.png}\n')
+            get_plot1(infile,'pathTime_'+path)
+            texfile.write('\\newpage \section{Per event incremental time for '+ path.replace('_','\_') +'} \centering \includegraphics[scale=0.6]{incPathTime'+ path.replace('_','') +'temp.png}\n')
+            get_plot1(infile,'incPathTime_'+path)
+            texfile.write('\section{Running time per event for '+path.replace('_','\_')+'}')	
+            for modules in names[path].values():
+                texfile.write('\subsection{'+ modules +'} \centering \includegraphics[scale=0.6]{moduleInPathScaledTime'+ path.replace('_','') + modules +'temp.png}\n')
+                get_plot1(infile,'moduleInPathScaledTime_'+ path +'_'+ modules)
+    texfile.write('\\end{document}')
+    texfile.close()
 
 
 
 
 ###################################################################
 def get_plot1(file,allnames):
-	''' Function to create the plot and save it as.png file '''
+    ''' Function to create the plot and save it as.png file '''
 ###################################################################
-	file = TFile(file,'read')
-	histo = file.Get(allnames)
-	can = TCanvas('can', '', 800,600)
-	can.cd()
-	histo.UseCurrentStyle()
-	histo.Draw()
-	can.SetBorderMode(0)
-	can.SetFillColor(kWhite)
-	can.SaveAs(allnames.replace('_','')+'temp.png')
-	del can
+    file = TFile(file,'read')
+    histo = file.Get(allnames)
+    can = TCanvas('can', '', 800,600)
+    can.cd()
+    histo.UseCurrentStyle()
+    histo.Draw()
+    can.SetBorderMode(0)
+    can.SetFillColor(kWhite)
+    can.SaveAs(allnames.replace('_','')+'temp.png')
+    del can
 
 
 
 ###################################################################
 def get_plot2(infile,allnames):
-        ''' Function to create the plot and save it as.png file '''
+    ''' Function to create the plot and save it as.png file '''
 ###################################################################
-        file1 = TFile(infile,'read')
-        histo = file1.Get(allnames)
-	can = TCanvas('can', '', 1600,1000)
-        can.cd()
-        histo.UseCurrentStyle()
-        histo.Draw()
-	if histo.GetNbinsX() > 50:
-		histo.GetXaxis().SetLabelSize(0.02)
-	else:
-		histo.GetXaxis().SetLabelSize(0.03)
-        can.SetBorderMode(0)
-	can.SetBorderSize(0)
-        can.SetFillColor(kWhite)
-	can.SetBottomMargin(0.4)
-        can.SaveAs(allnames.replace('_','')+'temp.png')
-        del can
+    file1 = TFile(infile,'read')
+    histo = file1.Get(allnames)
+    can = TCanvas('can', '', 1600,1000)
+    can.cd()
+    histo.UseCurrentStyle()
+    histo.Draw()
+    if histo.GetNbinsX() > 50:
+        histo.GetXaxis().SetLabelSize(0.02)
+    else:
+        histo.GetXaxis().SetLabelSize(0.03)
+    can.SetBorderMode(0)
+    can.SetBorderSize(0)
+    can.SetFillColor(kWhite)
+    can.SetBottomMargin(0.4)
+    can.SaveAs(allnames.replace('_','')+'temp.png')
+    del can
 
 ###############################################################
 def main(argv):
 ###############################################################
-        print("\nPython script that creates Timing Summary pdf files")
-        print("For more info, please contact Alejandro Gomez")
-        print("email: alejandro.gomez@cern.ch\n")
+    print("\nPython script that creates Timing Summary pdf files")
+    print("For more info, please contact Alejandro Gomez")
+    print("email: alejandro.gomez@cern.ch\n")
 
-	infile = None
-	outfile = None
-	path = None
-	call_maininfo = False
-	call_pathsinfo = False
-	call_modulesinfo = False
-	call_specificinfo = False
-	try:
-		opts, args = getopt.getopt(argv, 'hi:o:tbpms:', ['help', 'input=', 'output='])
-		if not opts:
-			print('No options supplied')
-			usage()
-	except getopt.GetoptError as e:
-		print(e)
-		usage()
-		sys.exit(2)
-	for opt, arg in opts:
-		if opt in ('h', '--help'):
-			usage()
-			sys.exit(2)
-		elif opt == '-b':
-			print('Running in batch mode') 
-		elif opt in ('-i', '--input'):
-			infile = arg
-			outfile = infile.replace('.root','')
-		elif opt in ('-o', '--output'):
-			outfile = arg
-		elif opt == '-t':
-			call_maininfo = True
-		elif opt == '-p':
-			call_pathsinfo = True
-		elif opt == '-m':
-			call_modulesinfo = True
-		elif opt == '-s':
-			path = arg
-			call_specificinfo = True
-		else:
-			usage()
-			sys.exit(2)
-		 
-	
-	if call_maininfo:
-		print('Creating the Main Info Timing Summary pdf')
-		print('Creating plots...')
-		maininfo(infile,outfile)
-		print('Compiling tex file......')
-		subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-main.tex'])
-		print('Verifing......') 
-		subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-main.tex'])    #twice for better compilation
-		print('Removing temp files.........')
-		os.remove(outfile+'-main.aux')
-		os.remove(outfile+'-main.log')
-		os.remove(outfile+'-main.out')
-		os.remove(outfile+'-main.tex')
-                os.remove(outfile+'-main.toc')
-		for filename in glob.glob('*temp.png'):
-			os.remove(filename)
-		print('{0}-main.pdf is done'.format(outfile))
+    infile = None
+    outfile = None
+    path = None
+    call_maininfo = False
+    call_pathsinfo = False
+    call_modulesinfo = False
+    call_specificinfo = False
+    try:
+        opts, args = getopt.getopt(argv, 'hi:o:tbpms:', ['help', 'input=', 'output='])
+        if not opts:
+            print('No options supplied')
+            usage()
+    except getopt.GetoptError as e:
+        print(e)
+        usage()
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt in ('h', '--help'):
+            usage()
+            sys.exit(2)
+        elif opt == '-b':
+            print('Running in batch mode') 
+        elif opt in ('-i', '--input'):
+            infile = arg
+            outfile = infile.replace('.root','')
+        elif opt in ('-o', '--output'):
+            outfile = arg
+        elif opt == '-t':
+            call_maininfo = True
+        elif opt == '-p':
+            call_pathsinfo = True
+        elif opt == '-m':
+            call_modulesinfo = True
+        elif opt == '-s':
+            path = arg
+            call_specificinfo = True
+        else:
+            usage()
+            sys.exit(2)
 
-	if call_pathsinfo:
-		print('Creating the Paths Info Timing Summary pdf')
-		print('This process takes awhile... please be patient')
-		print('Creating plots...')
-		pathsinfo(infile,outfile)
-		print('Compiling tex file......')
-		subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-paths.tex'])
-		print('Verifing......') 
-		subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-paths.tex'])    #twice for better compilation
-		print('Removing temp files.........')
-		os.remove(outfile+'-paths.aux')
-		os.remove(outfile+'-paths.log')
-		os.remove(outfile+'-paths.out')
-		os.remove(outfile+'-paths.tex')
-		os.remove(outfile+'-paths.toc')
-		for filename in glob.glob('*temp.png'):
-			os.remove(filename)
-		print('{0}-paths.pdf is done'.format(outfile))
 
-        if call_modulesinfo:
-                print('Creating the Modules Info Timing Summary pdf')
-                print('This process takes awhile... please be patient')
-                print('Creating plots...')
-                moduleinfo(infile,outfile)
-                print('Compiling tex file......')
-		subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-modules.tex'])
-		subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-runningModules.tex'])
-                print('Verifing......')
-		subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-modules.tex'])    #twice for better compilation
-		subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-runningModules.tex'])    #twice for better compilation
-                print('Removing temp files.........')
-                os.remove(outfile+'-modules.aux')
-                os.remove(outfile+'-runningModules.aux')
-                os.remove(outfile+'-modules.log') 
-                os.remove(outfile+'-runningModules.log') 
-                os.remove(outfile+'-modules.out')
-                os.remove(outfile+'-runningModules.out')
-                os.remove(outfile+'-modules.tex')
-                os.remove(outfile+'-runningModules.tex')
-                os.remove(outfile+'-modules.toc')
-                os.remove(outfile+'-runningModules.toc')
-                for filename in glob.glob('*temp.png'):
-                        os.remove(filename) 
-                print('{0}-modules.pdf is done'.format(outfile)) 
-                print('{0}-runningModules.pdf is done'.format(outfile)) 
+    if call_maininfo:
+        print('Creating the Main Info Timing Summary pdf')
+        print('Creating plots...')
+        maininfo(infile,outfile)
+        print('Compiling tex file......')
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-main.tex'])
+        print('Verifing......') 
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-main.tex'])    #twice for better compilation
+        print('Removing temp files.........')
+        os.remove(outfile+'-main.aux')
+        os.remove(outfile+'-main.log')
+        os.remove(outfile+'-main.out')
+        os.remove(outfile+'-main.tex')
+        os.remove(outfile+'-main.toc')
+        for filename in glob.glob('*temp.png'):
+            os.remove(filename)
+        print('{0}-main.pdf is done'.format(outfile))
 
-        if call_specificinfo:
-                print('Creating the Main Info + '+ path +' Timing Summary pdf')
-                print('This process takes awhile... please be patient')
-                print('Creating plots...')
-                specificpathinfo(infile,outfile,path)
-                print('Compiling tex file......')
-                subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-'+path+'.tex'])
-                print('Verifing......')
-                subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-'+path+'.tex'])    #twice for better compilation
-                print('Removing temp files.........')
-                os.remove(outfile+'-'+path+'.aux')
-                os.remove(outfile+'-'+path+'.log')
-                os.remove(outfile+'-'+path+'.out')
-                os.remove(outfile+'-'+path+'.tex')
-                os.remove(outfile+'-'+path+'.toc')
-                for filename in glob.glob('*temp.png'):
-                        os.remove(filename)
-                print('{0}-'.format(outfile)+path+'.pdf is done')
+    if call_pathsinfo:
+        print('Creating the Paths Info Timing Summary pdf')
+        print('This process takes awhile... please be patient')
+        print('Creating plots...')
+        pathsinfo(infile,outfile)
+        print('Compiling tex file......')
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-paths.tex'])
+        print('Verifing......') 
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-paths.tex'])    #twice for better compilation
+        print('Removing temp files.........')
+        os.remove(outfile+'-paths.aux')
+        os.remove(outfile+'-paths.log')
+        os.remove(outfile+'-paths.out')
+        os.remove(outfile+'-paths.tex')
+        os.remove(outfile+'-paths.toc')
+        for filename in glob.glob('*temp.png'):
+            os.remove(filename)
+        print('{0}-paths.pdf is done'.format(outfile))
+
+    if call_modulesinfo:
+        print('Creating the Modules Info Timing Summary pdf')
+        print('This process takes awhile... please be patient')
+        print('Creating plots...')
+        moduleinfo(infile,outfile)
+        print('Compiling tex file......')
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-modules.tex'])
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-runningModules.tex'])
+        print('Verifing......')
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-modules.tex'])    #twice for better compilation
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-runningModules.tex'])    #twice for better compilation
+        print('Removing temp files.........')
+        os.remove(outfile+'-modules.aux')
+        os.remove(outfile+'-runningModules.aux')
+        os.remove(outfile+'-modules.log') 
+        os.remove(outfile+'-runningModules.log') 
+        os.remove(outfile+'-modules.out')
+        os.remove(outfile+'-runningModules.out')
+        os.remove(outfile+'-modules.tex')
+        os.remove(outfile+'-runningModules.tex')
+        os.remove(outfile+'-modules.toc')
+        os.remove(outfile+'-runningModules.toc')
+        for filename in glob.glob('*temp.png'):
+            os.remove(filename) 
+        print('{0}-modules.pdf is done'.format(outfile)) 
+        print('{0}-runningModules.pdf is done'.format(outfile)) 
+
+    if call_specificinfo:
+        print('Creating the Main Info + '+ path +' Timing Summary pdf')
+        print('This process takes awhile... please be patient')
+        print('Creating plots...')
+        specificpathinfo(infile,outfile,path)
+        print('Compiling tex file......')
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-'+path+'.tex'])
+        print('Verifing......')
+        subprocess.call(['pdflatex', '-interaction=batchmode', outfile+'-'+path+'.tex'])    #twice for better compilation
+        print('Removing temp files.........')
+        os.remove(outfile+'-'+path+'.aux')
+        os.remove(outfile+'-'+path+'.log')
+        os.remove(outfile+'-'+path+'.out')
+        os.remove(outfile+'-'+path+'.tex')
+        os.remove(outfile+'-'+path+'.toc')
+        for filename in glob.glob('*temp.png'):
+            os.remove(filename)
+        print('{0}-'.format(outfile)+path+'.pdf is done')
 
 
 #######################################################
 if __name__ =='__main__':
 #######################################################
-	main(sys.argv[1:])
+    main(sys.argv[1:])

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -7,17 +7,17 @@ def make_efficiency_string(objtype, plot_type, triggerpath):
     # --- IMPORTANT: Add here a elif if you are introduce a new collection
     #                (see EVTColContainer::getTypeString) 
     if objtype == "Mu" :
-	objtypeLatex="#mu"
+        objtypeLatex="#mu"
     elif objtype == "refittedStandAloneMuons": 
-	objtypeLatex="refittedStandAlone #mu"
+        objtypeLatex="refittedStandAlone #mu"
     elif objtype == "Ele": 
-	objtypeLatex="e"
+        objtypeLatex="e"
     elif objtype == "Photon": 
-	objtypeLatex="#gamma"
+        objtypeLatex="#gamma"
     elif objtype == "PFTau": 
-	objtypeLatex="#tau"
+        objtypeLatex="#tau"
     else:
-	objtypeLatex=objtype
+        objtypeLatex=objtype
     numer_description = "# gen %s passed the %s" % (objtypeLatex,triggerpath)
     denom_description = "# gen %s " % (objtypeLatex)
 
@@ -54,7 +54,7 @@ def make_efficiency_string(objtype, plot_type, triggerpath):
     all_titles = "%s for trigger %s; %s; %s" % (title, triggerpath,
                                         xAxis, yAxis)
     return "Eff_%s_%s '%s' %s_%s %s" % (input_type,triggerpath,
-		    all_titles,input_type,triggerpath,input_type)
+                    all_titles,input_type,triggerpath,input_type)
 
 
 #--- IMPORTANT: Trigger are extracted from the hltExoticaValidator_cfi.py module

--- a/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
@@ -21,16 +21,16 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
         if not getattr(self.cfg_ana, 'saveTLorentzVectors', False):
             fourVectorType.removeVariable("p4")
 
- 
+
         self.collections = {}      
         self.globalObjects = {}
         self.globalVariables = []
         if hasattr(cfg_ana,"collections"):
-                self.collections.update(cfg_ana.collections)
+            self.collections.update(cfg_ana.collections)
         if hasattr(cfg_ana,"globalObjects"):
-                self.globalObjects.update(cfg_ana.globalObjects)
+            self.globalObjects.update(cfg_ana.globalObjects)
         if hasattr(cfg_ana,"globalVariables"):
-                self.globalVariables=cfg_ana.globalVariables[:]
+            self.globalVariables=cfg_ana.globalVariables[:]
 
     def beginLoop(self, setup) :
         super(AutoFillTreeProducer, self).beginLoop(setup)
@@ -105,7 +105,7 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
                 c.makeBranchesScalar(tree, isMC)
             else:
                 c.makeBranchesVector(tree, isMC)
-            
+
     def fillCoreVariables(self, tr, event, isMC):
         """Here we fill the variables that we always want and that are hard-coded"""
         tr.fill('run', event.input.eventAuxiliary().id().run())
@@ -125,31 +125,31 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
             tr.fill('xsec', getattr(self.cfg_comp,'xSection',1.0))
             ## PU weights, check if a PU analyzer actually filled it
             if hasattr(event,"nPU"):
-                    tr.fill("nTrueInt", event.nPU)
-                    tr.fill("puWeight", event.puWeight)
+                tr.fill("nTrueInt", event.nPU)
+                tr.fill("puWeight", event.puWeight)
             else :
-                    tr.fill("nTrueInt", -1)
-                    tr.fill("puWeight", 1.0)
-                
+                tr.fill("nTrueInt", -1)
+                tr.fill("puWeight", 1.0)
+
             tr.fill("genWeight", self.mchandles['GenInfo'].product().weight())
             ## PDF weights
             if hasattr(event,"pdfWeights") :
-              for (pdf,nvals) in self.pdfWeights:
-                if len(event.pdfWeights[pdf]) != nvals:
-                    raise RuntimeError("PDF lenght mismatch for %s, declared %d but the event has %d" % (pdf,nvals,event.pdfWeights[pdf]))
-                if self.scalar:
-                    for i,w in enumerate(event.pdfWeights[pdf]):
-                        tr.fill('pdfWeight_%s_%d' % (pdf,i), w)
-                else:
-                    tr.vfill('pdfWeight_%s' % pdf, event.pdfWeights[pdf])
+                for (pdf,nvals) in self.pdfWeights:
+                    if len(event.pdfWeights[pdf]) != nvals:
+                        raise RuntimeError("PDF lenght mismatch for %s, declared %d but the event has %d" % (pdf,nvals,event.pdfWeights[pdf]))
+                    if self.scalar:
+                        for i,w in enumerate(event.pdfWeights[pdf]):
+                            tr.fill('pdfWeight_%s_%d' % (pdf,i), w)
+                    else:
+                        tr.vfill('pdfWeight_%s' % pdf, event.pdfWeights[pdf])
 
     def process(self, event):
-	if hasattr(self.cfg_ana,"filter") :	
-		if not self.cfg_ana.filter(event) :
-			return True #do not stop processing, just filter myself
+        if hasattr(self.cfg_ana,"filter") :	
+            if not self.cfg_ana.filter(event) :
+                return True #do not stop processing, just filter myself
         self.readCollections( event.input)
         self.fillTree(event)
-         
+
     def fillTree(self, event, resetFirst=True):
         isMC = self.cfg_comp.isMC 
         if resetFirst: self.tree.reset()
@@ -177,13 +177,13 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
                 c.fillBranchesVector(self.tree, getattr(event, cn), isMC)
 
         self.tree.tree.Fill()      
-    
+
     def getPythonWrapper(self):
         """
         This function produces a string that contains a Python wrapper for the event.
         The wrapper is automatically generated based on the collections and allows the full
         event contents to be accessed from subsequent Analyzers using e.g.
-        
+
         leps = event.selLeptons #is of type selLeptons
         pt0 = leps[0].pt
 
@@ -204,6 +204,6 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
         for cname, coll in self.collections.items():
             classes += coll.get_py_wrapper_class(isMC)
             anclass += "        event.{0} = {0}.make_array(event)\n".format(coll.name)
-        
+
         return classes + "\n" + anclass
 

--- a/PhysicsTools/Heppy/python/analyzers/eventtopology/AlphaTAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/eventtopology/AlphaTAnalyzer.py
@@ -45,13 +45,13 @@ class AlphaTAnalyzer( Analyzer ):
 
         if len(jets) == 0:
             return 0.
-        
+
         px  = ROOT.std.vector('double')()
         py  = ROOT.std.vector('double')()
         et  = ROOT.std.vector('double')()
 
         #Make alphaT from lead 10 jets
-	for jet in jets[:10]:
+        for jet in jets[:10]:
             px.push_back(jet.px())
             py.push_back(jet.py())
             et.push_back(jet.et())

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -34,12 +34,12 @@ def cleanJetsAndLeptons(jets,leptons,deltaR,arbitration):
             if d2i < dr2:
                 choice = arbitration(j,l)
                 if choice == j:
-                   # if the two match, and we prefer the jet, then drop the lepton and be done
-                   goodlep[il] = False
-                   break 
+                    # if the two match, and we prefer the jet, then drop the lepton and be done
+                    goodlep[il] = False
+                    break 
                 elif choice == (j,l) or choice == (l,j):
-                   # asked to keep both, so we don't consider this match
-                   continue
+                    # asked to keep both, so we don't consider this match
+                    continue
             if d2i < d2m:
                 ibest, d2m = i, d2i
         # this lepton has been killed by a jet, then we clean the jet that best matches it
@@ -51,14 +51,14 @@ def cleanJetsAndLeptons(jets,leptons,deltaR,arbitration):
 
 
 def shiftJERfactor(JERShift, aeta):
-        factor = 1.079 + JERShift*0.026
-        if   aeta > 3.2: factor = 1.056 + JERShift * 0.191
-        elif aeta > 2.8: factor = 1.395 + JERShift * 0.063
-        elif aeta > 2.3: factor = 1.254 + JERShift * 0.062
-        elif aeta > 1.7: factor = 1.208 + JERShift * 0.046
-        elif aeta > 1.1: factor = 1.121 + JERShift * 0.029
-        elif aeta > 0.5: factor = 1.099 + JERShift * 0.028
-        return factor 
+    factor = 1.079 + JERShift*0.026
+    if   aeta > 3.2: factor = 1.056 + JERShift * 0.191
+    elif aeta > 2.8: factor = 1.395 + JERShift * 0.063
+    elif aeta > 2.3: factor = 1.254 + JERShift * 0.062
+    elif aeta > 1.7: factor = 1.208 + JERShift * 0.046
+    elif aeta > 1.1: factor = 1.121 + JERShift * 0.029
+    elif aeta > 0.5: factor = 1.099 + JERShift * 0.028
+    return factor 
 
 
 
@@ -76,22 +76,22 @@ class JetAnalyzer( Analyzer ):
         if   self.recalibrateJets == "MC"  : self.recalibrateJets =     self.cfg_comp.isMC
         elif self.recalibrateJets == "Data": self.recalibrateJets = not self.cfg_comp.isMC
         elif self.recalibrateJets not in [True,False]: raise RuntimeError("recalibrateJets must be any of { True, False, 'MC', 'Data' }, while it is %r " % self.recalibrateJets)
-       
+
         calculateSeparateCorrections = getattr(cfg_ana,"calculateSeparateCorrections", False);
         calculateType1METCorrection  = getattr(cfg_ana,"calculateType1METCorrection",  False);
         self.doJEC = self.recalibrateJets or (self.shiftJEC != 0) or self.addJECShifts or calculateSeparateCorrections or calculateType1METCorrection
         if self.doJEC:
-          doResidual = getattr(cfg_ana, 'applyL2L3Residual', 'Data')
-          if   doResidual == "MC":   doResidual = self.cfg_comp.isMC
-          elif doResidual == "Data": doResidual = not self.cfg_comp.isMC
-          elif doResidual not in [True,False]: raise RuntimeError("If specified, applyL2L3Residual must be any of { True, False, 'MC', 'Data'(default)}")
-          GT = getattr(cfg_comp, 'jecGT', mcGT if self.cfg_comp.isMC else dataGT)
-          # Now take care of the optional arguments
-          kwargs = { 'calculateSeparateCorrections':calculateSeparateCorrections,
-                     'calculateType1METCorrection' :calculateType1METCorrection, }
-          if kwargs['calculateType1METCorrection']: kwargs['type1METParams'] = cfg_ana.type1METParams
-          # instantiate the jet re-calibrator
-          self.jetReCalibrator = JetReCalibrator(GT, cfg_ana.recalibrationType, doResidual, cfg_ana.jecPath, **kwargs)
+            doResidual = getattr(cfg_ana, 'applyL2L3Residual', 'Data')
+            if   doResidual == "MC":   doResidual = self.cfg_comp.isMC
+            elif doResidual == "Data": doResidual = not self.cfg_comp.isMC
+            elif doResidual not in [True,False]: raise RuntimeError("If specified, applyL2L3Residual must be any of { True, False, 'MC', 'Data'(default)}")
+            GT = getattr(cfg_comp, 'jecGT', mcGT if self.cfg_comp.isMC else dataGT)
+            # Now take care of the optional arguments
+            kwargs = { 'calculateSeparateCorrections':calculateSeparateCorrections,
+                       'calculateType1METCorrection' :calculateType1METCorrection, }
+            if kwargs['calculateType1METCorrection']: kwargs['type1METParams'] = cfg_ana.type1METParams
+            # instantiate the jet re-calibrator
+            self.jetReCalibrator = JetReCalibrator(GT, cfg_ana.recalibrationType, doResidual, cfg_ana.jecPath, **kwargs)
         self.doPuId = getattr(self.cfg_ana, 'doPuId', True)
         self.jetLepDR = getattr(self.cfg_ana, 'jetLepDR', 0.4)
         self.jetLepArbitration = getattr(self.cfg_ana, 'jetLepArbitration', lambda jet,lepton: lepton) 
@@ -119,7 +119,7 @@ class JetAnalyzer( Analyzer ):
         self.shiftJER = self.cfg_ana.shiftJER if hasattr(self.cfg_ana, 'shiftJER') else 0
         self.addJERShifts = self.cfg_ana.addJERShifts if hasattr(self.cfg_ana, 'addJERShifts') else 0
         self.handles['rho'] = AutoHandle( self.cfg_ana.rho, 'double' )
-    
+
     def beginLoop(self, setup):
         super(JetAnalyzer,self).beginLoop(setup)
 
@@ -130,12 +130,12 @@ class JetAnalyzer( Analyzer ):
 
         ## Read jets, if necessary recalibrate and shift MET
         if self.cfg_ana.copyJetsByValue: 
-          import ROOT
-          #from ROOT.heppy import JetUtils
-          allJets = map(lambda j:Jet(ROOT.heppy.JetUtils.copyJet(j)), self.handles['jets'].product())  #copy-by-value is safe if JetAnalyzer is ran more than once
+            import ROOT
+            #from ROOT.heppy import JetUtils
+            allJets = map(lambda j:Jet(ROOT.heppy.JetUtils.copyJet(j)), self.handles['jets'].product())  #copy-by-value is safe if JetAnalyzer is ran more than once
         else: 
-          allJets = map(Jet, self.handles['jets'].product()) 
-    
+            allJets = map(Jet, self.handles['jets'].product()) 
+
         #set dummy MC flavour for all jets in case we want to ntuplize discarded jets later
         for jet in allJets:
             jet.mcFlavour = 0
@@ -173,11 +173,11 @@ class JetAnalyzer( Analyzer ):
                 self.smearJets(event, allJets)
 
 
-                
-        
-	##Sort Jets by pT 
+
+
+        ##Sort Jets by pT 
         allJets.sort(key = lambda j : j.pt(), reverse = True)
-        
+
         leptons = []
         if hasattr(event, 'selectedLeptons'):
             leptons = [ l for l in event.selectedLeptons if l.pt() > self.lepPtMin and self.lepSelCut(l) ]
@@ -186,7 +186,7 @@ class JetAnalyzer( Analyzer ):
         if self.cfg_ana.cleanJetsFromIsoTracks and hasattr(event, 'selectedIsoCleanTrack'):
             leptons = leptons[:] + event.selectedIsoCleanTrack
 
-	## Apply jet selection
+        ## Apply jet selection
         self.jets = []
         self.jetsFailId = []
         self.jetsAllNoID = []
@@ -195,14 +195,14 @@ class JetAnalyzer( Analyzer ):
             #Check if lepton and jet have overlapping PF candidates 
             leps_with_overlaps = []
             if getattr(self.cfg_ana, 'checkLeptonPFOverlap', True):
-              for i in range(jet.numberOfSourceCandidatePtrs()):
-                p1 = jet.sourceCandidatePtr(i) #Ptr<Candidate> p1
-                for lep in leptons:
-                    for j in range(lep.numberOfSourceCandidatePtrs()):
-                        p2 = lep.sourceCandidatePtr(j)
-                        has_overlaps = p1.key() == p2.key() and p1.refCore().id().productIndex() == p2.refCore().id().productIndex() and p1.refCore().id().processIndex() == p2.refCore().id().processIndex()
-                        if has_overlaps:
-                            leps_with_overlaps += [lep]
+                for i in range(jet.numberOfSourceCandidatePtrs()):
+                    p1 = jet.sourceCandidatePtr(i) #Ptr<Candidate> p1
+                    for lep in leptons:
+                        for j in range(lep.numberOfSourceCandidatePtrs()):
+                            p2 = lep.sourceCandidatePtr(j)
+                            has_overlaps = p1.key() == p2.key() and p1.refCore().id().productIndex() == p2.refCore().id().productIndex() and p1.refCore().id().processIndex() == p2.refCore().id().processIndex()
+                            if has_overlaps:
+                                leps_with_overlaps += [lep]
             if len(leps_with_overlaps)>0:
                 for lep in leps_with_overlaps:
                     lep.jetOverlap = jet
@@ -282,9 +282,9 @@ class JetAnalyzer( Analyzer ):
         for jet in self.noIdCleanJetsAll:
             if not self.testJetID( jet ):
                 self.cleanJetsFailIdAll.append(jet)
-        
+
         self.cleanJetsFailId = [j for j in self.cleanJetsFailIdAll if abs(j.eta()) <  self.cfg_ana.jetEtaCentral ]
-        
+
         ## Jet Id, after jet/photon cleaning
         self.gamma_cleanJetsFailIdAll = []
         for jet in self.gamma_noIdCleanJetsAll:
@@ -292,7 +292,7 @@ class JetAnalyzer( Analyzer ):
                 self.gamma_cleanJetsFailIdAll.append(jet)
 
         self.gamma_cleanJetsFailId = [j for j in self.gamma_cleanJetsFailIdAll if abs(j.eta()) <  self.cfg_ana.jetEtaCentral ]
-        
+
         ## Associate jets to leptons
         incleptons = event.inclusiveLeptons if hasattr(event, 'inclusiveLeptons') else event.selectedLeptons
         jlpairs = matchObjectCollection(incleptons, allJets, self.jetLepDR**2)
@@ -323,22 +323,22 @@ class JetAnalyzer( Analyzer ):
                     self.deltaMetFromJetSmearing[1] += j.deltaMetFromJetSmearing[1]
 
             self.cleanGenJets = cleanNearestJetOnly(self.genJets, leptons, self.jetLepDR)
-            
+
             if self.cfg_ana.cleanGenJetsFromPhoton:
                 self.cleanGenJets = cleanNearestJetOnly(self.cleanGenJets, photons, self.jetLepDR)
 
-	    if getattr(self.cfg_ana, 'attachNeutrinos', True) and hasattr(self.cfg_ana,"genNuSelection") :
-		jetNus=[x for x in event.genParticles if abs(x.pdgId()) in [12,14,16] and self.cfg_ana.genNuSelection(x) ]
-	 	pairs= matchObjectCollection (jetNus, self.genJets, 0.4**2)
-                
-		for (nu,genJet) in six.iteritems(pairs) :
-		     if genJet is not None :
-			if not hasattr(genJet,"nu") :
-				genJet.nu=nu.p4()
-			else :
-				genJet.nu+=nu.p4()
-			
-            
+            if getattr(self.cfg_ana, 'attachNeutrinos', True) and hasattr(self.cfg_ana,"genNuSelection") :
+                jetNus=[x for x in event.genParticles if abs(x.pdgId()) in [12,14,16] and self.cfg_ana.genNuSelection(x) ]
+                pairs= matchObjectCollection (jetNus, self.genJets, 0.4**2)
+
+                for (nu,genJet) in six.iteritems(pairs) :
+                    if genJet is not None :
+                        if not hasattr(genJet,"nu") :
+                            genJet.nu=nu.p4()
+                        else :
+                            genJet.nu+=nu.p4()
+
+
             if self.cfg_ana.do_mc_match:
                 self.jetFlavour(event)
 
@@ -374,10 +374,10 @@ class JetAnalyzer( Analyzer ):
                 setattr(event,"partons"                +self.cfg_ana.collectionPostFix, self.partons                )
                 setattr(event,"heaviestQCDFlavour"     +self.cfg_ana.collectionPostFix, self.heaviestQCDFlavour     )
 
- 
+
         return True
 
-        
+
 
     def testJetID(self, jet):
         jet.puJetIdPassed = jet.puJetId() 
@@ -386,7 +386,7 @@ class JetAnalyzer( Analyzer ):
             return True
         else:
             return jet.pfJetIdPassed and (jet.puJetIdPassed or not(self.doPuId)) 
-        
+
     def testJetNoID( self, jet ):
         # 2 is loose pile-up jet id
         return jet.pt() > self.cfg_ana.jetPt and \
@@ -413,20 +413,20 @@ class JetAnalyzer( Analyzer ):
             parton = match[jet]
             jet.partonId = (parton.pdgId() if parton != None else 0)
             jet.partonMotherId = (parton.mother(0).pdgId() if parton != None and parton.numberOfMothers()>0 else 0)
-        
+
         for jet in self.jets:
-           (bmatch, dr) = bestMatch(jet, self.bqObjects)
-           if dr < 0.4:
-               jet.mcFlavour = 5
-           else:
-               (cmatch, dr) = bestMatch(jet, self.cqObjects) 
-               if dr < 0.4:
-                   jet.mcFlavour = 4
-               else:
-                   jet.mcFlavour = 0
+            (bmatch, dr) = bestMatch(jet, self.bqObjects)
+            if dr < 0.4:
+                jet.mcFlavour = 5
+            else:
+                (cmatch, dr) = bestMatch(jet, self.cqObjects) 
+                if dr < 0.4:
+                    jet.mcFlavour = 4
+                else:
+                    jet.mcFlavour = 0
 
         self.heaviestQCDFlavour = 5 if len(self.bqObjects) else (4 if len(self.cqObjects) else 1);
- 
+
     def matchJets(self, event, jets):
         match = matchObjectCollection2(jets,
                                        event.genbquarks + event.genwzquarks,
@@ -444,32 +444,32 @@ class JetAnalyzer( Analyzer ):
             jet.mcJet = match[jet]
 
 
- 
+
     def smearJets(self, event, jets):
         # https://twiki.cern.ch/twiki/bin/viewauth/CMS/TWikiTopRefSyst#Jet_energy_resolution
-       for jet in jets:
+        for jet in jets:
             gen = jet.mcJet 
             if gen != None:
-               genpt, jetpt, aeta = gen.pt(), jet.pt(), abs(jet.eta())
-               # from https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution
-               #8 TeV tables
-               factor = shiftJERfactor(self.shiftJER, aeta)
-               ptscale = max(0.0, (jetpt + (factor-1)*(jetpt-genpt))/jetpt)             
-               #print "get with pt %.1f (gen pt %.1f, ptscale = %.3f)" % (jetpt,genpt,ptscale)
-               jet.deltaMetFromJetSmearing = [ -(ptscale-1)*jet.rawFactor()*jet.px(), -(ptscale-1)*jet.rawFactor()*jet.py() ]
-               if ptscale != 0:
-                  jet.setP4(jet.p4()*ptscale)
-                  # leave the uncorrected unchanged for sync
-                  jet.setRawFactor(jet.rawFactor()/ptscale)
+                genpt, jetpt, aeta = gen.pt(), jet.pt(), abs(jet.eta())
+                # from https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution
+                #8 TeV tables
+                factor = shiftJERfactor(self.shiftJER, aeta)
+                ptscale = max(0.0, (jetpt + (factor-1)*(jetpt-genpt))/jetpt)             
+                #print "get with pt %.1f (gen pt %.1f, ptscale = %.3f)" % (jetpt,genpt,ptscale)
+                jet.deltaMetFromJetSmearing = [ -(ptscale-1)*jet.rawFactor()*jet.px(), -(ptscale-1)*jet.rawFactor()*jet.py() ]
+                if ptscale != 0:
+                    jet.setP4(jet.p4()*ptscale)
+                    # leave the uncorrected unchanged for sync
+                    jet.setRawFactor(jet.rawFactor()/ptscale)
             #else: print "jet with pt %.1d, eta %.2f is unmatched" % (jet.pt(), jet.eta())
-               if (self.shiftJER==0) and (self.addJERShifts):
-                   setattr(jet, "corrJER", ptscale )
-                   factorJERUp= shiftJERfactor(1, aeta)
-                   ptscaleJERUp = max(0.0, (jetpt + (factorJERUp-1)*(jetpt-genpt))/jetpt)
-                   setattr(jet, "corrJERUp", ptscaleJERUp)
-                   factorJERDown= shiftJERfactor(-1, aeta)
-                   ptscaleJERDown = max(0.0, (jetpt + (factorJERDown-1)*(jetpt-genpt))/jetpt)
-                   setattr(jet, "corrJERDown", ptscaleJERDown)
+                if (self.shiftJER==0) and (self.addJERShifts):
+                    setattr(jet, "corrJER", ptscale )
+                    factorJERUp= shiftJERfactor(1, aeta)
+                    ptscaleJERUp = max(0.0, (jetpt + (factorJERUp-1)*(jetpt-genpt))/jetpt)
+                    setattr(jet, "corrJERUp", ptscaleJERUp)
+                    factorJERDown= shiftJERfactor(-1, aeta)
+                    ptscaleJERDown = max(0.0, (jetpt + (factorJERDown-1)*(jetpt-genpt))/jetpt)
+                    setattr(jet, "corrJERDown", ptscaleJERDown)
 
 
 

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -39,7 +39,7 @@ class Electron( Lepton ):
         elif id == "MVA_ID_NonTrig_Phys14Fix_HZZ":     return self.mvaIDRun2("NonTrigPhys14Fix","HZZ")
         elif id == "MVA_ID_NonTrig_Spring15_HZZ":     return self.mvaIDRun2("NonTrigSpring15MiniAOD","HZZ")
         elif id.startswith("POG_Cuts_ID_"):
-                return self.cutBasedId(id.replace("POG_Cuts_ID_","POG_"))
+            return self.cutBasedId(id.replace("POG_Cuts_ID_","POG_"))
         for ID in self.electronIDs():
             if ID.first == id:
                 return ID.second
@@ -214,105 +214,105 @@ class Electron( Lepton ):
         return self._mvaRun2[name]
 
     def mvaIDTight(self, full5x5=False):
-            eta = abs(self.superCluster().eta())
-            if self.pt() < 20:
-                if   (eta < 0.8)  : return self.mvaTrigV0(full5x5) > +0.00;
-                elif (eta < 1.479): return self.mvaTrigV0(full5x5) > +0.10;
-                else              : return self.mvaTrigV0(full5x5) > +0.62;
-            else:
-                if   (eta < 0.8)  : return self.mvaTrigV0(full5x5) > +0.94;
-                elif (eta < 1.479): return self.mvaTrigV0(full5x5) > +0.85;
-                else              : return self.mvaTrigV0(full5x5) > +0.92;
+        eta = abs(self.superCluster().eta())
+        if self.pt() < 20:
+            if   (eta < 0.8)  : return self.mvaTrigV0(full5x5) > +0.00;
+            elif (eta < 1.479): return self.mvaTrigV0(full5x5) > +0.10;
+            else              : return self.mvaTrigV0(full5x5) > +0.62;
+        else:
+            if   (eta < 0.8)  : return self.mvaTrigV0(full5x5) > +0.94;
+            elif (eta < 1.479): return self.mvaTrigV0(full5x5) > +0.85;
+            else              : return self.mvaTrigV0(full5x5) > +0.92;
 
     def mvaIDLoose(self, full5x5=False):
-            eta = abs(self.superCluster().eta())
-            if self.pt() < 10:
-                if   (eta < 0.8)  : return self.mvaNonTrigV0(full5x5) > +0.47;
-                elif (eta < 1.479): return self.mvaNonTrigV0(full5x5) > +0.004;
-                else              : return self.mvaNonTrigV0(full5x5) > +0.295;
-            else:
-                if   (eta < 0.8)  : return self.mvaNonTrigV0(full5x5) > -0.34;
-                elif (eta < 1.479): return self.mvaNonTrigV0(full5x5) > -0.65;
-                else              : return self.mvaNonTrigV0(full5x5) > +0.60;
+        eta = abs(self.superCluster().eta())
+        if self.pt() < 10:
+            if   (eta < 0.8)  : return self.mvaNonTrigV0(full5x5) > +0.47;
+            elif (eta < 1.479): return self.mvaNonTrigV0(full5x5) > +0.004;
+            else              : return self.mvaNonTrigV0(full5x5) > +0.295;
+        else:
+            if   (eta < 0.8)  : return self.mvaNonTrigV0(full5x5) > -0.34;
+            elif (eta < 1.479): return self.mvaNonTrigV0(full5x5) > -0.65;
+            else              : return self.mvaNonTrigV0(full5x5) > +0.60;
 
     def mvaIDRun2(self, name, wp):
-            eta = abs(self.superCluster().eta())
-            if name == "NonTrigPhys14":
-                if wp=="Loose":
-                    if   (eta < 0.8)  : return self.mvaRun2(name) > +0.35;
-                    elif (eta < 1.479): return self.mvaRun2(name) > +0.20;
-                    else              : return self.mvaRun2(name) > -0.52;
-                elif wp=="VLoose":
+        eta = abs(self.superCluster().eta())
+        if name == "NonTrigPhys14":
+            if wp=="Loose":
+                if   (eta < 0.8)  : return self.mvaRun2(name) > +0.35;
+                elif (eta < 1.479): return self.mvaRun2(name) > +0.20;
+                else              : return self.mvaRun2(name) > -0.52;
+            elif wp=="VLoose":
+                if   (eta < 0.8)  : return self.mvaRun2(name) > -0.11;
+                elif (eta < 1.479): return self.mvaRun2(name) > -0.35;
+                else              : return self.mvaRun2(name) > -0.55;
+            elif wp=="Tight":
+                if   (eta < 0.8)  : return self.mvaRun2(name) > 0.73;
+                elif (eta < 1.479): return self.mvaRun2(name) > 0.57;
+                else              : return self.mvaRun2(name) > 0.05;
+            else: raise RuntimeError("Ele MVA ID Working point not found")
+        elif name == "NonTrigPhys14Fix":
+            if wp == "HZZ":
+                if self.pt() <= 10:
+                    if   eta < 0.8  : return self.mvaRun2(name) > -0.586;
+                    elif eta < 1.479: return self.mvaRun2(name) > -0.712;
+                    else            : return self.mvaRun2(name) > -0.662;
+                else:
+                    if   eta < 0.8  : return self.mvaRun2(name) > -0.652;
+                    elif eta < 1.479: return self.mvaRun2(name) > -0.701;
+                    else            : return self.mvaRun2(name) > -0.350;
+            else: raise RuntimeError("Ele MVA ID Working point not found")
+        elif name in ("NonTrigSpring15","NonTrigSpring15MiniAOD"):
+            if wp=="VLoose":
+                if self.pt() <= 10:
                     if   (eta < 0.8)  : return self.mvaRun2(name) > -0.11;
-                    elif (eta < 1.479): return self.mvaRun2(name) > -0.35;
-                    else              : return self.mvaRun2(name) > -0.55;
-                elif wp=="Tight":
-                    if   (eta < 0.8)  : return self.mvaRun2(name) > 0.73;
-                    elif (eta < 1.479): return self.mvaRun2(name) > 0.57;
-                    else              : return self.mvaRun2(name) > 0.05;
-                else: raise RuntimeError("Ele MVA ID Working point not found")
-            elif name == "NonTrigPhys14Fix":
-                if wp == "HZZ":
-                    if self.pt() <= 10:
-                        if   eta < 0.8  : return self.mvaRun2(name) > -0.586;
-                        elif eta < 1.479: return self.mvaRun2(name) > -0.712;
-                        else            : return self.mvaRun2(name) > -0.662;
-                    else:
-                        if   eta < 0.8  : return self.mvaRun2(name) > -0.652;
-                        elif eta < 1.479: return self.mvaRun2(name) > -0.701;
-                        else            : return self.mvaRun2(name) > -0.350;
-                else: raise RuntimeError("Ele MVA ID Working point not found")
-            elif name in ("NonTrigSpring15","NonTrigSpring15MiniAOD"):
-                if wp=="VLoose":
-                    if self.pt() <= 10:
-                        if   (eta < 0.8)  : return self.mvaRun2(name) > -0.11;
-                        elif (eta < 1.479): return self.mvaRun2(name) > -0.55;
-                        else              : return self.mvaRun2(name) > -0.60;
-                    else:
-                        if   (eta < 0.8)  : return self.mvaRun2(name) > -0.16;
-                        elif (eta < 1.479): return self.mvaRun2(name) > -0.65;
-                        else              : return self.mvaRun2(name) > -0.74;                        
-                elif wp=="VLooseIdEmu":
-                    if   (eta < 0.8)  : return self.mvaRun2(name) > -0.70;
-                    elif (eta < 1.479): return self.mvaRun2(name) > -0.83;
-                    else              : return self.mvaRun2(name) > -0.92;
-                elif wp=="VLooseIdIsoEmu":
-                    if   (eta < 0.8)  : return self.mvaRun2(name) > -0.155;
-                    elif (eta < 1.479): return self.mvaRun2(name) > -0.56;
-                    else              : return self.mvaRun2(name) > -0.76;
-                elif wp=="Tight":
-                    if   (eta < 0.8)  : return self.mvaRun2(name) > 0.87;
-                    elif (eta < 1.479): return self.mvaRun2(name) > 0.60;
-                    else              : return self.mvaRun2(name) > 0.17;
-                elif wp == "HZZ":
-                    if self.pt() <= 10:
-                        if   eta < 0.8  : return self.mvaRun2(name) > -0.265;
-                        elif eta < 1.479: return self.mvaRun2(name) > -0.556;
-                        else            : return self.mvaRun2(name) > -0.551;
-                    else:
-                        if   eta < 0.8  : return self.mvaRun2(name) > -0.072;
-                        elif eta < 1.479: return self.mvaRun2(name) > -0.286;
-                        else            : return self.mvaRun2(name) > -0.267;
-                elif wp == "POG80":
-                    if self.pt() > 10.:
-                        if eta < 0.8: return self.mvaRun2(name) > 0.967083
-                        elif eta < 1.479: return self.mvaRun2(name) > 0.929117
-                        else: return self.mvaRun2(name) > 0.726311
-                    else: # pt <= 10
-                        if eta < 0.8: return self.mvaRun2(name) > 0.287435
-                        elif eta < 1.479: return self.mvaRun2(name) > 0.221846
-                        else: return self.mvaRun2(name) > -0.303263
-                elif wp == "POG90":
-                    if self.pt() > 10.:
-                        if eta < 0.8: return self.mvaRun2(name) > 0.913286
-                        elif eta < 1.479: return self.mvaRun2(name) > 0.805013
-                        else: return self.mvaRun2(name) > 0.358969
-                    else: # pt <= 10
-                        if eta < 0.8: return self.mvaRun2(name) > -0.083313
-                        elif eta < 1.479: return self.mvaRun2(name) > -0.235222
-                        else: return self.mvaRun2(name) > -0.67099
-                else: raise RuntimeError("Ele MVA ID Working point not found")
-            else: raise RuntimeError("Ele MVA ID type not found")
+                    elif (eta < 1.479): return self.mvaRun2(name) > -0.55;
+                    else              : return self.mvaRun2(name) > -0.60;
+                else:
+                    if   (eta < 0.8)  : return self.mvaRun2(name) > -0.16;
+                    elif (eta < 1.479): return self.mvaRun2(name) > -0.65;
+                    else              : return self.mvaRun2(name) > -0.74;                        
+            elif wp=="VLooseIdEmu":
+                if   (eta < 0.8)  : return self.mvaRun2(name) > -0.70;
+                elif (eta < 1.479): return self.mvaRun2(name) > -0.83;
+                else              : return self.mvaRun2(name) > -0.92;
+            elif wp=="VLooseIdIsoEmu":
+                if   (eta < 0.8)  : return self.mvaRun2(name) > -0.155;
+                elif (eta < 1.479): return self.mvaRun2(name) > -0.56;
+                else              : return self.mvaRun2(name) > -0.76;
+            elif wp=="Tight":
+                if   (eta < 0.8)  : return self.mvaRun2(name) > 0.87;
+                elif (eta < 1.479): return self.mvaRun2(name) > 0.60;
+                else              : return self.mvaRun2(name) > 0.17;
+            elif wp == "HZZ":
+                if self.pt() <= 10:
+                    if   eta < 0.8  : return self.mvaRun2(name) > -0.265;
+                    elif eta < 1.479: return self.mvaRun2(name) > -0.556;
+                    else            : return self.mvaRun2(name) > -0.551;
+                else:
+                    if   eta < 0.8  : return self.mvaRun2(name) > -0.072;
+                    elif eta < 1.479: return self.mvaRun2(name) > -0.286;
+                    else            : return self.mvaRun2(name) > -0.267;
+            elif wp == "POG80":
+                if self.pt() > 10.:
+                    if eta < 0.8: return self.mvaRun2(name) > 0.967083
+                    elif eta < 1.479: return self.mvaRun2(name) > 0.929117
+                    else: return self.mvaRun2(name) > 0.726311
+                else: # pt <= 10
+                    if eta < 0.8: return self.mvaRun2(name) > 0.287435
+                    elif eta < 1.479: return self.mvaRun2(name) > 0.221846
+                    else: return self.mvaRun2(name) > -0.303263
+            elif wp == "POG90":
+                if self.pt() > 10.:
+                    if eta < 0.8: return self.mvaRun2(name) > 0.913286
+                    elif eta < 1.479: return self.mvaRun2(name) > 0.805013
+                    else: return self.mvaRun2(name) > 0.358969
+                else: # pt <= 10
+                    if eta < 0.8: return self.mvaRun2(name) > -0.083313
+                    elif eta < 1.479: return self.mvaRun2(name) > -0.235222
+                    else: return self.mvaRun2(name) > -0.67099
+            else: raise RuntimeError("Ele MVA ID Working point not found")
+        else: raise RuntimeError("Ele MVA ID type not found")
 
 
 
@@ -361,7 +361,7 @@ class Electron( Lepton ):
         elif puCorr in ["none","None",None]:
             offset = 0
         else:
-             raise RuntimeError("Unsupported PU correction scheme %s" % puCorr)
+            raise RuntimeError("Unsupported PU correction scheme %s" % puCorr)
         return self.chargedHadronIsoR(R)+max(0.,photonIso+self.neutralHadronIsoR(R)-offset)            
 
 
@@ -379,7 +379,7 @@ class Electron( Lepton ):
         return self.gsfTrack().dxyError()
 
     def p4(self):
-	 return ROOT.reco.Candidate.p4(self.physObj)
+        return ROOT.reco.Candidate.p4(self.physObj)
 
 #    def p4(self):
 #        return self.physObj.p4(self.physObj.candidateP4Kind()) # if kind == None else kind)
@@ -400,9 +400,9 @@ class Electron( Lepton ):
 
     def lostInner(self) :
         if hasattr(self.gsfTrack(),"trackerExpectedHitsInner") :
-		return self.gsfTrack().trackerExpectedHitsInner().numberOfLostHits()
-	else :
-		return self.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS)
+            return self.gsfTrack().trackerExpectedHitsInner().numberOfLostHits()
+        else :
+            return self.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS)
 
     def validCandidateP4Kind(self):
         raw = self.physObj.candidateP4Kind()
@@ -410,4 +410,4 @@ class Electron( Lepton ):
 
     def ptErr(self):
         return self.p4Error(self.candidateP4Kind())*self.pt()/self.p() if self.validCandidateP4Kind() else None
- 
+

--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -118,7 +118,7 @@ class Jet(PhysicsObject):
             #elif self.jetID("POG_PFID_Medium") : return 2;  commented this line because this working point doesn't exist anymore (as 12/05/15)
             elif self.jetID("POG_PFID_Loose")  : return 1;
             else                               : return 0;
-        
+
         # jetID from here: https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID#Recommendations_for_13_TeV_data
         if name == "POG_PFID_Loose":    return ((eta<3.0 and ((npr>1 and phf<0.99 and nhf<0.99) and (eta>2.4 or (elf<0.99 and chf>0 and chm>0)))) or (eta>3.0 and (phf<0.90 and npn>10)));
         if name == "POG_PFID_Medium":   return (npr>1 and phf<0.95 and nhf<0.95 and muf < 0.8) and (eta>2.4 or (elf<0.99 and chf>0 and chm>0));
@@ -146,13 +146,13 @@ class Jet(PhysicsObject):
         puMva = self.puMva(label)
         wp = loose_53X_WP
         eta = abs(self.eta())
-        
+
         for etamin, etamax, cut in wp:
             if not(eta>=etamin and eta<etamax):
                 continue
             return puMva>cut
         return -99
-        
+
     def rawFactor(self):
         return self.jecFactor('Uncorrected') * self._rawFactorMultiplier
 
@@ -184,7 +184,7 @@ class Jet(PhysicsObject):
         if ret == -1000 and name.startswith("pf"):
             ret = self.bDiscriminator(name[2].lower()+name[3:])
         return ret
- 
+
     def btagWP(self,name):
         global _btagWPs
         (disc,val) = _btagWPs[name]
@@ -202,89 +202,89 @@ class Jet(PhysicsObject):
     def leadTrackPt(self):
         lt=self.leadingTrack()
         if lt :
-             return lt.pt()
+            return lt.pt()
         else :
-             return 0. 
+            return 0. 
     def qgl(self) :
-       if not hasattr(self,"qgl_value") :
-	  if hasattr(self,"qgl_rho") : #check if qgl calculator is configured
-              self.computeQGvars()
-              self.qgl_value=self.qgl_calc(self,self.qgl_rho)
-	  else :
-              self.qgl_value=-1. #if no qgl calculator configured
-		  
-       return self.qgl_value
+        if not hasattr(self,"qgl_value") :
+            if hasattr(self,"qgl_rho") : #check if qgl calculator is configured
+                self.computeQGvars()
+                self.qgl_value=self.qgl_calc(self,self.qgl_rho)
+            else :
+                self.qgl_value=-1. #if no qgl calculator configured
+
+        return self.qgl_value
 
     def computeQGvars(self):
-       #return immediately if qgvars already computed or if qgl is disabled
-       if not hasattr(self,"qgl_rho") or getattr(self,"hasQGVvars",False) :
-	  return self
-       self.hasQGvars = True
-	 
-       jet = self
-       jet.mult = 0
-       sum_weight = 0.
-       sum_pt = 0.    
-       sum_deta = 0.  
-       sum_dphi = 0.  
-       sum_deta2 = 0. 
-       sum_detadphi = 0.
-       sum_dphi2 = 0.   
+        #return immediately if qgvars already computed or if qgl is disabled
+        if not hasattr(self,"qgl_rho") or getattr(self,"hasQGVvars",False) :
+            return self
+        self.hasQGvars = True
+
+        jet = self
+        jet.mult = 0
+        sum_weight = 0.
+        sum_pt = 0.    
+        sum_deta = 0.  
+        sum_dphi = 0.  
+        sum_deta2 = 0. 
+        sum_detadphi = 0.
+        sum_dphi2 = 0.   
 
 
 
-       for ii in range(0, jet.numberOfDaughters()) :
+        for ii in range(0, jet.numberOfDaughters()) :
 
-         part = jet.daughter(ii)
+            part = jet.daughter(ii)
 
-         if part.charge() == 0 : # neutral particles 
+            if part.charge() == 0 : # neutral particles 
 
-           if part.pt() < 1.: continue
+                if part.pt() < 1.: continue
 
-         else : # charged particles
+            else : # charged particles
 
-           if part.trackHighPurity()==False: continue
-           if part.fromPV()<=1: continue             
-
-
-         jet.mult += 1
-
-         deta = part.eta() - jet.eta()
-         dphi = deltaPhi(part.phi(), jet.phi())
-         partPt = part.pt()                    
-         weight = partPt*partPt                
-         sum_weight += weight                  
-         sum_pt += partPt                      
-         sum_deta += deta*weight               
-         sum_dphi += dphi*weight               
-         sum_deta2 += deta*deta*weight         
-         sum_detadphi += deta*dphi*weight      
-         sum_dphi2 += dphi*dphi*weight         
+                if part.trackHighPurity()==False: continue
+                if part.fromPV()<=1: continue             
 
 
+            jet.mult += 1
+
+            deta = part.eta() - jet.eta()
+            dphi = deltaPhi(part.phi(), jet.phi())
+            partPt = part.pt()                    
+            weight = partPt*partPt                
+            sum_weight += weight                  
+            sum_pt += partPt                      
+            sum_deta += deta*weight               
+            sum_dphi += dphi*weight               
+            sum_deta2 += deta*deta*weight         
+            sum_detadphi += deta*dphi*weight      
+            sum_dphi2 += dphi*dphi*weight         
 
 
-       a = 0.
-       b = 0.
-       c = 0.
 
-       if sum_weight > 0 :
-         jet.ptd = math.sqrt(sum_weight)/sum_pt
-         ave_deta = sum_deta/sum_weight        
-         ave_dphi = sum_dphi/sum_weight        
-         ave_deta2 = sum_deta2/sum_weight      
-         ave_dphi2 = sum_dphi2/sum_weight      
-         a = ave_deta2 - ave_deta*ave_deta     
-         b = ave_dphi2 - ave_dphi*ave_dphi     
-         c = -(sum_detadphi/sum_weight - ave_deta*ave_dphi)
-       else: jet.ptd = 0.                                  
 
-       delta = math.sqrt(math.fabs((a-b)*(a-b)+4.*c*c))
+        a = 0.
+        b = 0.
+        c = 0.
 
-       if a+b-delta > 0: jet.axis2 = -math.log(math.sqrt(0.5*(a+b-delta)))
-       else: jet.axis2 = -1.                                              
-       return jet	
-   
+        if sum_weight > 0 :
+            jet.ptd = math.sqrt(sum_weight)/sum_pt
+            ave_deta = sum_deta/sum_weight        
+            ave_dphi = sum_dphi/sum_weight        
+            ave_deta2 = sum_deta2/sum_weight      
+            ave_dphi2 = sum_dphi2/sum_weight      
+            a = ave_deta2 - ave_deta*ave_deta     
+            b = ave_dphi2 - ave_dphi*ave_dphi     
+            c = -(sum_detadphi/sum_weight - ave_deta*ave_dphi)
+        else: jet.ptd = 0.                                  
+
+        delta = math.sqrt(math.fabs((a-b)*(a-b)+4.*c*c))
+
+        if a+b-delta > 0: jet.axis2 = -math.log(math.sqrt(0.5*(a+b-delta)))
+        else: jet.axis2 = -1.                                              
+        return jet	
+
 
 
 class GenJet( PhysicsObject):

--- a/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
@@ -41,9 +41,9 @@ class Lepton( PhysicsObject):
 
     def lostInner(self):
         if hasattr(self.innerTrack(),"trackerExpectedHitsInner") :
-		return self.innerTrack().trackerExpectedHitsInner().numberOfLostHits()
-	else :	
-		return self.innerTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS)	
+            return self.innerTrack().trackerExpectedHitsInner().numberOfLostHits()
+        else :	
+            return self.innerTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS)	
 
     def p4WithFSR(self):
         ret = self.p4()

--- a/PhysicsTools/Heppy/python/utils/cmsswPreprocessor.py
+++ b/PhysicsTools/Heppy/python/utils/cmsswPreprocessor.py
@@ -9,124 +9,124 @@ from math import ceil
 from PhysicsTools.HeppyCore.framework.config import CFG
 from PhysicsTools.Heppy.utils.edmUtils import edmFileLs
 class CmsswPreprocessor :
-	def __init__(self,configFile,command="cmsRun", addOrigAsSecondary=True, prefetch=False, options={}) :
-		self.configFile=configFile
-		self.command=command
-		self.addOrigAsSecondary=addOrigAsSecondary
-		self.prefetch=prefetch
-		self.garbageFiles=[]
-                self.options=options
-	
-	def prefetchOneXrootdFile(self,fname):
-		tmpdir = os.environ['TMPDIR'] if 'TMPDIR' in os.environ else "/tmp"
-		rndchars  = "".join([hex(ord(i))[2:] for i in os.urandom(8)])
-		localfile = "%s/%s-%s.root" % (tmpdir, os.path.basename(fname).replace(".root",""), rndchars)
-		try:
-		    print("Fetching %s to local path %s " % (fname,localfile))
-		    start = timeit.default_timer()
-		    subprocess.check_output(["xrdcp","-f","-N",fname,localfile])
-		    print("Time used for transferring the file locally: %s s" % (timeit.default_timer() - start))
-		    return (localfile,True)
-		except:
-		    print("Could not save file locally, will run from remote")
-		    if os.path.exists(localfile): os.remove(localfile) # delete in case of incomplete transfer
-		    return (fname,False)
-	def maybePrefetchFiles(self,component):
-		newfiles = []
-		component._preprocessor_tempFiles = []
-		for fn in component.files:
-		    if self.prefetch and fn.startswith("root://"):
-		        (newfile,istemp) = self.prefetchOneXrootdFile(fn)
-		        newfiles.append(newfile)
-		        if istemp: 
-		            component._preprocessor_tempFiles.append(newfile)
-		    else:
-		        newfiles.append(fn)
-		component.files = newfiles
-	def endLoop(self,component):
-		for fname in component._preprocessor_tempFiles:
-		    print("Removing local cache file ",fname)
-		    os.remove(fname)
-		component._preprocessor_tempFiles = []
-	def run(self,component,wd,firstEvent,nEvents):
-		if firstEvent != 0: raise RuntimeError("The preprocessor can't skip events at the moment")
-                fineSplitIndex, fineSplitFactor = getattr(component, 'fineSplit', (1,1))
-                if fineSplitFactor > 1:
-                    if len(component.files) != 1:
-                        raise RuntimeError("Any component with fineSplit > 1 is supposed to have just a single file, while %s has %s" % (component.name, component.files))
-                    evtsInFile = edmFileLs(component.files[0])['events']
-                    if nEvents in (None, -1) or nEvents > evtsInFile: nEvents =  evtsInFile
-                    nEvents = int(ceil(nEvents/float(fineSplitFactor)))
-                    firstEvent = fineSplitIndex * nEvents
-                    # Now we will run on these events, and the output will contain only those
-                    # Thus, we switch off fine-split in the component
-                    component.fineSplit = (1,1)
-		if nEvents is None:
-			nEvents = -1
-		self.maybePrefetchFiles(component)
-		cmsswConfig = imp.load_source("cmsRunProcess",os.path.expandvars(self.configFile))
-		inputfiles= []
-		for fn in component.files :
-			if not re.match("file:.*",fn) and not re.match("root:.*",fn) :
-				fn="file:"+fn
-			inputfiles.append(fn)
+    def __init__(self,configFile,command="cmsRun", addOrigAsSecondary=True, prefetch=False, options={}) :
+        self.configFile=configFile
+        self.command=command
+        self.addOrigAsSecondary=addOrigAsSecondary
+        self.prefetch=prefetch
+        self.garbageFiles=[]
+        self.options=options
 
-                # Four cases: 
-                # - no options, cmsswConfig with initialize function
-                #     run initialize with default parameters
-                # - filled options, cmsswConfig with initialize function
-                #     pass on options to initialize
-                # - no options, classic cmsswConfig
-                #     legacy mode
-                # - filled options, classic cmsswConfig
-                #     legacy mode but warn that options are not passed on
+    def prefetchOneXrootdFile(self,fname):
+        tmpdir = os.environ['TMPDIR'] if 'TMPDIR' in os.environ else "/tmp"
+        rndchars  = "".join([hex(ord(i))[2:] for i in os.urandom(8)])
+        localfile = "%s/%s-%s.root" % (tmpdir, os.path.basename(fname).replace(".root",""), rndchars)
+        try:
+            print("Fetching %s to local path %s " % (fname,localfile))
+            start = timeit.default_timer()
+            subprocess.check_output(["xrdcp","-f","-N",fname,localfile])
+            print("Time used for transferring the file locally: %s s" % (timeit.default_timer() - start))
+            return (localfile,True)
+        except:
+            print("Could not save file locally, will run from remote")
+            if os.path.exists(localfile): os.remove(localfile) # delete in case of incomplete transfer
+            return (fname,False)
+    def maybePrefetchFiles(self,component):
+        newfiles = []
+        component._preprocessor_tempFiles = []
+        for fn in component.files:
+            if self.prefetch and fn.startswith("root://"):
+                (newfile,istemp) = self.prefetchOneXrootdFile(fn)
+                newfiles.append(newfile)
+                if istemp: 
+                    component._preprocessor_tempFiles.append(newfile)
+            else:
+                newfiles.append(fn)
+        component.files = newfiles
+    def endLoop(self,component):
+        for fname in component._preprocessor_tempFiles:
+            print("Removing local cache file ",fname)
+            os.remove(fname)
+        component._preprocessor_tempFiles = []
+    def run(self,component,wd,firstEvent,nEvents):
+        if firstEvent != 0: raise RuntimeError("The preprocessor can't skip events at the moment")
+        fineSplitIndex, fineSplitFactor = getattr(component, 'fineSplit', (1,1))
+        if fineSplitFactor > 1:
+            if len(component.files) != 1:
+                raise RuntimeError("Any component with fineSplit > 1 is supposed to have just a single file, while %s has %s" % (component.name, component.files))
+            evtsInFile = edmFileLs(component.files[0])['events']
+            if nEvents in (None, -1) or nEvents > evtsInFile: nEvents =  evtsInFile
+            nEvents = int(ceil(nEvents/float(fineSplitFactor)))
+            firstEvent = fineSplitIndex * nEvents
+            # Now we will run on these events, and the output will contain only those
+            # Thus, we switch off fine-split in the component
+            component.fineSplit = (1,1)
+        if nEvents is None:
+            nEvents = -1
+        self.maybePrefetchFiles(component)
+        cmsswConfig = imp.load_source("cmsRunProcess",os.path.expandvars(self.configFile))
+        inputfiles= []
+        for fn in component.files :
+            if not re.match("file:.*",fn) and not re.match("root:.*",fn) :
+                fn="file:"+fn
+            inputfiles.append(fn)
 
-                if hasattr(cmsswConfig, "initialize"):
-                        if len(self.options) == 0:                                
-                                cmsswConfig.process = cmsswConfig.initialize()                                 
-                        else:                                
-                                cmsswConfig.process = cmsswConfig.initialize(**self.options)                                 
-                else:
-                        if len(self.options) == 0:                             
-                                pass
-                        else:
-                                print("WARNING: cmsswPreprocessor received options but can't pass on to cmsswConfig")
-                
-		cmsswConfig.process.source.fileNames = inputfiles
-		# cmsRun will not create the output file if maxEvents==0, leading to crash of the analysis downstream.
-		# Thus, we set nEvents = 1 if the input file is empty (the output file will be empty as well).
-		cmsswConfig.process.maxEvents.input = 1 if (fineSplitFactor>1 and nEvents==0) else nEvents
-		cmsswConfig.process.source.skipEvents = cmsswConfig.cms.untracked.uint32(0 if (fineSplitFactor>1 and nEvents==0) else firstEvent)
-		#fixme: implement skipEvent / firstevent
+        # Four cases: 
+        # - no options, cmsswConfig with initialize function
+        #     run initialize with default parameters
+        # - filled options, cmsswConfig with initialize function
+        #     pass on options to initialize
+        # - no options, classic cmsswConfig
+        #     legacy mode
+        # - filled options, classic cmsswConfig
+        #     legacy mode but warn that options are not passed on
 
-		outfilename=wd+"/cmsswPreProcessing.root"
-		# for outName in cmsswConfig.process.endpath.moduleNames():
-		for module in cmsswConfig.process.endpaths.viewvalues():
-			for outName in module.moduleNames():
-				out = getattr(cmsswConfig.process,outName)
-			if not hasattr(out,"fileName"): continue
-    			out.fileName = outfilename
+        if hasattr(cmsswConfig, "initialize"):
+            if len(self.options) == 0:                                
+                cmsswConfig.process = cmsswConfig.initialize()                                 
+            else:                                
+                cmsswConfig.process = cmsswConfig.initialize(**self.options)                                 
+        else:
+            if len(self.options) == 0:                             
+                pass
+            else:
+                print("WARNING: cmsswPreprocessor received options but can't pass on to cmsswConfig")
 
-		if not hasattr(component,"options"):
-			component.options = CFG(name="postCmsrunOptions")
-                #use original as primary and new as secondary 
-                #component.options.inputFiles= component.files
-		#component.options.secondaryInputFiles=[outfilename]
+        cmsswConfig.process.source.fileNames = inputfiles
+        # cmsRun will not create the output file if maxEvents==0, leading to crash of the analysis downstream.
+        # Thus, we set nEvents = 1 if the input file is empty (the output file will be empty as well).
+        cmsswConfig.process.maxEvents.input = 1 if (fineSplitFactor>1 and nEvents==0) else nEvents
+        cmsswConfig.process.source.skipEvents = cmsswConfig.cms.untracked.uint32(0 if (fineSplitFactor>1 and nEvents==0) else firstEvent)
+        #fixme: implement skipEvent / firstevent
 
-                #use new as primary and original as secondary
-                if self.addOrigAsSecondary:
-                    component.options.secondaryInputFiles= component.files
-		component.options.inputFiles=[outfilename]
-                component.files=[outfilename]
+        outfilename=wd+"/cmsswPreProcessing.root"
+        # for outName in cmsswConfig.process.endpath.moduleNames():
+        for module in cmsswConfig.process.endpaths.viewvalues():
+            for outName in module.moduleNames():
+                out = getattr(cmsswConfig.process,outName)
+            if not hasattr(out,"fileName"): continue
+            out.fileName = outfilename
 
-		configfile=wd+"/cmsRun_config.py"
-		f = open(configfile, 'w')
-		f.write(cmsswConfig.process.dumpPython())
-		f.close()
-		runstring="%s %s >& %s/cmsRun.log" % (self.command,configfile,wd)
-		print("Running pre-processor: %s " %runstring)
-                ret=os.system(runstring)
-                if ret != 0:
-                     print("CMSRUN failed")
-                     exit(ret)
-		return component
+        if not hasattr(component,"options"):
+            component.options = CFG(name="postCmsrunOptions")
+        #use original as primary and new as secondary 
+        #component.options.inputFiles= component.files
+        #component.options.secondaryInputFiles=[outfilename]
+
+        #use new as primary and original as secondary
+        if self.addOrigAsSecondary:
+            component.options.secondaryInputFiles= component.files
+        component.options.inputFiles=[outfilename]
+        component.files=[outfilename]
+
+        configfile=wd+"/cmsRun_config.py"
+        f = open(configfile, 'w')
+        f.write(cmsswConfig.process.dumpPython())
+        f.close()
+        runstring="%s %s >& %s/cmsRun.log" % (self.command,configfile,wd)
+        print("Running pre-processor: %s " %runstring)
+        ret=os.system(runstring)
+        if ret != 0:
+            print("CMSRUN failed")
+            exit(ret)
+        return component

--- a/PhysicsTools/HeppyCore/python/framework/analyzer.py
+++ b/PhysicsTools/HeppyCore/python/framework/analyzer.py
@@ -32,9 +32,9 @@ class Analyzer(object):
         self.cfg_ana = cfg_ana
         self.cfg_comp = cfg_comp
         self.looperName = looperName
-	if hasattr(cfg_ana,"nosubdir") and cfg_ana.nosubdir:
-       	    self.dirName = self.looperName
-	else:
+        if hasattr(cfg_ana,"nosubdir") and cfg_ana.nosubdir:
+            self.dirName = self.looperName
+        else:
             self.dirName = '/'.join( [self.looperName, self.name] )
             os.mkdir( self.dirName )
 

--- a/PhysicsTools/HeppyCore/python/framework/eventsfwlite.py
+++ b/PhysicsTools/HeppyCore/python/framework/eventsfwlite.py
@@ -16,16 +16,16 @@ gInterpreter.ProcessLine("using edm::refhelper::FindUsingAdvance;")
 
 class Events(object):
     def __init__(self, files, tree_name,  options=None):
-	if options is not None :
-		if not hasattr(options,"inputFiles"):
-		 	options.inputFiles=files
-		if not hasattr(options,"maxEvents"):
-			options.maxEvents = 0	
-		if not hasattr(options,"secondaryInputFiles"):
-			options.secondaryInputFiles = []
-	        self.events = FWLiteEvents(options=options)
-	else :
-	        self.events = FWLiteEvents(files)
+        if options is not None :
+            if not hasattr(options,"inputFiles"):
+                options.inputFiles=files
+            if not hasattr(options,"maxEvents"):
+                options.maxEvents = 0	
+            if not hasattr(options,"secondaryInputFiles"):
+                options.secondaryInputFiles = []
+            self.events = FWLiteEvents(options=options)
+        else :
+            self.events = FWLiteEvents(files)
 
     def __len__(self):
         return self.events.size()

--- a/PhysicsTools/HeppyCore/python/utils/deltar.py
+++ b/PhysicsTools/HeppyCore/python/utils/deltar.py
@@ -44,12 +44,12 @@ def matchObjectCollection3 ( objects, matchCollection, deltaRMax = 0.3, filter =
     By default, the matching is true only if delta R is smaller than 0.3. 
     '''
     #
-                                                                                                                                                                                                                                       
+
     pairs = {}
     if len(objects)==0:
-            return pairs
+        return pairs
     if len(matchCollection)==0:
-            return dict( list(zip(objects, [None]*len(objects))) )
+        return dict( list(zip(objects, [None]*len(objects))) )
     # build all possible combinations
 
     objectCoords = [ (o.eta(),o.phi(),o) for o in objects ]
@@ -77,8 +77,8 @@ def matchObjectCollection3 ( objects, matchCollection, deltaRMax = 0.3, filter =
     #
 
     for object in objects:
-       if object.matched == False:
-           pairs[object] = None
+        if object.matched == False:
+            pairs[object] = None
     #
 
     return pairs
@@ -168,12 +168,12 @@ def matchObjectCollection2 ( objects, matchCollection, deltaRMax = 0.3 ):
     Reco and Gen objects get the "matched" attribute, true is they are re part of a matched tulpe.
     By default, the matching is true only if delta R is smaller than 0.3.
     '''
-    
+
     pairs = {}
     if len(objects)==0:
-            return pairs
+        return pairs
     if len(matchCollection)==0:
-            return dict( list(zip(objects, [None]*len(objects))) )
+        return dict( list(zip(objects, [None]*len(objects))) )
     # build all possible combinations
     allPairs = sorted([(deltaR2 (object.eta(), object.phi(), match.eta(), match.phi()), (object, match)) for object in objects for match in matchCollection])
 
@@ -183,19 +183,19 @@ def matchObjectCollection2 ( objects, matchCollection, deltaRMax = 0.3 ):
         object.matched = False
     for match in matchCollection:
         match.matched = False
-    
+
     deltaR2Max = deltaRMax * deltaRMax
     for dR2, (object, match) in allPairs:
-	if dR2 > deltaR2Max:
-		break
+        if dR2 > deltaR2Max:
+            break
         if dR2 < deltaR2Max and object.matched == False and match.matched == False:
             object.matched = True
             match.matched = True
             pairs[object] = match
-    
+
     for object in objects:
-       if object.matched == False:
-	   pairs[object] = None
+        if object.matched == False:
+            pairs[object] = None
 
     return pairs
     # by now, the matched attribute remains in the objects, for future usage

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -14,8 +14,8 @@ from PhysicsTools.HeppyCore.utils.batchmanager import BatchManager
 from PhysicsTools.HeppyCore.framework.heppy_loop import split
 
 def batchScriptPADOVA( index, jobDir='./'):
-   '''prepare the LSF version of the batch script, to run on LSF'''
-   script = """#!/bin/bash
+    '''prepare the LSF version of the batch script, to run on LSF'''
+    script = """#!/bin/bash
 #BSUB -q local
 #BSUB -J test
 #BSUB -o test.log
@@ -40,11 +40,11 @@ exit $?
 #echo cp -r Loop/* $LS_SUBCWD 
 """.format(jdir=jobDir)
 
-   return script
+    return script
 
 def batchScriptPISA( index, remoteDir=''):
-   '''prepare the LSF version of the batch script, to run on LSF'''
-   script = """#!/bin/bash
+    '''prepare the LSF version of the batch script, to run on LSF'''
+    script = """#!/bin/bash
 #BSUB -q cms
 echo 'PWD:'
 pwd
@@ -72,12 +72,12 @@ exit $?
 #echo 'sending the job directory back'
 #echo cp -r Loop/* $LS_SUBCWD 
 """
-   return script
+    return script
 
 def batchScriptCERN( jobDir, remoteDir=''):
-   '''prepare the LSF version of the batch script, to run on LSF'''
-   
-   dirCopy = """echo 'sending the logs back'  # will send also root files if copy failed
+    '''prepare the LSF version of the batch script, to run on LSF'''
+
+    dirCopy = """echo 'sending the logs back'  # will send also root files if copy failed
 rm Loop/cmsswPreProcessing.root
 cp -r Loop/* $LS_SUBCWD
 if [ $? -ne 0 ]; then
@@ -86,10 +86,10 @@ else
    echo 'job directory copy succeeded'
 fi"""
 
-   if remoteDir=='':
-      cpCmd=dirCopy
-   elif  remoteDir.startswith("root://eoscms.cern.ch//eos/cms/store/"):
-       cpCmd="""echo 'sending root files to remote dir'
+    if remoteDir=='':
+        cpCmd=dirCopy
+    elif  remoteDir.startswith("root://eoscms.cern.ch//eos/cms/store/"):
+        cpCmd="""echo 'sending root files to remote dir'
 export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH # 
 for f in Loop/*/tree*.root
 do
@@ -132,15 +132,15 @@ else
    echo 'job directory copy succeeded'
 fi
 """.format(
-          idx = jobDir[jobDir.find("_Chunk")+6:].strip("/") if '_Chunk' in jobDir else 'all',
-          srm = (""+remoteDir+jobDir[ jobDir.rfind("/") : (jobDir.find("_Chunk") if '_Chunk' in jobDir else len(jobDir)) ]).replace("root://eoscms.cern.ch/","")
-          )
-   else:
-       print("chosen location not supported yet: ", remoteDir)
-       print('path must start with /store/')
-       sys.exit(1)
+           idx = jobDir[jobDir.find("_Chunk")+6:].strip("/") if '_Chunk' in jobDir else 'all',
+           srm = (""+remoteDir+jobDir[ jobDir.rfind("/") : (jobDir.find("_Chunk") if '_Chunk' in jobDir else len(jobDir)) ]).replace("root://eoscms.cern.ch/","")
+           )
+    else:
+        print("chosen location not supported yet: ", remoteDir)
+        print('path must start with /store/')
+        sys.exit(1)
 
-   script = """#!/bin/bash
+    script = """#!/bin/bash
 #BSUB -q 8nm
 echo 'environment:'
 echo
@@ -161,21 +161,21 @@ echo
 {copy}
 """.format(copy=cpCmd)
 
-   return script
+    return script
 
 
 def batchScriptPSI( index, jobDir, remoteDir=''):
-   '''prepare the SGE version of the batch script, to run on the PSI tier3 batch system'''
+    '''prepare the SGE version of the batch script, to run on the PSI tier3 batch system'''
 
-   cmssw_release = os.environ['CMSSW_BASE']
-   VO_CMS_SW_DIR = "/swshare/cms"  # $VO_CMS_SW_DIR doesn't seem to work in the new SL6 t3wn
+    cmssw_release = os.environ['CMSSW_BASE']
+    VO_CMS_SW_DIR = "/swshare/cms"  # $VO_CMS_SW_DIR doesn't seem to work in the new SL6 t3wn
 
-   if remoteDir=='':
-       cpCmd="""echo 'sending the job directory back'
+    if remoteDir=='':
+        cpCmd="""echo 'sending the job directory back'
 rm Loop/cmsswPreProcessing.root
 cp -r Loop/* $SUBMISIONDIR"""
-   elif remoteDir.startswith("/pnfs/psi.ch"):
-       cpCmd="""echo 'sending root files to remote dir'
+    elif remoteDir.startswith("/pnfs/psi.ch"):
+        cpCmd="""echo 'sending root files to remote dir'
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib64/dcap/ # Fabio's workaround to fix gfal-tools
 for f in Loop/mt2*.root
 do
@@ -193,13 +193,13 @@ do
 done
 rm Loop/cmsswPreProcessing.root
 cp -r Loop/* $SUBMISIONDIR""".format(idx=index, srm='srm://t3se01.psi.ch'+remoteDir+jobDir[jobDir.rfind("/"):jobDir.find("_Chunk")])
-   else:
-      print("remote directory not supported yet: ", remoteDir)
-      print('path must start with "/pnfs/psi.ch"')
-      sys.exit(1)
-      
+    else:
+        print("remote directory not supported yet: ", remoteDir)
+        print('path must start with "/pnfs/psi.ch"')
+        sys.exit(1)
 
-   script = """#!/bin/bash
+
+    script = """#!/bin/bash
 shopt expand_aliases
 ##### MONITORING/DEBUG INFORMATION ###############################
 DATE_START=`date +%s`
@@ -258,14 +258,14 @@ echo "Wallclock running time: $RUNTIME s"
 exit 0
 """.format(jdir=jobDir, vo=VO_CMS_SW_DIR,cmssw=cmssw_release, copy=cpCmd)
 
-   return script
+    return script
 
 def batchScriptIC(jobDir):
-   '''prepare a IC version of the batch script'''
+    '''prepare a IC version of the batch script'''
 
 
-   cmssw_release = os.environ['CMSSW_BASE']
-   script = """#!/bin/bash
+    cmssw_release = os.environ['CMSSW_BASE']
+    script = """#!/bin/bash
 export X509_USER_PROXY=/home/hep/$USER/myproxy
 source /vols/cms/grid/setup.sh
 cd {jobdir}
@@ -278,60 +278,60 @@ echo
 echo 'sending the job directory back'
 mv Loop/* ./ && rm -r Loop
 """.format(jobdir = jobDir,cmssw = cmssw_release)
-   return script
+    return script
 
 def batchScriptLocal(  remoteDir, index ):
-   '''prepare a local version of the batch script, to run using nohup'''
+    '''prepare a local version of the batch script, to run using nohup'''
 
-   script = """#!/bin/bash
+    script = """#!/bin/bash
 echo 'running'
 python $CMSSW_BASE/src/PhysicsTools/HeppyCore/python/framework/looper.py pycfg.py config.pck --options=options.json
 echo
 echo 'sending the job directory back'
 mv Loop/* ./
 """ 
-   return script
+    return script
 
 
 class MyBatchManager( BatchManager ):
-   '''Batch manager specific to cmsRun processes.''' 
-         
-   def PrepareJobUser(self, jobDir, value ):
-       '''Prepare one job. This function is called by the base class.'''
-       print(value)
-       print(components[value])
+    '''Batch manager specific to cmsRun processes.''' 
 
-       #prepare the batch script
-       scriptFileName = jobDir+'/batchScript.sh'
-       scriptFile = open(scriptFileName,'w')
-       storeDir = self.remoteOutputDir_.replace('/castor/cern.ch/cms','')
-       mode = self.RunningMode(options.batch)
-       if mode == 'LXPLUS':
-           scriptFile.write( batchScriptCERN( jobDir, storeDir ) ) 
-       elif mode == 'PSI':
-           scriptFile.write( batchScriptPSI ( value, jobDir, storeDir ) ) # storeDir not implemented at the moment
-       elif mode == 'LOCAL':
-           scriptFile.write( batchScriptLocal( storeDir, value) )  # watch out arguments are swapped (although not used)
-       elif mode == 'PISA' :
-	   scriptFile.write( batchScriptPISA( storeDir, value) ) 	
-       elif mode == 'PADOVA' :
-           scriptFile.write( batchScriptPADOVA( value, jobDir) )        
-       elif mode == 'IC':
-           scriptFile.write( batchScriptIC(jobDir) )
-       scriptFile.close()
-       os.system('chmod +x %s' % scriptFileName)
-       
-       shutil.copyfile(cfgFileName, jobDir+'/pycfg.py')
+    def PrepareJobUser(self, jobDir, value ):
+        '''Prepare one job. This function is called by the base class.'''
+        print(value)
+        print(components[value])
+
+        #prepare the batch script
+        scriptFileName = jobDir+'/batchScript.sh'
+        scriptFile = open(scriptFileName,'w')
+        storeDir = self.remoteOutputDir_.replace('/castor/cern.ch/cms','')
+        mode = self.RunningMode(options.batch)
+        if mode == 'LXPLUS':
+            scriptFile.write( batchScriptCERN( jobDir, storeDir ) ) 
+        elif mode == 'PSI':
+            scriptFile.write( batchScriptPSI ( value, jobDir, storeDir ) ) # storeDir not implemented at the moment
+        elif mode == 'LOCAL':
+            scriptFile.write( batchScriptLocal( storeDir, value) )  # watch out arguments are swapped (although not used)
+        elif mode == 'PISA' :
+            scriptFile.write( batchScriptPISA( storeDir, value) ) 	
+        elif mode == 'PADOVA' :
+            scriptFile.write( batchScriptPADOVA( value, jobDir) )        
+        elif mode == 'IC':
+            scriptFile.write( batchScriptIC(jobDir) )
+        scriptFile.close()
+        os.system('chmod +x %s' % scriptFileName)
+
+        shutil.copyfile(cfgFileName, jobDir+'/pycfg.py')
 #      jobConfig = copy.deepcopy(config)
 #      jobConfig.components = [ components[value] ]
-       cfgFile = open(jobDir+'/config.pck','w')
-       pickle.dump(  components[value] , cfgFile )
-       # pickle.dump( cfo, cfgFile )
-       cfgFile.close()
-       if hasattr(self,"heppyOptions_"):
-          optjsonfile = open(jobDir+'/options.json','w')
-          optjsonfile.write(json.dumps(self.heppyOptions_))
-          optjsonfile.close()
+        cfgFile = open(jobDir+'/config.pck','w')
+        pickle.dump(  components[value] , cfgFile )
+        # pickle.dump( cfo, cfgFile )
+        cfgFile.close()
+        if hasattr(self,"heppyOptions_"):
+            optjsonfile = open(jobDir+'/options.json','w')
+            optjsonfile.write(json.dumps(self.heppyOptions_))
+            optjsonfile.close()
 
 if __name__ == '__main__':
     batchManager = MyBatchManager()

--- a/PhysicsTools/PatAlgos/python/tools/coreTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/coreTools.py
@@ -201,4 +201,4 @@ def _removeMCMatchingForPATObject(process, matcherName, producerName, postfix=""
         attr = objectProducer.genParticleMatch.getModuleLabel()
         objectProducer.genParticleMatch = ''
     if hasattr(process,attr): delattr(process,attr)
-    
+

--- a/PhysicsTools/PatAlgos/python/tools/helpers.py
+++ b/PhysicsTools/PatAlgos/python/tools/helpers.py
@@ -31,27 +31,27 @@ def addToProcessAndTask(label, module, process, task):
     task.add(getattr(process, label))
 
 def addESProducers(process,config):
-	config = config.replace("/",".")
-	#import RecoBTag.Configuration.RecoBTag_cff as btag
-	#print btag
-	module = __import__(config)
-	for name in dir(sys.modules[config]):
-		item = getattr(sys.modules[config],name)
-		if isinstance(item,cms._Labelable) and not isinstance(item,cms._ModuleSequenceType) and not name.startswith('_') and not (name == "source" or name == "looper" or name == "subProcess") and not isinstance(item, cms.PSet):
-			if 'ESProducer' in item.type_():
-				setattr(process,name,item)
+    config = config.replace("/",".")
+    #import RecoBTag.Configuration.RecoBTag_cff as btag
+    #print btag
+    module = __import__(config)
+    for name in dir(sys.modules[config]):
+        item = getattr(sys.modules[config],name)
+        if isinstance(item,cms._Labelable) and not isinstance(item,cms._ModuleSequenceType) and not name.startswith('_') and not (name == "source" or name == "looper" or name == "subProcess") and not isinstance(item, cms.PSet):
+            if 'ESProducer' in item.type_():
+                setattr(process,name,item)
 
 def loadWithPrefix(process,moduleName,prefix='',loadedProducersAndFilters=None):
-        loadWithPrePostfix(process,moduleName,prefix,'',loadedProducersAndFilters)
+    loadWithPrePostfix(process,moduleName,prefix,'',loadedProducersAndFilters)
 
 def loadWithPostfix(process,moduleName,postfix='',loadedProducersAndFilters=None):
-        loadWithPrePostfix(process,moduleName,'',postfix,loadedProducersAndFilters)
+    loadWithPrePostfix(process,moduleName,'',postfix,loadedProducersAndFilters)
 
 def loadWithPrePostfix(process,moduleName,prefix='',postfix='',loadedProducersAndFilters=None):
-	moduleName = moduleName.replace("/",".")
-        module = __import__(moduleName)
-	#print module.PatAlgos.patSequences_cff.patDefaultSequence
-        extendWithPrePostfix(process,sys.modules[moduleName],prefix,postfix,loadedProducersAndFilters)
+    moduleName = moduleName.replace("/",".")
+    module = __import__(moduleName)
+    #print module.PatAlgos.patSequences_cff.patDefaultSequence
+    extendWithPrePostfix(process,sys.modules[moduleName],prefix,postfix,loadedProducersAndFilters)
 
 def addToTask(loadedProducersAndFilters, module):
     if loadedProducersAndFilters:
@@ -255,19 +255,19 @@ def contains(sequence, moduleName):
 
 
 def cloneProcessingSnippet(process, sequence, postfix, removePostfix="", noClones = [], addToTask = False):
-   """
-   ------------------------------------------------------------------
-   copy a sequence plus the modules and sequences therein
-   both are renamed by getting a postfix
-   input tags are automatically adjusted
-   ------------------------------------------------------------------
-   """
-   result = sequence
-   if not postfix == "":
-       visitor = CloneSequenceVisitor(process, sequence.label(), postfix, removePostfix, noClones, addToTask)
-       sequence.visit(visitor)
-       result = visitor.clonedSequence()
-   return result
+    """
+    ------------------------------------------------------------------
+    copy a sequence plus the modules and sequences therein
+    both are renamed by getting a postfix
+    input tags are automatically adjusted
+    ------------------------------------------------------------------
+    """
+    result = sequence
+    if not postfix == "":
+        visitor = CloneSequenceVisitor(process, sequence.label(), postfix, removePostfix, noClones, addToTask)
+        sequence.visit(visitor)
+        result = visitor.clonedSequence()
+    return result
 
 def listDependencyChain(process, module, sources, verbose=False):
     """
@@ -321,7 +321,7 @@ def listDependencyChain(process, module, sources, verbose=False):
             # then add them and their processed dependencies to our deps
             mydeps.add(d)
             if d in flatgraph: 
-                 mydeps.update(flatgraph[d])
+                mydeps.update(flatgraph[d])
         flatgraph[tip] = mydeps
     flatdeps = {}
     allmodules = set()
@@ -336,7 +336,7 @@ def listDependencyChain(process, module, sources, verbose=False):
             if module in flatdeps and m in flatdeps[module]:
                 modulelist.insert(i, module)
                 break
-	if module not in modulelist:
+        if module not in modulelist:
             modulelist.append(module)
     # Validate
     for i,m1 in enumerate(modulelist):
@@ -363,20 +363,20 @@ def addKeepStatement(process, oldKeep, newKeeps, verbose=False):
 
 
 if __name__=="__main__":
-   import unittest
-   class TestModuleCommand(unittest.TestCase):
-       def setUp(self):
-           """Nothing to do """
-           pass
-       def testCloning(self):
-           p = cms.Process("test")
-           p.a = cms.EDProducer("a", src=cms.InputTag("gen"))
-           p.b = cms.EDProducer("b", src=cms.InputTag("a"))
-           p.c = cms.EDProducer("c", src=cms.InputTag("b","instance"))
-           p.s = cms.Sequence(p.a*p.b*p.c *p.a)
-           cloneProcessingSnippet(p, p.s, "New", addToTask = True)
-           self.assertEqual(p.dumpPython(),
-"""import FWCore.ParameterSet.Config as cms
+    import unittest
+    class TestModuleCommand(unittest.TestCase):
+        def setUp(self):
+            """Nothing to do """
+            pass
+        def testCloning(self):
+            p = cms.Process("test")
+            p.a = cms.EDProducer("a", src=cms.InputTag("gen"))
+            p.b = cms.EDProducer("b", src=cms.InputTag("a"))
+            p.c = cms.EDProducer("c", src=cms.InputTag("b","instance"))
+            p.s = cms.Sequence(p.a*p.b*p.c *p.a)
+            cloneProcessingSnippet(p, p.s, "New", addToTask = True)
+            self.assertEqual(p.dumpPython(),
+ """import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("test")
 
@@ -420,24 +420,24 @@ process.sNew = cms.Sequence(process.aNew+process.bNew+process.cNew+process.aNew)
 
 
 """)
-       def testContains(self):
-           p = cms.Process("test")
-           p.a = cms.EDProducer("a", src=cms.InputTag("gen"))
-           p.b = cms.EDProducer("ab", src=cms.InputTag("a"))
-           p.c = cms.EDProducer("ac", src=cms.InputTag("b"))
-           p.s1 = cms.Sequence(p.a*p.b*p.c)
-           p.s2 = cms.Sequence(p.b*p.c)
-           self.assert_( contains(p.s1, "a") )
-           self.assert_( not contains(p.s2, "a") )
-       def testJetCollectionString(self):
-           self.assertEqual(jetCollectionString(algo = 'Foo', type = 'Bar'), 'patJetsFooBar')
-           self.assertEqual(jetCollectionString(prefix = 'prefix', algo = 'Foo', type = 'Bar'), 'prefixPatJetsFooBar')
-       def testListModules(self):
-           p = cms.Process("test")
-           p.a = cms.EDProducer("a", src=cms.InputTag("gen"))
-           p.b = cms.EDProducer("ab", src=cms.InputTag("a"))
-           p.c = cms.EDProducer("ac", src=cms.InputTag("b"))
-           p.s = cms.Sequence(p.a*p.b*p.c)
-           self.assertEqual([p.a,p.b,p.c], listModules(p.s))
+        def testContains(self):
+            p = cms.Process("test")
+            p.a = cms.EDProducer("a", src=cms.InputTag("gen"))
+            p.b = cms.EDProducer("ab", src=cms.InputTag("a"))
+            p.c = cms.EDProducer("ac", src=cms.InputTag("b"))
+            p.s1 = cms.Sequence(p.a*p.b*p.c)
+            p.s2 = cms.Sequence(p.b*p.c)
+            self.assert_( contains(p.s1, "a") )
+            self.assert_( not contains(p.s2, "a") )
+        def testJetCollectionString(self):
+            self.assertEqual(jetCollectionString(algo = 'Foo', type = 'Bar'), 'patJetsFooBar')
+            self.assertEqual(jetCollectionString(prefix = 'prefix', algo = 'Foo', type = 'Bar'), 'prefixPatJetsFooBar')
+        def testListModules(self):
+            p = cms.Process("test")
+            p.a = cms.EDProducer("a", src=cms.InputTag("gen"))
+            p.b = cms.EDProducer("ab", src=cms.InputTag("a"))
+            p.c = cms.EDProducer("ac", src=cms.InputTag("b"))
+            p.s = cms.Sequence(p.a*p.b*p.c)
+            self.assertEqual([p.a,p.b,p.c], listModules(p.s))
 
-   unittest.main()
+    unittest.main()

--- a/PhysicsTools/PatAlgos/python/tools/pfTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/pfTools.py
@@ -99,133 +99,133 @@ def reconfigurePF2PATTaus(process,
       selectionDependsOn=["DiscriminationByLeadingTrackFinding"],
       producerFromType=lambda producer: producer+"Producer",
       postfix = ""):
-   print("patTaus will be produced from taus of type: %s that pass %s" \
-	 % (tauType, pf2patSelection))
+    print("patTaus will be produced from taus of type: %s that pass %s" \
+          % (tauType, pf2patSelection))
 
 
 
-   # Get the prototype of tau producer to make, i.e. fixedConePFTauProducer
-   producerName = producerFromType(tauType)
-   # Set as the source for the pf2pat taus (pfTaus) selector
-   applyPostfix(process,"pfTaus", postfix).src = producerName+postfix
-   # Start our pf2pat taus base sequence
-   oldTauSansRefs = getattr(process,'pfTausProducerSansRefs'+postfix)
-   oldTau = getattr(process,'pfTausProducer'+postfix)
-   ## copy tau and setup it properly
-   newTauSansRefs = None
-   newTau = getattr(process,producerName+postfix).clone()
+    # Get the prototype of tau producer to make, i.e. fixedConePFTauProducer
+    producerName = producerFromType(tauType)
+    # Set as the source for the pf2pat taus (pfTaus) selector
+    applyPostfix(process,"pfTaus", postfix).src = producerName+postfix
+    # Start our pf2pat taus base sequence
+    oldTauSansRefs = getattr(process,'pfTausProducerSansRefs'+postfix)
+    oldTau = getattr(process,'pfTausProducer'+postfix)
+    ## copy tau and setup it properly
+    newTauSansRefs = None
+    newTau = getattr(process,producerName+postfix).clone()
 
-   ## adapted to new structure in RecoTauProducers PLEASE CHECK!!!
-   if tauType=='shrinkingConePFTau':
-       newTauSansRefs = getattr(process,producerName+"SansRefs").clone()
-       newTauSansRefs.modifiers[1] = cms.PSet(
-           pfTauTagInfoSrc = cms.InputTag("pfTauTagInfoProducer"+postfix),
-           name = cms.string('pfTauTTIworkaround'+postfix),
-           plugin = cms.string('RecoTauTagInfoWorkaroundModifer')
-           )
-       newTau.modifiers[1] = newTauSansRefs.modifiers[1]
-       newTauSansRefs.piZeroSrc = "pfJetsLegacyTaNCPiZeros"+postfix
-       newTau.piZeroSrc = newTauSansRefs.piZeroSrc
-       newTauSansRefs.builders[0].pfCandSrc = oldTauSansRefs.builders[0].pfCandSrc
-       newTauSansRefs.jetRegionSrc = oldTauSansRefs.jetRegionSrc
-       newTauSansRefs.jetSrc = oldTauSansRefs.jetSrc
-   elif tauType=='fixedConePFTau':
-       newTau.piZeroSrc = "pfJetsLegacyTaNCPiZeros"+postfix
-   elif tauType=='hpsPFTau':
-       newTau = getattr(process,'combinatoricRecoTaus'+postfix).clone()
-       newTau.piZeroSrc="pfJetsLegacyHPSPiZeros"+postfix
-       newTau.modifiers[3] = cms.PSet(
-           pfTauTagInfoSrc = cms.InputTag("pfTauTagInfoProducer"+postfix),
-           name = cms.string('pfTauTTIworkaround'+postfix),
-           plugin = cms.string('RecoTauTagInfoWorkaroundModifer')
-           )
-       from PhysicsTools.PatAlgos.tools.helpers import cloneProcessingSnippet
-       #cloneProcessingSnippet(process, process.produceHPSPFTaus, postfix, addToTask = True)
-       setattr(process,'produceHPSPFTaus'+postfix,cms.Sequence(applyPostfix(process,'hpsSelectionDiscriminator',postfix)+applyPostfix(process,'hpsPFTauProducerSansRefs',postfix)+applyPostfix(process,'hpsPFTauProducer',postfix)))
-       massSearchReplaceParam(getattr(process,"produceHPSPFTaus"+postfix),
-                              "PFTauProducer",
-                              cms.InputTag("combinatoricRecoTaus"+postfix),
-                              cms.InputTag("pfTausBase"+postfix) )
-       massSearchReplaceParam(getattr(process,"produceHPSPFTaus"+postfix),
-                              "src",
-                              cms.InputTag("combinatoricRecoTaus"+postfix),
-                              cms.InputTag("pfTausBase"+postfix) )
-   ### Next three lines crash, oldTau does not have any of these attributes. Why?###
-   #newTau.builders[0].pfCandSrc = oldTau.builders[0].pfCandSrc
-   #newTau.jetRegionSrc = oldTau.jetRegionSrc
-   #newTau.jetSrc = oldTau.jetSrc
-   #newTau.builders[0].pfCandSrc = cms.InputTag("pfNoElectronJME" + postfix)
-   #newTau.jetRegionSrc = cms.InputTag("pfTauPFJets08Region" + postfix)
-   #newTau.jetSrc = cms.InputTag("pfJetsPFBRECO" + postfix)
-   # replace old tau producer by new one put it into baseSequence
-   task = getPatAlgosToolsTask(process)
-   addToProcessAndTask("pfTausBase"+postfix, newTau, process, task)
-   if tauType=='shrinkingConePFTau':
-       addToProcessAndTask("pfTausBaseSansRefs"+postfix, newTauSansRefs, process, task)
-       getattr(process,"pfTausBase"+postfix).src = "pfTausBaseSansRefs"+postfix
-       baseSequence += getattr(process,"pfTausBaseSansRefs"+postfix)
+    ## adapted to new structure in RecoTauProducers PLEASE CHECK!!!
+    if tauType=='shrinkingConePFTau':
+        newTauSansRefs = getattr(process,producerName+"SansRefs").clone()
+        newTauSansRefs.modifiers[1] = cms.PSet(
+            pfTauTagInfoSrc = cms.InputTag("pfTauTagInfoProducer"+postfix),
+            name = cms.string('pfTauTTIworkaround'+postfix),
+            plugin = cms.string('RecoTauTagInfoWorkaroundModifer')
+            )
+        newTau.modifiers[1] = newTauSansRefs.modifiers[1]
+        newTauSansRefs.piZeroSrc = "pfJetsLegacyTaNCPiZeros"+postfix
+        newTau.piZeroSrc = newTauSansRefs.piZeroSrc
+        newTauSansRefs.builders[0].pfCandSrc = oldTauSansRefs.builders[0].pfCandSrc
+        newTauSansRefs.jetRegionSrc = oldTauSansRefs.jetRegionSrc
+        newTauSansRefs.jetSrc = oldTauSansRefs.jetSrc
+    elif tauType=='fixedConePFTau':
+        newTau.piZeroSrc = "pfJetsLegacyTaNCPiZeros"+postfix
+    elif tauType=='hpsPFTau':
+        newTau = getattr(process,'combinatoricRecoTaus'+postfix).clone()
+        newTau.piZeroSrc="pfJetsLegacyHPSPiZeros"+postfix
+        newTau.modifiers[3] = cms.PSet(
+            pfTauTagInfoSrc = cms.InputTag("pfTauTagInfoProducer"+postfix),
+            name = cms.string('pfTauTTIworkaround'+postfix),
+            plugin = cms.string('RecoTauTagInfoWorkaroundModifer')
+            )
+        from PhysicsTools.PatAlgos.tools.helpers import cloneProcessingSnippet
+        #cloneProcessingSnippet(process, process.produceHPSPFTaus, postfix, addToTask = True)
+        setattr(process,'produceHPSPFTaus'+postfix,cms.Sequence(applyPostfix(process,'hpsSelectionDiscriminator',postfix)+applyPostfix(process,'hpsPFTauProducerSansRefs',postfix)+applyPostfix(process,'hpsPFTauProducer',postfix)))
+        massSearchReplaceParam(getattr(process,"produceHPSPFTaus"+postfix),
+                               "PFTauProducer",
+                               cms.InputTag("combinatoricRecoTaus"+postfix),
+                               cms.InputTag("pfTausBase"+postfix) )
+        massSearchReplaceParam(getattr(process,"produceHPSPFTaus"+postfix),
+                               "src",
+                               cms.InputTag("combinatoricRecoTaus"+postfix),
+                               cms.InputTag("pfTausBase"+postfix) )
+    ### Next three lines crash, oldTau does not have any of these attributes. Why?###
+    #newTau.builders[0].pfCandSrc = oldTau.builders[0].pfCandSrc
+    #newTau.jetRegionSrc = oldTau.jetRegionSrc
+    #newTau.jetSrc = oldTau.jetSrc
+    #newTau.builders[0].pfCandSrc = cms.InputTag("pfNoElectronJME" + postfix)
+    #newTau.jetRegionSrc = cms.InputTag("pfTauPFJets08Region" + postfix)
+    #newTau.jetSrc = cms.InputTag("pfJetsPFBRECO" + postfix)
+    # replace old tau producer by new one put it into baseSequence
+    task = getPatAlgosToolsTask(process)
+    addToProcessAndTask("pfTausBase"+postfix, newTau, process, task)
+    if tauType=='shrinkingConePFTau':
+        addToProcessAndTask("pfTausBaseSansRefs"+postfix, newTauSansRefs, process, task)
+        getattr(process,"pfTausBase"+postfix).src = "pfTausBaseSansRefs"+postfix
+        baseSequence += getattr(process,"pfTausBaseSansRefs"+postfix)
 
-   #make custom mapper to take postfix into account (could have gone with lambda of lambda but... )
-   def producerIsTauTypeMapperWithPostfix(tauProducer):
-       return lambda x: producerIsTauTypeMapper(tauProducer)+x.group(1)+postfix
+    #make custom mapper to take postfix into account (could have gone with lambda of lambda but... )
+    def producerIsTauTypeMapperWithPostfix(tauProducer):
+        return lambda x: producerIsTauTypeMapper(tauProducer)+x.group(1)+postfix
 
-   def recoTauTypeMapperWithGroup(tauProducer):
-       return "%s(.*)"%recoTauTypeMapper(tauProducer)
+    def recoTauTypeMapperWithGroup(tauProducer):
+        return "%s(.*)"%recoTauTypeMapper(tauProducer)
 
-   # Get our prediscriminants
-   for predisc in selectionDependsOn:
-      # Get the prototype
-      originalName = tauType+predisc # i.e. fixedConePFTauProducerDiscriminationByLeadingTrackFinding
-      clonedName = "pfTausBase"+predisc+postfix
-      clonedDisc = getattr(process, originalName).clone()
-      addToProcessAndTask(clonedName, clonedDisc, process, task)
+    # Get our prediscriminants
+    for predisc in selectionDependsOn:
+        # Get the prototype
+        originalName = tauType+predisc # i.e. fixedConePFTauProducerDiscriminationByLeadingTrackFinding
+        clonedName = "pfTausBase"+predisc+postfix
+        clonedDisc = getattr(process, originalName).clone()
+        addToProcessAndTask(clonedName, clonedDisc, process, task)
 
-      tauCollectionToSelect = None
-      if tauType != 'hpsPFTau' :
-          tauCollectionToSelect = "pfTausBase"+postfix
-          #cms.InputTag(clonedDisc.PFTauProducer.value()+postfix)
-      else:
-          tauCollectionToSelect = "hpsPFTauProducer"+postfix
-      # Adapt this discriminator for the cloned prediscriminators
-      adaptTauDiscriminator(clonedDisc, newTauProducer="pfTausBase",
-                            oldTauTypeMapper=recoTauTypeMapperWithGroup,
-                            newTauTypeMapper=producerIsTauTypeMapperWithPostfix,
-                            preservePFTauProducer=True)
-      clonedDisc.PFTauProducer = tauCollectionToSelect
+        tauCollectionToSelect = None
+        if tauType != 'hpsPFTau' :
+            tauCollectionToSelect = "pfTausBase"+postfix
+            #cms.InputTag(clonedDisc.PFTauProducer.value()+postfix)
+        else:
+            tauCollectionToSelect = "hpsPFTauProducer"+postfix
+        # Adapt this discriminator for the cloned prediscriminators
+        adaptTauDiscriminator(clonedDisc, newTauProducer="pfTausBase",
+                              oldTauTypeMapper=recoTauTypeMapperWithGroup,
+                              newTauTypeMapper=producerIsTauTypeMapperWithPostfix,
+                              preservePFTauProducer=True)
+        clonedDisc.PFTauProducer = tauCollectionToSelect
 
-   # Reconfigure the pf2pat PFTau selector discrimination sources
-   getattr(process,"pfTaus" + postfix).discriminators = cms.VPSet()
-   for selection in pf2patSelection:
-      # Get our discriminator that will be used to select pfTaus
-      originalName = tauType+selection
-      clonedName = "pfTausBase"+selection+postfix
-      clonedDisc = getattr(process, originalName).clone()
-      addToProcessAndTask(clonedName, clonedDisc, process, task)
+    # Reconfigure the pf2pat PFTau selector discrimination sources
+    getattr(process,"pfTaus" + postfix).discriminators = cms.VPSet()
+    for selection in pf2patSelection:
+        # Get our discriminator that will be used to select pfTaus
+        originalName = tauType+selection
+        clonedName = "pfTausBase"+selection+postfix
+        clonedDisc = getattr(process, originalName).clone()
+        addToProcessAndTask(clonedName, clonedDisc, process, task)
 
-      tauCollectionToSelect = None
+        tauCollectionToSelect = None
 
-      if tauType != 'hpsPFTau' :
-          tauCollectionToSelect = cms.InputTag("pfTausBase"+postfix)
-          #cms.InputTag(clonedDisc.PFTauProducer.value()+postfix)
-      else:
-          tauCollectionToSelect = cms.InputTag("hpsPFTauProducer"+postfix)
-      #Adapt our cloned discriminator to the new prediscriminants
-      adaptTauDiscriminator(clonedDisc, newTauProducer="pfTausBase",
-                            oldTauTypeMapper=recoTauTypeMapperWithGroup,
-                            newTauTypeMapper=producerIsTauTypeMapperWithPostfix,
-                            preservePFTauProducer=True)
-      clonedDisc.PFTauProducer = tauCollectionToSelect
+        if tauType != 'hpsPFTau' :
+            tauCollectionToSelect = cms.InputTag("pfTausBase"+postfix)
+            #cms.InputTag(clonedDisc.PFTauProducer.value()+postfix)
+        else:
+            tauCollectionToSelect = cms.InputTag("hpsPFTauProducer"+postfix)
+        #Adapt our cloned discriminator to the new prediscriminants
+        adaptTauDiscriminator(clonedDisc, newTauProducer="pfTausBase",
+                              oldTauTypeMapper=recoTauTypeMapperWithGroup,
+                              newTauTypeMapper=producerIsTauTypeMapperWithPostfix,
+                              preservePFTauProducer=True)
+        clonedDisc.PFTauProducer = tauCollectionToSelect
 
-      # Add this selection to our pfTau selectors
-      getattr(process,"pfTaus" + postfix).discriminators.append(cms.PSet(
-         discriminator=cms.InputTag(clonedName), selectionCut=cms.double(0.5)))
-      # Set the input of the final selector.
-      if tauType != 'hpsPFTau':
-          getattr(process,"pfTaus" + postfix).src = "pfTausBase"+postfix
-      else:
-          # If we are using HPS taus, we need to take the output of the clenaed
-          # collection
-          getattr(process,"pfTaus" + postfix).src = "hpsPFTauProducer"+postfix
+        # Add this selection to our pfTau selectors
+        getattr(process,"pfTaus" + postfix).discriminators.append(cms.PSet(
+           discriminator=cms.InputTag(clonedName), selectionCut=cms.double(0.5)))
+        # Set the input of the final selector.
+        if tauType != 'hpsPFTau':
+            getattr(process,"pfTaus" + postfix).src = "pfTausBase"+postfix
+        else:
+            # If we are using HPS taus, we need to take the output of the clenaed
+            # collection
+            getattr(process,"pfTaus" + postfix).src = "hpsPFTauProducer"+postfix
 
 
 
@@ -246,7 +246,7 @@ def adaptPFTaus(process,tauType = 'shrinkingConePFTau', postfix = ""):
     # to use preselected collection (old default) uncomment line below
     #applyPostfix(process,"patTaus", postfix).tauSource = cms.InputTag("pfTaus"+postfix)
 
-	### apparently not needed anymore, function gone from tauTools.py###
+        ### apparently not needed anymore, function gone from tauTools.py###
     #redoPFTauDiscriminators(process,
                             #cms.InputTag(tauType+'Producer'),
                             #applyPostfix(process,"patTaus", postfix).tauSource,
@@ -254,16 +254,16 @@ def adaptPFTaus(process,tauType = 'shrinkingConePFTau', postfix = ""):
 
 
     if tauType != 'hpsPFTau' :
-	switchToPFTauByType(process, pfTauType=tauType,
-				patTauLabel="pfTausBase"+postfix,
-				tauSource=cms.InputTag(tauType+'Producer'+postfix),
-				postfix=postfix)
+        switchToPFTauByType(process, pfTauType=tauType,
+                                patTauLabel="pfTausBase"+postfix,
+                                tauSource=cms.InputTag(tauType+'Producer'+postfix),
+                                postfix=postfix)
         getattr(process,"patTaus" + postfix).tauSource = cms.InputTag("pfTausBase"+postfix)
     else:
-	switchToPFTauByType(process, pfTauType=tauType,
-				patTauLabel="",
-				tauSource=cms.InputTag(tauType+'Producer'+postfix),
-				postfix=postfix)
+        switchToPFTauByType(process, pfTauType=tauType,
+                                patTauLabel="",
+                                tauSource=cms.InputTag(tauType+'Producer'+postfix),
+                                postfix=postfix)
         getattr(process,"patTaus" + postfix).tauSource = cms.InputTag("hpsPFTauProducer"+postfix)
 
 
@@ -354,7 +354,7 @@ def switchToPFJets(process, input=cms.InputTag('pfNoTauClones'), algo='AK4', pos
             applyPostfix(process, "patJetCorrFactors", postfix).useRho = True
             applyPostfix(process, "pfJetsPFBRECO", postfix).doAreaFastjet = True
             # do correct treatment for TypeI MET corrections
-	    #type1=True
+            #type1=True
             if type1:
                 for mod in process.producerNames().split(' '):
 
@@ -409,7 +409,7 @@ def usePF2PAT(process,runPF2PAT=True, jetAlgo='AK4', runOnMC=True, postfix="", j
     # CREATE ADDITIONAL FUNCTIONS IF NEEDED.
 
     if typeIMetCorrections:
-    	jetCorrections = (jetCorrections[0],jetCorrections[1],'Type-1')
+        jetCorrections = (jetCorrections[0],jetCorrections[1],'Type-1')
     """Switch PAT to use PF2PAT instead of AOD sources. if 'runPF2PAT' is true, we'll also add PF2PAT in front of the PAT sequence"""
 
     # -------- CORE ---------------
@@ -417,10 +417,10 @@ def usePF2PAT(process,runPF2PAT=True, jetAlgo='AK4', runOnMC=True, postfix="", j
     patAlgosToolsTask = getPatAlgosToolsTask(process)
     taskLabel = patAlgosToolsTask.label()
     if runPF2PAT:
-	loadWithPostfix(process,'PhysicsTools.PatAlgos.patSequences_cff',postfix, loadedProducersAndFilters=taskLabel)
-	loadWithPostfix(process,"CommonTools.ParticleFlow.PFBRECO_cff",postfix, loadedProducersAndFilters=taskLabel)
+        loadWithPostfix(process,'PhysicsTools.PatAlgos.patSequences_cff',postfix, loadedProducersAndFilters=taskLabel)
+        loadWithPostfix(process,"CommonTools.ParticleFlow.PFBRECO_cff",postfix, loadedProducersAndFilters=taskLabel)
     else:
-	loadWithPostfix(process,'PhysicsTools.PatAlgos.patSequences_cff',postfix, loadedProducersAndFilters=taskLabel)
+        loadWithPostfix(process,'PhysicsTools.PatAlgos.patSequences_cff',postfix, loadedProducersAndFilters=taskLabel)
 
 
 
@@ -450,7 +450,7 @@ def usePF2PAT(process,runPF2PAT=True, jetAlgo='AK4', runOnMC=True, postfix="", j
 
     else :
         if not 'L2L3Residual' in jetCorrections[1]:
-		### think of a more accurate warning
+                ### think of a more accurate warning
             print('#################################################')
             print('WARNING! Not using L2L3Residual but this is data.')
             print('If this is okay with you, disregard this message.')

--- a/PhysicsTools/PatUtils/python/tools/runJetUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runJetUncertainties.py
@@ -9,7 +9,7 @@ from PhysicsTools.PatUtils.tools.jmeUncertaintyTools import JetMEtUncertaintyToo
 from PhysicsTools.PatUtils.patPFMETCorrections_cff import *
 import RecoMET.METProducers.METSigParams_cfi as jetResolutions
 from PhysicsTools.PatAlgos.producersLayer1.metProducer_cfi import patMETs
- 
+
 class RunJetUncertainties(JetMEtUncertaintyTools):
 
     """ Produce collection of pat::Jets with jet energy and resolution shifted up/down,
@@ -19,7 +19,7 @@ class RunJetUncertainties(JetMEtUncertaintyTools):
     _defaultParameters = dicttypes.SortedKeysDict()
     def __init__(self):
         JetMEtUncertaintyTools.__init__(self)
-	self.addParameter(self._defaultParameters, 'dRjetCleaning', 0.5, 
+        self.addParameter(self._defaultParameters, 'dRjetCleaning', 0.5, 
                           "Eta-phi distance for extra jet cleaning", Type=float)
         self._parameters = copy.deepcopy(self._defaultParameters)
         self._comment = ""
@@ -68,9 +68,9 @@ class RunJetUncertainties(JetMEtUncertaintyTools):
             dRjetCleaning = self._defaultParameters['dRjetCleaning'].value
 
         self.setParameter('dRjetCleaning', dRjetCleaning)
-  
+
         self.apply(process) 
-        
+
     def toolCode(self, process):        
         electronCollection = self._parameters['electronCollection'].value
         photonCollection = self._parameters['photonCollection'].value
@@ -105,7 +105,7 @@ class RunJetUncertainties(JetMEtUncertaintyTools):
             self._addCleanedJets(process, jetCollection,
                                  electronCollection, photonCollection, muonCollection, tauCollection,
                                  jetUncertaintySequence, postfix)
-        
+
         # smear jet energies to account for difference in jet resolutions between MC and Data
         # (cf. JME-10-014 PAS)        
         jetCollectionResUp = None
@@ -148,18 +148,18 @@ class RunJetUncertainties(JetMEtUncertaintyTools):
         setattr(process, "shiftedParticlesForJetUncertainties" + postfix, shiftedParticleSequence)        
         jetUncertaintySequence += getattr(process, "shiftedParticlesForJetUncertainties" + postfix)
         collectionsToKeep.extend(addCollectionsToKeep)
-        
+
         # insert metUncertaintySequence into patDefaultSequence
         if addToPatDefaultSequence:
             if not hasattr(process, "patDefaultSequence"):
                 raise ValueError("PAT default sequence is not defined !!")
             process.patDefaultSequence += jetUncertaintySequence        
-       
+
         # add shifted + unshifted collections pf pat::Electrons/Photons,
         # Muons, Taus, Jets and MET to PAT-tuple event content
         if outputModule is not None and hasattr(process, outputModule):
             getattr(process, outputModule).outputCommands = _addEventContent(
                 getattr(process, outputModule).outputCommands,
                 [ 'keep *_%s_*_%s' % (collectionToKeep, process.name_()) for collectionToKeep in collectionsToKeep ])
-       
+
 runJetUncertainties = RunJetUncertainties()

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -18,10 +18,10 @@ def isValidInputTag(input):
 
 
 class RunMETCorrectionsAndUncertainties(ConfigToolBase):
-  
+
     _label='RunMETCorrectionsAndUncertainties'
     _defaultParameters=dicttypes.SortedKeysDict()
-    
+
     def __init__(self):
         ConfigToolBase.__init__(self)
         self.addParameter(self._defaultParameters, 'metType', "PF",
@@ -34,17 +34,17 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.addParameter(self._defaultParameters, 'produceIntermediateCorrections', False,
                           "enable/disable the production of all correction schemes (only for the most common)", Type=bool)
         self.addParameter(self._defaultParameters, 'electronCollection', cms.InputTag('selectedPatElectrons'),
-	                  "Input electron collection", Type=cms.InputTag, acceptNoneValue=True)
+                          "Input electron collection", Type=cms.InputTag, acceptNoneValue=True)
 #  empty default InputTag for photons to avoid double-counting wrt. cleanPatElectrons collection
-	self.addParameter(self._defaultParameters, 'photonCollection', cms.InputTag('selectedPatPhotons'),
-	                  "Input photon collection", Type=cms.InputTag, acceptNoneValue=True)
-	self.addParameter(self._defaultParameters, 'muonCollection', cms.InputTag('selectedPatMuons'),
+        self.addParameter(self._defaultParameters, 'photonCollection', cms.InputTag('selectedPatPhotons'),
+                          "Input photon collection", Type=cms.InputTag, acceptNoneValue=True)
+        self.addParameter(self._defaultParameters, 'muonCollection', cms.InputTag('selectedPatMuons'),
                           "Input muon collection", Type=cms.InputTag, acceptNoneValue=True)
-	self.addParameter(self._defaultParameters, 'tauCollection', cms.InputTag('selectedPatTaus'),
+        self.addParameter(self._defaultParameters, 'tauCollection', cms.InputTag('selectedPatTaus'),
                           "Input tau collection", Type=cms.InputTag, acceptNoneValue=True)
-	self.addParameter(self._defaultParameters, 'jetCollectionUnskimmed', cms.InputTag('patJets'),
+        self.addParameter(self._defaultParameters, 'jetCollectionUnskimmed', cms.InputTag('patJets'),
                           "Input unskimmed jet collection for T1 MET computation", Type=cms.InputTag, acceptNoneValue=True)
-	self.addParameter(self._defaultParameters, 'pfCandCollection', cms.InputTag('particleFlow'),
+        self.addParameter(self._defaultParameters, 'pfCandCollection', cms.InputTag('particleFlow'),
                           "pf Candidate collection", Type=cms.InputTag, acceptNoneValue=True)
         self.addParameter(self._defaultParameters, 'autoJetCleaning', 'LepClean',
                           "Enable the jet cleaning for the uncertainty computation: Full for tau/photons/jet cleaning, Partial for jet cleaning, LepClean for jet cleaning with muon and electrons only, None or Manual for no cleaning", Type=str)
@@ -61,7 +61,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                           "Extra JES uncertainty file", Type=str)
         self.addParameter(self._defaultParameters, 'jecUncertaintyTag', None,
                           "JES uncertainty Tag", acceptNoneValue=True) # Type=str,
-        
+
         self.addParameter(self._defaultParameters, 'mvaMetLeptons',["Electrons","Muons"],
                           "Leptons to be used for recoil computation in the MVA MET, available values are: Electrons, Muons, Taus, Photons", allowedValues=["Electrons","Muons","Taus","Photons",""])
 
@@ -69,7 +69,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                           "Flag to enable/disable that metUncertaintySequence is inserted into patDefaultSequence", Type=bool)
         self.addParameter(self._defaultParameters, 'manualJetConfig', False,
                   "Enable jet configuration options", Type=bool)
-	self.addParameter(self._defaultParameters, 'jetSelection', 'pt>15 && abs(eta)<9.9',
+        self.addParameter(self._defaultParameters, 'jetSelection', 'pt>15 && abs(eta)<9.9',
                           "Advanced jet kinematic selection", Type=str)
         self.addParameter(self._defaultParameters, 'recoMetFromPFCs', False,
                   "Recompute the MET from scratch using the pfCandidate collection", Type=bool)
@@ -169,7 +169,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             jecUncertaintyFile = self._defaultParameters['jecUncertaintyFile'].value
         if jecUncertaintyTag  is None:
             jecUncertaintyTag = self._defaultParameters['jecUncertaintyTag'].value
-            
+
         if mvaMetLeptons is None:
             mvaMetLeptons = self._defaultParameters['mvaMetLeptons'].value
 
@@ -213,7 +213,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.setParameter('jecUncertaintyTag',jecUncertaintyTag),
 
         self.setParameter('mvaMetLeptons',mvaMetLeptons),
-        
+
         self.setParameter('addToPatDefaultSequence',addToPatDefaultSequence),
         self.setParameter('jetSelection',jetSelection),
         self.setParameter('recoMetFromPFCs',recoMetFromPFCs),
@@ -233,7 +233,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if metType == "Puppi":
             self.setParameter('metType',"PF") 
             self.setParameter('Puppi',True) 
-            
+
         #jet energy scale uncertainty needs
         if manualJetConfig:
             self.setParameter('CHS',CHS)
@@ -243,11 +243,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         else:
              #internal jet configuration
             self.jetConfiguration()
-        
+
         #met reprocessing and jet reclustering
         if recoMetFromPFCs:
             self.setParameter('reclusterJets',True)
-        
+
         #ZD: puppi jet reclustering breaks the puppi jets
         #overwriting of jet reclustering parameter for puppi
         if self._parameters["Puppi"].value and not onMiniAOD:
@@ -256,9 +256,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #jet collection overloading for automatic jet reclustering or JEC application
         if reclusterJets:
             self.setParameter('jetCollectionUnskimmed',cms.InputTag('patJets'))
-            
+
         self.apply(process)
-        
+
 
     def toolCode(self, process):
         metType                 = self._parameters['metType'].value
@@ -286,7 +286,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         reclusterJets           = self._parameters['reclusterJets'].value
         onMiniAOD               = self._parameters['onMiniAOD'].value
         postfix                 = self._parameters['postfix'].value
-        
+
         #prepare jet configuration
         jetUncInfos = { "jCorrPayload":jetFlavor, "jCorLabelUpToL3":jetCorLabelUpToL3,
                         "jCorLabelL3Res":jetCorLabelL3Res, "jecUncFile":jecUncertaintyFile,
@@ -296,7 +296,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             jetUncInfos[ "jecUncTag" ] = ""
         elif(jecUncertaintyTag!=None):
             jetUncInfos[ "jecUncTag" ] = jecUncertaintyTag
-            
+
         patMetModuleSequence = cms.Sequence()
 
         # recompute the MET (and thus the jets as well for correction) from scratch
@@ -306,21 +306,21 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                          onMiniAOD,
                                          patMetModuleSequence,
                                          postfix)
-            
+
         elif onMiniAOD: #raw MET extraction if running on miniAODs
             self.extractMET(process, "raw", patMetModuleSequence, postfix)
 
         #jet AK4 reclustering if needed for JECs
-        
+
         if reclusterJets:
             jetCollectionUnskimmed = self.ak4JetReclustering(process, pfCandCollection, 
                                                              patMetModuleSequence, postfix)
-        
+
         # or reapplication of jecs
         if onMiniAOD:
             if not reclusterJets and reapplyJEC:
                 jetCollectionUnskimmed = self.updateJECs(process, jetCollectionUnskimmed, patMetModuleSequence, postfix)
-                
+
 
         #getting the jet collection that will be used for corrections 
         #and uncertainty computation
@@ -330,16 +330,16 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                             autoJetCleaning,
                                                             patMetModuleSequence,
                                                             postfix)
-        
+
         #pre-preparation to run over miniAOD 
         if onMiniAOD:            
             self.miniAODConfigurationPre(process, patMetModuleSequence, pfCandCollection, postfix)
 
         #default MET production
         self.produceMET(process, metType,patMetModuleSequence, postfix)
-        
-            
-        
+
+
+
         #preparation to run over miniAOD (met reproduction) 
         if onMiniAOD:
             self.miniAODConfiguration(process, 
@@ -370,7 +370,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if self._parameters["Puppi"].value:
                 getattr(process,"patPFMetT1T2SmearCorr"+postfix).offsetCorrLabel = cms.InputTag("")
 
- 
+
         #compute the uncertainty on the MET
         patMetUncertaintySequence = cms.Sequence()
         tmpUncSequence =cms.Sequence()
@@ -390,7 +390,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                                   jetCollection,
                                                                   jetUncInfos,
                                                                   postfix)
-        
+
         if not hasattr(process, "patMetCorrectionSequence"+postfix):
             setattr(process, "patMetCorrectionSequence"+postfix, patMetCorrectionSequence)
         if not hasattr(process, "patMetUncertaintySequence"+postfix):
@@ -401,7 +401,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 setattr(process, metModName+"patMetUncertaintySequence"+postfix , tmpUncSequence)
                 tmpSeq = getattr(process, "patMetUncertaintySequence"+postfix)
                 tmpSeq += getattr(process, metModName+"patMetUncertaintySequence"+postfix)
-                
+
         if not hasattr(process, "patShiftedModuleSequence"+postfix):
             setattr(process, "patShiftedModuleSequence"+postfix, patShiftedModuleSequence)
         else:
@@ -409,17 +409,17 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 setattr(process, metModName+"patShiftedModuleSequence"+postfix , patShiftedModuleSequence)
                 tmpSeq = getattr(process, "patShiftedModuleSequence"+postfix)              
                 tmpSeq += getattr(process, metModName+"patShiftedModuleSequence"+postfix)
-                
+
         if not hasattr(process, "patMetModuleSequence"+postfix):
             setattr(process, "patMetModuleSequence"+postfix, patMetModuleSequence)
-        
+
         #prepare and fill the final sequence containing all the sub-sequence
         fullPatMetSequence = cms.Sequence()
         fullPatMetSequence += getattr(process, "patMetModuleSequence"+postfix)
         fullPatMetSequence += getattr(process, "patMetCorrectionSequence"+postfix)
         fullPatMetSequence += getattr(process, "patMetUncertaintySequence"+postfix)
         fullPatMetSequence += getattr(process, "patShiftedModuleSequence"+postfix)
-        
+
         #adding the slimmed MET
         if hasattr(process, "patCaloMet"):
             fullPatMetSequence +=getattr(process, "patCaloMet")
@@ -433,13 +433,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         #last modification for miniAODs
         self.miniAODConfigurationPost(process, postfix)
-        
+
         # insert the fullPatMetSequence into patDefaultSequence if needed
         if addToPatDefaultSequence:
             if not hasattr(process, "patDefaultSequence"):
                 raise ValueError("PAT default sequence is not defined !!")
             process.patDefaultSequence += getattr(process, "fullPatMetSequence"+postfix)
-    
+
 #====================================================================================================
     def produceMET(self, process,  metType, metModuleSequence, postfix):
 
@@ -458,11 +458,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             addToProcessAndTask('pat'+metType+'Met'+postfix,  getattr(process,'patPFMet' ).clone(), process, task)
             getattr(process, "patPFMet"+postfix).metSource = cms.InputTag("pfMet"+postfix)
             getattr(process, "patPFMet"+postfix).srcPFCands = self._parameters["pfCandCollection"].value
-        
+
         if self._parameters["runOnData"].value:
             getattr(process, "patPFMet"+postfix).addGenMET  = False
-           
-            
+
+
         #MM: FIXME MVA
         if metType == "MVA": # and not hasattr(process, 'pat'+metType+'Met'):
            # process.load("PhysicsTools.PatUtils.patPFMETCorrections_cff")
@@ -477,14 +477,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 #====================================================================================================
     def getCorrectedMET(self, process, metType, correctionLevel,produceIntermediateCorrections, 
                         jetCollection, metModuleSequence, postfix ):
-        
+
         # default outputs
         patMetCorrectionSequence = cms.Sequence()
         metModName = "pat"+metType+"Met"+postfix
-       
+
         if metType == "MVA": #corrections are irrelevant for the MVA MET (except jet smearing?)
             return patMetCorrectionSequence, metModName
-                           
+
         corNames = { #not really needed but in case we have changes in the future....
             "T0":"T0pc",
             "T1":"T1",
@@ -492,8 +492,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             "Txy":"Txy",
             "Smear":"Smear",
             }
-        
-        
+
+
         #if empty correction level, no need to try something
         for cor in correctionLevel:
             if cor not in corNames.keys():
@@ -524,11 +524,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 configtools.cloneProcessingSnippet(process, getattr(process,"patPFMetSmearCorrSequence"), postfix, addToTask = True)
             if not hasattr(process, "patPFMetT2SmearCorrSequence"+postfix):
                 configtools.cloneProcessingSnippet(process, getattr(process,"patPFMetT2SmearCorrSequence"), postfix, addToTask = True)
-           
+
         corModules = {}
         for mod in corModNames.keys():
             corModules[mod] = getattr(process, corModNames[mod] )
-                  
+
         corTags = {
             #"T0":cms.InputTag('patPFMetT0Corr'+postfix),
             #"T1":cms.InputTag('patPFMetT1T2Corr'+postfix, 'type1'),
@@ -560,13 +560,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #if both are here, consider smeared corJets for the full T1+Smear correction
         if "T1" in correctionLevel and "Smear" in correctionLevel:
             corrections.remove(cms.InputTag(corTags["T1"][0],corTags["T1"][1]))
-            
+
         #Txy parameter tuning
         if "Txy" in correctionLevel:
             self.tuneTxyParameters(process, corScheme, postfix)
             getattr(process, "patPFMetTxyCorr"+postfix).srcPFlow = self._parameters["pfCandCollection"].value
-            
-     
+
+
         #Enable MET significance if the type1 MET is computed
         if "T1" in correctionLevel:
             getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(True)
@@ -601,7 +601,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, "corrPfMetType1"+postfix).jetCorrLabelRes = cms.InputTag("ak4PFL1FastL2L3ResidualCorrector")
             getattr(process, "corrPfMetType1"+postfix).offsetCorrLabel = cms.InputTag("ak4PFL1FastjetCorrector")
             getattr(process, "basicJetsForMet"+postfix).offsetCorrLabel = cms.InputTag("ak4PFL1FastjetCorrector")
-        
+
         if "T1" in correctionLevel and self._parameters["Puppi"].value:  
             addToProcessAndTask("corrPfMetType1"+postfix, getattr(process, "corrPfMetType1" ).clone(), process, task)
             getattr(process, "corrPfMetType1"+postfix).src =  cms.InputTag("ak4PFJets"+postfix)
@@ -624,34 +624,34 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                        srcCorrections = cms.VInputTag(corrections)
                      )
             sequenceName="patMetCorrectionSequence"
-            
+
         #MM: FIXME MVA
         #if metType == "MVA":
         #    return patMetCorrectionSequence, metModName #FIXME
         #    corMetProducer = self.createMVAMETModule(process)
         #    sequenceName="pfMVAMEtSequence"
-            
+
         addToProcessAndTask(metModName, corMetProducer, process, task)
 
         # adding the full sequence only if it does not exist
         if not hasattr(process, sequenceName+postfix):
-            
+
             for corModule in correctionSequence:
                 patMetCorrectionSequence += corModule
-                
+
             setattr(process, sequenceName+postfix, patMetCorrectionSequence)
-            
+
         else: #if it exists, only add the missing correction modules, no need to redo everything
             patMetCorrectionSequence = getattr(process, "patMetCorrectionSequence"+postfix)#cms.Sequence()
-            
+
             #setattr(process, sequenceName+postfix,patMetCorrectionSequence)
             for cor in corModNames.keys():
                 if not configtools.contains(patMetCorrectionSequence, corTags[cor][0]) and cor in correctionLevel:
                     patMetCorrectionSequence += corModules[cor]
-                    
+
         #plug the main patMetproducer
         patMetCorrectionSequence += getattr(process, metModName)
-        
+
         #create the intermediate MET steps
         #and finally add the met producers in the sequence for scheduled mode
         if produceIntermediateCorrections:
@@ -661,7 +661,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 patMetCorrectionSequence += getattr(process, met)
 
         return patMetCorrectionSequence, metModName
-                
+
 
 #====================================================================================================
     def addIntermediateMETs(self, process, metType, correctionLevel, corScheme, corTags, corNames, postfix):
@@ -682,16 +682,16 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             for j in range(nCor):
                 ids[j] = tmp%nCor
                 tmp = tmp//nCor
-                
+
                 if j != 0 and ids[j-1] < ids[j]:
                     exists=True
                 for k in range(0,j):
                     if ids[k] == ids[j] and ids[k]!=0:
                         exists=True
-                            
+
             if exists or sum(ids[j] for j in range(nCor))==0:
                 continue
-            
+
             for cor in range(nCor):
                 cid = ids[nCor-cor-1]
                 cKey = correctionLevel[cid-1]
@@ -707,23 +707,23 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             corName='pat'+metType+'Met' + corName + postfix
             if configtools.contains(getattr(process,"patMetCorrectionSequence"+postfix), corName ) and hasattr(process, corName):
                 continue
-            
+
             interMets[corName] =  cms.EDProducer("CorrectedPATMETProducer",
                  src = cms.InputTag('pat'+metType+'Met' + postfix),
                  srcCorrections = cms.VInputTag(corrections)
                )
-        
+
 
         return interMets
 
-                
+
 #====================================================================================================
     def getMETUncertainties(self, process, metType, metModName, electronCollection,
                             photonCollection, muonCollection, tauCollection, 
                             pfCandCollection, jetCollection, jetUncInfos, 
                             postfix):
 
-        
+
         # uncertainty sequence
         metUncSequence = cms.Sequence()
         shiftedModuleSequence = cms.Sequence()
@@ -741,7 +741,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 preId="Smeared"
 
             metJERUncModules = self.getVariations(process, metModName, "Jet",preId, jetCollection, "Res", metUncSequence, postfix=postfix )
-            
+
             for mod in metJERUncModules.keys():
                 addToProcessAndTask(mod, metJERUncModules[mod], process, task)
                 shiftedModuleSequence += getattr(process, mod)
@@ -758,7 +758,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                            )
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
-                
+
             #electron projection ==
             pfCandsNoJetsNoEle = cms.EDProducer("CandPtrProjector", 
                                                 src = cms.InputTag("pfCandsNoJets"+postfix),
@@ -766,7 +766,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                 )
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
-        
+
             #muon projection ==
             pfCandsNoJetsNoEleNoMu = cms.EDProducer("CandPtrProjector", 
                                               src = cms.InputTag("pfCandsNoJetsNoEle"+postfix),
@@ -801,18 +801,18 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                               "Unclustered":cms.InputTag("pfCandsForUnclusteredUnc"+postfix),
                               "Tau":tauCollection,
                               }
-        
+
         for obj in objectCollections.keys():
             if not isValidInputTag(objectCollections[obj]): # or objectCollections[obj]=="":
                 print("INFO : %s collection %s does not exists, no energy scale shifting will be performed in MET uncertainty tools" %(obj, objectCollections[obj]))
             else:
                 metObjUncModules = self.getVariations(process, metModName, obj,"", objectCollections[obj], "En", metUncSequence, jetUncInfos, postfix )
-                
+
                 #adding the shifted MET produced to the proper patMetModuleSequence
                 for mod in metObjUncModules.keys():
                     addToProcessAndTask(mod, metObjUncModules[mod], process, task)
                     shiftedModuleSequence += getattr(process, mod)
-                    
+
         #return the sequence containing the shifted collections producers
         return metUncSequence, shiftedModuleSequence
 
@@ -821,14 +821,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                          varyByNsigmas, jetUncInfos=None, postfix=""):
 
         shiftedModuleUp = None
-        
+
         if identifier == "Electron":
             shiftedModuleUp = cms.EDProducer("ShiftedParticleProducer",
                                              src = objectCollection,
                                              uncertainty = cms.string('((abs(y)<1.479)?(0.006+0*x):(0.015+0*x))'),
                                              shiftBy = cms.double(+1.*varyByNsigmas)
                                              )
-            
+
         if identifier == "Photon":
             shiftedModuleUp = cms.EDProducer("ShiftedParticleProducer",
                                              src = objectCollection,
@@ -842,7 +842,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                              uncertainty = cms.string('((x<100)?(0.002+0*y):(0.05+0*y))'),
                                              shiftBy = cms.double(+1.*varyByNsigmas)
                                              )
-            
+
         if identifier == "Tau":
             shiftedModuleUp = cms.EDProducer("ShiftedParticleProducer",
                                              src = objectCollection,
@@ -918,7 +918,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 #====================================================================================================
     def removePostfix(self, name, postfix):
-        
+
         if postfix=="":
             return name
 
@@ -927,7 +927,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             baseName = baseName[0:-len(postfix)]
         else:
             raise Exception("Tried to remove postfix %s from %s, but it wasn't there" % (postfix, baseName))
-        
+
         return baseName
 
 #====================================================================================================
@@ -956,7 +956,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             "T0pcT1SmearTxy_25ns":metCors.patMultPhiCorrParams_T0pcT1SmearTxy_25ns,
             "T0pcT1T2SmearTxy_25ns":metCors.patMultPhiCorrParams_T0pcT1T2SmearTxy_25ns
             }
-        
+
         getattr(process, "patPFMetTxyCorr"+postfix).parameters = xyTags[corScheme+"_25ns"] 
         ##for automatic switch to 50ns / 25ns corrections ==> does not work...
         #from Configuration.StandardSequences.Eras import eras
@@ -979,7 +979,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         #create the shifted collection producers=========================================
         shiftedCollModules = {'Up':None, 'Down':None}
-        
+
         if identifier=="Jet" and varType=="Res":
             smear=False
             if "Smear" in metModName:
@@ -1015,7 +1015,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 #========================================================================================
     def copyCentralMETProducer(self, process, shiftedCollModules, identifier, metModName, varType, postfix):
-        
+
         # remove the postfix to put it at the end
         shiftedMetProducers = {}
         baseName = self.removePostfix(metModName, postfix)
@@ -1029,7 +1029,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 #========================================================================================
     def createShiftedJetResModule(self, process, smear, objectCollection, varyByNsigmas, varDir, postfix ):
-        
+
         smearedJetModule = self.createSmearedJetModule(process, objectCollection, smear, varyByNsigmas, varDir, postfix)
 
         return smearedJetModule
@@ -1045,7 +1045,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         # remove the postfix to put it at the end
         baseName = self.removePostfix(metModName, postfix)
-       
+
         #adding the shifted collection producers to the sequence, create the shifted MET correction Modules and add them as well
         for mod in shiftedCollModules.keys():
             modName = "shiftedPat"+preId+identifier+varType+mod+postfix
@@ -1055,7 +1055,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if not hasattr(process, modName):
                 addToProcessAndTask(modName, shiftedCollModules[mod], process, task)
                 metUncSequence += getattr(process, modName)
-            
+
             #removing the uncorrected
             modName = "shiftedPat"+preId+identifier+varType+mod+postfix
 
@@ -1067,7 +1067,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 if not hasattr(process, modMETShiftName):
                     addToProcessAndTask(modMETShiftName, shiftedMETCorrModule, process, task)
                     metUncSequence += getattr(process, modMETShiftName)
-                
+
                 #and finally prepare the shifted MET producers
                 modName = baseName+identifier+varType+mod+postfix
                 shiftedMETModule = getattr(process, metModName).clone(
@@ -1105,7 +1105,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #        setattr(process, puJetIdName, puJetIdProducer)
             #        metUncSequence += getattr(process, puJetIdName)
             #        shiftedMETModule.srcMVAPileupJetId = cms.InputTag(puJetIdName,"fullDiscriminant")
-             
+
            #==========================================================================================
 
         return shiftedMetProducers
@@ -1153,7 +1153,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if identifier == "Jet":
                 corJetCollection = cms.InputTag(shiftedCollection)
                 uncorJetCollection = cms.InputTag("uncorrected"+shiftedCollection)
-                
+
 
         #leptons
         mvaMetLeptons = self._parameters["mvaMetLeptons"].value
@@ -1182,7 +1182,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         if not hasattr(process, "pfCandsNotInJetsForMetCorr"):
             process.load("JetMETCorrections.Type1MET.correctionTerms.PfMetType1Type2_cff")
- 
+
         #MM: it's bloody stupid to make it that way....
         # compute the shifted particles ====
         unclCandModule = cms.EDProducer("ShiftedPFCandidateProducer",
@@ -1192,8 +1192,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                         )
         setattr(process, "pfCandsNotInJetsUnclusteredEn"+var+postfix, unclCandModule)
         metUncSequence += getattr(process, "pfCandsNotInJetsUnclusteredEn"+var+postfix)
-            
-     
+
+
 
         #replace the old unclustered particles by the shifted ones....
         pfCandCollection = self._parameters["pfCandCollection"].value
@@ -1226,7 +1226,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 #========================================================================================
     def createSmearedJetModule(self, process, jetCollection, smear, varyByNsigmas, varDir, postfix):
-        
+
         smearedJetModule = None
 
         modName = "pat"
@@ -1236,8 +1236,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             selJetModName += "SmearCorr"
         else:
             modName += "Jets"
-            
-            
+
+
         if varDir != "":
             modName += "Res"+varDir
             selJetModName += "Res"+varDir
@@ -1320,12 +1320,12 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, "pfMet"+postfix).src = pfCandCollection
             getattr(process, "pfMet"+postfix).calculateSignificance = False
             patMetModuleSequence += getattr(process, "pfMet"+postfix)
-            
+
             #PAT METs
             process.load("PhysicsTools.PatAlgos.producersLayer1.metProducer_cff")
             task.add(process.makePatMETsTask)
             configtools.cloneProcessingSnippet(process, getattr(process,"patMETCorrections"), postfix, addToTask = True)
-                  
+
             #T1 pfMet for AOD to mAOD only
             if not onMiniAOD: #or self._parameters["Puppi"].value:
                 #correction duplication needed
@@ -1337,7 +1337,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(True)
                 if postfix=="NoHF":
                     getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(False)
-                
+
                 if self._parameters["Puppi"].value:
                     getattr(process, 'patMETs'+postfix).srcPFCands = cms.InputTag('puppiForMET')
                     getattr(process, 'patMETs'+postfix).srcJets = cms.InputTag('cleanedPatJets'+postfix)
@@ -1360,25 +1360,25 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         else:
             addToProcessAndTask("met"+correctionLevel+postfix, pfMet, process, task)
             patMetModuleSequence += getattr(process, "met"+correctionLevel+postfix)
-   
+
         if not hasattr(process, "genMetExtractor"+postfix) and not self._parameters["runOnData"].value:
             genMetExtractor = cms.EDProducer("GenMETExtractor",
                                              metSource= cms.InputTag("slimmedMETs",processName=cms.InputTag.skipCurrentProcess())
                                              )
             addToProcessAndTask("genMetExtractor"+postfix, genMetExtractor, process, task)
             patMetModuleSequence += getattr(process, "genMetExtractor"+postfix)
-                                             
-        
+
+
     def updateJECs(self,process,jetCollection, patMetModuleSequence, postfix):
         from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors
-        
+
         patJetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
             src = cms.InputTag("slimmedJets" if not self._parameters["Puppi"].value else "slimmedJetsPuppi"),
             levels = ['L1FastJet', 
                       'L2Relative', 
                       'L3Absolute'],
             payload = 'AK4PFchs' if not self._parameters["Puppi"].value else 'AK4PFPuppi' ) # always CHS from miniAODs, except for puppi
-        
+
         if self._parameters["runOnData"].value:
             patJetCorrFactorsReapplyJEC.levels.append("L2L3Residual")
 
@@ -1417,7 +1417,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                          )
         addToProcessAndTask("basicJetsForMet"+postfix, basicJetsForMet, process, task)
         patMetModuleSequence += getattr(process, "basicJetsForMet"+postfix)
-        
+
         from PhysicsTools.PatAlgos.selectionLayer1.jetSelector_cfi import selectedPatJets
         jetSelector = selectedPatJets.clone(
             src = cms.InputTag("basicJetsForMet"+postfix),
@@ -1425,14 +1425,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             )
         addToProcessAndTask("jetSelectorForMet"+postfix, jetSelector, process, task)
         patMetModuleSequence += getattr(process, "jetSelectorForMet"+postfix)
-        
+
         jetCollection = self.jetCleaning(process, "jetSelectorForMet"+postfix, autoJetCleaning, patMetModuleSequence, postfix)
 
         return jetCollection
 
 
     def ak4JetReclustering(self,process, pfCandCollection, patMetModuleSequence, postfix):
-        
+
         task = getPatAlgosToolsTask(process)
 
         chs = self._parameters["CHS"].value
@@ -1475,7 +1475,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             addToProcessAndTask(jetColName, ak4PFJets.clone(), process, task)
             getattr(process, jetColName).src = pfCandColl 
             getattr(process, jetColName).doAreaFastjet = True
-            
+
             #puppi
             if self._parameters["Puppi"].value:
                 getattr(process, jetColName).src = cms.InputTag("puppi")
@@ -1491,7 +1491,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                 jetCorrections = ('AK4PF'+CHSname, corLevels , ''),
                                 postfix=postfix
                                 )
-            
+
             getattr(process,"patJets"+postfix).addGenJetMatch = False 
             getattr(process,"patJets"+postfix).addGenPartonMatch = False 
             getattr(process,"patJets"+postfix).addPartonJetMatch = False 
@@ -1503,7 +1503,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 del getattr(process,"patJets"+postfix).genPartonMatch
                 del getattr(process,"patJets"+postfix).genJetMatch
             getattr(process,"patJets"+postfix).getJetMCFlavour = False
-            
+
             getattr(process,"patJetCorrFactors"+postfix).src=cms.InputTag(jetColName)
             getattr(process,"patJetCorrFactors"+postfix).primaryVertices= cms.InputTag("offlineSlimmedPrimaryVertices")
             if self._parameters["Puppi"].value:
@@ -1512,69 +1512,69 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             patMetModuleSequence += getattr(process, "patJets"+postfix)
 
         return cms.InputTag("patJets"+postfix)
-        
+
 
 
     def miniAODConfigurationPre(self, process, patMetModuleSequence, pfCandCollection, postfix):
-        
+
             #extractor for caloMET === temporary for the beginning of the data taking
-            self.extractMET(process,"rawCalo",patMetModuleSequence,postfix)
-            caloMetName="metrawCalo" if hasattr(process,"metrawCalo") else "metrawCalo"+postfix
-            from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
-            addMETCollection(process,
-                             labelName = "patCaloMet",
-                             metSource = caloMetName
-                             )
-            getattr(process,"patCaloMet").addGenMET = False
+        self.extractMET(process,"rawCalo",patMetModuleSequence,postfix)
+        caloMetName="metrawCalo" if hasattr(process,"metrawCalo") else "metrawCalo"+postfix
+        from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
+        addMETCollection(process,
+                         labelName = "patCaloMet",
+                         metSource = caloMetName
+                         )
+        getattr(process,"patCaloMet").addGenMET = False
 
-            ##adding the necessary chs and track met configuration
-            task = getPatAlgosToolsTask(process)
+        ##adding the necessary chs and track met configuration
+        task = getPatAlgosToolsTask(process)
 
-            pfCHS = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0)>0"))
-            addToProcessAndTask("pfCHS", pfCHS, process, task)
-            pfMetCHS = cms.EDProducer("PFMETProducer",
-                                      src = cms.InputTag('pfCHS'),
-                                      alias = cms.string('pfMet'),
-                                      globalThreshold = cms.double(0.0),
-                                      calculateSignificance = cms.bool(False),
-                                      )            
+        pfCHS = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0)>0"))
+        addToProcessAndTask("pfCHS", pfCHS, process, task)
+        pfMetCHS = cms.EDProducer("PFMETProducer",
+                                  src = cms.InputTag('pfCHS'),
+                                  alias = cms.string('pfMet'),
+                                  globalThreshold = cms.double(0.0),
+                                  calculateSignificance = cms.bool(False),
+                                  )            
 
-            addToProcessAndTask("pfMetCHS", pfMetCHS, process, task)
+        addToProcessAndTask("pfMetCHS", pfMetCHS, process, task)
 
-            addMETCollection(process,
-                             labelName = "patCHSMet",
-                             metSource = "pfMetCHS"
-                             )
+        addMETCollection(process,
+                         labelName = "patCHSMet",
+                         metSource = "pfMetCHS"
+                         )
 
-            process.patCHSMet.computeMETSignificant = cms.bool(False)
-            process.patCHSMet.addGenMET = cms.bool(False)
+        process.patCHSMet.computeMETSignificant = cms.bool(False)
+        process.patCHSMet.addGenMET = cms.bool(False)
 
-            patMetModuleSequence += getattr(process, "pfCHS")
-            patMetModuleSequence += getattr(process, "pfMetCHS")
-            patMetModuleSequence += getattr(process, "patCHSMet")
+        patMetModuleSequence += getattr(process, "pfCHS")
+        patMetModuleSequence += getattr(process, "pfMetCHS")
+        patMetModuleSequence += getattr(process, "patCHSMet")
 
-            pfTrk = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0) > 0 && charge()!=0"))
-            addToProcessAndTask("pfTrk", pfTrk, process, task)
-            pfMetTrk = cms.EDProducer("PFMETProducer",
-                                      src = cms.InputTag('pfTrk'),
-                                      alias = cms.string('pfMet'),
-                                      globalThreshold = cms.double(0.0),
-                                      calculateSignificance = cms.bool(False),
-                                      )            
+        pfTrk = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0) > 0 && charge()!=0"))
+        addToProcessAndTask("pfTrk", pfTrk, process, task)
+        pfMetTrk = cms.EDProducer("PFMETProducer",
+                                  src = cms.InputTag('pfTrk'),
+                                  alias = cms.string('pfMet'),
+                                  globalThreshold = cms.double(0.0),
+                                  calculateSignificance = cms.bool(False),
+                                  )            
 
-            addToProcessAndTask("pfMetTrk", pfMetTrk, process, task)
+        addToProcessAndTask("pfMetTrk", pfMetTrk, process, task)
 
-            addMETCollection(process,
-                             labelName = "patTrkMet",
-                             metSource = "pfMetTrk"
-                             )
+        addMETCollection(process,
+                         labelName = "patTrkMet",
+                         metSource = "pfMetTrk"
+                         )
 
-            process.patTrkMet.computeMETSignificant = cms.bool(False)
-            process.patTrkMet.addGenMET = cms.bool(False)
+        process.patTrkMet.computeMETSignificant = cms.bool(False)
+        process.patTrkMet.addGenMET = cms.bool(False)
 
-            patMetModuleSequence += getattr(process, "pfTrk")
-            patMetModuleSequence += getattr(process, "pfMetTrk")
-            patMetModuleSequence += getattr(process, "patTrkMet")
+        patMetModuleSequence += getattr(process, "pfTrk")
+        patMetModuleSequence += getattr(process, "pfMetTrk")
+        patMetModuleSequence += getattr(process, "patTrkMet")
 
 
     def miniAODConfigurationPost(self, process, postfix):
@@ -1601,8 +1601,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if not self._parameters["runOnData"].value:
                 getattr(process, "patPFMet"+postfix).addGenMET  = True
                 getattr(process, "patPFMet"+postfix).genMETSource = cms.InputTag("genMetExtractor"+postfix)
-                   
-                
+
+
         if "Smear" in self._parameters['correctionLevel'].value:
             getattr(process, "patSmearedJets"+postfix).genJets = cms.InputTag("slimmedGenJets")
 
@@ -1626,7 +1626,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
             getattr(process,"slimmedMETs"+postfix).runningOnMiniAOD = True
             getattr(process,"slimmedMETs"+postfix).t01Variation = cms.InputTag("slimmedMETs" if not self._parameters["Puppi"].value else "slimmedMETsPuppi",processName=cms.InputTag.skipCurrentProcess())
-         
+
 
             #smearing and type0 variations not yet supported in reprocessing
             #del getattr(process,"slimmedMETs"+postfix).t1SmearedVarsAndUncs
@@ -1654,7 +1654,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             self.setParameter("CHS",False)
             jetCorLabelUpToL3Name += "Puppi"
             jetCorLabelL3ResName += "Puppi"
-            
+
         else:
             self.setParameter("CHS",False)
 
@@ -1668,7 +1668,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         self.setParameter("jetCorLabelUpToL3",jetCorLabelUpToL3Name )
         self.setParameter("jetCorLabelL3Res",jetCorLabelL3ResName )
-        
+
     # function enabling the auto jet cleaning for uncertainties ===============
     def jetCleaning(self, process, jetCollectionName, autoJetCleaning, jetProductionSequence, postfix ):
 
@@ -1680,7 +1680,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         muonCollection = self._parameters["muonCollection"].value
         photonCollection = self._parameters["photonCollection"].value
         tauCollection = self._parameters["tauCollection"].value
-        
+
         task = getPatAlgosToolsTask(process)
 
         if autoJetCleaning == "Full" : # auto clean taus, photons and jets
@@ -1695,7 +1695,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 addToProcessAndTask("cleanedPatTaus"+postfix, cleanPatTauProducer, process, task)
                 jetProductionSequence += getattr(process, "cleanedPatTaus"+postfix)
                 tauCollection = cms.InputTag("cleanedPatTaus"+postfix)
-            
+
             if isValidInputTag(photonCollection): 
                 process.load("PhysicsTools.PatAlgos.cleaningLayer1.photonCleaner_cfi")
                 task.add(process.cleanPatPhotons)
@@ -1722,12 +1722,12 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             cleanPatJetProducer.checkOverlaps.photons.src = photonCollection
         else:
             del cleanPatJetProducer.checkOverlaps.photons
-            
+
         if isValidInputTag(tauCollection) and autoJetCleaning != "LepClean":
             cleanPatJetProducer.checkOverlaps.taus.src = tauCollection
         else:
             del cleanPatJetProducer.checkOverlaps.taus
-           
+
         # not used at all and electrons are already cleaned
         del cleanPatJetProducer.checkOverlaps.tkIsoElectrons
 
@@ -1758,7 +1758,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                         postfix=""):
 
     runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()
-    
+
     #MET flavors
     runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T0","T1","T2","Smear","Txy"],
@@ -1778,7 +1778,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       recoMetFromPFCs=recoMetFromPFCs,
                                       postfix=postfix
                                       )
-    
+
     #MET T1 uncertainties
     runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T1"],
@@ -1798,7 +1798,7 @@ def runMetCorAndUncForMiniAODProduction(process, metType="PF",
                                       recoMetFromPFCs=recoMetFromPFCs,
                                       postfix=postfix
                                       )
-    
+
     #MET T1 Smeared JER uncertainties
     runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T1","Smear"],
@@ -1874,7 +1874,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       CHS=CHS,
                                       postfix=postfix,
                                       )
-    
+
     #MET T1+Txy / Smear
     runMETCorrectionsAndUncertainties(process, metType=metType,
                                       correctionLevel=["T1","Txy"],

--- a/PhysicsTools/PythonAnalysis/examples/MCTruth.py
+++ b/PhysicsTools/PythonAnalysis/examples/MCTruth.py
@@ -23,7 +23,7 @@ sourceBranch.SetAddress(source)
 
 # now loop over the events
 for index in all(events):
-    
+
     # update all branches - the buffers are filled automatically
     # Hint: put all you branches in a list and loop over it
     sourceBranch.GetEntry(index)

--- a/PhysicsTools/PythonAnalysis/examples/interactiveExample.py
+++ b/PhysicsTools/PythonAnalysis/examples/interactiveExample.py
@@ -23,9 +23,9 @@ events = EventTree(theFile)
 
 print "Start looping over some events"
 for event in events:
-      photons = event.photons
-      print "  Number of photons in event %i: %i" % (event, len(photons))
-      if event > 2: break  # workaround will become obsolete 
+    photons = event.photons
+    print "  Number of photons in event %i: %i" % (event, len(photons))
+    if event > 2: break  # workaround will become obsolete 
 
 
 

--- a/RecoEgamma/Configuration/python/customizeOldEGReco.py
+++ b/RecoEgamma/Configuration/python/customizeOldEGReco.py
@@ -61,14 +61,14 @@ def _configurePFForGEDEGamma(process):
 
     process.gedGsfElectronsTmp.useEcalRegression = cms.bool(False)
     process.gedGsfElectronsTmp.useCombinationRegression = cms.bool(False)
-        
+
     #for later
     process.particleFlowBlock.SCBarrel = cms.InputTag('correctedHybridSuperClusters')
     process.particleFlowBlock.SCEndcap = cms.InputTag('correctedMulti5x5SuperClustersWithPreshower')
     process.particleFlowBlock.SuperClusterMatchByRef = cms.bool(False)
     #add in conversions
     ## for PF
-    
+
     process.allConversionSequence += process.allConversionOldEGSequence
     process.pfConversions.conversionCollection = cms.InputTag('allConversionsOldEG')
     process.photons.conversionProducer = cms.InputTag('oldegConversions')
@@ -87,7 +87,7 @@ def _configurePFForGEDEGamma(process):
     process.particleFlowTmp.usePFElectrons = cms.bool(True)
     process.particleFlowTmp.sumPtTrackIso = cms.double(2.0)
     process.particleFlowTmp.photon_HoE =  cms.double(0.10)
-    
+
     #re-route PF linker to use old EG collections
     process.particleFlow.GsfElectrons = cms.InputTag('gsfElectrons')
     process.particleFlow.Photons = cms.InputTag('pfPhotonTranslator:pfphot')
@@ -97,24 +97,24 @@ def _configurePFForGEDEGamma(process):
 
 def _customize_DQM(process):
     try:
-	process.ecalBarrelClusterTask.SuperClusterCollection = cms.InputTag("correctedHybridSuperClusters")
-	process.ecalBarrelClusterTask.BasicClusterCollection = cms.InputTag("hybridSuperClusters","hybridBarrelBasicClusters")
-	process.ecalEndcapClusterTask.SuperClusterCollection = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapSuperClusters")
-	process.ecalEndcapClusterTask.BasicClusterCollection = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapBasicClusters")
+        process.ecalBarrelClusterTask.SuperClusterCollection = cms.InputTag("correctedHybridSuperClusters")
+        process.ecalBarrelClusterTask.BasicClusterCollection = cms.InputTag("hybridSuperClusters","hybridBarrelBasicClusters")
+        process.ecalEndcapClusterTask.SuperClusterCollection = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapSuperClusters")
+        process.ecalEndcapClusterTask.BasicClusterCollection = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapBasicClusters")
     except AttributeError:
-	pass
+        pass
     try:
-	process.ecalBarrelClusterTaskExtras.SuperClusterCollection = cms.InputTag("correctedHybridSuperClusters")
-	process.ecalEndcapClusterTaskExtras.SuperClusterCollection = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapSuperClusters")
+        process.ecalBarrelClusterTaskExtras.SuperClusterCollection = cms.InputTag("correctedHybridSuperClusters")
+        process.ecalEndcapClusterTaskExtras.SuperClusterCollection = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapSuperClusters")
     except AttributeError:
-	pass
+        pass
     try:
-	process.ecalBarrelRecoSummary.superClusterCollection_EB = cms.InputTag("correctedHybridSuperClusters")
-	process.ecalBarrelRecoSummary.basicClusterCollection_EB = cms.InputTag("hybridSuperClusters","hybridBarrelBasicClusters")
-	process.ecalEndcapRecoSummary.superClusterCollection_EE = cms.InputTag("correctedMulti5x5SuperClustersWithPreshower")
-	process.ecalEndcapRecoSummary.basicClusterCollection_EE = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapBasicClusters")
+        process.ecalBarrelRecoSummary.superClusterCollection_EB = cms.InputTag("correctedHybridSuperClusters")
+        process.ecalBarrelRecoSummary.basicClusterCollection_EB = cms.InputTag("hybridSuperClusters","hybridBarrelBasicClusters")
+        process.ecalEndcapRecoSummary.superClusterCollection_EE = cms.InputTag("correctedMulti5x5SuperClustersWithPreshower")
+        process.ecalEndcapRecoSummary.basicClusterCollection_EE = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapBasicClusters")
     except AttributeError:
-	pass 
+        pass 
 
     return process
 
@@ -194,7 +194,7 @@ def _customize_FastSim(process):
     process.interestingGedEleIsoDetIdEE.emObjectLabel = cms.InputTag('gsfElectrons')
     process.interestingEgammaIsoDetIds.remove(process.interestingGedGamIsoDetIdEB)
     process.interestingEgammaIsoDetIds.remove(process.interestingGedGamIsoDetIdEE)
-        
+
     process.reducedEcalRecHitsEB.interestingDetIdCollections = cms.VInputTag(
         # ecal
         cms.InputTag("interestingEcalDetIdEB"),
@@ -255,7 +255,7 @@ def _customize_Reco(process):
     process.interestingGedEleIsoDetIdEE.emObjectLabel = cms.InputTag('gsfElectrons')
     process.interestingEgammaIsoDetIds.remove(process.interestingGedGamIsoDetIdEB)
     process.interestingEgammaIsoDetIds.remove(process.interestingGedGamIsoDetIdEE)
-    
+
     process.reducedEcalRecHitsEB.interestingDetIdCollections = cms.VInputTag(
         # ecal
         cms.InputTag("interestingEcalDetIdEB"),

--- a/RecoLuminosity/LumiDB/python/csvLumibyLSParser.py
+++ b/RecoLuminosity/LumiDB/python/csvLumibyLSParser.py
@@ -15,7 +15,7 @@ class csvLumibyLSParser(object):
         self.__result={}
         self.__strresult={}
         self.__filename=filename
-	self.__RunX=RunX
+        self.__RunX=RunX
         csvReader=csv.reader(open(filename),delimiter=',')
         oldRun=0
         runnumber=0
@@ -49,10 +49,10 @@ class csvLumibyLSParser(object):
                     oldRun = runnumber
 
             try:
-		if RunX=='Run2':
-                	delivered, recorded = float( row[4] ), float( row[5] )
-		if RunX=='Run1':
-			delivered, recorded = float( row[5] ), float( row[6] )
+                if RunX=='Run2':
+                    delivered, recorded = float( row[4] ), float( row[5] )
+                if RunX=='Run1':
+                    delivered, recorded = float( row[5] ), float( row[6] )
             except:
                 print('Record not parsed, Run = %d, LS = %d' % (runnumber, lsnumber))                
 
@@ -73,7 +73,7 @@ class csvLumibyLSParser(object):
 #                   # have to save lumi sections to fill once we get a non-zero lumi value
 #                   llist.append(lsnumber)
 #                   NonValidLumi=1
-                    
+
             elems = [ delivered,recorded ]
             ldict[lsnumber]=elems
 
@@ -93,7 +93,7 @@ class csvLumibyLSParser(object):
         return len(self.__result)
     def numls(self,run):
         return len(self.__result[run])
-        
+
 if __name__ == '__main__':
     result={}
     #filename='../test/lumi_by_LS_all.csv'

--- a/RecoLuminosity/LumiDB/scripts/estimatePileup_makeJSON_2015.py
+++ b/RecoLuminosity/LumiDB/scripts/estimatePileup_makeJSON_2015.py
@@ -22,10 +22,10 @@ def CalcPileup (deadTable, parameters, luminometer, mode='deadtable'):
 
     for lumiSection, deadArray in sorted (six.iteritems(deadTable)):
         numerator = 0
-	if luminometer == "HFOC":
-		threshold = 8.
-	else:
-		threshold = 1.2
+        if luminometer == "HFOC":
+            threshold = 8.
+        else:
+            threshold = 1.2
         if mode == 'csv':
             numerator     = float (deadArray[1])
             denominator   = float (deadArray[0])
@@ -35,8 +35,8 @@ def CalcPileup (deadTable, parameters, luminometer, mode='deadtable'):
                 numerator = 0
             if denominator:
                 livetime = numerator / denominator
-        
-	
+
+
 
             #print "params", parameters.lumiSectionLen, parameters.rotationTime
 
@@ -45,46 +45,46 @@ def CalcPileup (deadTable, parameters, luminometer, mode='deadtable'):
             return
         # totalInstLumi = reduce(lambda x, y: x+y, instLumiArray) # not needed
         if lumiSection > 0:
-             TotalLumi = 0 
-             TotalInt = 0
-             TotalInt2 = 0
-             TotalWeight = 0
-             TotalWeight2 = 0
-             FilledXings = 0
-             for xing, xingInstLumi, xingDelvLumi in instLumiArray:
-                 if selBXs and xing not in selBXs:
+            TotalLumi = 0 
+            TotalInt = 0
+            TotalInt2 = 0
+            TotalWeight = 0
+            TotalWeight2 = 0
+            FilledXings = 0
+            for xing, xingInstLumi, xingDelvLumi in instLumiArray:
+                if selBXs and xing not in selBXs:
                     continue
-                 xingIntLumi = xingInstLumi * livetime  # * parameters.lumiSectionLen
-                 mean = xingInstLumi * parameters.rotationTime / parameters.lumiSectionLen
-                 if mean > 100:
+                xingIntLumi = xingInstLumi * livetime  # * parameters.lumiSectionLen
+                mean = xingInstLumi * parameters.rotationTime / parameters.lumiSectionLen
+                if mean > 100:
                     if runNumber:
                         print("mean number of pileup events > 100 for run %d, lum %d : m %f l %f" % \
                           (runNumber, lumiSection, mean, xingInstLumi))
                     else:
                         print("mean number of pileup events > 100 for lum %d: m %f l %f" % \
                           (lumiSection, mean, xingInstLumi))
-                 #print "mean number of pileup events for lum %d: m %f idx %d l %f" % (lumiSection, mean, xing, xingIntLumi)
+                #print "mean number of pileup events for lum %d: m %f idx %d l %f" % (lumiSection, mean, xing, xingIntLumi)
 
-                 if xingInstLumi > threshold:
+                if xingInstLumi > threshold:
 
                     TotalLumi = TotalLumi+xingIntLumi
                     TotalInt+= mean*xingIntLumi
                     FilledXings = FilledXings+1
                     #print "xing inst lumi %f %f %d" % (xingIntLumi,TotalLumi,FilledXings)
 
-             #compute weighted mean, then loop again to get weighted RMS       
-             MeanInt = 0
-             if TotalLumi >0:
-                 MeanInt = TotalInt/TotalLumi
-             for xing, xingInstLumi, xingDelvlumi in instLumiArray:
-                 if selBXs and xing not in selBXs:
+            #compute weighted mean, then loop again to get weighted RMS       
+            MeanInt = 0
+            if TotalLumi >0:
+                MeanInt = TotalInt/TotalLumi
+            for xing, xingInstLumi, xingDelvlumi in instLumiArray:
+                if selBXs and xing not in selBXs:
                     continue
-                 if xingInstLumi > threshold:
-                     xingIntLumi = xingInstLumi * livetime # * parameters.lumiSectionLen
-                     mean = xingInstLumi * parameters.rotationTime / parameters.lumiSectionLen
-                     TotalInt2+= xingIntLumi*(mean-MeanInt)*(mean-MeanInt)
-                     TotalWeight+= xingIntLumi
-                     TotalWeight2+= xingIntLumi*xingIntLumi
+                if xingInstLumi > threshold:
+                    xingIntLumi = xingInstLumi * livetime # * parameters.lumiSectionLen
+                    mean = xingInstLumi * parameters.rotationTime / parameters.lumiSectionLen
+                    TotalInt2+= xingIntLumi*(mean-MeanInt)*(mean-MeanInt)
+                    TotalWeight+= xingIntLumi
+                    TotalWeight2+= xingIntLumi*xingIntLumi
 
 
 
@@ -104,7 +104,7 @@ def CalcPileup (deadTable, parameters, luminometer, mode='deadtable'):
             LumiArray.append(RMSLumi)
             LumiArray.append(MeanInt)
             lumiX=MeanInt*parameters.lumiSectionLen*FilledXings*(1./parameters.rotationTime)
-    
+
     #print lumiX
    # if TotalLumi<(lumiX*0.8):
 #	print lumiSection
@@ -116,7 +116,7 @@ def CalcPileup (deadTable, parameters, luminometer, mode='deadtable'):
 
     #print FilledXings
     return LumiArray
-    
+
 
 
 ##############################
@@ -189,14 +189,14 @@ if __name__ == '__main__':
         for line in events:
             runLumiDict = {}    
             csvDict = {}
-            
+
             if re.search( '^#', line):
                 continue
 
             pieces = sepRE.split (line.strip())
 
             ipiece = 0
-            
+
             if len (pieces) < 15: # means we are missing data; keep track of LS, lumi
                 InGap = 1
                 try:
@@ -215,7 +215,7 @@ if __name__ == '__main__':
             try:
                 run,       lumi     = int  ( pieces[0] ), int  ( pieces[2] )
                 delivered, recorded = float( pieces[11] ), float( pieces[12] )
-		luminometer = str( pieces[14] )
+                luminometer = str( pieces[14] )
                 xingInstLumiArray = [( int(orbit), float(lum), float(lumdelv) ) \
                                      for orbit, lum, lumdelv in zip( pieces[15::3],
                                                                      pieces[16::3],
@@ -270,7 +270,7 @@ if __name__ == '__main__':
                     OUTPUTLINE+= '[1,0.0,0.0,0.0],'
 
             for runNumber, lumiDict in sorted( six.iteritems(csvDict) ):
-	#	print runNumber
+        #	print runNumber
                 LumiArray = CalcPileup (lumiDict, parameters, luminometer,
                                      mode='csv')
 
@@ -300,10 +300,10 @@ if __name__ == '__main__':
         outputfile = open(output,'w')
         if not outputfile:
             raise RuntimeError("Could not open '%s' as an output JSON file" % output)
-                    
+
         outputfile.write(OUTPUTLINE)
         outputfile.close()
 
         sys.exit()
 
-        
+

--- a/RecoLuminosity/LumiDB/scripts/lumiData2.py
+++ b/RecoLuminosity/LumiDB/scripts/lumiData2.py
@@ -18,34 +18,34 @@ def main():
     # add optional arguments
     parser.add_argument('-P',dest='authpath',action='store',help='path to authentication file')
     parser.add_argument('-siteconfpath',dest='siteconfpath',action='store',
-			default=None,
+                        default=None,
                         required=False,
-			help='specific path to site-local-config.xml file, optional. If path undefined, fallback to cern proxy&server')
+                        help='specific path to site-local-config.xml file, optional. If path undefined, fallback to cern proxy&server')
     parser.add_argument('action',choices=['listrun'],help='command actions')
     parser.add_argument('--minrun',
-			dest='minrun',
-			action='store',
-			type=int,
-			help='min run number')
+                        dest='minrun',
+                        action='store',
+                        type=int,
+                        help='min run number')
     parser.add_argument('--maxrun',
-			dest='maxrun',
-			action='store',
-			type=int,
-			help='max run number')
+                        dest='maxrun',
+                        action='store',
+                        type=int,
+                        help='max run number')
     parser.add_argument('--minfill',
-			dest='minfill',
-			type=int,
-			action='store',
-			help='min fill number')
+                        dest='minfill',
+                        type=int,
+                        action='store',
+                        help='min fill number')
     parser.add_argument('--maxfill',
-			dest='maxfill',
-			type=int,
-			action='store',
-			help='max fill number')
+                        dest='maxfill',
+                        type=int,
+                        action='store',
+                        help='max fill number')
     parser.add_argument('--verbose',
-			dest='verbose',
-			action='store_true',
-			help='verbose mode for printing' )
+                        dest='verbose',
+                        action='store_true',
+                        help='verbose mode for printing' )
     parser.add_argument('--debug',dest='debug',action='store_true',help='debug')
     # parse arguments
     options=parser.parse_args()
@@ -60,13 +60,13 @@ def main():
     runlist=lumiCalcAPI.runList(schema,None,runmin=options.minrun,runmax=options.maxrun,startT=None,stopT=None,l1keyPattern=None,hltkeyPattern=None,amodetag=None,nominalEnergy=None,energyFlut=None,requiretrg=reqTrg,requirehlt=reqHLT)
     session.transaction().commit()
     if options.action == 'listrun':
-	    if not runlist:
-	        print('[]')
-		sys.exit(0)
-	    singlelist=sorted(listRemoveDuplicate(runlist))
-	    print(singlelist)
+        if not runlist:
+            print('[]')
+            sys.exit(0)
+        singlelist=sorted(listRemoveDuplicate(runlist))
+        print(singlelist)
     del session
     del svc
 if __name__=='__main__':
     main()
-    
+

--- a/RecoVertex/BeamSpotProducer/scripts/BeamSpotWorkflow.py
+++ b/RecoVertex/BeamSpotProducer/scripts/BeamSpotWorkflow.py
@@ -70,11 +70,11 @@ def getLastUploadedIOV(tagName,destDB="oracle://cms_orcoff_prod/CMS_COND_31X_BEA
 
     aCommand = listIOVCommand + " | grep DB= | tail -1 | awk \'{print $1}\'"
     output = commands.getstatusoutput( aCommand )
-    
+
     #WARNING when we pass to lumi IOV this should be long long
     if output[1] == '':
-      exit("ERROR: The tag " + tagName + " exists but I can't get the value of the last IOV")
-      
+        exit("ERROR: The tag " + tagName + " exists but I can't get the value of the last IOV")
+
     return long(output[1])
 
 ########################################################################
@@ -109,7 +109,7 @@ def getListOfRunsAndLumiFromDBS(dataSet,lastRun=-1):
         print(" >> " + queryCommand)
         output = []
         for i in range(0,3):
-	    output = commands.getstatusoutput( queryCommand )
+            output = commands.getstatusoutput( queryCommand )
             if output[0] == 0 and not (output[1].find("ERROR") != -1 or output[1].find("Error") != -1) :
                 break
         if output[0] != 0:
@@ -173,7 +173,7 @@ def getListOfRunsAndLumiFromRR(firstRun=-1):
         if tries==maxAttempts:
             error = "Run registry unaccessible.....exiting now"
             return {};
-    
+
 
     listOfRuns=[]
     for line in run_data.split("\n"):
@@ -181,7 +181,7 @@ def getListOfRunsAndLumiFromRR(firstRun=-1):
         if run.isdigit():
             listOfRuns.append(run)
 
-    
+
     firstRun = listOfRuns[len(listOfRuns)-1];
     lastRun  = listOfRuns[0];
     sel_dcstable="{groupName} ='" + Group + "' and {runNumber} >= " + str(firstRun) + " and {runNumber} <= " + str(lastRun) + " and {parDcsBpix} = 1 and {parDcsFpix} = 1 and {parDcsTibtid} = 1 and {parDcsTecM} = 1 and {parDcsTecP} = 1 and {parDcsTob} = 1 and {parDcsEbminus} = 1 and {parDcsEbplus} = 1 and {parDcsEeMinus} = 1 and {parDcsEePlus} = 1 and {parDcsEsMinus} = 1 and {parDcsEsPlus} = 1 and {parDcsHbheA} = 1 and {parDcsHbheB} = 1 and {parDcsHbheC} = 1 and {parDcsH0} = 1 and {parDcsHf} = 1"
@@ -227,7 +227,7 @@ def getLastClosedRun(DBSListOfFiles):
     else:
         runs.sort()
         return long(runs[len(runs)-2])
-    
+
 ########################################################################
 def getRunNumberFromFileName(fileName):
 #    regExp = re.search('(\D+)_(\d+)_(\d+)_(\d+)',fileName)
@@ -242,7 +242,7 @@ def getRunNumberFromDBSName(fileName):
     if not regExp:
         return -1
     return long(regExp.group(3)+regExp.group(4))
-    
+
 ########################################################################
 def getNewRunList(fromDir,lastUploadedIOV):
     newRunList = []
@@ -341,7 +341,7 @@ def selectFilesToProcess(listOfRunsAndLumiFromDBS,listOfRunsAndLumiFromRR,newRun
                         else:
                             print("WARNING: Timeout DBS_VERY_BIG_MISMATCH_Run" + str(run) + " is in progress.")
                         return filesToProcess
-                    
+
             else:
                 timeoutManager("DBS_VERY_BIG_MISMATCH_Run"+str(run))
                 timeoutManager("DBS_MISMATCH_Run"+str(run))
@@ -374,7 +374,7 @@ def selectFilesToProcess(listOfRunsAndLumiFromDBS,listOfRunsAndLumiFromRR,newRun
                 #print errors
                 #print badProcessed
                 #print badRunRegistry
-                    
+
                 if len(badRRProcessed) != 0:    
                     print("I have not processed some of the lumis that are in the run registry for run: " + str(run))
                     for lumi in badDBSProcessed:
@@ -429,7 +429,7 @@ def selectFilesToProcess(listOfRunsAndLumiFromDBS,listOfRunsAndLumiFromRR,newRun
                 else:
                     print("WARNING: Timeout MISSING_RUNREGRUN_Run" + str(run) + " is in progress.")
                 return filesToProcess
-                    
+
     return filesToProcess
 ########################################################################
 def compareLumiLists(listA,listB,errors=[],tolerance=0):
@@ -467,7 +467,7 @@ def compareLumiLists(listA,listB,errors=[],tolerance=0):
             errors.append("Lumi (" + str(lumi) + ") is in listB but not in listA")
             badA.append(lumi)
             #print "Bad A: " + str(lumi)
-            
+
     return badA,badB
 
 ########################################################################
@@ -485,7 +485,7 @@ def removeUncompleteRuns(newRunList,dataSet):
             print("I haven't processed all files yet : " + str(processedRuns[run]) + " out of " + str(nFiles) + " for run: " + str(run))
         else:
             print("All files have been processed for run: " + str(run) + " (" + str(processedRuns[run]) + " out of " + str(nFiles) + ")")
-            
+
 ########################################################################
 def aselectFilesToProcess(listOfFilesToProcess,newRunList):
     selectedFiles = []
@@ -540,7 +540,7 @@ def main():
             return
         else:
             lock()
-            
+
 
     destDB = 'oracle://cms_orcon_prod/CMS_COND_31X_BEAMSPOT'
     if option.Test:
@@ -581,12 +581,12 @@ def main():
     if archiveDir[len(archiveDir)-1] != '/':
         archiveDir = archiveDir + '/'
     if not os.path.isdir(archiveDir):
-	os.mkdir(archiveDir)
+        os.mkdir(archiveDir)
 
     if workingDir[len(workingDir)-1] != '/':
         workingDir = workingDir + '/'
     if not os.path.isdir(workingDir):
-	os.mkdir(workingDir)
+        os.mkdir(workingDir)
     else:
         os.system("rm -f "+ workingDir + "*") 
 
@@ -597,7 +597,7 @@ def main():
         lastUploadedIOV = getLastUploadedIOV(databaseTag)
     else:
         lastUploadedIOV = getLastUploadedIOV(databaseTag,destDB)
-        
+
     #lastUploadedIOV = 133885
     #lastUploadedIOV = 575216380019329
     if dbIOVBase == "lumiid":
@@ -627,7 +627,7 @@ def main():
     print("Getting list of files from DBS")
     listOfRunsAndLumiFromDBS = getListOfRunsAndLumiFromDBS(dataSet,lastUploadedIOV)
     if len(listOfRunsAndLumiFromDBS) == 0:
-       exit("There are no files in DBS to process") 
+        exit("There are no files in DBS to process") 
     print("Getting list of files from RR")
     listOfRunsAndLumiFromRR  = getListOfRunsAndLumiFromRR(lastUploadedIOV) 
     if(not listOfRunsAndLumiFromRR):
@@ -642,8 +642,8 @@ def main():
     print("Getting list of files to process")
     selectedFilesToProcess = selectFilesToProcess(listOfRunsAndLumiFromDBS,listOfRunsAndLumiFromRR,copiedFiles,archiveDir,dataSet,mailList,dbsTolerance,dbsTolerancePercent,rrTolerance,missingFilesTolerance,missingLumisTimeout)
     if len(selectedFilesToProcess) == 0:
-       exit("There are no files to process")
-        
+        exit("There are no files to process")
+
     #print selectedFilesToProcess
     ######### Copy files to working directory
     print("Copying files from archive to working directory")
@@ -675,12 +675,12 @@ def main():
     runBased = False
     if dbIOVBase == "runnumber":
         runBased = True
-        
+
     payloadList = createWeightedPayloads(workingDir+payloadFileName,beamSpotObjList,runBased)
     if len(payloadList) == 0:
         error = "WARNING: I wasn't able to create any payload even if I have some BeamSpot objects."
         exit(error)
-       
+
 
     tmpPayloadFileName = workingDir + "SingleTmpPayloadFile.txt"
     tmpSqliteFileName  = workingDir + "SingleTmpSqliteFile.db"
@@ -709,14 +709,14 @@ def main():
             error = "An error occurred while writing the sqlite file: " + tmpSqliteFileName
             exit(error)
         readSqliteFile(tmpSqliteFileName,databaseTag,readDBTemplate,workingDir)
-        
+
         ##############################################################
         #WARNING I am not sure if I am packing the right values
         if dbIOVBase == "runnumber":
             iov_since = str(payload.Run)
             iov_till  = iov_since
         elif dbIOVBase == "lumiid":
-	    iov_since = str( pack(int(payload.Run), int(payload.IOVfirst)) )
+            iov_since = str( pack(int(payload.Run), int(payload.IOVfirst)) )
             iov_till  = str( pack(int(payload.Run), int(payload.IOVlast)) )
         elif dbIOVBase == "timestamp":
             error = "ERROR: IOV " + dbIOVBase + " still not implemented."
@@ -729,11 +729,11 @@ def main():
             iovSinceFirst = iov_since
         if payloadNumber == len(payloadList)-1:
             iovTillLast   = iov_till
-            
+
         appendSqliteFile(final_sqlite_file_name + ".db", tmpSqliteFileName, databaseTag, iov_since, iov_till ,workingDir)
         os.system("rm -f " + tmpPayloadFileName + " " + tmpSqliteFileName)
 
-        
+
     #### CREATE payload for merged output
 
     print(" create MERGED payload card for dropbox ...")
@@ -756,10 +756,10 @@ def main():
         checkType = "hlt"
     dfile.write('IOVCheck ' + checkType + '\n')
     dfile.write('usertext Beam spot position\n')
-            
+
     dfile.close()
 
-                                                                                                
+
 
     if option.upload:
         print(" scp files to offline Drop Box")
@@ -768,7 +768,7 @@ def main():
             dropbox = "/DropBox_test"
         print("UPLOADING TO TEST DB")
         uploadSqliteFile(workingDir, final_sqlite_file_name, dropbox)
-                   
+
     archive_sqlite_file_name = "Payloads_" + iovSinceFirst + "_" + iovTillLast + "_" + final_sqlite_file_name
     archive_results_file_name = "Payloads_" + iovSinceFirst + "_" + iovTillLast + "_" + databaseTag + ".txt"
     if not os.path.isdir(archiveDir + 'payloads'):
@@ -776,11 +776,11 @@ def main():
     commands.getstatusoutput('mv ' + sqlite_file   + ' ' + archiveDir + 'payloads/' + archive_sqlite_file_name + '.db')
     commands.getstatusoutput('mv ' + metadata_file + ' ' + archiveDir + 'payloads/' + archive_sqlite_file_name + '.txt')
     commands.getstatusoutput('cp ' + workingDir + payloadFileName + ' ' + archiveDir + 'payloads/' + archive_results_file_name)
-  
+
     print(archiveDir + "payloads/" + archive_sqlite_file_name + '.db')
     print(archiveDir + "payloads/" + archive_sqlite_file_name + '.txt')
 
     rmLock()
-    
+
 if __name__ == '__main__':
     main()

--- a/RecoVertex/BeamSpotProducer/scripts/CommonMethods.py
+++ b/RecoVertex/BeamSpotProducer/scripts/CommonMethods.py
@@ -68,7 +68,7 @@ def timeoutManager(type,timeout=-1,fileName=".timeout"):
 def setLockName(name):
     global lockFile
     lockFile = name
-    
+
 ###########################################################################################
 def checkLock():
     global lockFile
@@ -76,7 +76,7 @@ def checkLock():
         return True
     else:
         return False
-    
+
 ###########################################################################################
 def lock():
     global lockFile
@@ -158,7 +158,7 @@ def sendEmail(mailList,error):
 ###########################################################################################
 def dirExists(dir):
     if dir.find("castor") != -1:
-    	lsCommand = "nsls " + dir
+        lsCommand = "nsls " + dir
         output = commands.getstatusoutput( lsCommand )
         return not output[0]
     else:
@@ -169,7 +169,7 @@ def ls(dir,filter=""):
     lsCommand      = ''
     listOfFiles    = []
     if dir.find('castor') != -1:
-    	lsCommand = 'ns'
+        lsCommand = 'ns'
     elif not os.path.exists(dir):
         print("ERROR: File or directory " + dir + " doesn't exist")
         return listOfFiles
@@ -192,15 +192,15 @@ def cp(fromDir,toDir,listOfFiles,overwrite=False,smallList=False):
     cpCommand   = ''
     copiedFiles = []
     if fromDir.find('castor') != -1 or toDir.find('castor') != -1 :
-    	cpCommand = 'rf'
+        cpCommand = 'rf'
     elif fromDir.find('resilient') != -1:
-    	cpCommand = 'dc'
+        cpCommand = 'dc'
     if fromDir[len(fromDir)-1] != '/':
         fromDir += '/'
 
     if toDir[len(toDir)-1] != '/':
         toDir += '/'
-        
+
     for file in listOfFiles:
         if os.path.isfile(toDir+file):
             if overwrite:
@@ -210,9 +210,9 @@ def cp(fromDir,toDir,listOfFiles,overwrite=False,smallList=False):
                 if not smallList:
                     copiedFiles.append(file)
                 continue
-    	# copy to local disk
-    	aCommand = cpCommand + 'cp '+ fromDir + file + " " + toDir
-    	print(" >> " + aCommand)
+        # copy to local disk
+        aCommand = cpCommand + 'cp '+ fromDir + file + " " + toDir
+        print(" >> " + aCommand)
         tmpStatus = commands.getstatusoutput( aCommand )
         if tmpStatus[0] == 0:
             copiedFiles.append(file)
@@ -261,9 +261,9 @@ def cmp_list_run(a,b):
 def cmp_list_lumi(a,b):
     if int(a.Run) < int(b.Run): return -1
     if int(a.Run) == int(b.Run):
-	if int(a.IOVfirst) < int(b.IOVfirst): return -1
-	if int(a.IOVfirst) == int(b.IOVfirst): return 0
-	if int(a.IOVfirst) > int(b.IOVfirst): return 1
+        if int(a.IOVfirst) < int(b.IOVfirst): return -1
+        if int(a.IOVfirst) == int(b.IOVfirst): return 0
+        if int(a.IOVfirst) > int(b.IOVfirst): return 1
     if int(a.Run) > int(b.Run) : return 1
 
 ###########################################################################################
@@ -275,13 +275,13 @@ def weight(x1, x1err,x2,x2err):
     x2err  = float(x2err)
     tmperr = 0.
     if x2err < 1e-6 :
-	x2err = 1e-6
+        x2err = 1e-6
     if x1err < 1e-6:
-	x1 = x2/(x2err * x2err)
-	tmperr = 1/(x2err*x2err)
+        x1 = x2/(x2err * x2err)
+        tmperr = 1/(x2err*x2err)
     else:
-	x1 = x1/(x1err*x1err) + x2/(x2err * x2err)
-	tmperr = 1/(x1err*x1err) + 1/(x2err*x2err)
+        x1 = x1/(x1err*x1err) + x2/(x2err * x2err)
+        tmperr = 1/(x1err*x1err) + 1/(x2err*x2err)
     x1 = x1/tmperr
     x1err = 1/tmperr
     x1err = math.sqrt(x1err)
@@ -331,11 +331,11 @@ def deltaSig( x ):
 def readBeamSpotFile(fileName,listbeam=[],IOVbase="runbase", firstRun='1',lastRun='4999999999'):
     tmpbeam = BeamSpot()
     tmpbeamsize = 0
-    
+
     #firstRun = "1"
     #lastRun  = "4999999999"
     if IOVbase == "lumibase" and firstRun=='1' and lastRun=='4999999999' :
-    	firstRun = "1:1"
+        firstRun = "1:1"
         lastRun = "4999999999:4999999999"
 
     inputfiletype = 0
@@ -345,238 +345,238 @@ def readBeamSpotFile(fileName,listbeam=[],IOVbase="runbase", firstRun='1',lastRu
     # for bx
     maplist = {}
     hasBX = False
-            
+
     tmpfile = open(fileName)
     atmpline = tmpfile.readline()
     if atmpline.find('Runnumber') != -1:
-	inputfiletype = 1
+        inputfiletype = 1
         if len(atmpline.split()) > 2:
             hasBX = True
             print(" Input data has been calculated as function of BUNCH CROSSINGS.")
     tmpfile.seek(0)
 
-        
+
     if inputfiletype ==1:
 
-	tmpBX = 0
-	for line in tmpfile:
-            
-	    if line.find('Type') != -1:
-		tmpbeam.Type = int(line.split()[1])
-		tmpbeamsize += 1
-	    if line.find('X0') != -1:
-		tmpbeam.X = line.split()[1]
-		#tmpbeam.Xerr = line.split()[4]
-		tmpbeamsize += 1
+        tmpBX = 0
+        for line in tmpfile:
+
+            if line.find('Type') != -1:
+                tmpbeam.Type = int(line.split()[1])
+                tmpbeamsize += 1
+            if line.find('X0') != -1:
+                tmpbeam.X = line.split()[1]
+                #tmpbeam.Xerr = line.split()[4]
+                tmpbeamsize += 1
             #print " x = " + str(tmpbeam.X)
-	    if line.find('Y0') != -1:
-		tmpbeam.Y = line.split()[1]
-		#tmpbeam.Yerr = line.split()[4]
-		tmpbeamsize += 1
+            if line.find('Y0') != -1:
+                tmpbeam.Y = line.split()[1]
+                #tmpbeam.Yerr = line.split()[4]
+                tmpbeamsize += 1
             #print " y =" + str(tmpbeam.Y)
-	    if line.find('Z0') != -1 and line.find('sigmaZ0') == -1:
-		tmpbeam.Z = line.split()[1]
-		#tmpbeam.Zerr = line.split()[4]
-		tmpbeamsize += 1
-	    if line.find('sigmaZ0') !=-1:
-		tmpbeam.sigmaZ = line.split()[1]
-		#tmpbeam.sigmaZerr = line.split()[5]
-		tmpbeamsize += 1
+            if line.find('Z0') != -1 and line.find('sigmaZ0') == -1:
+                tmpbeam.Z = line.split()[1]
+                #tmpbeam.Zerr = line.split()[4]
+                tmpbeamsize += 1
+            if line.find('sigmaZ0') !=-1:
+                tmpbeam.sigmaZ = line.split()[1]
+                #tmpbeam.sigmaZerr = line.split()[5]
+                tmpbeamsize += 1
             if line.find('dxdz') != -1:
-		tmpbeam.dxdz = line.split()[1]
-		#tmpbeam.dxdzerr = line.split()[4]
-		tmpbeamsize += 1
-	    if line.find('dydz') != -1:
-		tmpbeam.dydz = line.split()[1]
-		#tmpbeam.dydzerr = line.split()[4]
-		tmpbeamsize += 1
-	    if line.find('BeamWidthX') != -1:
-		tmpbeam.beamWidthX = line.split()[1]
-		#tmpbeam.beamWidthXerr = line.split()[6]
-		tmpbeamsize += 1
-	    if line.find('BeamWidthY') != -1:
-		tmpbeam.beamWidthY = line.split()[1]
-		#tmpbeam.beamWidthYerr = line.split()[6]
-		tmpbeamsize += 1
-	    if line.find('Cov(0,j)') != -1:
-		tmpbeam.Xerr = str(math.sqrt( float( line.split()[1] ) ) )
-		tmpbeamsize += 1
-	    if line.find('Cov(1,j)') != -1:
-		tmpbeam.Yerr = str(math.sqrt( float( line.split()[2] ) ) )
-		tmpbeamsize += 1
-	    if line.find('Cov(2,j)') != -1:
-		tmpbeam.Zerr = str(math.sqrt( float( line.split()[3] ) ) )
-		tmpbeamsize += 1
-	    if line.find('Cov(3,j)') != -1:
-		tmpbeam.sigmaZerr = str(math.sqrt( float( line.split()[4] ) ) )
-		tmpbeamsize += 1
+                tmpbeam.dxdz = line.split()[1]
+                #tmpbeam.dxdzerr = line.split()[4]
+                tmpbeamsize += 1
+            if line.find('dydz') != -1:
+                tmpbeam.dydz = line.split()[1]
+                #tmpbeam.dydzerr = line.split()[4]
+                tmpbeamsize += 1
+            if line.find('BeamWidthX') != -1:
+                tmpbeam.beamWidthX = line.split()[1]
+                #tmpbeam.beamWidthXerr = line.split()[6]
+                tmpbeamsize += 1
+            if line.find('BeamWidthY') != -1:
+                tmpbeam.beamWidthY = line.split()[1]
+                #tmpbeam.beamWidthYerr = line.split()[6]
+                tmpbeamsize += 1
+            if line.find('Cov(0,j)') != -1:
+                tmpbeam.Xerr = str(math.sqrt( float( line.split()[1] ) ) )
+                tmpbeamsize += 1
+            if line.find('Cov(1,j)') != -1:
+                tmpbeam.Yerr = str(math.sqrt( float( line.split()[2] ) ) )
+                tmpbeamsize += 1
+            if line.find('Cov(2,j)') != -1:
+                tmpbeam.Zerr = str(math.sqrt( float( line.split()[3] ) ) )
+                tmpbeamsize += 1
+            if line.find('Cov(3,j)') != -1:
+                tmpbeam.sigmaZerr = str(math.sqrt( float( line.split()[4] ) ) )
+                tmpbeamsize += 1
             if line.find('Cov(4,j)') != -1:
-		tmpbeam.dxdzerr = str(math.sqrt( float( line.split()[5] ) ) )
-		tmpbeamsize += 1
-	    if line.find('Cov(5,j)') != -1:
-		tmpbeam.dydzerr = str(math.sqrt( float( line.split()[6] ) ) )
-		tmpbeamsize += 1
-	    if line.find('Cov(6,j)') != -1:
-		tmpbeam.beamWidthXerr = str(math.sqrt( float( line.split()[7] ) ) )
+                tmpbeam.dxdzerr = str(math.sqrt( float( line.split()[5] ) ) )
+                tmpbeamsize += 1
+            if line.find('Cov(5,j)') != -1:
+                tmpbeam.dydzerr = str(math.sqrt( float( line.split()[6] ) ) )
+                tmpbeamsize += 1
+            if line.find('Cov(6,j)') != -1:
+                tmpbeam.beamWidthXerr = str(math.sqrt( float( line.split()[7] ) ) )
                 tmpbeam.beamWidthYerr = tmpbeam.beamWidthXerr
-		tmpbeamsize += 1
-	    if line.find('LumiRange')  != -1:
+                tmpbeamsize += 1
+            if line.find('LumiRange')  != -1:
                 if IOVbase=="lumibase":
                     tmpbeam.IOVfirst = line.split()[1]
                     tmpbeam.IOVlast = line.split()[3]
-		tmpbeamsize += 1
+                tmpbeamsize += 1
             if line.find('Runnumber') != -1:
-		tmpbeam.Run = line.split()[1]
-		if IOVbase == "runbase":
-		    tmpbeam.IOVfirst = line.split()[1]
-		    tmpbeam.IOVlast = line.split()[1]
+                tmpbeam.Run = line.split()[1]
+                if IOVbase == "runbase":
+                    tmpbeam.IOVfirst = line.split()[1]
+                    tmpbeam.IOVlast = line.split()[1]
                 if hasBX:
                     tmpBX = line.split()[3]
-		tmpbeamsize += 1
+                tmpbeamsize += 1
             if line.find('BeginTimeOfFit') != -1:
-		tmpbeam.IOVBeginTime = line.split()[1] +" "+line.split()[2] +" "+line.split()[3]
-		if IOVbase =="timebase":
-		    tmpbeam.IOVfirst =  time.mktime( time.strptime(line.split()[1] +  " " + line.split()[2] + " " + line.split()[3],"%Y.%m.%d %H:%M:%S %Z") )
-		tmpbeamsize += 1
+                tmpbeam.IOVBeginTime = line.split()[1] +" "+line.split()[2] +" "+line.split()[3]
+                if IOVbase =="timebase":
+                    tmpbeam.IOVfirst =  time.mktime( time.strptime(line.split()[1] +  " " + line.split()[2] + " " + line.split()[3],"%Y.%m.%d %H:%M:%S %Z") )
+                tmpbeamsize += 1
             if line.find('EndTimeOfFit') != -1:
-		tmpbeam.IOVEndTime = line.split()[1] +" "+line.split()[2] +" "+line.split()[3]
-		if IOVbase =="timebase":
-		    tmpbeam.IOVlast = time.mktime( time.strptime(line.split()[1] +  " " + line.split()[2] + " " + line.split()[3],"%Y.%m.%d %H:%M:%S %Z") )
-		tmpbeamsize += 1
-	    if tmpbeamsize == 20:
-		if IOVbase=="lumibase":
-		    tmprunfirst = int(firstRun.split(":")[0])
-		    tmprunlast  = int(lastRun.split(":")[0])
-		    tmplumifirst = int(firstRun.split(":")[1])
-		    tmplumilast  = int(lastRun.split(":")[1])
-		    acceptiov1 = acceptiov2 = False
-		    # check lumis in the same run
-		    if tmprunfirst == tmprunlast and int(tmpbeam.Run)==tmprunfirst:
-			if int(tmpbeam.IOVfirst) >= tmplumifirst and int(tmpbeam.IOVlast)<=tmplumilast:
-			    acceptiov1 = acceptiov2 = True
-		    # if different runs make sure you select the correct range of lumis
-		    elif int(tmpbeam.Run) == tmprunfirst:
-			if int(tmpbeam.IOVfirst) >= tmplumifirst: acceptiov1 = True
-		    elif int(tmpbeam.Run) == tmprunlast:
-			if int(tmpbeam.IOVlast) <= tmplumilast: acceptiov2 = True
-		    elif tmprunfirst <= int(tmpbeam.Run) and tmprunlast >= int(tmpbeam.Run): 
-			acceptiov1 = acceptiov2 = True
-			
-		    if acceptiov1 and acceptiov2:
-			if tmpbeam.Type != 2:
-			    print("invalid fit, skip Run "+str(tmpbeam.Run)+" IOV: "+str(tmpbeam.IOVfirst) + " to "+ str(tmpbeam.IOVlast))
+                tmpbeam.IOVEndTime = line.split()[1] +" "+line.split()[2] +" "+line.split()[3]
+                if IOVbase =="timebase":
+                    tmpbeam.IOVlast = time.mktime( time.strptime(line.split()[1] +  " " + line.split()[2] + " " + line.split()[3],"%Y.%m.%d %H:%M:%S %Z") )
+                tmpbeamsize += 1
+            if tmpbeamsize == 20:
+                if IOVbase=="lumibase":
+                    tmprunfirst = int(firstRun.split(":")[0])
+                    tmprunlast  = int(lastRun.split(":")[0])
+                    tmplumifirst = int(firstRun.split(":")[1])
+                    tmplumilast  = int(lastRun.split(":")[1])
+                    acceptiov1 = acceptiov2 = False
+                    # check lumis in the same run
+                    if tmprunfirst == tmprunlast and int(tmpbeam.Run)==tmprunfirst:
+                        if int(tmpbeam.IOVfirst) >= tmplumifirst and int(tmpbeam.IOVlast)<=tmplumilast:
+                            acceptiov1 = acceptiov2 = True
+                    # if different runs make sure you select the correct range of lumis
+                    elif int(tmpbeam.Run) == tmprunfirst:
+                        if int(tmpbeam.IOVfirst) >= tmplumifirst: acceptiov1 = True
+                    elif int(tmpbeam.Run) == tmprunlast:
+                        if int(tmpbeam.IOVlast) <= tmplumilast: acceptiov2 = True
+                    elif tmprunfirst <= int(tmpbeam.Run) and tmprunlast >= int(tmpbeam.Run): 
+                        acceptiov1 = acceptiov2 = True
+
+                    if acceptiov1 and acceptiov2:
+                        if tmpbeam.Type != 2:
+                            print("invalid fit, skip Run "+str(tmpbeam.Run)+" IOV: "+str(tmpbeam.IOVfirst) + " to "+ str(tmpbeam.IOVlast))
                         elif isnan(tmpbeam.Z) or isnan(tmpbeam.Zerr) or isnan(tmpbeam.sigmaZerr) or isnan(tmpbeam.beamWidthXerr) or isnan(tmpbeam.beamWidthYerr):
                             print("invalid fit, NaN values!! skip Run "+str(tmpbeam.Run)+" IOV: "+str(tmpbeam.IOVfirst) + " to "+ str(tmpbeam.IOVlast))                       
-			elif hasBX:
+                        elif hasBX:
                             if (tmpBX in maplist) == False:
                                 maplist[tmpBX] = [tmpbeam]
                             else:
                                 maplist[tmpBX].append(tmpbeam)
                         else:
-			    listbeam.append(tmpbeam)
+                            listbeam.append(tmpbeam)
 
-		elif int(tmpbeam.IOVfirst) >= int(firstRun) and int(tmpbeam.IOVlast) <= int(lastRun):
-		    if tmpbeam.Type != 2:
-			print("invalid fit, skip Run "+str(tmpbeam.Run)+" IOV: "+str(tmpbeam.IOVfirst) + " to "+ str(tmpbeam.IOVlast))
+                elif int(tmpbeam.IOVfirst) >= int(firstRun) and int(tmpbeam.IOVlast) <= int(lastRun):
+                    if tmpbeam.Type != 2:
+                        print("invalid fit, skip Run "+str(tmpbeam.Run)+" IOV: "+str(tmpbeam.IOVfirst) + " to "+ str(tmpbeam.IOVlast))
                     elif isnan(tmpbeam.Z) or isnan(tmpbeam.Zerr) or isnan(tmpbeam.sigmaZerr) or isnan(tmpbeam.beamWidthXerr) or isnan(tmpbeam.beamWidthYerr):
                         print("invalid fit, NaN values!! skip Run "+str(tmpbeam.Run)+" IOV: "+str(tmpbeam.IOVfirst) + " to "+ str(tmpbeam.IOVlast))
-		    else:
-			listbeam.append(tmpbeam)
-                        
-		tmpbeamsize = 0
-		tmpbeam = BeamSpot()
+                    else:
+                        listbeam.append(tmpbeam)
+
+                tmpbeamsize = 0
+                tmpbeam = BeamSpot()
                 tmpBX = 0
     else:
 
-	for line in tmpfile:
-	
-	    if line.find('X0') != -1:
-		tmpbeam.X = line.split()[2]
-		tmpbeam.Xerr = line.split()[4]
-		tmpbeamsize += 1
+        for line in tmpfile:
+
+            if line.find('X0') != -1:
+                tmpbeam.X = line.split()[2]
+                tmpbeam.Xerr = line.split()[4]
+                tmpbeamsize += 1
             #print " x = " + str(tmpbeam.X)
-	    if line.find('Y0') != -1:
-		tmpbeam.Y = line.split()[2]
-		tmpbeam.Yerr = line.split()[4]
-		tmpbeamsize += 1
+            if line.find('Y0') != -1:
+                tmpbeam.Y = line.split()[2]
+                tmpbeam.Yerr = line.split()[4]
+                tmpbeamsize += 1
             #print " y =" + str(tmpbeam.Y)
-	    if line.find('Z0') != -1 and line.find('Sigma Z0') == -1:
-		tmpbeam.Z = line.split()[2]
-		tmpbeam.Zerr = line.split()[4]
-		tmpbeamsize += 1
+            if line.find('Z0') != -1 and line.find('Sigma Z0') == -1:
+                tmpbeam.Z = line.split()[2]
+                tmpbeam.Zerr = line.split()[4]
+                tmpbeamsize += 1
             #print " z =" + str(tmpbeam.Z)
-	    if line.find('Sigma Z0') !=-1:
-		tmpbeam.sigmaZ = line.split()[3]
-		tmpbeam.sigmaZerr = line.split()[5]
-		tmpbeamsize += 1
-	    if line.find('dxdz') != -1:
-		tmpbeam.dxdz = line.split()[2]
-		tmpbeam.dxdzerr = line.split()[4]
-		tmpbeamsize += 1
-	    if line.find('dydz') != -1:
-		tmpbeam.dydz = line.split()[2]
-		tmpbeam.dydzerr = line.split()[4]
-		tmpbeamsize += 1
-	    if line.find('Beam Width X') != -1:
-		tmpbeam.beamWidthX = line.split()[4]
-		tmpbeam.beamWidthXerr = line.split()[6]
-		tmpbeamsize += 1
-	    if line.find('Beam Width Y') != -1:
-		tmpbeam.beamWidthY = line.split()[4]
-		tmpbeam.beamWidthYerr = line.split()[6]
-		tmpbeamsize += 1
-	#if line.find('Run ') != -1:
-	    if line.find('for runs')  != -1:
-	    #tmpbeam.IOVfirst = line.split()[6].strip(',')
-	        tmpbeam.Run      = line.split()[2]
-		if IOVbase == "runbase":
-		  tmpbeam.IOVfirst = line.split()[2]
-		  tmpbeam.IOVlast = line.split()[4]
-		tmpbeamsize += 1
-	    if line.find('LumiSection')  != -1:
+            if line.find('Sigma Z0') !=-1:
+                tmpbeam.sigmaZ = line.split()[3]
+                tmpbeam.sigmaZerr = line.split()[5]
+                tmpbeamsize += 1
+            if line.find('dxdz') != -1:
+                tmpbeam.dxdz = line.split()[2]
+                tmpbeam.dxdzerr = line.split()[4]
+                tmpbeamsize += 1
+            if line.find('dydz') != -1:
+                tmpbeam.dydz = line.split()[2]
+                tmpbeam.dydzerr = line.split()[4]
+                tmpbeamsize += 1
+            if line.find('Beam Width X') != -1:
+                tmpbeam.beamWidthX = line.split()[4]
+                tmpbeam.beamWidthXerr = line.split()[6]
+                tmpbeamsize += 1
+            if line.find('Beam Width Y') != -1:
+                tmpbeam.beamWidthY = line.split()[4]
+                tmpbeam.beamWidthYerr = line.split()[6]
+                tmpbeamsize += 1
+        #if line.find('Run ') != -1:
+            if line.find('for runs')  != -1:
+            #tmpbeam.IOVfirst = line.split()[6].strip(',')
+                tmpbeam.Run      = line.split()[2]
+                if IOVbase == "runbase":
+                    tmpbeam.IOVfirst = line.split()[2]
+                    tmpbeam.IOVlast = line.split()[4]
+                tmpbeamsize += 1
+            if line.find('LumiSection')  != -1:
                 if IOVbase=="lumibase":
                     tmpbeam.IOVfirst = line.split()[10]
                     tmpbeam.IOVlast = line.split()[10]
-		tmpbeamsize += 1
-	    if tmpbeamsize == 10:
+                tmpbeamsize += 1
+            if tmpbeamsize == 10:
 
-		if IOVbase=="lumibase":
-		    tmprunfirst = int(firstRun.split(":")[0])
-		    tmprunlast  = int(lastRun.split(":")[0])
-		    tmplumifirst = int(firstRun.split(":")[1])
-		    tmplumilast  = int(lastRun.split(":")[1])
-		    acceptiov1 = acceptiov2 = False
-		    # check lumis in the same run
-		    if tmprunfirst == tmprunlast and int(tmpbeam.Run)==tmprunfirst:
-			if int(tmpbeam.IOVfirst) >= tmplumifirst and int(tmpbeam.IOVlast)<=tmplumilast:
-			    acceptiov1 = acceptiov2 = True
-		    # if different runs make sure you select the correct range of lumis
-		    elif int(tmpbeam.Run) == tmprunfirst:
-			if int(tmpbeam.IOVfirst) >= tmplumifirst: acceptiov1 = True
-		    elif int(tmpbeam.Run) == tmprunlast:
-			if int(tmpbeam.IOVlast) <= tmplumilast: acceptiov2 = True
-		    elif tmprunfirst <= int(tmpbeam.Run) and tmprunlast >= int(tmpbeam.Run): 
-			acceptiov1 = acceptiov2 = True
-			
-		    if acceptiov1 and acceptiov2:
-			if isnan(tmpbeam.Z) or isnan(tmpbeam.Zerr) or isnan(tmpbeam.sigmaZerr) or isnan(tmpbeam.beamWidthXerr) or isnan(tmpbeam.beamWidthYerr):
+                if IOVbase=="lumibase":
+                    tmprunfirst = int(firstRun.split(":")[0])
+                    tmprunlast  = int(lastRun.split(":")[0])
+                    tmplumifirst = int(firstRun.split(":")[1])
+                    tmplumilast  = int(lastRun.split(":")[1])
+                    acceptiov1 = acceptiov2 = False
+                    # check lumis in the same run
+                    if tmprunfirst == tmprunlast and int(tmpbeam.Run)==tmprunfirst:
+                        if int(tmpbeam.IOVfirst) >= tmplumifirst and int(tmpbeam.IOVlast)<=tmplumilast:
+                            acceptiov1 = acceptiov2 = True
+                    # if different runs make sure you select the correct range of lumis
+                    elif int(tmpbeam.Run) == tmprunfirst:
+                        if int(tmpbeam.IOVfirst) >= tmplumifirst: acceptiov1 = True
+                    elif int(tmpbeam.Run) == tmprunlast:
+                        if int(tmpbeam.IOVlast) <= tmplumilast: acceptiov2 = True
+                    elif tmprunfirst <= int(tmpbeam.Run) and tmprunlast >= int(tmpbeam.Run): 
+                        acceptiov1 = acceptiov2 = True
+
+                    if acceptiov1 and acceptiov2:
+                        if isnan(tmpbeam.Z) or isnan(tmpbeam.Zerr) or isnan(tmpbeam.sigmaZerr) or isnan(tmpbeam.beamWidthXerr) or isnan(tmpbeam.beamWidthYerr):
                             print("invalid fit, NaN values!! skip Run "+str(tmpbeam.Run)+" IOV: "+str(tmpbeam.IOVfirst) + " to "+ str(tmpbeam.IOVlast))                       
-			elif hasBX:
+                        elif hasBX:
                             if (tmpBX in maplist) == False:
                                 maplist[tmpBX] = [tmpbeam]
                             else:
                                 maplist[tmpBX].append(tmpbeam)
                         else:
-			    listbeam.append(tmpbeam)
+                            listbeam.append(tmpbeam)
 
-		elif int(tmpbeam.IOVfirst) >= int(firstRun) and int(tmpbeam.IOVlast) <= int(lastRun):
-		    if isnan(tmpbeam.Z) or isnan(tmpbeam.Zerr) or isnan(tmpbeam.sigmaZerr) or isnan(tmpbeam.beamWidthXerr) or isnan(tmpbeam.beamWidthYerr):
+                elif int(tmpbeam.IOVfirst) >= int(firstRun) and int(tmpbeam.IOVlast) <= int(lastRun):
+                    if isnan(tmpbeam.Z) or isnan(tmpbeam.Zerr) or isnan(tmpbeam.sigmaZerr) or isnan(tmpbeam.beamWidthXerr) or isnan(tmpbeam.beamWidthYerr):
                         print("invalid fit, NaN values!! skip Run "+str(tmpbeam.Run)+" IOV: "+str(tmpbeam.IOVfirst) + " to "+ str(tmpbeam.IOVlast))
-		    else:
-			listbeam.append(tmpbeam)
-                        
-		tmpbeamsize = 0
-		tmpbeam = BeamSpot()
+                    else:
+                        listbeam.append(tmpbeam)
+
+                tmpbeamsize = 0
+                tmpbeam = BeamSpot()
                 tmpBX = 0
 
     tmpfile.close()
@@ -592,10 +592,10 @@ def readBeamSpotFile(fileName,listbeam=[],IOVbase="runbase", firstRun='1',lastRu
 def sortAndCleanBeamList(listbeam=[],IOVbase="lumibase"):
     # sort the list
     if IOVbase == "lumibase":
-	listbeam.sort( cmp = cmp_list_lumi )
+        listbeam.sort( cmp = cmp_list_lumi )
     else:
-	listbeam.sort( cmp = cmp_list_run )
-    
+        listbeam.sort( cmp = cmp_list_run )
+
     # first clean list of data for consecutive duplicates and bad fits
     tmpremovelist = []
     for ii in range(0,len(listbeam)):
@@ -605,14 +605,14 @@ def sortAndCleanBeamList(listbeam=[],IOVbase="lumibase"):
         if datax == '0' and IOVbase =="runbase":
             print(" iov = 0? skip this IOV = "+ str(ibeam.IOVfirst) + " to " + str(ibeam.IOVlast))
             tmpremovelist.append(ibeam)
-        
+
         if ii < len(listbeam) -1:
             #print listbeam[ii+1].IOVfirst
-	    if IOVbase =="lumibase":
-		if ibeam.Run == listbeam[ii+1].Run and ibeam.IOVfirst == listbeam[ii+1].IOVfirst:
-		    print(" duplicate IOV = "+datax+", keep only last duplicate entry")
-		    tmpremovelist.append(ibeam)
-	    elif datax == listbeam[ii+1].IOVfirst:
+            if IOVbase =="lumibase":
+                if ibeam.Run == listbeam[ii+1].Run and ibeam.IOVfirst == listbeam[ii+1].IOVfirst:
+                    print(" duplicate IOV = "+datax+", keep only last duplicate entry")
+                    tmpremovelist.append(ibeam)
+            elif datax == listbeam[ii+1].IOVfirst:
                 print(" duplicate IOV = "+datax+", keep only last duplicate entry")
                 tmpremovelist.append(ibeam)
 
@@ -641,8 +641,8 @@ def createWeightedPayloads(fileName,listbeam=[],weighted=True):
             tmpbeam.Type = 2
         docheck = False
         docreate = False
-	#print "Currently testing ii="+str(ii)+" Lumi1: "+str(ibeam.IOVfirst)
-	    
+        #print "Currently testing ii="+str(ii)+" Lumi1: "+str(ibeam.IOVfirst)
+
         # check last iov
         if ii < len(listbeam) - 1: 
             inextbeam = listbeam[ii+1]
@@ -671,7 +671,7 @@ def createWeightedPayloads(fileName,listbeam=[],weighted=True):
         #print "wx = " + ibeam.beamWidthX + " err= "+ ibeam.beamWidthXerr
         (tmpbeam.beamWidthX, tmpbeam.beamWidthXerr) = weight(tmpbeam.beamWidthX, tmpbeam.beamWidthXerr, ibeam.beamWidthX, ibeam.beamWidthXerr)
         (tmpbeam.beamWidthY, tmpbeam.beamWidthYerr) = weight(tmpbeam.beamWidthY, tmpbeam.beamWidthYerr, ibeam.beamWidthY, ibeam.beamWidthYerr)
-        
+
         if weighted:
             docheck = False
         # check offsets
@@ -680,11 +680,11 @@ def createWeightedPayloads(fileName,listbeam=[],weighted=True):
 
             # define minimum limit
             min_limit = 0.0025
-            
+
             # limit for x and y
             limit = float(ibeam.beamWidthX)/2.
             if limit < min_limit: limit = min_limit
-            
+
             # check movements in X
             adelta1 = delta(ibeam.X, ibeam.Xerr, inextbeam.X, inextbeam.Xerr)
             adelta2 = (0.,1.e9)
@@ -698,14 +698,14 @@ def createWeightedPayloads(fileName,listbeam=[],weighted=True):
             adelta2widthy = (0.,1.e9)
             adelta1z0 = delta(ibeam.Z, ibeam.Zerr, inextbeam.Z, inextbeam.Zerr)
             adelta1sigmaZ = delta(ibeam.sigmaZ, ibeam.sigmaZerr, inextbeam.sigmaZ, inextbeam.sigmaZerr)
-            
+
             if iNNbeam.Type != -1:
                 adelta2 = delta(inextbeam.X, inextbeam.Xerr, iNNbeam.X, iNNbeam.Xerr)
                 adelta2dxdz = delta(inextbeam.dxdz, inextbeam.dxdzerr, iNNbeam.dxdz, iNNbeam.dxdzerr)
                 adelta2dydz = delta(inextbeam.dydz, inextbeam.dydzerr, iNNbeam.dydz, iNNbeam.dydzerr)
                 adelta2widthx = delta(inextbeam.beamWidthX, inextbeam.beamWidthXerr, iNNbeam.beamWidthX, iNNbeam.beamWidthXerr)
                 adelta2widthy = delta(inextbeam.beamWidthY, inextbeam.beamWidthYerr, iNNbeam.beamWidthY, iNNbeam.beamWidthYerr)
-                
+
             deltaX = deltaSig(adelta1) > 3.5 and adelta1[0] >= limit
             if ii < len(listbeam) -2:
                 if deltaX==False and adelta1[0]*adelta2[0] > 0. and  math.fabs(adelta1[0]+adelta2[0]) >= limit:
@@ -722,7 +722,7 @@ def createWeightedPayloads(fileName,listbeam=[],weighted=True):
             adelta2 = (0.,1.e9)
             if iNNbeam.Type != -1:
                 adelta2 = delta(inextbeam.Y, inextbeam.Yerr, iNNbeam.Y, iNNbeam.Yerr)
-                
+
             deltaY = deltaSig(adelta1) > 3.5 and adelta1[0] >= limit
             if ii < len(listbeam) -2:
                 if deltaY==False and adelta1[0]*adelta2[0] > 0. and  math.fabs(adelta1[0]+adelta2[0]) >= limit:
@@ -730,10 +730,10 @@ def createWeightedPayloads(fileName,listbeam=[],weighted=True):
                 elif deltaY==True and adelta1[0]*adelta2[0]<=0 and adelta2[0] != 0 and math.fabs(adelta1[0]/adelta2[0]) > 0.33 and math.fabs(adelta1[0]/adelta2[0]) < 3:
                     deltaY = False
             # check movements in Z                                                    
-            
+
             limit = float(ibeam.sigmaZ)/2.
             deltaZ = deltaSig(adelta1z0) > 3.5 and math.fabs(adelta1z0[0]) >= limit
-            
+
             deltasigmaZ = deltaSig(adelta1sigmaZ) > 5.0
 
             # check dxdz
@@ -746,12 +746,12 @@ def createWeightedPayloads(fileName,listbeam=[],weighted=True):
             deltadydz   = deltaSig(adelta) > 5.0
             if deltadydz and adelta1dydz[0]*adelta2dydz[0]<=0 and adelta2dydz[0] != 0 and math.fabs(adelta1dydz[0]/adelta2dydz[0]) > 0.33 and math.fabs(adelta1dydz[0]/adelta2dydz[0]) < 3:
                 deltadydz = False
-            
+
             adelta = delta(ibeam.beamWidthX, ibeam.beamWidthXerr, inextbeam.beamWidthX, inextbeam.beamWidthXerr)
             deltawidthX = deltaSig(adelta) > 5
             if deltawidthX and adelta1widthx[0]*adelta2widthx[0]<=0 and adelta2widthx[0] != 0 and math.fabs(adelta1widthx[0]/adelta2widthx[0]) > 0.33 and math.fabs(adelta1widthx[0]/adelta2widthx[0]) < 3:
                 deltawidthX = False
-                
+
             adelta = delta(ibeam.beamWidthY, ibeam.beamWidthYerr, inextbeam.beamWidthY, inextbeam.beamWidthYerr) 
             deltawidthY = deltaSig(adelta) > 5
             if deltawidthY and adelta1widthy[0]*adelta2widthy[0]<=0 and adelta2widthy[0] != 0 and math.fabs(adelta1widthy[0]/adelta2widthy[0]) > 0.33 and math.fabs(adelta1widthy[0]/adelta2widthy[0]) < 3:
@@ -839,13 +839,13 @@ def createWeightedPayloadsNew(fileName,listbeam=[],weighted=True):
                 #print " x= "+ibeam.X+" +/- "+ibeam.Xerr
                 #print "weighted average x = "+tmpbeam.X +" +//- "+tmpbeam.Xerr
                 print("close payload because of movement in X= "+str(deltaX)+", Y= "+str(deltaY) + ", Z= "+str(deltaZ)+", sigmaZ= "+str(deltasigmaZ)+", dxdz= "+str(deltadxdz)+", dydz= "+str(deltadydz)+", widthX= "+str(deltawidthX)+", widthY= "+str(deltawidthY))
-        
+
         #WARNING this will only be fine for Run based IOVs
         if ii >= len(listbeam) - 1 or listbeam[ii].Run != listbeam[ii+1].Run :
             print("close payload because end of run has been reached. Run " + listbeam[ii].Run)
             docreate = True
             lastToUse = ii
-        
+
 
          # check maximum lumi counts
 #?        if countlumi == maxNlumis:
@@ -873,7 +873,7 @@ def createWeightedPayloadsNew(fileName,listbeam=[],weighted=True):
             newlistbeam.append(tmpbeam)
             firstToUse = lastToUse+1
             print("Run: " + tmpbeam.Run + " Lumi1: " + str(tmpbeam.IOVfirst) + " Lumi2: " + str(tmpbeam.IOVlast))
-            
+
     payloadfile = open(fileName,"w")
     for iload in newlistbeam:
         dump( iload, payloadfile )
@@ -884,34 +884,34 @@ def writeSqliteFile(sqliteFileName,tagName,timeType,beamSpotFile,sqliteTemplateF
     writeDBOut = tmpDir + "write2DB_" + tagName + ".py"
     wFile      = open(sqliteTemplateFile)
     wNewFile   = open(writeDBOut,'w')
-    
+
     writeDBTags = [('SQLITEFILE','sqlite_file:' + sqliteFileName),
                    ('TAGNAME',tagName),
                    ('TIMETYPE',timeType),
                    ('BEAMSPOTFILE',beamSpotFile)]
-    
+
     for line in wFile:
         for itag in writeDBTags:
             line = line.replace(itag[0],itag[1])
         wNewFile.write(line)
-            
+
     wNewFile.close()
     print("writing sqlite file ...")
     status_wDB = commands.getstatusoutput('cmsRun '+ writeDBOut)
     print(status_wDB[1])
-        
+
     os.system("rm -f " + writeDBOut)
     return not status_wDB[0]
 
 ###########################################################################################
 def readSqliteFile(sqliteFileName,tagName,sqliteTemplateFile,tmpDir="/tmp/"):
     readDBOut = tmpDir + "readDB_" + tagName + ".py"
-    
+
     rFile = open(sqliteTemplateFile)
     rNewFile = open(readDBOut,'w')
-    
+
     readDBTags = [('SQLITEFILE','sqlite_file:' + sqliteFileName),
-		  ('TAGNAME',tagName)]
+                  ('TAGNAME',tagName)]
 
     for line in rFile:
         for itag in readDBTags:
@@ -920,7 +920,7 @@ def readSqliteFile(sqliteFileName,tagName,sqliteTemplateFile,tmpDir="/tmp/"):
 
     rNewFile.close()
     status_rDB = commands.getstatusoutput('cmsRun '+ readDBOut)
-    
+
     outtext = status_rDB[1]
     print(outtext)
     os.system("rm -f " + readDBOut)

--- a/RecoVertex/BeamSpotProducer/scripts/beamvalidation.py
+++ b/RecoVertex/BeamSpotProducer/scripts/beamvalidation.py
@@ -83,7 +83,7 @@ def cmp_tags(a,b):
 
     if yeara < yearb: return -1
     if yeara > yearb: return 1
-    
+
     suffix = "_offline"
     if a.find("_express") != -1:
         suffix = "_express"
@@ -92,16 +92,16 @@ def cmp_tags(a,b):
 
     tmpa = a.replace("BeamSpotObjects_2009_v","")
     tmpa = tmpa.replace(suffix,"")
-    
+
     tmpb = b.replace("BeamSpotObjects_2009_v","")
     tmpb = tmpb.replace(suffix,"")
-        
+
     na = int(tmpa)
     nb = int(tmpb)
     if na < nb: return -1
     if na == nb: return 0
     if na > nb: return 1
-    
+
 #___
 
 def dump_header(lines):
@@ -136,7 +136,7 @@ def write_tags(tags, lines):
 
     lines.append('<tr>'+end)
     for i in tags.keys():
-        
+
         lines.append('<th>'+i)
         lines.append('</th>'+end)
     lines.append('</tr>'+end)
@@ -165,21 +165,21 @@ def write_iovs(iovs, lines):
     # lumi type
     lines.append('<tr>'+end)
     for i in iovs.keys():
-	aIOVlist = iovs[i]
-	aIOV = IOV()
-	if len(aIOVlist) > 0:
-	    aIOV = aIOVlist[0]
-	lines.append('<td> '+aIOV.type+' </td>'+end)
+        aIOVlist = iovs[i]
+        aIOV = IOV()
+        if len(aIOVlist) > 0:
+            aIOV = aIOVlist[0]
+        lines.append('<td> '+aIOV.type+' </td>'+end)
     lines.append('</tr>'+end)
     # print iovs
     for niovs in range(0,len(iovs[iovs.keys()[0]])):
         lines.append('<tr>'+end)
         for i in iovs.keys():
             aIOVlist = iovs[i]
-	    aIOV = IOV()
-	    if len(aIOVlist) > niovs:
-		aIOV = aIOVlist[niovs]
-	    lines.append('<td> '+aIOV.IOVfirst +' - '+aIOV.IOVlast+' </td>'+end)
+            aIOV = IOV()
+            if len(aIOVlist) > niovs:
+                aIOV = aIOVlist[niovs]
+            lines.append('<td> '+aIOV.IOVfirst +' - '+aIOV.IOVlast+' </td>'+end)
         lines.append('</tr>'+end)
 
 #______________
@@ -189,9 +189,9 @@ def get_listoftags(dest, auth,):
     print(queryTags_cmd)
     outcmd = commands.getstatusoutput( queryTags_cmd )
     print(outcmd[1])
-    
+
     listtags = outcmd[1].split()
-    
+
     listtags_offline = []
     for itag in listtags:
         if itag[len(itag)-7:len(itag)] == "offline":
@@ -233,19 +233,19 @@ def get_lastIOVs( listoftags, dest, auth ):
 
     results = {}
     for itag in dbtags:
-        
+
         lasttag = listoftags[itag][0]
         #fix for the moment to read old tags
         if itag != "offline":
             lasttag = listoftags[itag][1]
-        
+
         queryIOVs_cmd = "cmscond_list_iov -c "+dest+" -P "+auth+" -t "+ lasttag
         print(queryIOVs_cmd)
-        
+
         outcmd = commands.getstatusoutput( queryIOVs_cmd )
-        
+
         tmparr = outcmd[1].split('\n')
-    
+
         TimeType = tmparr[1].split()[1]
         listIOVs = []
 
@@ -297,8 +297,8 @@ def get_plots(path,output, iovs, tag):
     initial=iovs[len(iovs)-1].IOVfirst
     final =iovs[0].IOVfirst
     if iovs[0].type == "lumiid":
-	initial = str(unpack(initial)[0])+":"+str(unpack(initial)[1])
-	final =  str(unpack(final)[0])+":"+str(unpack(final)[1])
+        initial = str(unpack(initial)[0])+":"+str(unpack(initial)[1])
+        final =  str(unpack(final)[0])+":"+str(unpack(final)[1])
 
     initial = str(int(initial) -100 )
     cmd = path+"/plotBeamSpotDB.py -b -P -t "+tag+" -i "+initial +" -f "+final
@@ -311,12 +311,12 @@ def get_plots(path,output, iovs, tag):
 
     pngfiles = outcmd[1].split('\n')
     print(pngfiles)
-    
+
     cmd = "cp *.png "+os.path.dirname(output)
     outcmd = commands.getstatusoutput( cmd )
     cmd = "rm *.png"
     outcmd = commands.getstatusoutput( cmd )
-    
+
     pngfiles.sort()
     return pngfiles
 
@@ -332,16 +332,16 @@ def write_plots(lines, plots,web):
 
 ''')
     for i in range(0,len(plots)):
-	plot = plots[i]
+        plot = plots[i]
         plot = os.path.basename(plot)
-	if i%2 == 0:
-	    lines.append("<tr>"+end)
-	lines.append("<td> <a href=\""+web+"/"+plot+"\"> <img src="+plot+" alt="+plot+" width='700' height='250' /> </a> </td>"+end)
-	if i%2 == 1:
-	    lines.append("</tr>"+end)
+        if i%2 == 0:
+            lines.append("<tr>"+end)
+        lines.append("<td> <a href=\""+web+"/"+plot+"\"> <img src="+plot+" alt="+plot+" width='700' height='250' /> </a> </td>"+end)
+        if i%2 == 1:
+            lines.append("</tr>"+end)
 
     lines.append('</table>'+end)
-    
+
 #________________________________
 def get_productionFiles( directory ):
 
@@ -367,7 +367,7 @@ def get_productionIOVs( directory ):
 #______________________________
 if __name__ == '__main__':
 
-    
+
     # COMMAND LINE OPTIONS
     #################################
     option,args = parse(__doc__)
@@ -376,26 +376,26 @@ if __name__ == '__main__':
     #htmlwebsite = "http://cmsrocstor.fnal.gov/lpc1/cmsroc/yumiceva/tmp/"
     htmlwebsite = "https://yumiceva.web.cern.ch/yumiceva/beamspot/"
     if option.web: htmlwebsite = option.web
-    
+
     ## Get the latest tags
     #dest = "frontier://cmsfrontier.cern.ch:8000/Frontier/CMS_COND_31X_BEAMSPOT"
     dest = "oracle://cms_orcoff_prod/CMS_COND_31X_BEAMSPOT"
     auth = "/afs/cern.ch/cms/DB/conddb"
     #cmscond_list_iov -c oracle://cms_orcoff_prep/CMS_COND_BEAMSPOT -P /afs/cern.ch/cms/DB/conddb  -a
-    
+
     list_tags = get_listoftags( dest, auth)
-        
+
     # Get the latest IOVs from last tag
     list_lastIOVs = get_lastIOVs( list_tags, dest, auth)
 
     # get latest processed runs
     processedruns = get_productionIOVs('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_BSPOT/yumiceva/tmp_lumi_workflow/')
-    
+
     # create web page
     lines = []
     end = '\n'
     br = '<BR>'+end
-    
+
     dump_header(lines)
 
     lines.append('<h2>The three latest IOVs</h2>'+end)
@@ -405,7 +405,7 @@ if __name__ == '__main__':
 ''')
     write_iovs( list_lastIOVs, lines )
     lines.append('</table>'+end)
-    
+
     lines.append('<h2>Latest data processed</h2>'+end)
     lines.append(br)
     #lines.append('to be written'+end)
@@ -424,7 +424,7 @@ if __name__ == '__main__':
     lasttag = list_lastIOVs.keys()[0]
     lines.append('<h2>Plots of the latest IOVs from condDB tag: '+lasttag+' </h2>'+end)
     lines.append(br)
-    
+
     pngfiles = get_plots(option.path,option.output, list_lastIOVs[lasttag], lasttag)
     write_plots( lines, pngfiles, htmlwebsite )
 
@@ -433,11 +433,11 @@ if __name__ == '__main__':
     outfile = open(option.output,'w')
     #print lines
     outfile.writelines( lines )
-    
-    
-    
 
 
 
 
-    
+
+
+
+

--- a/RecoVertex/BeamSpotProducer/scripts/checkPayloads.py
+++ b/RecoVertex/BeamSpotProducer/scripts/checkPayloads.py
@@ -22,20 +22,20 @@ def getUploadedIOVs(tagName,destDB="oracle://cms_orcoff_prod/CMS_COND_31X_BEAMSP
             exit(dbError[1])
         else:
             exit("ERROR: Can\'t connect to db because:\n" + dbError[1])
-            
-            
+
+
     aCommand = listIOVCommand + " | grep DB= | awk \'{print $1}\'"
     #print aCommand
     output = commands.getstatusoutput( aCommand )
-            
+
     #WARNING when we pass to lumi IOV this should be long long
     if output[1] == '':
         exit("ERROR: The tag " + tagName + " exists but I can't get the value of the last IOV")
-                
+
     runs = []    
     for run in output[1].split('\n'):
         runs.append(long(run))
-                
+
     return runs
 
 #####################################################################################
@@ -75,7 +75,7 @@ def getListOfRunsAndLumiFromRR(firstRun=-1,error=""):
             tries += 1
             print("Trying to get run data. This fails only 2-3 times so don't panic yet...", tries, "/", maxAttempts)
             time.sleep(1)
-	    print("Exception type: ", sys.exc_info()[0])
+            print("Exception type: ", sys.exc_info()[0])
         if tries==maxAttempts:
             error = "Ok, now panic...run registry unaccessible...I'll get the runs from a json file!"
             print(error);
@@ -101,7 +101,7 @@ def getListOfRunsAndLumiFromRR(firstRun=-1,error=""):
             tries += 1
             print("I was able to get the list of runs and now I am trying to access the detector status", tries, "/", maxAttempts)
             time.sleep(1)
-	    print("Exception type: ", sys.exc_info()[0])
+            print("Exception type: ", sys.exc_info()[0])
 
         if tries==maxAttempts:
             error = "Ok, now panic...run registry unaccessible...I'll get the runs from a json file!"
@@ -125,12 +125,12 @@ def getListOfRunsAndLumiFromRR(firstRun=-1,error=""):
     #    if tries==maxAttempts:
     #        error = "Run registry unaccessible.....exiting now"
     #        sys.exit(error)
-                
-                
-                        
+
+
+
     selected_dcs={}
     jsonList=json.loads(dcs_data)
-    
+
     #for element in jsonList:
     for element in listOfRuns:
         #if element in listOfRuns:
@@ -188,7 +188,7 @@ def main():
     #142653 Strips not in data taking
     #143977 No Beam Strips and Pixels bad
     #148859 Strips and Pixels HV off waiting for beam 
-    
+
     knownMissingRunList = [132573,132958,133081,133242,133472,133473,136290,138560,138562,139455,140133,140182,142461,142465,142503,142653,143977,148859]
     tagName = "BeamSpotObjects_2009" + dbBase + sigmaZ + "_v" + tagNumber + "_offline"
     print("Checking payloads for tag " + tagName)
@@ -222,8 +222,8 @@ def main():
                 extraMsg = " but this run is know to be bad " #+ runErrors[run]
                 if not printExtra: continue
             print("Run: " + str(run) + " is missing for DB tag " + tagName + extraMsg) 
-    
+
 
 if __name__ == "__main__":
     main()
-            
+

--- a/RecoVertex/BeamSpotProducer/scripts/createPayload.py
+++ b/RecoVertex/BeamSpotProducer/scripts/createPayload.py
@@ -56,31 +56,31 @@ def copyToWorkflowdir(path):
     listoffiles    = []
     tmplistoffiles = []
     if path.find('castor') != -1:
-    	print("Getting files from castor ...")
-    	lsCommand = 'ns'
-    	cpCommand = 'rf'
+        print("Getting files from castor ...")
+        lsCommand = 'ns'
+        cpCommand = 'rf'
     elif not os.path.exists(path):
         exit("ERROR: File or directory " + path + " doesn't exist") 
 
     if path[len(path)-4:len(path)] != '.txt':
- 	if path[len(path)-1] != '/':
- 	    path = path + '/'
-	
- 	aCommand  = lsCommand  + 'ls '+ path + " | grep .txt"
+        if path[len(path)-1] != '/':
+            path = path + '/'
 
- 	tmpstatus = commands.getstatusoutput( aCommand )
- 	tmplistoffiles = tmpstatus[1].split('\n')
+        aCommand  = lsCommand  + 'ls '+ path + " | grep .txt"
+
+        tmpstatus = commands.getstatusoutput( aCommand )
+        tmplistoffiles = tmpstatus[1].split('\n')
         if len(tmplistoffiles) == 1:
             if tmplistoffiles[0] == '':
                 exit('ERROR: No files found in directory ' + path)
             if tmplistoffiles[0].find('No such file or directory') != -1:
                 exit("ERROR: File or directory " + path + " doesn't exist") 
-            
+
     else:
         tmplistoffiles.append(path[path.rfind('/')+1:len(path)])
-	path = path[0:path.rfind('/')+1]
+        path = path[0:path.rfind('/')+1]
 
- 
+
     archiveName = path
     if path == './':
         archiveName = os.getcwd() + '/'
@@ -92,7 +92,7 @@ def copyToWorkflowdir(path):
     if tagType != '' :
         workflowdirArchive = workflowdirArchive[:len(workflowdirArchive)-1] + '_' + tagType + '/'
     if not os.path.isdir(workflowdirArchive):
-    	os.mkdir(workflowdirArchive)
+        os.mkdir(workflowdirArchive)
     elif(option.newarchive):
 #        tmpTime = str(datetime.datetime.now())
 #        tmpTime = tmpTime.replace(' ','-')
@@ -107,9 +107,9 @@ def copyToWorkflowdir(path):
                 break
             elif n == 100000-1:
                 exit('ERROR: Unbelievable! do you ever clean ' + workflowdir + '?. I think you have to remove some directories!') 
-                 
+
     for ifile in tmplistoffiles:
-    	if ifile.find('.txt') != -1:
+        if ifile.find('.txt') != -1:
             if os.path.isfile(workflowdirArchive+"/"+ifile):
                 if option.overwrite:
                     print("File " + ifile + " already exists in destination. We will overwrite it.")
@@ -117,10 +117,10 @@ def copyToWorkflowdir(path):
                     print("File " + ifile + " already exists in destination. Keep original file.")
                     listoffiles.append( workflowdirArchive + ifile )
                     continue
-    	    listoffiles.append( workflowdirArchive + ifile )
-    	    # copy to local disk
-    	    aCommand = cpCommand + 'cp '+ path + ifile + " " + workflowdirArchive
-    	    print(" >> " + aCommand)
+            listoffiles.append( workflowdirArchive + ifile )
+            # copy to local disk
+            aCommand = cpCommand + 'cp '+ path + ifile + " " + workflowdirArchive
+            print(" >> " + aCommand)
             tmpstatus = commands.getstatusoutput( aCommand )
     return listoffiles
 
@@ -130,30 +130,30 @@ def mkWorkflowdir():
     global workflowdirTmp
     global workflowdirArchive
     if not os.path.isdir(workflowdir):
-	print("Making " + workflowdir + " directory...")
-	os.mkdir(workflowdir)
+        print("Making " + workflowdir + " directory...")
+        os.mkdir(workflowdir)
 
     if not os.path.isdir(workflowdirLastPayloads):
-    	os.mkdir(workflowdirLastPayloads)
+        os.mkdir(workflowdirLastPayloads)
     else:
-    	os.system("rm -f "+ workflowdirLastPayloads + "*")
-       
+        os.system("rm -f "+ workflowdirLastPayloads + "*")
+
     if not os.path.isdir(workflowdirTmp):
-    	os.mkdir(workflowdirTmp)
+        os.mkdir(workflowdirTmp)
     else:
-    	os.system("rm -f "+ workflowdirTmp + "*")
+        os.system("rm -f "+ workflowdirTmp + "*")
 
     if not os.path.isdir(workflowdirArchive):
-    	os.mkdir(workflowdirArchive)
+        os.mkdir(workflowdirArchive)
 
 ###############################################################################################3
 if __name__ == '__main__':
     #if len(sys.argv) < 2:
 #	print "\n [usage] createPayload <beamspot file> <tag name> <IOV since> <IOV till=-1=inf> <IOV comment> <destDB=oracle://cms_orcon_prod/CMS_COND_31X_BEAMSPOT>"
-	#print " e.g. createPayload BeamFitResults_template.txt BeamSpotObjects_2009_v1_express 122745 \"\" \"beam spot for early collisions\" \"oracle://cms_orcon_prod/CMS_COND_31X_BEAMSPOT\"\n"
-	#sys.exit()
+        #print " e.g. createPayload BeamFitResults_template.txt BeamSpotObjects_2009_v1_express 122745 \"\" \"beam spot for early collisions\" \"oracle://cms_orcon_prod/CMS_COND_31X_BEAMSPOT\"\n"
+        #sys.exit()
 
-    
+
      # COMMAND LINE OPTIONS
     #################################
     option,args = parse(__doc__)
@@ -163,25 +163,25 @@ if __name__ == '__main__':
     if option.Output:
         workflowdir = option.Output
         if workflowdir[len(workflowdir)-1] != '/':
- 	    workflowdir = workflowdir + '/'
+            workflowdir = workflowdir + '/'
     workflowdirLastPayloads = workflowdir + "lastPayloads/"
     workflowdirTmp          = workflowdir + "tmp/"
     workflowdirArchive      = workflowdir + "archive/"
-    
+
     if ( (option.data and option.tag) or (option.data and option.copy)):
         mkWorkflowdir()
-    
+
     if not option.data:
-	print("ERROR: You must provide the data file or the a directory with data files")
-	exit()
+        print("ERROR: You must provide the data file or the a directory with data files")
+        exit()
 
     if option.copy:
-      copyToWorkflowdir(option.data)
-      exit("Files copied in " + workflowdirArchive)
-    
+        copyToWorkflowdir(option.data)
+        exit("Files copied in " + workflowdirArchive)
+
     tagname = ''
     if option.tag:
-	tagname = option.tag
+        tagname = option.tag
         if tagname.find("offline") != -1:
             tagType = "offline"
         elif tagname.find("prompt") != -1:
@@ -195,8 +195,8 @@ if __name__ == '__main__':
             tagType = "offline"
 
     else:	
-	print("ERROR: You must provide the database tag name")
-	exit()
+        print("ERROR: You must provide the database tag name")
+        exit()
 
     IOVbase = 'runbase'
     timetype = 'runnumber'
@@ -204,8 +204,8 @@ if __name__ == '__main__':
         if option.IOVbase != "runbase" and option.IOVbase != "lumibase" and option.IOVbase != "timebase":
             print("\n\n unknown iov base option: "+ option.IOVbase +" \n\n\n")
             exit()
-	IOVbase = option.IOVbase
-    
+        IOVbase = option.IOVbase
+
     listoffiles = copyToWorkflowdir(option.data)
     # sort list of data files in chronological order
     sortedlist = {}
@@ -224,28 +224,28 @@ if __name__ == '__main__':
                 atime = line.split()[1]
                 sortedlist[atime] = block
             break
-        
-	tmpfile = open(beam_file)
-	atime = ''
-	arun = ''
-	alumis = ''
-	skip = False
-	for line in tmpfile:
-	    if line.find('Runnumber') != -1:
-		arun = line.split()[1]
-	    if line.find("EndTimeOfFit") != -1:
-		atime = time.strptime(line.split()[1] +  " " + line.split()[2] + " " + line.split()[3],"%Y.%m.%d %H:%M:%S %Z")
-	    if line.find("LumiRange") != -1:
-		alumi = line.split()[3]
-	    if line.find('Type') != -1 and line.split()[1] == '0':
-		skip = True		
-	if skip:
-	    print(" zero fit result, skip file " + beam_file + " with time stamp:")
-	    print(" run " + arun + " lumis " + alumis)
-	else:
-	    sortedlist[int(pack(int(arun), int(alumi)))] = beam_file
-		
-	tmpfile.close()
+
+        tmpfile = open(beam_file)
+        atime = ''
+        arun = ''
+        alumis = ''
+        skip = False
+        for line in tmpfile:
+            if line.find('Runnumber') != -1:
+                arun = line.split()[1]
+            if line.find("EndTimeOfFit") != -1:
+                atime = time.strptime(line.split()[1] +  " " + line.split()[2] + " " + line.split()[3],"%Y.%m.%d %H:%M:%S %Z")
+            if line.find("LumiRange") != -1:
+                alumi = line.split()[3]
+            if line.find('Type') != -1 and line.split()[1] == '0':
+                skip = True		
+        if skip:
+            print(" zero fit result, skip file " + beam_file + " with time stamp:")
+            print(" run " + arun + " lumis " + alumis)
+        else:
+            sortedlist[int(pack(int(arun), int(alumi)))] = beam_file
+
+        tmpfile.close()
 
     keys = sorted(sortedlist.keys())
 
@@ -254,40 +254,40 @@ if __name__ == '__main__':
         os.mkdir(workflowdirArchive + "AllIOVs")
     allbeam_file = workflowdirArchive + "AllIOVs/" + tagname + "_all_IOVs.txt"
 #    if os.path.isfile(allbeam_file):
-        
+
     allfile = open( allbeam_file, 'a')
     print(" merging all results into file: " + allbeam_file)
 
     # check if merged sqlite file exists
     if os.path.exists(workflowdirArchive+"payloads/Combined.db"):
         os.system("rm "+workflowdirArchive+"payloads/Combined.db")
-    
-    
+
+
     nfile = 0
     iov_since_first = '1'
     total_files = len(keys)
-    
+
     destDB = 'oracle://cms_orcon_prod/CMS_COND_31X_BEAMSPOT'
     if option.Test:
         destDB = 'oracle://cms_orcoff_prep/CMS_COND_BEAMSPOT'
 
     iov_comment = 'Beam spot position'
     for key in keys:
-	
-	iov_since = '1'
-	iov_till = ''
-	
-	suffix = "_" + str(nfile)
-	writedb_template = os.getenv("CMSSW_BASE") + "/src/RecoVertex/BeamSpotProducer/test/write2DB_template.py"
-	readdb_template  = os.getenv("CMSSW_BASE") + "/src/RecoVertex/BeamSpotProducer/test/readDB_template.py"
+
+        iov_since = '1'
+        iov_till = ''
+
+        suffix = "_" + str(nfile)
+        writedb_template = os.getenv("CMSSW_BASE") + "/src/RecoVertex/BeamSpotProducer/test/write2DB_template.py"
+        readdb_template  = os.getenv("CMSSW_BASE") + "/src/RecoVertex/BeamSpotProducer/test/readDB_template.py"
         sqlite_file_name = tagname + suffix
-	sqlite_file   = workflowdirTmp + sqlite_file_name + '.db'
-	metadata_file = workflowdirTmp + sqlite_file_name + '.txt'
-	nfile = nfile + 1
-               
+        sqlite_file   = workflowdirTmp + sqlite_file_name + '.db'
+        metadata_file = workflowdirTmp + sqlite_file_name + '.txt'
+        nfile = nfile + 1
+
     #### WRITE sqlite file
-	
-	beam_file = sortedlist[key]
+
+        beam_file = sortedlist[key]
         tmp_datafilename = workflowdirTmp+"tmp_datafile.txt"
         if option.merged:
             tmpfile = file(tmp_datafilename,'w')
@@ -295,81 +295,81 @@ if __name__ == '__main__':
             tmpfile.close()
             beam_file = tmp_datafilename
 
-	print("read input beamspot file: " + beam_file)
-	tmpfile = open(beam_file)
+        print("read input beamspot file: " + beam_file)
+        tmpfile = open(beam_file)
         beam_file_tmp = workflowdirTmp + beam_file[beam_file.rfind('/')+1:] + ".tmp"
-	newtmpfile = open(beam_file_tmp,"w")
-	tmp_run = ""
-	tmp_lumi_since = ""
+        newtmpfile = open(beam_file_tmp,"w")
+        tmp_run = ""
+        tmp_lumi_since = ""
         tmp_lumi_till = ""
-	for line in tmpfile:
-	    if line.find("Runnumber") != -1:
-		iov_since = line.split()[1]
-		iov_till = iov_since
-		tmp_run = line.split()[1]
-	    elif line.find("LumiRange") != -1:
-		tmp_lumi_since = line.split()[1]
+        for line in tmpfile:
+            if line.find("Runnumber") != -1:
+                iov_since = line.split()[1]
+                iov_till = iov_since
+                tmp_run = line.split()[1]
+            elif line.find("LumiRange") != -1:
+                tmp_lumi_since = line.split()[1]
                 tmp_lumi_till = line.split()[3]
-	    elif line.find("BeginTimeOfFit") == -1 and line.find("EndTimeOfFit") == -1 and line.find("LumiRange") == -1:
+            elif line.find("BeginTimeOfFit") == -1 and line.find("EndTimeOfFit") == -1 and line.find("LumiRange") == -1:
                 if line.find("sigmaZ0") != -1 and option.zlarge:
                     line = "sigmaZ0 10\n"
                 if line.find("Cov(3,j)") != -1 and option.zlarge:
                     line = "Cov(3,j) 0 0 0 2.5e-05 0 0 0\n"
-		newtmpfile.write(line)
+                newtmpfile.write(line)
             allfile.write(line)
 
-	# pack run number and lumi section
-	if IOVbase == "lumibase":
+        # pack run number and lumi section
+        if IOVbase == "lumibase":
             timetype = "lumiid"
-	    iov_since = str( pack(int(tmp_run), int(tmp_lumi_since)) )
+            iov_since = str( pack(int(tmp_run), int(tmp_lumi_since)) )
             iov_till = str( pack(int(tmp_run), int(tmp_lumi_till)) )
         # keep first iov for merged output metafile
         if nfile == 1:
             iov_since_first = iov_since
-        
-	tmpfile.close()
-	newtmpfile.close()
+
+        tmpfile.close()
+        newtmpfile.close()
         if option.copy:
             continue
-        
-	beam_file = beam_file_tmp
+
+        beam_file = beam_file_tmp
 
         if not writeSqliteFile(sqlite_file,tagname,timetype,beam_file,writedb_template,workflowdirTmp):
             print("An error occurred while writing the sqlite file: " + sqlite_file)
 
-	commands.getstatusoutput('rm -f ' + beam_file)
+        commands.getstatusoutput('rm -f ' + beam_file)
         ##### READ and check sqlite file
         readSqliteFile(sqlite_file,tagname,readdb_template,workflowdirTmp)
-        
+
         #### Merge sqlite files
         if not os.path.isdir(workflowdirArchive + 'payloads'):
             os.mkdir(workflowdirArchive + 'payloads')
-        
+
         print(" merge sqlite file ...")
         appendSqliteFile("Combined.db", sqlite_file, tagname, iov_since, iov_till ,workflowdirTmp)
-        
+
         # keep last payload for express, and prompt tags
         if nfile == total_files:
             print(" this is the last IOV. You can use this payload for express and prompt conditions.")
             os.system("cp "+sqlite_file+ " "+workflowdirArchive+"payloads/express.db")
             print("a copy of this payload has been placed at:")
             print(workflowdirArchive+"payloads/express.db")
-        
+
         # clean up
-	os.system("rm "+ sqlite_file)
+        os.system("rm "+ sqlite_file)
         print(" clean up done.")
 
     os.system("mv " + workflowdirTmp + "Combined.db " + workflowdirArchive + "payloads/")
     allfile.close()
-            
+
     #### CREATE payload for merged output
-            
+
     print(" create MERGED payload card for dropbox ...")
-    
+
     sqlite_file   = workflowdirArchive+'payloads/Combined.db'
     metadata_file = workflowdirArchive+'payloads/Combined.txt'
     dfile = open(metadata_file,'w')
-        
+
     dfile.write('destDB '+ destDB +'\n')
     dfile.write('tag '+ tagname +'\n')
     dfile.write('inputtag' +'\n')
@@ -384,12 +384,12 @@ if __name__ == '__main__':
         checkType = "hlt"
     dfile.write('IOVCheck ' + checkType + '\n')
     dfile.write('usertext ' + iov_comment +'\n')
-        
+
     dfile.close()
-        
+
     uuid = commands.getstatusoutput('uuidgen -t')[1]
     final_sqlite_file_name = tagname + '@' + uuid
-        
+
     if not os.path.isdir(workflowdirArchive + 'payloads'):
         os.mkdir(workflowdirArchive + 'payloads')
     commands.getstatusoutput('cp ' + sqlite_file   + ' ' + workflowdirArchive + 'payloads/' + final_sqlite_file_name + '.db')
@@ -400,7 +400,7 @@ if __name__ == '__main__':
 
     print(workflowdirLastPayloads + final_sqlite_file_name + '.db')
     print(workflowdirLastPayloads + final_sqlite_file_name + '.txt')
-        
+
     if option.upload:
         print(" scp files to offline Drop Box")
         dropbox = "/DropBox"

--- a/RecoVertex/BeamSpotProducer/scripts/getBeamSpotDB.py
+++ b/RecoVertex/BeamSpotProducer/scripts/getBeamSpotDB.py
@@ -108,15 +108,15 @@ if __name__ == '__main__':
     #################################
     option,args = parse(__doc__)
     if not args and not option: exit()
-    
+
     tagname = ''
     globaltag = ''
-    
+
     if ((option.tag and option.globaltag)) == False: 
-	print(" NEED to provide beam spot DB tag name, or global tag")
-	exit()
+        print(" NEED to provide beam spot DB tag name, or global tag")
+        exit()
     elif option.tag:
-	tagname = option.tag
+        tagname = option.tag
     elif option.globaltag:
         globaltag = option.globaltag
         cmd = 'cmscond_tagtree_list -c frontier://cmsfrontier.cern.ch:8000/Frontier/CMS_COND_31X_GLOBALTAG -P /afs/cern.ch/cms/DB/conddb -T '+globaltag+' | grep BeamSpot'
@@ -125,33 +125,33 @@ if __name__ == '__main__':
         atag = atag[2]
         tagname = atag.replace("tag:","")
         print(" Global tag: "+globaltag+" includes the beam spot tag: "+tagname)
-    
+
     iov_since = ''
     iov_till = ''
     destDB = 'frontier://PromptProd/CMS_COND_31X_BEAMSPOT'
     if option.destDB:
         destDB = option.destDB
-    
+
     auth = '/afs/cern.ch/cms/DB/conddb'
     if option.auth:
         auth = option.auth
-    
+
     run = '1'
     if option.run:
         run = option.run
     lumi = '1'
     if option.lumi:
         lumi = option.lumi
-        
+
     #sqlite_file = "sqlite_file:"+ tagname +".db"
 
-    
+
     ##### READ 
 
     #print "read back sqlite file to check content ..."
-    
+
     readdb_out = "readDB_"+tagname+".py"
-    
+
     rnewfile = open(readdb_out,'w')
 
     rnewfile.write('''
@@ -170,7 +170,7 @@ process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
     rnewfile.write('tag = cms.string(\''+tagname+'\')\n')
     rnewfile.write(')),\n')
     rnewfile.write('connect = cms.string(\''+destDB+'\')\n')
-    
+
     #connect = cms.string('sqlite_file:Early900GeVCollision_7p4cm_STARTUP_mc.db')
     #connect = cms.string('oracle://cms_orcoff_prod/CMS_COND_31X_BEAMSPOT')
     #connect = cms.string('frontier://PromptProd/CMS_COND_31X_BEAMSPOT')
@@ -199,10 +199,10 @@ process.beamspot = cms.EDAnalyzer("BeamSpotFromDB")
 process.p = cms.Path(process.beamspot)
 
 ''')
-        
+
     rnewfile.close()
     status_rDB = commands.getstatusoutput('cmsRun '+ readdb_out)
-    
+
     outtext = status_rDB[1]
     print(outtext)
 
@@ -210,6 +210,6 @@ process.p = cms.Path(process.beamspot)
     #os.system("rm "+ readdb_out)
 
     print("DONE.\n")
-    
+
 #_________________________________    
-        
+

--- a/RecoVertex/BeamSpotProducer/scripts/ntuplemaker.py
+++ b/RecoVertex/BeamSpotProducer/scripts/ntuplemaker.py
@@ -59,16 +59,16 @@ def getFill( json, run ):
     thefill = 0
     run = int(run)
     keys = json.keys()
-    
+
     for i in keys:
 
         run0 = int(json[i][0])
         run1 = int(json[i][1])
         if run>= run0 and run<=run1:
             thefill = i
-    
+
     return int(thefill)
-    
+
 if __name__ == '__main__':
 
 
@@ -100,7 +100,7 @@ if __name__ == '__main__':
         Int_t     lumi[2];\
         Int_t     fill;\
         };" );
-    
+
     bntuple = spot()
     fntuple = TFile( 'bntuple.root', 'RECREATE' )
     tbylumi = TTree( 'bylumi', 'beam spot data lumi by lumi' )
@@ -114,7 +114,7 @@ if __name__ == '__main__':
     tbylumi.Branch('slope', AddressOf( bntuple, 'slope'),'slope[2]/F')
     tbylumi.Branch('slopeErr', AddressOf( bntuple, 'slopeError'),'slopeError[2]/F')
     tbylumi.Branch('time', AddressOf( bntuple, 'time'),'time[2]/F')
-            
+
     tbyIOV = TTree( 'byIOV', 'beam spot data by IOV' )
     tbyIOV.Branch('fill', AddressOf( bntuple, 'fill'), 'fill/I' )
     tbyIOV.Branch('run', AddressOf( bntuple, 'run'), 'run/I' )
@@ -126,7 +126,7 @@ if __name__ == '__main__':
     tbyIOV.Branch('slope', AddressOf( bntuple, 'slope'),'slope[2]/F')
     tbyIOV.Branch('slopeErr', AddressOf( bntuple, 'slopeError'),'slopeError[2]/F')
     tbyIOV.Branch('time', AddressOf( bntuple, 'time'),'time[2]/F')
-    
+
     tbyrun = TTree( 'byrun', 'beam spot data by run' )
     tbyrun.Branch('fill', AddressOf( bntuple, 'fill'), 'fill/I' )
     tbyrun.Branch('run', AddressOf( bntuple, 'run'), 'run/I' )
@@ -138,37 +138,37 @@ if __name__ == '__main__':
     tbyrun.Branch('slope', AddressOf( bntuple, 'slope'),'slope[2]/F')
     tbyrun.Branch('slopeErr', AddressOf( bntuple, 'slopeError'),'slopeError[2]/F')
     tbyrun.Branch('time', AddressOf( bntuple, 'time'),'time[2]/F')
-                    
+
 
     # COMMAND LINE OPTIONS
     #################################
     option,args = parse(__doc__)
     if not args and not option: exit()
-    
+
     if not option.data: 
-	print(" need to provide beam spot data file")
-	exit()
-    
+        print(" need to provide beam spot data file")
+        exit()
+
     if option.batch:
         ROOT.gROOT.SetBatch()
-        
+
     datafilename = "tmp_beamspot.dat"
     if option.create:
         datafilename = option.create
-    
+
     getDBdata = True
     if option.data:
         getDBdata = False
-   
+
     IOVbase = 'lumibase'
     firstRun = "0:0"
     lastRun = "4999999999:4999999999"
-    
+
     if option.initial:
         firstRun = option.initial
     if option.final:
         lastRun = option.final
-        
+
     # GET IOVs
     ################################
 
@@ -185,19 +185,19 @@ if __name__ == '__main__':
         iline = jline = 0
         totlines = len(tmplistiov)
         for line in tmplistiov:
-	
+
             if line.find('since') != -1:
                 passline = True
                 jline = iline
             if passline and iline > jline and iline < totlines-1:
                 linedata = line.split()
-	        #print linedata
+                #print linedata
                 aIOV = IOV()
                 aIOV.since = int(linedata[0])
                 aIOV.till = int(linedata[1])
                 iovlist.append( aIOV )
             iline += 1
-    
+
         print(" total number of IOVs = " + str(len(iovlist)))
 
 
@@ -209,7 +209,7 @@ if __name__ == '__main__':
             otherArgs = " -d " + option.destDB
             if option.auth:
                 otherArgs = otherArgs + " -a "+ option.auth
-        
+
         print(" get beam spot data from DB for IOVs. This can take a few minutes ...")
 
         tmpfile = open(datafilename,'w')
@@ -227,7 +227,7 @@ if __name__ == '__main__':
                 #tmplumilast  = int(lastRun.split(":")[1])
                 tmprunfirst = pack( int(firstRun.split(":")[0]) , int(firstRun.split(":")[1]) )
                 tmprunlast  = pack( int(lastRun.split(":")[0]) , int(lasstRun.split(":")[1]) )
-	    #print "since = " + str(iIOV.since) + " till = "+ str(iIOV.till)
+            #print "since = " + str(iIOV.since) + " till = "+ str(iIOV.till)
             if iIOV.since >= int(tmprunfirst) and int(tmprunlast) < 0 and iIOV.since <= int(tmprunfirst):
                 print(" IOV: " + str(iIOV.since))
                 passiov = True
@@ -245,12 +245,12 @@ if __name__ == '__main__':
                     acommand = 'getBeamSpotDB.py -t '+ tag + " -r " + str(tmprun) +" -l "+tmplumi +otherArgs
                 status = commands.getstatusoutput( acommand )
                 tmpfile.write(status[1])
-    
+
         print(" beam spot data collected and stored in file " + datafilename)
-    
+
         tmpfile.close()
 
-    
+
     # PROCESS DATA
     ###################################
 
@@ -261,14 +261,14 @@ if __name__ == '__main__':
             files = tmp[1].split()
             datafilename = "combined_all.txt"
             output = open(datafilename,"w")
-            
+
             for f in files:
                 if os.path.isdir(option.data+"/"+f) is False:
                     input = open(option.data +"/"+f)
                     output.writelines(input.readlines())
             output.close()
             print(" data files have been collected in "+datafilename)
-            
+
         elif os.path.exists(option.data):
             datafilename = option.data
         else:
@@ -285,16 +285,16 @@ if __name__ == '__main__':
         listbeam = listmap[option.Xrossing]
     else:
         readBeamSpotFile(datafilename,listbeam,IOVbase,firstRun,lastRun)
-    
+
     sortAndCleanBeamList(listbeam,IOVbase)
-	    
-    
+
+
     ###################################    
-    
+
     for ii in range(0,len(listbeam)):
-	    
+
         ibeam = listbeam[ii]
-        
+
         bntuple.position = array('f', [float(ibeam.X), float(ibeam.Y), float(ibeam.Z)])
         bntuple.posError = array('f', [float(ibeam.Xerr),float(ibeam.Yerr),float(ibeam.Zerr)])
         bntuple.width = array('f', [float(ibeam.beamWidthX), float(ibeam.beamWidthY), float(ibeam.sigmaZ)])
@@ -316,7 +316,7 @@ if __name__ == '__main__':
     for ii in range(0,len(iovlist)):
 
         ibeam = iovlist[ii]
-        
+
         bntuple.position = array('f', [float(ibeam.X), float(ibeam.Y), float(ibeam.Z)])
         bntuple.posError = array('f', [float(ibeam.Xerr),float(ibeam.Yerr),float(ibeam.Zerr)])
         bntuple.width = array('f', [float(ibeam.beamWidthX), float(ibeam.beamWidthY), float(ibeam.sigmaZ)])
@@ -329,12 +329,12 @@ if __name__ == '__main__':
         line = ibeam.IOVEndTime
         endtime = time.mktime( time.strptime(line.split()[0] +  " " + line.split()[1] + " " + line.split()[2],"%Y.%m.%d %H:%M:%S %Z") )
         bntuple.time = array('f', [begintime, endtime])
-                                        
+
         tbyIOV.Fill()
-                                                                                
+
     weightedlist = listbeam
     weightedlist = createWeightedPayloads("tmp.txt",weightedlist,True)
-    
+
     for ii in range(0,len(weightedlist)):
 
         ibeam = weightedlist[ii]
@@ -351,7 +351,7 @@ if __name__ == '__main__':
         line = ibeam.IOVEndTime
         endtime = time.mktime( time.strptime(line.split()[0] +  " " + line.split()[1] + " " + line.split()[2],"%Y.%m.%d %H:%M:%S %Z") )
         bntuple.time = array('f', [begintime, endtime])
-                                        
+
         tbyrun.Fill()
 
 
@@ -361,7 +361,7 @@ if __name__ == '__main__':
     tbyIOV.Write()
     tbyrun.Write()
     fntuple.Close()
-            
+
     # CLEAN temporal files
     ###################################
     #os.system('rm tmp_beamspotdata.log')

--- a/RecoVertex/BeamSpotProducer/scripts/plotBeamSpotDB.py
+++ b/RecoVertex/BeamSpotProducer/scripts/plotBeamSpotDB.py
@@ -83,7 +83,7 @@ def SetStyle():
     ROOT.gStyle.SetGridColor(0)
     ROOT.gStyle.SetGridStyle(3)
     ROOT.gStyle.SetGridWidth(1)
-                  
+
     ROOT.gStyle.SetFrameBorderMode(0)
     ROOT.gStyle.SetFrameFillColor(0)
     ROOT.gStyle.SetTitleColor(1)
@@ -113,12 +113,12 @@ def SetStyle():
     #ROOT.gStyle.SetLineStyleString(2,"[12 12]") // postscript dashes
 
     ROOT.gStyle.SetMarkerSize(0.6)
-    
+
     # do not display any of the standard histogram decorations
     ROOT.gStyle.SetOptTitle(0)
     ROOT.gStyle.SetOptStat(0) #("m")
     ROOT.gStyle.SetOptFit(0)
-    
+
     #ROOT.gStyle.SetPalette(1,0)
     ROOT.gStyle.cd()
     ROOT.gROOT.ForceStyle()
@@ -129,7 +129,7 @@ if __name__ == '__main__':
 
     # style
     SetStyle()
-    
+
     printCanvas = False
     printFormat = "png"
     printBanner = False
@@ -139,52 +139,52 @@ if __name__ == '__main__':
     #################################
     option,args = parse(__doc__)
     if not args and not option: exit()
-    
+
     tag = ''
     if not option.tag and not option.data: 
-	print(" need to provide DB tag name or beam spot data file")
-	exit()
+        print(" need to provide DB tag name or beam spot data file")
+        exit()
     else:
-	tag = option.tag
+        tag = option.tag
 
     if option.batch:
         ROOT.gROOT.SetBatch()
-        
+
     datafilename = "tmp_beamspot.dat"
     if option.create:
         datafilename = option.create
-    
+
     getDBdata = True
     if option.data:
         getDBdata = False
-   
+
     IOVbase = 'runbase'
     if option.IOVbase:
         if option.IOVbase != "runbase" and option.IOVbase != "lumibase" and option.IOVbase != "timebase":
             print("\n\n unknown iov base option: "+ option.IOVbase +" \n\n\n")
             exit()
-	IOVbase = option.IOVbase
-    
+        IOVbase = option.IOVbase
+
     firstRun = "0"
     lastRun  = "4999999999"
     if IOVbase == "lumibase":
-	firstRun = "0:0"
-	lastRun = "4999999999:4999999999"
-    
+        firstRun = "0:0"
+        lastRun = "4999999999:4999999999"
+
     if option.initial:
         firstRun = option.initial
     if option.final:
         lastRun = option.final
-        
+
     # GET IOVs
     ################################
 
     if getDBdata:
 
         print(" read DB to get list of IOVs for the given tag")
-	mydestdb = 'frontier://PromptProd/CMS_COND_31X_BEAMSPOT'
-	if option.destDB:
-		mydestdb = option.destDB
+        mydestdb = 'frontier://PromptProd/CMS_COND_31X_BEAMSPOT'
+        if option.destDB:
+            mydestdb = option.destDB
         acommand = 'cmscond_list_iov -c '+mydestdb+' -P /afs/cern.ch/cms/DB/conddb -t '+ tag
         tmpstatus = commands.getstatusoutput( acommand )
         tmplistiov = tmpstatus[1].split('\n')
@@ -195,19 +195,19 @@ if __name__ == '__main__':
         iline = jline = 0
         totlines = len(tmplistiov)
         for line in tmplistiov:
-	
+
             if line.find('since') != -1:
                 passline = True
                 jline = iline
             if passline and iline > jline and iline < totlines-1:
                 linedata = line.split()
-	        #print linedata
+                #print linedata
                 aIOV = IOV()
                 aIOV.since = int(linedata[0])
                 aIOV.till = int(linedata[1])
                 iovlist.append( aIOV )
             iline += 1
-    
+
         print(" total number of IOVs = " + str(len(iovlist)))
 
 
@@ -219,7 +219,7 @@ if __name__ == '__main__':
             otherArgs = " -d " + option.destDB
             if option.auth:
                 otherArgs = otherArgs + " -a "+ option.auth
-        
+
         print(" get beam spot data from DB for IOVs. This can take a few minutes ...")
 
         tmpfile = open(datafilename,'w')
@@ -237,7 +237,7 @@ if __name__ == '__main__':
                 #tmplumilast  = int(lastRun.split(":")[1])
                 tmprunfirst = pack( int(firstRun.split(":")[0]) , int(firstRun.split(":")[1]) )
                 tmprunlast  = pack( int(lastRun.split(":")[0]) , int(lastRun.split(":")[1]) )
-	    #print "since = " + str(iIOV.since) + " till = "+ str(iIOV.till)
+            #print "since = " + str(iIOV.since) + " till = "+ str(iIOV.till)
             if iIOV.since >= int(tmprunfirst) and int(tmprunlast) < 0 and iIOV.since <= int(tmprunfirst):
                 print(" IOV: " + str(iIOV.since))
                 passiov = True
@@ -253,15 +253,15 @@ if __name__ == '__main__':
                     tmprun = unpack(iIOV.since)[0]
                     tmplumi = unpack(iIOV.since)[1]
                     acommand = 'getBeamSpotDB.py -t '+ tag + " -r " + str(tmprun) +" -l "+str(tmplumi) +otherArgs
-		    print(acommand)
+                    print(acommand)
                 status = commands.getstatusoutput( acommand )
                 tmpfile.write(status[1])
-    
+
         print(" beam spot data collected and stored in file " + datafilename)
-    
+
         tmpfile.close()
 
-    
+
     # PROCESS DATA
     ###################################
 
@@ -272,13 +272,13 @@ if __name__ == '__main__':
             files = tmp[1].split()
             datafilename = "combined_all.txt"
             output = open(datafilename,"w")
-            
+
             for f in files:
                 input = open(option.data +"/"+f)
                 output.writelines(input.readlines())
             output.close()
             print(" data files have been collected in "+datafilename)
-            
+
         elif os.path.exists(option.data):
             datafilename = option.data
         else:
@@ -295,9 +295,9 @@ if __name__ == '__main__':
         listbeam = listmap[option.Xrossing]
     else:
         readBeamSpotFile(datafilename,listbeam,IOVbase,firstRun,lastRun)
-    
+
     sortAndCleanBeamList(listbeam,IOVbase)
-	    
+
     if IOVbase == "lumibase" and option.payload:
         weighted = True;
         if not option.weighted:
@@ -322,59 +322,59 @@ if __name__ == '__main__':
         graphXaxis = "Time"
         #dh = ROOT.TDatime(2010,06,01,00,00,00)
         ROOT.gStyle.SetTimeOffset(0) #dh.Convert())
-                    
+
     graphYaxis = ['beam spot X [cm]','beam spot Y [cm]','beam spot Z [cm]', 'beam spot #sigma_{Z} [cm]', 'beam spot dX/dZ', 'beam spot dY/dZ','beam width X [cm]', 'beam width Y [cm]']
 
     cvlist = []
 
     for ig in range(0,8):
-	cvlist.append( TCanvas(graphnamelist[ig],graphtitlelist[ig], 1200, 600) )
-	if option.graph:
-	    graphlist.append( TGraphErrors( len(listbeam) ) )
+        cvlist.append( TCanvas(graphnamelist[ig],graphtitlelist[ig], 1200, 600) )
+        if option.graph:
+            graphlist.append( TGraphErrors( len(listbeam) ) )
         else:
-	    graphlist.append( TH1F("name","title",len(listbeam),0,len(listbeam)) )
-        
-	graphlist[ig].SetName(graphnamelist[ig])
+            graphlist.append( TH1F("name","title",len(listbeam),0,len(listbeam)) )
+
+        graphlist[ig].SetName(graphnamelist[ig])
         graphlist[ig].SetTitle(graphtitlelist[ig])
-	ipoint = 0
-	for ii in range(0,len(listbeam)):
-	    
-	    ibeam = listbeam[ii]
-	    datax = dataxerr = 0.
-	    datay = datayerr = 0.
-	    if graphnamelist[ig] == 'X':
-		datay = ibeam.X
-		datayerr = ibeam.Xerr
-	    if graphnamelist[ig] == 'Y':
-		datay = ibeam.Y
-		datayerr = ibeam.Yerr
-	    if graphnamelist[ig] == 'Z':
-		datay = ibeam.Z
-		datayerr = ibeam.Zerr
-	    if graphnamelist[ig] == 'SigmaZ':
-		datay = ibeam.sigmaZ
-		datayerr = ibeam.sigmaZerr
-	    if graphnamelist[ig] == 'dxdz':
-		datay = ibeam.dxdz
-		datayerr = ibeam.dxdzerr
-	    if graphnamelist[ig] == 'dydz':
-		datay = ibeam.dydz
-		datayerr = ibeam.dydzerr
-	    if graphnamelist[ig] == 'beamWidthX':
-		datay = ibeam.beamWidthX
-		datayerr = ibeam.beamWidthXerr
-	    if graphnamelist[ig] == 'beamWidthY':
-		datay = ibeam.beamWidthY
-		datayerr = ibeam.beamWidthYerr
+        ipoint = 0
+        for ii in range(0,len(listbeam)):
+
+            ibeam = listbeam[ii]
+            datax = dataxerr = 0.
+            datay = datayerr = 0.
+            if graphnamelist[ig] == 'X':
+                datay = ibeam.X
+                datayerr = ibeam.Xerr
+            if graphnamelist[ig] == 'Y':
+                datay = ibeam.Y
+                datayerr = ibeam.Yerr
+            if graphnamelist[ig] == 'Z':
+                datay = ibeam.Z
+                datayerr = ibeam.Zerr
+            if graphnamelist[ig] == 'SigmaZ':
+                datay = ibeam.sigmaZ
+                datayerr = ibeam.sigmaZerr
+            if graphnamelist[ig] == 'dxdz':
+                datay = ibeam.dxdz
+                datayerr = ibeam.dxdzerr
+            if graphnamelist[ig] == 'dydz':
+                datay = ibeam.dydz
+                datayerr = ibeam.dydzerr
+            if graphnamelist[ig] == 'beamWidthX':
+                datay = ibeam.beamWidthX
+                datayerr = ibeam.beamWidthXerr
+            if graphnamelist[ig] == 'beamWidthY':
+                datay = ibeam.beamWidthY
+                datayerr = ibeam.beamWidthYerr
 
             datax = ibeam.IOVfirst
-	    if IOVbase=="lumibase":
-		datax = str(ibeam.Run) + ":" + str(ibeam.IOVfirst)
-		if ibeam.IOVfirst != ibeam.IOVlast:
-		    datax = str(ibeam.Run) + ":" + str(ibeam.IOVfirst)+"-"+str(ibeam.IOVlast)
+            if IOVbase=="lumibase":
+                datax = str(ibeam.Run) + ":" + str(ibeam.IOVfirst)
+                if ibeam.IOVfirst != ibeam.IOVlast:
+                    datax = str(ibeam.Run) + ":" + str(ibeam.IOVfirst)+"-"+str(ibeam.IOVlast)
             #print datax
-	    if option.graph:
-		if IOVbase=="lumibase":
+            if option.graph:
+                if IOVbase=="lumibase":
                     #first = int( pack( int(ibeam.Run) , int(ibeam.IOVfirst) ) )
                     #last = int( pack( int(ibeam.Run) , int(ibeam.IOVlast) ) )
                     first = ibeam.IOVfirst
@@ -403,36 +403,36 @@ if __name__ == '__main__':
                     if time.daylight and ptm.tm_isdst:
                         datax += offset_daylight
                     ##################################
-                    
-		    dataxerr =  (float(last) - float(first))/2
-		graphlist[ig].SetPoint(ipoint, float(datax), float(datay) )
-		graphlist[ig].SetPointError(ipoint, float(dataxerr), float(datayerr) )
-	    else:
-		graphlist[ig].GetXaxis().SetBinLabel(ipoint +1 , str(datax) )
-		graphlist[ig].SetBinContent(ipoint +1, float(datay) )
-		graphlist[ig].SetBinError(ipoint +1, float(datayerr) )
+
+                    dataxerr =  (float(last) - float(first))/2
+                graphlist[ig].SetPoint(ipoint, float(datax), float(datay) )
+                graphlist[ig].SetPointError(ipoint, float(dataxerr), float(datayerr) )
+            else:
+                graphlist[ig].GetXaxis().SetBinLabel(ipoint +1 , str(datax) )
+                graphlist[ig].SetBinContent(ipoint +1, float(datay) )
+                graphlist[ig].SetBinError(ipoint +1, float(datayerr) )
 
             ipoint += 1
-	if option.Time:
+        if option.Time:
             ## print local time
             da_last.Print()
             print("GMT = " + str(time.strftime('%Y-%m-%d %H:%M:%S',time.gmtime(last - time.timezone))))
             graphlist[ig].GetXaxis().SetTimeDisplay(1);
             graphlist[ig].GetXaxis().SetTimeFormat("#splitline{%Y/%m/%d}{%H:%M}")           
-	if option.graph:
-	    graphlist[ig].Draw('AP')
+        if option.graph:
+            graphlist[ig].Draw('AP')
         else:
-	    graphlist[ig].Draw('P E1 X0')
-	    graphlist[ig].GetXaxis().SetTitle(graphXaxis)
-	    graphlist[ig].GetYaxis().SetTitle(graphYaxis[ig])
+            graphlist[ig].Draw('P E1 X0')
+            graphlist[ig].GetXaxis().SetTitle(graphXaxis)
+            graphlist[ig].GetYaxis().SetTitle(graphYaxis[ig])
             #graphlist[ig].Fit('pol1')
-	cvlist[ig].Update()
+        cvlist[ig].Update()
         cvlist[ig].SetGrid()
         if option.Print:
             suffix = ''
             if option.suffix:
                 suffix = option.suffix
-	    cvlist[ig].Print(graphnamelist[ig]+"_"+suffix+".png")
+            cvlist[ig].Print(graphnamelist[ig]+"_"+suffix+".png")
         if option.wait:
             raw_input( 'Press ENTER to continue\n ' )
         #graphlist[0].Print('all')
@@ -444,8 +444,8 @@ if __name__ == '__main__':
 
         outroot.Close()
         print(" plots have been written to "+option.output)
-        
-    
+
+
 
     # CLEAN temporal files
     ###################################

--- a/RecoVertex/BeamSpotProducer/scripts/rename.py
+++ b/RecoVertex/BeamSpotProducer/scripts/rename.py
@@ -26,7 +26,7 @@ def main():
         sourceDir = sourceDirList[n] + '/'
         destDir   = path + destDirList[n] + '/'
         if not dirExists(sourceDir):
-	    print(sourceDir + " doesn't exist!")
+            print(sourceDir + " doesn't exist!")
             continue
         fileList = ls(sourceDir)
         if not os.path.isdir(destDir):
@@ -44,7 +44,7 @@ def main():
             regExp = re.search('(\D+)(\d+)_(\d+)_[a-zA-Z0-9]+.txt',fileName)
             #if regExp:
                 #print regExp.group(1) + regExp.group(2) + "_" + str(1) + "_" + regExp.group(3) + ".txt" 
-                
+
             fullFileName = destDir + fileName
             print(fullFileName)
             runNumber = -1
@@ -80,6 +80,6 @@ def main():
 
 
 
-        
+
 if __name__ == "__main__":
     main()

--- a/SUSYBSMAnalysis/HSCP/python/LaunchOnCondor.py
+++ b/SUSYBSMAnalysis/HSCP/python/LaunchOnCondor.py
@@ -36,344 +36,344 @@ LSFlog = True
 runInteractively = False
 
 def CreateTheConfigFile(argv):
-        global Jobs_Name
-        global Jobs_Index
-	global Jobs_Count
-	global Jobs_Seed
-	global Jobs_Skip
-	global Jobs_NEvent
-	global Jobs_Inputs
-        global Jobs_FinalCmds
-	global Path_Cfg
-	global CopyRights
-        Path_Cfg   = Farm_Directories[1]+Jobs_Index+Jobs_Name+'_cfg.py'
+    global Jobs_Name
+    global Jobs_Index
+    global Jobs_Count
+    global Jobs_Seed
+    global Jobs_Skip
+    global Jobs_NEvent
+    global Jobs_Inputs
+    global Jobs_FinalCmds
+    global Path_Cfg
+    global CopyRights
+    Path_Cfg   = Farm_Directories[1]+Jobs_Index+Jobs_Name+'_cfg.py'
 
-	config_file=open(argv[1],'r')
-	config_txt   = '\n\n' + CopyRights + '\n\n'
-	config_txt  += config_file.read()
-	config_file.close()
-	i = 2
-	while i < len(argv)-1:
-		config_txt = config_txt.replace(argv[i],argv[i+1])
-		i+=2
+    config_file=open(argv[1],'r')
+    config_txt   = '\n\n' + CopyRights + '\n\n'
+    config_txt  += config_file.read()
+    config_file.close()
+    i = 2
+    while i < len(argv)-1:
+        config_txt = config_txt.replace(argv[i],argv[i+1])
+        i+=2
 
-	#Default Replacements
-	config_txt = config_txt.replace("XXX_I_XXX"   		,"%04i"%Jobs_Count)
-        config_txt = config_txt.replace("XXX_PATH_XXX"		,os.getcwd())
-        config_txt = config_txt.replace("XXX_OUTPUT_XXX"        ,Jobs_Name)
-        config_txt = config_txt.replace("XXX_NAME_XXX"  	,Jobs_Index+Jobs_Name)
-	config_txt = config_txt.replace("XXX_SEED_XXX"  	,str(Jobs_Seed+Jobs_Count))
-        config_txt = config_txt.replace("XXX_NEVENTS_XXX"	,str(Jobs_NEvent))
-        config_txt = config_txt.replace("XXX_SKIP_XXX"     	,str(Jobs_Skip))
-	if Jobs_Count < len(Jobs_Inputs):
-		config_txt = config_txt.replace("XXX_INPUT_XXX"         ,Jobs_Inputs[Jobs_Count])
+    #Default Replacements
+    config_txt = config_txt.replace("XXX_I_XXX"   		,"%04i"%Jobs_Count)
+    config_txt = config_txt.replace("XXX_PATH_XXX"		,os.getcwd())
+    config_txt = config_txt.replace("XXX_OUTPUT_XXX"        ,Jobs_Name)
+    config_txt = config_txt.replace("XXX_NAME_XXX"  	,Jobs_Index+Jobs_Name)
+    config_txt = config_txt.replace("XXX_SEED_XXX"  	,str(Jobs_Seed+Jobs_Count))
+    config_txt = config_txt.replace("XXX_NEVENTS_XXX"	,str(Jobs_NEvent))
+    config_txt = config_txt.replace("XXX_SKIP_XXX"     	,str(Jobs_Skip))
+    if Jobs_Count < len(Jobs_Inputs):
+        config_txt = config_txt.replace("XXX_INPUT_XXX"         ,Jobs_Inputs[Jobs_Count])
 
-	config_file=open(Path_Cfg,'w')
-	config_file.write(config_txt)
-	config_file.close()
+    config_file=open(Path_Cfg,'w')
+    config_file.write(config_txt)
+    config_file.close()
 
 def CreateTheShellFile(argv):
-	global Path_Shell
-	global Path_Cfg
-	global CopyRights	
-	global Jobs_RunHere
-	global Jobs_FinalCmds
-        Path_Shell = Farm_Directories[1]+Jobs_Index+Jobs_Name+'.sh'
+    global Path_Shell
+    global Path_Cfg
+    global CopyRights	
+    global Jobs_RunHere
+    global Jobs_FinalCmds
+    Path_Shell = Farm_Directories[1]+Jobs_Index+Jobs_Name+'.sh'
 
-	function_argument='('
-        for i in range(2,len(argv)):
-                function_argument+="%s" % argv[i]
-                if i != len(argv)-1:
-                        function_argument+=', '
-        function_argument+=')'
+    function_argument='('
+    for i in range(2,len(argv)):
+        function_argument+="%s" % argv[i]
+        if i != len(argv)-1:
+            function_argument+=', '
+    function_argument+=')'
 
-	shell_file=open(Path_Shell,'w')
-	shell_file.write('#! /bin/sh\n')
-	shell_file.write(CopyRights + '\n')
-	shell_file.write('export SCRAM_ARCH='+os.getenv("SCRAM_ARCH","slc5_amd64_gcc462")+'\n')
-        shell_file.write('export BUILD_ARCH='+os.getenv("BUILD_ARCH","slc5_amd64_gcc462")+'\n')
-        shell_file.write('export VO_CMS_SW_DIR='+os.getenv("VO_CMS_SW_DIR","/nfs/soft/cms")+'\n')
-	#shell_file.write('source /nfs/soft/cms/cmsset_default.sh\n')
-	shell_file.write('cd ' + os.getcwd() + '\n')
-	shell_file.write('eval `scramv1 runtime -sh`\n')
+    shell_file=open(Path_Shell,'w')
+    shell_file.write('#! /bin/sh\n')
+    shell_file.write(CopyRights + '\n')
+    shell_file.write('export SCRAM_ARCH='+os.getenv("SCRAM_ARCH","slc5_amd64_gcc462")+'\n')
+    shell_file.write('export BUILD_ARCH='+os.getenv("BUILD_ARCH","slc5_amd64_gcc462")+'\n')
+    shell_file.write('export VO_CMS_SW_DIR='+os.getenv("VO_CMS_SW_DIR","/nfs/soft/cms")+'\n')
+    #shell_file.write('source /nfs/soft/cms/cmsset_default.sh\n')
+    shell_file.write('cd ' + os.getcwd() + '\n')
+    shell_file.write('eval `scramv1 runtime -sh`\n')
 
-	if   argv[0]=='BASH':
-		if Jobs_RunHere==0:
-                	shell_file.write('cd -\n')
-                shell_file.write(argv[1] + " %s\n" % function_argument)
-        elif argv[0]=='ROOT':
-		if Jobs_RunHere==0:
-                	shell_file.write('cd -\n')
-	        shell_file.write('root -l -b << EOF\n')
-	        shell_file.write('   TString makeshared(gSystem->GetMakeSharedLib());\n')
-	        shell_file.write('   TString dummy = makeshared.ReplaceAll("-W ", "-Wno-deprecated-declarations -Wno-deprecated -Wno-unused-local-typedefs ");\n')
-                shell_file.write('   TString dummy = makeshared.ReplaceAll("-Wshadow ", " -std=c++0x -D__USE_XOPEN2K8 ");\n')
-                shell_file.write('   cout << "Compilling with the following arguments: " << makeshared << endl;\n')
-	        shell_file.write('   gSystem->SetMakeSharedLib(makeshared);\n')
-		shell_file.write('   gSystem->SetIncludePath( "-I$ROOFITSYS/include" );\n')  
-                shell_file.write('   .x %s+' % argv[1] + function_argument + '\n')
-	        shell_file.write('   .q\n')
-	        shell_file.write('EOF\n\n')
-        elif argv[0]=='FWLITE':                 
-		if Jobs_RunHere==0:
-                	shell_file.write('cd -\n')
-	        shell_file.write('root -l -b << EOF\n')
-                shell_file.write('   TString makeshared(gSystem->GetMakeSharedLib());\n')
-                shell_file.write('   TString dummy = makeshared.ReplaceAll("-W ", "-Wno-deprecated-declarations -Wno-deprecated ");\n')
-                shell_file.write('   TString dummy = makeshared.ReplaceAll("-Wshadow ", " -std=c++0x -D__USE_XOPEN2K8 ");\n')
-                shell_file.write('   cout << "Compilling with the following arguments: " << makeshared << endl;\n')
-                shell_file.write('   gSystem->SetMakeSharedLib(makeshared);\n')
-                shell_file.write('   gSystem->SetIncludePath("-I$ROOFITSYS/include");\n')
-	        shell_file.write('   gSystem->Load("libFWCoreFWLite");\n')
-	        shell_file.write('   FWLiteEnabler::enable();\n')
-	        shell_file.write('   gSystem->Load("libDataFormatsFWLite.so");\n')
-	        shell_file.write('   gSystem->Load("libAnalysisDataFormatsSUSYBSMObjects.so");\n')
-	        shell_file.write('   gSystem->Load("libDataFormatsVertexReco.so");\n')
-	        shell_file.write('   gSystem->Load("libDataFormatsHepMCCandidate.so");\n')
-                shell_file.write('   gSystem->Load("libPhysicsToolsUtilities.so");\n')
-                shell_file.write('   gSystem->Load("libdcap.so");\n')
-                shell_file.write('   .x %s+' % argv[1] + function_argument + '\n')
-	        shell_file.write('   .q\n')
-	        shell_file.write('EOF\n\n')
-        elif argv[0]=='CMSSW':
-		CreateTheConfigFile(argv);
-		if Jobs_RunHere==0:
-			shell_file.write('cd -\n')
-		shell_file.write('cmsRun ' + os.getcwd() + '/'+Path_Cfg + '\n')
-	else:
-		print() #Program to use is not specified... Guess it is bash command		
-                shell_file.write('#Program to use is not specified... Guess it is bash command\n')
-		shell_file.write(argv[1] + " %s\n" % function_argument)
+    if   argv[0]=='BASH':
+        if Jobs_RunHere==0:
+            shell_file.write('cd -\n')
+        shell_file.write(argv[1] + " %s\n" % function_argument)
+    elif argv[0]=='ROOT':
+        if Jobs_RunHere==0:
+            shell_file.write('cd -\n')
+        shell_file.write('root -l -b << EOF\n')
+        shell_file.write('   TString makeshared(gSystem->GetMakeSharedLib());\n')
+        shell_file.write('   TString dummy = makeshared.ReplaceAll("-W ", "-Wno-deprecated-declarations -Wno-deprecated -Wno-unused-local-typedefs ");\n')
+        shell_file.write('   TString dummy = makeshared.ReplaceAll("-Wshadow ", " -std=c++0x -D__USE_XOPEN2K8 ");\n')
+        shell_file.write('   cout << "Compilling with the following arguments: " << makeshared << endl;\n')
+        shell_file.write('   gSystem->SetMakeSharedLib(makeshared);\n')
+        shell_file.write('   gSystem->SetIncludePath( "-I$ROOFITSYS/include" );\n')  
+        shell_file.write('   .x %s+' % argv[1] + function_argument + '\n')
+        shell_file.write('   .q\n')
+        shell_file.write('EOF\n\n')
+    elif argv[0]=='FWLITE':                 
+        if Jobs_RunHere==0:
+            shell_file.write('cd -\n')
+        shell_file.write('root -l -b << EOF\n')
+        shell_file.write('   TString makeshared(gSystem->GetMakeSharedLib());\n')
+        shell_file.write('   TString dummy = makeshared.ReplaceAll("-W ", "-Wno-deprecated-declarations -Wno-deprecated ");\n')
+        shell_file.write('   TString dummy = makeshared.ReplaceAll("-Wshadow ", " -std=c++0x -D__USE_XOPEN2K8 ");\n')
+        shell_file.write('   cout << "Compilling with the following arguments: " << makeshared << endl;\n')
+        shell_file.write('   gSystem->SetMakeSharedLib(makeshared);\n')
+        shell_file.write('   gSystem->SetIncludePath("-I$ROOFITSYS/include");\n')
+        shell_file.write('   gSystem->Load("libFWCoreFWLite");\n')
+        shell_file.write('   FWLiteEnabler::enable();\n')
+        shell_file.write('   gSystem->Load("libDataFormatsFWLite.so");\n')
+        shell_file.write('   gSystem->Load("libAnalysisDataFormatsSUSYBSMObjects.so");\n')
+        shell_file.write('   gSystem->Load("libDataFormatsVertexReco.so");\n')
+        shell_file.write('   gSystem->Load("libDataFormatsHepMCCandidate.so");\n')
+        shell_file.write('   gSystem->Load("libPhysicsToolsUtilities.so");\n')
+        shell_file.write('   gSystem->Load("libdcap.so");\n')
+        shell_file.write('   .x %s+' % argv[1] + function_argument + '\n')
+        shell_file.write('   .q\n')
+        shell_file.write('EOF\n\n')
+    elif argv[0]=='CMSSW':
+        CreateTheConfigFile(argv);
+        if Jobs_RunHere==0:
+            shell_file.write('cd -\n')
+        shell_file.write('cmsRun ' + os.getcwd() + '/'+Path_Cfg + '\n')
+    else:
+        print() #Program to use is not specified... Guess it is bash command		
+        shell_file.write('#Program to use is not specified... Guess it is bash command\n')
+        shell_file.write(argv[1] + " %s\n" % function_argument)
 
-        for i in range(len(Jobs_FinalCmds)):
-		shell_file.write(Jobs_FinalCmds[i]+'\n')
-	shell_file.write('mv '+ Jobs_Name+'* '+os.getcwd()+'/'+Farm_Directories[3]+'\n')
-	shell_file.close()
-	os.system("chmod 777 "+Path_Shell)
+    for i in range(len(Jobs_FinalCmds)):
+        shell_file.write(Jobs_FinalCmds[i]+'\n')
+    shell_file.write('mv '+ Jobs_Name+'* '+os.getcwd()+'/'+Farm_Directories[3]+'\n')
+    shell_file.close()
+    os.system("chmod 777 "+Path_Shell)
 
 
 def CreateTheCmdFile():
-        global useLSF
-        global Path_Cmd
-        global CopyRights
-        Path_Cmd   = Farm_Directories[1]+Jobs_Name+'.cmd'
-	cmd_file=open(Path_Cmd,'w')
+    global useLSF
+    global Path_Cmd
+    global CopyRights
+    Path_Cmd   = Farm_Directories[1]+Jobs_Name+'.cmd'
+    cmd_file=open(Path_Cmd,'w')
 
-	if useLSF:
-		cmd_file.write(CopyRights + '\n')
-	else:
-		cmd_file.write('Universe                = vanilla\n')
-		cmd_file.write('Environment             = CONDORJOBID=$(Process)\n')
-		cmd_file.write('notification            = Error\n')
-		#code specific for louvain
-		if(commands.getstatusoutput("uname -n")[1].find("ucl.ac.be")!=-1):
-        		cmd_file.write('requirements            = (CMSFARM=?=True)&&(Memory > 200)\n')
-		else:
-			cmd_file.write('requirements            = (Memory > 200)\n')
-		cmd_file.write('should_transfer_files   = YES\n')
-		cmd_file.write('when_to_transfer_output = ON_EXIT\n')
-	cmd_file.close()
+    if useLSF:
+        cmd_file.write(CopyRights + '\n')
+    else:
+        cmd_file.write('Universe                = vanilla\n')
+        cmd_file.write('Environment             = CONDORJOBID=$(Process)\n')
+        cmd_file.write('notification            = Error\n')
+        #code specific for louvain
+        if(commands.getstatusoutput("uname -n")[1].find("ucl.ac.be")!=-1):
+            cmd_file.write('requirements            = (CMSFARM=?=True)&&(Memory > 200)\n')
+        else:
+            cmd_file.write('requirements            = (Memory > 200)\n')
+        cmd_file.write('should_transfer_files   = YES\n')
+        cmd_file.write('when_to_transfer_output = ON_EXIT\n')
+    cmd_file.close()
 
 def AddJobToCmdFile():
-        global runInteractively
-        global useLSF
-	global Path_Shell
-        global Path_Cmd
-	global Path_Log
-        Path_Log   = Farm_Directories[2]+Jobs_Index+Jobs_Name
-        cmd_file=open(Path_Cmd,'a')
+    global runInteractively
+    global useLSF
+    global Path_Shell
+    global Path_Cmd
+    global Path_Log
+    Path_Log   = Farm_Directories[2]+Jobs_Index+Jobs_Name
+    cmd_file=open(Path_Cmd,'a')
 
-        if runInteractively:
-           cmd_file.write("sh "+ os.getcwd() + "/"+Path_Shell + "\n")
-	elif useLSF:
-           if LSFlog :
-		cmd_file.write("bsub -q " + Jobs_Queue + " -J " + Jobs_Name+Jobs_Index + " '" + os.getcwd() + "/"+Path_Shell + " 0 ele'\n")
-           else :
-                cmd_file.write("bsub -o /dev/null -q " + Jobs_Queue + " -J " + Jobs_Name+Jobs_Index + " '" + os.getcwd() + "/"+Path_Shell + " 0 ele'\n")
-	else:
-        	cmd_file.write('\n')
-	        cmd_file.write('Executable              = %s\n'     % Path_Shell)
-        	cmd_file.write('output                  = %s.out\n' % Path_Log)
-	        cmd_file.write('error                   = %s.err\n' % Path_Log)
-        	cmd_file.write('log                     = %s.log\n' % Path_Log)
-	        cmd_file.write('Queue 1\n')
-        cmd_file.close()
+    if runInteractively:
+        cmd_file.write("sh "+ os.getcwd() + "/"+Path_Shell + "\n")
+    elif useLSF:
+        if LSFlog :
+            cmd_file.write("bsub -q " + Jobs_Queue + " -J " + Jobs_Name+Jobs_Index + " '" + os.getcwd() + "/"+Path_Shell + " 0 ele'\n")
+        else :
+            cmd_file.write("bsub -o /dev/null -q " + Jobs_Queue + " -J " + Jobs_Name+Jobs_Index + " '" + os.getcwd() + "/"+Path_Shell + " 0 ele'\n")
+    else:
+        cmd_file.write('\n')
+        cmd_file.write('Executable              = %s\n'     % Path_Shell)
+        cmd_file.write('output                  = %s.out\n' % Path_Log)
+        cmd_file.write('error                   = %s.err\n' % Path_Log)
+        cmd_file.write('log                     = %s.log\n' % Path_Log)
+        cmd_file.write('Queue 1\n')
+    cmd_file.close()
 
 def CreateDirectoryStructure(FarmDirectory):
-        global Jobs_Name
-        global Farm_Directories
-	Farm_Directories = [FarmDirectory+'/', FarmDirectory+'/inputs/', FarmDirectory+'/logs/', FarmDirectory+'/outputs/']
-        for i in range(0,len(Farm_Directories)):
-		if os.path.isdir(Farm_Directories[i]) == False:
-	        	os.system('mkdir ' + Farm_Directories[i])
+    global Jobs_Name
+    global Farm_Directories
+    Farm_Directories = [FarmDirectory+'/', FarmDirectory+'/inputs/', FarmDirectory+'/logs/', FarmDirectory+'/outputs/']
+    for i in range(0,len(Farm_Directories)):
+        if os.path.isdir(Farm_Directories[i]) == False:
+            os.system('mkdir ' + Farm_Directories[i])
 
 def SendCluster_LoadInputFiles(path, NJobs):
-        global Jobs_Inputs
-	input_file  = open(path,'r')
-	input_lines = input_file.readlines()
-	input_file.close()
-	#input_lines.sort()
-	
-	BlockSize = (len(input_lines)/NJobs)
-	LineIndex  = 0
-	JobIndex   = 0
-	BlockIndex = 0	
-	Jobs_Inputs = [""]
-	while LineIndex < len(input_lines):
-		Jobs_Inputs[JobIndex] += input_lines[LineIndex]
-		LineIndex +=1
-		BlockIndex+=1
-		if BlockIndex>BlockSize:
-			BlockIndex = 0
-			JobIndex  += 1
-			Jobs_Inputs.append("")
-	return JobIndex+1
+    global Jobs_Inputs
+    input_file  = open(path,'r')
+    input_lines = input_file.readlines()
+    input_file.close()
+    #input_lines.sort()
+
+    BlockSize = (len(input_lines)/NJobs)
+    LineIndex  = 0
+    JobIndex   = 0
+    BlockIndex = 0	
+    Jobs_Inputs = [""]
+    while LineIndex < len(input_lines):
+        Jobs_Inputs[JobIndex] += input_lines[LineIndex]
+        LineIndex +=1
+        BlockIndex+=1
+        if BlockIndex>BlockSize:
+            BlockIndex = 0
+            JobIndex  += 1
+            Jobs_Inputs.append("")
+    return JobIndex+1
 
 def SendCluster_Create(FarmDirectory, JobName):
-	global useLSF
-	global Jobs_Name
-	global Jobs_Count
-        global Farm_Directories
-        global runInteractively
+    global useLSF
+    global Jobs_Name
+    global Jobs_Count
+    global Farm_Directories
+    global runInteractively
 
-        if(runInteractively): useLSF=True
+    if(runInteractively): useLSF=True
 
-	#determine if the submission system is LSF batch or condor
-	command_out = commands.getstatusoutput("bjobs")[1]
-	if(command_out.find("command not found")<0): useLSF = True
-	else:				  	     useLSF = False;
+    #determine if the submission system is LSF batch or condor
+    command_out = commands.getstatusoutput("bjobs")[1]
+    if(command_out.find("command not found")<0): useLSF = True
+    else:				  	     useLSF = False;
 
-	Jobs_Name  = JobName
-	Jobs_Count = 0
-        CreateDirectoryStructure(FarmDirectory)
-        CreateTheCmdFile()
+    Jobs_Name  = JobName
+    Jobs_Count = 0
+    CreateDirectoryStructure(FarmDirectory)
+    CreateTheCmdFile()
 
 def SendCluster_Push(Argv):
-        global Farm_Directories
-        global Jobs_Count
-        global Jobs_Index
-	global Path_Shell
-	global Path_Log
+    global Farm_Directories
+    global Jobs_Count
+    global Jobs_Index
+    global Path_Shell
+    global Path_Log
 
-	Jobs_Index = "%04i_" % Jobs_Count
-        if Jobs_Count==0 and (Argv[0]=="ROOT" or Argv[0]=="FWLITE"):                
-                #First Need to Compile the macro --> Create a temporary shell path with no arguments
-                print("Compiling the Macro...")
-                CreateTheShellFile([Argv[0],Argv[1]])
-                os.system('sh '+Path_Shell)
-                os.system('rm '+Path_Shell)
-		print("Getting the jobs...")
-	print(Argv)
-        CreateTheShellFile(Argv)
-        AddJobToCmdFile()
-	Jobs_Count = Jobs_Count+1
+    Jobs_Index = "%04i_" % Jobs_Count
+    if Jobs_Count==0 and (Argv[0]=="ROOT" or Argv[0]=="FWLITE"):                
+        #First Need to Compile the macro --> Create a temporary shell path with no arguments
+        print("Compiling the Macro...")
+        CreateTheShellFile([Argv[0],Argv[1]])
+        os.system('sh '+Path_Shell)
+        os.system('rm '+Path_Shell)
+        print("Getting the jobs...")
+    print(Argv)
+    CreateTheShellFile(Argv)
+    AddJobToCmdFile()
+    Jobs_Count = Jobs_Count+1
 
 def SendCluster_Submit():
-        global useLSF
-	global CopyRights
-        global Jobs_Count
-        global Path_Cmd
+    global useLSF
+    global CopyRights
+    global Jobs_Count
+    global Path_Cmd
 
-	if useLSF:
-		os.system("sh " + Path_Cmd)
-	else:
-		os.system("condor_submit " + Path_Cmd)  
+    if useLSF:
+        os.system("sh " + Path_Cmd)
+    else:
+        os.system("condor_submit " + Path_Cmd)  
 
-	print('\n'+CopyRights)
-	print('%i Job(s) has/have been submitted on the Computing Cluster' % Jobs_Count)
+    print('\n'+CopyRights)
+    print('%i Job(s) has/have been submitted on the Computing Cluster' % Jobs_Count)
 
 def SendSingleJob(FarmDirectory, JobName, Argv):
-	SendCluster_Create(FarmDirectory, JobName, Argv)
-	SendCluster_Push(FarmDirectory, JobName, Argv)
-	SendCluster_Submit(FarmDirectory, JobName,Argv)
+    SendCluster_Create(FarmDirectory, JobName, Argv)
+    SendCluster_Push(FarmDirectory, JobName, Argv)
+    SendCluster_Submit(FarmDirectory, JobName,Argv)
 
 def SendCMSJobs(FarmDirectory, JobName, ConfigFile, InputFiles, NJobs, Argv):
-	SendCluster_Create(FarmDirectory, JobName)
-	NJobs = SendCluster_LoadInputFiles(InputFiles, NJobs)
-	for i in range(NJobs):
-        	LaunchOnCondor.SendCluster_Push  (["CMSSW", ConfigFile])
-	LaunchOnCondor.SendCluster_Submit()
+    SendCluster_Create(FarmDirectory, JobName)
+    NJobs = SendCluster_LoadInputFiles(InputFiles, NJobs)
+    for i in range(NJobs):
+        LaunchOnCondor.SendCluster_Push  (["CMSSW", ConfigFile])
+    LaunchOnCondor.SendCluster_Submit()
 
 
 
 def GetListOfFiles(Prefix, InputPattern, Suffix):
-      List = []
+    List = []
 
-      if(InputPattern.find('/store/cmst3')==0) :
-         index = InputPattern.rfind('/')
-         Listtmp = commands.getstatusoutput('cmsLs ' + InputPattern[0:index] + ' | awk \'{print $5}\'')[1].split('\n')
-         pattern = InputPattern[index+1:len(InputPattern)]
-         for file in Listtmp:
+    if(InputPattern.find('/store/cmst3')==0) :
+        index = InputPattern.rfind('/')
+        Listtmp = commands.getstatusoutput('cmsLs ' + InputPattern[0:index] + ' | awk \'{print $5}\'')[1].split('\n')
+        pattern = InputPattern[index+1:len(InputPattern)]
+        for file in Listtmp:
             if fnmatch.fnmatch(file, pattern): List.append(InputPattern[0:index]+'/'+file)
-      elif(InputPattern.find('/castor/')==0):
-         index = InputPattern.rfind('/')
-         Listtmp = commands.getstatusoutput('rfdir ' + InputPattern[0:index] + ' | awk \'{print $9}\'')[1].split('\n')
-         pattern = InputPattern[index+1:len(InputPattern)]
-         for file in Listtmp:
+    elif(InputPattern.find('/castor/')==0):
+        index = InputPattern.rfind('/')
+        Listtmp = commands.getstatusoutput('rfdir ' + InputPattern[0:index] + ' | awk \'{print $9}\'')[1].split('\n')
+        pattern = InputPattern[index+1:len(InputPattern)]
+        for file in Listtmp:
             if fnmatch.fnmatch(file, pattern): List.append(InputPattern[0:index]+'/'+file)
-      else :
-         List = glob.glob(InputPattern)
+    else :
+        List = glob.glob(InputPattern)
 
-      List = sorted(List)
-      for i in range(len(List)):
-         List[i] = Prefix + List[i] + Suffix
-      return List
+    List = sorted(List)
+    for i in range(len(List)):
+        List[i] = Prefix + List[i] + Suffix
+    return List
 
 
 def ListToString(InputList):
-   outString = ""
-   for i in range(len(InputList)):
-      outString += InputList[i]
-   return outString
+    outString = ""
+    for i in range(len(InputList)):
+        outString += InputList[i]
+    return outString
 
 def ListToFile(InputList, outputFile):
-   out_file=open(outputFile,'w')
-   for i in range(len(InputList)):
-      out_file.write('     ' + InputList[i] + '\n')
-   out_file.close()
+    out_file=open(outputFile,'w')
+    for i in range(len(InputList)):
+        out_file.write('     ' + InputList[i] + '\n')
+    out_file.close()
 
 def FileToList(path):
-   input_file  = open(path,'r')
-   input_lines = input_file.readlines()
-   input_file.close()
-   input_lines.sort()
-   return input_lines
+    input_file  = open(path,'r')
+    input_lines = input_file.readlines()
+    input_file.close()
+    input_lines.sort()
+    return input_lines
 
 
 def SendCMSMergeJob(FarmDirectory, JobName, InputFiles, OutputFile, KeepStatement):
-        SendCluster_Create(FarmDirectory, JobName)
-        Temp_Cfg   = Farm_Directories[1]+Jobs_Index+Jobs_Name+'_TEMP_cfg.py'
+    SendCluster_Create(FarmDirectory, JobName)
+    Temp_Cfg   = Farm_Directories[1]+Jobs_Index+Jobs_Name+'_TEMP_cfg.py'
 
-	if len(InputFiles)==0:
-		print('Empty InputFile List for Job named "%s", Job will not be submitted' % JobName)
-		return
+    if len(InputFiles)==0:
+        print('Empty InputFile List for Job named "%s", Job will not be submitted' % JobName)
+        return
 
-	InputFilesString = ""
-        for i in range(len(InputFiles)):
-		InputFilesString += "     " + InputFiles[i] + '\n'
+    InputFilesString = ""
+    for i in range(len(InputFiles)):
+        InputFilesString += "     " + InputFiles[i] + '\n'
 
-	cfg_file=open(Temp_Cfg,'w')
-        cfg_file.write('import FWCore.ParameterSet.Config as cms\n')
-        cfg_file.write('process = cms.Process("Merge")\n')
-        cfg_file.write('\n')
-        cfg_file.write('process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )\n')
-        cfg_file.write('process.load("FWCore.MessageService.MessageLogger_cfi")\n')
-        cfg_file.write('\n')
-        cfg_file.write('process.MessageLogger.cerr.FwkReport.reportEvery = 50000\n')
-        cfg_file.write('process.source = cms.Source("PoolSource",\n')
-        cfg_file.write('   fileNames = cms.untracked.vstring(\n')
-        cfg_file.write('%s' % InputFilesString)
-        cfg_file.write('   )\n')
-        cfg_file.write(')\n')
-        cfg_file.write('\n')
-        cfg_file.write('process.OUT = cms.OutputModule("PoolOutputModule",\n')
-        cfg_file.write('    outputCommands = cms.untracked.vstring(%s),\n' % KeepStatement)
-        cfg_file.write('    fileName = cms.untracked.string(%s)\n' % OutputFile)
-        cfg_file.write(')\n')
-        cfg_file.write('\n')
-        cfg_file.write('process.endPath = cms.EndPath(process.OUT)\n')
-	cfg_file.close()
-        SendCluster_Push  (["CMSSW", Temp_Cfg])
-        SendCluster_Submit()
-        os.system('rm '+ Temp_Cfg)
+    cfg_file=open(Temp_Cfg,'w')
+    cfg_file.write('import FWCore.ParameterSet.Config as cms\n')
+    cfg_file.write('process = cms.Process("Merge")\n')
+    cfg_file.write('\n')
+    cfg_file.write('process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )\n')
+    cfg_file.write('process.load("FWCore.MessageService.MessageLogger_cfi")\n')
+    cfg_file.write('\n')
+    cfg_file.write('process.MessageLogger.cerr.FwkReport.reportEvery = 50000\n')
+    cfg_file.write('process.source = cms.Source("PoolSource",\n')
+    cfg_file.write('   fileNames = cms.untracked.vstring(\n')
+    cfg_file.write('%s' % InputFilesString)
+    cfg_file.write('   )\n')
+    cfg_file.write(')\n')
+    cfg_file.write('\n')
+    cfg_file.write('process.OUT = cms.OutputModule("PoolOutputModule",\n')
+    cfg_file.write('    outputCommands = cms.untracked.vstring(%s),\n' % KeepStatement)
+    cfg_file.write('    fileName = cms.untracked.string(%s)\n' % OutputFile)
+    cfg_file.write(')\n')
+    cfg_file.write('\n')
+    cfg_file.write('process.endPath = cms.EndPath(process.OUT)\n')
+    cfg_file.close()
+    SendCluster_Push  (["CMSSW", Temp_Cfg])
+    SendCluster_Submit()
+    os.system('rm '+ Temp_Cfg)
 

--- a/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
+++ b/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 def customise(process):
-    
+
     FLAVOR = process.generator.hscpFlavor.value()
     MASS_POINT = process.generator.massPoint.value()
     SLHA_FILE = process.generator.SLHAFileForPythia8.value()
@@ -17,33 +17,33 @@ def customise(process):
     if hasattr(process,'g4SimHits'):
         # defined watches
         process.g4SimHits.Watchers = cms.VPSet (
-	    cms.PSet(
-	        type = cms.string('RHStopTracer'),
-		RHStopTracer = cms.PSet(
-		verbose = cms.untracked.bool (False),
-		traceParticle = cms.string ("((anti_)?~|tau1).*"), #this one regular expression is needed to look for ~HIP*, anti_~HIP*, ~tau1, anti_~tau1, ~g_rho0, ~g_Deltabar0, ~T_uu1++, etc
-		stopRegularParticles = cms.untracked.bool (False)
-		)        
-	    )
-	)
-	# defined custom Physics List
-	process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/CustomPhysics')
-	# add verbosity
-	process.g4SimHits.Physics.Verbosity = cms.untracked.int32(0)
-	#process.g4SimHits.G4Commands = cms.vstring("/control/cout/ignoreThreadsExcept 0")
-	# check flavor of exotics and choose exotica Physics List
-	if FLAVOR=="gluino" or FLAVOR=="stop":
-          process.customPhysicsSetup.processesDef = PROCESS_FILE
-          process.g4SimHits.Physics.ExoticaPhysicsSS = cms.untracked.bool(False)
-	elif FLAVOR =="stau":
-          process.g4SimHits.Physics.ExoticaPhysicsSS = cms.untracked.bool(False)
+            cms.PSet(
+                type = cms.string('RHStopTracer'),
+                RHStopTracer = cms.PSet(
+                verbose = cms.untracked.bool (False),
+                traceParticle = cms.string ("((anti_)?~|tau1).*"), #this one regular expression is needed to look for ~HIP*, anti_~HIP*, ~tau1, anti_~tau1, ~g_rho0, ~g_Deltabar0, ~T_uu1++, etc
+                stopRegularParticles = cms.untracked.bool (False)
+                )        
+            )
+        )
+        # defined custom Physics List
+        process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/CustomPhysics')
+        # add verbosity
+        process.g4SimHits.Physics.Verbosity = cms.untracked.int32(0)
+        #process.g4SimHits.G4Commands = cms.vstring("/control/cout/ignoreThreadsExcept 0")
+        # check flavor of exotics and choose exotica Physics List
+        if FLAVOR=="gluino" or FLAVOR=="stop":
+            process.customPhysicsSetup.processesDef = PROCESS_FILE
+            process.g4SimHits.Physics.ExoticaPhysicsSS = cms.untracked.bool(False)
+        elif FLAVOR =="stau":
+            process.g4SimHits.Physics.ExoticaPhysicsSS = cms.untracked.bool(False)
         else:
-          print("Wrong flavor %s. Only accepted are gluino, stau, stop." % FLAVOR)
+            print("Wrong flavor %s. Only accepted are gluino, stau, stop." % FLAVOR)
         # add custom options
         process.g4SimHits.Physics = cms.PSet(
             process.g4SimHits.Physics, #keep all default value and add others
             process.customPhysicsSetup
         )	
 
-	return (process)
-	
+        return (process)
+

--- a/SimG4Core/CustomPhysics/python/Exotica_MT_SIM_cfi.py
+++ b/SimG4Core/CustomPhysics/python/Exotica_MT_SIM_cfi.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 def customise(process):
-    
+
     FLAVOR = process.generator.hscpFlavor.value()
     MASS_POINT = process.generator.massPoint.value()
     SLHA_FILE = process.generator.slhaFile.value()
@@ -15,24 +15,24 @@ def customise(process):
     process.customPhysicsSetup.reggeModel = USE_REGGE
 
     if hasattr(process,'g4SimHits'):
-	# defined custom Physics List
-	process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/CustomPhysics')
-	# add verbosity
-	process.g4SimHits.Physics.Verbosity = cms.untracked.int32(0)
-	#process.g4SimHits.G4Commands = cms.vstring("/control/cout/ignoreThreadsExcept 0")
-	# check flavor of exotics and choose exotica Physics List
-	if FLAVOR=="gluino" or FLAVOR=="stop":
-          process.customPhysicsSetup.processesDef = PROCESS_FILE
-          process.g4SimHits.Physics.ExoticaPhysicsSS = cms.untracked.bool(False)
-	elif FLAVOR =="stau":
-          process.g4SimHits.Physics.ExoticaPhysicsSS = cms.untracked.bool(False)
+        # defined custom Physics List
+        process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/CustomPhysics')
+        # add verbosity
+        process.g4SimHits.Physics.Verbosity = cms.untracked.int32(0)
+        #process.g4SimHits.G4Commands = cms.vstring("/control/cout/ignoreThreadsExcept 0")
+        # check flavor of exotics and choose exotica Physics List
+        if FLAVOR=="gluino" or FLAVOR=="stop":
+            process.customPhysicsSetup.processesDef = PROCESS_FILE
+            process.g4SimHits.Physics.ExoticaPhysicsSS = cms.untracked.bool(False)
+        elif FLAVOR =="stau":
+            process.g4SimHits.Physics.ExoticaPhysicsSS = cms.untracked.bool(False)
         else:
-          print("Wrong flavor %s. Only accepted are gluino, stau, stop." % FLAVOR)
+            print("Wrong flavor %s. Only accepted are gluino, stau, stop." % FLAVOR)
         # add custom options
         process.g4SimHits.Physics = cms.PSet(
             process.g4SimHits.Physics, #keep all default value and add others
             process.customPhysicsSetup
         )	
 
-	return (process)
-	
+        return (process)
+

--- a/SimGeneral/Configuration/python/RandomRunSource.py
+++ b/SimGeneral/Configuration/python/RandomRunSource.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 class RandomRunSource (cms.Source):
@@ -19,7 +20,7 @@ class RandomRunSource (cms.Source):
         #this is the same random generator used to set the seeds for the RandomNumberGeneratorService
         random = SystemRandom()
         runProb = random.uniform(0,totalProb)
-        print runProb
+        print(runProb)
         sumProb = 0
         runNumber = 0
         for r,p in self.__dict__['runsAndProbs']:

--- a/SimGeneral/Configuration/python/ThrowAndSetRandomRun.py
+++ b/SimGeneral/Configuration/python/ThrowAndSetRandomRun.py
@@ -1,33 +1,34 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 # function to modify an existing Cms Source in order to set the run number
 # aimed at setting non trivial run number in MC production - be it GEN-SIM or DIGI step
 
 def throwAndSetRandomRun(source,runsAndProbs):
-        """Pass a list of tuple pairs, with the first item of the pair a run number
-        and the second number of the pair a weight.  The function will normalize the
-        weights so you do not have to worry about that.  The pairs will be used to randomly choose what Run
-        should be assigned to the job.
-        """
-        from random import SystemRandom
-        totalProb = 0.
-        for r,p in runsAndProbs:
-            totalProb+=p
-        #this is the same random generator used to set the seeds for the RandomNumberGeneratorService
-        random = SystemRandom()
-        runProb = random.uniform(0,totalProb)
-        sumProb = 0
-        runNumber = 0
-        for r,p in runsAndProbs:
-            sumProb+=p
-            if sumProb >= runProb:
-                runNumber = r
-                break
-        print 'setting runNumber to: ',runNumber
-        if source.type_() == "PoolSource":
-            source.setRunNumber = cms.untracked.uint32(runNumber)
-        else:
-            #sources that inherit from ConfigurableInputSource use 'firstRun'
-            source.firstRun = cms.untracked.uint32(runNumber)
+    """Pass a list of tuple pairs, with the first item of the pair a run number
+    and the second number of the pair a weight.  The function will normalize the
+    weights so you do not have to worry about that.  The pairs will be used to randomly choose what Run
+    should be assigned to the job.
+    """
+    from random import SystemRandom
+    totalProb = 0.
+    for r,p in runsAndProbs:
+        totalProb+=p
+    #this is the same random generator used to set the seeds for the RandomNumberGeneratorService
+    random = SystemRandom()
+    runProb = random.uniform(0,totalProb)
+    sumProb = 0
+    runNumber = 0
+    for r,p in runsAndProbs:
+        sumProb+=p
+        if sumProb >= runProb:
+            runNumber = r
+            break
+    print('setting runNumber to: ',runNumber)
+    if source.type_() == "PoolSource":
+        source.setRunNumber = cms.untracked.uint32(runNumber)
+    else:
+        #sources that inherit from ConfigurableInputSource use 'firstRun'
+        source.firstRun = cms.untracked.uint32(runNumber)
 
-        return
+    return

--- a/SimGeneral/MixingModule/python/mix_fromDB_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_fromDB_cfi.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 # here we define part of the configuration of MixingModule
@@ -30,7 +31,7 @@ mix = cms.EDProducer("MixingModule",
 
     input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('readDB'),
-	sequential = cms.untracked.bool(False),                          
+        sequential = cms.untracked.bool(False),                          
         fileNames = FileNames 
     ),
 
@@ -57,8 +58,8 @@ mix = cms.EDProducer("MixingModule",
 
 
 if mix.readDB == cms.bool(True):
-    print ' '
-    print 'MixingModule will be configured from db; this is mix.readDB : ',mix.readDB
+    print(' ')
+    print('MixingModule will be configured from db; this is mix.readDB : ',mix.readDB)
 else :
-    print ' '
-    print 'MixingModule is NOT going to be configured from db; this is mix.readDB : ',mix.readDB
+    print(' ')
+    print('MixingModule is NOT going to be configured from db; this is mix.readDB : ',mix.readDB)

--- a/SimMuon/RPCDigitizer/python/rpcChamberMasker_cff.py
+++ b/SimMuon/RPCDigitizer/python/rpcChamberMasker_cff.py
@@ -69,9 +69,9 @@ def appendRPCChamberMaskerAtUnpacking(process):
                 muonRPCDigis = cms.PSet(initialSeed = cms.untracked.uint32(789342))
                 )
 
-	process.filteredRPCDigiSequence = cms.Sequence(process.preRPCDigis \
+        process.filteredRPCDigiSequence = cms.Sequence(process.preRPCDigis \
                                                        + process.muonRPCDigis)
         process.RawToDigi.replace(process.muonRPCDigis, \
                                   process.filteredRPCDigiSequence)
-    
+
     return process

--- a/SimTracker/Configuration/python/SimTracker_SetDeconv_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_SetDeconv_cff.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 def customise(process):
-	# Signal in Deconvolution Mode
-        for ps in process.mix.digitizers:
-            if ps.accumulatorType == cms.string('SiStripDigitizer'):
-	        ps.APVpeakmode = cms.bool(False)
-	        return(process)
+    # Signal in Deconvolution Mode
+    for ps in process.mix.digitizers:
+        if ps.accumulatorType == cms.string('SiStripDigitizer'):
+            ps.APVpeakmode = cms.bool(False)
+            return(process)
 

--- a/SimTracker/Configuration/python/SimTracker_SetPeak_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_SetPeak_cff.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 def customise(process):
-	# Signal in Deconvolution Mode
-        for ps in process.mix.digitizers:
-            if ps.accumulatorType == cms.string('SiStripDigitizer'):
-	        ps.APVpeakmode = cms.bool(True)
-	        ps.electronPerAdc = cms.double(262.0) #this is the value measured in peak... should we add 15%?
-	        return(process)
+    # Signal in Deconvolution Mode
+    for ps in process.mix.digitizers:
+        if ps.accumulatorType == cms.string('SiStripDigitizer'):
+            ps.APVpeakmode = cms.bool(True)
+            ps.electronPerAdc = cms.double(262.0) #this is the value measured in peak... should we add 15%?
+            return(process)
 

--- a/SimTransport/HectorProducer/python/FastSimWithCTPPS_cff.py
+++ b/SimTransport/HectorProducer/python/FastSimWithCTPPS_cff.py
@@ -1,51 +1,51 @@
 import FWCore.ParameterSet.Config as cms
 
 def customise(process):
-	if hasattr(process.VtxSmeared,"X0"):
-		VertexX = process.VtxSmeared.X0
-		VertexY = process.VtxSmeared.Y0
-		VertexZ = process.VtxSmeared.Z0
+    if hasattr(process.VtxSmeared,"X0"):
+        VertexX = process.VtxSmeared.X0
+        VertexY = process.VtxSmeared.Y0
+        VertexZ = process.VtxSmeared.Z0
 
-	if hasattr(process.VtxSmeared,"MeanX"):
-		VertexX = process.VtxSmeared.MeanX
-		VertexY = process.VtxSmeared.MeanY
-		VertexZ = process.VtxSmeared.MeanZ
-
-
-	
-	process.load('SimTransport.HectorProducer.HectorTransportCTPPS_cfi')
-	process.LHCTransport.CTPPSHector.VtxMeanX  = VertexX
-	process.LHCTransport.CTPPSHector.VtxMeanY  = VertexY
-	process.LHCTransport.CTPPSHector.VtxMeanZ = VertexZ
-
-	###################################
-	process.load('FastSimulation.CTPPSSimHitProducer.CTPPSSimHitProducer_cfi')
-	process.load('FastSimulation.CTPPSRecHitProducer.CTPPSRecHitProducer_cfi')
-	process.load('FastSimulation.CTPPSFastTrackingProducer.CTPPSFastTrackingProducer_cfi')
-	###################################
-	process.mix.mixObjects.mixSH.crossingFrames.append('CTPPSHits')
-	process.mix.mixObjects.mixSH.input.append(cms.InputTag("CTPPSSimHits","CTPPSHits"))
-	process.mix.mixObjects.mixSH.subdets.append('CTPPSHits')
-       
-			
-	# CTPPS simHit sequence 
-	process.simulation_step.replace(process.psim,process.psim+process.CTPPSSimHits)
-        # SimTransport on path
-        process.transport_step = cms.Path(process.generator+process.LHCTransport)
-
-	process.schedule.insert(2,process.transport_step)
+    if hasattr(process.VtxSmeared,"MeanX"):
+        VertexX = process.VtxSmeared.MeanX
+        VertexY = process.VtxSmeared.MeanY
+        VertexZ = process.VtxSmeared.MeanZ
 
 
-	# output
-    	outputModule = None
-    	outdict = process.outputModules_()
-    	if "AODSIMoutput" in outdict:
-	    process.AODSIMoutput.outputCommands.extend(cms.untracked.vstring('keep *_CTPPSSimHits_*_*','keep *_CTPPSFastRecHits_*_*'
+
+    process.load('SimTransport.HectorProducer.HectorTransportCTPPS_cfi')
+    process.LHCTransport.CTPPSHector.VtxMeanX  = VertexX
+    process.LHCTransport.CTPPSHector.VtxMeanY  = VertexY
+    process.LHCTransport.CTPPSHector.VtxMeanZ = VertexZ
+
+    ###################################
+    process.load('FastSimulation.CTPPSSimHitProducer.CTPPSSimHitProducer_cfi')
+    process.load('FastSimulation.CTPPSRecHitProducer.CTPPSRecHitProducer_cfi')
+    process.load('FastSimulation.CTPPSFastTrackingProducer.CTPPSFastTrackingProducer_cfi')
+    ###################################
+    process.mix.mixObjects.mixSH.crossingFrames.append('CTPPSHits')
+    process.mix.mixObjects.mixSH.input.append(cms.InputTag("CTPPSSimHits","CTPPSHits"))
+    process.mix.mixObjects.mixSH.subdets.append('CTPPSHits')
+
+
+    # CTPPS simHit sequence 
+    process.simulation_step.replace(process.psim,process.psim+process.CTPPSSimHits)
+    # SimTransport on path
+    process.transport_step = cms.Path(process.generator+process.LHCTransport)
+
+    process.schedule.insert(2,process.transport_step)
+
+
+    # output
+    outputModule = None
+    outdict = process.outputModules_()
+    if "AODSIMoutput" in outdict:
+        process.AODSIMoutput.outputCommands.extend(cms.untracked.vstring('keep *_CTPPSSimHits_*_*','keep *_CTPPSFastRecHits_*_*'
 ,'keep *_CTPPSFastTracks_*_*'))
-	    process.reconstruction_step.replace(process.reconstruction,process.reconstruction*process.CTPPSFastRecHits*process.CTPPSFastTracks) 	
-    	elif "FASTPUoutput" in outdict:
-	    process.FASTPUoutput.outputCommands.extend(cms.untracked.vstring('keep *_CTPPSSimHits_*_*')) 	
-			
-	
-	return(process)
+        process.reconstruction_step.replace(process.reconstruction,process.reconstruction*process.CTPPSFastRecHits*process.CTPPSFastTracks) 	
+    elif "FASTPUoutput" in outdict:
+        process.FASTPUoutput.outputCommands.extend(cms.untracked.vstring('keep *_CTPPSSimHits_*_*')) 	
+
+
+    return(process)
 

--- a/SimTransport/HectorProducer/python/FullSimWithCTPPS_cff.py
+++ b/SimTransport/HectorProducer/python/FullSimWithCTPPS_cff.py
@@ -1,30 +1,30 @@
 import FWCore.ParameterSet.Config as cms
 def customise(process):
 
-	if hasattr(process.VtxSmeared,"X0"):
-           VertexX = process.VtxSmeared.X0
-           VertexY = process.VtxSmeared.Y0
-           VertexZ = process.VtxSmeared.Z0
+    if hasattr(process.VtxSmeared,"X0"):
+        VertexX = process.VtxSmeared.X0
+        VertexY = process.VtxSmeared.Y0
+        VertexZ = process.VtxSmeared.Z0
 
-        if hasattr(process.VtxSmeared,"MeanX"):
-           VertexX = process.VtxSmeared.MeanX
-           VertexY = process.VtxSmeared.MeanY
-           VertexZ = process.VtxSmeared.MeanZ
+    if hasattr(process.VtxSmeared,"MeanX"):
+        VertexX = process.VtxSmeared.MeanX
+        VertexY = process.VtxSmeared.MeanY
+        VertexZ = process.VtxSmeared.MeanZ
 
-	process.load("SimG4Core.Application.g4SimHits_cfi")
-	process.g4SimHits.Generator.HepMCProductLabel   = 'LHCTransport'
-	process.g4SimHits.Generator.MinEtaCut        = -13.0
-	process.g4SimHits.Generator.MaxEtaCut        = 13.0
+    process.load("SimG4Core.Application.g4SimHits_cfi")
+    process.g4SimHits.Generator.HepMCProductLabel   = 'LHCTransport'
+    process.g4SimHits.Generator.MinEtaCut        = -13.0
+    process.g4SimHits.Generator.MaxEtaCut        = 13.0
 
-	process.g4SimHits.SteppingAction.MaxTrackTime = cms.double(2000.0)
- 	process.g4SimHits.StackingAction.MaxTrackTime = cms.double(2000.0)
+    process.g4SimHits.SteppingAction.MaxTrackTime = cms.double(2000.0)
+    process.g4SimHits.StackingAction.MaxTrackTime = cms.double(2000.0)
 
-	process.load('SimTransport.HectorProducer.HectorTransportCTPPS_cfi')
-	process.LHCTransport.CTPPSHector.VtxMeanX  = VertexX
-        process.LHCTransport.CTPPSHector.VtxMeanY  = VertexY
-	process.LHCTransport.CTPPSHector.VtxMeanZ  = VertexZ
-	
-	process.transport_step = cms.Path(process.LHCTransport)
-	process.psim = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")*process.LHCTransport*process.g4SimHits)
+    process.load('SimTransport.HectorProducer.HectorTransportCTPPS_cfi')
+    process.LHCTransport.CTPPSHector.VtxMeanX  = VertexX
+    process.LHCTransport.CTPPSHector.VtxMeanY  = VertexY
+    process.LHCTransport.CTPPSHector.VtxMeanZ  = VertexZ
 
-	return(process)
+    process.transport_step = cms.Path(process.LHCTransport)
+    process.psim = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")*process.LHCTransport*process.g4SimHits)
+
+    return(process)

--- a/TauAnalysis/MCEmbeddingTools/python/customisers.py
+++ b/TauAnalysis/MCEmbeddingTools/python/customisers.py
@@ -23,14 +23,14 @@ import six
 
 
 class module_manipulate():
-	def __init__(self, module_name, manipulator_name, steps = ["SELECT","CLEAN","SIM","MERGE"], instance=[""], merge_prefix = ""):
-		self.module_name = module_name
-		self.manipulator_name = manipulator_name
-		self.steps = steps
-		self.instance = instance
-		self.merger_name = manipulator_name+"ColMerger"
-		self.cleaner_name = manipulator_name+"ColCleaner"
-		self.merge_prefix = merge_prefix
+    def __init__(self, module_name, manipulator_name, steps = ["SELECT","CLEAN","SIM","MERGE"], instance=[""], merge_prefix = ""):
+        self.module_name = module_name
+        self.manipulator_name = manipulator_name
+        self.steps = steps
+        self.instance = instance
+        self.merger_name = manipulator_name+"ColMerger"
+        self.cleaner_name = manipulator_name+"ColCleaner"
+        self.merge_prefix = merge_prefix
 
 
 
@@ -68,429 +68,429 @@ to_bemanipulate.append(module_manipulate(module_name = 'rpcRecHits', manipulator
 
 
 def modify_outputModules(process, keep_drop_list = [], module_veto_list = [] ):
-	outputModulesList = [key for key,value in six.iteritems(process.outputModules)]
-	for outputModule in outputModulesList:
-		if outputModule in module_veto_list:
-			continue
-		outputModule = getattr(process, outputModule)
-		for add_element in keep_drop_list:
-			outputModule.outputCommands.extend(add_element)
-	return process
+    outputModulesList = [key for key,value in six.iteritems(process.outputModules)]
+    for outputModule in outputModulesList:
+        if outputModule in module_veto_list:
+            continue
+        outputModule = getattr(process, outputModule)
+        for add_element in keep_drop_list:
+            outputModule.outputCommands.extend(add_element)
+    return process
 
 
 
 ################################ Customizer for Selecting ###########################
 
 def keepSelected(dataTier):
-	 ret_vstring = cms.untracked.vstring(
-	               #  "drop *_*_*_"+dataTier,
-			 "keep *_patMuonsAfterID_*_"+dataTier,
-			 "keep *_slimmedMuons_*_"+dataTier,
-			 "keep *_selectedMuonsForEmbedding_*_"+dataTier,
-			 "keep recoVertexs_offlineSlimmedPrimaryVertices_*_"+dataTier,
-			 "keep *_firstStepPrimaryVertices_*_"+dataTier,
-			 "keep *_offlineBeamSpot_*_"+dataTier
-			 )
-	 for akt_manimod in to_bemanipulate:
-		if "CLEAN" in akt_manimod.steps:
-			ret_vstring.append("keep *_"+akt_manimod.module_name+"_*_"+dataTier)
-	 return ret_vstring
+    ret_vstring = cms.untracked.vstring(
+                  #  "drop *_*_*_"+dataTier,
+                    "keep *_patMuonsAfterID_*_"+dataTier,
+                    "keep *_slimmedMuons_*_"+dataTier,
+                    "keep *_selectedMuonsForEmbedding_*_"+dataTier,
+                    "keep recoVertexs_offlineSlimmedPrimaryVertices_*_"+dataTier,
+                    "keep *_firstStepPrimaryVertices_*_"+dataTier,
+                    "keep *_offlineBeamSpot_*_"+dataTier
+                    )
+    for akt_manimod in to_bemanipulate:
+        if "CLEAN" in akt_manimod.steps:
+            ret_vstring.append("keep *_"+akt_manimod.module_name+"_*_"+dataTier)
+    return ret_vstring
 
 def customiseSelecting(process,reselect=False):
-	if reselect:
-		process._Process__name = "RESELECT"
-		dataTier="RESELECT"
-	else:
-		process._Process__name = "SELECT"
-		dataTier="SELECT"
+    if reselect:
+        process._Process__name = "RESELECT"
+        dataTier="RESELECT"
+    else:
+        process._Process__name = "SELECT"
+        dataTier="SELECT"
 
-	process.load('TauAnalysis.MCEmbeddingTools.SelectingProcedure_cff')
-	process.patMuonsAfterKinCuts.src = cms.InputTag("slimmedMuons","",dataTier)
-	process.patMuonsAfterID = process.patMuonsAfterLooseID.clone()
+    process.load('TauAnalysis.MCEmbeddingTools.SelectingProcedure_cff')
+    process.patMuonsAfterKinCuts.src = cms.InputTag("slimmedMuons","",dataTier)
+    process.patMuonsAfterID = process.patMuonsAfterLooseID.clone()
 
-	process.selecting = cms.Path(process.makePatMuonsZmumuSelection)
-	process.schedule.insert(-1, process.selecting)
+    process.selecting = cms.Path(process.makePatMuonsZmumuSelection)
+    process.schedule.insert(-1, process.selecting)
 
-	outputModulesList = [key for key,value in six.iteritems(process.outputModules)]
-	for outputModule in outputModulesList:
-		outputModule = getattr(process, outputModule)
-		outputModule.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("selecting"))
-		outputModule.outputCommands.extend(keepSelected(dataTier))
-		
-	process = customisoptions(process)
-	return modify_outputModules(process,[keepSelected(dataTier)])
+    outputModulesList = [key for key,value in six.iteritems(process.outputModules)]
+    for outputModule in outputModulesList:
+        outputModule = getattr(process, outputModule)
+        outputModule.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("selecting"))
+        outputModule.outputCommands.extend(keepSelected(dataTier))
+
+    process = customisoptions(process)
+    return modify_outputModules(process,[keepSelected(dataTier)])
 
 def customiseSelecting_Reselect(process):
-	return customiseSelecting(process,reselect=True)
+    return customiseSelecting(process,reselect=True)
 
 ################################ Customizer for cleaining ###########################
 def keepCleaned():
-	 ret_vstring = cms.untracked.vstring(
+    ret_vstring = cms.untracked.vstring(
 #	 	                 "drop *_*_*_LHEembeddingCLEAN",
 #	 	                 "drop *_*_*_CLEAN"
-	 	                 )
-	 
-	 for akt_manimod in to_bemanipulate:
-		if "MERGE" in akt_manimod.steps:
-			ret_vstring.append("keep *_"+akt_manimod.module_name+"_*_LHEembeddingCLEAN")
-			ret_vstring.append("keep *_"+akt_manimod.module_name+"_*_CLEAN")
-	 ret_vstring.append("keep *_standAloneMuons_*_LHEembeddingCLEAN")
-	 ret_vstring.append("keep *_glbTrackQual_*_LHEembeddingCLEAN")
-	 return ret_vstring
+                            )
+
+    for akt_manimod in to_bemanipulate:
+        if "MERGE" in akt_manimod.steps:
+            ret_vstring.append("keep *_"+akt_manimod.module_name+"_*_LHEembeddingCLEAN")
+            ret_vstring.append("keep *_"+akt_manimod.module_name+"_*_CLEAN")
+    ret_vstring.append("keep *_standAloneMuons_*_LHEembeddingCLEAN")
+    ret_vstring.append("keep *_glbTrackQual_*_LHEembeddingCLEAN")
+    return ret_vstring
 
 
 
 def customiseCleaning(process, changeProcessname=True,reselect=False):
-	if changeProcessname:
-		process._Process__name = "CLEAN"
-	if reselect:
-		dataTier="RESELECT"
-	else: 
-		dataTier="SELECT"
-	## Needed for the Calo Cleaner, could also be put into a function wich fix the input parameters
-	from TrackingTools.TrackAssociator.default_cfi import TrackAssociatorParameterBlock
-	TrackAssociatorParameterBlock.TrackAssociatorParameters.CSCSegmentCollectionLabel = cms.InputTag("cscSegments","",dataTier)
-	TrackAssociatorParameterBlock.TrackAssociatorParameters.CaloTowerCollectionLabel = cms.InputTag("towerMaker","",dataTier)
-	TrackAssociatorParameterBlock.TrackAssociatorParameters.DTRecSegment4DCollectionLabel = cms.InputTag("dt4DSegments","",dataTier)
-	TrackAssociatorParameterBlock.TrackAssociatorParameters.EBRecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB",dataTier)
-	TrackAssociatorParameterBlock.TrackAssociatorParameters.EERecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE",dataTier)
-	TrackAssociatorParameterBlock.TrackAssociatorParameters.HBHERecHitCollectionLabel = cms.InputTag("hbhereco","",dataTier)
-	TrackAssociatorParameterBlock.TrackAssociatorParameters.HORecHitCollectionLabel = cms.InputTag("horeco","",dataTier)
+    if changeProcessname:
+        process._Process__name = "CLEAN"
+    if reselect:
+        dataTier="RESELECT"
+    else: 
+        dataTier="SELECT"
+    ## Needed for the Calo Cleaner, could also be put into a function wich fix the input parameters
+    from TrackingTools.TrackAssociator.default_cfi import TrackAssociatorParameterBlock
+    TrackAssociatorParameterBlock.TrackAssociatorParameters.CSCSegmentCollectionLabel = cms.InputTag("cscSegments","",dataTier)
+    TrackAssociatorParameterBlock.TrackAssociatorParameters.CaloTowerCollectionLabel = cms.InputTag("towerMaker","",dataTier)
+    TrackAssociatorParameterBlock.TrackAssociatorParameters.DTRecSegment4DCollectionLabel = cms.InputTag("dt4DSegments","",dataTier)
+    TrackAssociatorParameterBlock.TrackAssociatorParameters.EBRecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB",dataTier)
+    TrackAssociatorParameterBlock.TrackAssociatorParameters.EERecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE",dataTier)
+    TrackAssociatorParameterBlock.TrackAssociatorParameters.HBHERecHitCollectionLabel = cms.InputTag("hbhereco","",dataTier)
+    TrackAssociatorParameterBlock.TrackAssociatorParameters.HORecHitCollectionLabel = cms.InputTag("horeco","",dataTier)
 
 
-	MuonImput = cms.InputTag("selectedMuonsForEmbedding","","")  ## This are the muon
-	for akt_manimod in to_bemanipulate:
-		if "CLEAN" in akt_manimod.steps:
-			oldCollections_in = cms.VInputTag()
-			for instance in akt_manimod.instance:
-				oldCollections_in.append(cms.InputTag(akt_manimod.module_name,instance,dataTier))
-			setattr(process, akt_manimod.module_name, cms.EDProducer(akt_manimod.cleaner_name,MuonCollection = MuonImput,TrackAssociatorParameters = TrackAssociatorParameterBlock.TrackAssociatorParameters,oldCollection = oldCollections_in))
-	process.ecalPreshowerRecHit.TrackAssociatorParameters.usePreshower = cms.bool(True)
-	process = customisoptions(process)	
-	return modify_outputModules(process,[keepSelected(dataTier),keepCleaned()],["MINIAODoutput"])
+    MuonImput = cms.InputTag("selectedMuonsForEmbedding","","")  ## This are the muon
+    for akt_manimod in to_bemanipulate:
+        if "CLEAN" in akt_manimod.steps:
+            oldCollections_in = cms.VInputTag()
+            for instance in akt_manimod.instance:
+                oldCollections_in.append(cms.InputTag(akt_manimod.module_name,instance,dataTier))
+            setattr(process, akt_manimod.module_name, cms.EDProducer(akt_manimod.cleaner_name,MuonCollection = MuonImput,TrackAssociatorParameters = TrackAssociatorParameterBlock.TrackAssociatorParameters,oldCollection = oldCollections_in))
+    process.ecalPreshowerRecHit.TrackAssociatorParameters.usePreshower = cms.bool(True)
+    process = customisoptions(process)	
+    return modify_outputModules(process,[keepSelected(dataTier),keepCleaned()],["MINIAODoutput"])
 
 
 ################################ Customizer for simulaton ###########################
 def keepLHE():
-	ret_vstring = cms.untracked.vstring()
-	ret_vstring.append("keep *_externalLHEProducer_*_LHEembedding")
-	ret_vstring.append("keep *_externalLHEProducer_*_LHEembeddingCLEAN")
-	return ret_vstring
+    ret_vstring = cms.untracked.vstring()
+    ret_vstring.append("keep *_externalLHEProducer_*_LHEembedding")
+    ret_vstring.append("keep *_externalLHEProducer_*_LHEembeddingCLEAN")
+    return ret_vstring
 
 
 def keepSimulated():
-	ret_vstring = cms.untracked.vstring()
-	for akt_manimod in to_bemanipulate:
-		if "MERGE" in akt_manimod.steps:
-			ret_vstring.append("keep *_"+akt_manimod.module_name+"_*_SIMembedding")
-	ret_vstring.append("keep *_genParticles_*_SIMembedding")
-	ret_vstring.append("keep *_standAloneMuons_*_SIMembedding")
-	ret_vstring.append("keep *_glbTrackQual_*_SIMembedding")
-	ret_vstring.append("keep *_generator_*_SIMembedding")
-	ret_vstring.append("keep *_addPileupInfo_*_SIMembedding")
-	ret_vstring.append("keep *_slimmedAddPileupInfo_*_*")
-	return ret_vstring
+    ret_vstring = cms.untracked.vstring()
+    for akt_manimod in to_bemanipulate:
+        if "MERGE" in akt_manimod.steps:
+            ret_vstring.append("keep *_"+akt_manimod.module_name+"_*_SIMembedding")
+    ret_vstring.append("keep *_genParticles_*_SIMembedding")
+    ret_vstring.append("keep *_standAloneMuons_*_SIMembedding")
+    ret_vstring.append("keep *_glbTrackQual_*_SIMembedding")
+    ret_vstring.append("keep *_generator_*_SIMembedding")
+    ret_vstring.append("keep *_addPileupInfo_*_SIMembedding")
+    ret_vstring.append("keep *_slimmedAddPileupInfo_*_*")
+    return ret_vstring
 
 
 
 
 def customiseLHE(process, changeProcessname=True,reselect=False):
-	if reselect:
-		dataTier="RESELECT"
-	else: 
-		dataTier="SELECT"
-	if changeProcessname:
-		process._Process__name = "LHEembedding"
-	process.load('TauAnalysis.MCEmbeddingTools.EmbeddingLHEProducer_cfi')
-	if reselect:
-		process.externalLHEProducer.vertices=cms.InputTag("offlineSlimmedPrimaryVertices","","RESELECT")
-	process.lheproduction = cms.Path(process.makeexternalLHEProducer)
-	process.schedule.insert(0,process.lheproduction)
-	
-	
-	process = customisoptions(process)
-	return modify_outputModules(process,[keepSelected(dataTier),keepCleaned(), keepLHE()],["MINIAODoutput"])
+    if reselect:
+        dataTier="RESELECT"
+    else: 
+        dataTier="SELECT"
+    if changeProcessname:
+        process._Process__name = "LHEembedding"
+    process.load('TauAnalysis.MCEmbeddingTools.EmbeddingLHEProducer_cfi')
+    if reselect:
+        process.externalLHEProducer.vertices=cms.InputTag("offlineSlimmedPrimaryVertices","","RESELECT")
+    process.lheproduction = cms.Path(process.makeexternalLHEProducer)
+    process.schedule.insert(0,process.lheproduction)
+
+
+    process = customisoptions(process)
+    return modify_outputModules(process,[keepSelected(dataTier),keepCleaned(), keepLHE()],["MINIAODoutput"])
 
 
 def customiseGenerator(process, changeProcessname=True,reselect=False):
-	if reselect:
-		dataTier="RESELECT"
-	else:
-		dataTier="SELECT"
-	if changeProcessname:
-		process._Process__name = "SIMembedding"
+    if reselect:
+        dataTier="RESELECT"
+    else:
+        dataTier="SELECT"
+    if changeProcessname:
+        process._Process__name = "SIMembedding"
 
-	## here correct the vertex collection
-	
-	process.load('TauAnalysis.MCEmbeddingTools.EmbeddingVertexCorrector_cfi')
-	process.VtxSmeared = process.VtxCorrectedToInput.clone()
-	print("Correcting Vertex in genEvent to one from input. Replaced 'VtxSmeared' with the Corrector.")
+    ## here correct the vertex collection
 
-	# Remove BeamSpot Production, use the one from selected data instead.
-	process.reconstruction.remove(process.offlineBeamSpot)
+    process.load('TauAnalysis.MCEmbeddingTools.EmbeddingVertexCorrector_cfi')
+    process.VtxSmeared = process.VtxCorrectedToInput.clone()
+    print("Correcting Vertex in genEvent to one from input. Replaced 'VtxSmeared' with the Corrector.")
 
-	# Disable noise simulation
-	process.mix.digitizers.castor.doNoise = cms.bool(False)
+    # Remove BeamSpot Production, use the one from selected data instead.
+    process.reconstruction.remove(process.offlineBeamSpot)
 
-	process.mix.digitizers.ecal.doESNoise = cms.bool(False)
-	process.mix.digitizers.ecal.doENoise = cms.bool(False)
+    # Disable noise simulation
+    process.mix.digitizers.castor.doNoise = cms.bool(False)
 
-	process.mix.digitizers.hcal.doNoise = cms.bool(False)
-	process.mix.digitizers.hcal.doThermalNoise = cms.bool(False)
-	process.mix.digitizers.hcal.doHPDNoise = cms.bool(False)
+    process.mix.digitizers.ecal.doESNoise = cms.bool(False)
+    process.mix.digitizers.ecal.doENoise = cms.bool(False)
 
-	process.mix.digitizers.pixel.AddNoisyPixels = cms.bool(False)
-	process.mix.digitizers.pixel.AddNoise = cms.bool(False)
+    process.mix.digitizers.hcal.doNoise = cms.bool(False)
+    process.mix.digitizers.hcal.doThermalNoise = cms.bool(False)
+    process.mix.digitizers.hcal.doHPDNoise = cms.bool(False)
 
-	process.mix.digitizers.strip.Noise = cms.bool(False)
-	
-	
-	process = customisoptions(process) 
-	##process = fix_input_tags(process)
-	
-	return modify_outputModules(process,[keepSelected(dataTier),keepCleaned(),keepSimulated()],["AODSIMoutput"])
+    process.mix.digitizers.pixel.AddNoisyPixels = cms.bool(False)
+    process.mix.digitizers.pixel.AddNoise = cms.bool(False)
+
+    process.mix.digitizers.strip.Noise = cms.bool(False)
+
+
+    process = customisoptions(process) 
+    ##process = fix_input_tags(process)
+
+    return modify_outputModules(process,[keepSelected(dataTier),keepCleaned(),keepSimulated()],["AODSIMoutput"])
 
 def customiseGenerator_Reselect(process):
-	return customiseGenerator(process,reselect=True)
+    return customiseGenerator(process,reselect=True)
 
 ################################ Customizer for merging ###########################
 def keepMerged(dataTier="SELECT"):
-	ret_vstring = cms.untracked.vstring()
-	ret_vstring.append("drop *_*_*_"+dataTier)
-	ret_vstring.append("keep *_prunedGenParticles_*_MERGE")
-	ret_vstring.append("keep *_generator_*_SIMembedding")
-	return ret_vstring
+    ret_vstring = cms.untracked.vstring()
+    ret_vstring.append("drop *_*_*_"+dataTier)
+    ret_vstring.append("keep *_prunedGenParticles_*_MERGE")
+    ret_vstring.append("keep *_generator_*_SIMembedding")
+    return ret_vstring
 
 
 def customiseKeepPrunedGenParticles(process,reselect=False):
-	if reselect:
-		dataTier="RESELECT"
-	else:
-		dataTier="SELECT"
-	
-	process.load('PhysicsTools.PatAlgos.slimming.genParticles_cff')
-	process.merge_step += process.prunedGenParticlesWithStatusOne
-	process.load('PhysicsTools.PatAlgos.slimming.prunedGenParticles_cfi')
-	process.merge_step += process.prunedGenParticles
-	process.load('PhysicsTools.PatAlgos.slimming.packedGenParticles_cfi')
-	process.merge_step += process.packedGenParticles
-	
-	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.muonMatch_cfi')
-	process.merge_step += process.muonMatch
-	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.electronMatch_cfi')
-	process.merge_step += process.electronMatch
-	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.photonMatch_cfi')
-	process.merge_step += process.photonMatch
-	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.tauMatch_cfi')
-	process.merge_step += process.tauMatch
-	process.load('PhysicsTools.JetMCAlgos.TauGenJets_cfi')
-	process.merge_step += process.tauGenJets
-	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.jetFlavourId_cff')
-	process.merge_step += process.patJetPartons
-	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi')
-	process.merge_step += process.patJetPartonMatch
-	
-	process.muonMatch.matched = "prunedGenParticles"
-	process.electronMatch.matched = "prunedGenParticles"
-	process.electronMatch.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
-	process.photonMatch.matched = "prunedGenParticles"
-	process.photonMatch.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
-	process.tauMatch.matched = "prunedGenParticles"
-	process.tauGenJets.GenParticles = "prunedGenParticles"
-	##Boosted taus
-	#process.tauMatchBoosted.matched = "prunedGenParticles"
-	#process.tauGenJetsBoosted.GenParticles = "prunedGenParticles"
-	process.patJetPartons.particles = "prunedGenParticles"
-	process.patJetPartonMatch.matched = "prunedGenParticles"
-	process.patJetPartonMatch.mcStatus = [ 3, 23 ]
-	process.patJetGenJetMatch.matched = "slimmedGenJets"
-	process.patJetGenJetMatchAK8.matched =  "slimmedGenJetsAK8"
-	process.patMuons.embedGenMatch = False
-	process.patElectrons.embedGenMatch = False
-	process.patPhotons.embedGenMatch = False
-	process.patTaus.embedGenMatch = False
-	process.patTausBoosted.embedGenMatch = False
-	process.patJets.embedGenPartonMatch = False
-	#also jet flavour must be switched
-	process.patJetFlavourAssociation.rParam = 0.4
-	
-	process.schedule.insert(0,process.merge_step)
-	process = customisoptions(process)  
-	return modify_outputModules(process, [keepMerged(dataTier)])
+    if reselect:
+        dataTier="RESELECT"
+    else:
+        dataTier="SELECT"
+
+    process.load('PhysicsTools.PatAlgos.slimming.genParticles_cff')
+    process.merge_step += process.prunedGenParticlesWithStatusOne
+    process.load('PhysicsTools.PatAlgos.slimming.prunedGenParticles_cfi')
+    process.merge_step += process.prunedGenParticles
+    process.load('PhysicsTools.PatAlgos.slimming.packedGenParticles_cfi')
+    process.merge_step += process.packedGenParticles
+
+    process.load('PhysicsTools.PatAlgos.mcMatchLayer0.muonMatch_cfi')
+    process.merge_step += process.muonMatch
+    process.load('PhysicsTools.PatAlgos.mcMatchLayer0.electronMatch_cfi')
+    process.merge_step += process.electronMatch
+    process.load('PhysicsTools.PatAlgos.mcMatchLayer0.photonMatch_cfi')
+    process.merge_step += process.photonMatch
+    process.load('PhysicsTools.PatAlgos.mcMatchLayer0.tauMatch_cfi')
+    process.merge_step += process.tauMatch
+    process.load('PhysicsTools.JetMCAlgos.TauGenJets_cfi')
+    process.merge_step += process.tauGenJets
+    process.load('PhysicsTools.PatAlgos.mcMatchLayer0.jetFlavourId_cff')
+    process.merge_step += process.patJetPartons
+    process.load('PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi')
+    process.merge_step += process.patJetPartonMatch
+
+    process.muonMatch.matched = "prunedGenParticles"
+    process.electronMatch.matched = "prunedGenParticles"
+    process.electronMatch.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.photonMatch.matched = "prunedGenParticles"
+    process.photonMatch.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.tauMatch.matched = "prunedGenParticles"
+    process.tauGenJets.GenParticles = "prunedGenParticles"
+    ##Boosted taus
+    #process.tauMatchBoosted.matched = "prunedGenParticles"
+    #process.tauGenJetsBoosted.GenParticles = "prunedGenParticles"
+    process.patJetPartons.particles = "prunedGenParticles"
+    process.patJetPartonMatch.matched = "prunedGenParticles"
+    process.patJetPartonMatch.mcStatus = [ 3, 23 ]
+    process.patJetGenJetMatch.matched = "slimmedGenJets"
+    process.patJetGenJetMatchAK8.matched =  "slimmedGenJetsAK8"
+    process.patMuons.embedGenMatch = False
+    process.patElectrons.embedGenMatch = False
+    process.patPhotons.embedGenMatch = False
+    process.patTaus.embedGenMatch = False
+    process.patTausBoosted.embedGenMatch = False
+    process.patJets.embedGenPartonMatch = False
+    #also jet flavour must be switched
+    process.patJetFlavourAssociation.rParam = 0.4
+
+    process.schedule.insert(0,process.merge_step)
+    process = customisoptions(process)  
+    return modify_outputModules(process, [keepMerged(dataTier)])
 
 
 def customiseMerging(process, changeProcessname=True,reselect=False):
-	if changeProcessname:
-		process._Process__name = "MERGE"
-	if reselect:
-		dataTier="RESELECT"
-	else:
-		dataTier="SELECT"
+    if changeProcessname:
+        process._Process__name = "MERGE"
+    if reselect:
+        dataTier="RESELECT"
+    else:
+        dataTier="SELECT"
 
 
-	process.source.inputCommands = cms.untracked.vstring()
-	process.source.inputCommands.append("keep *_*_*_*")
-	
-	#process.source.inputCommands.append("drop *_*_*_SELECT")
-	#process.source.inputCommands.append("drop *_*_*_SIMembedding")
-	#process.source.inputCommands.append("drop *_*_*_LHEembeddingCLEAN")
-	#process.source.inputCommands.extend(keepSimulated())
-	#process.source.inputCommands.extend(keepCleaned())
+    process.source.inputCommands = cms.untracked.vstring()
+    process.source.inputCommands.append("keep *_*_*_*")
 
-	process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
-	process.merge_step = cms.Path()
+    #process.source.inputCommands.append("drop *_*_*_SELECT")
+    #process.source.inputCommands.append("drop *_*_*_SIMembedding")
+    #process.source.inputCommands.append("drop *_*_*_LHEembeddingCLEAN")
+    #process.source.inputCommands.extend(keepSimulated())
+    #process.source.inputCommands.extend(keepCleaned())
 
-
-	for akt_manimod in to_bemanipulate:
-		if "MERGE" in akt_manimod.steps:
-	#if akt_manimod.module_name != 'particleFlowTmp':
-	#  continue
-			print(akt_manimod.module_name)
-			mergCollections_in = cms.VInputTag()
-			for instance in akt_manimod.instance:
-				mergCollections_in.append(cms.InputTag(akt_manimod.merge_prefix+akt_manimod.module_name,instance,"SIMembedding"))
-				mergCollections_in.append(cms.InputTag(akt_manimod.merge_prefix+akt_manimod.module_name,instance,"LHEembeddingCLEAN"))##  Mayb make some process history magic which finds out if it was CLEAN or LHEembeddingCLEAN step
-			setattr(process, akt_manimod.module_name, cms.EDProducer(akt_manimod.merger_name,
-								 mergCollections = mergCollections_in
-								 )
-			)
-			process.merge_step +=getattr(process, akt_manimod.module_name)
+    process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+    process.merge_step = cms.Path()
 
 
-	process.merge_step += process.doAlldEdXEstimators
-	process.merge_step += process.vertexreco
-	process.unsortedOfflinePrimaryVertices.beamSpotLabel = cms.InputTag("offlineBeamSpot","",dataTier)
-	process.ak4CaloJetsForTrk.srcPVs = cms.InputTag("firstStepPrimaryVertices","",dataTier)
+    for akt_manimod in to_bemanipulate:
+        if "MERGE" in akt_manimod.steps:
+    #if akt_manimod.module_name != 'particleFlowTmp':
+    #  continue
+            print(akt_manimod.module_name)
+            mergCollections_in = cms.VInputTag()
+            for instance in akt_manimod.instance:
+                mergCollections_in.append(cms.InputTag(akt_manimod.merge_prefix+akt_manimod.module_name,instance,"SIMembedding"))
+                mergCollections_in.append(cms.InputTag(akt_manimod.merge_prefix+akt_manimod.module_name,instance,"LHEembeddingCLEAN"))##  Mayb make some process history magic which finds out if it was CLEAN or LHEembeddingCLEAN step
+            setattr(process, akt_manimod.module_name, cms.EDProducer(akt_manimod.merger_name,
+                                                     mergCollections = mergCollections_in
+                                                     )
+            )
+            process.merge_step +=getattr(process, akt_manimod.module_name)
 
-	process.muons.FillDetectorBasedIsolation = cms.bool(False)
-	process.muons.FillSelectorMaps = cms.bool(False)
-	process.muons.FillShoweringInfo = cms.bool(False)
-	process.muons.FillCosmicsIdMap = cms.bool(False)
+
+    process.merge_step += process.doAlldEdXEstimators
+    process.merge_step += process.vertexreco
+    process.unsortedOfflinePrimaryVertices.beamSpotLabel = cms.InputTag("offlineBeamSpot","",dataTier)
+    process.ak4CaloJetsForTrk.srcPVs = cms.InputTag("firstStepPrimaryVertices","",dataTier)
+
+    process.muons.FillDetectorBasedIsolation = cms.bool(False)
+    process.muons.FillSelectorMaps = cms.bool(False)
+    process.muons.FillShoweringInfo = cms.bool(False)
+    process.muons.FillCosmicsIdMap = cms.bool(False)
 
 
-	process.merge_step += process.highlevelreco
+    process.merge_step += process.highlevelreco
 
-	#process.merge_step.remove(process.reducedEcalRecHitsEE)
-	#process.merge_step.remove(process.reducedEcalRecHitsEB)
+    #process.merge_step.remove(process.reducedEcalRecHitsEE)
+    #process.merge_step.remove(process.reducedEcalRecHitsEB)
 
-	process.merge_step.remove(process.ak4JetTracksAssociatorExplicit)
+    process.merge_step.remove(process.ak4JetTracksAssociatorExplicit)
 
-	process.merge_step.remove(process.pfTrack)
-	process.merge_step.remove(process.pfConversions)
-	process.merge_step.remove(process.pfV0)
-	process.merge_step.remove(process.particleFlowDisplacedVertexCandidate)
-	process.merge_step.remove(process.particleFlowDisplacedVertex)
-	process.merge_step.remove(process.pfDisplacedTrackerVertex)
-	process.merge_step.remove(process.pfTrackElec)
-	process.merge_step.remove(process.electronsWithPresel)
-	process.merge_step.remove(process.mvaElectrons)
-	process.merge_step.remove(process.particleFlowBlock)
-	process.merge_step.remove(process.particleFlowEGamma)
-	process.merge_step.remove(process.gedGsfElectronCores)
-	#  process.merge_step.remove(process.gedGsfElectronsTmp)
-	process.merge_step.remove(process.gedPhotonCore)
-	process.merge_step.remove(process.ecalDrivenGsfElectronCores)
-	process.merge_step.remove(process.ecalDrivenGsfElectrons)
-	process.merge_step.remove(process.uncleanedOnlyElectronSeeds)
-	process.merge_step.remove(process.uncleanedOnlyAllConversions)
-	process.merge_step.remove(process.uncleanedOnlyPfTrack)
-	process.merge_step.remove(process.uncleanedOnlyPfTrackElec)
-	process.merge_step.remove(process.uncleanedOnlyGsfElectrons)
-	process.merge_step.remove(process.uncleanedOnlyElectronCkfTrackCandidates)
-	process.merge_step.remove(process.cosmicsVeto)
-	process.merge_step.remove(process.cosmicsVetoTrackCandidates)
+    process.merge_step.remove(process.pfTrack)
+    process.merge_step.remove(process.pfConversions)
+    process.merge_step.remove(process.pfV0)
+    process.merge_step.remove(process.particleFlowDisplacedVertexCandidate)
+    process.merge_step.remove(process.particleFlowDisplacedVertex)
+    process.merge_step.remove(process.pfDisplacedTrackerVertex)
+    process.merge_step.remove(process.pfTrackElec)
+    process.merge_step.remove(process.electronsWithPresel)
+    process.merge_step.remove(process.mvaElectrons)
+    process.merge_step.remove(process.particleFlowBlock)
+    process.merge_step.remove(process.particleFlowEGamma)
+    process.merge_step.remove(process.gedGsfElectronCores)
+    #  process.merge_step.remove(process.gedGsfElectronsTmp)
+    process.merge_step.remove(process.gedPhotonCore)
+    process.merge_step.remove(process.ecalDrivenGsfElectronCores)
+    process.merge_step.remove(process.ecalDrivenGsfElectrons)
+    process.merge_step.remove(process.uncleanedOnlyElectronSeeds)
+    process.merge_step.remove(process.uncleanedOnlyAllConversions)
+    process.merge_step.remove(process.uncleanedOnlyPfTrack)
+    process.merge_step.remove(process.uncleanedOnlyPfTrackElec)
+    process.merge_step.remove(process.uncleanedOnlyGsfElectrons)
+    process.merge_step.remove(process.uncleanedOnlyElectronCkfTrackCandidates)
+    process.merge_step.remove(process.cosmicsVeto)
+    process.merge_step.remove(process.cosmicsVetoTrackCandidates)
  #   process.merge_step.remove(process.ecalDrivenGsfElectronCores)
  #   process.merge_step.remove(process.ecalDrivenGsfElectrons)
  #   process.merge_step.remove(process.gedPhotonsTmp)
  #   process.merge_step.remove(process.particleFlowTmp)
-	process.merge_step.remove(process.hcalnoise)
+    process.merge_step.remove(process.hcalnoise)
 
-	process.load('CommonTools.ParticleFlow.genForPF2PAT_cff')
-		
-	process.merge_step += process.genForPF2PATSequence
-	
-	process.schedule.insert(0,process.merge_step)
-	 # process.load('PhysicsTools.PatAlgos.slimming.slimmedGenJets_cfi')
-	
-	process = customisoptions(process) 
-	return modify_outputModules(process, [keepMerged(dataTier)])
+    process.load('CommonTools.ParticleFlow.genForPF2PAT_cff')
+
+    process.merge_step += process.genForPF2PATSequence
+
+    process.schedule.insert(0,process.merge_step)
+    # process.load('PhysicsTools.PatAlgos.slimming.slimmedGenJets_cfi')
+
+    process = customisoptions(process) 
+    return modify_outputModules(process, [keepMerged(dataTier)])
 
 def customiseMerging_Reselect(process, changeProcessname=True):
-	return customiseMerging(process, changeProcessname=changeProcessname, reselect=True)
-	
+    return customiseMerging(process, changeProcessname=changeProcessname, reselect=True)
+
 ################################ cross Customizers ###########################
 
 def customiseLHEandCleaning(process,reselect=False):
-	process._Process__name = "LHEembeddingCLEAN"
-	process = customiseCleaning(process,changeProcessname=False,reselect=reselect)
-	process = customiseLHE(process,changeProcessname=False,reselect=reselect)
-	return process
+    process._Process__name = "LHEembeddingCLEAN"
+    process = customiseCleaning(process,changeProcessname=False,reselect=reselect)
+    process = customiseLHE(process,changeProcessname=False,reselect=reselect)
+    return process
 
 def customiseLHEandCleaning_Reselect(process):
-	return customiseLHEandCleaning(process,reselect=True)
+    return customiseLHEandCleaning(process,reselect=True)
 
 ################################ additionla Customizer ###########################
 
 def customisoptions(process):
-	if not hasattr(process, "options"):
-		process.options = cms.untracked.PSet()
-	process.options.emptyRunLumiMode = cms.untracked.string('doNotHandleEmptyRunsAndLumis')
-	if not hasattr(process, "bunchSpacingProducer"):
-		process.bunchSpacingProducer = cms.EDProducer("BunchSpacingProducer")
-	process.bunchSpacingProducer.bunchSpacingOverride = cms.uint32(25)
-	process.bunchSpacingProducer.overrideBunchSpacing = cms.bool(True)
-	process.options.numberOfThreads = cms.untracked.uint32(1)
-	process.options.numberOfStreams = cms.untracked.uint32(0)
-	return process
+    if not hasattr(process, "options"):
+        process.options = cms.untracked.PSet()
+    process.options.emptyRunLumiMode = cms.untracked.string('doNotHandleEmptyRunsAndLumis')
+    if not hasattr(process, "bunchSpacingProducer"):
+        process.bunchSpacingProducer = cms.EDProducer("BunchSpacingProducer")
+    process.bunchSpacingProducer.bunchSpacingOverride = cms.uint32(25)
+    process.bunchSpacingProducer.overrideBunchSpacing = cms.bool(True)
+    process.options.numberOfThreads = cms.untracked.uint32(1)
+    process.options.numberOfStreams = cms.untracked.uint32(0)
+    return process
 
 ############################### MC specific Customizer ###########################
 
 def customiseFilterZToMuMu(process):
-	process.load("TauAnalysis.MCEmbeddingTools.DYToMuMuGenFilter_cfi")
-	process.ZToMuMuFilter = cms.Path(process.dYToMuMuGenFilter)
-	process.schedule.insert(-1,process.ZToMuMuFilter)
-	return process
+    process.load("TauAnalysis.MCEmbeddingTools.DYToMuMuGenFilter_cfi")
+    process.ZToMuMuFilter = cms.Path(process.dYToMuMuGenFilter)
+    process.schedule.insert(-1,process.ZToMuMuFilter)
+    return process
 
 def customiseFilterTTbartoMuMu(process):
-	process.load("TauAnalysis.MCEmbeddingTools.TTbartoMuMuGenFilter_cfi")
-	process.MCFilter = cms.Path(process.TTbartoMuMuGenFilter)
-	return customiseMCFilter(process)
+    process.load("TauAnalysis.MCEmbeddingTools.TTbartoMuMuGenFilter_cfi")
+    process.MCFilter = cms.Path(process.TTbartoMuMuGenFilter)
+    return customiseMCFilter(process)
 
 def customiseMCFilter(process):
-	process.schedule.insert(-1,process.MCFilter)
-	outputModulesList = [key for key,value in six.iteritems(process.outputModules)]
-	for outputModule in outputModulesList:
-		outputModule = getattr(process, outputModule)
-		outputModule.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("MCFilter"))
-	return process
+    process.schedule.insert(-1,process.MCFilter)
+    outputModulesList = [key for key,value in six.iteritems(process.outputModules)]
+    for outputModule in outputModulesList:
+        outputModule = getattr(process, outputModule)
+        outputModule.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("MCFilter"))
+    return process
 
 def fix_input_tags(process, formodules = ["generalTracks","cscSegments","dt4DSegments","rpcRecHits"]):
-	def change_tags_process(test_input):
-		if isinstance(test_input, cms.InputTag):
-			if test_input.getModuleLabel() in formodules:
-				test_input.setProcessName(process._Process__name)
+    def change_tags_process(test_input):
+        if isinstance(test_input, cms.InputTag):
+            if test_input.getModuleLabel() in formodules:
+                test_input.setProcessName(process._Process__name)
 
-	def search_for_tags(pset):
-		if isinstance(pset, dict):
-			for key in pset:
-				if isinstance(pset[key], cms.VInputTag):
-					for akt_inputTag in pset[key]:
-						change_tags_process(akt_inputTag)
-				elif isinstance(pset[key], cms.PSet):
-					search_for_tags(pset[key].__dict__)
-				elif isinstance(pset[key], cms.VPSet):
-					for akt_pset in pset[key]:
-						search_for_tags(akt_pset.__dict__)
-				else:
-					change_tags_process(pset[key])
-		else:
-			print("must be python dict not a ",type(pset))
-			
-	for module in process.producers_():
-		search_for_tags(getattr(process, module).__dict__)
-	for module in process.filters_():
-		search_for_tags(getattr(process, module).__dict__)
-	for module in process.analyzers_():
-		search_for_tags(getattr(process, module).__dict__)
+    def search_for_tags(pset):
+        if isinstance(pset, dict):
+            for key in pset:
+                if isinstance(pset[key], cms.VInputTag):
+                    for akt_inputTag in pset[key]:
+                        change_tags_process(akt_inputTag)
+                elif isinstance(pset[key], cms.PSet):
+                    search_for_tags(pset[key].__dict__)
+                elif isinstance(pset[key], cms.VPSet):
+                    for akt_pset in pset[key]:
+                        search_for_tags(akt_pset.__dict__)
+                else:
+                    change_tags_process(pset[key])
+        else:
+            print("must be python dict not a ",type(pset))
 
-	return process
+    for module in process.producers_():
+        search_for_tags(getattr(process, module).__dict__)
+    for module in process.filters_():
+        search_for_tags(getattr(process, module).__dict__)
+    for module in process.analyzers_():
+        search_for_tags(getattr(process, module).__dict__)
+
+    return process

--- a/Utilities/RelMon/python/dqm_interfaces.py
+++ b/Utilities/RelMon/python/dqm_interfaces.py
@@ -47,724 +47,724 @@ class InvalidNumberOfArguments(Error):
 
     def __init__(self,msg):
         self.msg = msg
-   
+
 #-----------------------------------------------------------------------------    
 
 class DQMcommunicator(object):
-  
-  """Communicate with the DQM Document server"""
-  
-  #-----------------------------------------------------------------------------
-  
-  base_dir='/data/json/archive/'
-  
-  def __init__(self,
-               server,
-               is_private=False,
-               ident="DQMToJson/1.0 python/%d.%d.%d" % version_info[:3]):
-    self.ident = ident
-    self.server = server
-    self.is_private = is_private
-    self.DQMpwd=DQMcommunicator.base_dir
-    self.prevDQMpwd=self.DQMpwd
-    self.opener=None
-    if not self.is_private:
-      self.opener=build_opener(X509CertOpen())
-  #-----------------------------------------------------------------------------
-  
-  def open_url(self,url):
-    url=url.replace(' ','%20')
-    datareq = Request(url)
-    datareq.add_header('User-agent', self.ident)    
-    url_obj=0
-    if not self.is_private:
-      url_obj=self.opener.open(datareq)   
-      #url_obj=build_opener(X509CertOpen()).open(datareq) 
-    else:
-      url_obj=urlopen(datareq)
-      
-    return url_obj
-  
-  #-----------------------------------------------------------------------------
-  
-  def get_data(self, full_url):
-    #print "getting data from %s" %full_url
-    data = self.open_url(full_url).read()
-    
-    data = sub("-inf", '0', data)
-    data = sub("\s+inf", '0', data)
-    data = sub("\s+nan", '0', data)
-    data = sub('""(CMSSW.*?)""', '"\\1"', data)
-   
-    return data
-  
-  #-----------------------------------------------------------------------------
 
-  def ls_url(self, url):
-    url=url.replace(" ","%20")
-    url=self.server+url
-    #print "listing "+url
-    form_folder={}
-    raw_folder=None
-    try:
-      raw_folder=eval(self.get_data(url))
-    except:
-      print("Retrying..")
-      for ntrials in xrange(5):
+    """Communicate with the DQM Document server"""
+
+    #-----------------------------------------------------------------------------
+
+    base_dir='/data/json/archive/'
+
+    def __init__(self,
+                 server,
+                 is_private=False,
+                 ident="DQMToJson/1.0 python/%d.%d.%d" % version_info[:3]):
+        self.ident = ident
+        self.server = server
+        self.is_private = is_private
+        self.DQMpwd=DQMcommunicator.base_dir
+        self.prevDQMpwd=self.DQMpwd
+        self.opener=None
+        if not self.is_private:
+            self.opener=build_opener(X509CertOpen())
+    #-----------------------------------------------------------------------------
+
+    def open_url(self,url):
+        url=url.replace(' ','%20')
+        datareq = Request(url)
+        datareq.add_header('User-agent', self.ident)    
+        url_obj=0
+        if not self.is_private:
+            url_obj=self.opener.open(datareq)   
+            #url_obj=build_opener(X509CertOpen()).open(datareq) 
+        else:
+            url_obj=urlopen(datareq)
+
+        return url_obj
+
+    #-----------------------------------------------------------------------------
+
+    def get_data(self, full_url):
+        #print "getting data from %s" %full_url
+        data = self.open_url(full_url).read()
+
+        data = sub("-inf", '0', data)
+        data = sub("\s+inf", '0', data)
+        data = sub("\s+nan", '0', data)
+        data = sub('""(CMSSW.*?)""', '"\\1"', data)
+
+        return data
+
+    #-----------------------------------------------------------------------------
+
+    def ls_url(self, url):
+        url=url.replace(" ","%20")
+        url=self.server+url
+        #print "listing "+url
+        form_folder={}
+        raw_folder=None
         try:
-          if ntrials!=0:
-            sleep(2)
-          #raw_folder=loads(self.get_data(url))
-          raw_folder=eval(self.get_data(url))
-          break
+            raw_folder=eval(self.get_data(url))
         except:
-          print("Could not fetch %s. Retrying" %url)
-        
-    #raw_folder=loads(self.get_data(url))
-    for content_dict in raw_folder["contents"]:      
-      if "subdir" in content_dict:
-        form_folder[content_dict["subdir"]]={"type":'dir'}
-      elif "obj" in content_dict:
-        properties=content_dict["properties"]
-        obj_name=content_dict["obj"]
-        obj_type=properties["type"]
-        obj_kind=properties["kind"]
-        obj_as_string=''
-        if "rootobj" in content_dict:
-          obj_as_string=content_dict["rootobj"]
-        form_folder[obj_name]={'type':obj_type,'obj_as_string':obj_as_string,"kind":obj_kind}
-    #for k,v in form_folder.items():
-      #print "* %s --> %s" %(k,v["type"])
-    
-    return form_folder        
-  
-  #-----------------------------------------------------------------------------
- 
-  def ls(self, url='', fetch_root=False):
-    if len(url)==0:
-      url=join(self.DQMpwd,url)
-    
-    form_folder={}   
-    
-    if fetch_root:
-      url='%s?rootcontent=1'%url
-    form_folder=self.ls_url(url)
+            print("Retrying..")
+            for ntrials in xrange(5):
+                try:
+                    if ntrials!=0:
+                        sleep(2)
+                    #raw_folder=loads(self.get_data(url))
+                    raw_folder=eval(self.get_data(url))
+                    break
+                except:
+                    print("Could not fetch %s. Retrying" %url)
 
-    return form_folder
-    
-  #-----------------------------------------------------------------------------
+        #raw_folder=loads(self.get_data(url))
+        for content_dict in raw_folder["contents"]:      
+            if "subdir" in content_dict:
+                form_folder[content_dict["subdir"]]={"type":'dir'}
+            elif "obj" in content_dict:
+                properties=content_dict["properties"]
+                obj_name=content_dict["obj"]
+                obj_type=properties["type"]
+                obj_kind=properties["kind"]
+                obj_as_string=''
+                if "rootobj" in content_dict:
+                    obj_as_string=content_dict["rootobj"]
+                form_folder[obj_name]={'type':obj_type,'obj_as_string':obj_as_string,"kind":obj_kind}
+        #for k,v in form_folder.items():
+            #print "* %s --> %s" %(k,v["type"])
 
-  def cd(self, *args):
-    len_args=len(args)
-    full_url=""
-    if len_args!=1 and len_args!=3:
-      raise InvalidNumberOfArguments
-    if len_args==3:
-      dataset, run, folder = args    
-      full_url='%s/data/json/archive/%s/%s/%s' % (self.server, dataset, run, folder)
-    if len_args==1:
-      folder=args[0]
-      if folder==self.DQMpwd:
-        full_url=self.DQMpwd
-      elif folder=="..":
-        full_url=self.DQMpwd[:self.DQMpwd.rfind("/")]
-      elif folder=="-":
-        full_url=self.oldDQMpwd
-      elif folder=="":
-        full_url=DQMcommunicator.base_dir
-      else:
-        full_url=self.DQMpwd+"/"+folder
-        
-    full_url=full_url.replace(' ','%20')
-    #print "cd: "+full_url
-    
-    self.oldDQMpwd=self.DQMpwd
-    self.DQMpwd=full_url   
-    #print "In %s" %self.DQMpwd
-  
-  #-----------------------------------------------------------------------------
-  
-  def get_samples(self, samples_string="*"):
-    """
-    A sample contains, among the other things, a data type, a dataset name 
-    and a run.
-    """
-    full_url='%s/data/json/samples?match=%s' % (self.server, samples_string)
-    samples_dict=eval(self.get_data(full_url))
-    return samples_dict["samples"]
+        return form_folder        
 
-  #-----------------------------------------------------------------------------
-  
-  def get_datasets_list(self, dataset_string=""):
-    samples_list=self.get_samples(dataset_string)    
-    datasets_list=[]
-    for sample in samples_list:
-      temp_datasets_list =  map(lambda item:item["dataset"] ,sample['items'])
-      for temp_dataset in temp_datasets_list:
-        if not temp_dataset in datasets_list:
-          datasets_list.append(temp_dataset)
-    return datasets_list
-    
-  #-----------------------------------------------------------------------------
-    
-  def get_RelVal_CMSSW_versions(self,query):
-    """Get the available cmssw versions for the relvals.
-    """
-    relvals_list=self.get_datasets_list(query)
-    # The samples are of the form /RelValTHISISMYFAVOURITECHANNEL/CMSSW_VERSION/GEN-SIM-WHATEVER-RECO
-    cmssw_versions_with_duplicates=map (lambda x: x.split("/")[2],relvals_list)
-    return list(set(cmssw_versions_with_duplicates))
-    
-  #-----------------------------------------------------------------------------    
-    
-  def get_runs_list(self, dataset_string):
-    slash="/"
-    while(dataset_string.endswith(slash) or dataset_string.beginswith(slash)):
-      dataset_string=dataset_string.strip("/")
-    samples_list=self.get_samples(dataset_string)
-    runlist=[]
-    # Get all the runs in all the items which are in every sample
-    map( lambda sample: map (lambda item: runlist.append(item['run']), sample['items']), samples_list)
-    return runlist
-  
-  #-----------------------------------------------------------------------------  
-  
-  def get_dataset_runs(self,dataset_string):
-    dataset_runs={}
-    for dataset in self.get_datasets_list(dataset_string):
-      dataset_runs[dataset]=self.get_runs_list(dataset)
-    return dataset_runs
+    #-----------------------------------------------------------------------------
 
-  #-----------------------------------------------------------------------------  
-  
-  def get_common_runs(self,dataset_string1,dataset_string2):
-    set1=set(self.get_runs_list(dataset_string1))
-    set2=set(self.get_runs_list(dataset_string2))
-    set1.intersection_update(set2)
-    return list (set2)
+    def ls(self, url='', fetch_root=False):
+        if len(url)==0:
+            url=join(self.DQMpwd,url)
 
-  #-----------------------------------------------------------------------------  
-  
-  def get_root_objects_list(self, url=""):
-    if len(url)==0:
-      url=self.DQMpwd
-    else:
-      url="/"+url    
-    url = url.replace(" ","%20")
-    objects=[]
-    for name,description in self.ls(url,True).items():     
-      if "dir" not in description["type"]  and "ROOT" in description["kind"]:
-        objects.append(literal2root(description["obj_as_string"],description["type"]))
-    return objects
+        form_folder={}   
 
-  #-----------------------------------------------------------------------------  
-  
-  def get_root_objects(self, url=""):
-    if len(url)==0:
-      url=self.DQMpwd
-    else:
-      url=self.server+"/"+url    
-    url = url.replace(" ","%20")
-    objects={}
-    for name,description in self.ls(url,True).items():     
-      if "dir" not in description["type"] and "ROOT" in description["kind"]:
-        objects[name]=literal2root(description["obj_as_string"],description["type"])
-    return objects
+        if fetch_root:
+            url='%s?rootcontent=1'%url
+        form_folder=self.ls_url(url)
 
- #-------------------------------------------------------------------------------
-  
-  def get_root_objects_list_recursive(self, url=""):
-    null_url = (len(url)==0)    
-    if len(url)==0:
-      url=self.DQMpwd
-    else:
-      url="/"+url    
-    url = url.replace(" ","%20")      
-    if not null_url: 
-      self.cd(url)
-    objects=[]
-    for name,description in self.ls("",True).items():     
-      if "dir" in description["type"]:
-        objects+=self.get_root_objects_list_recursive(name)
+        return form_folder
+
+    #-----------------------------------------------------------------------------
+
+    def cd(self, *args):
+        len_args=len(args)
+        full_url=""
+        if len_args!=1 and len_args!=3:
+            raise InvalidNumberOfArguments
+        if len_args==3:
+            dataset, run, folder = args    
+            full_url='%s/data/json/archive/%s/%s/%s' % (self.server, dataset, run, folder)
+        if len_args==1:
+            folder=args[0]
+            if folder==self.DQMpwd:
+                full_url=self.DQMpwd
+            elif folder=="..":
+                full_url=self.DQMpwd[:self.DQMpwd.rfind("/")]
+            elif folder=="-":
+                full_url=self.oldDQMpwd
+            elif folder=="":
+                full_url=DQMcommunicator.base_dir
+            else:
+                full_url=self.DQMpwd+"/"+folder
+
+        full_url=full_url.replace(' ','%20')
+        #print "cd: "+full_url
+
+        self.oldDQMpwd=self.DQMpwd
+        self.DQMpwd=full_url   
+        #print "In %s" %self.DQMpwd
+
+    #-----------------------------------------------------------------------------
+
+    def get_samples(self, samples_string="*"):
+        """
+        A sample contains, among the other things, a data type, a dataset name 
+        and a run.
+        """
+        full_url='%s/data/json/samples?match=%s' % (self.server, samples_string)
+        samples_dict=eval(self.get_data(full_url))
+        return samples_dict["samples"]
+
+    #-----------------------------------------------------------------------------
+
+    def get_datasets_list(self, dataset_string=""):
+        samples_list=self.get_samples(dataset_string)    
+        datasets_list=[]
+        for sample in samples_list:
+            temp_datasets_list =  map(lambda item:item["dataset"] ,sample['items'])
+            for temp_dataset in temp_datasets_list:
+                if not temp_dataset in datasets_list:
+                    datasets_list.append(temp_dataset)
+        return datasets_list
+
+    #-----------------------------------------------------------------------------
+
+    def get_RelVal_CMSSW_versions(self,query):
+        """Get the available cmssw versions for the relvals.
+        """
+        relvals_list=self.get_datasets_list(query)
+        # The samples are of the form /RelValTHISISMYFAVOURITECHANNEL/CMSSW_VERSION/GEN-SIM-WHATEVER-RECO
+        cmssw_versions_with_duplicates=map (lambda x: x.split("/")[2],relvals_list)
+        return list(set(cmssw_versions_with_duplicates))
+
+    #-----------------------------------------------------------------------------    
+
+    def get_runs_list(self, dataset_string):
+        slash="/"
+        while(dataset_string.endswith(slash) or dataset_string.beginswith(slash)):
+            dataset_string=dataset_string.strip("/")
+        samples_list=self.get_samples(dataset_string)
+        runlist=[]
+        # Get all the runs in all the items which are in every sample
+        map( lambda sample: map (lambda item: runlist.append(item['run']), sample['items']), samples_list)
+        return runlist
+
+    #-----------------------------------------------------------------------------  
+
+    def get_dataset_runs(self,dataset_string):
+        dataset_runs={}
+        for dataset in self.get_datasets_list(dataset_string):
+            dataset_runs[dataset]=self.get_runs_list(dataset)
+        return dataset_runs
+
+    #-----------------------------------------------------------------------------  
+
+    def get_common_runs(self,dataset_string1,dataset_string2):
+        set1=set(self.get_runs_list(dataset_string1))
+        set2=set(self.get_runs_list(dataset_string2))
+        set1.intersection_update(set2)
+        return list (set2)
+
+    #-----------------------------------------------------------------------------  
+
+    def get_root_objects_list(self, url=""):
+        if len(url)==0:
+            url=self.DQMpwd
+        else:
+            url="/"+url    
+        url = url.replace(" ","%20")
+        objects=[]
+        for name,description in self.ls(url,True).items():     
+            if "dir" not in description["type"]  and "ROOT" in description["kind"]:
+                objects.append(literal2root(description["obj_as_string"],description["type"]))
+        return objects
+
+    #-----------------------------------------------------------------------------  
+
+    def get_root_objects(self, url=""):
+        if len(url)==0:
+            url=self.DQMpwd
+        else:
+            url=self.server+"/"+url    
+        url = url.replace(" ","%20")
+        objects={}
+        for name,description in self.ls(url,True).items():     
+            if "dir" not in description["type"] and "ROOT" in description["kind"]:
+                objects[name]=literal2root(description["obj_as_string"],description["type"])
+        return objects
+
+     #-------------------------------------------------------------------------------
+
+    def get_root_objects_list_recursive(self, url=""):
+        null_url = (len(url)==0)    
+        if len(url)==0:
+            url=self.DQMpwd
+        else:
+            url="/"+url    
+        url = url.replace(" ","%20")      
+        if not null_url: 
+            self.cd(url)
+        objects=[]
+        for name,description in self.ls("",True).items():     
+            if "dir" in description["type"]:
+                objects+=self.get_root_objects_list_recursive(name)
+                self.cd("..")
+            elif  "ROOT" in description["kind"]:
+                objects.append(literal2root(description["obj_as_string"],description["type"]))
+        if not null_url: 
+            self.cd("..")
+        return objects
+
+     #-------------------------------------------------------------------------------
+
+    def get_root_objects_names_list_recursive(self, url="",present_url=""):
+        null_url = (len(url)==0)
+        if (not null_url):
+            if len(present_url)==0:
+                present_url=url
+            else:
+                present_url+="_%s"%url
+        if len(url)==0:
+            url=self.DQMpwd
+        else:
+            url="/"+url    
+        url = url.replace(" ","%20")
+        if not null_url:
+            self.cd(url)
+        objects_names=[]
+        for name,description in self.ls("",False).items():     
+            if "dir" in description["type"]:        
+                objects_names+=self.get_root_objects_names_list_recursive(name,present_url)
+                self.cd("..")
+            elif  "ROOT" in description["kind"]:
+                objects_names.append("%s_%s"%(present_url,name))
+        if not null_url: 
+            self.cd("..")
+        return objects_names
+
+     #-------------------------------------------------------------------------------
+
+    def get_root_objects_recursive(self, url="",present_url=""):
+        null_url = (len(url)==0)
+        if (not null_url):
+            if len(present_url)==0:
+                present_url=url
+            else:
+                present_url+="_%s"%url
+        if len(url)==0:
+            url=self.DQMpwd
+        else:
+            url="/"+url    
+        url = url.replace(" ","%20")
+        #if not null_url:
+        self.cd(url)
+        objects={}
+        for name,description in self.ls("",True).items():     
+            if "dir" in description["type"]:
+                objects.update(self.get_root_objects_recursive(name,present_url))
+                self.cd("..")
+            elif  "ROOT" in description["kind"]:
+                objects["%s_%s"%(present_url,name)]=literal2root(description["obj_as_string"],description["type"])
+        #if not null_url:
         self.cd("..")
-      elif  "ROOT" in description["kind"]:
-        objects.append(literal2root(description["obj_as_string"],description["type"]))
-    if not null_url: 
-      self.cd("..")
-    return objects
-    
- #-------------------------------------------------------------------------------
-  
-  def get_root_objects_names_list_recursive(self, url="",present_url=""):
-    null_url = (len(url)==0)
-    if (not null_url):
-      if len(present_url)==0:
-        present_url=url
-      else:
-        present_url+="_%s"%url
-    if len(url)==0:
-      url=self.DQMpwd
-    else:
-      url="/"+url    
-    url = url.replace(" ","%20")
-    if not null_url:
-      self.cd(url)
-    objects_names=[]
-    for name,description in self.ls("",False).items():     
-      if "dir" in description["type"]:        
-        objects_names+=self.get_root_objects_names_list_recursive(name,present_url)
-        self.cd("..")
-      elif  "ROOT" in description["kind"]:
-        objects_names.append("%s_%s"%(present_url,name))
-    if not null_url: 
-      self.cd("..")
-    return objects_names
-    
- #-------------------------------------------------------------------------------
-  
-  def get_root_objects_recursive(self, url="",present_url=""):
-    null_url = (len(url)==0)
-    if (not null_url):
-      if len(present_url)==0:
-        present_url=url
-      else:
-        present_url+="_%s"%url
-    if len(url)==0:
-      url=self.DQMpwd
-    else:
-      url="/"+url    
-    url = url.replace(" ","%20")
-    #if not null_url:
-    self.cd(url)
-    objects={}
-    for name,description in self.ls("",True).items():     
-      if "dir" in description["type"]:
-        objects.update(self.get_root_objects_recursive(name,present_url))
-        self.cd("..")
-      elif  "ROOT" in description["kind"]:
-        objects["%s_%s"%(present_url,name)]=literal2root(description["obj_as_string"],description["type"])
-    #if not null_url:
-    self.cd("..")
-    return objects
+        return objects
 
 #-------------------------------------------------------------------------------
 
 class DirID(object):
-  """Structure used to identify a directory in the walked tree,
-  It carries the name and depth information.
-  """
-  def __init__(self,name,depth,mother=""):
-    self.name=name
-    self.compname=recompile(name)
-    self.mother=mother
-    self.depth=depth
-  def __eq__(self,dirid):
-    depth2=dirid.depth
-    compname2=dirid.compname
-    name2=dirid.name
-    is_equal = False
-    #if self.name in name2 or name2 in self.name:
-    if search(self.compname,name2)!=None or search(compname2,self.name)!=None:
-      is_equal = self.depth*depth2 <0 or self.depth==depth2
-    if len(self.mother)*len(dirid.mother)>0:
-      is_equal = is_equal and self.mother==dirid.mother
-    return is_equal
-    
-  def __repr__(self):
-    return "Directory %s at level %s" %(self.name,self.depth)
-    
+    """Structure used to identify a directory in the walked tree,
+    It carries the name and depth information.
+    """
+    def __init__(self,name,depth,mother=""):
+        self.name=name
+        self.compname=recompile(name)
+        self.mother=mother
+        self.depth=depth
+    def __eq__(self,dirid):
+        depth2=dirid.depth
+        compname2=dirid.compname
+        name2=dirid.name
+        is_equal = False
+        #if self.name in name2 or name2 in self.name:
+        if search(self.compname,name2)!=None or search(compname2,self.name)!=None:
+            is_equal = self.depth*depth2 <0 or self.depth==depth2
+        if len(self.mother)*len(dirid.mother)>0:
+            is_equal = is_equal and self.mother==dirid.mother
+        return is_equal
+
+    def __repr__(self):
+        return "Directory %s at level %s" %(self.name,self.depth)
+
 #-------------------------------------------------------------------------------
 class DirFetcher(Thread):
-  """ Fetch the content of the single "directory" in the dqm.
-  """
-  def __init__ (self,comm,directory):
-      Thread.__init__(self)
-      self.comm = comm
-      self.directory = directory
-      self.contents=None    
-  def run(self):
-    self.contents = self.comm.ls(self.directory,True)
+    """ Fetch the content of the single "directory" in the dqm.
+    """
+    def __init__ (self,comm,directory):
+        Thread.__init__(self)
+        self.comm = comm
+        self.directory = directory
+        self.contents=None    
+    def run(self):
+        self.contents = self.comm.ls(self.directory,True)
 
 #-------------------------------------------------------------------------------
 
 class DirWalkerDB(Thread):
-  """An interface to the DQM document db. It is threaded to compensate the 
-  latency introduced by the finite response time of the server.
-  """
-  def __init__ (self,comm1,comm2,base1,base2,directory,depth=0,do_pngs=True,stat_test="KS",test_threshold=.5,black_list=[]):
-    Thread.__init__(self)
-    self.comm1 = deepcopy(comm1)
-    self.comm2 = deepcopy(comm2)
-    self.base1,self.base2 = base1,base2
-    self.directory = directory
-    self.depth=depth
-    self.do_pngs=do_pngs
-    self.test_threshold=test_threshold
-    self.stat_test=stat_test
-    self.black_list=black_list
-    # name of the thread
-    self.name+="_%s" %directory.name
-  
-  def run(self):
-    
-    this_dir=DirID(self.directory.name,self.depth)
-    if this_dir in self.black_list: 
-      print("Skipping %s since blacklisted!" %this_dir)
-      return 0 
-    
-    self.depth+=1
-    
-    the_test=Statistical_Tests[self.stat_test](self.test_threshold)
-    #print "Test %s with threshold %s" %(self.stat_test,self.test_threshold)
-    
-    directory1=self.base1+"/"+self.directory.mother_dir+"/"+self.directory.name
-    directory2=self.base2+"/"+self.directory.mother_dir+"/"+self.directory.name
-    
-    fetchers =(DirFetcher(self.comm1,directory1),DirFetcher(self.comm2,directory2))
-    for fetcher in fetchers:
-      fetcher.start()
-    for fetcher in fetchers:  
-      fetcher.join()
-    
-    contents1 = fetchers[0].contents
-    contents2 = fetchers[1].contents
-    set1= set(contents1.keys())
-    set2= set(contents2.keys())  
-    
-    walkers=[]
-    self_directory_directories=self.directory.subdirs
-    self_directory_comparisons=self.directory.comparisons
-    contents_names=list(set1.intersection(set2))
+    """An interface to the DQM document db. It is threaded to compensate the 
+    latency introduced by the finite response time of the server.
+    """
+    def __init__ (self,comm1,comm2,base1,base2,directory,depth=0,do_pngs=True,stat_test="KS",test_threshold=.5,black_list=[]):
+        Thread.__init__(self)
+        self.comm1 = deepcopy(comm1)
+        self.comm2 = deepcopy(comm2)
+        self.base1,self.base2 = base1,base2
+        self.directory = directory
+        self.depth=depth
+        self.do_pngs=do_pngs
+        self.test_threshold=test_threshold
+        self.stat_test=stat_test
+        self.black_list=black_list
+        # name of the thread
+        self.name+="_%s" %directory.name
 
-    for name in contents_names:
-      content = contents1[name]
-      if "dir" in content["type"]:
-        #if this_dir not in DirWalker.white_list:continue              
-        subdir=Directory(name,join(self.directory.mother_dir,self.directory.name))        
-        dirwalker=DirWalkerDB(self.comm1,self.comm2,self.base1,self.base2,subdir,self.depth,
-                              self.do_pngs,self.stat_test,self.test_threshold,self.black_list)
-        dirwalker.start()
-        walkers.append(dirwalker)
-        n_threads=activeCount()
-        if n_threads>5:
-          #print >> stderr, "Threads that are running: %s. Joining them." %(n_threads)    
-          dirwalker.join()
-      elif content["kind"]=="ROOT":
+    def run(self):
+
+        this_dir=DirID(self.directory.name,self.depth)
+        if this_dir in self.black_list: 
+            print("Skipping %s since blacklisted!" %this_dir)
+            return 0 
+
+        self.depth+=1
+
+        the_test=Statistical_Tests[self.stat_test](self.test_threshold)
+        #print "Test %s with threshold %s" %(self.stat_test,self.test_threshold)
+
+        directory1=self.base1+"/"+self.directory.mother_dir+"/"+self.directory.name
+        directory2=self.base2+"/"+self.directory.mother_dir+"/"+self.directory.name
+
+        fetchers =(DirFetcher(self.comm1,directory1),DirFetcher(self.comm2,directory2))
+        for fetcher in fetchers:
+            fetcher.start()
+        for fetcher in fetchers:  
+            fetcher.join()
+
+        contents1 = fetchers[0].contents
+        contents2 = fetchers[1].contents
+        set1= set(contents1.keys())
+        set2= set(contents2.keys())  
+
+        walkers=[]
+        self_directory_directories=self.directory.subdirs
+        self_directory_comparisons=self.directory.comparisons
+        contents_names=list(set1.intersection(set2))
+
+        for name in contents_names:
+            content = contents1[name]
+            if "dir" in content["type"]:
+                #if this_dir not in DirWalker.white_list:continue              
+                subdir=Directory(name,join(self.directory.mother_dir,self.directory.name))        
+                dirwalker=DirWalkerDB(self.comm1,self.comm2,self.base1,self.base2,subdir,self.depth,
+                                      self.do_pngs,self.stat_test,self.test_threshold,self.black_list)
+                dirwalker.start()
+                walkers.append(dirwalker)
+                n_threads=activeCount()
+                if n_threads>5:
+                    #print >> stderr, "Threads that are running: %s. Joining them." %(n_threads)    
+                    dirwalker.join()
+            elif content["kind"]=="ROOT":
 #	print directory1,name
-        comparison=Comparison(name,
-                              join(self.directory.mother_dir,self.directory.name),
-                              literal2root(content["obj_as_string"],content["type"]),
-                              literal2root(contents2[name]["obj_as_string"],content["type"]),
-                              deepcopy(the_test),
-                              do_pngs=self.do_pngs)
-        self_directory_comparisons.append(comparison)
-    
-    
-    for walker in walkers:
-      walker.join()
-      walker_directory=walker.directory
-      if not walker_directory.is_empty():
-        self_directory_directories.append(walker_directory)
-        
+                comparison=Comparison(name,
+                                      join(self.directory.mother_dir,self.directory.name),
+                                      literal2root(content["obj_as_string"],content["type"]),
+                                      literal2root(contents2[name]["obj_as_string"],content["type"]),
+                                      deepcopy(the_test),
+                                      do_pngs=self.do_pngs)
+                self_directory_comparisons.append(comparison)
+
+
+        for walker in walkers:
+            walker.join()
+            walker_directory=walker.directory
+            if not walker_directory.is_empty():
+                self_directory_directories.append(walker_directory)
+
 #-------------------------------------------------------------------------------
 
 class DQMRootFile(object):
-  """ Class acting as interface between the user and the harvested DQMRootFile.  
-  It skips the directories created by the DQM infrastructure so to provide an
-  interface as similar as possible to a real direcory structure and to the 
-  directory structure provided by the db interface.
-  """
-  def __init__(self,rootfilename):
-    dqmdatadir="DQMData"
-    self.rootfile=TFile(rootfilename)  
-    self.rootfilepwd=self.rootfile.GetDirectory(dqmdatadir)
-    self.rootfileprevpwd=self.rootfile.GetDirectory(dqmdatadir)
-    if self.rootfilepwd == None:
-      print("Directory %s does not exist: skipping. Is this a custom rootfile?" %dqmdatadir)
-      self.rootfilepwd=self.rootfile
-      self.rootfileprevpwd=self.rootfile
-  
-  def __is_null(self,directory,name):
-    is_null = not directory
-    if is_null:
-        print("Directory %s does not exist!" %name, file=stderr)
-    return is_null
+    """ Class acting as interface between the user and the harvested DQMRootFile.  
+    It skips the directories created by the DQM infrastructure so to provide an
+    interface as similar as possible to a real direcory structure and to the 
+    directory structure provided by the db interface.
+    """
+    def __init__(self,rootfilename):
+        dqmdatadir="DQMData"
+        self.rootfile=TFile(rootfilename)  
+        self.rootfilepwd=self.rootfile.GetDirectory(dqmdatadir)
+        self.rootfileprevpwd=self.rootfile.GetDirectory(dqmdatadir)
+        if self.rootfilepwd == None:
+            print("Directory %s does not exist: skipping. Is this a custom rootfile?" %dqmdatadir)
+            self.rootfilepwd=self.rootfile
+            self.rootfileprevpwd=self.rootfile
 
-  def ls(self,directory_name=""):
-    contents={}
-    directory=None
-    if len(directory_name)==0:
-      directory=self.rootfilepwd      
-    
-    directory=self.rootfilepwd.GetDirectory(directory_name)    
-    if self.__is_null(directory,directory_name):
-      return contents
-    
-    for key in directory.GetListOfKeys():
-      contents[key.GetName()]=key.GetClassName()
-    return contents
-  
-  def cd(self,directory_name):
-    """Change the current TDirectoryFile. The familiar "-" and ".." directories 
-    can be accessed as well.
-    """
-    if directory_name=="-":
-      tmp=self.rootfilepwd
-      self.rootfilepwd=self.rootfileprevpwd
-      self.rootfileprevpwd=tmp
-    if directory_name=="..":
-      #print "Setting prevpwd"
-      self.rootfileprevpwd=self.rootfilepwd
-      #print "The mom"
-      mom=self.rootfilepwd.GetMotherDir()
-      #print "In directory +%s+" %self.rootfilepwd
-      #print "Deleting the TFileDir"
-      if "Run " not in self.rootfilepwd.GetName():
-        self.rootfilepwd.Delete()
-      #print "Setting pwd to mom"
-      self.rootfilepwd=mom
-    else:
-      new_directory=self.rootfilepwd.GetDirectory(directory_name)
-      if not self.__is_null(new_directory,directory_name):
-          self.rootfileprevpwd=self.rootfilepwd
-          self.rootfilepwd=new_directory
-    
-  def getObj(self,objname):
-    """Get a TObject from the rootfile.
-    """
-    obj=self.rootfilepwd.Get(objname)
-    if not self.__is_null(obj,objname):
-      return obj
+    def __is_null(self,directory,name):
+        is_null = not directory
+        if is_null:
+            print("Directory %s does not exist!" %name, file=stderr)
+        return is_null
+
+    def ls(self,directory_name=""):
+        contents={}
+        directory=None
+        if len(directory_name)==0:
+            directory=self.rootfilepwd      
+
+        directory=self.rootfilepwd.GetDirectory(directory_name)    
+        if self.__is_null(directory,directory_name):
+            return contents
+
+        for key in directory.GetListOfKeys():
+            contents[key.GetName()]=key.GetClassName()
+        return contents
+
+    def cd(self,directory_name):
+        """Change the current TDirectoryFile. The familiar "-" and ".." directories 
+        can be accessed as well.
+        """
+        if directory_name=="-":
+            tmp=self.rootfilepwd
+            self.rootfilepwd=self.rootfileprevpwd
+            self.rootfileprevpwd=tmp
+        if directory_name=="..":
+            #print "Setting prevpwd"
+            self.rootfileprevpwd=self.rootfilepwd
+            #print "The mom"
+            mom=self.rootfilepwd.GetMotherDir()
+            #print "In directory +%s+" %self.rootfilepwd
+            #print "Deleting the TFileDir"
+            if "Run " not in self.rootfilepwd.GetName():
+                self.rootfilepwd.Delete()
+            #print "Setting pwd to mom"
+            self.rootfilepwd=mom
+        else:
+            new_directory=self.rootfilepwd.GetDirectory(directory_name)
+            if not self.__is_null(new_directory,directory_name):
+                self.rootfileprevpwd=self.rootfilepwd
+                self.rootfilepwd=new_directory
+
+    def getObj(self,objname):
+        """Get a TObject from the rootfile.
+        """
+        obj=self.rootfilepwd.Get(objname)
+        if not self.__is_null(obj,objname):
+            return obj
 
 #-------------------------------------------------------------------------------
 
 class DirWalkerFile(object):
-  def __init__(self, name, topdirname,rootfilename1, rootfilename2, run=-1, black_list=[], stat_test="KS", test_threshold=.5,draw_success=True,do_pngs=False, black_list_histos=[]):
-    self.name=name
-    self.dqmrootfile1=DQMRootFile(abspath(rootfilename1))
-    self.dqmrootfile2=DQMRootFile(abspath(rootfilename2))
-    self.run=run
-    self.stat_test=Statistical_Tests[stat_test](test_threshold)
-    self.workdir=getcwd()
-    self.black_list=black_list
-    self.directory=Directory(topdirname)
-    #print "DIRWALKERFILE %s %s" %(draw_success,do_pngs)
-    self.directory.draw_success=draw_success
-    self.directory.do_pngs=do_pngs
-    self.black_list_histos = black_list_histos
-    self.different_histograms = {}
-    self.filename1 = basename(rootfilename2)
-    self.filename2 = basename(rootfilename1)
+    def __init__(self, name, topdirname,rootfilename1, rootfilename2, run=-1, black_list=[], stat_test="KS", test_threshold=.5,draw_success=True,do_pngs=False, black_list_histos=[]):
+        self.name=name
+        self.dqmrootfile1=DQMRootFile(abspath(rootfilename1))
+        self.dqmrootfile2=DQMRootFile(abspath(rootfilename2))
+        self.run=run
+        self.stat_test=Statistical_Tests[stat_test](test_threshold)
+        self.workdir=getcwd()
+        self.black_list=black_list
+        self.directory=Directory(topdirname)
+        #print "DIRWALKERFILE %s %s" %(draw_success,do_pngs)
+        self.directory.draw_success=draw_success
+        self.directory.do_pngs=do_pngs
+        self.black_list_histos = black_list_histos
+        self.different_histograms = {}
+        self.filename1 = basename(rootfilename2)
+        self.filename2 = basename(rootfilename1)
 
-  def __del__(self):
-    chdir(self.workdir)
-     
-  def cd(self,directory_name, on_disk=False, regexp=False,):
-    if regexp == True:
-        if len(directory_name)!=0:
-            if on_disk:
-                if not exists(directory_name):
-                    makedirs(directory_name)
-                    chdir(directory_name)  
-            tmp = self.dqmrootfile2.ls().keys()
-            for elem in tmp:
-                if "Run" in elem:
-                    next_dir = elem
-            self.dqmrootfile2.cd(next_dir)
-            tmp = self.dqmrootfile1.ls().keys()
-            for elem in tmp:
-                if "Run" in elem:
-                    next_dir = elem
-            self.dqmrootfile1.cd(next_dir)
-    else:
-        if len(directory_name)!=0:
-            if on_disk:
-                if not exists(directory_name):
-                    makedirs(directory_name)
-                    chdir(directory_name)
-            self.dqmrootfile2.cd(directory_name)
-            self.dqmrootfile1.cd(directory_name)
-    
-  def ls(self,directory_name=""):
-    """Return common objects to the 2 files.
-    """
-    contents1=self.dqmrootfile1.ls(directory_name)
-    contents2=self.dqmrootfile2.ls(directory_name)
-    #print "cont1: %s"%(contents1)
-    #print "cont2: %s"%(contents2)
-    contents={}
-    self.different_histograms['file1']= {}
-    self.different_histograms['file2']= {}
-    keys = [key for key in contents2.keys() if key in contents1] #set of all possible contents from both files
-    #print " ## keys: %s" %(keys)
-    for key in keys:  #iterate on all unique keys
-      if contents1[key]!=contents2[key]:
-        diff_file1 = set(contents1.keys()) - set(contents2.keys()) #set of contents that file1 is missing
-        diff_file2 = set(contents2.keys()) - set(contents1.keys()) #--'-- that file2 is missing
-        for key1 in diff_file1:
-            obj_type = contents1[key1]
-            if obj_type == "TDirectoryFile":
-              self.different_histograms['file1'][key1] = contents1[key1] #if direcory
-              #print "\n Missing inside a dir: ", self.ls(key1)
-              #contents[key] = contents1[key1]
-            if obj_type[:2]!="TH" and obj_type[:3]!="TPr" : #if histogram
-              continue
-            self.different_histograms['file1'][key1] = contents1[key1]
-        for key1 in diff_file2:
-            obj_type = contents2[key1]
-            if obj_type == "TDirectoryFile":
-              self.different_histograms['file2'][key1] = contents2[key1] #if direcory
-              #print "\n Missing inside a dir: ", self.ls(key1)
-              #contents[key] = contents2[key1]
-            if obj_type[:2]!="TH" and obj_type[:3]!="TPr" : #if histogram
-              continue
-            self.different_histograms['file2'][key1] = contents2[key1]
-      contents[key]=contents1[key]
-    return contents
-  
-  def getObjs(self,name):
-    h1=self.dqmrootfile1.getObj(name)
-    h2=self.dqmrootfile2.getObj(name)
-    return h1,h2
-  
-  def __fill_single_dir(self,dir_name,directory,mother_name="",depth=0):
-    #print "MOTHER NAME  = +%s+" %mother_name
-   #print "About to study %s (in dir %s)" %(dir_name,getcwd())
-        
-    # see if in black_list
-    this_dir=DirID(dir_name,depth)
-    #print "  ## this_dir: %s"%(this_dir)
-    if this_dir in self.black_list: 
-      #print "Directory %s skipped because black-listed" %dir_name
-      return 0        
-        
-    depth+=1
-    
-    self.cd(dir_name)
-    #if dir_name == 'HLTJETMET':
-    #    print self.ls()
-    
-    #print "Test %s with thre %s" %(self.stat_test.name, self.stat_test.threshold)
-    
-    contents=self.ls()
-    if depth==1:
-      n_top_contents=len(contents)
-    
-    #print contents
-    cont_counter=1
-    comparisons=[]
-    for name,obj_type in contents.items():
-      if obj_type=="TDirectoryFile":        
-        #We have a dir, launch recursion!
-        #Some feedback on the progress
-        if depth==1:
-          print("Studying directory %s, %s/%s" %(name,cont_counter,n_top_contents))
-          cont_counter+=1          
- 
-        #print "Studying directory",name
-        # ok recursion on!
-        subdir=Directory(name)
-        subdir.draw_success=directory.draw_success
-        subdir.do_pngs=directory.do_pngs
-        self.__fill_single_dir(name,subdir,join(mother_name,dir_name),depth)
-        if not subdir.is_empty():
-          if depth==1:
-            print(" ->Appending %s..." %name, end=' ')
-          directory.subdirs.append(subdir)
-          if depth==1:
-            print("Appended.")
-      else:
-        # We have probably an histo. Let's make the plot and the png.        
-        if obj_type[:2]!="TH" and obj_type[:3]!="TPr" :
-          continue
-        h1,h2=self.getObjs(name)
-        #print "COMPARISON : +%s+%s+" %(mother_name,dir_name)
-        path = join(mother_name,dir_name,name)
-        if path in self.black_list_histos:
-          print("  Skipping %s" %(path))
-          directory.comparisons.append(Comparison(name,
-                              join(mother_name,dir_name),
-                              h1,h2,
-                              deepcopy(self.stat_test),
-                              draw_success=directory.draw_success,
-                              do_pngs=directory.do_pngs, skip=True))
+    def __del__(self):
+        chdir(self.workdir)
+
+    def cd(self,directory_name, on_disk=False, regexp=False,):
+        if regexp == True:
+            if len(directory_name)!=0:
+                if on_disk:
+                    if not exists(directory_name):
+                        makedirs(directory_name)
+                        chdir(directory_name)  
+                tmp = self.dqmrootfile2.ls().keys()
+                for elem in tmp:
+                    if "Run" in elem:
+                        next_dir = elem
+                self.dqmrootfile2.cd(next_dir)
+                tmp = self.dqmrootfile1.ls().keys()
+                for elem in tmp:
+                    if "Run" in elem:
+                        next_dir = elem
+                self.dqmrootfile1.cd(next_dir)
         else:
-          directory.comparisons.append(Comparison(name,
-                                join(mother_name,dir_name),
-                                h1,h2,
-                                deepcopy(self.stat_test),
-                                draw_success=directory.draw_success,
-                                do_pngs=directory.do_pngs, skip=False))
-          directory.filename1 = self.filename1
-          directory.filename2 = self.filename2
-          directory.different_histograms['file1'] = self.different_histograms['file1']
-          directory.different_histograms['file2'] = self.different_histograms['file2']
+            if len(directory_name)!=0:
+                if on_disk:
+                    if not exists(directory_name):
+                        makedirs(directory_name)
+                        chdir(directory_name)
+                self.dqmrootfile2.cd(directory_name)
+                self.dqmrootfile1.cd(directory_name)
 
-    self.cd("..")
-   
-  def walk(self):
-    # Build the top dir in the rootfile first
-    rundir=""
-    if self.run<0:
-      # change dir in the first one...
-      #print  self.ls().keys()
-      first_run_dir = ""
-      try:
-        first_run_dir = filter(lambda k: "Run " in k, self.ls().keys())[0]
-      except:
-         print("\nRundir not there: Is this a generic rootfile?\n")
-      rundir=first_run_dir
-      try:
-	self.run= int(rundir.split(" ")[1])
-      except:
-        print("Setting run number to 0")
-        self.run= 0
-    else:
-      rundir="Run %s"%self.run
-    
-    try:
-      self.cd(rundir, False, True) #True -> for checking the Rundir in case of different runs
-    except:
-      print("\nRundir not there: Is this a generic rootfile?\n")
-    
-    # Let's rock!
-    self.__fill_single_dir(self.directory.name,self.directory)
-    print("Finished")
-    n_left_threads=len(tcanvas_print_processes)
-    if n_left_threads>0:
-      print("Waiting for %s threads to finish..." %n_left_threads)
-      for p in tcanvas_print_processes:
-        p.join()  
+    def ls(self,directory_name=""):
+        """Return common objects to the 2 files.
+        """
+        contents1=self.dqmrootfile1.ls(directory_name)
+        contents2=self.dqmrootfile2.ls(directory_name)
+        #print "cont1: %s"%(contents1)
+        #print "cont2: %s"%(contents2)
+        contents={}
+        self.different_histograms['file1']= {}
+        self.different_histograms['file2']= {}
+        keys = [key for key in contents2.keys() if key in contents1] #set of all possible contents from both files
+        #print " ## keys: %s" %(keys)
+        for key in keys:  #iterate on all unique keys
+            if contents1[key]!=contents2[key]:
+                diff_file1 = set(contents1.keys()) - set(contents2.keys()) #set of contents that file1 is missing
+                diff_file2 = set(contents2.keys()) - set(contents1.keys()) #--'-- that file2 is missing
+                for key1 in diff_file1:
+                    obj_type = contents1[key1]
+                    if obj_type == "TDirectoryFile":
+                        self.different_histograms['file1'][key1] = contents1[key1] #if direcory
+                        #print "\n Missing inside a dir: ", self.ls(key1)
+                        #contents[key] = contents1[key1]
+                    if obj_type[:2]!="TH" and obj_type[:3]!="TPr" : #if histogram
+                        continue
+                    self.different_histograms['file1'][key1] = contents1[key1]
+                for key1 in diff_file2:
+                    obj_type = contents2[key1]
+                    if obj_type == "TDirectoryFile":
+                        self.different_histograms['file2'][key1] = contents2[key1] #if direcory
+                        #print "\n Missing inside a dir: ", self.ls(key1)
+                        #contents[key] = contents2[key1]
+                    if obj_type[:2]!="TH" and obj_type[:3]!="TPr" : #if histogram
+                        continue
+                    self.different_histograms['file2'][key1] = contents2[key1]
+            contents[key]=contents1[key]
+        return contents
+
+    def getObjs(self,name):
+        h1=self.dqmrootfile1.getObj(name)
+        h2=self.dqmrootfile2.getObj(name)
+        return h1,h2
+
+    def __fill_single_dir(self,dir_name,directory,mother_name="",depth=0):
+        #print "MOTHER NAME  = +%s+" %mother_name
+     #print "About to study %s (in dir %s)" %(dir_name,getcwd())
+
+        # see if in black_list
+        this_dir=DirID(dir_name,depth)
+        #print "  ## this_dir: %s"%(this_dir)
+        if this_dir in self.black_list: 
+            #print "Directory %s skipped because black-listed" %dir_name
+            return 0        
+
+        depth+=1
+
+        self.cd(dir_name)
+        #if dir_name == 'HLTJETMET':
+        #    print self.ls()
+
+        #print "Test %s with thre %s" %(self.stat_test.name, self.stat_test.threshold)
+
+        contents=self.ls()
+        if depth==1:
+            n_top_contents=len(contents)
+
+        #print contents
+        cont_counter=1
+        comparisons=[]
+        for name,obj_type in contents.items():
+            if obj_type=="TDirectoryFile":        
+                #We have a dir, launch recursion!
+                #Some feedback on the progress
+                if depth==1:
+                    print("Studying directory %s, %s/%s" %(name,cont_counter,n_top_contents))
+                    cont_counter+=1          
+
+                #print "Studying directory",name
+                # ok recursion on!
+                subdir=Directory(name)
+                subdir.draw_success=directory.draw_success
+                subdir.do_pngs=directory.do_pngs
+                self.__fill_single_dir(name,subdir,join(mother_name,dir_name),depth)
+                if not subdir.is_empty():
+                    if depth==1:
+                        print(" ->Appending %s..." %name, end=' ')
+                    directory.subdirs.append(subdir)
+                    if depth==1:
+                        print("Appended.")
+            else:
+                # We have probably an histo. Let's make the plot and the png.        
+                if obj_type[:2]!="TH" and obj_type[:3]!="TPr" :
+                    continue
+                h1,h2=self.getObjs(name)
+                #print "COMPARISON : +%s+%s+" %(mother_name,dir_name)
+                path = join(mother_name,dir_name,name)
+                if path in self.black_list_histos:
+                    print("  Skipping %s" %(path))
+                    directory.comparisons.append(Comparison(name,
+                                        join(mother_name,dir_name),
+                                        h1,h2,
+                                        deepcopy(self.stat_test),
+                                        draw_success=directory.draw_success,
+                                        do_pngs=directory.do_pngs, skip=True))
+                else:
+                    directory.comparisons.append(Comparison(name,
+                                          join(mother_name,dir_name),
+                                          h1,h2,
+                                          deepcopy(self.stat_test),
+                                          draw_success=directory.draw_success,
+                                          do_pngs=directory.do_pngs, skip=False))
+                    directory.filename1 = self.filename1
+                    directory.filename2 = self.filename2
+                    directory.different_histograms['file1'] = self.different_histograms['file1']
+                    directory.different_histograms['file2'] = self.different_histograms['file2']
+
+        self.cd("..")
+
+    def walk(self):
+        # Build the top dir in the rootfile first
+        rundir=""
+        if self.run<0:
+            # change dir in the first one...
+            #print  self.ls().keys()
+            first_run_dir = ""
+            try:
+                first_run_dir = filter(lambda k: "Run " in k, self.ls().keys())[0]
+            except:
+                print("\nRundir not there: Is this a generic rootfile?\n")
+            rundir=first_run_dir
+            try:
+                self.run= int(rundir.split(" ")[1])
+            except:
+                print("Setting run number to 0")
+                self.run= 0
+        else:
+            rundir="Run %s"%self.run
+
+        try:
+            self.cd(rundir, False, True) #True -> for checking the Rundir in case of different runs
+        except:
+            print("\nRundir not there: Is this a generic rootfile?\n")
+
+        # Let's rock!
+        self.__fill_single_dir(self.directory.name,self.directory)
+        print("Finished")
+        n_left_threads=len(tcanvas_print_processes)
+        if n_left_threads>0:
+            print("Waiting for %s threads to finish..." %n_left_threads)
+            for p in tcanvas_print_processes:
+                p.join()  
 
 #-------------------------------------------------------------------------------
 
 class DirWalkerFile_thread_wrapper(Thread):
-  def __init__(self, walker):
-    Thread.__init__(self)
-    self.walker=walker
-  def run(self):
-    self.walker.walk()
-    
+    def __init__(self, walker):
+        Thread.__init__(self)
+        self.walker=walker
+    def run(self):
+        self.walker.walk()
+
 #-------------------------------------------------------------------------------
 
 def string2blacklist(black_list_str):
-  black_list=[]
-  # replace the + with " ":
-  black_list_str=black_list_str.replace("__"," ")
-  if len(black_list_str)>0:
-    for ele in black_list_str.split(","):
-      dirname,level=ele.split("@")
-      level=int(level)
-      dirid=None
-      if "/" not in dirname:
-        dirid=DirID(dirname,level)
-      else:
-        mother,daughter=dirname.split("/")
-        dirid=DirID(daughter,level,mother)
-      if not dirid in black_list:
-        black_list.append(dirid)
-        
-  return black_list
-    
+    black_list=[]
+    # replace the + with " ":
+    black_list_str=black_list_str.replace("__"," ")
+    if len(black_list_str)>0:
+        for ele in black_list_str.split(","):
+            dirname,level=ele.split("@")
+            level=int(level)
+            dirid=None
+            if "/" not in dirname:
+                dirid=DirID(dirname,level)
+            else:
+                mother,daughter=dirname.split("/")
+                dirid=DirID(daughter,level,mother)
+            if not dirid in black_list:
+                black_list.append(dirid)
+
+    return black_list
+
 #-------------------------------------------------------------------------------
-  
+

--- a/Utilities/ReleaseScripts/python/cmsCodeRules/showPage.py
+++ b/Utilities/ReleaseScripts/python/cmsCodeRules/showPage.py
@@ -56,7 +56,7 @@ class BuildViewer(object):
 
         self.formatter.writeAnchor(ref='top')
         self.formatter.writeH2("CMSSW code rules violation for "+ib)
-            
+
         self.formatter.startTable([20,20,20,20,50], 
 ['Rule','Packages', 'Files','Sum of violations','Description'], id =
 'descriptionTable', tableAttr='border="0" cellspacing="5" cellpadding="5"')
@@ -64,7 +64,7 @@ class BuildViewer(object):
         for ruleName in rulesNames:
             try:
                 ruleRes = rulesResults[ruleName]
-		totalViolations = 0
+                totalViolations = 0
                 totalFiles = 0
                 for package, packageResult in ruleRes:
                     totalFiles += len(packageResult)
@@ -133,7 +133,7 @@ def numberConverter(number):
     number = str(number)
     length = len(number)
     if  length < 3:
-       number = (3-length)*str(0) + number
+        number = (3-length)*str(0) + number
     return number
 
 def createLogFiles(rulesResult, logsDir, ib):

--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -12,7 +12,7 @@ scriptPath = os.path.dirname( os.path.abspath(sys.argv[0]) )
 if scriptPath not in sys.path:
     sys.path.append(scriptPath)
 
-        
+
 class testit(Thread):
     def __init__(self,dirName, commandList):
         Thread.__init__(self)
@@ -24,7 +24,7 @@ class testit(Thread):
         self.npass=[]
 
         return
-    
+
     def run(self):
 
         startime='date %s' %time.asctime()
@@ -37,7 +37,7 @@ class testit(Thread):
 
             commandbase = command.replace(' ','_').replace('/','_')
             logfile='%s.log' % commandbase[:150].replace("'",'').replace('"','').replace('../','')
-            
+
             executable = 'cd '+self.dirName+'; '+command+' > '+logfile+' 2>&1'
 
             ret = os.system(executable)
@@ -45,7 +45,7 @@ class testit(Thread):
 
         endtime='date %s' %time.asctime()
         tottime='%s-%s'%(endtime,startime)
-    
+
         for i in range(len(self.commandList)):
             command = self.commandList[i]
             exitcode = exitCodes[i]
@@ -81,7 +81,7 @@ class StandardTester(object):
         return nActive
 
     def prepare(self):
-    
+
         self.devPath = os.environ['LOCALRT'] + '/src/'
         self.relPath = self.devPath
         if 'CMSSW_RELEASE_BASE' in os.environ and (os.environ['CMSSW_RELEASE_BASE'] != ""): self.relPath = os.environ['CMSSW_RELEASE_BASE'] + '/src/'
@@ -95,7 +95,7 @@ class StandardTester(object):
 
         hltFlag_data = ' realData=True  globalTag=@ inputFiles=@ '
         hltFlag_mc   = ' realData=False globalTag=@ inputFiles=@ '
- 
+
         hltTests = {
                     'hlt_mc_Fake' : ['cmsDriver.py TTbar_Tauola_8TeV_TuneCUETP8M1_cfi -s GEN,SIM,DIGI,L1,DIGI2RAW  --mc --scenario=pp -n 10 --conditions auto:run1_mc_Fake --relval 9000,50 --datatier "GEN-SIM-RAW" --eventcontent RAWSIM --customise=HLTrigger/Configuration/CustomConfigs.L1T --fileout file:RelVal_Raw_Fake_MC.root',
                                'cmsRun '+self.file2Path('HLTrigger/Configuration/test/OnLine_HLT_Fake.py')+hltFlag_mc,
@@ -154,7 +154,7 @@ class StandardTester(object):
         for dirName, commandList in hltTests.items():
             self.commands[dirName] = commandList
         return
-	
+
     def dumpTest(self):
         print(",".join(self.commands.keys()))
         return
@@ -174,48 +174,48 @@ class StandardTester(object):
         os.chdir('addOnTests')
 
         nfail=0
-    	npass=0
-    	report=''
-    	
-    	print('Running in %s thread(s)' % self.maxThreads)
-    	
+        npass=0
+        report=''
+
+        print('Running in %s thread(s)' % self.maxThreads)
+
         for dirName, command in self.commands.items():
 
-    	    if testList and not dirName in testList:
+            if testList and not dirName in testList:
                 del self.commands[dirName]
                 continue
 
             # make sure we don't run more than the allowed number of threads:
-    	    while self.activeThreads() >= self.maxThreads:
-    	        time.sleep(10)
+            while self.activeThreads() >= self.maxThreads:
+                time.sleep(10)
                 continue
-    	    
-    	    print('Preparing to run %s' % str(command))
-    	    current = testit(dirName, command)
-    	    self.threadList.append(current)
-    	    current.start()
+
+            print('Preparing to run %s' % str(command))
+            current = testit(dirName, command)
+            self.threadList.append(current)
+            current.start()
             time.sleep(random.randint(1,5)) # try to avoid race cond by sleeping random amount of time [1,5] sec 
-            
+
         # wait until all threads are finished
         while self.activeThreads() > 0:
-    	    time.sleep(5)
-    	    
-    	# all threads are done now, check status ...
-    	for pingle in self.threadList:
-    	    pingle.join()
+            time.sleep(5)
+
+        # all threads are done now, check status ...
+        for pingle in self.threadList:
+            pingle.join()
             for f in pingle.nfail: nfail  += f
             for p in pingle.npass: npass  += p
-    	    report += pingle.report
-    	    print(pingle.report)
+            report += pingle.report
+            print(pingle.report)
             sys.stdout.flush()
-            
-    	reportSumm = '\n %s tests passed, %s failed \n' %(npass,nfail)
-    	print(reportSumm)
-    	
-    	runall_report_name='runall-report.log'
-    	runall_report=open(runall_report_name,'w')
-    	runall_report.write(report+reportSumm)
-    	runall_report.close()
+
+        reportSumm = '\n %s tests passed, %s failed \n' %(npass,nfail)
+        print(reportSumm)
+
+        runall_report_name='runall-report.log'
+        runall_report=open(runall_report_name,'w')
+        runall_report.write(report+reportSumm)
+        runall_report.close()
 
         # get the logs to the logs dir:
         print('==> in :', os.getcwd())
@@ -231,8 +231,8 @@ class StandardTester(object):
         pickle.dump(self.commands, open('logs/addOnTests.pkl', 'w') )
 
         os.chdir(actDir)
-        
-    	return
+
+        return
 
     def upload(self, tgtDir):
 
@@ -240,7 +240,7 @@ class StandardTester(object):
 
         if not os.path.exists(tgtDir):
             os.makedirs(tgtDir)
-        
+
         cmd = 'tar cf - addOnTests.log addOnTests/logs | (cd '+tgtDir+' ; tar xf - ) '
         try:
             print('executing: ',cmd)
@@ -249,20 +249,20 @@ class StandardTester(object):
                 print("ERROR uploading logs:", ret, cmd)
         except Exception as e:
             print("EXCEPTION while uploading addOnTest-logs : ", str(e))
-            
-    	return
 
-                
+        return
+
+
 def main(argv) :
 
     import getopt
-    
+
     try:
         opts, args = getopt.getopt(argv, "dj:t:", ["nproc=", 'uploadDir=', 'tests=','noRun','dump'])
     except getopt.GetoptError as e:
         print("unknown option", str(e))
         sys.exit(2)
-        
+
     np        = 4
     uploadDir = None
     runTests  = True
@@ -289,6 +289,6 @@ def main(argv) :
         if uploadDir:
             tester.upload(uploadDir)
     return
-    
+
 if __name__ == '__main__' :
     main(sys.argv[1:])

--- a/Utilities/ReleaseScripts/scripts/cmstc.py
+++ b/Utilities/ReleaseScripts/scripts/cmstc.py
@@ -22,207 +22,207 @@ import getpass
 import ws_sso_content_reader
 
 class TagCollector(object):
-	"""CMS TagCollector Python API"""
+    """CMS TagCollector Python API"""
 
-	def __init__(self,useCert=False):
-		self._url = _tagcollector_url
-		self.useCert = useCert
-		self.login = False
-		if self.useCert:
-			self.login = True
-			self._cj = cookielib.CookieJar()
-			self._opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(self._cj))
+    def __init__(self,useCert=False):
+        self._url = _tagcollector_url
+        self.useCert = useCert
+        self.login = False
+        if self.useCert:
+            self.login = True
+            self._cj = cookielib.CookieJar()
+            self._opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(self._cj))
 
-        def __del__(self):
- 		if self.login: self.signOut()
+    def __del__(self):
+        if self.login: self.signOut()
 
-	def _open(self, page, params = None, data = None):
-		url = self._url + page + '?'
-		if params:
-			url += urllib.urlencode(params)
-		if data:
-			data = urllib.urlencode(data)
-		if self.useCert:
-		  	return ws_sso_content_reader.getContent(url, '~/.globus/usercert.pem', '~/.globus/userkey.pem', data)
-		try:
-			return self._opener.open(url, data).read()
-		except urllib2.HTTPError as e:
-			raise Exception(e.read().strip())
+    def _open(self, page, params = None, data = None):
+        url = self._url + page + '?'
+        if params:
+            url += urllib.urlencode(params)
+        if data:
+            data = urllib.urlencode(data)
+        if self.useCert:
+            return ws_sso_content_reader.getContent(url, '~/.globus/usercert.pem', '~/.globus/userkey.pem', data)
+        try:
+            return self._opener.open(url, data).read()
+        except urllib2.HTTPError as e:
+            raise Exception(e.read().strip())
 
-	def _openjson(self, page, params = None, data = None):
-		return json.loads(self._open(page, params, data))
+    def _openjson(self, page, params = None, data = None):
+        return json.loads(self._open(page, params, data))
 
-	def signIn(self, username, password):
-		if self.useCert: return
-		"""Sign in to TagCollector."""
-		self._open('signIn', data = {'password': password, 'user_name': username})
-		self.login = True
+    def signIn(self, username, password):
+        if self.useCert: return
+        """Sign in to TagCollector."""
+        self._open('signIn', data = {'password': password, 'user_name': username})
+        self.login = True
 
-	def signInInteractive(self):
-		if self.useCert: return
-		"""Sign in to TagCollector, asking for the username and password."""
-		username = raw_input('Username: ')
-		password = getpass.getpass()
-		self.signIn(username, password)
-		return username
+    def signInInteractive(self):
+        if self.useCert: return
+        """Sign in to TagCollector, asking for the username and password."""
+        username = raw_input('Username: ')
+        password = getpass.getpass()
+        self.signIn(username, password)
+        return username
 
-	def signOut(self):
-		if self.useCert: return
-		"""Sign out of TagCollector."""
-		self._open('signOut')
-		self.login = False
+    def signOut(self):
+        if self.useCert: return
+        """Sign out of TagCollector."""
+        self._open('signOut')
+        self.login = False
 
-	def getPackageTags(self, package):
-		"""Get the tags published in TagCollector for a package.
-		Note: TagCollector's published tags are a subset of CVS' tags."""
-		return self._openjson('public/py_getPackageTags', {'package': package})
+    def getPackageTags(self, package):
+        """Get the tags published in TagCollector for a package.
+        Note: TagCollector's published tags are a subset of CVS' tags."""
+        return self._openjson('public/py_getPackageTags', {'package': package})
 
-	def getPackageTagDescriptionFirstLine(self, package, tag):
-		"""Get the first line of the descriptions of a tag."""
-		return self._openjson('public/py_getPackageTagDescriptionFirstLine', {'package': package, 'tag': tag})
+    def getPackageTagDescriptionFirstLine(self, package, tag):
+        """Get the first line of the descriptions of a tag."""
+        return self._openjson('public/py_getPackageTagDescriptionFirstLine', {'package': package, 'tag': tag})
 
-	def getPackageTagReleases(self, package, tag):
-		"""Get the releases where a tag is."""
-		return self._openjson('public/py_getPackageTagReleases', {'package': package, 'tag': tag})
+    def getPackageTagReleases(self, package, tag):
+        """Get the releases where a tag is."""
+        return self._openjson('public/py_getPackageTagReleases', {'package': package, 'tag': tag})
 
-	def getReleasesTags(self, releases, diff = False):
-		"""Get the tags of one or more release.
-		Optionally, return only the tags that differ between releases."""
-		releases = json.dumps(releases)
-		diff = json.dumps(diff)
-		return self._openjson('public/py_getReleasesTags', {'releases': releases, 'diff': diff})
+    def getReleasesTags(self, releases, diff = False):
+        """Get the tags of one or more release.
+        Optionally, return only the tags that differ between releases."""
+        releases = json.dumps(releases)
+        diff = json.dumps(diff)
+        return self._openjson('public/py_getReleasesTags', {'releases': releases, 'diff': diff})
 
-	def getReleaseTags(self, release):
-		"""Get the tags of one release."""
-		return self.getReleasesTags((release, ))
+    def getReleaseTags(self, release):
+        """Get the tags of one release."""
+        return self.getReleasesTags((release, ))
 
-	def getTagsetTags(self, tagset):
-		"""Get the tags of one tagset."""
-		return self._openjson('public/py_getTagsetTags', {'tagset': tagset})
+    def getTagsetTags(self, tagset):
+        """Get the tags of one tagset."""
+        return self._openjson('public/py_getTagsetTags', {'tagset': tagset})
 
-	def getTagsetInformation(self, tagset):
-		"""Get the information of one tagset."""
-		return self._openjson('public/py_getTagsetInformation', {'tagset': tagset})
+    def getTagsetInformation(self, tagset):
+        """Get the information of one tagset."""
+        return self._openjson('public/py_getTagsetInformation', {'tagset': tagset})
 
-	def getPendingApprovalTags(self, args, allow_multiple_tags = False):
-		"""Prints Pending Approval tags of one or more releases,
-                one or more tagsets, or both (i.e. it joins all the tags).
-		Prints an error if several tags appear for a single package.
-		Suitable for piping to addpkg (note: at the moment,
-		addpkg does not read from stdin, use "-f" instead)."""
-		args = json.dumps(args)
-		allow_multiple_tags = json.dumps(allow_multiple_tags)
-		return self._openjson('public/py_getPendingApprovalTags', {'args': args, 'allow_multiple_tags': allow_multiple_tags})
-	
-	def getTagsetsTagsPendingSignatures(self, user_name, show_all, author_tagsets, release_names = None):
-		"""Prints Pending Signature tags of one or more releases,
-                one or more tagsets, or both (i.e. it joins all the tags).
-		Prints an error if several tags appear for a single package.
-		Suitable for piping to addpkg (note: at the moment,
-		addpkg does not read from stdin, use "-f" instead)."""
-		if not release_names == None:
-			return self._openjson('public/py_getTagsetsTagsPendingSignatures', {'user_name': user_name, 'show_all': show_all, 'author_tagsets': author_tagsets, 'release_names': json.dumps(release_names)})
-		else:
-			return self._openjson('public/py_getTagsetsTagsPendingSignatures', {'user_name': user_name, 'show_all': show_all, 'author_tagsets': author_tagsets})
+    def getPendingApprovalTags(self, args, allow_multiple_tags = False):
+        """Prints Pending Approval tags of one or more releases,
+        one or more tagsets, or both (i.e. it joins all the tags).
+        Prints an error if several tags appear for a single package.
+        Suitable for piping to addpkg (note: at the moment,
+        addpkg does not read from stdin, use "-f" instead)."""
+        args = json.dumps(args)
+        allow_multiple_tags = json.dumps(allow_multiple_tags)
+        return self._openjson('public/py_getPendingApprovalTags', {'args': args, 'allow_multiple_tags': allow_multiple_tags})
 
-	def commentTagsets(self, tagset_ids, comment):
-		"""Comment one or more tagsets.
-		Requirement: Signed in."""
-		tagset_ids = json.dumps(tagset_ids)
-		if len(comment) < 1:
-			raise Exception("Error: Expected a comment.")
-		self._open('commentTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
+    def getTagsetsTagsPendingSignatures(self, user_name, show_all, author_tagsets, release_names = None):
+        """Prints Pending Signature tags of one or more releases,
+        one or more tagsets, or both (i.e. it joins all the tags).
+        Prints an error if several tags appear for a single package.
+        Suitable for piping to addpkg (note: at the moment,
+        addpkg does not read from stdin, use "-f" instead)."""
+        if not release_names == None:
+            return self._openjson('public/py_getTagsetsTagsPendingSignatures', {'user_name': user_name, 'show_all': show_all, 'author_tagsets': author_tagsets, 'release_names': json.dumps(release_names)})
+        else:
+            return self._openjson('public/py_getTagsetsTagsPendingSignatures', {'user_name': user_name, 'show_all': show_all, 'author_tagsets': author_tagsets})
 
-	def signTagsets(self, tagset_ids, comment = ''):
-		"""Sign one or more tagsets.
-		Requirement: Signed in as a L2."""
-		tagset_ids = json.dumps(tagset_ids)
-		self._open('signTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
+    def commentTagsets(self, tagset_ids, comment):
+        """Comment one or more tagsets.
+        Requirement: Signed in."""
+        tagset_ids = json.dumps(tagset_ids)
+        if len(comment) < 1:
+            raise Exception("Error: Expected a comment.")
+        self._open('commentTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
 
-	def signTagsetsAll(self, tagset_ids, comment = ''):
-		"""Sign all one or more tagsets.
-		Requirement: Signed in as a top-level admin."""
-		tagset_ids = json.dumps(tagset_ids)
-		self._open('signTagsetsAll', {'tagset_ids': tagset_ids, 'comment': comment})
+    def signTagsets(self, tagset_ids, comment = ''):
+        """Sign one or more tagsets.
+        Requirement: Signed in as a L2."""
+        tagset_ids = json.dumps(tagset_ids)
+        self._open('signTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
 
-	def rejectTagsetsPendingSignatures(self, tagset_ids, comment = ''):
-		"""Reject one or more tagsets Pending Signatures.
-		Requirement: Signed in as a L2s or as a Release Manager
-                for the tagset's release or as the author of the tagset."""
-		tagset_ids = json.dumps(tagset_ids)
-		self._open('rejectTagsetsPendingSignatures', {'tagset_ids': tagset_ids, 'comment': comment})
+    def signTagsetsAll(self, tagset_ids, comment = ''):
+        """Sign all one or more tagsets.
+        Requirement: Signed in as a top-level admin."""
+        tagset_ids = json.dumps(tagset_ids)
+        self._open('signTagsetsAll', {'tagset_ids': tagset_ids, 'comment': comment})
 
-	def approveTagsets(self, tagset_ids, comment = ''):
-		"""Approve one or more tagsets.
-		Requirement: Signed in as a Release Manager for each tagset's release."""
-		tagset_ids = json.dumps(tagset_ids)
-		self._open('approveTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
+    def rejectTagsetsPendingSignatures(self, tagset_ids, comment = ''):
+        """Reject one or more tagsets Pending Signatures.
+        Requirement: Signed in as a L2s or as a Release Manager
+        for the tagset's release or as the author of the tagset."""
+        tagset_ids = json.dumps(tagset_ids)
+        self._open('rejectTagsetsPendingSignatures', {'tagset_ids': tagset_ids, 'comment': comment})
 
-	def bypassTagsets(self, tagset_ids, comment = ''):
-		"""Bypass one or more tagsets.
-		Requirement: Signed in as a Release Manager for each tagset's release."""
-		tagset_ids = json.dumps(tagset_ids)
-		self._open('bypassTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
+    def approveTagsets(self, tagset_ids, comment = ''):
+        """Approve one or more tagsets.
+        Requirement: Signed in as a Release Manager for each tagset's release."""
+        tagset_ids = json.dumps(tagset_ids)
+        self._open('approveTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
 
-	def rejectTagsetsPendingApproval(self, tagset_ids, comment = ''):
-		"""Reject one or more tagsets Pending Approval.
-		Requirement: Signed in as a Release Manager."""
-		tagset_ids = json.dumps(tagset_ids)
-		self._open('rejectTagsetsPendingApproval', {'tagset_ids': tagset_ids, 'comment': comment})
+    def bypassTagsets(self, tagset_ids, comment = ''):
+        """Bypass one or more tagsets.
+        Requirement: Signed in as a Release Manager for each tagset's release."""
+        tagset_ids = json.dumps(tagset_ids)
+        self._open('bypassTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
 
-	def removeTagsets(self, tagset_ids, comment = ''):
-		"""Remove one or more tagsets from the History (i.e. stack of the release).
-		Requirement: Signed in as a Release Manager."""
-		tagset_ids = json.dumps(tagset_ids)
-		self._open('removeTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
+    def rejectTagsetsPendingApproval(self, tagset_ids, comment = ''):
+        """Reject one or more tagsets Pending Approval.
+        Requirement: Signed in as a Release Manager."""
+        tagset_ids = json.dumps(tagset_ids)
+        self._open('rejectTagsetsPendingApproval', {'tagset_ids': tagset_ids, 'comment': comment})
 
-	def getPackagesPendingApproval(self):
-		"""Get New Package Requests which are Pending Approval."""
-		return self._openjson('public/py_getPackagesPendingApproval')
+    def removeTagsets(self, tagset_ids, comment = ''):
+        """Remove one or more tagsets from the History (i.e. stack of the release).
+        Requirement: Signed in as a Release Manager."""
+        tagset_ids = json.dumps(tagset_ids)
+        self._open('removeTagsets', {'tagset_ids': tagset_ids, 'comment': comment})
 
-	def getPackageManagersRequested(self, package):
-		"""Get the Package Managers (administrators and developers) requested in a New Package Request."""
-		return self._openjson('public/py_getPackageManagersRequested', {'package': package})
+    def getPackagesPendingApproval(self):
+        """Get New Package Requests which are Pending Approval."""
+        return self._openjson('public/py_getPackagesPendingApproval')
 
-	def search(self, term):
-		"""Searches for releases, packages, tagsets, users and categories.
-		Requirement: Signed in."""
-		return self._openjson('search', {'term': term})
+    def getPackageManagersRequested(self, package):
+        """Get the Package Managers (administrators and developers) requested in a New Package Request."""
+        return self._openjson('public/py_getPackageManagersRequested', {'package': package})
 
-	def approvePackage(self, package):
-		"""Approve a New Package Request.
-		Requirement: Signed in as a Creator (i.e. people in the top-level .admin/developers file).
-		Warning: This does *not* create the package in CVS."""
-		self._open('approveNewPackageRequest', {'package_name': package})
+    def search(self, term):
+        """Searches for releases, packages, tagsets, users and categories.
+        Requirement: Signed in."""
+        return self._openjson('search', {'term': term})
 
-	def getIBs(self, filt = '', limit = 10):
-		"""Get the name and creation date of Integration Builds.
-		By default, it only returns the latest 10 IBs.
-		Optionally, filter by name."""
-		return self._openjson('public/py_getIBs', {'filt': filt, 'limit': limit})
-	
-        def deprecateReleases(self, *releases):
-                """ Deprecate releases"""
-                if not self.login:
-		        raise Exception("Error: Not logged in?!")
-                self._open('deprecateReleases', {"releases": ",".join(releases)})
-                  
-	def createRelease(self, base_release_name, new_release_name, new_state, new_private, new_type, new_description, release_managers, copy_queues, tags):
-		"""Create a new release.
-		Requirement: Signed in as a release manager."""
-		if self.login:
-		    self._open('copyRelease', {'release_name': base_release_name, 'new_release_name': new_release_name, 'new_state': new_state, 'new_private': new_private, 'new_type': new_type, 'new_description': new_description, 'release_managers': release_managers, 'copy_queues': copy_queues, 'tags': tags})
-		else:
-			raise Exception("Error: Not logged in?!")
-		
-	def requestCustomIB(self, release_name, architectures, tags):
-		"""Request a CustomIB.
-		Requirement: Signed in."""
-		if self.login:
-		    self._open('requestCustomIB', {'release_name': release_name, 'architecture_names': architectures, 'tags': tags})
-		else:
-			raise Exception("Error: Not logged in?!")
-		
-	def getReleaseArchitectures(self, release, default='0'):
-		"""Returns release architectures."""
-		return self._openjson('public/py_getReleaseArchitectures', {'release': release, 'default': default})
+    def approvePackage(self, package):
+        """Approve a New Package Request.
+        Requirement: Signed in as a Creator (i.e. people in the top-level .admin/developers file).
+        Warning: This does *not* create the package in CVS."""
+        self._open('approveNewPackageRequest', {'package_name': package})
+
+    def getIBs(self, filt = '', limit = 10):
+        """Get the name and creation date of Integration Builds.
+        By default, it only returns the latest 10 IBs.
+        Optionally, filter by name."""
+        return self._openjson('public/py_getIBs', {'filt': filt, 'limit': limit})
+
+    def deprecateReleases(self, *releases):
+        """ Deprecate releases"""
+        if not self.login:
+            raise Exception("Error: Not logged in?!")
+        self._open('deprecateReleases', {"releases": ",".join(releases)})
+
+    def createRelease(self, base_release_name, new_release_name, new_state, new_private, new_type, new_description, release_managers, copy_queues, tags):
+        """Create a new release.
+        Requirement: Signed in as a release manager."""
+        if self.login:
+            self._open('copyRelease', {'release_name': base_release_name, 'new_release_name': new_release_name, 'new_state': new_state, 'new_private': new_private, 'new_type': new_type, 'new_description': new_description, 'release_managers': release_managers, 'copy_queues': copy_queues, 'tags': tags})
+        else:
+            raise Exception("Error: Not logged in?!")
+
+    def requestCustomIB(self, release_name, architectures, tags):
+        """Request a CustomIB.
+        Requirement: Signed in."""
+        if self.login:
+            self._open('requestCustomIB', {'release_name': release_name, 'architecture_names': architectures, 'tags': tags})
+        else:
+            raise Exception("Error: Not logged in?!")
+
+    def getReleaseArchitectures(self, release, default='0'):
+        """Returns release architectures."""
+        return self._openjson('public/py_getReleaseArchitectures', {'release': release, 'default': default})

--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -34,7 +34,7 @@ typedefsDict = \
 #Ordered List to search for matched packages
 equivDict = \
      [
-	 {'TrajectoryState'         : ['TrajectoryStateOnSurface']},
+         {'TrajectoryState'         : ['TrajectoryStateOnSurface']},
          {'TrackTriggerAssociation' : ['(TTClusterAssociationMap|TTStubAssociationMap|TTTrackAssociationMap).*Phase2TrackerDigi',
                                        '(TTStub|TTCluster|TTTrack).*Phase2TrackerDigi']},
          {'L1TCalorimeter'        : ['l1t::CaloTower.*']},
@@ -48,21 +48,21 @@ equivDict = \
          {'Egamma'                : ['reco::ElectronID']},
          {'TopObjects'            : ['reco::CATopJetProperties']},
          {'TauReco'               : ['reco::L2TauIsolationInfo','reco::RecoTauPiZero','reco::BaseTau']},
-	 {'ValidationFormats'     : ['PGlobalDigi::.+','PGlobalRecHit::.+']},
+         {'ValidationFormats'     : ['PGlobalDigi::.+','PGlobalRecHit::.+']},
          {'TrajectorySeed'        : ['TrajectorySeed']},
          {'TrackCandidate'        : ['TrackCandidate']},
-	 {'PatternTools'          : ['MomentumConstraint','VertexConstraint','Trajectory']},
-	 {'TrackerRecHit2D'       : ['SiStrip(Matched|)RecHit[12]D','SiTrackerGSRecHit[12]D','SiPixelRecHit']},
-	 {'MuonReco'              : ['reco::Muon(Ref|)(Vector|)']},
-	 {'MuonSeed'              : ['L3MuonTrajectorySeed']},
-	 {'HepMCCandidate'        : ['reco::GenParticle.*']},
-	 {'L1Trigger'             : ['l1extra::L1.+Particle']},
-	 {'TrackInfo'             : ['reco::TrackingRecHitInfo']},
-	 {'EgammaCandidates'      : ['reco::GsfElectron.*','reco::Photon.*']},
-	 {'HcalIsolatedTrack'     : ['reco::IsolatedPixelTrackCandidate', 'reco::EcalIsolatedParticleCandidate', 'reco::HcalIsolatedTrackCandidate']},
-	 {'HcalRecHit'            : ['HFRecHit','HORecHit','ZDCRecHit','HBHERecHit']},
+         {'PatternTools'          : ['MomentumConstraint','VertexConstraint','Trajectory']},
+         {'TrackerRecHit2D'       : ['SiStrip(Matched|)RecHit[12]D','SiTrackerGSRecHit[12]D','SiPixelRecHit']},
+         {'MuonReco'              : ['reco::Muon(Ref|)(Vector|)']},
+         {'MuonSeed'              : ['L3MuonTrajectorySeed']},
+         {'HepMCCandidate'        : ['reco::GenParticle.*']},
+         {'L1Trigger'             : ['l1extra::L1.+Particle']},
+         {'TrackInfo'             : ['reco::TrackingRecHitInfo']},
+         {'EgammaCandidates'      : ['reco::GsfElectron.*','reco::Photon.*']},
+         {'HcalIsolatedTrack'     : ['reco::IsolatedPixelTrackCandidate', 'reco::EcalIsolatedParticleCandidate', 'reco::HcalIsolatedTrackCandidate']},
+         {'HcalRecHit'            : ['HFRecHit','HORecHit','ZDCRecHit','HBHERecHit']},
          {'PFRootEvent'           : ['EventColin::']},
-	 {'CaloTowers'            : ['CaloTower.*']},
+         {'CaloTowers'            : ['CaloTower.*']},
          {'GsfTrackReco'          : ['GsfTrack.*']},
          {'METReco'               : ['reco::(Calo|PF|Gen|)MET','reco::PFClusterMET']},
          {'ParticleFlowReco'      : ['reco::RecoPFClusterRefCandidateRef.*']},
@@ -96,10 +96,10 @@ def searchClassDefXml ():
     print("Searching for 'classes_def.xml' in '%s'." % os.path.join(os.environ.get('CMSSW_BASE'),'src'))
     xmlFiles = []
     for srcDir in [os.environ.get('CMSSW_BASE'),os.environ.get('CMSSW_RELEASE_BASE')]:
-      if not len(srcDir): continue
-      for xml in commands.getoutput ('cd '+os.path.join(srcDir,'src')+'; find . -name "*classes_def*.xml" -follow -print').split ('\n'):
-        if xml and (not xml in xmlFiles):
-          xmlFiles.append(xml)
+        if not len(srcDir): continue
+        for xml in commands.getoutput ('cd '+os.path.join(srcDir,'src')+'; find . -name "*classes_def*.xml" -follow -print').split ('\n'):
+            if xml and (not xml in xmlFiles):
+                xmlFiles.append(xml)
     if options.showXMLs:
         pprint.pprint (xmlFiles)
     # try and figure out the names of the packages
@@ -137,7 +137,7 @@ def searchClassDefXml ():
         simpleObjectREs = []
         if options.lostDefs:
             lostMatch = srcClassNameRE.search (filename)
-	    if lostMatch:
+            if lostMatch:
                 exceptName = lostMatch.group (1)
                 regexList = equivREs[exceptName]
                 xcount = len(regexList)-1
@@ -146,12 +146,12 @@ def searchClassDefXml ():
                     print(regexList[xcount][0])
                     sys.exit()
             else: continue
-	if options.verbose:
+        if options.verbose:
             print("filename", filename)
         try:
             filepath = os.path.join(os.environ.get('CMSSW_BASE'),'src',filename)
             if not os.path.exists(filepath):
-              filepath = os.path.join(os.environ.get('CMSSW_RELEASE_BASE'),'src',filename)
+                filepath = os.path.join(os.environ.get('CMSSW_RELEASE_BASE'),'src',filename)
             xmlObj = xml2obj (filename = filepath,
                               filtering = True,
                               nameChangeDict = ncdict)
@@ -250,21 +250,21 @@ def searchDuplicatePlugins ():
     if os.environ.get('SCRAM_ARCH').startswith('osx'): libenv = 'DYLD_FALLBACK_LIBRARY_PATH'
     biglib = '/biglib/'+os.environ.get('SCRAM_ARCH')
     for libdir in os.environ.get(libenv).split(':'):
-      if libdir.endswith(biglib): continue
-      if os.path.exists(libdir+'/.edmplugincache'): edmpluginFile = edmpluginFile + ' ' + libdir+'/.edmplugincache'
+        if libdir.endswith(biglib): continue
+        if os.path.exists(libdir+'/.edmplugincache'): edmpluginFile = edmpluginFile + ' ' + libdir+'/.edmplugincache'
     if edmpluginFile == '': edmpluginFile = os.path.join(os.environ.get('CMSSW_BASE'),'lib',os.environ.get('SCRAM_ARCH'),'.edmplugincache')
     cmd = "cat %s | awk '{print $2\" \"$1}' | sort | uniq | awk '{print $1}' | sort | uniq -c | grep '2 ' | awk '{print $2}'" % edmpluginFile
     output = commands.getoutput (cmd).split('\n')
     for line in output:
-      if line in ignoreEdmDP: continue
-      line = line.replace("*","\*")
-      cmd = "cat %s | grep ' %s ' | awk '{print $1}' | sort | uniq " % (edmpluginFile,line)
-      out1 = commands.getoutput (cmd).split('\n')
-      print(line)
-      for plugin in out1:
-        if plugin:
-            print("   **"+plugin+"**")
-      print()
+        if line in ignoreEdmDP: continue
+        line = line.replace("*","\*")
+        cmd = "cat %s | grep ' %s ' | awk '{print $1}' | sort | uniq " % (edmpluginFile,line)
+        out1 = commands.getoutput (cmd).split('\n')
+        print(line)
+        for plugin in out1:
+            if plugin:
+                print("   **"+plugin+"**")
+        print()
 
 if __name__ == "__main__":
     # setup options parser

--- a/Utilities/ReleaseScripts/scripts/storeTreeInfo.py
+++ b/Utilities/ReleaseScripts/scripts/storeTreeInfo.py
@@ -11,7 +11,7 @@ class TreeAnalyzer(object):
         self.fileSizes = {}
         self.outFileName = outFileName
         print("going to write to:",self.outFileName)
-        
+
     def analyzePath(self, dirIn) :
 
         for (path, dirs, files) in os.walk(dirIn):
@@ -19,17 +19,17 @@ class TreeAnalyzer(object):
             if 'CVS' in path: continue
             if '.glimpse_' in path: continue
             if 'Configuration/PyReleaseValidation/data/run/' in path: continue
-            
+
             for file in files:
                 if '.glimpse_index' in file: continue
-            	fileName = os.path.join(path, file)
-            	fileSize = os.path.getsize(fileName)
-            	if path in self.dirSizes.keys() :
-            	    self.dirSizes[path] += fileSize
-            	else:
-            	    self.dirSizes[path] =  fileSize
-            	if os.path.isfile(fileName):
-            	    self.fileSizes[fileName] = fileSize
+                fileName = os.path.join(path, file)
+                fileSize = os.path.getsize(fileName)
+                if path in self.dirSizes.keys() :
+                    self.dirSizes[path] += fileSize
+                else:
+                    self.dirSizes[path] =  fileSize
+                if os.path.isfile(fileName):
+                    self.fileSizes[fileName] = fileSize
 
         try:
             import json
@@ -48,7 +48,7 @@ class TreeAnalyzer(object):
             print('treeInfo info  written to ', pklFileName)
         except Exception as e:
             print("error writing pkl file:", str(e))
-        
+
     def show(self):
 
         # for p,s in self.dirSizes.items():
@@ -76,7 +76,7 @@ class TreeAnalyzer(object):
 def main():
 
     import getopt
-    
+
     try:
         opts, args = getopt.getopt(sys.argv[1:], "c:o:", ['checkDir=', 'outFile='])
 

--- a/Utilities/StaticAnalyzers/scripts/symbols.py
+++ b/Utilities/StaticAnalyzers/scripts/symbols.py
@@ -24,7 +24,7 @@ def get_symbols(fname):
     lines = subprocess.check_output(["nm", "-g", fname])
     for l in lines.splitlines():
         m = nm_line_re.match(l)
-	if not m : continue
+        if not m : continue
         symbol = m.group('symbol')
         if m.group('code') == 'U':
             requires[os.path.basename(fname)].add(symbol)
@@ -32,24 +32,24 @@ def get_symbols(fname):
             provides[symbol].add(os.path.basename(fname))
 
 def get_libraries(fname):
-	lines = subprocess.check_output(["ldd",fname])
-	for l in lines.splitlines():
-		m = ldd_line_re.match(l)
-		if not m: continue
-		library = m.group(2)
-		libraries[os.path.basename(fname)].add(os.path.basename(library.rstrip('\r\n')))
+    lines = subprocess.check_output(["ldd",fname])
+    for l in lines.splitlines():
+        m = ldd_line_re.match(l)
+        if not m: continue
+        library = m.group(2)
+        libraries[os.path.basename(fname)].add(os.path.basename(library.rstrip('\r\n')))
 
 
 paths=os.environ['LD_LIBRARY_PATH'].split(':')
 
 for p in paths:
-	for dirpath, dirnames, filenames in os.walk(p):
-	    for f in filenames:
-	        fpth=os.path.realpath(os.path.join(dirpath,f))
-    		filetype = subprocess.check_output(["file", fpth])
-    		if filetype.find("dynamically linked") >= 0 :
-	            get_symbols(fpth)
-                    get_libraries(fpth)
+    for dirpath, dirnames, filenames in os.walk(p):
+        for f in filenames:
+            fpth=os.path.realpath(os.path.join(dirpath,f))
+            filetype = subprocess.check_output(["file", fpth])
+            if filetype.find("dynamically linked") >= 0 :
+                get_symbols(fpth)
+                get_libraries(fpth)
 
 for fname, symbols in requires.items():
     deps=set()
@@ -61,35 +61,35 @@ for fname, symbols in requires.items():
     unmet = set()
     demangled = set()
     for s in symbols: 
-	if s not in provides and not symbols_re_skip.search(s) : unmet.add(s) 
+        if s not in provides and not symbols_re_skip.search(s) : unmet.add(s) 
     for u in sorted(unmet):
-	dm = subprocess.check_output(["c++filt",u])
-	demangled.add(dm.rstrip('\r\n'))
+        dm = subprocess.check_output(["c++filt",u])
+        demangled.add(dm.rstrip('\r\n'))
     if demangled :  print(fname + ': undefined : ' + ',  '.join(sorted(demangled)))
 
 import networkx as nx
 G=nx.DiGraph()
 for key,values in dependencies.items():
-	G.add_node(key)
-	for val in values: G.add_edge(key,val)
+    G.add_node(key)
+    for val in values: G.add_edge(key,val)
 
 for node in nx.nodes_iter(G):
-	s = nx.dfs_successors(G,node)
-	deps=set()
-	if s : 
-		for key,vals in s.items() : 
-			if key != node : deps.add(key)
-			for v in vals :
-				deps.add(v)
-	print(node + ': primary and secondary dependencies :' + ', '.join(sorted(deps)))
+    s = nx.dfs_successors(G,node)
+    deps=set()
+    if s : 
+        for key,vals in s.items() : 
+            if key != node : deps.add(key)
+            for v in vals :
+                deps.add(v)
+    print(node + ': primary and secondary dependencies :' + ', '.join(sorted(deps)))
 
 import pydot
 
 H=nx.DiGraph()
 for key,values in dependencies.items():
-	H.add_node(os.path.basename(key))
-	for val in values: H.add_edge(os.path.basename(key),os.path.basename(val))
+    H.add_node(os.path.basename(key))
+    for val in values: H.add_edge(os.path.basename(key),os.path.basename(val))
 for node in nx.nodes_iter(H):
-	T = nx.dfs_tree(H,node)
-	name = node + ".dot"
-	nx.write_dot(T,name)
+    T = nx.dfs_tree(H,node)
+    name = node + ".dot"
+    nx.write_dot(T,name)

--- a/Validation/Geometry/python/plot_hgcal_utils.py
+++ b/Validation/Geometry/python/plot_hgcal_utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from ROOT import TStyle, kWhite, kTRUE
 from ROOT import gROOT, gStyle
 from ROOT import kGray, kAzure, kMagenta, kOrange, kWhite
@@ -100,7 +101,7 @@ def TwikiPrintout(plotname, label, zoom):
     label = label.replace(" ", "_")
 
     zoomstring = ""
-    
+
     if zoom == "all":
         zoomstring = ""
         zoomtitle = "in all HGCal"
@@ -114,34 +115,34 @@ def TwikiPrintout(plotname, label, zoom):
         zoomtitle = "in Z- endcap of HGCal"
         zoomdir = "%s/ZMinusZoom/" % label
     else :
-        print "WRONG OPTION"
-    
+        print("WRONG OPTION")
+
 
     #Here for the hide button
     if plotname == "x_vs_z_vs_Rsum":
-        print "%%TWISTY{ mode=\"div\" showlink=\"Click to see the %s plots %s \" hidelink=\"Hide %s %s\" showimgright=\"%%ICONURLPATH{toggleopen-small}%%\" hideimgright=\"%%ICONURLPATH{toggleclose-small}%%\"}%%" % (label,zoomtitle, label, zoomtitle)
-    
+        print("%%TWISTY{ mode=\"div\" showlink=\"Click to see the %s plots %s \" hidelink=\"Hide %s %s\" showimgright=\"%%ICONURLPATH{toggleopen-small}%%\" hideimgright=\"%%ICONURLPATH{toggleclose-small}%%\"}%%" % (label,zoomtitle, label, zoomtitle))
+
     if "Rsum" in plotname and "x_vs" in plotname and not "cos" in plotname: 
-        print "| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the accumulated material budget as seen by the track, as the track travels throughout the detector.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring)
+        print("| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the accumulated material budget as seen by the track, as the track travels throughout the detector.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring))
 
     if "Rsum" in plotname and "l_vs" in plotname and not "cos" in plotname: 
-        print "| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the accumulated material budget as seen by the track, as the track travels throughout the detector.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring)
-     
+        print("| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the accumulated material budget as seen by the track, as the track travels throughout the detector.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring))
+
     if "Rsumcos" in plotname and "x_vs" in plotname: 
-        print "| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the orthogonal accumulated material budget, that is cos(theta) what the track sees.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring)
+        print("| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the orthogonal accumulated material budget, that is cos(theta) what the track sees.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring))
 
     if "Rsumcos" in plotname and "l_vs" in plotname: 
-        print "| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the orthogonal accumulated material budget, that is cos(theta) what the track sees.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring)
-     
+        print("| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the orthogonal accumulated material budget, that is cos(theta) what the track sees.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring))
+
     if "Rloc" in plotname and "x_vs" in plotname and not "cos" in plotname: 
-         print "| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the local mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the local material budget as seen by the track, as the track travels throughout the detector.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring)
+        print("| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the local mean value of the material budget in units of radiation length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the local material budget as seen by the track, as the track travels throughout the detector.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring))
 
     if "Rloc" in plotname and "l_vs" in plotname and not "cos" in plotname: 
-         print "| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the local mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the local material budget as seen by the track, as the track travels throughout the detector.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring)
+        print("| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the local mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the local material budget as seen by the track, as the track travels throughout the detector.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring))
 
     #Here again for the closing of the hide button
     if plotname == "l_vs_z_vs_Rloc":
-        print "%ENDTWISTY%"
+        print("%ENDTWISTY%")
 
     """ 
     I won't put the local cos plots for now, only the sum cos above
@@ -151,7 +152,7 @@ def TwikiPrintout(plotname, label, zoom):
     if "Rloccos" in plotname and "l_vs" in plotname: 
          print "| <img alt=\"HGCal_%s%s%s.png\" height=\"300\" width=\"550\" src=\"http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.png\" /> | The plot on the left shows the 2D profile histogram for *%s* %s that displays the local mean value of the material budget in units of interaction length in each R-z cell. R-z cell is 1 cm x 1 mm. The plot depicts the orthogonal accumulated material budget, that is cos(theta) what the track sees.[[http://apsallid.web.cern.ch/apsallid/HGCalMaterial/%sHGCal_%s%s%s.pdf][Click to enlarge plot]] |" % (plotname,label,zoomstring,zoomdir,plotname,label,zoomstring, label, zoomtitle,zoomdir,plotname,label,zoomstring)
     """
- 
+
 def acustompalette(): 
     NRGBs = 7
     NCont = 100

--- a/Validation/Performance/python/cmssw_exportdb_xml.py
+++ b/Validation/Performance/python/cmssw_exportdb_xml.py
@@ -3,322 +3,322 @@ from xml.dom import minidom
 import types, os
 
 def createNode(xml_doc, node_name, values = {}, parent = None):
-	if (parent == None):
-		parent = xml_doc
-	#create node
-	node = xml_doc.createElement(node_name)
-	# assign the values
-	for (key, value) in values.items():
-		node.setAttribute(key, str(value))
-	parent.appendChild(node)
+    if (parent == None):
+        parent = xml_doc
+    #create node
+    node = xml_doc.createElement(node_name)
+    # assign the values
+    for (key, value) in values.items():
+        node.setAttribute(key, str(value))
+    parent.appendChild(node)
 
-	return node
+    return node
 
 
 def initXML(xmldoc):
-	""" opens existing or creates a new XML file 
-		
-	  ---- one of the erliest functions - quite nasty looking :)"""	
-	
-	try:
-		node_xml = xmldoc.getElementsByTagName("xml")[0]
-	except IndexError:
-		#doc = minidom.Document()
-		node_xml =  createNode(xmldoc, "xml") 
+    """ opens existing or creates a new XML file 
 
-	return node_xml
+      ---- one of the erliest functions - quite nasty looking :)"""	
+
+    try:
+        node_xml = xmldoc.getElementsByTagName("xml")[0]
+    except IndexError:
+        #doc = minidom.Document()
+        node_xml =  createNode(xmldoc, "xml") 
+
+    return node_xml
 
 def xml_delete_children(nodes, child_name): 
-	for x in nodes.getElementsByTagName(child_name):
-		nodes.removeChild(x) 
+    for x in nodes.getElementsByTagName(child_name):
+        nodes.removeChild(x) 
 
 
 def xml_export_ModuleTimeRecord(data_dict, curr_stat_node, xml_doc):
-	#print "Dict: "+str(data_dict)
-	# create a module tag to be used to put the data into
-	module_node =createNode(xml_doc, "Module", values = data_dict, parent = curr_stat_node)
+    #print "Dict: "+str(data_dict)
+    # create a module tag to be used to put the data into
+    module_node =createNode(xml_doc, "Module", values = data_dict, parent = curr_stat_node)
 
-	# clean it up if there are old stats of ModuleTime, now there shouldn't be any anymore!
-	#xml_delete_children(module_node, "ModuleTime") 
+    # clean it up if there are old stats of ModuleTime, now there shouldn't be any anymore!
+    #xml_delete_children(module_node, "ModuleTime") 
 
-	# we create a new XML element having the statistics data
-	moduletime_stat =createNode(xml_doc, "ModuleTime", values = data_dict["stats"], parent = module_node)
+    # we create a new XML element having the statistics data
+    moduletime_stat =createNode(xml_doc, "ModuleTime", values = data_dict["stats"], parent = module_node)
 
-	module_node.appendChild(moduletime_stat)
+    module_node.appendChild(moduletime_stat)
 
 def xml_export_EventTimeRecord(evt_time_data, curr_stat_node, xml_doc):
-	#print "a"+str(evt_time_data)
-	(evt_num, evt_time) = evt_time_data
+    #print "a"+str(evt_time_data)
+    (evt_num, evt_time) = evt_time_data
 
-	event_node =createNode(xml_doc, "EventTime", values = {"evt_num": evt_num, "time": evt_time}, parent = curr_stat_node)
+    event_node =createNode(xml_doc, "EventTime", values = {"evt_num": evt_num, "time": evt_time}, parent = curr_stat_node)
 
 def xml_export_EventRssRecord(evt_time_data, curr_stat_node, xml_doc):
-	#print "a"+str(evt_time_data)
-	(evt_num, evt_time) = evt_time_data
-	event_node =createNode(xml_doc, "EventRSS", values = {"evt_num": evt_num, "time": evt_time}, parent = curr_stat_node)
+    #print "a"+str(evt_time_data)
+    (evt_num, evt_time) = evt_time_data
+    event_node =createNode(xml_doc, "EventRSS", values = {"evt_num": evt_num, "time": evt_time}, parent = curr_stat_node)
 
 def xml_export_EventVsizeRecord(evt_time_data, curr_stat_node, xml_doc):
-	#print "a"+str(evt_time_data)
-	(evt_num, evt_time) = evt_time_data
-	event_node =createNode(xml_doc, "EventVSIZE", values = {"evt_num": evt_num, "time": evt_time}, parent = curr_stat_node)
+    #print "a"+str(evt_time_data)
+    (evt_num, evt_time) = evt_time_data
+    event_node =createNode(xml_doc, "EventVSIZE", values = {"evt_num": evt_num, "time": evt_time}, parent = curr_stat_node)
 
 def xml_export_EdmRecord(data, curr_stat_node, xml_doc):
-	event_node =createNode(xml_doc, "EdmSize", values = data, parent = curr_stat_node)
+    event_node =createNode(xml_doc, "EdmSize", values = data, parent = curr_stat_node)
 
 def xml_export_IgSummary(data, curr_stat_node, xml_doc):
-	event_node =createNode(xml_doc, "IgSummary", values = data, parent = curr_stat_node)
+    event_node =createNode(xml_doc, "IgSummary", values = data, parent = curr_stat_node)
 
 def xml_export_Memcheck(data, curr_stat_node, xml_doc):
-	event_node =createNode(xml_doc, "Memcheck", values = data, parent = curr_stat_node)	
+    event_node =createNode(xml_doc, "Memcheck", values = data, parent = curr_stat_node)	
 
 
 def xml_export_SequenceRecord(data, curr_seq_node, xml_doc):
-	seq_node =createNode(xml_doc, "Sequence", values = data, parent = curr_seq_node)
+    seq_node =createNode(xml_doc, "Sequence", values = data, parent = curr_seq_node)
 
 def xml_init_Sequences(xml_doc, release):
-	#TODO: this was copied from init_XML - it should not be like that - refactor
-	""" opens existing or creates a new XML file 
-		returns the (existing or created) unique element for statiscs"""	
-	try:
-		node_xml = xml_doc.getElementsByTagName("xml")[0]
-	except IndexError:
-		#doc = minidom.Document()
-		node_xml =  createNode(xml_doc, "xml") 
-	
-	nodes =node_xml.getElementsByTagName("Sequences")
+    #TODO: this was copied from init_XML - it should not be like that - refactor
+    """ opens existing or creates a new XML file 
+            returns the (existing or created) unique element for statiscs"""	
+    try:
+        node_xml = xml_doc.getElementsByTagName("xml")[0]
+    except IndexError:
+        #doc = minidom.Document()
+        node_xml =  createNode(xml_doc, "xml") 
 
-	currentNode = [node for node in nodes 		
-		if (release ==node.attributes["release"].value)]
-	#TODO: end of copied
+    nodes =node_xml.getElementsByTagName("Sequences")
 
-	if (currentNode):
-		currentNode = currentNode[0]
-		#TODO: this part looks nasty
-	else:
-		values={"release": release}
-		# we create a new XML element having all the statistics data for our candle, step, release
-		currentNode = createNode(node_name= "Sequences", xml_doc=xml_doc, parent=node_xml, 
-			values=values)
-		node_xml.appendChild(currentNode)
-	return currentNode
+    currentNode = [node for node in nodes 		
+            if (release ==node.attributes["release"].value)]
+    #TODO: end of copied
+
+    if (currentNode):
+        currentNode = currentNode[0]
+        #TODO: this part looks nasty
+    else:
+        values={"release": release}
+        # we create a new XML element having all the statistics data for our candle, step, release
+        currentNode = createNode(node_name= "Sequences", xml_doc=xml_doc, parent=node_xml, 
+                values=values)
+        node_xml.appendChild(currentNode)
+    return currentNode
 
 def _getXMLNode(xml_doc):
-	""" opens existing or creates a new XML object """
-	try:
-		node_xml = xml_doc.getElementsByTagName("xml")[0]
-	except IndexError:
-		#doc = minidom.Document()
-		node_xml =  createNode(xml_doc, "xml") 
-	return node_xml
-	
+    """ opens existing or creates a new XML object """
+    try:
+        node_xml = xml_doc.getElementsByTagName("xml")[0]
+    except IndexError:
+        #doc = minidom.Document()
+        node_xml =  createNode(xml_doc, "xml") 
+    return node_xml
+
 
 
 
 def xml_export_Sequences(xml_doc, sequences, release):
-	 currentNode = xml_init_Sequences(xml_doc, release)
-	 xml_delete_children(currentNode, "Sequence") 
+    currentNode = xml_init_Sequences(xml_doc, release)
+    xml_delete_children(currentNode, "Sequence") 
 
-	 if (sequences):
-		for seq in sequences:
-			xml_export_SequenceRecord(data=seq, curr_seq_node=currentNode, xml_doc=xml_doc)
+    if (sequences):
+        for seq in sequences:
+            xml_export_SequenceRecord(data=seq, curr_seq_node=currentNode, xml_doc=xml_doc)
 
 
 def export_xml(release, jobID, timelog_result, xml_doc, metadata = None, edmSize_result =None, parentNode = None):
-	""" jobID is a dictionary now ! """
+    """ jobID is a dictionary now ! """
 
-	if not parentNode:
-		#get the root XML node
-		parentNode = _getXMLNode(xml_doc)
+    if not parentNode:
+        #get the root XML node
+        parentNode = _getXMLNode(xml_doc)
 
-	#create jobStats node
-	values=jobID
-	values.update({"release": release})
-	if (metadata):
-		values.update(metadata)
+    #create jobStats node
+    values=jobID
+    values.update({"release": release})
+    if (metadata):
+        values.update(metadata)
 
-	# we create a new XML element having all the statistics data for our candle, step, release
-	jobStatsNode = createNode(node_name= "jobStats", xml_doc=xml_doc, parent=parentNode, 
-		values=values)
+    # we create a new XML element having all the statistics data for our candle, step, release
+    jobStatsNode = createNode(node_name= "jobStats", xml_doc=xml_doc, parent=parentNode, 
+            values=values)
 
-	#TODO: load current module data or delete
+    #TODO: load current module data or delete
 
- 	(mod_timelog_result, evt_timelog_result, rss_result, vsize_result) = timelog_result
+    (mod_timelog_result, evt_timelog_result, rss_result, vsize_result) = timelog_result
 
-	# modules data
-	for (mod_name, mod_time_result) in mod_timelog_result.items():
-		xml_export_ModuleTimeRecord(mod_time_result, jobStatsNode, xml_doc)
+    # modules data
+    for (mod_name, mod_time_result) in mod_timelog_result.items():
+        xml_export_ModuleTimeRecord(mod_time_result, jobStatsNode, xml_doc)
 
-	""" #TODO: actualy we're not supposed to have any of the old statistics
+    """ #TODO: actualy we're not supposed to have any of the old statistics
 	# clean it up if there are old stats of EventTime,RSS,VSIZE
 	xml_delete_children(jobStatsNode, "EventTime") 
 	xml_delete_children(jobStatsNode, "EventRSS") 
 	xml_delete_children(jobStatsNode, "EventVSIZE") 
 	xml_delete_children(jobStatsNode, "EdmSize") """
 
-	#events data - so far only total time per event
-	if (evt_timelog_result):
-		for evt_time_item in evt_timelog_result:
-			xml_export_EventTimeRecord(evt_time_item, jobStatsNode, xml_doc)
+    #events data - so far only total time per event
+    if (evt_timelog_result):
+        for evt_time_item in evt_timelog_result:
+            xml_export_EventTimeRecord(evt_time_item, jobStatsNode, xml_doc)
 
-	# rss
-	if (rss_result):
-		for evt_time_item in rss_result:
-			xml_export_EventRssRecord(evt_time_item, jobStatsNode, xml_doc)
+    # rss
+    if (rss_result):
+        for evt_time_item in rss_result:
+            xml_export_EventRssRecord(evt_time_item, jobStatsNode, xml_doc)
 
-	# vsize
-	if (vsize_result):
-		for evt_time_item in vsize_result:
-			xml_export_EventVsizeRecord(evt_time_item, jobStatsNode, xml_doc)
-	# edmSize
-	if (edmSize_result):
-		for edmItem in edmSize_result:
-			xml_export_EdmRecord(edmItem, jobStatsNode, xml_doc)		
+    # vsize
+    if (vsize_result):
+        for evt_time_item in vsize_result:
+            xml_export_EventVsizeRecord(evt_time_item, jobStatsNode, xml_doc)
+    # edmSize
+    if (edmSize_result):
+        for edmItem in edmSize_result:
+            xml_export_EdmRecord(edmItem, jobStatsNode, xml_doc)		
 
 def export_xml_ig(release, jobID, igprof_result, xml_doc, metadata = None, parentNode = None):
-	""" jobID is a dictionary now ! """
+    """ jobID is a dictionary now ! """
 
-	if not parentNode:
-		#get the root XML node
-		parentNode = _getXMLNode(xml_doc)
+    if not parentNode:
+        #get the root XML node
+        parentNode = _getXMLNode(xml_doc)
 
-	#create jobStats node
-	values=jobID
-	values.update({"release": release})
-	if (metadata):
-		values.update(metadata)
+    #create jobStats node
+    values=jobID
+    values.update({"release": release})
+    if (metadata):
+        values.update(metadata)
 
-	# we create a new XML element having all the statistics data for our candle, step, release
-	jobStatsNode = createNode(node_name= "jobStats", xml_doc=xml_doc, parent=parentNode, 
-		values=values)
+    # we create a new XML element having all the statistics data for our candle, step, release
+    jobStatsNode = createNode(node_name= "jobStats", xml_doc=xml_doc, parent=parentNode, 
+            values=values)
 
-	for igsumm in igprof_result:
-		xml_export_IgSummary(igsumm, jobStatsNode, xml_doc)		
+    for igsumm in igprof_result:
+        xml_export_IgSummary(igsumm, jobStatsNode, xml_doc)		
 
 def export_xml_memcheck(release, jobID, memcheck_errors, xml_doc, metadata = None, parentNode = None):
-	if not parentNode:
-		parentNode = _getXMLNode(xml_doc)
+    if not parentNode:
+        parentNode = _getXMLNode(xml_doc)
 
-	values=jobID
-	values.update({"release": release})
-	if (metadata):
-		values.update(metadata)
+    values=jobID
+    values.update({"release": release})
+    if (metadata):
+        values.update(metadata)
 
-	# we create a new XML element having all the statistics data for our candle, step, release
-	jobStatsNode = createNode(node_name= "jobStats", xml_doc=xml_doc, parent=parentNode, 
-		values=values)
+    # we create a new XML element having all the statistics data for our candle, step, release
+    jobStatsNode = createNode(node_name= "jobStats", xml_doc=xml_doc, parent=parentNode, 
+            values=values)
 
-	xml_export_Memcheck(memcheck_errors, jobStatsNode, xml_doc)		
+    xml_export_Memcheck(memcheck_errors, jobStatsNode, xml_doc)		
 
 def exportRunInfo(xml_doc, run_info, release = None, print_out = False):
-	node_xml = _getXMLNode(xml_doc)
-	#get the simple string values
-	str_values = run_info["General"]
-	
-	#if we have the forced release name (e.g. icludes some special tags for testing but not official release) 
-	# so TODO: probably the test_release_based_on string would be the same so we still save the (original) test release based string
+    node_xml = _getXMLNode(xml_doc)
+    #get the simple string values
+    str_values = run_info["General"]
 
-	if release:
-		str_values["release"] = release
-	else:
-		str_values["release"] = str_values["test_release_based_on"]
+    #if we have the forced release name (e.g. icludes some special tags for testing but not official release) 
+    # so TODO: probably the test_release_based_on string would be the same so we still save the (original) test release based string
 
-	runInfoNode = createNode(node_name= "RunInfo", xml_doc=xml_doc, parent=node_xml, 
-			values=str_values)
-	#create nodes for TestResults:
-	for (testName, result) in run_info["TestResults"].items():
-		#either we have one node or multiple ones (if list)
-		if isinstance(result, list):
-			for result_item in result:
-				result_item.update({"testname": testName})
+    if release:
+        str_values["release"] = release
+    else:
+        str_values["release"] = str_values["test_release_based_on"]
 
-				#We have JOBS so FAR only for TimeSize which we represent as a list
-				jobs = []
-				#we don't want jobs to be dumped as string
-				if "jobs" in result_item:
-					jobs = result_item["jobs"]
-					del result_item["jobs"]
+    runInfoNode = createNode(node_name= "RunInfo", xml_doc=xml_doc, parent=node_xml, 
+                    values=str_values)
+    #create nodes for TestResults:
+    for (testName, result) in run_info["TestResults"].items():
+        #either we have one node or multiple ones (if list)
+        if isinstance(result, list):
+            for result_item in result:
+                result_item.update({"testname": testName})
 
-				testNode = createNode(node_name="testResult", xml_doc=xml_doc, parent=runInfoNode, values=result_item) 
+                #We have JOBS so FAR only for TimeSize which we represent as a list
+                jobs = []
+                #we don't want jobs to be dumped as string
+                if "jobs" in result_item:
+                    jobs = result_item["jobs"]
+                    del result_item["jobs"]
+
+                testNode = createNode(node_name="testResult", xml_doc=xml_doc, parent=runInfoNode, values=result_item) 
 
 
-				for job in jobs:
-					 #print job
-					 if testName == "TimeSize":
-						 export_xml(xml_doc = xml_doc, parentNode = testNode, **job)
-					 elif testName == "IgProf_Mem":
-						 export_xml_ig(xml_doc = xml_doc, parentNode = testNode, **job)
-					 elif testName == "IgProf_Perf":
-						 export_xml_ig(xml_doc = xml_doc, parentNode = testNode, **job)
-					 elif testName == "Memcheck":
-						 export_xml_memcheck(xml_doc = xml_doc, parentNode = testNode, **job)
-		else:
-			result.update({"testname": testName})
-			createNode(node_name="testResult", xml_doc=xml_doc, parent=runInfoNode, values=result)
+                for job in jobs:
+                    #print job
+                    if testName == "TimeSize":
+                        export_xml(xml_doc = xml_doc, parentNode = testNode, **job)
+                    elif testName == "IgProf_Mem":
+                        export_xml_ig(xml_doc = xml_doc, parentNode = testNode, **job)
+                    elif testName == "IgProf_Perf":
+                        export_xml_ig(xml_doc = xml_doc, parentNode = testNode, **job)
+                    elif testName == "Memcheck":
+                        export_xml_memcheck(xml_doc = xml_doc, parentNode = testNode, **job)
+        else:
+            result.update({"testname": testName})
+            createNode(node_name="testResult", xml_doc=xml_doc, parent=runInfoNode, values=result)
 
-	#DO we have some unrecognized JOBS?
-	if len(run_info['unrecognized_jobs']):
-		unrecognizedJobsNode = createNode(node_name="Unrecognized_JOBS", xml_doc=xml_doc, parent=runInfoNode, values={}) 
+    #DO we have some unrecognized JOBS?
+    if len(run_info['unrecognized_jobs']):
+        unrecognizedJobsNode = createNode(node_name="Unrecognized_JOBS", xml_doc=xml_doc, parent=runInfoNode, values={}) 
 
-		for job in run_info['unrecognized_jobs']:
-			 #print job
-			 testName = job["metadata"]["testname"]
-			 if testName == "TimeSize":
-				 export_xml(xml_doc = xml_doc, parentNode = unrecognizedJobsNode, **job)
-			 elif testName == "IgProf_Mem":
-				 export_xml_ig(xml_doc = xml_doc, parentNode = unrecognizedJobsNode, **job)		
-			 elif testName == "IgProf_Perf":
-				 export_xml_ig(xml_doc = xml_doc, parentNode = unrecognizedJobsNode, **job)
-			 elif testName == "Memcheck":
-				 export_xml_memcheck(xml_doc = xml_doc, parentNode = unrecognizedJobsNode, **job)
+        for job in run_info['unrecognized_jobs']:
+            #print job
+            testName = job["metadata"]["testname"]
+            if testName == "TimeSize":
+                export_xml(xml_doc = xml_doc, parentNode = unrecognizedJobsNode, **job)
+            elif testName == "IgProf_Mem":
+                export_xml_ig(xml_doc = xml_doc, parentNode = unrecognizedJobsNode, **job)		
+            elif testName == "IgProf_Perf":
+                export_xml_ig(xml_doc = xml_doc, parentNode = unrecognizedJobsNode, **job)
+            elif testName == "Memcheck":
+                export_xml_memcheck(xml_doc = xml_doc, parentNode = unrecognizedJobsNode, **job)
 
-		
-	#cmsSciMark
-	cmsSciMarkNode = createNode(node_name="cmsSciMarks", xml_doc=xml_doc, parent=runInfoNode, values = {})
-	for csiMark in run_info["cmsSciMark"]:
-		#print csiMark
-		createNode(node_name="cmsSciMark", xml_doc=xml_doc, parent=cmsSciMarkNode, values=csiMark)
-	if print_out:
-		print(xml_doc.toprettyxml(indent="\t"))
+
+    #cmsSciMark
+    cmsSciMarkNode = createNode(node_name="cmsSciMarks", xml_doc=xml_doc, parent=runInfoNode, values = {})
+    for csiMark in run_info["cmsSciMark"]:
+        #print csiMark
+        createNode(node_name="cmsSciMark", xml_doc=xml_doc, parent=cmsSciMarkNode, values=csiMark)
+    if print_out:
+        print(xml_doc.toprettyxml(indent="\t"))
 
 def exportECRules(xml_doc, rules):
-	node_xml = _getXMLNode(xml_doc)
-	runInfoNode = createNode(node_name= "EventContentRules", xml_doc=xml_doc, parent=node_xml, 
-			values=rules)
+    node_xml = _getXMLNode(xml_doc)
+    runInfoNode = createNode(node_name= "EventContentRules", xml_doc=xml_doc, parent=node_xml, 
+                    values=rules)
 
 def write_xml(xml_doc, remotedir,xmlFileName):
-	xml = xml_doc.toprettyxml(indent="  ")
+    xml = xml_doc.toprettyxml(indent="  ")
 
-	# return xml as string (if requested)
-	if (xmlFileName == ""):
-		return xml
-	#Adding a modification to make sure the file is written in /tmp/$USER_perfsuite_xml dir (to allow any used to harvest any workdir without permission issues.
-	tmp_dir="/tmp/%s_perfsuite_xml"%os.getenv("USER")
-	if not os.path.exists(tmp_dir):
-		os.system("mkdir %s"%tmp_dir)
-	xmlFileName=os.path.join(tmp_dir,xmlFileName)
-	# or save that as file
-	out = open(xmlFileName, "w")
-	#print xml locally
-	out.write(xml)
-	out.close()
-	print("Now copying %s to stage directory %s..."%(xmlFileName,remotedir))
-	
-	#FIXME: Here we could decide to archive it on CASTOR on a dedicated directory
-	if ":" in remotedir: #CAVEAT: since we report the timestamp as part of the xml filename we need to be careful..
-		(host,dir)=remotedir.split(":")
-		#change to the directory to avoid tar replicating /tmp/$USER_perfsuite_xml/ directory structure remotely:
-		copy_cmd='cd %s; tar cf - %s|ssh %s "cd %s;tar xf -"'%(tmp_dir,os.path.basename(xmlFileName),host,dir)
-	else:
-		if not os.path.exists(remotedir):
-			os.system("mkdir %s"%remotedir)
-		#tarpipe_cmd='cd %s;tar cf - %s|(cd %s;tar xf -)'%(tmp_dir,os.path.basename(xmlFileName),remotedir)
-		copy_cmd='cp -pR %s/%s %s'%(tmp_dir,os.path.basename(xmlFileName),remotedir) 
-	try:
-		print(copy_cmd)
-		os.system(copy_cmd)
-		print("Successfully copied XML report %s to stage directory %s"%(xmlFileName,remotedir))
-	except Exception as e :
-		print("Issues with copying XML report %s to stage directory %s!\n%s"%(xmlFileName,remotedir,str(e)))
-	#os.system("cd -") #just in case...
-		
-	
+    # return xml as string (if requested)
+    if (xmlFileName == ""):
+        return xml
+    #Adding a modification to make sure the file is written in /tmp/$USER_perfsuite_xml dir (to allow any used to harvest any workdir without permission issues.
+    tmp_dir="/tmp/%s_perfsuite_xml"%os.getenv("USER")
+    if not os.path.exists(tmp_dir):
+        os.system("mkdir %s"%tmp_dir)
+    xmlFileName=os.path.join(tmp_dir,xmlFileName)
+    # or save that as file
+    out = open(xmlFileName, "w")
+    #print xml locally
+    out.write(xml)
+    out.close()
+    print("Now copying %s to stage directory %s..."%(xmlFileName,remotedir))
+
+    #FIXME: Here we could decide to archive it on CASTOR on a dedicated directory
+    if ":" in remotedir: #CAVEAT: since we report the timestamp as part of the xml filename we need to be careful..
+        (host,dir)=remotedir.split(":")
+        #change to the directory to avoid tar replicating /tmp/$USER_perfsuite_xml/ directory structure remotely:
+        copy_cmd='cd %s; tar cf - %s|ssh %s "cd %s;tar xf -"'%(tmp_dir,os.path.basename(xmlFileName),host,dir)
+    else:
+        if not os.path.exists(remotedir):
+            os.system("mkdir %s"%remotedir)
+        #tarpipe_cmd='cd %s;tar cf - %s|(cd %s;tar xf -)'%(tmp_dir,os.path.basename(xmlFileName),remotedir)
+        copy_cmd='cp -pR %s/%s %s'%(tmp_dir,os.path.basename(xmlFileName),remotedir) 
+    try:
+        print(copy_cmd)
+        os.system(copy_cmd)
+        print("Successfully copied XML report %s to stage directory %s"%(xmlFileName,remotedir))
+    except Exception as e :
+        print("Issues with copying XML report %s to stage directory %s!\n%s"%(xmlFileName,remotedir,str(e)))
+    #os.system("cd -") #just in case...
+
+

--- a/Validation/Performance/python/parserPerfsuiteMetadata.py
+++ b/Validation/Performance/python/parserPerfsuiteMetadata.py
@@ -7,377 +7,377 @@ import glob
 from commands import getstatusoutput
 
 class parserPerfsuiteMetadata:
-	""" 
-		The whole parsing works as following. We split the file into 3 parts (we keep 3 variables of line lists:self.lines_general, self.lines_timesize, self.lines_other ):
+    """ 
+            The whole parsing works as following. We split the file into 3 parts (we keep 3 variables of line lists:self.lines_general, self.lines_timesize, self.lines_other ):
 
-			* General info
-		As most of the info are simple one line strings, we define some regular expressions defining and matching each of those lines. The regular expressions are associated with data which we can get from them. e.g. ^Suite started at (.+) on (.+) by user (.+)$ would match only the line defining the time suite started and on which machine. It's associated with tuple of field names for general info which will be filled in. in this way we get info = {'start_time': start-taken-from-regexp, 'host': host, 'user': user}. This is done by calling simple function _applyParsingRules which checks each lines with each if one passes another, if it does fills in the result dictionary with the result.
- 		Additionaly we get the cpu and memmory info from /proc/cpuinfo /proc/meminfo
+                    * General info
+            As most of the info are simple one line strings, we define some regular expressions defining and matching each of those lines. The regular expressions are associated with data which we can get from them. e.g. ^Suite started at (.+) on (.+) by user (.+)$ would match only the line defining the time suite started and on which machine. It's associated with tuple of field names for general info which will be filled in. in this way we get info = {'start_time': start-taken-from-regexp, 'host': host, 'user': user}. This is done by calling simple function _applyParsingRules which checks each lines with each if one passes another, if it does fills in the result dictionary with the result.
+            Additionaly we get the cpu and memmory info from /proc/cpuinfo /proc/meminfo
 
-			* TimeSize test
-	  	We use the same technique a little bit also. But at first we divide the timesize lines by job (individual run of cmssw - per candle, and pileup/not). Then for each of the jobs we apply our parsing rules, also we find the starting and ending times (i.e. We know that start timestamp is somethere after certain line containing "Written out cmsRelvalreport.py input file at:")
+                    * TimeSize test
+            We use the same technique a little bit also. But at first we divide the timesize lines by job (individual run of cmssw - per candle, and pileup/not). Then for each of the jobs we apply our parsing rules, also we find the starting and ending times (i.e. We know that start timestamp is somethere after certain line containing "Written out cmsRelvalreport.py input file at:")
 
-			* All other tests
-		We find the stating that the test is being launched (containing the test name, core and num events). Above we have the thread number, and below the starting time.
-		The ending time can be ONLY connected with the starting time by the Thread-ID. The problem is that the file names different the same test instance like <Launching "PILE UP Memcheck"> and <"Memcheck" stopped>.
-	"""
-	_LINE_SEPARATOR = "|"
-	def validateSteps(self, steps):
-		""" Simple function for error detection. TODO: we could use a list of possible steps also """
-		return not (not steps or len(steps) > self._MAX_STEPS)
+                    * All other tests
+            We find the stating that the test is being launched (containing the test name, core and num events). Above we have the thread number, and below the starting time.
+            The ending time can be ONLY connected with the starting time by the Thread-ID. The problem is that the file names different the same test instance like <Launching "PILE UP Memcheck"> and <"Memcheck" stopped>.
+    """
+    _LINE_SEPARATOR = "|"
+    def validateSteps(self, steps):
+        """ Simple function for error detection. TODO: we could use a list of possible steps also """
+        return not (not steps or len(steps) > self._MAX_STEPS)
 
-	def __init__(self, path):
-		
-		self._MAX_STEPS  = 5 # MAXIMUM NUMBER OF STEPS PER RUN (taskset relvalreport.py...)
-		self._DEBUG = False
+    def __init__(self, path):
 
-
-		self._path = path
-		
-		""" some initialisation to speedup the other functions """
-		#for cmsscimark
-		self.reCmsScimarkTest = re.compile(r"""^Composite Score:(\s*)([^\s]+)$""")
-
-		#TimeSize
-		""" the separator for beginning of timeSize / end of general statistics """
-		self._timeSizeStart = re.compile(r"""^Launching the TimeSize tests \(TimingReport, TimeReport, SimpleMemoryCheck, EdmSize\) with (\d+) events each$""")
-		""" (the first timestamp is the start of TimeSize) """
+        self._MAX_STEPS  = 5 # MAXIMUM NUMBER OF STEPS PER RUN (taskset relvalreport.py...)
+        self._DEBUG = False
 
 
-		""" the separator for end of timeSize / beginning of IgProf_Perf, IgProf_Mem,  Memcheck, Callgrind tests """
-		self._timeSizeEnd = re.compile(r"""^Stopping all cmsScimark jobs now$""")
+        self._path = path
 
-		#Other tests:
-		self._otherStart = re.compile(r"^Preparing")
+        """ some initialisation to speedup the other functions """
+        #for cmsscimark
+        self.reCmsScimarkTest = re.compile(r"""^Composite Score:(\s*)([^\s]+)$""")
 
-		""" 
+        #TimeSize
+        """ the separator for beginning of timeSize / end of general statistics """
+        self._timeSizeStart = re.compile(r"""^Launching the TimeSize tests \(TimingReport, TimeReport, SimpleMemoryCheck, EdmSize\) with (\d+) events each$""")
+        """ (the first timestamp is the start of TimeSize) """
+
+
+        """ the separator for end of timeSize / beginning of IgProf_Perf, IgProf_Mem,  Memcheck, Callgrind tests """
+        self._timeSizeEnd = re.compile(r"""^Stopping all cmsScimark jobs now$""")
+
+        #Other tests:
+        self._otherStart = re.compile(r"^Preparing")
+
+        """ 
 		----- READ THE DATA -----
 		"""
-		lines = self.readInput(path)
-		""" split the whole file  into parts """
-		#Let's not assume there are ALWAYS TimeSize tests in the runs of the Performance Suite!:
-		#Check first:  
-		#FIXME: Vidmantas did not think to this case... will need to implement protectionb against it for all the IB tests...
-		#To do as soon as possible...
-		#Maybe revisit the strategy if it can be done quickly.
-		timesize_end= [lines.index(line)  for line in lines if self._timeSizeEnd.match(line)]
-		if timesize_end:
-			timesize_end_index = timesize_end[0]
-		else:
-			timesize_end_index=0
-		timesize_start=[lines.index(line) for line in lines if self._timeSizeStart.match(line)]
-		general_stop=[lines.index(line) for line in lines if self._otherStart.match(line)]
-		if timesize_start:
-			timesize_start_index = timesize_start[0]
-			general_stop_index = timesize_start_index
-		elif general_stop:
-			timesize_start_index=timesize_end_index+1
-			general_stop_index=general_stop[0]
-		else:
-			timesize_start_index=0
-			general_stop_index=-1
+        lines = self.readInput(path)
+        """ split the whole file  into parts """
+        #Let's not assume there are ALWAYS TimeSize tests in the runs of the Performance Suite!:
+        #Check first:  
+        #FIXME: Vidmantas did not think to this case... will need to implement protectionb against it for all the IB tests...
+        #To do as soon as possible...
+        #Maybe revisit the strategy if it can be done quickly.
+        timesize_end= [lines.index(line)  for line in lines if self._timeSizeEnd.match(line)]
+        if timesize_end:
+            timesize_end_index = timesize_end[0]
+        else:
+            timesize_end_index=0
+        timesize_start=[lines.index(line) for line in lines if self._timeSizeStart.match(line)]
+        general_stop=[lines.index(line) for line in lines if self._otherStart.match(line)]
+        if timesize_start:
+            timesize_start_index = timesize_start[0]
+            general_stop_index = timesize_start_index
+        elif general_stop:
+            timesize_start_index=timesize_end_index+1
+            general_stop_index=general_stop[0]
+        else:
+            timesize_start_index=0
+            general_stop_index=-1
 
-		""" we split the structure:
+        """ we split the structure:
 			* general
 			* timesize
 			* all others [igprof etc]
 		"""
-	
-		""" we get the indexes of spliting """
-		#Not OK to use timsize_start_index for the general lines... want to be general, also to cases of no TimeSize tests...
-		#self.lines_general = lines[:timesize_start_index]
-		self.lines_general = lines[:general_stop_index]
-		self.lines_timesize = lines[timesize_start_index:timesize_end_index+1]
-		self.lines_other = lines[timesize_end_index:]		
-	
-		""" a list of missing fields """
-		self.missing_fields = []
 
-	@staticmethod
-	def isTimeStamp(line):
-		"""
-		Returns whether the string is a timestamp (if not returns None)
+        """ we get the indexes of spliting """
+        #Not OK to use timsize_start_index for the general lines... want to be general, also to cases of no TimeSize tests...
+        #self.lines_general = lines[:timesize_start_index]
+        self.lines_general = lines[:general_stop_index]
+        self.lines_timesize = lines[timesize_start_index:timesize_end_index+1]
+        self.lines_other = lines[timesize_end_index:]		
 
-		>>> parserPerfsuiteMetadata.isTimeStamp("Fri Aug 14 01:16:03 2009")
-		True
-		>>> parserPerfsuiteMetadata.isTimeStamp("Fri Augx 14 01:16:03 2009")
+        """ a list of missing fields """
+        self.missing_fields = []
 
-		"""
-		datetime_format = "%a %b %d %H:%M:%S %Y" # we use default date format
-		try:
-			time.strptime(line, datetime_format)
-			return True
-		except ValueError:
-			return None
-	
-	@staticmethod
-	def findFirstIndex_ofStartsWith(job_lines, start_of_line):
-		return [job_lines.index(line) 
-			for line in job_lines 
-			if line.startswith(start_of_line)][0]
-	
-	def findLineBefore(self, line_index, lines, test_condition):
-		""" finds a line satisfying the `test_condition` comming before the `line_index` """
-		# we're going backwards the lines list
-		for line_index in  xrange(line_index -1, -1, -1):
-			line = lines[line_index]
+    @staticmethod
+    def isTimeStamp(line):
+        """
+        Returns whether the string is a timestamp (if not returns None)
 
-			if test_condition(line):
-				return line
-		raise ValueError
+        >>> parserPerfsuiteMetadata.isTimeStamp("Fri Aug 14 01:16:03 2009")
+        True
+        >>> parserPerfsuiteMetadata.isTimeStamp("Fri Augx 14 01:16:03 2009")
 
+        """
+        datetime_format = "%a %b %d %H:%M:%S %Y" # we use default date format
+        try:
+            time.strptime(line, datetime_format)
+            return True
+        except ValueError:
+            return None
 
-	def findLineAfter(self, line_index, lines, test_condition, return_index = False):
-		""" finds a line satisfying the `test_condition` comming after the `line_index` """
-		# we're going forward the lines list
-		for line_index in xrange(line_index + 1, len(lines)):
-			line = lines[line_index]
+    @staticmethod
+    def findFirstIndex_ofStartsWith(job_lines, start_of_line):
+        return [job_lines.index(line) 
+                for line in job_lines 
+                if line.startswith(start_of_line)][0]
 
-			if test_condition(line):	
-				if return_index:
-					return line_index
-				return line
+    def findLineBefore(self, line_index, lines, test_condition):
+        """ finds a line satisfying the `test_condition` comming before the `line_index` """
+        # we're going backwards the lines list
+        for line_index in  xrange(line_index -1, -1, -1):
+            line = lines[line_index]
 
-	def firstTimeStampBefore(self, line_index, lines):
-		""" returns the first timestamp BEFORE the line with given index """
-
-		return self.findLineBefore(line_index, lines, test_condition = self.isTimeStamp)
-
-	def firstTimeStampAfter(self, line_index, lines):
-		""" returns the first timestamp AFTER the line with given index """
-
-		return self.findLineAfter(line_index, lines, test_condition = self.isTimeStamp)
-
-	def handleParsingError(self, message):
-		if self._DEBUG:
-			raise ValueError(message)
-		print(" ======== AND ERROR WHILE PARSING METADATA ====")
-		print(message)
-		print(" =============== end ========================= ")
-
-	#IgProf_Perf, IgProf_Mem,  Memcheck, Callgrind
-	#TODO: divide the input using separators
-
-	""" reads the input cmsPerfsuite.log file  """
-	def readInput(self, path, fileName = "cmsPerfSuite.log"):
-		try:
-			f = open(os.path.join(path, fileName), "r")
-			lines =  [s.strip() for s in f.readlines()]
-			f.close()
-		except IOError:
-			lines = []
-
-		#print self._lines
-		return lines
+            if test_condition(line):
+                return line
+        raise ValueError
 
 
+    def findLineAfter(self, line_index, lines, test_condition, return_index = False):
+        """ finds a line satisfying the `test_condition` comming after the `line_index` """
+        # we're going forward the lines list
+        for line_index in xrange(line_index + 1, len(lines)):
+            line = lines[line_index]
+
+            if test_condition(line):	
+                if return_index:
+                    return line_index
+                return line
+
+    def firstTimeStampBefore(self, line_index, lines):
+        """ returns the first timestamp BEFORE the line with given index """
+
+        return self.findLineBefore(line_index, lines, test_condition = self.isTimeStamp)
+
+    def firstTimeStampAfter(self, line_index, lines):
+        """ returns the first timestamp AFTER the line with given index """
+
+        return self.findLineAfter(line_index, lines, test_condition = self.isTimeStamp)
+
+    def handleParsingError(self, message):
+        if self._DEBUG:
+            raise ValueError(message)
+        print(" ======== AND ERROR WHILE PARSING METADATA ====")
+        print(message)
+        print(" =============== end ========================= ")
+
+    #IgProf_Perf, IgProf_Mem,  Memcheck, Callgrind
+    #TODO: divide the input using separators
+
+    """ reads the input cmsPerfsuite.log file  """
+    def readInput(self, path, fileName = "cmsPerfSuite.log"):
+        try:
+            f = open(os.path.join(path, fileName), "r")
+            lines =  [s.strip() for s in f.readlines()]
+            f.close()
+        except IOError:
+            lines = []
+
+        #print self._lines
+        return lines
 
 
-	def getMachineInfo(self):
-		""" Returns the cpu and memory info  """
 
-		""" cpu info """
 
-		"""
+    def getMachineInfo(self):
+        """ Returns the cpu and memory info  """
+
+        """ cpu info """
+
+        """
  		we assume that:
 		 * num_cores = max(core id+1) [it's counted from 0]
 		 * 'model name' is processor type [we will return only the first one - we assume others to be same!!??
 		 * cpu MHz - is the speed of CPU
 		"""
-		#TODO: BUT cpu MHz show not the maximum speed but current, 
-		"""
+        #TODO: BUT cpu MHz show not the maximum speed but current, 
+        """
 		for 
 			model name	: Intel(R) Core(TM)2 Duo CPU     L9400  @ 1.86GHz
 			cpu MHz		: 800.000
 			cache size	: 6144 KB
 		"""
-		cpu_result = {}
-		try:
-			f= open(os.path.join(self._path, "cpuinfo"), "r")
+        cpu_result = {}
+        try:
+            f= open(os.path.join(self._path, "cpuinfo"), "r")
 
-			#we split data into a list of tuples = [(attr_name, attr_value), ...]
-			cpu_attributes = [l.strip().split(":") for l in f.readlines()]
-			#print cpu_attributes
-			f.close()
-			cpu_result = {
-				"num_cores": max ([int(attr[1].strip())+1 for attr in cpu_attributes if attr[0].strip() == "processor"]), #Bug... Vidmantas used "core id"
-				"cpu_speed_MHZ": max ([attr[1].strip() for attr in cpu_attributes if attr[0].strip() == "cpu MHz"]),
-				"cpu_cache_size": [attr[1].strip() for attr in cpu_attributes if attr[0].strip() == "cache size"][0],
-				"cpu_model_name": [attr[1].strip() for attr in cpu_attributes if attr[0].strip() == "model name"][0]
-			}
-		except IOError as e:
-			print(e)
-
-		
-		
+            #we split data into a list of tuples = [(attr_name, attr_value), ...]
+            cpu_attributes = [l.strip().split(":") for l in f.readlines()]
+            #print cpu_attributes
+            f.close()
+            cpu_result = {
+                    "num_cores": max ([int(attr[1].strip())+1 for attr in cpu_attributes if attr[0].strip() == "processor"]), #Bug... Vidmantas used "core id"
+                    "cpu_speed_MHZ": max ([attr[1].strip() for attr in cpu_attributes if attr[0].strip() == "cpu MHz"]),
+                    "cpu_cache_size": [attr[1].strip() for attr in cpu_attributes if attr[0].strip() == "cache size"][0],
+                    "cpu_model_name": [attr[1].strip() for attr in cpu_attributes if attr[0].strip() == "model name"][0]
+            }
+        except IOError as e:
+            print(e)
 
 
-		""" memory info """
-		mem_result = {}
-
-		try:
-			f= open(os.path.join(self._path, "meminfo"), "r")
-
-			#we split data into a list of tuples = [(attr_name, attr_value), ...]
-			mem_attributes = [l.strip().split(":") for l in f.readlines()]
-
-			mem_result = {
-				"memory_total_ram": [attr[1].strip() for attr in mem_attributes if attr[0].strip() == "MemTotal"][0]
-			}
-
-		except IOError as e:
-			print(e)
-	
-		cpu_result.update(mem_result)
-		return cpu_result
 
 
-	
-	def _applyParsingRules(self, parsing_rules, lines):
-		""" 
-			Applies the (provided) regular expression rules (=rule[1] for rule in parsing_rules)
-			to each line and if it matches the line,
-			puts the mached information to the dictionary as the specified keys (=rule[0]) which is later returned
-			Rule[3] contains whether the field is required to be found. If so and it isn't found the exception would be raised.
-			rules = [
-			  ( (field_name_1_to_match, field_name_2), regular expression, /optionaly: is the field required? if so "req"/ )
-			]
-		 """
-		""" we call a shared parsing helper """
-		#parsing_rules = map(parsingRulesHelper.rulesRegexpCompileFunction, parsing_rules)
-		#print parsing_rules
-		(info, missing_fields) = parsingRulesHelper.rulesParser(parsing_rules, lines, compileRules = True)
 
-		self.missing_fields.extend(missing_fields)
+        """ memory info """
+        mem_result = {}
 
-		return info
+        try:
+            f= open(os.path.join(self._path, "meminfo"), "r")
+
+            #we split data into a list of tuples = [(attr_name, attr_value), ...]
+            mem_attributes = [l.strip().split(":") for l in f.readlines()]
+
+            mem_result = {
+                    "memory_total_ram": [attr[1].strip() for attr in mem_attributes if attr[0].strip() == "MemTotal"][0]
+            }
+
+        except IOError as e:
+            print(e)
+
+        cpu_result.update(mem_result)
+        return cpu_result
 
 
-	def parseGeneralInfo(self):
-		lines = self.lines_general
-		""" we define a simple list (tuple) of rules for parsing, the first part tuple defines the parameters to be fetched from the
+
+    def _applyParsingRules(self, parsing_rules, lines):
+        """ 
+                Applies the (provided) regular expression rules (=rule[1] for rule in parsing_rules)
+                to each line and if it matches the line,
+                puts the mached information to the dictionary as the specified keys (=rule[0]) which is later returned
+                Rule[3] contains whether the field is required to be found. If so and it isn't found the exception would be raised.
+                rules = [
+                  ( (field_name_1_to_match, field_name_2), regular expression, /optionaly: is the field required? if so "req"/ )
+                ]
+         """
+        """ we call a shared parsing helper """
+        #parsing_rules = map(parsingRulesHelper.rulesRegexpCompileFunction, parsing_rules)
+        #print parsing_rules
+        (info, missing_fields) = parsingRulesHelper.rulesParser(parsing_rules, lines, compileRules = True)
+
+        self.missing_fields.extend(missing_fields)
+
+        return info
+
+
+    def parseGeneralInfo(self):
+        lines = self.lines_general
+        """ we define a simple list (tuple) of rules for parsing, the first part tuple defines the parameters to be fetched from the
 			regexp while the second one is the regexp itself """
-		#TIP: don't forget that tuple of one ends with ,
-		parsing_rules = (
-			(("", "num_cores", "run_on_cpus"), r"""^This machine \((.+)\) is assumed to have (\d+) cores, and the suite will be run on cpu \[(.+)\]$"""),
-			(("start_time", "host", "local_workdir", "user"), r"""^Performance Suite started running at (.+) on (.+) in directory (.+), run by user (.+)$""", "req"),
-			(("architecture",) ,r"""^Current Architecture is (.+)$"""),
-			(("test_release_based_on",), r"""^Test Release based on: (.+)$""", "req"),
-			(("base_release_path",) , r"""^Base Release in: (.+)$"""),
-			(("test_release_local_path",) , r"""^Your Test release in: (.+)$"""),
+        #TIP: don't forget that tuple of one ends with ,
+        parsing_rules = (
+                (("", "num_cores", "run_on_cpus"), r"""^This machine \((.+)\) is assumed to have (\d+) cores, and the suite will be run on cpu \[(.+)\]$"""),
+                (("start_time", "host", "local_workdir", "user"), r"""^Performance Suite started running at (.+) on (.+) in directory (.+), run by user (.+)$""", "req"),
+                (("architecture",) ,r"""^Current Architecture is (.+)$"""),
+                (("test_release_based_on",), r"""^Test Release based on: (.+)$""", "req"),
+                (("base_release_path",) , r"""^Base Release in: (.+)$"""),
+                (("test_release_local_path",) , r"""^Your Test release in: (.+)$"""),
 
-			(("castor_dir",) , r"""^The performance suite results tarball will be stored in CASTOR at (.+)$"""),
-			
-			(("TimeSize_events",) , r"""^(\d+) TimeSize events$"""),
-			(("IgProf_events",) , r"""^(\d+) IgProf events$"""),
-			(("CallGrind_events",) , r"""^(\d+) Callgrind events$"""),
-			(("Memcheck_events",) , r"""^(\d+) Memcheck events$"""), 
+                (("castor_dir",) , r"""^The performance suite results tarball will be stored in CASTOR at (.+)$"""),
 
-			(("candles_TimeSize",) , r"""^TimeSizeCandles \[(.*)\]$"""),
-			(("candles_TimeSizePU",) , r"""^TimeSizePUCandles \[(.*)\]$"""),
-			
-			(("candles_Memcheck",) , r"""^MemcheckCandles \[(.*)\]$"""),
-			(("candles_MemcheckPU",) , r"""^MemcheckPUCandles \[(.*)\]$"""),
+                (("TimeSize_events",) , r"""^(\d+) TimeSize events$"""),
+                (("IgProf_events",) , r"""^(\d+) IgProf events$"""),
+                (("CallGrind_events",) , r"""^(\d+) Callgrind events$"""),
+                (("Memcheck_events",) , r"""^(\d+) Memcheck events$"""), 
 
-			(("candles_Callgrind",) , r"""^CallgrindCandles \[(.*)\]$"""),
-			(("candles_CallgrindPU",) , r"""^CallgrindPUCandles \[(.*)\]$"""),
+                (("candles_TimeSize",) , r"""^TimeSizeCandles \[(.*)\]$"""),
+                (("candles_TimeSizePU",) , r"""^TimeSizePUCandles \[(.*)\]$"""),
 
-			(("candles_IgProfPU",) , r"""^IgProfPUCandles \[(.*)\]$"""),
-			(("candles_IgProf",) , r"""^IgProfCandles \[(.*)\]$"""),
+                (("candles_Memcheck",) , r"""^MemcheckCandles \[(.*)\]$"""),
+                (("candles_MemcheckPU",) , r"""^MemcheckPUCandles \[(.*)\]$"""),
 
+                (("candles_Callgrind",) , r"""^CallgrindCandles \[(.*)\]$"""),
+                (("candles_CallgrindPU",) , r"""^CallgrindPUCandles \[(.*)\]$"""),
 
-			(("cmsScimark_before",) , r"""^(\d+) cmsScimark benchmarks before starting the tests$"""),
-			(("cmsScimark_after",) , r"""^(\d+) cmsScimarkLarge benchmarks before starting the tests$"""),
-			(("cmsDriverOptions",) , r"""^Running cmsDriver.py with user defined options: --cmsdriver="(.+)"$"""),
-
-			(("HEPSPEC06_SCORE",) ,r"""^This machine's HEPSPEC06 score is: (.+)$"""),
+                (("candles_IgProfPU",) , r"""^IgProfPUCandles \[(.*)\]$"""),
+                (("candles_IgProf",) , r"""^IgProfCandles \[(.*)\]$"""),
 
 
-		)
-		""" we apply the defined parsing rules to extract the required fields of information into the dictionary (as defined in parsing rules) """
-		info = self._applyParsingRules(parsing_rules, lines)
+                (("cmsScimark_before",) , r"""^(\d+) cmsScimark benchmarks before starting the tests$"""),
+                (("cmsScimark_after",) , r"""^(\d+) cmsScimarkLarge benchmarks before starting the tests$"""),
+                (("cmsDriverOptions",) , r"""^Running cmsDriver.py with user defined options: --cmsdriver="(.+)"$"""),
+
+                (("HEPSPEC06_SCORE",) ,r"""^This machine's HEPSPEC06 score is: (.+)$"""),
 
 
-		""" postprocess the candles list """
-		candles = {}
-		for field, value in info.items():
-			if field.startswith("candles_"):
-				test = field.replace("candles_", "")
-				value = [v.strip(" '") for v in value.split(",")]
-				#if value:
-				candles[test]=value
-				del info[field]
-		#print candles
-		info["candles"] = self._LINE_SEPARATOR.join([k+":"+",".join(v) for (k, v) in candles.items()])
+        )
+        """ we apply the defined parsing rules to extract the required fields of information into the dictionary (as defined in parsing rules) """
+        info = self._applyParsingRules(parsing_rules, lines)
 
 
-		""" TAGS """
-		""" 
+        """ postprocess the candles list """
+        candles = {}
+        for field, value in info.items():
+            if field.startswith("candles_"):
+                test = field.replace("candles_", "")
+                value = [v.strip(" '") for v in value.split(",")]
+                #if value:
+                candles[test]=value
+                del info[field]
+        #print candles
+        info["candles"] = self._LINE_SEPARATOR.join([k+":"+",".join(v) for (k, v) in candles.items()])
+
+
+        """ TAGS """
+        """ 
 		--- Tag ---    --- RelTag --- -------- Package --------                        
 		HEAD           V05-03-06      IgTools/IgProf                                   
 		V01-06-05      V01-06-04      Validation/Performance                           
 		---------------------------------------
 		total packages: 2 (2 displayed)
 		"""
-		tags_start_index = -1 # set some default
-		try:
-			tags_start_index = [i for i in xrange(0, len(lines)) if lines[i].startswith("--- Tag ---")][0]
-		except:
-			pass
-		if tags_start_index > -1:
-			tags_end_index = [i for i in xrange(tags_start_index + 1, len(lines)) if lines[i].startswith("---------------------------------------")][0]
-			# print "tags start index: %s, end index: %s" % (tags_start_index, tags_end_index)
-			tags = lines[tags_start_index:tags_end_index+2]
-			# print [tag.split("  ") for tag in tags]
-			# print "\n".join(tags)
-	        else: # no tags found, make an empty list ...
-			tags = []
-		""" we join the tags with separator to store as simple string """
-		info["tags"] = self._LINE_SEPARATOR.join(tags)
-		#FILES/PATHS
-	
-
-		""" get the command line """
-		try:
-			cmd_index = self.findFirstIndex_ofStartsWith(lines, "Performance suite invoked with command line:") + 1 #that's the next line
-			info["command_line"] = 	lines[cmd_index]
-		except IndexError as e:
-			if self._DEBUG:
-				print(e)
-			info["command_line"] = 	""
-		
-		try:
-			cmd_parsed_start = self.findFirstIndex_ofStartsWith(lines, "Initial PerfSuite Arguments:") + 1
-			cmd_parsed_end = self.findFirstIndex_ofStartsWith(lines, "Running cmsDriver.py")
-			info["command_line_parsed"] = self._LINE_SEPARATOR.join(lines[cmd_parsed_start:cmd_parsed_end])
-		except IndexError as e:
-			if self._DEBUG:
-				print(e)
-			info["command_line"] = 	""
-
-		return  info
-
-	
-	def parseAllOtherTests(self):
-		#make it general, for whatever test comes...
-		test = {}
-
-		parsing_rules = (
-			(("", "candle", ), r"""^(Candle|ONLY) (.+) will be PROCESSED$""", "req"),
-			#e.g.: --conditions FrontierConditions_GlobalTag,MC_31X_V4::All --eventcontent RECOSIM
-			(("cms_driver_options", ), r"""^Using user-specified cmsDriver.py options: (.+)$"""),
-			(("", "conditions", ""), r"""^Using user-specified cmsDriver.py options: (.*)--conditions ([^\s]+)(.*)$""", "req"),
-			# for this we cannot guarrantee that it has been found, TODO: we might count the number of pileup candles and compare with arguments
-			(("",  "pileup_type", ""), r"""^Using user-specified cmsDriver.py options:(.*)--pileup=([^\s]+)(.*)$"""),
-			#not shure if event content is required
-			(("",  "event_content", ""), r"""^Using user-specified cmsDriver.py options:(.*)--eventcontent ([^\s]+)(.*)$""", "req"),
-			#TODO: after changeing the splitter to "taskset -c ..." this is no longer included into the part of correct job
-			#(("input_user_root_file", ), r"""^For these tests will use user input file (.+)$"""),
-		)
+        tags_start_index = -1 # set some default
+        try:
+            tags_start_index = [i for i in xrange(0, len(lines)) if lines[i].startswith("--- Tag ---")][0]
+        except:
+            pass
+        if tags_start_index > -1:
+            tags_end_index = [i for i in xrange(tags_start_index + 1, len(lines)) if lines[i].startswith("---------------------------------------")][0]
+            # print "tags start index: %s, end index: %s" % (tags_start_index, tags_end_index)
+            tags = lines[tags_start_index:tags_end_index+2]
+            # print [tag.split("  ") for tag in tags]
+            # print "\n".join(tags)
+        else: # no tags found, make an empty list ...
+            tags = []
+        """ we join the tags with separator to store as simple string """
+        info["tags"] = self._LINE_SEPARATOR.join(tags)
+        #FILES/PATHS
 
 
-		lines = self.lines_other
-		"""
+        """ get the command line """
+        try:
+            cmd_index = self.findFirstIndex_ofStartsWith(lines, "Performance suite invoked with command line:") + 1 #that's the next line
+            info["command_line"] = 	lines[cmd_index]
+        except IndexError as e:
+            if self._DEBUG:
+                print(e)
+            info["command_line"] = 	""
+
+        try:
+            cmd_parsed_start = self.findFirstIndex_ofStartsWith(lines, "Initial PerfSuite Arguments:") + 1
+            cmd_parsed_end = self.findFirstIndex_ofStartsWith(lines, "Running cmsDriver.py")
+            info["command_line_parsed"] = self._LINE_SEPARATOR.join(lines[cmd_parsed_start:cmd_parsed_end])
+        except IndexError as e:
+            if self._DEBUG:
+                print(e)
+            info["command_line"] = 	""
+
+        return  info
+
+
+    def parseAllOtherTests(self):
+        #make it general, for whatever test comes...
+        test = {}
+
+        parsing_rules = (
+                (("", "candle", ), r"""^(Candle|ONLY) (.+) will be PROCESSED$""", "req"),
+                #e.g.: --conditions FrontierConditions_GlobalTag,MC_31X_V4::All --eventcontent RECOSIM
+                (("cms_driver_options", ), r"""^Using user-specified cmsDriver.py options: (.+)$"""),
+                (("", "conditions", ""), r"""^Using user-specified cmsDriver.py options: (.*)--conditions ([^\s]+)(.*)$""", "req"),
+                # for this we cannot guarrantee that it has been found, TODO: we might count the number of pileup candles and compare with arguments
+                (("",  "pileup_type", ""), r"""^Using user-specified cmsDriver.py options:(.*)--pileup=([^\s]+)(.*)$"""),
+                #not shure if event content is required
+                (("",  "event_content", ""), r"""^Using user-specified cmsDriver.py options:(.*)--eventcontent ([^\s]+)(.*)$""", "req"),
+                #TODO: after changeing the splitter to "taskset -c ..." this is no longer included into the part of correct job
+                #(("input_user_root_file", ), r"""^For these tests will use user input file (.+)$"""),
+        )
+
+
+        lines = self.lines_other
+        """
 
 		for each of IgProf_Perf, IgProf_Mem,  Memcheck, Callgrind tests we have such a structure of input file:
 		* beginning ->> and start timestamp- the firstone:
@@ -392,112 +392,112 @@ class parserPerfsuiteMetadata:
 
 		* ending - the last timestamp "before is done running ...."
 		"""
-		# we take the first TimeStamp after the starting message and the first before the finishing message in 2 rounds..
-	
-		#TODO: if threads would be changed it would stop working!!!
+        # we take the first TimeStamp after the starting message and the first before the finishing message in 2 rounds..
 
-		# i.e. Memcheck, cpu, events
-		reSubmit = re.compile(r"""^Let's submit (.+) test on core (\d+)$""")
-		
-		reStart = re.compile(r"""^Launching the (PILE UP |)(.*) tests on cpu (\d+) with (\d+) events each$""")
+        #TODO: if threads would be changed it would stop working!!!
 
-		# i.e. Memcheck, thread name,id,core number
-		reEnd = re.compile(r"""^(.*) test, in thread <simpleGenReportThread\((.+), stopped -(\d+)\)> is done running on core (\d+)$""")
-		
-		reAddThread =  re.compile(r"""^Adding thread <simpleGenReportThread\((.+), started -(\d+)\)> to the list of active threads$""")
+        # i.e. Memcheck, cpu, events
+        reSubmit = re.compile(r"""^Let's submit (.+) test on core (\d+)$""")
 
-		reWaiting = re.compile(r"""^Waiting for tests to be done...$""")
+        reStart = re.compile(r"""^Launching the (PILE UP |)(.*) tests on cpu (\d+) with (\d+) events each$""")
 
-		reExitCode = re.compile(r"""Individual cmsRelvalreport.py ExitCode (\d+)""")
-		""" we search for lines being either: (it's a little pascal'ish but we need the index!) """
+        # i.e. Memcheck, thread name,id,core number
+        reEnd = re.compile(r"""^(.*) test, in thread <simpleGenReportThread\((.+), stopped -(\d+)\)> is done running on core (\d+)$""")
 
-		jobs = []
+        reAddThread =  re.compile(r"""^Adding thread <simpleGenReportThread\((.+), started -(\d+)\)> to the list of active threads$""")
 
-		#can split it into jobs ! just have to reparse it for the exit codes later....
-		for line_index in xrange(0, len(lines)):
-			line = lines[line_index]
-			if reSubmit.match(line):
-				end_index = self.findLineAfter(line_index, lines, test_condition=lambda l: reWaiting.match(l), return_index = True)
-				jobs.append(lines[line_index:end_index])
+        reWaiting = re.compile(r"""^Waiting for tests to be done...$""")
 
-		for job_lines in jobs:
-			#print job_lines
-			info = self._applyParsingRules(parsing_rules, job_lines)
-			#Fixing here the compatibility with new cmsdriver.py --conditions option
-			#(for which now we have autoconditions and FrontierConditions_GlobalTag is optional):
-			if 'auto:' in info['conditions']:
-				from Configuration.AlCa.autoCond import autoCond
-				info['conditions'] = autoCond[ info['conditions'].split(':')[1] ].split("::")[0]
-			else:
-				if 'FrontierConditions_GlobalTag' in info['conditions']:
-					info['conditions']=info['conditions'].split(",")[1]
+        reExitCode = re.compile(r"""Individual cmsRelvalreport.py ExitCode (\d+)""")
+        """ we search for lines being either: (it's a little pascal'ish but we need the index!) """
 
-			steps_start = self.findFirstIndex_ofStartsWith(job_lines, "You defined your own steps to run:")
-			steps_end = self.findFirstIndex_ofStartsWith(job_lines, "*Candle ")
-			#probably it includes steps until we found *Candle... ?
-			steps = job_lines[steps_start + 1:steps_end]
-			if not self.validateSteps(steps):
-				self.handleParsingError( "Steps were not found corrently: %s for current job: %s" % (str(steps), str(job_lines)))
-				
-				""" quite nasty - just a work around """
-				print("Trying to recover from this error in case of old cmssw")
-				
-				""" we assume that steps are between the following sentance and a TimeStamp """
-				steps_start = self.findFirstIndex_ofStartsWith(job_lines, "Steps passed to writeCommands")
-				steps_end = self.findLineAfter(steps_start, job_lines, test_condition = self.isTimeStamp, return_index = True)
-				
-				steps = job_lines[steps_start + 1:steps_end]
-				if not self.validateSteps(steps):
-					self.handleParsingError( "EVEN AFTER RECOVERY Steps were not found corrently! : %s for current job: %s" % (str(steps), str(job_lines)))
-				else:
-					print("RECOVERY SEEMS to be successful: %s" % str(steps))
+        jobs = []
 
-			info["steps"] = self._LINE_SEPARATOR.join(steps) #!!!! STEPS MIGHT CONTAIN COMMA: ","
+        #can split it into jobs ! just have to reparse it for the exit codes later....
+        for line_index in xrange(0, len(lines)):
+            line = lines[line_index]
+            if reSubmit.match(line):
+                end_index = self.findLineAfter(line_index, lines, test_condition=lambda l: reWaiting.match(l), return_index = True)
+                jobs.append(lines[line_index:end_index])
 
-			start_id_index = self.findLineAfter(0, job_lines, test_condition = reStart.match, return_index = True)
-			pileUp, testName, testCore, testEventsNum = reStart.match(job_lines[start_id_index]).groups()			
-			info["testname"] = testName
+        for job_lines in jobs:
+            #print job_lines
+            info = self._applyParsingRules(parsing_rules, job_lines)
+            #Fixing here the compatibility with new cmsdriver.py --conditions option
+            #(for which now we have autoconditions and FrontierConditions_GlobalTag is optional):
+            if 'auto:' in info['conditions']:
+                from Configuration.AlCa.autoCond import autoCond
+                info['conditions'] = autoCond[ info['conditions'].split(':')[1] ].split("::")[0]
+            else:
+                if 'FrontierConditions_GlobalTag' in info['conditions']:
+                    info['conditions']=info['conditions'].split(",")[1]
 
-			thread_id_index = self.findLineAfter(0, job_lines, test_condition = reAddThread.match, return_index = True)
-			info["start"] = self.firstTimeStampAfter(thread_id_index, job_lines)
+            steps_start = self.findFirstIndex_ofStartsWith(job_lines, "You defined your own steps to run:")
+            steps_end = self.findFirstIndex_ofStartsWith(job_lines, "*Candle ")
+            #probably it includes steps until we found *Candle... ?
+            steps = job_lines[steps_start + 1:steps_end]
+            if not self.validateSteps(steps):
+                self.handleParsingError( "Steps were not found corrently: %s for current job: %s" % (str(steps), str(job_lines)))
 
-			thread_id, thread_number = reAddThread.match(job_lines[thread_id_index]).groups()
-			info["thread_id"] = thread_id
-			
-			if testName not in test:
-				test[testName] = []
-			test[testName].append(info)
-		
-		for line_index in xrange(0, len(lines)):
-			line = lines[line_index]
+                """ quite nasty - just a work around """
+                print("Trying to recover from this error in case of old cmssw")
 
-			if reEnd.match(line):
-				testName, thread_id, thread_num, testCore = reEnd.match(line).groups()
-				time = self.firstTimeStampBefore(line_index, lines)
-				try:
-					exit_code = ""
-					#we search for the exit code
-					line_exitcode = self.findLineBefore(line_index, lines, test_condition=lambda l: reExitCode.match(l))
-					exit_code, = reExitCode.match(line_exitcode).groups()
-				except Exception as e:
-					print("Error while getting exit code (Other test): %s" + str(e))
-					
-				for key, thread in test.items():
-					for i in range(0, len(thread)):
-						if thread[i]["thread_id"] == thread_id:
-							thread[i].update({"end": time, "exit_code": exit_code})
-							break
-				
-		return test
-						
+                """ we assume that steps are between the following sentance and a TimeStamp """
+                steps_start = self.findFirstIndex_ofStartsWith(job_lines, "Steps passed to writeCommands")
+                steps_end = self.findLineAfter(steps_start, job_lines, test_condition = self.isTimeStamp, return_index = True)
 
-	def parseTimeSize(self):
-		""" parses the timeSize """
-		timesize_result = []
+                steps = job_lines[steps_start + 1:steps_end]
+                if not self.validateSteps(steps):
+                    self.handleParsingError( "EVEN AFTER RECOVERY Steps were not found corrently! : %s for current job: %s" % (str(steps), str(job_lines)))
+                else:
+                    print("RECOVERY SEEMS to be successful: %s" % str(steps))
 
-		# TODO: we will use the first timestamp after the "or these tests will use user input file..."
-		#TODO: do we have to save the name of input file somewhere?
-		"""
+            info["steps"] = self._LINE_SEPARATOR.join(steps) #!!!! STEPS MIGHT CONTAIN COMMA: ","
+
+            start_id_index = self.findLineAfter(0, job_lines, test_condition = reStart.match, return_index = True)
+            pileUp, testName, testCore, testEventsNum = reStart.match(job_lines[start_id_index]).groups()			
+            info["testname"] = testName
+
+            thread_id_index = self.findLineAfter(0, job_lines, test_condition = reAddThread.match, return_index = True)
+            info["start"] = self.firstTimeStampAfter(thread_id_index, job_lines)
+
+            thread_id, thread_number = reAddThread.match(job_lines[thread_id_index]).groups()
+            info["thread_id"] = thread_id
+
+            if testName not in test:
+                test[testName] = []
+            test[testName].append(info)
+
+        for line_index in xrange(0, len(lines)):
+            line = lines[line_index]
+
+            if reEnd.match(line):
+                testName, thread_id, thread_num, testCore = reEnd.match(line).groups()
+                time = self.firstTimeStampBefore(line_index, lines)
+                try:
+                    exit_code = ""
+                    #we search for the exit code
+                    line_exitcode = self.findLineBefore(line_index, lines, test_condition=lambda l: reExitCode.match(l))
+                    exit_code, = reExitCode.match(line_exitcode).groups()
+                except Exception as e:
+                    print("Error while getting exit code (Other test): %s" + str(e))
+
+                for key, thread in test.items():
+                    for i in range(0, len(thread)):
+                        if thread[i]["thread_id"] == thread_id:
+                            thread[i].update({"end": time, "exit_code": exit_code})
+                            break
+
+        return test
+
+
+    def parseTimeSize(self):
+        """ parses the timeSize """
+        timesize_result = []
+
+        # TODO: we will use the first timestamp after the "or these tests will use user input file..."
+        #TODO: do we have to save the name of input file somewhere?
+        """
 		the structure of input file:
 		* beginning ->> and start timestamp- the firstone:		
 			>>> [optional:For these tests will use user input file /build/RAWReference/MinBias_RAW_320_IDEAL.root]
@@ -515,280 +515,280 @@ class parserPerfsuiteMetadata:
 			Individual cmsRelvalreport.py ExitCode 0
 		* ending - the last timestamp "... ExitCode ...."
 		"""
-		#TODO: do we need the cmsDriver --conditions? I suppose it would the global per work directory = 1 perfsuite run (so samefor all candles in one work dir)
-		# TODO: which candle definition to use?
-		""" divide into separate jobs """
-		lines = self.lines_timesize
-		jobs = []
-		start = False
-		timesize_start_indicator = re.compile(r"""^taskset -c (\d+) cmsRelvalreportInput.py""")
-		for line_index in xrange(0, len(lines)):
-			line = lines[line_index]
-			# search for start of each TimeSize job (with a certain candle and step)
-			if timesize_start_indicator.match(line):
-				if start:
-					jobs.append(lines[start:line_index])
-				start = line_index
-		#add the last one
-		jobs.append(lines[start:len(lines)])
-		#print "\n".join(str(i) for i in jobs)
+        #TODO: do we need the cmsDriver --conditions? I suppose it would the global per work directory = 1 perfsuite run (so samefor all candles in one work dir)
+        # TODO: which candle definition to use?
+        """ divide into separate jobs """
+        lines = self.lines_timesize
+        jobs = []
+        start = False
+        timesize_start_indicator = re.compile(r"""^taskset -c (\d+) cmsRelvalreportInput.py""")
+        for line_index in xrange(0, len(lines)):
+            line = lines[line_index]
+            # search for start of each TimeSize job (with a certain candle and step)
+            if timesize_start_indicator.match(line):
+                if start:
+                    jobs.append(lines[start:line_index])
+                start = line_index
+        #add the last one
+        jobs.append(lines[start:len(lines)])
+        #print "\n".join(str(i) for i in jobs)
 
-		parsing_rules = (
-			(("", "candle", ), r"""^(Candle|ONLY) (.+) will be PROCESSED$""", "req"),
-			#e.g.: --conditions FrontierConditions_GlobalTag,MC_31X_V4::All --eventcontent RECOSIM
-			(("cms_driver_options", ), r"""^Using user-specified cmsDriver.py options: (.+)$"""),
-			(("", "conditions", ""), r"""^Using user-specified cmsDriver.py options: (.*)--conditions ([^\s]+)(.*)$""", "req"),
-			# for this we cannot guarrantee that it has been found, TODO: we might count the number of pileup candles and compare with arguments
-			(("",  "pileup_type", ""), r"""^Using user-specified cmsDriver.py options:(.*)--pileup=([^\s]+)(.*)$"""),
-			#not shure if event content is required
-			(("",  "event_content", ""), r"""^Using user-specified cmsDriver.py options:(.*)--eventcontent ([^\s]+)(.*)$""", "req"),
-			#TODO: after changeing the splitter to "taskset -c ..." this is no longer included into the part of correct job
-			#(("input_user_root_file", ), r"""^For these tests will use user input file (.+)$"""),
-		)
+        parsing_rules = (
+                (("", "candle", ), r"""^(Candle|ONLY) (.+) will be PROCESSED$""", "req"),
+                #e.g.: --conditions FrontierConditions_GlobalTag,MC_31X_V4::All --eventcontent RECOSIM
+                (("cms_driver_options", ), r"""^Using user-specified cmsDriver.py options: (.+)$"""),
+                (("", "conditions", ""), r"""^Using user-specified cmsDriver.py options: (.*)--conditions ([^\s]+)(.*)$""", "req"),
+                # for this we cannot guarrantee that it has been found, TODO: we might count the number of pileup candles and compare with arguments
+                (("",  "pileup_type", ""), r"""^Using user-specified cmsDriver.py options:(.*)--pileup=([^\s]+)(.*)$"""),
+                #not shure if event content is required
+                (("",  "event_content", ""), r"""^Using user-specified cmsDriver.py options:(.*)--eventcontent ([^\s]+)(.*)$""", "req"),
+                #TODO: after changeing the splitter to "taskset -c ..." this is no longer included into the part of correct job
+                #(("input_user_root_file", ), r"""^For these tests will use user input file (.+)$"""),
+        )
 
-		#parse each of the TimeSize jobs: find candles, etc and start-end times
+        #parse each of the TimeSize jobs: find candles, etc and start-end times
 
-		reExit_code = re.compile(r"""Individual ([^\s]+) ExitCode (\d+)""")
+        reExit_code = re.compile(r"""Individual ([^\s]+) ExitCode (\d+)""")
 
-		if self._DEBUG:
-			print("TimeSize (%d) jobs: %s" % (len(jobs), str(jobs)))
+        if self._DEBUG:
+            print("TimeSize (%d) jobs: %s" % (len(jobs), str(jobs)))
 
-		for job_lines in jobs:
-			""" we apply the defined parsing rules to extract the required fields of information into the dictionary (as defined in parsing rules) """
-			info = self._applyParsingRules(parsing_rules, job_lines)
-			#Fixing here the compatibility with new cmsdriver.py --conditions option (for which now we have autoconditions and FrontierConditions_GlobalTag is optional):
-			if 'auto:' in info['conditions']:
-				from Configuration.AlCa.autoCond import autoCond
-				info['conditions'] = autoCond[ info['conditions'].split(':')[1] ].split("::")[0]
-			else:
-				if 'FrontierConditions_GlobalTag' in info['conditions']:
-					info['conditions']=info['conditions'].split(",")[1]
-																
-			#DEBUG:
-			#print "CONDITIONS are: %s"%info['conditions']
-			#start time - the index after which comes the time stamp
-			""" the following is not available on one of the releases, instead
+        for job_lines in jobs:
+            """ we apply the defined parsing rules to extract the required fields of information into the dictionary (as defined in parsing rules) """
+            info = self._applyParsingRules(parsing_rules, job_lines)
+            #Fixing here the compatibility with new cmsdriver.py --conditions option (for which now we have autoconditions and FrontierConditions_GlobalTag is optional):
+            if 'auto:' in info['conditions']:
+                from Configuration.AlCa.autoCond import autoCond
+                info['conditions'] = autoCond[ info['conditions'].split(':')[1] ].split("::")[0]
+            else:
+                if 'FrontierConditions_GlobalTag' in info['conditions']:
+                    info['conditions']=info['conditions'].split(",")[1]
+
+            #DEBUG:
+            #print "CONDITIONS are: %s"%info['conditions']
+            #start time - the index after which comes the time stamp
+            """ the following is not available on one of the releases, instead
 			use the first timestamp available on our job - that's the starting time :) """ 
-			
-			#start_time_after = self.findFirstIndex_ofStartsWith(job_lines, "Written out cmsRelvalreport.py input file at:")
-			#print start_time_after
-			info["start"] = self.firstTimeStampAfter(0, job_lines)
 
-			#TODO: improve in future (in case of some changes) we could use findBefore instead which uses the regexp as parameter for searching 
-			#end time - the index before which comes the time stamp
+            #start_time_after = self.findFirstIndex_ofStartsWith(job_lines, "Written out cmsRelvalreport.py input file at:")
+            #print start_time_after
+            info["start"] = self.firstTimeStampAfter(0, job_lines)
 
-			# On older files we have - "Individual Relvalreport.py ExitCode 0" instead of "Individual cmsRelvalreport.py ExitCode"
-			end_time_before = self.findLineAfter(0, job_lines, test_condition = reExit_code.match, return_index = True)
+            #TODO: improve in future (in case of some changes) we could use findBefore instead which uses the regexp as parameter for searching 
+            #end time - the index before which comes the time stamp
 
-			# on the same line we have the exit Code - so let's get it
-			nothing, exit_code = reExit_code.match(job_lines[end_time_before]).groups()
+            # On older files we have - "Individual Relvalreport.py ExitCode 0" instead of "Individual cmsRelvalreport.py ExitCode"
+            end_time_before = self.findLineAfter(0, job_lines, test_condition = reExit_code.match, return_index = True)
 
-			info["end"] = self.firstTimeStampBefore(end_time_before, job_lines)
-			info["exit_code"] = exit_code
+            # on the same line we have the exit Code - so let's get it
+            nothing, exit_code = reExit_code.match(job_lines[end_time_before]).groups()
 
-			steps_start = self.findFirstIndex_ofStartsWith(job_lines, "You defined your own steps to run:")
-			steps_end = self.findFirstIndex_ofStartsWith(job_lines, "*Candle ")
-			#probably it includes steps until we found *Candle... ?
-			steps = job_lines[steps_start + 1:steps_end]
-			if not self.validateSteps(steps):
-				self.handleParsingError( "Steps were not found corrently: %s for current job: %s" % (str(steps), str(job_lines)))
-				
-				""" quite nasty - just a work around """
-				print("Trying to recover from this error in case of old cmssw")
-				
-				""" we assume that steps are between the following sentance and a TimeStamp """
-				steps_start = self.findFirstIndex_ofStartsWith(job_lines, "Steps passed to writeCommands")
-				steps_end = self.findLineAfter(steps_start, job_lines, test_condition = self.isTimeStamp, return_index = True)
-				
-				steps = job_lines[steps_start + 1:steps_end]
-				if not self.validateSteps(steps):
-					self.handleParsingError( "EVEN AFTER RECOVERY Steps were not found corrently! : %s for current job: %s" % (str(steps), str(job_lines)))
-				else:
-					print("RECOVERY SEEMS to be successful: %s" % str(steps))
+            info["end"] = self.firstTimeStampBefore(end_time_before, job_lines)
+            info["exit_code"] = exit_code
 
-			info["steps"] = self._LINE_SEPARATOR.join(steps) #!!!! STEPS MIGHT CONTAIN COMMA: ","
-			
+            steps_start = self.findFirstIndex_ofStartsWith(job_lines, "You defined your own steps to run:")
+            steps_end = self.findFirstIndex_ofStartsWith(job_lines, "*Candle ")
+            #probably it includes steps until we found *Candle... ?
+            steps = job_lines[steps_start + 1:steps_end]
+            if not self.validateSteps(steps):
+                self.handleParsingError( "Steps were not found corrently: %s for current job: %s" % (str(steps), str(job_lines)))
 
-			timesize_result.append(info)
-		return {"TimeSize": timesize_result}
-	#TODO:
-	
+                """ quite nasty - just a work around """
+                print("Trying to recover from this error in case of old cmssw")
+
+                """ we assume that steps are between the following sentance and a TimeStamp """
+                steps_start = self.findFirstIndex_ofStartsWith(job_lines, "Steps passed to writeCommands")
+                steps_end = self.findLineAfter(steps_start, job_lines, test_condition = self.isTimeStamp, return_index = True)
+
+                steps = job_lines[steps_start + 1:steps_end]
+                if not self.validateSteps(steps):
+                    self.handleParsingError( "EVEN AFTER RECOVERY Steps were not found corrently! : %s for current job: %s" % (str(steps), str(job_lines)))
+                else:
+                    print("RECOVERY SEEMS to be successful: %s" % str(steps))
+
+            info["steps"] = self._LINE_SEPARATOR.join(steps) #!!!! STEPS MIGHT CONTAIN COMMA: ","
 
 
-	def readCmsScimarkTest(self, testName, testType, core):
-		lines  = self.readInput(self._path, fileName = testName + ".log")
-		scores = [{"score": self.reCmsScimarkTest.match(line).groups()[1], "type": testType, "core": core}
-				for line in lines 
-				if self.reCmsScimarkTest.match(line)]
-		#add the number of messurment
-		i = 0
-		for score in scores:
-			i += 1
-			score.update({"messurement_number": i})
-		return scores
-		
-	def readCmsScimark(self, main_cores = [1]):
-		main_core = main_cores[0]
-		#TODO: WE DO NOT ALWAYS REALLY KNOW THE MAIN CORE NUMBER! but we don't care too much
-		#we parse each of the SciMark files and the Composite scores
-		csimark = []
-		csimark.extend(self.readCmsScimarkTest(testName = "cmsScimark2", testType = "mainCore", core = main_core))
-		csimark.extend(self.readCmsScimarkTest(testName = "cmsScimark2_large", testType = "mainCore_Large", core = main_core))
+            timesize_result.append(info)
+        return {"TimeSize": timesize_result}
+    #TODO:
 
 
-		#we not always know the number of cores available so we will just search the directory to find out core numbers
-		reIsCsiMark_notusedcore = re.compile("^cmsScimark_(\d+).log$")
-		scimark_files = [reIsCsiMark_notusedcore.match(f).groups()[0]
-				for f in os.listdir(self._path)
-				 if reIsCsiMark_notusedcore.match(f) 
-					and os.path.isfile(os.path.join(self._path, f)) ]
 
-		for core_number in scimark_files:
-			try:
-				csimark.extend(self.readCmsScimarkTest(testName = "cmsScimark_%s" % str(core_number), testType = "NotUsedCore_%s" %str(core_number), core = core_number))
-			except IOError as e:
-				if self._DEBUG:
-					print(e)
-		return csimark
-		#print csimark
+    def readCmsScimarkTest(self, testName, testType, core):
+        lines  = self.readInput(self._path, fileName = testName + ".log")
+        scores = [{"score": self.reCmsScimarkTest.match(line).groups()[1], "type": testType, "core": core}
+                        for line in lines 
+                        if self.reCmsScimarkTest.match(line)]
+        #add the number of messurment
+        i = 0
+        for score in scores:
+            i += 1
+            score.update({"messurement_number": i})
+        return scores
 
-	def parseTheCompletion(self):
-		"""
-		 checks if the suite has successfully finished  
-			and if the tarball was successfully archived and uploaded to the castor """
-
-		parsing_rules = (
-			(("finishing_time", "", ""), r"""^Performance Suite finished running at (.+) on (.+) in directory (.+)$"""),
-			(("castor_md5",) , r"""^The md5 checksum of the tarball: (.+)$"""),	
-			(("successfully_archived_tarball", ), r"""^Successfully archived the tarball (.+) in CASTOR!$"""),
-			#TODO: WE MUST HAVE THE CASTOR URL, but for some of files it's not included [probably crashed]
-			(("castor_file_url",), r"""^The tarball can be found: (.+)$"""),			
-			(("castor_logfile_url",), r"""^The logfile can be found: (.+)$"""),
-		)
-
-		
-		""" we apply the defined parsing rules to extract the required fields of information into the dictionary (as defined in parsing rules) """
-		info = self._applyParsingRules(parsing_rules, self.lines_other)
-
-		""" did we detect any errors in log files ? """
-		info["no_errors_detected"] = [line for line in self.lines_other if line == "There were no errors detected in any of the log files!"] and "1" or "0"
-		if not info["successfully_archived_tarball"]:
-			info["castor_file_url"] = ""
-
-		if not info["castor_file_url"]:
-			#TODO: get the castor file url or abort
-			self.handleParsingError( "Castor tarball URL not found. Trying to get from environment")
-			lmdb_castor_url_is_valid = lambda url: url.startswith("/castor/")
-
-			url = ""
-			try:
-				#print "HERE!"
-				url=self.get_tarball_fromlog()
-				print("Extracted castor tarball full path by re-parsing cmsPerfSuite.log: %s"%url)
-				
-			except:
-				if "PERFDB_CASTOR_FILE_URL" in os.environ:
-					url = os.environ["PERFDB_CASTOR_FILE_URL"]
-					
-				else: #FIXME: add the possibility to get it directly from the cmsPerfSuite.log file (make sure it is dumped there before doing the tarball itself...)
-					print("Failed to get the tarball location from environment variable PERFDB_CASTOR_FILE_URL") 
-					self.handleParsingError( "Castor tarball URL not found. Provide interactively")
-
-			while True:
-				
-				if lmdb_castor_url_is_valid(url):
-					info["castor_file_url"] = url
-					break
-				print("Please enter a valid CASTOR url: has to start with /castor/ and should point to the tarball")
-				if os.isatty(0): url = sys.stdin.readline()
-				else: raise IOError("stdin is closed.")
+    def readCmsScimark(self, main_cores = [1]):
+        main_core = main_cores[0]
+        #TODO: WE DO NOT ALWAYS REALLY KNOW THE MAIN CORE NUMBER! but we don't care too much
+        #we parse each of the SciMark files and the Composite scores
+        csimark = []
+        csimark.extend(self.readCmsScimarkTest(testName = "cmsScimark2", testType = "mainCore", core = main_core))
+        csimark.extend(self.readCmsScimarkTest(testName = "cmsScimark2_large", testType = "mainCore_Large", core = main_core))
 
 
-		return info
-	def get_tarball_fromlog(self):
-		'''Return the tarball castor location by parsing the cmsPerfSuite.log file'''
-		print("Getting the url from the cmsPerfSuite.log")
-		log=open("cmsPerfSuite.log","r")
-		castor_dir="UNKNOWN_CASTOR_DIR"
-		tarball="UNKNOWN_TARBALL"
-		for line in log.readlines():
-			if 'castordir' in line:
-				castor_dir=line.split()[1]
-			if 'tgz' in line and tarball=="UNKNOWN_TARBALL": #Pick the first line that contains the tar command...
-				if 'tar' in line:
-					tarball=os.path.basename(line.split()[2])
-		castor_tarball=os.path.join(castor_dir,tarball)
-		return castor_tarball
+        #we not always know the number of cores available so we will just search the directory to find out core numbers
+        reIsCsiMark_notusedcore = re.compile("^cmsScimark_(\d+).log$")
+        scimark_files = [reIsCsiMark_notusedcore.match(f).groups()[0]
+                        for f in os.listdir(self._path)
+                         if reIsCsiMark_notusedcore.match(f) 
+                                and os.path.isfile(os.path.join(self._path, f)) ]
 
-	def parseAll(self):
-		result = {"General": {}, "TestResults":{}, "cmsSciMark":{}, 'unrecognized_jobs': []}
+        for core_number in scimark_files:
+            try:
+                csimark.extend(self.readCmsScimarkTest(testName = "cmsScimark_%s" % str(core_number), testType = "NotUsedCore_%s" %str(core_number), core = core_number))
+            except IOError as e:
+                if self._DEBUG:
+                    print(e)
+        return csimark
+        #print csimark
 
-		""" all the general info - start, arguments, host etc """
-		result["General"].update(self.parseGeneralInfo())
+    def parseTheCompletion(self):
+        """
+         checks if the suite has successfully finished  
+                and if the tarball was successfully archived and uploaded to the castor """
 
-		""" machine info - cpu, memmory """
-		result["General"].update(self.getMachineInfo())
-
-		""" we add info about how successfull was the run, when it finished and final castor url to the file! """
-		result["General"].update(self.parseTheCompletion())
-
-		print("Parsing TimeSize runs...")
-		if len(self.lines_timesize) > 0:
-			try:
-				result["TestResults"].update(self.parseTimeSize())
-			except Exception as e:
-				print("BAD BAD BAD UNHANDLED ERROR in parseTimeSize: " + str(e))
-
-		print("Parsing Other(IgProf, Memcheck, ...) runs...")
-		try:
-			result["TestResults"].update(self.parseAllOtherTests())
-		except Exception as e:
-			print("BAD BAD BAD UNHANDLED ERROR in parseAllOtherTests: " + str(e))
-
-		#print result["TestResults"]
+        parsing_rules = (
+                (("finishing_time", "", ""), r"""^Performance Suite finished running at (.+) on (.+) in directory (.+)$"""),
+                (("castor_md5",) , r"""^The md5 checksum of the tarball: (.+)$"""),	
+                (("successfully_archived_tarball", ), r"""^Successfully archived the tarball (.+) in CASTOR!$"""),
+                #TODO: WE MUST HAVE THE CASTOR URL, but for some of files it's not included [probably crashed]
+                (("castor_file_url",), r"""^The tarball can be found: (.+)$"""),			
+                (("castor_logfile_url",), r"""^The logfile can be found: (.+)$"""),
+        )
 
 
-		main_cores = [result["General"]["run_on_cpus"]]
-		num_cores = result["General"].get("num_cores", 0)
-		#DEBUG
-		#print "Number of cores was: %s"%num_cores
-		#TODO: temporarly - search for cores, use regexp
-		main_cores = [1]
+        """ we apply the defined parsing rules to extract the required fields of information into the dictionary (as defined in parsing rules) """
+        info = self._applyParsingRules(parsing_rules, self.lines_other)
 
-		# THE MAHCINE SCIMARKS
-		result["cmsSciMark"] = self.readCmsScimark(main_cores = main_cores)
+        """ did we detect any errors in log files ? """
+        info["no_errors_detected"] = [line for line in self.lines_other if line == "There were no errors detected in any of the log files!"] and "1" or "0"
+        if not info["successfully_archived_tarball"]:
+            info["castor_file_url"] = ""
 
-		if self.missing_fields:
-			self.handleParsingError("========== SOME REQUIRED FIELDS WERE NOT FOUND DURING PARSING ======= "+ str(self.missing_fields))
+        if not info["castor_file_url"]:
+            #TODO: get the castor file url or abort
+            self.handleParsingError( "Castor tarball URL not found. Trying to get from environment")
+            lmdb_castor_url_is_valid = lambda url: url.startswith("/castor/")
 
-		return result
-		
-		
+            url = ""
+            try:
+                #print "HERE!"
+                url=self.get_tarball_fromlog()
+                print("Extracted castor tarball full path by re-parsing cmsPerfSuite.log: %s"%url)
+
+            except:
+                if "PERFDB_CASTOR_FILE_URL" in os.environ:
+                    url = os.environ["PERFDB_CASTOR_FILE_URL"]
+
+                else: #FIXME: add the possibility to get it directly from the cmsPerfSuite.log file (make sure it is dumped there before doing the tarball itself...)
+                    print("Failed to get the tarball location from environment variable PERFDB_CASTOR_FILE_URL") 
+                    self.handleParsingError( "Castor tarball URL not found. Provide interactively")
+
+            while True:
+
+                if lmdb_castor_url_is_valid(url):
+                    info["castor_file_url"] = url
+                    break
+                print("Please enter a valid CASTOR url: has to start with /castor/ and should point to the tarball")
+                if os.isatty(0): url = sys.stdin.readline()
+                else: raise IOError("stdin is closed.")
+
+
+        return info
+    def get_tarball_fromlog(self):
+        '''Return the tarball castor location by parsing the cmsPerfSuite.log file'''
+        print("Getting the url from the cmsPerfSuite.log")
+        log=open("cmsPerfSuite.log","r")
+        castor_dir="UNKNOWN_CASTOR_DIR"
+        tarball="UNKNOWN_TARBALL"
+        for line in log.readlines():
+            if 'castordir' in line:
+                castor_dir=line.split()[1]
+            if 'tgz' in line and tarball=="UNKNOWN_TARBALL": #Pick the first line that contains the tar command...
+                if 'tar' in line:
+                    tarball=os.path.basename(line.split()[2])
+        castor_tarball=os.path.join(castor_dir,tarball)
+        return castor_tarball
+
+    def parseAll(self):
+        result = {"General": {}, "TestResults":{}, "cmsSciMark":{}, 'unrecognized_jobs': []}
+
+        """ all the general info - start, arguments, host etc """
+        result["General"].update(self.parseGeneralInfo())
+
+        """ machine info - cpu, memmory """
+        result["General"].update(self.getMachineInfo())
+
+        """ we add info about how successfull was the run, when it finished and final castor url to the file! """
+        result["General"].update(self.parseTheCompletion())
+
+        print("Parsing TimeSize runs...")
+        if len(self.lines_timesize) > 0:
+            try:
+                result["TestResults"].update(self.parseTimeSize())
+            except Exception as e:
+                print("BAD BAD BAD UNHANDLED ERROR in parseTimeSize: " + str(e))
+
+        print("Parsing Other(IgProf, Memcheck, ...) runs...")
+        try:
+            result["TestResults"].update(self.parseAllOtherTests())
+        except Exception as e:
+            print("BAD BAD BAD UNHANDLED ERROR in parseAllOtherTests: " + str(e))
+
+        #print result["TestResults"]
+
+
+        main_cores = [result["General"]["run_on_cpus"]]
+        num_cores = result["General"].get("num_cores", 0)
+        #DEBUG
+        #print "Number of cores was: %s"%num_cores
+        #TODO: temporarly - search for cores, use regexp
+        main_cores = [1]
+
+        # THE MAHCINE SCIMARKS
+        result["cmsSciMark"] = self.readCmsScimark(main_cores = main_cores)
+
+        if self.missing_fields:
+            self.handleParsingError("========== SOME REQUIRED FIELDS WERE NOT FOUND DURING PARSING ======= "+ str(self.missing_fields))
+
+        return result
+
+
 
 if __name__ == "__main__":
-	from xml.dom import minidom
-	import cmssw_exportdb_xml
-	#steps do not get parsed corectly
-	#path = "/home/vidma/Desktop/CERN_code/cmssw/data/CMSSW_3_1_0_pre7_--usersteps=RAW2DIGI-RECO_lxbuild107.cern.ch_relval/relval/CMSSW_3_1_0_pre7/work2" 
-	#path = "/home/vidma/Desktop/CERN_code/cmssw/data/CMSSW_3_2_0_--usersteps=GEN-SIM,DIGI_lxbuild106.cern.ch_relval/relval/CMSSW_3_2_0/workGENSIMDIGI"
-	#includes finishing time, succesfully archived tarball etc
-	#path = "/home/vidma/Desktop/CERN_code/cmssw/CVS_PerfSuiteDB/COMP/PerfSuiteDB/export_data_to_xml/example_of_files/PileUp"
-	path = os.path.abspath(".") #Better to point to the local dir than to some old Vidmantas' laptop dirs ;)
-	#p = parserPerfsuiteMetadata("/home/vidma/Desktop/CERN_code/cmssw/CVS_PerfSuiteDB/COMP/PerfSuiteDB/export_data_to_xml/example_of_files/PerfsuiteRun")
-	p = parserPerfsuiteMetadata(path)
-	run_info = p.parseAll()
-	
-	#print "======= GENERAL ========= "
-	#print "\n".join("%s : %s" % (k, v) for k, v in p.parseAll()["General"].items())
-	#print "======= Test results ========= "
-	#print "\n".join("%s : %s" % (k, v) for k, v in p.parseAll()["TestResults"].items())
+    from xml.dom import minidom
+    import cmssw_exportdb_xml
+    #steps do not get parsed corectly
+    #path = "/home/vidma/Desktop/CERN_code/cmssw/data/CMSSW_3_1_0_pre7_--usersteps=RAW2DIGI-RECO_lxbuild107.cern.ch_relval/relval/CMSSW_3_1_0_pre7/work2" 
+    #path = "/home/vidma/Desktop/CERN_code/cmssw/data/CMSSW_3_2_0_--usersteps=GEN-SIM,DIGI_lxbuild106.cern.ch_relval/relval/CMSSW_3_2_0/workGENSIMDIGI"
+    #includes finishing time, succesfully archived tarball etc
+    #path = "/home/vidma/Desktop/CERN_code/cmssw/CVS_PerfSuiteDB/COMP/PerfSuiteDB/export_data_to_xml/example_of_files/PileUp"
+    path = os.path.abspath(".") #Better to point to the local dir than to some old Vidmantas' laptop dirs ;)
+    #p = parserPerfsuiteMetadata("/home/vidma/Desktop/CERN_code/cmssw/CVS_PerfSuiteDB/COMP/PerfSuiteDB/export_data_to_xml/example_of_files/PerfsuiteRun")
+    p = parserPerfsuiteMetadata(path)
+    run_info = p.parseAll()
 
-	xml_doc = minidom.Document()
-	cmssw_exportdb_xml.exportRunInfo(xml_doc, run_info, print_out = True)
-	#print "General info:" + str(p.parseGeneralInfo())
-	import doctest
-	doctest.testmod()
-	
-	#print p.readCmsScimark()
+    #print "======= GENERAL ========= "
+    #print "\n".join("%s : %s" % (k, v) for k, v in p.parseAll()["General"].items())
+    #print "======= Test results ========= "
+    #print "\n".join("%s : %s" % (k, v) for k, v in p.parseAll()["TestResults"].items())
+
+    xml_doc = minidom.Document()
+    cmssw_exportdb_xml.exportRunInfo(xml_doc, run_info, print_out = True)
+    #print "General info:" + str(p.parseGeneralInfo())
+    import doctest
+    doctest.testmod()
+
+    #print p.readCmsScimark()
 
 

--- a/Validation/Performance/scripts/cmsPerfSuiteHarvest.py
+++ b/Validation/Performance/scripts/cmsPerfSuiteHarvest.py
@@ -50,9 +50,9 @@ def get_params(argv):
     * environment variable 
     in case of error returns None
 
-	And also the directory to put the xml files to: if none --> returns ""
+        And also the directory to put the xml files to: if none --> returns ""
     """
-    
+
     """ try to get the version for command line argument """
     #print argv
     #FIXME: this should be rewritten using getopt properly
@@ -68,47 +68,47 @@ def get_params(argv):
     for opt, arg in opts:
         if opt in ("-v", "--version"):
             version = arg
-	if opt == "--outdir":
-	     xml_dir = arg
-    
+        if opt == "--outdir":
+            xml_dir = arg
+
     """ if not get it from environment string """
     if not version:
         try:
             version = os.environ["CMSSW_VERSION"]
         except KeyError:
             pass
-    
+
     return (version, xml_dir)
-        
+
 def _eventContent_DEBUG(edm_report):
-	# for testing / information
-	EC_count = {}
-	if not _TEST_RUN:
-		# count the products in event-content's
-		for prod in edm_report:
-			ecs = parseEventContent.List_ECs_forProduct(prod)
-			for ec in ecs:
-				if ec not in EC_count:
-					EC_count[ec] = []	
-				EC_count[ec].append(prod)
-		#print out the statistics
-		for (ec, prods) in EC_count.items():
-			print("==== %s EVENT CONTENT: have %d items, the listing is: ===" % (ec, len(prods)))
-			# list of products
-			print("\n *".join(["%(cpp_type)s_%(module_name)s_%(module_label)s" % prod for prod in prods]))
+        # for testing / information
+    EC_count = {}
+    if not _TEST_RUN:
+        # count the products in event-content's
+        for prod in edm_report:
+            ecs = parseEventContent.List_ECs_forProduct(prod)
+            for ec in ecs:
+                if ec not in EC_count:
+                    EC_count[ec] = []	
+                EC_count[ec].append(prod)
+        #print out the statistics
+        for (ec, prods) in EC_count.items():
+            print("==== %s EVENT CONTENT: have %d items, the listing is: ===" % (ec, len(prods)))
+            # list of products
+            print("\n *".join(["%(cpp_type)s_%(module_name)s_%(module_label)s" % prod for prod in prods]))
 
 
 def assign_event_content_for_product(product):
-	""" returns modified product by adding the event content relationship """
+    """ returns modified product by adding the event content relationship """
 
-	if not _TEST_RUN:
-		product["event_content"] = ",".join(parseEventContent.List_ECs_forProduct(product))
-	return product
+    if not _TEST_RUN:
+        product["event_content"] = ",".join(parseEventContent.List_ECs_forProduct(product))
+    return product
 
 
 def get_modules_sequences_relationships():
-	(sequenceWithModules, sequenceWithModulesString) =ModuleToSequenceAssign.assignModulesToSeqs()
-	return [{"name": seq, "modules": ",".join(modules)} for (seq, modules) in sequenceWithModulesString.items()]
+    (sequenceWithModules, sequenceWithModulesString) =ModuleToSequenceAssign.assignModulesToSeqs()
+    return [{"name": seq, "modules": ",".join(modules)} for (seq, modules) in sequenceWithModulesString.items()]
 
 
 def exportIgProfReport(path, igProfReport, igProfType, runinfo):
@@ -126,212 +126,212 @@ def exportIgProfReport(path, igProfReport, igProfType, runinfo):
                 result['jobs'].append(igProfReport)
                 found = True
                 break
-		
+
     if not found:
         print("============ (almost) ERROR: NOT FOUND THE ENTRY in cmsPerfSuite.log, exporting as separate entry ======== ")
         print("JOB ID: %s " % str(jobID))
         print(" ====================== ")
         runinfo['unrecognized_jobs'].append(igProfReport)
         #export_xml(xml_doc = xmldoc, **igProfReport)	
-        
+
 
 def exportTimeSizeJob(path, timeSizeReport,  runinfo):
-		candleLong = os.path.split(path)[1].replace("_TimeSize", "").replace("_PU", "")
-		jobID = timeSizeReport["jobID"]
+    candleLong = os.path.split(path)[1].replace("_TimeSize", "").replace("_PU", "")
+    jobID = timeSizeReport["jobID"]
 
-		#search for a run Test to which could belong our JOB
-		found = False
-		if 'TimeSize' in runinfo['TestResults']:
-			for result in runinfo['TestResults']['TimeSize']:
-				#print result
-				""" If this is the testResult which fits TimeSize job """
-				#TODO: we do not check teh step when assigning because of the different names, check if this is really OK. make a decission which step name to use later, long or short one
-				#and jobID["step"] in result['steps'].split(parserPerfsuiteMetadata._LINE_SEPARATOR)
-				if result['candle'] == candleLong  and jobID["pileup_type"] == result['pileup_type'] and jobID["conditions"] == result['conditions'] and jobID["event_content"] == result['event_content']:
-					#print result
-					if "jobs" not in result:
-						result['jobs'] = []
-					result['jobs'].append(timeSizeReport)
-					found = True
-					break
-		
-		if not found:
-			print("============ (almost) ERROR: NOT FOUND THE ENTRY in cmsPerfSuite.log, exporting as separate entry ======== ")
-			print("JOB ID: %s " % str(jobID))
-			print(" ====================== ")
-			runinfo['unrecognized_jobs'].append(timeSizeReport)
-			#export_xml(xml_doc = xmldoc, **timeSizeReport)	
-			
+    #search for a run Test to which could belong our JOB
+    found = False
+    if 'TimeSize' in runinfo['TestResults']:
+        for result in runinfo['TestResults']['TimeSize']:
+                #print result
+            """ If this is the testResult which fits TimeSize job """
+            #TODO: we do not check teh step when assigning because of the different names, check if this is really OK. make a decission which step name to use later, long or short one
+            #and jobID["step"] in result['steps'].split(parserPerfsuiteMetadata._LINE_SEPARATOR)
+            if result['candle'] == candleLong  and jobID["pileup_type"] == result['pileup_type'] and jobID["conditions"] == result['conditions'] and jobID["event_content"] == result['event_content']:
+                    #print result
+                if "jobs" not in result:
+                    result['jobs'] = []
+                result['jobs'].append(timeSizeReport)
+                found = True
+                break
+
+    if not found:
+        print("============ (almost) ERROR: NOT FOUND THE ENTRY in cmsPerfSuite.log, exporting as separate entry ======== ")
+        print("JOB ID: %s " % str(jobID))
+        print(" ====================== ")
+        runinfo['unrecognized_jobs'].append(timeSizeReport)
+        #export_xml(xml_doc = xmldoc, **timeSizeReport)	
+
 def exportMemcheckReport(path, MemcheckReport, runinfo):
-		candleLong = os.path.split(path)[1].replace("_Memcheck", "").replace("_PU", "")
-		jobID = MemcheckReport["jobID"]
+    candleLong = os.path.split(path)[1].replace("_Memcheck", "").replace("_PU", "")
+    jobID = MemcheckReport["jobID"]
 
-		#search for a run Test to which could belong our JOB
-		found = False
-		if 'Memcheck' in runinfo['TestResults']:
-			for result in runinfo['TestResults']['Memcheck']:
-				#print result
-                                #print jobID
-				""" If this is the testResult which fits Memcheck job """
-				#TODO: we do not check teh step when assigning because of the different names, check if this is really OK. make a decission which step name to use later, long or short one
-				#and jobID["step"] in result['steps'].split(parserPerfsuiteMetadata._LINE_SEPARATOR)
-				if result['candle'] == candleLong  and jobID["pileup_type"] == result['pileup_type'] and jobID["conditions"] == result['conditions'] and jobID["event_content"] == result['event_content']:
-					#print result
-					if "jobs" not in result:
-						result['jobs'] = []
-					result['jobs'].append(MemcheckReport)
-					found = True
-					break
-		
-		if not found:
-			print("============ (almost) ERROR: NOT FOUND THE ENTRY in cmsPerfSuite.log, exporting as separate entry ======== ")
-			print("JOB ID: %s " % str(jobID))
-			print(" ====================== ")
-			runinfo['unrecognized_jobs'].append(MemcheckReport)
+    #search for a run Test to which could belong our JOB
+    found = False
+    if 'Memcheck' in runinfo['TestResults']:
+        for result in runinfo['TestResults']['Memcheck']:
+            #print result
+            #print jobID
+            """ If this is the testResult which fits Memcheck job """
+            #TODO: we do not check teh step when assigning because of the different names, check if this is really OK. make a decission which step name to use later, long or short one
+            #and jobID["step"] in result['steps'].split(parserPerfsuiteMetadata._LINE_SEPARATOR)
+            if result['candle'] == candleLong  and jobID["pileup_type"] == result['pileup_type'] and jobID["conditions"] == result['conditions'] and jobID["event_content"] == result['event_content']:
+                #print result
+                if "jobs" not in result:
+                    result['jobs'] = []
+                result['jobs'].append(MemcheckReport)
+                found = True
+                break
+
+    if not found:
+        print("============ (almost) ERROR: NOT FOUND THE ENTRY in cmsPerfSuite.log, exporting as separate entry ======== ")
+        print("JOB ID: %s " % str(jobID))
+        print(" ====================== ")
+        runinfo['unrecognized_jobs'].append(MemcheckReport)
 
 def process_timesize_dir(path, runinfo):
-	global release,event_content,conditions
-	""" if the release is not provided explicitly we take it from the Simulation candles file """
-	if (not release):
-		release_fromlogfile = read_SimulationCandles(path)
-		release  = release_fromlogfile 
-		print("release from simulation candles: %s" % release)
-	
-	if (not release):
-		# TODO: raise exception!
-		raise Exception("the release was not found!")
+    global release,event_content,conditions
+    """ if the release is not provided explicitly we take it from the Simulation candles file """
+    if (not release):
+        release_fromlogfile = read_SimulationCandles(path)
+        release  = release_fromlogfile 
+        print("release from simulation candles: %s" % release)
+
+    if (not release):
+        # TODO: raise exception!
+        raise Exception("the release was not found!")
 
 
-	""" process the TimingReport log files """
+    """ process the TimingReport log files """
 
-        # get the file list 
-	files = os.listdir(path)
-	timing_report_files = [os.path.join(path, f) for f in files
-				 if test_timing_report_log.search(f) 
-					and os.path.isfile(os.path.join(path, f)) ]
+    # get the file list 
+    files = os.listdir(path)
+    timing_report_files = [os.path.join(path, f) for f in files
+                             if test_timing_report_log.search(f) 
+                                    and os.path.isfile(os.path.join(path, f)) ]
 
-	# print timing_report_files
-	for timelog_f in timing_report_files:
-		print("\nProcessing file: %s" % timelog_f)
-		print("------- ")
-		
-		jobID = getJobID_fromTimeReportLogName(os.path.join(path, timelog_f))
-		print("jobID: %s" % str(jobID))
-		(candle, step, pileup_type, conditions, event_content) = jobID
-		jobID = dict(list(zip(("candle", "step", "pileup_type", "conditions", "event_content"), jobID)))
-		print("Dictionary based jobID %s: " % str(jobID))
-		
-		#if any of jobID fields except (isPILEUP) is empty we discard the job as all those are the jobID keys and we must have them
-		discard = len([key for key, value in jobID.items() if key != "pileup_type" and not value])
-		if discard:
-			print(" ====================== The job HAS BEEN DISCARDED =============== ")
-			print(" NOT ALL DATA WAS AVAILABLE ")
-			print(" JOB ID = %s " % str(jobID))
-			print(" ======================= end ===================================== ")
-			continue
+    # print timing_report_files
+    for timelog_f in timing_report_files:
+        print("\nProcessing file: %s" % timelog_f)
+        print("------- ")
 
-		# TODO: automaticaly detect type of report file!!!
-		(mod_timelog, evt_timelog, rss_data, vsize_data) =loadTimeLog(timelog_f)
-	
-		mod_timelog= processModuleTimeLogData(mod_timelog, groupBy = "module_name")
-		print("Number of modules grouped by (module_label+module_name): %s" % len(mod_timelog))
+        jobID = getJobID_fromTimeReportLogName(os.path.join(path, timelog_f))
+        print("jobID: %s" % str(jobID))
+        (candle, step, pileup_type, conditions, event_content) = jobID
+        jobID = dict(list(zip(("candle", "step", "pileup_type", "conditions", "event_content"), jobID)))
+        print("Dictionary based jobID %s: " % str(jobID))
 
-		# add to the list to generate the readable filename :)
-		steps[step] = 1
-		candles[candle] = 1
-                if pileup_type=="":
-                    pileups["NoPileUp"]=1
-                else:
-                    pileups[pileup_type] = 1
-	
-		# root file size (number)
-                root_file_size = getRootFileSize(path = path, candle = candle, step = step.replace(':', '='))
-                # number of events
-                num_events = read_ConfigurationFromSimulationCandles(path = path, step = step, is_pileup = pileup_type)["num_events"]
+        #if any of jobID fields except (isPILEUP) is empty we discard the job as all those are the jobID keys and we must have them
+        discard = len([key for key, value in jobID.items() if key != "pileup_type" and not value])
+        if discard:
+            print(" ====================== The job HAS BEEN DISCARDED =============== ")
+            print(" NOT ALL DATA WAS AVAILABLE ")
+            print(" JOB ID = %s " % str(jobID))
+            print(" ======================= end ===================================== ")
+            continue
 
-		#EdmSize
-		edm_report = parserEdmSize.getEdmReport(path = path, candle = candle, step = step)
-		if edm_report != False:
-			try:
-				# add event content data
-				edm_report  = map(assign_event_content_for_product, edm_report)
-				# for testing / imformation
-				_eventContent_DEBUG(edm_report)
-			except Exception as e:
-				print(e)
+        # TODO: automaticaly detect type of report file!!!
+        (mod_timelog, evt_timelog, rss_data, vsize_data) =loadTimeLog(timelog_f)
 
-		timeSizeReport = {
-				"jobID":jobID,
-				"release": release,
-                                "timelog_result": (mod_timelog, evt_timelog, rss_data, vsize_data), 
-				"metadata": {"testname": "TimeSize", "root_file_size": root_file_size, "num_events": num_events}, 
-				"edmSize_result": edm_report 
-		}
-		
-		# export to xml: actualy exporting gets suspended and put into runinfo
-		exportTimeSizeJob(path, timeSizeReport,  runinfo)
+        mod_timelog= processModuleTimeLogData(mod_timelog, groupBy = "module_name")
+        print("Number of modules grouped by (module_label+module_name): %s" % len(mod_timelog))
+
+        # add to the list to generate the readable filename :)
+        steps[step] = 1
+        candles[candle] = 1
+        if pileup_type=="":
+            pileups["NoPileUp"]=1
+        else:
+            pileups[pileup_type] = 1
+
+        # root file size (number)
+        root_file_size = getRootFileSize(path = path, candle = candle, step = step.replace(':', '='))
+        # number of events
+        num_events = read_ConfigurationFromSimulationCandles(path = path, step = step, is_pileup = pileup_type)["num_events"]
+
+        #EdmSize
+        edm_report = parserEdmSize.getEdmReport(path = path, candle = candle, step = step)
+        if edm_report != False:
+            try:
+            # add event content data
+                edm_report  = map(assign_event_content_for_product, edm_report)
+                # for testing / imformation
+                _eventContent_DEBUG(edm_report)
+            except Exception as e:
+                print(e)
+
+        timeSizeReport = {
+                        "jobID":jobID,
+                        "release": release,
+                        "timelog_result": (mod_timelog, evt_timelog, rss_data, vsize_data), 
+                        "metadata": {"testname": "TimeSize", "root_file_size": root_file_size, "num_events": num_events}, 
+                        "edmSize_result": edm_report 
+        }
+
+        # export to xml: actualy exporting gets suspended and put into runinfo
+        exportTimeSizeJob(path, timeSizeReport,  runinfo)
 
 def process_memcheck_dir(path, runinfo):
-	global release,event_content,conditions
-	""" if the release is not provided explicitly we take it from the Simulation candles file """
-	if (not release):
-		release_fromlogfile = read_SimulationCandles(path)
-		release  = release_fromlogfile 
-		print("release from simulation candles: %s" % release)
-	
-	if (not release):
-		# TODO: raise exception!
-		raise Exception("the release was not found!")
+    global release,event_content,conditions
+    """ if the release is not provided explicitly we take it from the Simulation candles file """
+    if (not release):
+        release_fromlogfile = read_SimulationCandles(path)
+        release  = release_fromlogfile 
+        print("release from simulation candles: %s" % release)
 
-	""" process the vlgd files """
+    if (not release):
+        # TODO: raise exception!
+        raise Exception("the release was not found!")
 
-        # get the file list 
-	files = os.listdir(path)
-	memcheck_files = [os.path.join(path, f) for f in files
-				 if test_memcheck_report_log.search(f) 
-					and os.path.isfile(os.path.join(path, f)) ]
+    """ process the vlgd files """
 
-        if len(memcheck_files) == 0: # Fast protection for old runs, where the _vlgd files is not created...
-            print("No _vlgd files found!")
-        else:
-            for file in memcheck_files:
-                jobID = getJobID_fromMemcheckLogName(os.path.join(path, file))
+    # get the file list 
+    files = os.listdir(path)
+    memcheck_files = [os.path.join(path, f) for f in files
+                             if test_memcheck_report_log.search(f) 
+                                    and os.path.isfile(os.path.join(path, f)) ]
 
-                (candle, step, pileup_type, conditions, event_content) = jobID
-                
-                print("jobID: %s" % str(jobID))
-                jobID = dict(list(zip(("candle", "step", "pileup_type", "conditions", "event_content"), jobID)))
+    if len(memcheck_files) == 0: # Fast protection for old runs, where the _vlgd files is not created...
+        print("No _vlgd files found!")
+    else:
+        for file in memcheck_files:
+            jobID = getJobID_fromMemcheckLogName(os.path.join(path, file))
 
-                print("Dictionary based jobID %s: " % str(jobID))
-            
-                #if any of jobID fields except (isPILEUP) is empty we discard the job as all those are the jobID keys and we must have them
-                discard = len([key for key, value in jobID.items() if key != "pileup_type" and not value])
-                if discard:
-                    print(" ====================== The job HAS BEEN DISCARDED =============== ")
-                    print(" NOT ALL DATA WAS AVAILABLE ")
-                    print(" JOB ID = %s " % str(jobID))
-                    print(" ======================= end ===================================== ")
-                    continue
-            
-                # add to the list to generate the readable filename :)
-                steps[step] = 1
-                candles[candle.upper()] = 1
-                if pileup_type=="":
-                    pileups["NoPileUp"]=1
-                else:
-                    pileups[pileup_type] = 1
-                
-                memerror = getMemcheckError(path)
+            (candle, step, pileup_type, conditions, event_content) = jobID
 
-                MemcheckReport = {
-                    "jobID": jobID,
-                    "release": release,
-                    "memcheck_errors": {"error_num": memerror},
-                    "metadata": {"testname": "Memcheck"},
-                    }
+            print("jobID: %s" % str(jobID))
+            jobID = dict(list(zip(("candle", "step", "pileup_type", "conditions", "event_content"), jobID)))
 
-                # export to xml: actualy exporting gets suspended and put into runinfo
-                exportMemcheckReport(path, MemcheckReport, runinfo)
+            print("Dictionary based jobID %s: " % str(jobID))
+
+            #if any of jobID fields except (isPILEUP) is empty we discard the job as all those are the jobID keys and we must have them
+            discard = len([key for key, value in jobID.items() if key != "pileup_type" and not value])
+            if discard:
+                print(" ====================== The job HAS BEEN DISCARDED =============== ")
+                print(" NOT ALL DATA WAS AVAILABLE ")
+                print(" JOB ID = %s " % str(jobID))
+                print(" ======================= end ===================================== ")
+                continue
+
+            # add to the list to generate the readable filename :)
+            steps[step] = 1
+            candles[candle.upper()] = 1
+            if pileup_type=="":
+                pileups["NoPileUp"]=1
+            else:
+                pileups[pileup_type] = 1
+
+            memerror = getMemcheckError(path)
+
+            MemcheckReport = {
+                "jobID": jobID,
+                "release": release,
+                "memcheck_errors": {"error_num": memerror},
+                "metadata": {"testname": "Memcheck"},
+                }
+
+            # export to xml: actualy exporting gets suspended and put into runinfo
+            exportMemcheckReport(path, MemcheckReport, runinfo)
 
 def getMemcheckError(path):
     globbed = glob.glob(os.path.join(path, "*memcheck_vlgd.xml"))
@@ -339,87 +339,87 @@ def getMemcheckError(path):
     errnum = 0
 
     for f in globbed:
-        #print f
+    #print f
         cmd = "grep '<error>' "+f+ " | wc -l "
         p = os.popen(cmd, 'r')
         errnum += int(p.readlines()[0])
-                        
+
     return errnum
-    
+
 
 def process_igprof_dir(path, runinfo):
-	global release,event_content,conditions
-	""" if the release is not provided explicitly we take it from the Simulation candles file """
-	if (not release):
-		release_fromlogfile = read_SimulationCandles(path)
-		release  = release_fromlogfile 
-		print("release from simulation candles: %s" % release)
-	
-	if (not release):
-		# TODO: raise exception!
-		raise Exception("the release was not found!")
+    global release,event_content,conditions
+    """ if the release is not provided explicitly we take it from the Simulation candles file """
+    if (not release):
+        release_fromlogfile = read_SimulationCandles(path)
+        release  = release_fromlogfile 
+        print("release from simulation candles: %s" % release)
 
-	""" process the IgProf sql3 files """
+    if (not release):
+        # TODO: raise exception!
+        raise Exception("the release was not found!")
 
-        # get the file list 
-	files = os.listdir(path)
-	igprof_files = [os.path.join(path, f) for f in files
-				 if test_igprof_report_log.search(f) 
-					and os.path.isfile(os.path.join(path, f)) ]
+    """ process the IgProf sql3 files """
 
-        if len(igprof_files) == 0: # No files...
-            print("No igprof files found!")
-        else:
-            for file in igprof_files:
-                jobID = getJobID_fromIgProfLogName(file)
+    # get the file list 
+    files = os.listdir(path)
+    igprof_files = [os.path.join(path, f) for f in files
+                             if test_igprof_report_log.search(f) 
+                                    and os.path.isfile(os.path.join(path, f)) ]
 
-                (candle, step, pileup_type, conditions, event_content) = jobID
+    if len(igprof_files) == 0: # No files...
+        print("No igprof files found!")
+    else:
+        for file in igprof_files:
+            jobID = getJobID_fromIgProfLogName(file)
 
-                print("jobID: %s" % str(jobID))
-                jobID = dict(list(zip(("candle", "step", "pileup_type", "conditions", "event_content"), jobID)))
-                
-                print("Dictionary based jobID %s: " % str(jobID))
-                
-                igProfType = path.split("/")[-1].replace("TTbar_", "").replace("MinBias_", "").replace("PU_", "")
-                
-	        #if any of jobID fields except (isPILEUP) is empty we discard the job as all those are the jobID keys and we must have them
-                discard = len([key for key, value in jobID.items() if key != "pileup_type" and not value])
-                if discard:
-                    print(" ====================== The job HAS BEEN DISCARDED =============== ")
-                    print(" NOT ALL DATA WAS AVAILABLE ")
-                    print(" JOB ID = %s " % str(jobID))
-                    print(" ======================= end ===================================== ")
-                    continue
-        
-                # add to the list to generate the readable filename :)
-                steps[step] = 1
-                candles[candle.upper()] = 1
-                if pileup_type=="":
-                    pileups["NoPileUp"]=1
-                else:
-                    pileups[pileup_type] = 1
-            
-                igs = getIgSummary(path)
-                #print igs
+            (candle, step, pileup_type, conditions, event_content) = jobID
 
-                igProfReport = {
-                    "jobID": jobID,
-                    "release": release, 
-                    "igprof_result": igs,
-                    "metadata": {"testname": igProfType},
-                    }
+            print("jobID: %s" % str(jobID))
+            jobID = dict(list(zip(("candle", "step", "pileup_type", "conditions", "event_content"), jobID)))
 
-                # print igProfReport
-                # export to xml: actualy exporting gets suspended and put into runinfo
-                exportIgProfReport(path, igProfReport, igProfType, runinfo)      
+            print("Dictionary based jobID %s: " % str(jobID))
+
+            igProfType = path.split("/")[-1].replace("TTbar_", "").replace("MinBias_", "").replace("PU_", "")
+
+            #if any of jobID fields except (isPILEUP) is empty we discard the job as all those are the jobID keys and we must have them
+            discard = len([key for key, value in jobID.items() if key != "pileup_type" and not value])
+            if discard:
+                print(" ====================== The job HAS BEEN DISCARDED =============== ")
+                print(" NOT ALL DATA WAS AVAILABLE ")
+                print(" JOB ID = %s " % str(jobID))
+                print(" ======================= end ===================================== ")
+                continue
+
+            # add to the list to generate the readable filename :)
+            steps[step] = 1
+            candles[candle.upper()] = 1
+            if pileup_type=="":
+                pileups["NoPileUp"]=1
+            else:
+                pileups[pileup_type] = 1
+
+            igs = getIgSummary(path)
+            #print igs
+
+            igProfReport = {
+                "jobID": jobID,
+                "release": release, 
+                "igprof_result": igs,
+                "metadata": {"testname": igProfType},
+                }
+
+            # print igProfReport
+            # export to xml: actualy exporting gets suspended and put into runinfo
+            exportIgProfReport(path, igProfReport, igProfType, runinfo)      
 
 #get IgProf summary information from the sql3 files
 def getIgSummary(path):
     igresult = []
     globbed = glob.glob(os.path.join(path, "*.sql3"))
-    
+
     for f in globbed:
-        #print f
+    #print f
         profileInfo = getSummaryInfo(f)
         if not profileInfo:
             continue
@@ -444,7 +444,7 @@ def getIgSummary(path):
             ig['cumcalls'] = cumcallsLast - cumcallsOne
 
     return igresult
-    
+
 def getSummaryInfo(database):
     summary_query="""SELECT counter, total_count, total_freq, tick_period
                      FROM summary;"""
@@ -456,7 +456,7 @@ def getSummaryInfo(database):
         return float(tick_period) * float(total_count), int(total_freq)
     else:
         return int(total_count), int(total_freq)
-    
+
 def doQuery(query, database):
     if os.path.exists("/usr/bin/sqlite3"):
         sqlite="/usr/bin/sqlite3"
@@ -466,60 +466,60 @@ def doQuery(query, database):
 
 #TimeSize
 def searchTimeSizeFiles(runinfo):
-	""" so far we will use the current dir to search in """
-	path = os.getcwd()
-	#print path
-	print('full path =', os.path.abspath(path))
+    """ so far we will use the current dir to search in """
+    path = os.getcwd()
+    #print path
+    print('full path =', os.path.abspath(path))
 
-	files = os.listdir(path)
-	
-	test_timeSizeDirs = re.compile("_TimeSize$", re.IGNORECASE)          
-	timesize_dirs = [os.path.join(path, f) for f in files if test_timeSizeDirs.search(f) and os.path.isdir(os.path.join(path, f))]
-	
-	for timesize_dir in timesize_dirs:
-		# print timesize_dir
-		process_timesize_dir(timesize_dir, runinfo)
+    files = os.listdir(path)
+
+    test_timeSizeDirs = re.compile("_TimeSize$", re.IGNORECASE)          
+    timesize_dirs = [os.path.join(path, f) for f in files if test_timeSizeDirs.search(f) and os.path.isdir(os.path.join(path, f))]
+
+    for timesize_dir in timesize_dirs:
+                # print timesize_dir
+        process_timesize_dir(timesize_dir, runinfo)
 
 #Memcheck
 def searchMemcheckFiles(runinfo):
-	""" so far we will use the current dir to search in """
-	path = os.getcwd()
-	#print path
-	print('full path =', os.path.abspath(path))
+    """ so far we will use the current dir to search in """
+    path = os.getcwd()
+    #print path
+    print('full path =', os.path.abspath(path))
 
-	files = os.listdir(path)
-	
-	test_MemcheckDirs = re.compile("_Memcheck(.*)$", re.IGNORECASE)          
-	memcheck_dirs = [os.path.join(path, f) for f in files if test_MemcheckDirs.search(f) and os.path.isdir(os.path.join(path, f))]
-	
-	for memcheck_dir in memcheck_dirs:
-		print(memcheck_dir)
-		process_memcheck_dir(memcheck_dir, runinfo)
+    files = os.listdir(path)
+
+    test_MemcheckDirs = re.compile("_Memcheck(.*)$", re.IGNORECASE)          
+    memcheck_dirs = [os.path.join(path, f) for f in files if test_MemcheckDirs.search(f) and os.path.isdir(os.path.join(path, f))]
+
+    for memcheck_dir in memcheck_dirs:
+        print(memcheck_dir)
+        process_memcheck_dir(memcheck_dir, runinfo)
 
 #IgProf
 def searchIgProfFiles(runinfo):
-	""" so far we will use the current dir to search in """
-	path = os.getcwd()
-	#print path
-	print('full path =', os.path.abspath(path))
+    """ so far we will use the current dir to search in """
+    path = os.getcwd()
+    #print path
+    print('full path =', os.path.abspath(path))
 
-	files = os.listdir(path)
-	
-	test_IgProfDirs = re.compile("_IgProf(.*)$", re.IGNORECASE)          
-	igprof_dirs = [os.path.join(path, f) for f in files if test_IgProfDirs.search(f) and os.path.isdir(os.path.join(path, f))]
-	
-	for igprof_dir in igprof_dirs:
-		print(igprof_dir)
-		process_igprof_dir(igprof_dir, runinfo)
+    files = os.listdir(path)
+
+    test_IgProfDirs = re.compile("_IgProf(.*)$", re.IGNORECASE)          
+    igprof_dirs = [os.path.join(path, f) for f in files if test_IgProfDirs.search(f) and os.path.isdir(os.path.join(path, f))]
+
+    for igprof_dir in igprof_dirs:
+        print(igprof_dir)
+        process_igprof_dir(igprof_dir, runinfo)
 
 def exportSequences():
     """ Exports the sequences to XML Doc """
     try:
-    	env_cmssw_version = os.environ["CMSSW_VERSION"]
+        env_cmssw_version = os.environ["CMSSW_VERSION"]
     except KeyError:
-    	print("<<<<<  ====== Error: cannot get CMSSW version [just integrity check for sequences]. \
+        print("<<<<<  ====== Error: cannot get CMSSW version [just integrity check for sequences]. \
 					 Is the CMSSW environment initialized? (use cmsenv) ==== >>>>")
-	env_cmssw_version = None
+        env_cmssw_version = None
 
     print(" ==== exporting the sequences. loading files for currently loaded CMSSW version: %s, while the CMSSW we are currently harversting is %s ===" %(env_cmssw_version, release))
     xml_export_Sequences(xml_doc = xmldoc, sequences = get_modules_sequences_relationships(), release=release)
@@ -527,16 +527,16 @@ def exportSequences():
 
 
 if __name__ == "__main__":
-	#searchFiles()
+        #searchFiles()
     #TO DO:
     #Use option parser! This is messy.
-    
+
     (release, output_dir) = get_params(sys.argv)
 
     if not release:
         """ print usage(sys.argv)
         sys.exit(2) """
-	print("The version was not provided explicitly, will try to get one from SimulationCandles file """)
+        print("The version was not provided explicitly, will try to get one from SimulationCandles file """)
 
 
     # Export the metadata from cmsPerfSuite.log (in current working directory!)
@@ -550,16 +550,16 @@ if __name__ == "__main__":
     EventContents_OK = False
 
     if not _TEST_RUN:
-	 try:
-		 import Validation.Performance.ModuleToSequenceAssign as ModuleToSequenceAssign
-		 Sequences_OK = True
-	 except Exception as e:
-		print(e)
-	 try:
-    	 	import Validation.Performance.parseEventContent as parseEventContent
-		EventContents_OK = True
-	 except Exception as e:
-		print(e)	
+        try:
+            import Validation.Performance.ModuleToSequenceAssign as ModuleToSequenceAssign
+            Sequences_OK = True
+        except Exception as e:
+            print(e)
+        try:
+            import Validation.Performance.parseEventContent as parseEventContent
+            EventContents_OK = True
+        except Exception as e:
+            print(e)	
 
     print("Parsing TimeSize report")
     # Search for TimeSize files: EdmSize, TimingReport
@@ -574,16 +574,16 @@ if __name__ == "__main__":
 
     print("Exporting sequences and event-content rules")
     if not _TEST_RUN:
-	    """ for testing on laptom we have no CMSSW """
-	    # export sequences (for currently loaded CMSSW)
-	    if Sequences_OK:
-	    	exportSequences()
+        """ for testing on laptom we have no CMSSW """
+        # export sequences (for currently loaded CMSSW)
+        if Sequences_OK:
+            exportSequences()
 
-            if EventContents_OK:
-		    # export event's content rules
-		    eventContentRules = parseEventContent.getTxtEventContentRules()
-		    cmssw_exportdb_xml.exportECRules(xmldoc, eventContentRules)
-		    
+        if EventContents_OK:
+                    # export event's content rules
+            eventContentRules = parseEventContent.getTxtEventContentRules()
+            cmssw_exportdb_xml.exportECRules(xmldoc, eventContentRules)
+
 
     cmssw_exportdb_xml.exportRunInfo(xmldoc, run_info, release = release)
     #save the XML file, TODO: change fileName after introducting the JobID

--- a/Validation/RecoB/scripts/Inspector.py
+++ b/Validation/RecoB/scripts/Inspector.py
@@ -20,83 +20,83 @@ from ROOT import TFile
 class Inspector:
 
     def SetFilename(self, value):
-	self.Filename = value
+        self.Filename = value
     def Verbose(self, value):
-	self.Verbose = value
+        self.Verbose = value
 
     def createXML(self, value):
-	self.XML = value
+        self.XML = value
 
     def SetTag(self,value):
-	self.tag = value
-	self.TagOption = True
+        self.tag = value
+        self.TagOption = True
 
     def Loop(self):
-		
-	afile = TFile(self.Filename)
-	afilename = self.Filename
-	stripfilename = afilename
 
-	try:
-	    if self.TagOption:
-		stripfilename = self.tag
-	except:
-	    stripfilename = afilename.split('/')[len(afilename.split('/')) -1]
-	    stripfilename = stripfilename[0:(len(stripfilename)-5)]
-	
-	alist = self.dir.GetListOfKeys()
+        afile = TFile(self.Filename)
+        afilename = self.Filename
+        stripfilename = afilename
 
-	for i in alist:
-	    aobj = i.ReadObj()
-	    if aobj.IsA().InheritsFrom("TDirectory"):
-		if self.Verbose:
-		    print(' found directory: '+i.GetName())
+        try:
+            if self.TagOption:
+                stripfilename = self.tag
+        except:
+            stripfilename = afilename.split('/')[len(afilename.split('/')) -1]
+            stripfilename = stripfilename[0:(len(stripfilename)-5)]
 
-		if self.XML:
-		    print('   <!-- '+i.GetName()+' -->')
+        alist = self.dir.GetListOfKeys()
 
-		bdir = self.dir
-		afile.GetObject(i.GetName(),bdir)
-		blist = bdir.GetListOfKeys()
-		for j in blist:
-		    bobj = j.ReadObj()
-		    if bobj.IsA().InheritsFrom(ROOT.TH1.Class()):
-			if self.Verbose:
-			    print('  --> found TH1: name = '+j.GetName() + ' title = '+j.GetTitle())
-			if self.XML:
-			    print('   <TH1 name=\"'+stripfilename+'_'+j.GetName()+'\" source=\"'+'/'+i.GetName()+'/'+j.GetName()+'\"/>')
-			
+        for i in alist:
+            aobj = i.ReadObj()
+            if aobj.IsA().InheritsFrom("TDirectory"):
+                if self.Verbose:
+                    print(' found directory: '+i.GetName())
+
+                if self.XML:
+                    print('   <!-- '+i.GetName()+' -->')
+
+                bdir = self.dir
+                afile.GetObject(i.GetName(),bdir)
+                blist = bdir.GetListOfKeys()
+                for j in blist:
+                    bobj = j.ReadObj()
+                    if bobj.IsA().InheritsFrom(ROOT.TH1.Class()):
+                        if self.Verbose:
+                            print('  --> found TH1: name = '+j.GetName() + ' title = '+j.GetTitle())
+                        if self.XML:
+                            print('   <TH1 name=\"'+stripfilename+'_'+j.GetName()+'\" source=\"'+'/'+i.GetName()+'/'+j.GetName()+'\"/>')
+
     def GetListObjects(self):
-	
-	afile = TFile(self.Filename)
-	
-	if afile.IsZombie():
-	    print(" error trying to open file: " + self.Filename)
-	    sys.exit()
-	
-	if self.XML:
 
-	    print('''
+        afile = TFile(self.Filename)
+
+        if afile.IsZombie():
+            print(" error trying to open file: " + self.Filename)
+            sys.exit()
+
+        if self.XML:
+
+            print('''
 <cuy>
 ''')	
-	    print('  <validation type=\"'+afile.GetName()+'\" file=\"'+self.Filename+'\" release=\"x.y.z\">')
-	
-	self.dir = ROOT.gDirectory
-	self.Loop()
+            print('  <validation type=\"'+afile.GetName()+'\" file=\"'+self.Filename+'\" release=\"x.y.z\">')
 
-	if self.XML:
+        self.dir = ROOT.gDirectory
+        self.Loop()
 
-	    print('''
+        if self.XML:
+
+            print('''
   </validation>
 
 </cuy>
 ''')
-	    
 
 
 
 
 
-    
+
+
 
 

--- a/Validation/RecoB/scripts/Style.py
+++ b/Validation/RecoB/scripts/Style.py
@@ -17,44 +17,44 @@ class Style:
 
     def SetStyle(self):
 
-	ROOT.gStyle.SetFrameBorderMode(0)
-	ROOT.gStyle.SetCanvasBorderMode(0)
-	ROOT.gStyle.SetPadBorderMode(0)
+        ROOT.gStyle.SetFrameBorderMode(0)
+        ROOT.gStyle.SetCanvasBorderMode(0)
+        ROOT.gStyle.SetPadBorderMode(0)
 
-	ROOT.gStyle.SetFrameFillColor(0)
-	ROOT.gStyle.SetPadColor(0)
-	ROOT.gStyle.SetCanvasColor(0)
-	ROOT.gStyle.SetTitleColor(1)
-	ROOT.gStyle.SetStatColor(0)
+        ROOT.gStyle.SetFrameFillColor(0)
+        ROOT.gStyle.SetPadColor(0)
+        ROOT.gStyle.SetCanvasColor(0)
+        ROOT.gStyle.SetTitleColor(1)
+        ROOT.gStyle.SetStatColor(0)
 
-	# set the paper & margin sizes
-	ROOT.gStyle.SetPaperSize(20,26)
-	ROOT.gStyle.SetPadTopMargin(0.06)
-	ROOT.gStyle.SetPadRightMargin(0.04)
-	ROOT.gStyle.SetPadBottomMargin(0.14)
-	ROOT.gStyle.SetPadLeftMargin(0.16)
-	ROOT.gStyle.SetPadTickX(1)
-	ROOT.gStyle.SetPadTickY(1)
-    
-	ROOT.gStyle.SetTextFont(42) #132
-	ROOT.gStyle.SetTextSize(0.09)
-	ROOT.gStyle.SetLabelFont(42,"xyz")
-	ROOT.gStyle.SetTitleFont(42,"xyz")
-	ROOT.gStyle.SetLabelSize(0.045,"xyz") #0.035
-	ROOT.gStyle.SetTitleSize(0.045,"xyz")
-	ROOT.gStyle.SetTitleOffset(1.5,"y")
-    
-	# use bold lines and markers
-	ROOT.gStyle.SetMarkerStyle(8)
-	ROOT.gStyle.SetHistLineWidth(2)
-	ROOT.gStyle.SetLineWidth(1)
+        # set the paper & margin sizes
+        ROOT.gStyle.SetPaperSize(20,26)
+        ROOT.gStyle.SetPadTopMargin(0.06)
+        ROOT.gStyle.SetPadRightMargin(0.04)
+        ROOT.gStyle.SetPadBottomMargin(0.14)
+        ROOT.gStyle.SetPadLeftMargin(0.16)
+        ROOT.gStyle.SetPadTickX(1)
+        ROOT.gStyle.SetPadTickY(1)
+
+        ROOT.gStyle.SetTextFont(42) #132
+        ROOT.gStyle.SetTextSize(0.09)
+        ROOT.gStyle.SetLabelFont(42,"xyz")
+        ROOT.gStyle.SetTitleFont(42,"xyz")
+        ROOT.gStyle.SetLabelSize(0.045,"xyz") #0.035
+        ROOT.gStyle.SetTitleSize(0.045,"xyz")
+        ROOT.gStyle.SetTitleOffset(1.5,"y")
+
+        # use bold lines and markers
+        ROOT.gStyle.SetMarkerStyle(8)
+        ROOT.gStyle.SetHistLineWidth(2)
+        ROOT.gStyle.SetLineWidth(1)
     #ROOT.gStyle.SetLineStyleString(2,"[12 12]") // postscript dashes
 
-	# do not display any of the standard histogram decorations
-	ROOT.gStyle.SetOptTitle(1)
-	ROOT.gStyle.SetOptStat(0) #("m")
-	ROOT.gStyle.SetOptFit(0)
-    
+        # do not display any of the standard histogram decorations
+        ROOT.gStyle.SetOptTitle(1)
+        ROOT.gStyle.SetOptStat(0) #("m")
+        ROOT.gStyle.SetOptFit(0)
+
     #ROOT.gStyle.SetPalette(1,0)
-	ROOT.gStyle.cd()
-	ROOT.gROOT.ForceStyle()
+        ROOT.gStyle.cd()
+        ROOT.gROOT.ForceStyle()

--- a/Validation/RecoB/scripts/cuy.py
+++ b/Validation/RecoB/scripts/cuy.py
@@ -49,9 +49,9 @@ except:
     print("\nCannot load PYROOT, make sure you have setup ROOT in the path")
     print("and pyroot library is also defined in the variable PYTHONPATH, try:\n")
     if (os.getenv("PYTHONPATH")):
-	print(" setenv PYTHONPATH ${PYTHONPATH}:$ROOTSYS/lib\n")
+        print(" setenv PYTHONPATH ${PYTHONPATH}:$ROOTSYS/lib\n")
     else:
-	print(" setenv PYTHONPATH $ROOTSYS/lib\n")
+        print(" setenv PYTHONPATH $ROOTSYS/lib\n")
     sys.exit()
 
 from ROOT import TFile
@@ -118,171 +118,171 @@ def parse(docstring, arglist=None):
 
 class ValElement:
     def __init__(self):
-	self.type = ""
-	self.filename = ""
-	self.release = ""
-	self.histos = {}
-	self.TH1s = {}
-	self.weight = None
+        self.type = ""
+        self.filename = ""
+        self.release = ""
+        self.histos = {}
+        self.TH1s = {}
+        self.weight = None
 
 class divideElement:
     def __init__(self):
-	self.name = ""
-	self.numerator = None
-	self.denominator = None
+        self.name = ""
+        self.numerator = None
+        self.denominator = None
 
 class plotElement:
     def __init__(self):
-	self.name = ""
-	self.title = ""
-	self.color = ""
+        self.name = ""
+        self.title = ""
+        self.color = ""
 
 class additionElement:
     def __init__(self):
-	self.name = ""
-	self.title = ""
-	self.SetLogy = ""
-	self.SetGrid = ""
-	self.histos = []
-	self.weight = []
-	
+        self.name = ""
+        self.title = ""
+        self.SetLogy = ""
+        self.SetGrid = ""
+        self.histos = []
+        self.weight = []
+
 class superimposeElement:
     def __init__(self):
-	self.name = ""
-	self.title = ""
-	self.SetLogy = ""
-	self.SetGrid = ""
-	self.histos = []
-	self.color = []
-	self.marker = []
-	self.legend = []
-	self.weight = []
+        self.name = ""
+        self.title = ""
+        self.SetLogy = ""
+        self.SetGrid = ""
+        self.histos = []
+        self.color = []
+        self.marker = []
+        self.legend = []
+        self.weight = []
         #self.flavour = []
 #**********************************
 class graphElement:
     def __init__(self):
-	self.name = ""
-	self.title = ""
-	self.SetLogy = ""
-	self.SetGrid = ""
-	self.histos = []
-	self.color = []
-	self.marker = []
-	self.legend = []
-	self.weight = []
+        self.name = ""
+        self.title = ""
+        self.SetLogy = ""
+        self.SetGrid = ""
+        self.histos = []
+        self.color = []
+        self.marker = []
+        self.legend = []
+        self.weight = []
         self.flavour = []
 #**********************************
 
 class FindIssue(handler.ContentHandler):
     def __init__(self):
-	self.data = {}
-	self.divide = {}
-	self.addition = {}
-	self.superimpose = {}
+        self.data = {}
+        self.divide = {}
+        self.addition = {}
+        self.superimpose = {}
         self.graph = {}
-	self.tmpaddname = ""
+        self.tmpaddname = ""
         self.plot = {}
-	self.size = 0
-	self.atype = ""
-	self.tmpsupername = ""
+        self.size = 0
+        self.atype = ""
+        self.tmpsupername = ""
         self.tmpgraphname = ""
 
     def startElement(self, name, attrs):
         if name == 'validation':
-	    self.size = self.size + 1
-	    self.atype = attrs.get('type',None)
-	    self.data[self.atype] = ValElement()
-	    self.data[self.atype].type = attrs.get('type',None)
-	    self.data[self.atype].filename = attrs.get('file',None)
-	    self.data[self.atype].release = attrs.get('release',None)
-	    self.data[self.atype].weight = attrs.get('weight','')
-	if name == 'TH1':
-	    self.data[self.atype].histos[attrs.get('name',None)] = attrs.get('source',None)
-	    #print attrs.get('name',None)
-	    #print attrs.get('source',None)
-	if name == 'divide':
-	    aname = attrs.get('name',None)
-	    self.divide[aname] = divideElement()
-	    self.divide[aname].name = aname
-	    self.divide[aname].numerator = attrs.get('numerator',None)
-	    self.divide[aname].denominator = attrs.get('denominator',None)
-	    self.divide[aname].DivideOption = attrs.get('DivideOption',None)
-	    self.divide[aname].Option = attrs.get('Option',None)
-	if name == 'addition':
-	    aname = attrs.get('name',None)
-	    self.addition[aname] = additionElement()
-	    self.tmpaddname = aname
-	    self.addition[aname].name = aname
-	    self.addition[aname].title = attrs.get('title',None)
-	    self.addition[aname].YTitle = attrs.get('YTitle',None)
-	    self.addition[aname].XTitle = attrs.get('XTitle',None)
-	    self.addition[aname].Option = attrs.get('Option',None)
-	    self.addition[aname].Weight = attrs.get('Wight',None)
-	    self.addition[aname].Normalize = attrs.get('Normalize',None)
-	    self.addition[aname].SetGrid = attrs.get('SetGrid',None)
-	if name == 'additionItem':
-	    #print "in element: " + self.tmpsupername
-	    self.addition[self.tmpaddname].histos.append(attrs.get('name',None))
-	    self.addition[self.tmpaddname].weight.append(attrs.get('weight',None))
-	if name == 'superimpose':
-	    aname = attrs.get('name',None)
-	    self.superimpose[aname] = superimposeElement()
-	    self.superimpose[aname].name = aname
-	    self.superimpose[aname].title = attrs.get('title',None)
-	    self.superimpose[aname].SetLogy = attrs.get('SetLogy',None)
-	    self.superimpose[aname].SetGrid = attrs.get('SetGrid',None)
-	    self.superimpose[aname].Normalize = attrs.get('Normalize',None)
-	    self.superimpose[aname].Stack     = attrs.get('Stack',None)
-	    self.superimpose[aname].YTitle = attrs.get('YTitle',None)
-	    self.superimpose[aname].XTitle = attrs.get('XTitle',None)
-	    self.superimpose[aname].projection = attrs.get('Projection',None)
-	    self.superimpose[aname].bin = attrs.get('bin',None)
-	    self.superimpose[aname].profile = attrs.get('Profile',None)
-	    self.superimpose[aname].Fill = attrs.get('Fill',None)
-	    self.superimpose[aname].Option = attrs.get('Option',None)
-	    self.superimpose[aname].Weight = attrs.get('Weight',None)
-	    self.superimpose[aname].Maximum = attrs.get('Maximum',None)
-	    self.superimpose[aname].Minimum = attrs.get('Minimum',None)
-	    self.superimpose[aname].Labels = attrs.get('Labels',None)
- 	    self.superimpose[aname].Rebin = attrs.get('Rebin',None)
-  	    self.tmpsupername = aname
-	if name == 'graph':
-	    aname = attrs.get('name',None)
-	    self.graph[aname] = graphElement()
-	    self.graph[aname].name = aname
-	    self.graph[aname].title = attrs.get('title',None)
-	    self.graph[aname].SetLogy = attrs.get('SetLogy',None)
-	    self.graph[aname].SetGrid = attrs.get('SetGrid',None)
-	    self.graph[aname].Normalize = attrs.get('Normalize',None)
-	    self.graph[aname].Stack     = attrs.get('Stack',None)
-	    self.graph[aname].YTitle = attrs.get('YTitle',None)
-	    self.graph[aname].XTitle = attrs.get('XTitle',None)
-	    self.graph[aname].projection = attrs.get('Projection',None)
-	    self.graph[aname].bin = attrs.get('bin',None)
-	    self.graph[aname].profile = attrs.get('Profile',None)
-	    self.graph[aname].Fill = attrs.get('Fill',None)
-	    self.graph[aname].Option = attrs.get('Option',None)
-	    self.graph[aname].Weight = attrs.get('Weight',None)
-	    self.graph[aname].Maximum = attrs.get('Maximum',None)
-	    self.graph[aname].Minimum = attrs.get('Minimum',None)
-	    self.graph[aname].Labels = attrs.get('Labels',None)
-	    self.tmpgraphname = aname
+            self.size = self.size + 1
+            self.atype = attrs.get('type',None)
+            self.data[self.atype] = ValElement()
+            self.data[self.atype].type = attrs.get('type',None)
+            self.data[self.atype].filename = attrs.get('file',None)
+            self.data[self.atype].release = attrs.get('release',None)
+            self.data[self.atype].weight = attrs.get('weight','')
+        if name == 'TH1':
+            self.data[self.atype].histos[attrs.get('name',None)] = attrs.get('source',None)
+            #print attrs.get('name',None)
+            #print attrs.get('source',None)
+        if name == 'divide':
+            aname = attrs.get('name',None)
+            self.divide[aname] = divideElement()
+            self.divide[aname].name = aname
+            self.divide[aname].numerator = attrs.get('numerator',None)
+            self.divide[aname].denominator = attrs.get('denominator',None)
+            self.divide[aname].DivideOption = attrs.get('DivideOption',None)
+            self.divide[aname].Option = attrs.get('Option',None)
+        if name == 'addition':
+            aname = attrs.get('name',None)
+            self.addition[aname] = additionElement()
+            self.tmpaddname = aname
+            self.addition[aname].name = aname
+            self.addition[aname].title = attrs.get('title',None)
+            self.addition[aname].YTitle = attrs.get('YTitle',None)
+            self.addition[aname].XTitle = attrs.get('XTitle',None)
+            self.addition[aname].Option = attrs.get('Option',None)
+            self.addition[aname].Weight = attrs.get('Wight',None)
+            self.addition[aname].Normalize = attrs.get('Normalize',None)
+            self.addition[aname].SetGrid = attrs.get('SetGrid',None)
+        if name == 'additionItem':
+            #print "in element: " + self.tmpsupername
+            self.addition[self.tmpaddname].histos.append(attrs.get('name',None))
+            self.addition[self.tmpaddname].weight.append(attrs.get('weight',None))
+        if name == 'superimpose':
+            aname = attrs.get('name',None)
+            self.superimpose[aname] = superimposeElement()
+            self.superimpose[aname].name = aname
+            self.superimpose[aname].title = attrs.get('title',None)
+            self.superimpose[aname].SetLogy = attrs.get('SetLogy',None)
+            self.superimpose[aname].SetGrid = attrs.get('SetGrid',None)
+            self.superimpose[aname].Normalize = attrs.get('Normalize',None)
+            self.superimpose[aname].Stack     = attrs.get('Stack',None)
+            self.superimpose[aname].YTitle = attrs.get('YTitle',None)
+            self.superimpose[aname].XTitle = attrs.get('XTitle',None)
+            self.superimpose[aname].projection = attrs.get('Projection',None)
+            self.superimpose[aname].bin = attrs.get('bin',None)
+            self.superimpose[aname].profile = attrs.get('Profile',None)
+            self.superimpose[aname].Fill = attrs.get('Fill',None)
+            self.superimpose[aname].Option = attrs.get('Option',None)
+            self.superimpose[aname].Weight = attrs.get('Weight',None)
+            self.superimpose[aname].Maximum = attrs.get('Maximum',None)
+            self.superimpose[aname].Minimum = attrs.get('Minimum',None)
+            self.superimpose[aname].Labels = attrs.get('Labels',None)
+            self.superimpose[aname].Rebin = attrs.get('Rebin',None)
+            self.tmpsupername = aname
+        if name == 'graph':
+            aname = attrs.get('name',None)
+            self.graph[aname] = graphElement()
+            self.graph[aname].name = aname
+            self.graph[aname].title = attrs.get('title',None)
+            self.graph[aname].SetLogy = attrs.get('SetLogy',None)
+            self.graph[aname].SetGrid = attrs.get('SetGrid',None)
+            self.graph[aname].Normalize = attrs.get('Normalize',None)
+            self.graph[aname].Stack     = attrs.get('Stack',None)
+            self.graph[aname].YTitle = attrs.get('YTitle',None)
+            self.graph[aname].XTitle = attrs.get('XTitle',None)
+            self.graph[aname].projection = attrs.get('Projection',None)
+            self.graph[aname].bin = attrs.get('bin',None)
+            self.graph[aname].profile = attrs.get('Profile',None)
+            self.graph[aname].Fill = attrs.get('Fill',None)
+            self.graph[aname].Option = attrs.get('Option',None)
+            self.graph[aname].Weight = attrs.get('Weight',None)
+            self.graph[aname].Maximum = attrs.get('Maximum',None)
+            self.graph[aname].Minimum = attrs.get('Minimum',None)
+            self.graph[aname].Labels = attrs.get('Labels',None)
+            self.tmpgraphname = aname
         if name == 'superimposeItem':
-	    #print "in element: " + self.tmpsupername
-	    self.superimpose[self.tmpsupername].histos.append(attrs.get('name',None))
-	    self.superimpose[self.tmpsupername].color.append(attrs.get('color',None))
-	    self.superimpose[self.tmpsupername].marker.append(attrs.get('MarkerStyle',None))
-	    self.superimpose[self.tmpsupername].legend.append(attrs.get('legend',None))
+            #print "in element: " + self.tmpsupername
+            self.superimpose[self.tmpsupername].histos.append(attrs.get('name',None))
+            self.superimpose[self.tmpsupername].color.append(attrs.get('color',None))
+            self.superimpose[self.tmpsupername].marker.append(attrs.get('MarkerStyle',None))
+            self.superimpose[self.tmpsupername].legend.append(attrs.get('legend',None))
             #self.superimpose[self.tmpsupername].flavour.append(attrs.get('flavour',None))
-	    #self.superimpose[self.tmpsupername].weight.append(attrs.get('weight',None))
-	if name == 'graphItem':
-	    #print "in element: " + self.tmpsupername
-	    self.graph[self.tmpgraphname].histos.append(attrs.get('name',None))
-	    self.graph[self.tmpgraphname].color.append(attrs.get('color',None))
-	    self.graph[self.tmpgraphname].marker.append(attrs.get('MarkerStyle',None))
-	    self.graph[self.tmpgraphname].legend.append(attrs.get('legend',None))
+            #self.superimpose[self.tmpsupername].weight.append(attrs.get('weight',None))
+        if name == 'graphItem':
+            #print "in element: " + self.tmpsupername
+            self.graph[self.tmpgraphname].histos.append(attrs.get('name',None))
+            self.graph[self.tmpgraphname].color.append(attrs.get('color',None))
+            self.graph[self.tmpgraphname].marker.append(attrs.get('MarkerStyle',None))
+            self.graph[self.tmpgraphname].legend.append(attrs.get('legend',None))
             self.graph[self.tmpgraphname].flavour.append(attrs.get('flavour',None))
-	    #self.se[self.tmpsupername].weight.append(attrs.get('weight',None))
+            #self.se[self.tmpsupername].weight.append(attrs.get('weight',None))
 
 
 
@@ -305,46 +305,46 @@ if __name__ == '__main__':
     if not args and not option: exit()
 
     if option.batch:
-	ROOT.gROOT.SetBatch()
+        ROOT.gROOT.SetBatch()
 
     if option.verbose:
-	verbose = True
+        verbose = True
 
     if option.list:
-	ins = Inspector.Inspector()
-	ins.Verbose(True)
-	ins.createXML(False)
-	ins.SetFilename(option.list)
-	ins.GetListObjects()
-	sys.exit()
+        ins = Inspector.Inspector()
+        ins.Verbose(True)
+        ins.createXML(False)
+        ins.SetFilename(option.list)
+        ins.GetListObjects()
+        sys.exit()
 
     if option.create:
-	createXML = Inspector.Inspector()
-	createXML.Verbose(False)
-	createXML.createXML(True)
-	if option.tag:
-	    createXML.SetTag(option.tag)
-	createXML.SetFilename(option.create)
-	createXML.GetListObjects()
-	sys.exit()
+        createXML = Inspector.Inspector()
+        createXML.Verbose(False)
+        createXML.createXML(True)
+        if option.tag:
+            createXML.SetTag(option.tag)
+        createXML.SetFilename(option.create)
+        createXML.GetListObjects()
+        sys.exit()
 
     if not option.xml: exit()
     if option.prt: 
-	printCanvas = True
-	printFormat = option.prt
+        printCanvas = True
+        printFormat = option.prt
 
     if option.flag:
-	printBanner = True
-	Banner = option.flag
+        printBanner = True
+        Banner = option.flag
 
     # check xml file
     try:
-	xmlfile = open(option.xml)
-	xmlfile.close()
+        xmlfile = open(option.xml)
+        xmlfile.close()
     except:
-	print(" ERROR: xml file \"" + option.xml + "\" does not exist")
-	sys.exit()
-    
+        print(" ERROR: xml file \"" + option.xml + "\" does not exist")
+        sys.exit()
+
     # Create a parser
     parser = make_parser()
 
@@ -377,27 +377,27 @@ if __name__ == '__main__':
     firstFilename = ''
 
     for ikey in thedata:
-	if verbose : print("= Processing set called: " + ikey)
-	afilename = thedata[ikey].filename
-	if firstFilename == '':
-	    firstFilename = afilename
-	arelease = ""
-	if thedata[ikey].release != None:
-	    arelease = thedata[ikey].release
-	if verbose : print("== filename: " + afilename)
-	if verbose : print("== release:  " + arelease)
-	if verbose : print("== weight:   " + thedata[ikey].weight)
-	thehistos = thedata[ikey].histos
-	afilelist[afilename] = TFile(afilename)
-	if verbose : print("== get histograms: ")
-	histonamekeys = thehistos.keys()
-	for ihname in histonamekeys:
-	    if verbose : print("=== Histogram name: \""+ ihname + "\" source: \""+thehistos[ihname]+"\"")
-	    thedata[ikey].TH1s[ihname] = ROOT.gDirectory.Get(thehistos[ihname])
-	    #SetOwnership(thedata[ikey].TH1s[ihname], 0)
-	    # check if file exists
-	    print(thedata[ikey].TH1s[ihname].GetName())
-            
+        if verbose : print("= Processing set called: " + ikey)
+        afilename = thedata[ikey].filename
+        if firstFilename == '':
+            firstFilename = afilename
+        arelease = ""
+        if thedata[ikey].release != None:
+            arelease = thedata[ikey].release
+        if verbose : print("== filename: " + afilename)
+        if verbose : print("== release:  " + arelease)
+        if verbose : print("== weight:   " + thedata[ikey].weight)
+        thehistos = thedata[ikey].histos
+        afilelist[afilename] = TFile(afilename)
+        if verbose : print("== get histograms: ")
+        histonamekeys = thehistos.keys()
+        for ihname in histonamekeys:
+            if verbose : print("=== Histogram name: \""+ ihname + "\" source: \""+thehistos[ihname]+"\"")
+            thedata[ikey].TH1s[ihname] = ROOT.gDirectory.Get(thehistos[ihname])
+            #SetOwnership(thedata[ikey].TH1s[ihname], 0)
+            # check if file exists
+            print(thedata[ikey].TH1s[ihname].GetName())
+
 
     # plot superimpose histograms
     #afilelist['../outputLayer2_ttbarmuonic_all.root'].cd()
@@ -407,381 +407,381 @@ if __name__ == '__main__':
 
     theaddition = dh.addition
     if verbose : print("= Create addition histograms:")
-    
+
     for ikey in theaddition:
-	if verbose : print("== plot name: \""+theaddition[ikey].name+"\" title: \""+theaddition[ikey].title+"\"")
-	listname = theaddition[ikey].histos
-	listweight = theaddition[ikey].weight
+        if verbose : print("== plot name: \""+theaddition[ikey].name+"\" title: \""+theaddition[ikey].title+"\"")
+        listname = theaddition[ikey].histos
+        listweight = theaddition[ikey].weight
 
-	#create canvas
-	cv[theaddition[ikey].name] = TCanvas(theaddition[ikey].name,theaddition[ikey].name,700,700)
+        #create canvas
+        cv[theaddition[ikey].name] = TCanvas(theaddition[ikey].name,theaddition[ikey].name,700,700)
 
-	isFirst = True
-	ihnameIt = 0
-	for ihname in listname:
-	    aweight = 1
-	    if listweight[ihnameIt]:
-	    #if thedata[jkey].weight != None and theaddition[ikey].Weight == "true":
-		aweight = float(listweight[ihnameIt])
-		#aweight = float(thedata[jkey].weight)
-	    for jkey in thedata:
-		tmpkeys = thedata[jkey].histos.keys()
-		for tmpname in tmpkeys:
-		    if tmpname == ihname:
-			ath = thedata[jkey].TH1s[tmpname]
-			if ath is None:
-			    print("ERROR: histogram name \""+tmpname+"\" does not exist in file "+thedata[jkey].filename)
-			    exit(0)
-			if verbose : print("=== add histogram: "+ath.GetName() + " from " + thedata[jkey].filename + " mean = " + "%.2f" % round(ath.GetMean(),2) + " weight= " + str(aweight))
-			#ath.Print("all")
-			if isFirst:
-			    newth = ath.Clone(theaddition[ikey].name)
-			    newth.Sumw2()
-			    if theaddition[ikey].Normalize == "true":
-				newth.Scale(1/newth.Integral())
-			    newth.Scale(aweight)
-			    isFirst = False
-			else:
-			    atmpth = ath.Clone()
-			    atmpth.Sumw2()
-			    if theaddition[ikey].Normalize == "true":
-				atmpth.Scale(1/atmpth.Integral())
-			    atmpth.Scale(aweight)
-			    newth.Add( atmpth )
-	    ihnameIt = ihnameIt + 1
+        isFirst = True
+        ihnameIt = 0
+        for ihname in listname:
+            aweight = 1
+            if listweight[ihnameIt]:
+            #if thedata[jkey].weight != None and theaddition[ikey].Weight == "true":
+                aweight = float(listweight[ihnameIt])
+                #aweight = float(thedata[jkey].weight)
+            for jkey in thedata:
+                tmpkeys = thedata[jkey].histos.keys()
+                for tmpname in tmpkeys:
+                    if tmpname == ihname:
+                        ath = thedata[jkey].TH1s[tmpname]
+                        if ath is None:
+                            print("ERROR: histogram name \""+tmpname+"\" does not exist in file "+thedata[jkey].filename)
+                            exit(0)
+                        if verbose : print("=== add histogram: "+ath.GetName() + " from " + thedata[jkey].filename + " mean = " + "%.2f" % round(ath.GetMean(),2) + " weight= " + str(aweight))
+                        #ath.Print("all")
+                        if isFirst:
+                            newth = ath.Clone(theaddition[ikey].name)
+                            newth.Sumw2()
+                            if theaddition[ikey].Normalize == "true":
+                                newth.Scale(1/newth.Integral())
+                            newth.Scale(aweight)
+                            isFirst = False
+                        else:
+                            atmpth = ath.Clone()
+                            atmpth.Sumw2()
+                            if theaddition[ikey].Normalize == "true":
+                                atmpth.Scale(1/atmpth.Integral())
+                            atmpth.Scale(aweight)
+                            newth.Add( atmpth )
+            ihnameIt = ihnameIt + 1
 
-	if theaddition[ikey].XTitle != None:
-	    newth.SetXTitle(theaddition[ikey].XTitle)
-	if theaddition[ikey].YTitle != None:
-	    newth.SetYTitle(theaddition[ikey].YTitle)
+        if theaddition[ikey].XTitle != None:
+            newth.SetXTitle(theaddition[ikey].XTitle)
+        if theaddition[ikey].YTitle != None:
+            newth.SetYTitle(theaddition[ikey].YTitle)
 
-	if theaddition[ikey].Option:
-	    newth.Draw(theaddition[ikey].Option)
-	else:
-	    newth.Draw()
+        if theaddition[ikey].Option:
+            newth.Draw(theaddition[ikey].Option)
+        else:
+            newth.Draw()
 
-	if theaddition[ikey].SetGrid == "true":
-	    cv[theaddition[ikey].name].SetGrid()
-	
-	cv[theaddition[ikey].name].Update()
+        if theaddition[ikey].SetGrid == "true":
+            cv[theaddition[ikey].name].SetGrid()
 
-	# add new histogram to the list
-	newth.SetName(theaddition[ikey].name)
-	newTH1list.append(newth.GetName())
-	thedata[newth.GetName()] = ValElement()
-	thedata[newth.GetName()].TH1s[newth.GetName()] = newth
-	thedata[newth.GetName()].histos[newth.GetName()] = newth.GetName()
+        cv[theaddition[ikey].name].Update()
 
-	# write new histograms to file
-	outputroot.cd()
-	newth.Write()
-	
-    
+        # add new histogram to the list
+        newth.SetName(theaddition[ikey].name)
+        newTH1list.append(newth.GetName())
+        thedata[newth.GetName()] = ValElement()
+        thedata[newth.GetName()].TH1s[newth.GetName()] = newth
+        thedata[newth.GetName()].histos[newth.GetName()] = newth.GetName()
+
+        # write new histograms to file
+        outputroot.cd()
+        newth.Write()
+
+
     if verbose : print("= Create ratio histograms:")
-    
+
     thedivition = dh.divide
     for ikey in thedivition:
-	if verbose : print("== plot name: \""+thedivition[ikey].name+"\" title: \""+"\"")
-	numerator = thedivition[ikey].numerator
-	denominator = thedivition[ikey].denominator
+        if verbose : print("== plot name: \""+thedivition[ikey].name+"\" title: \""+"\"")
+        numerator = thedivition[ikey].numerator
+        denominator = thedivition[ikey].denominator
 
-	#create canvas
-	cv[thedivition[ikey].name] = TCanvas(thedivition[ikey].name,thedivition[ikey].name,700,700)
+        #create canvas
+        cv[thedivition[ikey].name] = TCanvas(thedivition[ikey].name,thedivition[ikey].name,700,700)
 
-	for jkey in thedata:
-	    tmpkeys = thedata[jkey].histos.keys()
-	    for tmpname in tmpkeys:
-		if tmpname == numerator:
-		    numeratorth = thedata[jkey].TH1s[tmpname]
-		    if numeratorth is None:
-			print("ERROR: histogram name \""+tmpname+"\" does not exist in file "+thedata[jkey].filename)
-			exit(0)
-			#print "=== numerator histogram: "+numeratorth.GetName() + " from " + thedata[jkey].filename + " mean = " + "%.2f" % round(numeratorth.GetMean(),2) + " weight= " + str(aweight)
+        for jkey in thedata:
+            tmpkeys = thedata[jkey].histos.keys()
+            for tmpname in tmpkeys:
+                if tmpname == numerator:
+                    numeratorth = thedata[jkey].TH1s[tmpname]
+                    if numeratorth is None:
+                        print("ERROR: histogram name \""+tmpname+"\" does not exist in file "+thedata[jkey].filename)
+                        exit(0)
+                        #print "=== numerator histogram: "+numeratorth.GetName() + " from " + thedata[jkey].filename + " mean = " + "%.2f" % round(numeratorth.GetMean(),2) + " weight= " + str(aweight)
 
-		if tmpname == denominator:
-		    denominatorth = thedata[jkey].TH1s[tmpname]
-		    if denominatorth is None:
-			print("ERROR: histogram name \""+tmpname+"\" does not exist in file "+thedata[jkey].filename)
-			exit(0)
-			#print "=== denominator histogram: "+denominatorth.GetName() + " from " + thedata[jkey].filename + " mean = " + "%.2f" % round(denominatorth.GetMean(),2) + " weight= " + str(aweight)
+                if tmpname == denominator:
+                    denominatorth = thedata[jkey].TH1s[tmpname]
+                    if denominatorth is None:
+                        print("ERROR: histogram name \""+tmpname+"\" does not exist in file "+thedata[jkey].filename)
+                        exit(0)
+                        #print "=== denominator histogram: "+denominatorth.GetName() + " from " + thedata[jkey].filename + " mean = " + "%.2f" % round(denominatorth.GetMean(),2) + " weight= " + str(aweight)
 
 
-	
-	numeratorth.Sumw2()
-	denominatorth.Sumw2()
-	newth = numeratorth.Clone()
-	newth.Clear()
-	if thedivition[ikey].DivideOption is None:
-	    newth.Divide(numeratorth,denominatorth)
-	else:
-	    newth.Divide(numeratorth,denominatorth,1.,1.,thedivition[ikey].DivideOption)
+
+        numeratorth.Sumw2()
+        denominatorth.Sumw2()
+        newth = numeratorth.Clone()
+        newth.Clear()
+        if thedivition[ikey].DivideOption is None:
+            newth.Divide(numeratorth,denominatorth)
+        else:
+            newth.Divide(numeratorth,denominatorth,1.,1.,thedivition[ikey].DivideOption)
 #	if theaddition[ikey].XTitle != None:
 #	    newth.SetXTitle(theaddition[ikey].XTitle)
 #	if theaddition[ikey].YTitle != None:
 #	    newth.SetYTitle(theaddition[ikey].YTitle)
 
-	if thedivition[ikey].Option:
-	    newth.Draw(thedivition[ikey].Option)
-	else:
-	    newth.Draw()
+        if thedivition[ikey].Option:
+            newth.Draw(thedivition[ikey].Option)
+        else:
+            newth.Draw()
 
-	cv[thedivition[ikey].name].Update()
-	
-	
-	# pause
-	if option.wait:
-	    raw_input( 'Press ENTER to continue\n ' )
+        cv[thedivition[ikey].name].Update()
 
-	# add new histogram to the list
-	newth.SetName(thedivition[ikey].name)
-	newTH1list.append(newth.GetName())
-	thedata[newth.GetName()] = ValElement()
-	thedata[newth.GetName()].TH1s[newth.GetName()] = newth
-	thedata[newth.GetName()].histos[newth.GetName()] = newth.GetName()
-	
-	# write new histograms to file
-	outputroot.cd()
-	newth.Write()
+
+        # pause
+        if option.wait:
+            raw_input( 'Press ENTER to continue\n ' )
+
+        # add new histogram to the list
+        newth.SetName(thedivition[ikey].name)
+        newTH1list.append(newth.GetName())
+        thedata[newth.GetName()] = ValElement()
+        thedata[newth.GetName()].TH1s[newth.GetName()] = newth
+        thedata[newth.GetName()].histos[newth.GetName()] = newth.GetName()
+
+        # write new histograms to file
+        outputroot.cd()
+        newth.Write()
 
 
     thesuper = dh.superimpose
     if verbose : print("= Create superimpose histograms:")
     for ikey in thesuper:
-	if verbose : print("== plot name: \""+thesuper[ikey].name+"\" title: \""+thesuper[ikey].title+"\"")
-	listname = thesuper[ikey].histos
-	listcolor = thesuper[ikey].color
-	listmarker = thesuper[ikey].marker
-	listlegend = thesuper[ikey].legend
+        if verbose : print("== plot name: \""+thesuper[ikey].name+"\" title: \""+thesuper[ikey].title+"\"")
+        listname = thesuper[ikey].histos
+        listcolor = thesuper[ikey].color
+        listmarker = thesuper[ikey].marker
+        listlegend = thesuper[ikey].legend
         #listweight = thesuper[ikey].weight
-	dolegend = False
-	for il in listlegend:
-	    if il==None: dolegend = False
-	if verbose : print("dolegend = " +str(dolegend))
-	doNormalize = False
+        dolegend = False
+        for il in listlegend:
+            if il==None: dolegend = False
+        if verbose : print("dolegend = " +str(dolegend))
+        doNormalize = False
         doRebin=thesuper[ikey].Rebin
         if doRebin is not None :
             doRebin=int(doRebin)
             if verbose : print("Rebin is ", doRebin)
         if thesuper[ikey].Normalize == "true":
-	    doNormalize = True
-	    if verbose : print("normalize = " +str(doNormalize))
-	projectAxis = "no"
-	projectBin = -1 #all
-	if thesuper[ikey].projection == "x": projectAxis = "x"
-	if thesuper[ikey].projection == "y": projectAxis = "y"
-	if thesuper[ikey].bin != None: projectBin = thesuper[ikey].bin
-	profileAxis = "no"
-	if thesuper[ikey].profile == "x": profileAxis = "x"
-	if thesuper[ikey].profile == "y": profileAxis = "y"
-	doFill = False
-	if thesuper[ikey].Fill == "true": doFill = True
-	if verbose : print("fill option:"+ doFill)
-	#create canvas
-	cv[thesuper[ikey].name] = TCanvas(thesuper[ikey].name,thesuper[ikey].title,700,700)
-	#legend
-	aleg = TLegend(0.6,0.4,0.8,0.6)
-	SetOwnership( aleg, 0 ) 
-	aleg.SetMargin(0.12)
+            doNormalize = True
+            if verbose : print("normalize = " +str(doNormalize))
+        projectAxis = "no"
+        projectBin = -1 #all
+        if thesuper[ikey].projection == "x": projectAxis = "x"
+        if thesuper[ikey].projection == "y": projectAxis = "y"
+        if thesuper[ikey].bin != None: projectBin = thesuper[ikey].bin
+        profileAxis = "no"
+        if thesuper[ikey].profile == "x": profileAxis = "x"
+        if thesuper[ikey].profile == "y": profileAxis = "y"
+        doFill = False
+        if thesuper[ikey].Fill == "true": doFill = True
+        if verbose : print("fill option:"+ doFill)
+        #create canvas
+        cv[thesuper[ikey].name] = TCanvas(thesuper[ikey].name,thesuper[ikey].title,700,700)
+        #legend
+        aleg = TLegend(0.6,0.4,0.8,0.6)
+        SetOwnership( aleg, 0 ) 
+        aleg.SetMargin(0.12)
         aleg.SetTextSize(0.035)
         aleg.SetFillColor(10)
-	aleg.SetBorderSize(0)
+        aleg.SetBorderSize(0)
 
-	isFirst = 1
-	ii = 0
+        isFirst = 1
+        ii = 0
 
-	stacklist[thesuper[ikey].name] = THStack("astack"+thesuper[ikey].name,thesuper[ikey].title)
-	astack = stacklist[thesuper[ikey].name]
-	for ihname in listname:
-	
-	    for jkey in thedata:
-		tmpkeys = thedata[jkey].histos.keys()
-		
-		for tmpname in tmpkeys:
-		
-		    if tmpname == ihname:
-			ath = thedata[jkey].TH1s[tmpname]
-			if ath is None:
-			    print("ERROR: histogram name \""+tmpname+"\" does not exist in file "+thedata[jkey].filename)
-			    exit(0)
-			if verbose : print("=== superimpose histogram: "+ath.GetName() + " mean = " + "%.2f" % round(ath.GetMean(),2))
-			# project 2D histogram if requested
-			if projectAxis == "x":
-			    if projectBin == -1:
-				newthpx = ath.ProjectionX(ath.GetName()+"_px",0,-1,"e")
-			    else:
-				newthpx = ath.ProjectionX(ath.GetName()+"_px",int(projectBin),int(projectBin),"e")
-			    newth = newthpx.Clone()
-			if projectAxis == "y":
-			    if projectBin == -1:
-				newthpy = ath.ProjectionY(ath.GetName()+"_py",0,-1,"e")
-			    else:
-				newthpx = ath.ProjectionY(ath.GetName()+"_py",int(projectBin),int(projectBin),"e")
-			    newth = newthpy.Clone()
-			if profileAxis == "x":
-			    newthpx = ath.ProfileX(ath.GetName()+"_px",0,-1,"e")
-			    newth = newthpx.Clone()
-			if profileAxis == "y":
-			    newthpy = ath.ProfileY(ath.GetName()+"_py",0,-1,"e")
-			    newth = newthpy.Clone()
+        stacklist[thesuper[ikey].name] = THStack("astack"+thesuper[ikey].name,thesuper[ikey].title)
+        astack = stacklist[thesuper[ikey].name]
+        for ihname in listname:
 
-			# get weight
-			aweight = 1
-			if thedata[jkey].weight != None and thesuper[ikey].Weight=="true":
-			    aweight = float( thedata[jkey].weight )
-			if verbose: print(" with weight = " + str(aweight))
-			#if listweight[ii]:
-			 #   aweight = float( listweight[ii] )
+            for jkey in thedata:
+                tmpkeys = thedata[jkey].histos.keys()
 
-			# clone original histogram
-			if projectAxis == "no" and profileAxis == "no" :newth = ath.Clone()
+                for tmpname in tmpkeys:
+
+                    if tmpname == ihname:
+                        ath = thedata[jkey].TH1s[tmpname]
+                        if ath is None:
+                            print("ERROR: histogram name \""+tmpname+"\" does not exist in file "+thedata[jkey].filename)
+                            exit(0)
+                        if verbose : print("=== superimpose histogram: "+ath.GetName() + " mean = " + "%.2f" % round(ath.GetMean(),2))
+                        # project 2D histogram if requested
+                        if projectAxis == "x":
+                            if projectBin == -1:
+                                newthpx = ath.ProjectionX(ath.GetName()+"_px",0,-1,"e")
+                            else:
+                                newthpx = ath.ProjectionX(ath.GetName()+"_px",int(projectBin),int(projectBin),"e")
+                            newth = newthpx.Clone()
+                        if projectAxis == "y":
+                            if projectBin == -1:
+                                newthpy = ath.ProjectionY(ath.GetName()+"_py",0,-1,"e")
+                            else:
+                                newthpx = ath.ProjectionY(ath.GetName()+"_py",int(projectBin),int(projectBin),"e")
+                            newth = newthpy.Clone()
+                        if profileAxis == "x":
+                            newthpx = ath.ProfileX(ath.GetName()+"_px",0,-1,"e")
+                            newth = newthpx.Clone()
+                        if profileAxis == "y":
+                            newthpy = ath.ProfileY(ath.GetName()+"_py",0,-1,"e")
+                            newth = newthpy.Clone()
+
+                        # get weight
+                        aweight = 1
+                        if thedata[jkey].weight != None and thesuper[ikey].Weight=="true":
+                            aweight = float( thedata[jkey].weight )
+                        if verbose: print(" with weight = " + str(aweight))
+                        #if listweight[ii]:
+                         #   aweight = float( listweight[ii] )
+
+                        # clone original histogram
+                        if projectAxis == "no" and profileAxis == "no" :newth = ath.Clone()
 
                         if doRebin is not None and doRebin>0 :
                             newth.Rebin(doRebin)
 
                         newth.Sumw2()
-			newth.Scale(aweight)
-			
-			# check if we have color
-			if not listcolor[ii]:
-			    listcolor[ii] = 1
-			
-			newth.SetLineColor(int(listcolor[ii]))
-			newth.SetMarkerColor(int(listcolor[ii]))
-			
-			if doFill: newth.SetFillColor(int(listcolor[ii]))
+                        newth.Scale(aweight)
 
-			if listmarker[ii] != None:
-			    newth.SetMarkerStyle(int(listmarker[ii]))
-			# normalize
-			if doNormalize:
-			    newth.Scale(1./newth.Integral())
-			#print "   "+listlegend[ii]
-			
-			if thesuper[ikey].Labels != None:
-			    thelabels = thesuper[ikey].Labels.split(',')
-			    ib = 1
-			    #print thelabels
+                        # check if we have color
+                        if not listcolor[ii]:
+                            listcolor[ii] = 1
 
-			    for ilabel in thelabels:
-				newth.GetXaxis().SetBinLabel(ib,ilabel)
-				#if ib==1:
-				    #newth.GetXaxis().SetBinLabel(ib,"")
-				#newth.GetHistogram().GetXaxis().SetBinLabel(ib,ilabel)
-				ib += 1
-			    #if aweight==0.0081:
-			#	newth.SetBinContent(1, newth.GetBinContent(1) / 0.28756)
-			 #   if aweight==0.0883:
-				#newth.SetBinContent(1, newth.GetBinContent(1) / 0.01953)
-			    #if aweight==0.0731:
-				#newth.SetBinContent(1, newth.GetBinContent(1) / 0.0367)
-			    #if aweight==0.4003:
-				#newth.SetBinContent(1, newth.GetBinContent(1) / 0.5683)
-			    #if aweight==0.003:
-				#newth.SetBinContent(1, newth.GetBinContent(1) / 0.21173)
-			    #if aweight==0.0027:
-				#newth.SetBinContent(1, newth.GetBinContent(1) / 0.26394)
-			    #if aweight==0.0034:
-				#newth.SetBinContent(1, newth.GetBinContent(1) / 0.26394)
+                        newth.SetLineColor(int(listcolor[ii]))
+                        newth.SetMarkerColor(int(listcolor[ii]))
+
+                        if doFill: newth.SetFillColor(int(listcolor[ii]))
+
+                        if listmarker[ii] != None:
+                            newth.SetMarkerStyle(int(listmarker[ii]))
+                        # normalize
+                        if doNormalize:
+                            newth.Scale(1./newth.Integral())
+                        #print "   "+listlegend[ii]
+
+                        if thesuper[ikey].Labels != None:
+                            thelabels = thesuper[ikey].Labels.split(',')
+                            ib = 1
+                            #print thelabels
+
+                            for ilabel in thelabels:
+                                newth.GetXaxis().SetBinLabel(ib,ilabel)
+                                #if ib==1:
+                                    #newth.GetXaxis().SetBinLabel(ib,"")
+                                #newth.GetHistogram().GetXaxis().SetBinLabel(ib,ilabel)
+                                ib += 1
+                            #if aweight==0.0081:
+                        #	newth.SetBinContent(1, newth.GetBinContent(1) / 0.28756)
+                         #   if aweight==0.0883:
+                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.01953)
+                            #if aweight==0.0731:
+                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.0367)
+                            #if aweight==0.4003:
+                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.5683)
+                            #if aweight==0.003:
+                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.21173)
+                            #if aweight==0.0027:
+                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.26394)
+                            #if aweight==0.0034:
+                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.26394)
 
 
-			# stack histograms
-			if doFill:
-			    if thesuper[ikey].XTitle != None:
-				newth.SetXTitle("")
-			    astack.Add(newth,"HIST")
-			elif thesuper[ikey].Option:
-			    astack.Add(newth,thesuper[ikey].Option)
-			else:
-			    #newth.Fit("landau")
-			    astack.Add(newth)
-			    
-			astack.SetTitle(thesuper[ikey].title)
-			
-			if isFirst==1:
-			    newth.GetPainter().PaintStat(ROOT.gStyle.GetOptStat(),0);
-			    isFirst=0
-			    tmpsumth = newth.Clone()
-			else:
-			    tmpsumth.Add(newth)
-			#    newth.SetTitle(thesuper[ikey].title)
-			#    if thesuper[ikey].YTitle != None:
-			#	newth.SetYTitle(thesuper[ikey].YTitle)
-			#    newth.Draw()
-			#    isFirst=0
-			#else:
-			#    newth.Draw("same")
-			if dolegend and doFill: 
-			    aleg.AddEntry(newth,listlegend[ii],"F")
-			elif dolegend:
-			    aleg.AddEntry(newth,listlegend[ii],"P")
-			
-			newth.SetName(tmpname)
-			outputroot.cd()
-			newth.Write()
-	    ii = ii + 1
+                        # stack histograms
+                        if doFill:
+                            if thesuper[ikey].XTitle != None:
+                                newth.SetXTitle("")
+                            astack.Add(newth,"HIST")
+                        elif thesuper[ikey].Option:
+                            astack.Add(newth,thesuper[ikey].Option)
+                        else:
+                            #newth.Fit("landau")
+                            astack.Add(newth)
 
-	
-	if thesuper[ikey].Maximum != None:
-	    astack.SetMaximum( float(thesuper[ikey].Maximum) )
-	if thesuper[ikey].Minimum != None:
-	    astack.SetMinimum( float(thesuper[ikey].Minimum) )
-	if thesuper[ikey].Stack == "true":
-	    astack.Draw()
-	if thesuper[ikey].Stack == "false" or thesuper[ikey].Stack == None:
-	    astack.Draw()
-	    astack.Draw("nostack")
-	if thesuper[ikey].XTitle != None:
-	    astack.GetHistogram().SetXTitle(thesuper[ikey].XTitle)
-	if thesuper[ikey].YTitle != None:
-	    astack.GetHistogram().SetYTitle(thesuper[ikey].YTitle)
-	if doFill:
-	    astack.Draw("sameaxis")
+                        astack.SetTitle(thesuper[ikey].title)
 
-	
-	#thelabels = []
-	#if thesuper[ikey].Labels != None:
-	#    thelabels = thesuper[ikey].Labels.split(',')
-	#    ib = 1
-	#    print thelabels
+                        if isFirst==1:
+                            newth.GetPainter().PaintStat(ROOT.gStyle.GetOptStat(),0);
+                            isFirst=0
+                            tmpsumth = newth.Clone()
+                        else:
+                            tmpsumth.Add(newth)
+                        #    newth.SetTitle(thesuper[ikey].title)
+                        #    if thesuper[ikey].YTitle != None:
+                        #	newth.SetYTitle(thesuper[ikey].YTitle)
+                        #    newth.Draw()
+                        #    isFirst=0
+                        #else:
+                        #    newth.Draw("same")
+                        if dolegend and doFill: 
+                            aleg.AddEntry(newth,listlegend[ii],"F")
+                        elif dolegend:
+                            aleg.AddEntry(newth,listlegend[ii],"P")
 
-	 #   for ilabel in thelabels:
-	#	astack.GetXaxis().SetBinLabel(ib,ilabel)
-		#astack.GetHistogram().GetXaxis().SetBinLabel(ib,ilabel)
-		#ib += 1
-	#    astack.Draw()
-	#    astack.Draw("sameaxis")
+                        newth.SetName(tmpname)
+                        outputroot.cd()
+                        newth.Write()
+            ii = ii + 1
 
-	if dolegend: 
-	    aleg.Draw()
-	if thesuper[ikey].SetLogy == "true":
-	    cv[thesuper[ikey].name].SetLogy()
-	if thesuper[ikey].SetGrid == "true":
-	    cv[thesuper[ikey].name].SetGrid()
-	
-	# test smearing
-	#rn = ROOT.TRandom(12345)
-	#for iibin in range(0,tmpsumth.GetNbinsX()):
-	#    tmpsumth.SetBinContent(iibin, rn.Poisson(tmpsumth.GetBinContent(iibin)) )
-	#    if tmpsumth.GetBinContent(iibin) == 0:
-	#	tmpsumth.SetBinError(iibin, 0 )
-	#    else:
-	#	tmpsumth.SetBinError(iibin, 1/math.sqrt(tmpsumth.GetBinContent(iibin)) )
-			
-	#tmpsumth.Draw("same E1")
 
-	
-	if printBanner:
-	    tex = TLatex(0.35,0.95,Banner)
-	    tex.SetNDC()
-	    tex.SetTextSize(0.05)
-	    tex.Draw()
-	
-	cv[thesuper[ikey].name].Update()
-	#cv[thesuper[ikey].name].Print("test.png")
-	
-	# pause
-	if option.wait:
-	    raw_input( 'Press ENTER to continue\n ' )
+        if thesuper[ikey].Maximum != None:
+            astack.SetMaximum( float(thesuper[ikey].Maximum) )
+        if thesuper[ikey].Minimum != None:
+            astack.SetMinimum( float(thesuper[ikey].Minimum) )
+        if thesuper[ikey].Stack == "true":
+            astack.Draw()
+        if thesuper[ikey].Stack == "false" or thesuper[ikey].Stack == None:
+            astack.Draw()
+            astack.Draw("nostack")
+        if thesuper[ikey].XTitle != None:
+            astack.GetHistogram().SetXTitle(thesuper[ikey].XTitle)
+        if thesuper[ikey].YTitle != None:
+            astack.GetHistogram().SetYTitle(thesuper[ikey].YTitle)
+        if doFill:
+            astack.Draw("sameaxis")
+
+
+        #thelabels = []
+        #if thesuper[ikey].Labels != None:
+        #    thelabels = thesuper[ikey].Labels.split(',')
+        #    ib = 1
+        #    print thelabels
+
+         #   for ilabel in thelabels:
+        #	astack.GetXaxis().SetBinLabel(ib,ilabel)
+                #astack.GetHistogram().GetXaxis().SetBinLabel(ib,ilabel)
+                #ib += 1
+        #    astack.Draw()
+        #    astack.Draw("sameaxis")
+
+        if dolegend: 
+            aleg.Draw()
+        if thesuper[ikey].SetLogy == "true":
+            cv[thesuper[ikey].name].SetLogy()
+        if thesuper[ikey].SetGrid == "true":
+            cv[thesuper[ikey].name].SetGrid()
+
+        # test smearing
+        #rn = ROOT.TRandom(12345)
+        #for iibin in range(0,tmpsumth.GetNbinsX()):
+        #    tmpsumth.SetBinContent(iibin, rn.Poisson(tmpsumth.GetBinContent(iibin)) )
+        #    if tmpsumth.GetBinContent(iibin) == 0:
+        #	tmpsumth.SetBinError(iibin, 0 )
+        #    else:
+        #	tmpsumth.SetBinError(iibin, 1/math.sqrt(tmpsumth.GetBinContent(iibin)) )
+
+        #tmpsumth.Draw("same E1")
+
+
+        if printBanner:
+            tex = TLatex(0.35,0.95,Banner)
+            tex.SetNDC()
+            tex.SetTextSize(0.05)
+            tex.Draw()
+
+        cv[thesuper[ikey].name].Update()
+        #cv[thesuper[ikey].name].Print("test.png")
+
+        # pause
+        if option.wait:
+            raw_input( 'Press ENTER to continue\n ' )
 
 
 
@@ -837,31 +837,31 @@ if __name__ == '__main__':
         yBin_val = std.vector(int)()
         xErr_val = TVectorD()
         yErr_val = TVectorD()
-	zVal_val = TVectorD()
-	zErr_val = TVectorD()
+        zVal_val = TVectorD()
+        zErr_val = TVectorD()
         nVal_val = 0
-        
+
         xVal_ref = TVectorD()
         yVal_ref = TVectorD()
         yBin_ref = std.vector(int)()
         xErr_ref = TVectorD()
         yErr_ref = TVectorD()
-	zVal_ref = TVectorD()
-	zErr_ref = TVectorD()
+        zVal_ref = TVectorD()
+        zErr_ref = TVectorD()
         nVal_ref = 0
 
         RangeMax = 0.005
         RangeMin = 0.9
-        
+
         for ihname in listname:
-             
+
             for jkey in thedata:
                 tmpkeys = thedata[jkey].histos.keys()
-                        
+
                 for tmpname in tmpkeys:
-                    
+
                     if tmpname == ihname:
-                        
+
                         ath = thedata[jkey].TH1s[tmpname]
                         if ath is None:
                             print("ERROR: histogram name \""+tmpname+"\" does not exist in file "+thedata[jkey].filename)
@@ -875,56 +875,56 @@ if __name__ == '__main__':
                             BMid = 0.005+BinWidth/2
                             Err = BinWidth
                             for iBinB in range(1,nBinB+1):
-                               #BinWidth = (0.01+ath.GetMaximum())/200 #ath.GetBinWidth(iBinB)
-                               BMid = BMid+Err #BinWidth #ath.GetBinCenter(iBinB)
-                               #newh = TH1(ath)
-                               nAthBin = ath.GetNbinsX()-2
-                               #newh = TH1(ath)
-                               maxInHisto = ath.GetMaximum()
-                               minInHisto = ath.GetMinimum()
-                               #print minInHisto
-                               yClosestInit = 0
-                               iBinClosestInit = 0
-                               if BMid <= maxInHisto : yClosestInit = maxInHisto + 1
-                               else : yClosestInit = minInHisto - 1.0
-                               iBinClosest = iBinClosestInit
-                               yClosest    = yClosestInit
-                               for iAthBin in range(1,nAthBin+1):
-                                   yBin = ath.GetBinContent(iAthBin)
-                                   dif1 = BMid-yBin
-                                   if dif1 < 0 : dif1 = yBin-BMid
-                                   dif2 = yClosest-BMid
-                                   if dif2 < 0 : dif2 = BMid-yClosest
-                                   if dif1 < dif2:
-                                      yClosest = yBin
-                                      iBinClosest = iAthBin
-                               min = BMid-Err/2 
-                               max = BMid+Err/2
-                               #print iBinClosest
-                               if yClosest < min or  yClosest > max:
-                                       iBinClosest = 0
-                                       #print "iji"
-                               if iBinClosest > 0 and listmarker[ii] == "8":
-                                   #print "hhhhhhhhhhhhhhhh"
-                                   nVal_ref = nVal_ref+1
-                                   xVal_ref.ResizeTo(nVal_ref)
-                                   #yBin_ref.ResizeTo(nVal_ref)
-                                   xErr_ref.ResizeTo(nVal_ref)
-                                   xVal_ref[nVal_ref-1] = BMid
-                                   yBin_ref.push_back(iBinClosest)
-                                   xErr_ref[nVal_ref-1] = ath.GetBinError ( iBinClosest )
-                                   Err = xErr_ref[nVal_ref-1]
-                                   if Err < BinWidth : Err = BinWidth
-                               elif iBinClosest > 0:
-                                   nVal_val = nVal_val+1
-                                   xVal_val.ResizeTo(nVal_val)
-                                   #yBin_val.ResizeTo(nVal_val)
-                                   xErr_val.ResizeTo(nVal_val)
-                                   xVal_val[nVal_val-1] = BMid
-                                   yBin_val.push_back(iBinClosest)
-                                   xErr_val[nVal_val-1] = ath.GetBinError ( iBinClosest )
-                                   Err = xErr_val[nVal_val-1]
-                                   if Err < BinWidth : Err = BinWidth
+                                #BinWidth = (0.01+ath.GetMaximum())/200 #ath.GetBinWidth(iBinB)
+                                BMid = BMid+Err #BinWidth #ath.GetBinCenter(iBinB)
+                                #newh = TH1(ath)
+                                nAthBin = ath.GetNbinsX()-2
+                                #newh = TH1(ath)
+                                maxInHisto = ath.GetMaximum()
+                                minInHisto = ath.GetMinimum()
+                                #print minInHisto
+                                yClosestInit = 0
+                                iBinClosestInit = 0
+                                if BMid <= maxInHisto : yClosestInit = maxInHisto + 1
+                                else : yClosestInit = minInHisto - 1.0
+                                iBinClosest = iBinClosestInit
+                                yClosest    = yClosestInit
+                                for iAthBin in range(1,nAthBin+1):
+                                    yBin = ath.GetBinContent(iAthBin)
+                                    dif1 = BMid-yBin
+                                    if dif1 < 0 : dif1 = yBin-BMid
+                                    dif2 = yClosest-BMid
+                                    if dif2 < 0 : dif2 = BMid-yClosest
+                                    if dif1 < dif2:
+                                        yClosest = yBin
+                                        iBinClosest = iAthBin
+                                min = BMid-Err/2 
+                                max = BMid+Err/2
+                                #print iBinClosest
+                                if yClosest < min or  yClosest > max:
+                                    iBinClosest = 0
+                                    #print "iji"
+                                if iBinClosest > 0 and listmarker[ii] == "8":
+                                    #print "hhhhhhhhhhhhhhhh"
+                                    nVal_ref = nVal_ref+1
+                                    xVal_ref.ResizeTo(nVal_ref)
+                                    #yBin_ref.ResizeTo(nVal_ref)
+                                    xErr_ref.ResizeTo(nVal_ref)
+                                    xVal_ref[nVal_ref-1] = BMid
+                                    yBin_ref.push_back(iBinClosest)
+                                    xErr_ref[nVal_ref-1] = ath.GetBinError ( iBinClosest )
+                                    Err = xErr_ref[nVal_ref-1]
+                                    if Err < BinWidth : Err = BinWidth
+                                elif iBinClosest > 0:
+                                    nVal_val = nVal_val+1
+                                    xVal_val.ResizeTo(nVal_val)
+                                    #yBin_val.ResizeTo(nVal_val)
+                                    xErr_val.ResizeTo(nVal_val)
+                                    xVal_val[nVal_val-1] = BMid
+                                    yBin_val.push_back(iBinClosest)
+                                    xErr_val[nVal_val-1] = ath.GetBinError ( iBinClosest )
+                                    Err = xErr_val[nVal_val-1]
+                                    if Err < BinWidth : Err = BinWidth
                         elif listflavour[ii] == "4" and listmarker[ii] == "8":
                             yVal_ref.ResizeTo(nVal_ref)
                             yErr_ref.ResizeTo(nVal_ref)
@@ -932,7 +932,7 @@ if __name__ == '__main__':
                                 yVal_ref[iVal] = ath.GetBinContent (yBin_ref[iVal])
                                 if yVal_ref[iVal] > RangeMax : RangeMax = yVal_ref[iVal]
                                 yErr_ref[iVal] = ath.GetBinError (yBin_ref[iVal])
-			elif listflavour[ii] == "4":
+                        elif listflavour[ii] == "4":
                             yVal_val.ResizeTo(nVal_val)
                             yErr_val.ResizeTo(nVal_val)
                             for iVal in range(0,nVal_val):                                
@@ -957,17 +957,17 @@ if __name__ == '__main__':
         #print yVal_ref.GetNrows()
         #print xErr_ref.GetNrows()
         #print yErr_ref.GetNrows()
-        
-	#graphs = std.vector(TGraphErrors)()
+
+        #graphs = std.vector(TGraphErrors)()
         graphs = [TGraphErrors(xVal_ref,yVal_ref,xErr_ref,yErr_ref),
-	TGraphErrors(xVal_ref,zVal_ref,xErr_ref,zErr_ref),
-	TGraphErrors(xVal_val,yVal_val,xErr_val,yErr_val),
-	TGraphErrors(xVal_val,zVal_val,xErr_val,zErr_val)]
-	ii = 0
+        TGraphErrors(xVal_ref,zVal_ref,xErr_ref,zErr_ref),
+        TGraphErrors(xVal_val,yVal_val,xErr_val,yErr_val),
+        TGraphErrors(xVal_val,zVal_val,xErr_val,zErr_val)]
+        ii = 0
 
 
- 
-	for ii in range(0,4):
+
+        for ii in range(0,4):
 
                         # project 2D histogram if requested
                         #if projectAxis == "x":
@@ -990,107 +990,107 @@ if __name__ == '__main__':
                         #    newth = newthpy.Clone()
 
                         # get weight
-                        aweight = 1
-                        #if thedata[jkey].weight != None and thegraph[ikey].Weight=="true":
-                        #    aweight = float( thedata[jkey].weight )
-                        #if verbose: print " with weight = " + str(aweight)
-                        #if listweight[ii]:
+            aweight = 1
+            #if thedata[jkey].weight != None and thegraph[ikey].Weight=="true":
+            #    aweight = float( thedata[jkey].weight )
+            #if verbose: print " with weight = " + str(aweight)
+            #if listweight[ii]:
                          #   aweight = float( listweight[ii] )
 
-                        # clone original histogram
-                        #if projectAxis == "no" and profileAxis == "no" :newth = ath.Clone()
+            # clone original histogram
+            #if projectAxis == "no" and profileAxis == "no" :newth = ath.Clone()
 
-                        #newth.Sumw2()
-                        #newth.Scale(aweight)
+            #newth.Sumw2()
+            #newth.Scale(aweight)
 
-                        # check if we have color
-                        #if not listcolor[ii]:
-                        #    listcolor[ii] = 1
+            # check if we have color
+            #if not listcolor[ii]:
+            #    listcolor[ii] = 1
 
-			col = 2
-			mark = 22
-			if ii == 0 or ii == 2:
-				col = 1
-                        if ii == 0 or ii == 1:
-                            mark = 8
-				
-                        graphs[ii].SetLineColor(col)
-                        graphs[ii].SetMarkerStyle(mark)
-                        graphs[ii].SetMarkerColor(col)
-                        graphs[ii].SetTitle(thegraph[ikey].title)
-                        #if doFill: newth.SetFillColor(int(listcolor[ii]))
+            col = 2
+            mark = 22
+            if ii == 0 or ii == 2:
+                col = 1
+            if ii == 0 or ii == 1:
+                mark = 8
 
-                        #if listmarker[ii] != None:
-                        #    newth.SetMarkerStyle(int(listmarker[ii]))
-                        # normalize
-                        #if doNormalize:
-                        #    newth.Scale(1./newth.Integral())
-                        #print "   "+listlegend[ii]
+            graphs[ii].SetLineColor(col)
+            graphs[ii].SetMarkerStyle(mark)
+            graphs[ii].SetMarkerColor(col)
+            graphs[ii].SetTitle(thegraph[ikey].title)
+            #if doFill: newth.SetFillColor(int(listcolor[ii]))
 
-                        #if thegraph[ikey].Labels != None:
-                        #    thelabels = thesuper[ikey].Labels.split(',')
+            #if listmarker[ii] != None:
+            #    newth.SetMarkerStyle(int(listmarker[ii]))
+            # normalize
+            #if doNormalize:
+            #    newth.Scale(1./newth.Integral())
+            #print "   "+listlegend[ii]
+
+            #if thegraph[ikey].Labels != None:
+            #    thelabels = thesuper[ikey].Labels.split(',')
                          #   ib = 1
-                            #print thelabels
+                #print thelabels
 
                          #   for ilabel in thelabels:
                          #       newth.GetXaxis().SetBinLabel(ib,ilabel)
-                                #if ib==1:
+                #if ib==1:
                                     #newth.GetXaxis().SetBinLabel(ib,"")
-                                #newth.GetHistogram().GetXaxis().SetBinLabel(ib,ilabel)
-                          #      ib += 1
-                            #if aweight==0.0081:
-                        #       newth.SetBinContent(1, newth.GetBinContent(1) / 0.28756)
+                #newth.GetHistogram().GetXaxis().SetBinLabel(ib,ilabel)
+              #      ib += 1
+                #if aweight==0.0081:
+            #       newth.SetBinContent(1, newth.GetBinContent(1) / 0.28756)
                          #   if aweight==0.0883:
-                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.01953)
-                            #if aweight==0.0731:
-                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.0367)
-                            #if aweight==0.4003:
-                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.5683)
-                            #if aweight==0.003:
-                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.21173)
-                            #if aweight==0.0027:
-                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.26394)
-                            #if aweight==0.0034:
-                                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.26394)
+                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.01953)
+                #if aweight==0.0731:
+                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.0367)
+                #if aweight==0.4003:
+                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.5683)
+                #if aweight==0.003:
+                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.21173)
+                #if aweight==0.0027:
+                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.26394)
+                #if aweight==0.0034:
+                #newth.SetBinContent(1, newth.GetBinContent(1) / 0.26394)
 
 
-                        # stack histograms
-                        #if doFill:
+            # stack histograms
+            #if doFill:
                          #   if thegraph[ikey].XTitle != None:
-                        #        newth.SetXTitle("")
-                        #    astack.Add(newth,"HIST")
-                        #elif thegraph[ikey].Option:
-                        #    astack.Add(newth,thegraph[ikey].Option)
-                        #else:
-                            #newth.Fit("landau")
-                        #    astack.Add(newth)
+            #        newth.SetXTitle("")
+            #    astack.Add(newth,"HIST")
+            #elif thegraph[ikey].Option:
+            #    astack.Add(newth,thegraph[ikey].Option)
+            #else:
+                #newth.Fit("landau")
+            #    astack.Add(newth)
 
-                        #astack.SetTitle(thegraph[ikey].title)
+            #astack.SetTitle(thegraph[ikey].title)
 
-                        if isFirst==1:
-                            #graphs[ii].GetPainter().PaintStat(ROOT.gStyle.GetOptStat(),0);
-                            isFirst=0
-                            #tmpsumth = graphs[ii].Clone()
-                        #else:
-                        #    tmpsumth.Add(graphs[ii])
-                        #    newth.SetTitle(thesuper[ikey].title)
-                        #    if thesuper[ikey].YTitle != None:
-                        #       newth.SetYTitle(thesuper[ikey].YTitle)
-                        #    newth.Draw()
-                        #    isFirst=0
-                        #else:
-                        #    newth.Draw("same")
-                        #if dolegend and doFill:
-                        #    aleg.AddEntry(newth,listlegend[ii],"F")
-                        #elif dolegend:
-                        #    aleg.AddEntry(newth,listlegend[ii],"P")
+            if isFirst==1:
+                #graphs[ii].GetPainter().PaintStat(ROOT.gStyle.GetOptStat(),0);
+                isFirst=0
+                #tmpsumth = graphs[ii].Clone()
+            #else:
+            #    tmpsumth.Add(graphs[ii])
+            #    newth.SetTitle(thesuper[ikey].title)
+            #    if thesuper[ikey].YTitle != None:
+            #       newth.SetYTitle(thesuper[ikey].YTitle)
+            #    newth.Draw()
+            #    isFirst=0
+            #else:
+            #    newth.Draw("same")
+            #if dolegend and doFill:
+            #    aleg.AddEntry(newth,listlegend[ii],"F")
+            #elif dolegend:
+            #    aleg.AddEntry(newth,listlegend[ii],"P")
 
-                        #graphs[ii].SetName(tmpname)
-                        #if ii == 0 : graphs[ii].Draw()
-                        #else : graphs[ii].Draw("same")
-                        outputroot.cd()
-                        graphs[ii].Write()
-                        ii = ii + 1
+            #graphs[ii].SetName(tmpname)
+            #if ii == 0 : graphs[ii].Draw()
+            #else : graphs[ii].Draw("same")
+            outputroot.cd()
+            graphs[ii].Write()
+            ii = ii + 1
 
 
         #if thegraph[ikey].Maximum != None:
@@ -1116,7 +1116,7 @@ if __name__ == '__main__':
         #print RangeMin
         if RangeMin < 0.00001 : RangeMin = 0.00005
         graphs[0].GetYaxis().SetRangeUser(RangeMin,RangeMax)
-   
+
         #thelabels = []
         #if thesuper[ikey].Labels != None:
         #    thelabels = thesuper[ikey].Labels.split(',')
@@ -1172,32 +1172,32 @@ if __name__ == '__main__':
 
 #*********************************************************************
 
-    
+
     if printCanvas:
-	
-	for ikey in theaddition:
-	    cv[theaddition[ikey].name].Print(theaddition[ikey].name + "." + printFormat)
-	for ikey in thesuper:
-	    cv[thesuper[ikey].name].Print(thesuper[ikey].name + "." + printFormat)
-	for ikey in thegraph:
-	    cv[thegraph[ikey].name].Print(thegraph[ikey].name + "notgood." + printFormat)
-	
-    
+
+        for ikey in theaddition:
+            cv[theaddition[ikey].name].Print(theaddition[ikey].name + "." + printFormat)
+        for ikey in thesuper:
+            cv[thesuper[ikey].name].Print(thesuper[ikey].name + "." + printFormat)
+        for ikey in thegraph:
+            cv[thegraph[ikey].name].Print(thegraph[ikey].name + "notgood." + printFormat)
+
+
     #outputroot.Write()
     #outputroot.Close()
 
 #    if not option.wait:
     rep = ''
     while not rep in [ 'q', 'Q', '.q', 'qq' 'p']:
-	rep = raw_input( '\nenter: ["q",".q" to quit] ["p" or "print" to print all canvas]: ' )
-	if 0<len(rep):
-	    if rep=='quit': rep = 'q'
-	    if rep=='p' or rep=='print':
-		for ikey in theaddition:
-		    cv[theaddition[ikey].name].Print(theaddition[ikey].name + "." + printFormat)
-		for ikey in thesuper:
-		    cv[thesuper[ikey].name].Print(thesuper[ikey].name + "." + printFormat) 
+        rep = raw_input( '\nenter: ["q",".q" to quit] ["p" or "print" to print all canvas]: ' )
+        if 0<len(rep):
+            if rep=='quit': rep = 'q'
+            if rep=='p' or rep=='print':
+                for ikey in theaddition:
+                    cv[theaddition[ikey].name].Print(theaddition[ikey].name + "." + printFormat)
+                for ikey in thesuper:
+                    cv[thesuper[ikey].name].Print(thesuper[ikey].name + "." + printFormat) 
                 for ikey in thegraph:
-		    cv[thegraph[ikey].name].Print(thegraph[ikey].name + "." + printFormat)
-                                        
+                    cv[thegraph[ikey].name].Print(thegraph[ikey].name + "." + printFormat)
+
 

--- a/Validation/RecoTau/python/DeltaR.py
+++ b/Validation/RecoTau/python/DeltaR.py
@@ -30,22 +30,22 @@ def matchObjectCollection3 ( objects, matchCollection, deltaRMax = 0.3, filter =
     #
     pairs = {}
     if len(objects)==0:
-            return pairs
+        return pairs
     if len(matchCollection)==0:
-            return dict( zip(objects, [None]*len(objects)) )
+        return dict( zip(objects, [None]*len(objects)) )
     # build all possible combinations
-                                                                                                                                                                                            
+
     allPairs = sorted([(deltaR2 (object.eta(), object.phi(), match.eta(), match.phi()), (object, match)) for object in objects for match in matchCollection if list(filter(object,match)) ])
     #
     # to flag already matched objects
     # FIXME this variable remains appended to the object, I do not like it 
-                                                                                                                                                      
+
     for object in objects:
         object.matched = False
     for match in matchCollection:
         match.matched = False
     #
-                                                                                                                                                                                                                            
+
     deltaR2Max = deltaRMax * deltaRMax
     for dR2, (object, match) in allPairs:
         if dR2 > deltaR2Max:
@@ -55,12 +55,12 @@ def matchObjectCollection3 ( objects, matchCollection, deltaRMax = 0.3, filter =
             match.matched = True
             pairs[object] = match
     #
-                                                                                                                                                                                                                            
+
     for object in objects:
-       if object.matched == False:
-           pairs[object] = None
+        if object.matched == False:
+            pairs[object] = None
     #
-                                                                                                                                                                                                                            
+
     return pairs
     # by now, the matched attribute remains in the objects, for future usage
     # one could remove it with delattr (object, attrname) 
@@ -148,12 +148,12 @@ def matchObjectCollection2 ( objects, matchCollection, deltaRMax = 0.3 ):
     Reco and Gen objects get the "matched" attribute, true if they are part of a matched tuple.
     By default, the matching is true only if delta R is smaller than 0.3.
     '''
-    
+
     pairs = {}
     if len(objects)==0:
-            return pairs
+        return pairs
     if len(matchCollection)==0:
-            return dict( zip(objects, [None]*len(objects)) )
+        return dict( zip(objects, [None]*len(objects)) )
     # build all possible combinations
     allPairs = sorted([(deltaR2 (object.eta(), object.phi(), match.eta(), match.phi()), (object, match)) for object in objects for match in matchCollection])
 
@@ -163,19 +163,19 @@ def matchObjectCollection2 ( objects, matchCollection, deltaRMax = 0.3 ):
         object.matched = False
     for match in matchCollection:
         match.matched = False
-    
+
     deltaR2Max = deltaRMax * deltaRMax
     for dR2, (object, match) in allPairs:
-	if dR2 > deltaR2Max:
-		break
+        if dR2 > deltaR2Max:
+            break
         if dR2 < deltaR2Max and object.matched == False and match.matched == False:
             object.matched = True
             match.matched = True
             pairs[object] = match
-    
+
     for object in objects:
-       if object.matched == False:
-	   pairs[object] = None
+        if object.matched == False:
+            pairs[object] = None
 
     return pairs
     # by now, the matched attribute remains in the objects, for future usage
@@ -191,6 +191,6 @@ if __name__ == '__main__':
 
     print('dR2 = ', deltaR2( *fargs ))
     print('dR = ', deltaR( *fargs ))
-    
 
-    
+
+

--- a/Validation/Tools/scripts/simpleEdmComparison.py
+++ b/Validation/Tools/scripts/simpleEdmComparison.py
@@ -72,7 +72,7 @@ def compareEvents(event1, event2, handleName, label, options):
             if val1 != val2:
                 mismatch += 1
                 logging.error("Comparison problem %s != %s" % (val1, val2))
-	logging.debug("Compared %s elements" % count)
+        logging.debug("Compared %s elements" % count)
         return (count, mismatch)
 
 if __name__ == "__main__":


### PR DESCRIPTION
this PR reduces the # of files that don't compile with python3 by 6x (excluding test directory files which in any case do not always compile with python2). 

Changes are to fix whitespace errors (mix of tabs and spaces is no longer allowed) 

Changes done via:
autopep8 -i --select E101,W690 <file>
$CMSSW_RELEASE_BASE/../../../external/py2-future/0.16.0/bin/futurize -n -w --no-diffs -j 4 -f libfuturize.fixes.fix_print_with_import <file>

applied to any file that does not compile with python3