### PR TITLE
DD4hep: Use CMS-style Namespace Separator

### DIFF
--- a/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
@@ -26,8 +26,8 @@
     <Constant name="world_y" value="5*m"/>
     <Constant name="world_z" value="5*m"/>
     <Constant name="fm"      value="1e-12*m"/>
-    <Constant name="Air"     value="materials_Air"     type="string"/>
-    <Constant name="Vacuum"  value="materials_Vacuum"  type="string"/>
+    <Constant name="Air"     value="materials:Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials:Vacuum"  type="string"/>
   </ConstantsSection>
 
   <IncludeSection>

--- a/DetectorDescription/DDCMS/data/cms-test-ddangular-algorithm.xml
+++ b/DetectorDescription/DDCMS/data/cms-test-ddangular-algorithm.xml
@@ -26,8 +26,8 @@
     <Constant name="world_y" value="5*m"/>
     <Constant name="world_z" value="5*m"/>
     <Constant name="fm"      value="1e-12*m"/>
-    <Constant name="Air"     value="materials_Air"     type="string"/>
-    <Constant name="Vacuum"  value="materials_Vacuum"  type="string"/>
+    <Constant name="Air"     value="materials:Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials:Vacuum"  type="string"/>
   </ConstantsSection>
 
   <IncludeSection>

--- a/DetectorDescription/DDCMS/data/cms-test-shapes.xml
+++ b/DetectorDescription/DDCMS/data/cms-test-shapes.xml
@@ -26,8 +26,8 @@
     <Constant name="world_y" value="5*m"/>
     <Constant name="world_z" value="5*m"/>
     <Constant name="fm"      value="1e-12*m"/>
-    <Constant name="Air"     value="materials_Air"     type="string"/>
-    <Constant name="Vacuum"  value="materials_Vacuum"  type="string"/>
+    <Constant name="Air"     value="materials:Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials:Vacuum"  type="string"/>
   </ConstantsSection>
 
   <IncludeSection>

--- a/DetectorDescription/DDCMS/data/cms-tracker.xml
+++ b/DetectorDescription/DDCMS/data/cms-tracker.xml
@@ -23,8 +23,8 @@
     <Constant name="world_y" value="5*m"/>
     <Constant name="world_z" value="5*m"/>
     <Constant name="fm"      value="1e-12*m"/>
-    <Constant name="Air"     value="materials_Air"     type="string"/>
-    <Constant name="Vacuum"  value="materials_Vacuum"  type="string"/>
+    <Constant name="Air"     value="materials:Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials:Vacuum"  type="string"/>
   </ConstantsSection>
   <ConstantsSection label="servicescylinderb.xml" eval="true">
 	<Constant name="zero" value="0.0*fm"/>

--- a/DetectorDescription/DDCMS/data/cms_tracker.xml
+++ b/DetectorDescription/DDCMS/data/cms_tracker.xml
@@ -23,8 +23,8 @@
     <Constant name="world_y" value="5*m"/>
     <Constant name="world_z" value="5*m"/>
     <Constant name="fm"      value="1e-12*m"/>
-    <Constant name="Air"     value="materials_Air"     type="string"/>
-    <Constant name="Vacuum"  value="materials_Vacuum"  type="string"/>
+    <Constant name="Air"     value="materials:Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials:Vacuum"  type="string"/>
   </ConstantsSection>
   <ConstantsSection label="servicescylinderb.xml" eval="true">
 	<Constant name="zero" value="0.0*fm"/>

--- a/DetectorDescription/DDCMS/interface/DDNamespace.h
+++ b/DetectorDescription/DDCMS/interface/DDNamespace.h
@@ -72,4 +72,6 @@ namespace cms {
   };
 }
 
+#define NAMESPACE_SEP ':'
+
 #endif

--- a/DetectorDescription/DDCMS/plugins/DDCMSDetElementCreator.cc
+++ b/DetectorDescription/DDCMS/plugins/DDCMSDetElementCreator.cc
@@ -85,7 +85,7 @@ std::string
 cms::detElementName( dd4hep::PlacedVolume volume ) {
   if( volume.isValid()) {
     std::string name = volume.name();
-    std::string nnam = name.substr( name.find('_') + 1 );
+    std::string nnam = name.substr( name.find(NAMESPACE_SEP) + 1 );
     return nnam;
   }
   except("MyDDCMS","++ Cannot deduce name from invalid PlacedVolume handle!");

--- a/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
@@ -333,10 +333,9 @@ template <> void Converter<DDLConstant>::operator()(xml_h element) const  {
     if ( idp == string::npos || idp > idq )
       val.insert(idx,_ns.name());
     else if ( idp != string::npos && idp < idq )
-      val[idp] = '_';
+      val[idp] = NAMESPACE_SEP;
     idx = val.find('[',idx);
   }
-  while ( (idx=val.find(':')) != string::npos ) val[idx]='_';
   printout(_ns.context->debug_constants ? ALWAYS : DEBUG,
            "Constant","Unresolved: %s -> %s",real.c_str(),val.c_str());
   res->allConst[real] = val;
@@ -987,8 +986,10 @@ template <> void Converter<DDLAlgorithm>::operator()(xml_h element) const  {
     return;
   }
   try {
+    size_t            idx;
     SensitiveDetector sd;
     string            type = "DDCMS_"+_ns.realName(name);
+    while(( idx = type.find( NAMESPACE_SEP )) != string::npos ) type[idx] = '_';
 
     // SensitiveDetector and Segmentation currently are undefined. Let's keep it like this
     // until we found something better.....

--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -9,8 +9,6 @@
 using namespace std;
 using namespace cms;
 
-#define NAMESPACE_SEP '_'
-
 DDNamespace::DDNamespace( DDParsingContext* context, xml_h element )
   : context( context )
 {
@@ -96,16 +94,15 @@ DDNamespace::realName( const string& v ) const
   string val = v;
   while(( idx = val.find('[')) != string::npos )
   {
-    val.erase(idx,1);
-    idp = val.find(':');
-    idq = val.find(']');
-    val.erase(idq,1);
+    val.erase( idx, 1 );
+    idp = val.find( NAMESPACE_SEP, idx );
+    idq = val.find( ']', idx );
+    val.erase( idq, 1 );
     if( idp == string::npos || idp > idq )
       val.insert( idx, m_name );
     else if ( idp != string::npos && idp < idq )
       val[idp] = NAMESPACE_SEP;
   }
-  while(( idx = val.find(':')) != string::npos ) val[idx] = NAMESPACE_SEP;
   return val;
 }
 
@@ -113,9 +110,7 @@ string
 DDNamespace::nsName( const string& nam )
 {
   size_t idx;
-  if(( idx = nam.find(':')) != string::npos )
-    return nam.substr( 0, idx );
-  else if(( idx=nam.find('_')) != string::npos )
+  if(( idx = nam.find( NAMESPACE_SEP )) != string::npos )
     return nam.substr( 0, idx );
   return "";
 }
@@ -124,9 +119,7 @@ string
 DDNamespace::objName( const string& nam )
 {
   size_t idx;
-  if(( idx = nam.find(':')) != string::npos )
-    return nam.substr( idx + 1 );
-  else if (( idx=nam.find('_')) != string::npos )
+  if(( idx = nam.find( NAMESPACE_SEP )) != string::npos )
     return nam.substr( idx + 1 );
   return "";
 }
@@ -184,10 +177,10 @@ DDNamespace::rotation( const string& nam ) const
     return (*i).second;
   else if( nam == "NULL" )
     return s_null;
-  else if( nam.find("_NULL") == nam.length() - 5 )
+  else if( nam.find(":NULL") == nam.length() - 5 )
     return s_null;
   string n = nam;
-  if(( idx=nam.find(':')) != string::npos )
+  if(( idx = nam.find( NAMESPACE_SEP )) != string::npos )
   {
     n[idx] = NAMESPACE_SEP;
     i = context->rotations.find(n);
@@ -237,14 +230,14 @@ DDNamespace::volume( const string& nam, bool exc ) const
   if ( i != context->volumes.end() )  {
     return (*i).second;
   }
-  if ( (idx=nam.find(':')) != string::npos )  {
+  if(( idx = nam.find( NAMESPACE_SEP )) != string::npos )  {
     string n = nam;
     n[idx] = NAMESPACE_SEP;
-    i = context->volumes.find(n);
-    if ( i != context->volumes.end() )
+    i = context->volumes.find( n );
+    if( i != context->volumes.end())
       return (*i).second;
   }
-  if ( exc )  {
+  if( exc )  {
     throw runtime_error("Unknown volume identifier:"+nam);
   }
   return nullptr;
@@ -271,17 +264,17 @@ DDNamespace::solid( const string& nam ) const
 {
   size_t idx;
   string n = context->namespaces.back() + nam;
-  auto i = context->shapes.find(n);
-  if ( i != context->shapes.end() )
+  auto i = context->shapes.find( n );
+  if( i != context->shapes.end())
     return (*i).second;
-  if ( (idx=nam.find(':')) != string::npos )  {
-    n = realName(nam);
+  if(( idx = nam.find( NAMESPACE_SEP )) != string::npos ) {
+    n = realName( nam );
     n[idx] = NAMESPACE_SEP;
-    i = context->shapes.find(n);
+    i = context->shapes.find( n );
     if ( i != context->shapes.end() )
       return (*i).second;
   }  
   i = context->shapes.find(nam);
-  if ( i != context->shapes.end() ) return (*i).second;
+  if( i != context->shapes.end()) return (*i).second;
   throw runtime_error( "Unknown shape identifier:" + nam );
 }


### PR DESCRIPTION
* Use ```':'``` as a ```namespace:name``` separator
