### PR TITLE
update DeepFlavour training for 2016 NanoAOD and re-run it

### DIFF
--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -16,7 +16,7 @@ from PhysicsTools.NanoAOD.triggerObjects_cff import *
 from PhysicsTools.NanoAOD.isotracks_cff import *
 from PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff import *
 
-from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.Eras.Modifier_run2_nanoAOD_92X_cff import run2_nanoAOD_92X
 
 nanoMetadata = cms.EDProducer("UniqueStringProducer",
@@ -77,7 +77,7 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
     sysTypes = cms.vstring("central","central","central")
 )
 
-run2_nanoAOD_94X2016.toModify(btagWeightTable,
+run2_miniAOD_80XLegacy.toModify(btagWeightTable,                
     cut = cms.string("pt > 25. && abs(eta) < 2.4"),             #80X corresponds to 2016, |eta| < 2.4
     weightFiles = cms.vstring(                                  #80X corresponds to 2016 SFs
         btagSFdir+"CSVv2_Moriond17_B_H.csv",            
@@ -153,32 +153,8 @@ def nanoAOD_addDeepBTagFor80X(process):
     process.additionalendpath = cms.EndPath(patAlgosToolsTask)
     return process
 
-def nanoAOD_addDeepFlavourTagFor94X2016(process):
-    print "Updating process to run DeepFlavour btag on legacy 80X datasets"
-    updateJetCollection(
-               process,
-               jetSource = cms.InputTag('slimmedJets'),
-               jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute','L2L3Residual']), 'None'),
-               btagDiscriminators = ['pfDeepFlavourJetTags:probb','pfDeepFlavourJetTags:probbb','pfDeepFlavourJetTags:problepb'], ## to add discriminators
-               btagPrefix = ''
-           )
-    process.load("Configuration.StandardSequences.MagneticField_cff")
-    process.looseJetId.src="selectedUpdatedPatJets"
-    process.tightJetId.src="selectedUpdatedPatJets"
-    process.tightJetIdLepVeto.src="selectedUpdatedPatJets"
-    process.bJetVars.src="selectedUpdatedPatJets"
-    process.slimmedJetsWithUserData.src="selectedUpdatedPatJets"
-    process.qgtagger80x.srcJets="selectedUpdatedPatJets"
-    process.pfDeepFlavourJetTags.graph_path = 'RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb'
-    process.pfDeepFlavourJetTags.lp_names = ["cpf_input_batchnorm/keras_learning_phase"]
-    patAlgosToolsTask = getPatAlgosToolsTask(process)
-    patAlgosToolsTask .add(process.updatedPatJets)
-    patAlgosToolsTask .add(process.patJetCorrFactors)
-    process.additionalendpath = cms.EndPath(patAlgosToolsTask)
-    return process
-
 def nanoAOD_customizeCommon(process):
-    run2_nanoAOD_94X2016.toModify(process, nanoAOD_addDeepFlavourTagFor94X2016)
+    run2_miniAOD_80XLegacy.toModify(process, nanoAOD_addDeepBTagFor80X)
     return process
 
 
@@ -197,12 +173,15 @@ def nanoAOD_customizeMC(process):
     return process
 
 ### Era dependent customization
-_94x2016_sequence = nanoSequence.copy()
-#remove stuff
-_94x2016_sequence.remove(isoTrackTable)
-_94x2016_sequence.remove(isoTrackSequence)
+_80x_sequence = nanoSequence.copy()
+#remove stuff 
+_80x_sequence.remove(isoTrackTable)
+_80x_sequence.remove(isoTrackSequence)
 #add stuff
-_94x2016_sequence.insert(_94x2016_sequence.index(jetSequence), extraFlagsProducers)
-_94x2016_sequence.insert(_94x2016_sequence.index(l1bits)+1, extraFlagsTable)
+_80x_sequence.insert(_80x_sequence.index(jetSequence), extraFlagsProducers)
+_80x_sequence.insert(_80x_sequence.index(l1bits)+1, extraFlagsTable)
 
-run2_nanoAOD_94X2016.toReplaceWith( nanoSequence, _94x2016_sequence)
+run2_miniAOD_80XLegacy.toReplaceWith( nanoSequence, _80x_sequence)
+
+	
+

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -58,7 +58,7 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
     discNames = cms.vstring(
         "pfCombinedInclusiveSecondaryVertexV2BJetTags",
         "pfDeepCSVJetTags:probb+pfDeepCSVJetTags:probbb",       #if multiple MiniAOD branches need to be summed up (e.g., DeepCSV b+bb), separate them using '+' delimiter
-        "pfCombinedMVAV2BJetTags"        
+        "pfCombinedMVAV2BJetTags"
     ),
     discShortNames = cms.vstring(
         "CSVV2",
@@ -67,7 +67,7 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
     ),
     weightFiles = cms.vstring(                                  #default settings are for 2017 94X. toModify function is called later for other eras.
         btagSFdir+"CSVv2_94XSF_V2_B_F.csv",
-        btagSFdir+"DeepCSV_94XSF_V2_B_F.csv",                    
+        btagSFdir+"DeepCSV_94XSF_V2_B_F.csv",
         "unavailable"                                           #if SFs for an algorithm in an era is unavailable, the corresponding branch will not be stored
     ),
     operatingPoints = cms.vstring("3","3","3"),                 #loose = 0, medium = 1, tight = 2, reshaping = 3
@@ -80,19 +80,19 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
 run2_nanoAOD_94X2016.toModify(btagWeightTable,
     cut = cms.string("pt > 25. && abs(eta) < 2.4"),             #80X corresponds to 2016, |eta| < 2.4
     weightFiles = cms.vstring(                                  #80X corresponds to 2016 SFs
-        btagSFdir+"CSVv2_Moriond17_B_H.csv",            
-        "unavailable",                    
-        btagSFdir+"cMVAv2_Moriond17_B_H.csv"                                            
+        btagSFdir+"CSVv2_Moriond17_B_H.csv",
+        "unavailable",
+        btagSFdir+"cMVAv2_Moriond17_B_H.csv"
     )
 )
 
 run2_nanoAOD_92X.toModify(btagWeightTable,                      #92X corresponds to MCv1, for which SFs are unavailable
     weightFiles = cms.vstring(
         "unavailable",
-        "unavailable",                    
-        "unavailable"                                            
+        "unavailable",
+        "unavailable"
     )
-)                    
+)
 
 genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     genEvent = cms.InputTag("generator"),
@@ -108,20 +108,20 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     namedWeightIDs = cms.vstring(),
     namedWeightLabels = cms.vstring(),
     lheWeightPrecision = cms.int32(14),
-    maxPdfWeights = cms.uint32(150), 
+    maxPdfWeights = cms.uint32(150),
     debug = cms.untracked.bool(False),
 )
 lheInfoTable = cms.EDProducer("LHETablesProducer",
     lheInfo = cms.InputTag("externalLHEProducer"),
     precision = cms.int32(14),
-    storeLHEParticles = cms.bool(True) 
+    storeLHEParticles = cms.bool(True)
 )
 
 l1bits=cms.EDProducer("L1TriggerResultsConverter", src=cms.InputTag("gtStage2Digis"), legacyL1=cms.bool(False))
 
 nanoSequence = cms.Sequence(
         nanoMetadata + jetSequence + muonSequence + tauSequence + electronSequence+photonSequence+vertexSequence+metSequence+
-        isoTrackSequence + # must be after all the leptons 
+        isoTrackSequence + # must be after all the leptons
         linkedObjects  +
         jetTables + muonTables + tauTables + electronTables + photonTables +  globalTables +vertexTables+ metTables+simpleCleanerTable + triggerObjectTables + isoTrackTables +
 	l1bits)

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -16,7 +16,7 @@ from PhysicsTools.NanoAOD.triggerObjects_cff import *
 from PhysicsTools.NanoAOD.isotracks_cff import *
 from PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff import *
 
-from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
 from Configuration.Eras.Modifier_run2_nanoAOD_92X_cff import run2_nanoAOD_92X
 
 nanoMetadata = cms.EDProducer("UniqueStringProducer",
@@ -77,7 +77,7 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
     sysTypes = cms.vstring("central","central","central")
 )
 
-run2_miniAOD_80XLegacy.toModify(btagWeightTable,                
+run2_nanoAOD_94X2016.toModify(btagWeightTable,
     cut = cms.string("pt > 25. && abs(eta) < 2.4"),             #80X corresponds to 2016, |eta| < 2.4
     weightFiles = cms.vstring(                                  #80X corresponds to 2016 SFs
         btagSFdir+"CSVv2_Moriond17_B_H.csv",            
@@ -153,8 +153,32 @@ def nanoAOD_addDeepBTagFor80X(process):
     process.additionalendpath = cms.EndPath(patAlgosToolsTask)
     return process
 
+def nanoAOD_addDeepFlavourTagFor94X2016(process):
+    print "Updating process to run DeepFlavour btag on legacy 80X datasets"
+    updateJetCollection(
+               process,
+               jetSource = cms.InputTag('slimmedJets'),
+               jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute','L2L3Residual']), 'None'),
+               btagDiscriminators = ['pfDeepFlavourJetTags:probb','pfDeepFlavourJetTags:probbb','pfDeepFlavourJetTags:problepb'], ## to add discriminators
+               btagPrefix = ''
+           )
+    process.load("Configuration.StandardSequences.MagneticField_cff")
+    process.looseJetId.src="selectedUpdatedPatJets"
+    process.tightJetId.src="selectedUpdatedPatJets"
+    process.tightJetIdLepVeto.src="selectedUpdatedPatJets"
+    process.bJetVars.src="selectedUpdatedPatJets"
+    process.slimmedJetsWithUserData.src="selectedUpdatedPatJets"
+    process.qgtagger80x.srcJets="selectedUpdatedPatJets"
+    process.pfDeepFlavourJetTags.graph_path = 'RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb'
+    process.pfDeepFlavourJetTags.lp_names = ["cpf_input_batchnorm/keras_learning_phase"]
+    patAlgosToolsTask = getPatAlgosToolsTask(process)
+    patAlgosToolsTask .add(process.updatedPatJets)
+    patAlgosToolsTask .add(process.patJetCorrFactors)
+    process.additionalendpath = cms.EndPath(patAlgosToolsTask)
+    return process
+
 def nanoAOD_customizeCommon(process):
-    run2_miniAOD_80XLegacy.toModify(process, nanoAOD_addDeepBTagFor80X)
+    run2_nanoAOD_94X2016.toModify(process, nanoAOD_addDeepFlavourTagFor94X2016)
     return process
 
 
@@ -173,15 +197,12 @@ def nanoAOD_customizeMC(process):
     return process
 
 ### Era dependent customization
-_80x_sequence = nanoSequence.copy()
-#remove stuff 
-_80x_sequence.remove(isoTrackTable)
-_80x_sequence.remove(isoTrackSequence)
+_94x2016_sequence = nanoSequence.copy()
+#remove stuff
+_94x2016_sequence.remove(isoTrackTable)
+_94x2016_sequence.remove(isoTrackSequence)
 #add stuff
-_80x_sequence.insert(_80x_sequence.index(jetSequence), extraFlagsProducers)
-_80x_sequence.insert(_80x_sequence.index(l1bits)+1, extraFlagsTable)
+_94x2016_sequence.insert(_94x2016_sequence.index(jetSequence), extraFlagsProducers)
+_94x2016_sequence.insert(_94x2016_sequence.index(l1bits)+1, extraFlagsTable)
 
-run2_miniAOD_80XLegacy.toReplaceWith( nanoSequence, _80x_sequence)
-
-	
-
+run2_nanoAOD_94X2016.toReplaceWith( nanoSequence, _94x2016_sequence)

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -18,6 +18,7 @@ from PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff import *
 
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.Eras.Modifier_run2_nanoAOD_92X_cff import run2_nanoAOD_92X
+from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
 
 nanoMetadata = cms.EDProducer("UniqueStringProducer",
     strings = cms.PSet(
@@ -152,9 +153,34 @@ def nanoAOD_addDeepBTagFor80X(process):
     patAlgosToolsTask .add(process.patJetCorrFactors)
     process.additionalendpath = cms.EndPath(patAlgosToolsTask)
     return process
+def nanoAOD_addDeepFlavourTagFor94X2016(process):
+    print "Updating process to run DeepFlavour btag on legacy 80X datasets"
+    updateJetCollection(
+               process,
+               jetSource = cms.InputTag('slimmedJets'),
+               jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute','L2L3Residual']), 'None'),
+               btagDiscriminators = ['pfDeepFlavourJetTags:probb','pfDeepFlavourJetTags:probbb','pfDeepFlavourJetTags:problepb'], ## to add discriminators
+               btagPrefix = ''
+           )
+    process.load("Configuration.StandardSequences.MagneticField_cff")
+    process.looseJetId.src="selectedUpdatedPatJets"
+    process.tightJetId.src="selectedUpdatedPatJets"
+    process.tightJetIdLepVeto.src="selectedUpdatedPatJets"
+    process.bJetVars.src="selectedUpdatedPatJets"
+    process.slimmedJetsWithUserData.src="selectedUpdatedPatJets"
+    process.qgtagger80x.srcJets="selectedUpdatedPatJets"
+    process.pfDeepFlavourJetTags.graph_path = 'RecoBTag/Combined/data/DeepFlavourV03_10X_training/constant_graph.pb'
+    process.pfDeepFlavourJetTags.lp_names = ["cpf_input_batchnorm/keras_learning_phase"]
+    patAlgosToolsTask = getPatAlgosToolsTask(process)
+    patAlgosToolsTask .add(process.updatedPatJets)
+    patAlgosToolsTask .add(process.patJetCorrFactors)
+    process.additionalendpath = cms.EndPath(patAlgosToolsTask)
+    return process
+
 
 def nanoAOD_customizeCommon(process):
     run2_miniAOD_80XLegacy.toModify(process, nanoAOD_addDeepBTagFor80X)
+    run2_nanoAOD_94X2016.toModify(process, nanoAOD_addDeepFlavourTagFor94X2016)
     return process
 
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -58,7 +58,7 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
     discNames = cms.vstring(
         "pfCombinedInclusiveSecondaryVertexV2BJetTags",
         "pfDeepCSVJetTags:probb+pfDeepCSVJetTags:probbb",       #if multiple MiniAOD branches need to be summed up (e.g., DeepCSV b+bb), separate them using '+' delimiter
-        "pfCombinedMVAV2BJetTags"
+        "pfCombinedMVAV2BJetTags"        
     ),
     discShortNames = cms.vstring(
         "CSVV2",
@@ -67,7 +67,7 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
     ),
     weightFiles = cms.vstring(                                  #default settings are for 2017 94X. toModify function is called later for other eras.
         btagSFdir+"CSVv2_94XSF_V2_B_F.csv",
-        btagSFdir+"DeepCSV_94XSF_V2_B_F.csv",
+        btagSFdir+"DeepCSV_94XSF_V2_B_F.csv",                    
         "unavailable"                                           #if SFs for an algorithm in an era is unavailable, the corresponding branch will not be stored
     ),
     operatingPoints = cms.vstring("3","3","3"),                 #loose = 0, medium = 1, tight = 2, reshaping = 3
@@ -80,19 +80,19 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
 run2_nanoAOD_94X2016.toModify(btagWeightTable,
     cut = cms.string("pt > 25. && abs(eta) < 2.4"),             #80X corresponds to 2016, |eta| < 2.4
     weightFiles = cms.vstring(                                  #80X corresponds to 2016 SFs
-        btagSFdir+"CSVv2_Moriond17_B_H.csv",
-        "unavailable",
-        btagSFdir+"cMVAv2_Moriond17_B_H.csv"
+        btagSFdir+"CSVv2_Moriond17_B_H.csv",            
+        "unavailable",                    
+        btagSFdir+"cMVAv2_Moriond17_B_H.csv"                                            
     )
 )
 
 run2_nanoAOD_92X.toModify(btagWeightTable,                      #92X corresponds to MCv1, for which SFs are unavailable
     weightFiles = cms.vstring(
         "unavailable",
-        "unavailable",
-        "unavailable"
+        "unavailable",                    
+        "unavailable"                                            
     )
-)
+)                    
 
 genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     genEvent = cms.InputTag("generator"),
@@ -108,20 +108,20 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     namedWeightIDs = cms.vstring(),
     namedWeightLabels = cms.vstring(),
     lheWeightPrecision = cms.int32(14),
-    maxPdfWeights = cms.uint32(150),
+    maxPdfWeights = cms.uint32(150), 
     debug = cms.untracked.bool(False),
 )
 lheInfoTable = cms.EDProducer("LHETablesProducer",
     lheInfo = cms.InputTag("externalLHEProducer"),
     precision = cms.int32(14),
-    storeLHEParticles = cms.bool(True)
+    storeLHEParticles = cms.bool(True) 
 )
 
 l1bits=cms.EDProducer("L1TriggerResultsConverter", src=cms.InputTag("gtStage2Digis"), legacyL1=cms.bool(False))
 
 nanoSequence = cms.Sequence(
         nanoMetadata + jetSequence + muonSequence + tauSequence + electronSequence+photonSequence+vertexSequence+metSequence+
-        isoTrackSequence + # must be after all the leptons
+        isoTrackSequence + # must be after all the leptons 
         linkedObjects  +
         jetTables + muonTables + tauTables + electronTables + photonTables +  globalTables +vertexTables+ metTables+simpleCleanerTable + triggerObjectTables + isoTrackTables +
 	l1bits)


### PR DESCRIPTION
This PR, from @HeinerTholen / BTV POG, updates the NanoAOD configuration for the 2016 94X re-miniAOD to run an updated training of DeepFlavour.
As far as I know, it is the last outstanding request for this first NanoAOD pass.

The PR to master will come later today or some time tomorrow, with a change from `print` to `print()` following #24117