### PR TITLE
Cleanup pixel tracking code (10.2.x)

### DIFF
--- a/EventFilter/SiPixelRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/SiPixelRawToDigi/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<use   name="EventFilter/SiPixelRawToDigi"/>
-<library   file="*.cc" name="EventFilterSiPixelRawToDigiPlugins">
-  <flags   EDM_PLUGIN="1"/>
+<use name="EventFilter/SiPixelRawToDigi"/>
+<library file="*.cc" name="EventFilterSiPixelRawToDigiPlugins">
+  <flags EDM_PLUGIN="1"/>
 </library>

--- a/EventFilter/SiPixelRawToDigi/plugins/SealModule.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SealModule.cc
@@ -1,8 +1,0 @@
-#include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "SiPixelRawToDigi.h"
-#include "SiPixelDigiToRaw.h"
-
-DEFINE_FWK_MODULE(SiPixelDigiToRaw);
-DEFINE_FWK_MODULE(SiPixelRawToDigi);

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -147,5 +147,6 @@ void SiPixelDigiToRaw::produce( edm::Event& ev,
   
 }
 
-// -----------------------------------------------------------------------------
-
+// declare this as a framework plugin
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SiPixelDigiToRaw);

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -324,3 +324,7 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
     ev.put(std::move(disabled_channelcollection));
   }
 }
+
+// declare this as a framework plugin
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SiPixelRawToDigi);

--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
@@ -3,8 +3,7 @@ import FWCore.ParameterSet.Config as cms
 siPixelRecHits = cms.EDProducer("SiPixelRecHitConverter",
     src = cms.InputTag("siPixelClusters"),
     CPE = cms.string('PixelCPEGeneric'),
-    VerboseLevel = cms.untracked.int32(0),
-
+    VerboseLevel = cms.untracked.int32(0)
 )
 
 siPixelRecHitsPreSplitting = siPixelRecHits.clone(

--- a/RecoPixelVertexing/Configuration/python/customizePixelTracksForProfiling.py
+++ b/RecoPixelVertexing/Configuration/python/customizePixelTracksForProfiling.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+def customizePixelTracksForProfiling(process):
+    process.out = cms.OutputModule("AsciiOutputModule",
+        outputCommands = cms.untracked.vstring(
+            "keep *_pixelTracks_*_*",
+        ),
+        verbosity = cms.untracked.uint32(0),
+    )
+
+    process.outPath = cms.EndPath(process.out)
+
+    process.schedule = cms.Schedule(process.raw2digi_step, process.reconstruction_step, process.outPath)
+
+    return process

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrackFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrackFilter.cc
@@ -1,25 +1,19 @@
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h"
-
-#include "RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.h"
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/HitInfo.h"
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
+#include "DataFormats/SiPixelCluster/interface/SiPixelClusterShapeCache.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/HitInfo.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-
-#include "DataFormats/SiPixelCluster/interface/SiPixelClusterShapeCache.h"
 
 inline float sqr(float x) { return x*x; }
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
@@ -1,32 +1,24 @@
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h"
+#include <cmath>
 
-#include "RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.h"
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/HitInfo.h"
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-
-#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
-
-#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
-
+#include "DataFormats/GeometryVector/interface/Basic2DVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
-#include "DataFormats/GeometryVector/interface/Basic2DVector.h"
-
-#include<cmath>
-
-
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/HitInfo.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
 
 namespace {
   typedef Basic2DVector<float>   Vector2D;

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ThirdHitPrediction.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ThirdHitPrediction.cc
@@ -1,19 +1,14 @@
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ThirdHitPrediction.h"
-
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-
-#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
-#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
-#include "TrackingTools/DetLayers/interface/DetLayer.h"
-
-#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
-#include "RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.h"
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ThirdHitPrediction.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+#include "TrackingTools/DetLayers/interface/DetLayer.h"
+#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
 inline float sqr(float x) { return x*x; }
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/TrackFitter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/TrackFitter.cc
@@ -1,37 +1,29 @@
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-
-#include "DataFormats/GeometryVector/interface/LocalPoint.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
-
-#include "TrackingTools/DetLayers/interface/DetLayer.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
-
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
-
 #include "CommonTools/Statistics/interface/LinearFit.h"
+#include "CommonTools/Utils/interface/DynArray.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
-
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h"
-#include "RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackBuilder.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h"
+#include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
+#include "TrackingTools/DetLayers/interface/DetLayer.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
 using namespace std;
-#include "CommonTools/Utils/interface/DynArray.h"
-
 
 namespace {
+
 int getCharge
   (const DynArray<GlobalPoint> & points)
 {
@@ -42,8 +34,6 @@ int getCharge
    while (dphi < -M_PI) dphi += 2*M_PI;
    return (dphi > 0) ? -1 : 1;
 }
-
-
 
 }
 

--- a/RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h
@@ -1,5 +1,5 @@
-#ifndef CircleFromThreePoints_H
-#define CircleFromThreePoints_H
+#ifndef RecoPixelVertexing_PixelTrackFitting_interface_CircleFromThreePoints_h
+#define RecoPixelVertexing_PixelTrackFitting_interface_CircleFromThreePoints_h
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"
@@ -7,13 +7,13 @@
 /** Computes the curvature (1/radius) and, if possible, the center
  *  of the circle passing through three points.
  *  The input points are three dimensional for convenience, but the
- *  calculation is done in the transverse (x,y) plane. 
+ *  calculation is done in the transverse (x,y) plane.
  *  No verification of the reasonableness of the z coordinate is done.
  *  If the three points lie on a line the curvature is zero and the center
  *  position is undefined. The 3 points are assumed to make sense:
- *  if the distance between two of them is very small compared to 
+ *  if the distance between two of them is very small compared to
  *  the ditance to the third the result will be numerically unstable.
- */ 
+ */
 
 class CircleFromThreePoints {
 public:
@@ -26,11 +26,11 @@ public:
   /** Construct from three points (see class description).
    *  The order of points is not essential, but accuracy should be better if
    *  the second point lies between the other two on the circle.
-   *  The optional argument "precision" specifies how accurately the 
+   *  The optional argument "precision" specifies how accurately the
    *  straight line check has to be satisfied for setting the curvature
-   *  to zero and the center position to "undefined". 
+   *  to zero and the center position to "undefined".
    */
-  CircleFromThreePoints( const GlobalPoint& inner, 
+  CircleFromThreePoints( const GlobalPoint& inner,
 			 const GlobalPoint& mid,
 			 const GlobalPoint& outer,
 			 double precision = 1.e-7);
@@ -38,7 +38,7 @@ public:
 
   /** Returns the curvature (1/radius), in cm^(-1).
    *  The curvature is precomputed, this is just access method (takes no time).
-   *  If curvature is zero the center is undefined 
+   *  If curvature is zero the center is undefined
    *  (see description of presicion above).
    */
   float curvature() const { return theCurvature;}
@@ -49,15 +49,15 @@ public:
    *  If the curvature is very small the position of the center will
    *  be very inaccurate.
    */
-  Vector2D center() const { return theCenter; }  
+  Vector2D center() const { return theCenter; }
 
 private:
 
   float    theCurvature;
   Vector2D theCenter;
 
-  void init( const Vector2D& b, const Vector2D& c, 
+  void init( const Vector2D& b, const Vector2D& c,
 	     const Vector2D& offset, double precision);
 };
 
-#endif 
+#endif  // RecoPixelVertexing_PixelTrackFitting_interface_CircleFromThreePoints_h

--- a/RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.cc
@@ -1,4 +1,4 @@
-#include "CircleFromThreePoints.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 
 CircleFromThreePoints::CircleFromThreePoints( const GlobalPoint& inner,
                                     const GlobalPoint& mid,

--- a/RecoPixelVertexing/PixelTrackFitting/src/KFBasedPixelFitter.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/KFBasedPixelFitter.cc
@@ -24,7 +24,7 @@
 
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
-#include "CircleFromThreePoints.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "FWCore/Utilities/interface/InputTag.h"

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -25,7 +25,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h"
-#include "CircleFromThreePoints.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackBuilder.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackErrorParam.h"
 #include "DataFormats/GeometryVector/interface/Pi.h"

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
@@ -1,28 +1,21 @@
-#include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h"
+#include <vector>
 
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackExtra.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
-
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelFitter.h"
-
-#include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilter.h"
-
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleaner.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerWrapper.h"
-
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/TrackExtra.h"
-
+#include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilter.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h"
 #include "RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h"
-
-#include <vector>
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 
 using namespace pixeltrackfitting;
 using edm::ParameterSet;
@@ -34,12 +27,12 @@ PixelTrackReconstruction::PixelTrackReconstruction(const ParameterSet& cfg,
     theCleanerName(cfg.getParameter<std::string>("Cleaner"))
 {
   edm::InputTag filterTag = cfg.getParameter<edm::InputTag>("Filter");
-  if(filterTag.label() != "") {
+  if (not filterTag.label().empty()) {
     theFilterToken = iC.consumes<PixelTrackFilter>(filterTag);
   }
 }
-  
-PixelTrackReconstruction::~PixelTrackReconstruction() 
+
+PixelTrackReconstruction::~PixelTrackReconstruction()
 {
 }
 
@@ -66,8 +59,8 @@ void PixelTrackReconstruction::run(TracksWithTTRHs& tracks, edm::Event& ev, cons
     ev.getByToken(theFilterToken, hfilter);
     filter = hfilter.product();
   }
-  
-  std::vector<const TrackingRecHit *> hits;hits.reserve(4); 
+
+  std::vector<const TrackingRecHit *> hits;hits.reserve(4);
   for(const auto& regionHitSets: hitSets) {
     const TrackingRegion& region = regionHitSets.region();
 
@@ -75,7 +68,7 @@ void PixelTrackReconstruction::run(TracksWithTTRHs& tracks, edm::Event& ev, cons
       /// FIXME at some point we need to migrate the fitter...
       auto nHits = tuplet.size(); hits.resize(nHits);
       for (unsigned int iHit = 0; iHit < nHits; ++iHit) hits[iHit] = tuplet[iHit];
-   
+
       // fitting
       std::unique_ptr<reco::Track> track = fitter.run(hits, region);
       if (!track) continue;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
@@ -80,8 +80,8 @@ void CAHitNtupletEDProducerT<T_Generator>::produce(edm::Event& iEvent, const edm
   LogDebug("CAHitNtupletEDProducer") << "Creating ntuplets for " << regionDoublets.regionSize() << " regions, and " << regionDoublets.layerPairsSize() << " layer pairs";
   std::vector<OrderedHitSeeds> ntuplets;
   ntuplets.resize(regionDoublets.regionSize());
-  for(auto& ntuplet : ntuplets)  ntuplet.reserve(localRA_.upper()); 
-   
+  for(auto& ntuplet : ntuplets)  ntuplet.reserve(localRA_.upper());
+
   generator_.hitNtuplets(regionDoublets, ntuplets, iSetup, seedingLayerHits);
   int index = 0;
   for(const auto& regionLayerPairs: regionDoublets) {

--- a/RecoPixelVertexing/PixelTriplets/src/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/src/CACell.h
@@ -1,14 +1,13 @@
-#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CACELL_h
-#define RECOPIXELVERTEXING_PIXELTRIPLETS_CACELL_h
+#ifndef RecoPixelVertexing_PixelTriplets_src_CACell_h
+#define RecoPixelVertexing_PixelTriplets_src_CACell_h
 
-#include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include <array>
+#include <cmath>
 
 #include "DataFormats/Math/interface/deltaPhi.h"
-
-#include <cmath>
-#include <array>
+#include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 
 class CACellStatus {
 
@@ -298,4 +297,4 @@ private:
 };
 
 
-#endif /*CACELL_H_ */
+#endif // RecoPixelVertexing_PixelTriplets_src_CACell_h

--- a/RecoPixelVertexing/PixelTriplets/src/CAGraph.h
+++ b/RecoPixelVertexing/PixelTriplets/src/CAGraph.h
@@ -1,68 +1,58 @@
-#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CAGRAPH_H_
-#define RECOPIXELVERTEXING_PIXELTRIPLETS_CAGRAPH_H_
+#ifndef RecoPixelVertexing_PixelTriplets_src_CAGraph_h
+#define RecoPixelVertexing_PixelTriplets_src_CAGraph_h
 
-#include <vector>
 #include <array>
 #include <string>
+#include <vector>
 
 struct CALayer
 {
-	CALayer(const std::string& layerName, std::size_t numberOfHits )
-	: theName(layerName)
-	{
-		isOuterHitOfCell.resize(numberOfHits);
-	}
+  CALayer(const std::string &layerName, std::size_t numberOfHits)
+      : theName(layerName)
+  {
+    isOuterHitOfCell.resize(numberOfHits);
+  }
 
-	bool operator==(const std::string& otherString)
-	{
-		return otherString == theName;
-	}
+  bool operator==(const std::string &otherString) {
+    return otherString == theName;
+  }
 
-	std::string name() const
-	{
-		return theName;
-	}
+  const std::string& name() const { return theName; }
 
-	std::vector<int> theOuterLayerPairs;
-	std::vector<int> theInnerLayerPairs;
+  std::vector<int> theOuterLayerPairs;
+  std::vector<int> theInnerLayerPairs;
 
-	std::vector<int> theOuterLayers;
-	std::vector<int> theInnerLayers;
-	std::vector< std::vector<unsigned int> >  isOuterHitOfCell;
-
+  std::vector<int> theOuterLayers;
+  std::vector<int> theInnerLayers;
+  std::vector<std::vector<unsigned int>> isOuterHitOfCell;
 
 private:
-
-	std::string theName;
+  std::string theName;
 };
 
 struct CALayerPair
 {
+  CALayerPair(int a, int b)
 
-	CALayerPair(int a, int b)
+  {
+    theLayers[0] = a;
+    theLayers[1] = b;
+  }
 
-	{
-		theLayers[0] = a;
-		theLayers[1] = b;
-	}
+  bool operator==(const CALayerPair &otherLayerPair) {
+    return (theLayers[0] == otherLayerPair.theLayers[0]) &&
+           (theLayers[1] == otherLayerPair.theLayers[1]);
+  }
 
-
-
-	bool operator==(const CALayerPair& otherLayerPair)
-	{
-		return (theLayers[0] == otherLayerPair.theLayers[0])
-				&& (theLayers[1] == otherLayerPair.theLayers[1]);
-	}
-
-	std::array<int, 2> theLayers;
-	std::array<unsigned int, 2> theFoundCells= {{0,0}};
+  std::array<int, 2> theLayers;
+  std::array<unsigned int, 2> theFoundCells = {{0, 0}};
 };
 
 struct CAGraph
 {
-	std::vector<CALayer> theLayers;
-	std::vector<CALayerPair> theLayerPairs;
-	std::vector<int> theRootLayers;
+  std::vector<CALayer> theLayers;
+  std::vector<CALayerPair> theLayerPairs;
+  std::vector<int> theRootLayers;
 };
 
-#endif /* CAGRAPH_H_ */
+#endif // RecoPixelVertexing_PixelTriplets_src_CAGraph_h

--- a/RecoPixelVertexing/PixelTriplets/src/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CAHitQuadrupletGenerator.cc
@@ -1,35 +1,26 @@
-#include "RecoPixelVertexing/PixelTriplets/interface/CAHitQuadrupletGenerator.h"
+#include <functional>
 
-#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "CommonTools/Utils/interface/DynArray.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "DataFormats/Common/interface/Handle.h"
-
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/CAHitQuadrupletGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
-
 
 #include "CAGraph.h"
 #include "CellularAutomaton.h"
 
-#include "CommonTools/Utils/interface/DynArray.h"
-
-#include "FWCore/Utilities/interface/isFinite.h"
-
-#include <functional>
-
 namespace
 {
-
   template <typename T>
   T sqr(T x)
   {
-    return x*x;
+    return x * x;
   }
 }
-
-
 
 using namespace std;
 

--- a/RecoPixelVertexing/PixelTriplets/src/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CAHitTripletGenerator.cc
@@ -1,31 +1,26 @@
 #include <unordered_map>
 
-#include "RecoPixelVertexing/PixelTriplets/interface/CAHitTripletGenerator.h"
-
-#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
-
-#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "CommonTools/Utils/interface/DynArray.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "DataFormats/Common/interface/Handle.h"
-
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/CAHitTripletGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+
 #include "CAGraph.h"
 #include "CellularAutomaton.h"
 
-#include "CommonTools/Utils/interface/DynArray.h"
-
-#include "FWCore/Utilities/interface/isFinite.h"
-
 namespace
 {
-
-template<typename T>
-T sqr(T x)
-{
-	return x * x;
-}
+  template <typename T>
+  T sqr(T x)
+  {
+    return x * x;
+  }
 }
 
 using namespace std;

--- a/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.cc
@@ -1,265 +1,210 @@
+#include <queue>
+
 #include "CellularAutomaton.h"
 
-#include<queue>
-
-
-void CellularAutomaton::createAndConnectCells(const std::vector<const HitDoublets *>& hitDoublets, const TrackingRegion& region,
-		const float thetaCut, const float phiCut, const float hardPtCut)
+void CellularAutomaton::createAndConnectCells(
+    const std::vector<const HitDoublets *> & hitDoublets,
+    const TrackingRegion & region,
+    const float thetaCut,
+    const float phiCut,
+    const float hardPtCut)
 {
-        int tsize=0;
-        for ( auto hd :  hitDoublets) tsize+=hd->size();
-        allCells.reserve(tsize);
-        unsigned int cellId = 0;
-	float ptmin = region.ptMin();
-	float region_origin_x = region.origin().x();
-	float region_origin_y = region.origin().y();
-	float region_origin_radius = region.originRBound();
+  int tsize = 0;
+  for (auto hd : hitDoublets) {
+    tsize += hd->size();
+  }
+  allCells.reserve(tsize);
+  unsigned int cellId = 0;
+  float ptmin = region.ptMin();
+  float region_origin_x = region.origin().x();
+  float region_origin_y = region.origin().y();
+  float region_origin_radius = region.originRBound();
 
-	std::vector<bool> alreadyVisitedLayerPairs;
-	alreadyVisitedLayerPairs.resize(theLayerGraph.theLayerPairs.size());
-	for (auto visited : alreadyVisitedLayerPairs)
-	{
-		visited = false;
-	}
-	for (int rootVertex : theLayerGraph.theRootLayers)
-	{
+  std::vector<bool> alreadyVisitedLayerPairs;
+  alreadyVisitedLayerPairs.resize(theLayerGraph.theLayerPairs.size());
+  for (auto visited : alreadyVisitedLayerPairs) {
+    visited = false;
+  }
+  for (int rootVertex : theLayerGraph.theRootLayers) {
+    std::queue<int> LayerPairsToVisit;
 
-		std::queue<int> LayerPairsToVisit;
+    for (int LayerPair : theLayerGraph.theLayers[rootVertex].theOuterLayerPairs) {
+      LayerPairsToVisit.push(LayerPair);
+    }
 
-		for (int LayerPair : theLayerGraph.theLayers[rootVertex].theOuterLayerPairs)
-		{
-			LayerPairsToVisit.push(LayerPair);
+    unsigned int numberOfLayerPairsToVisitAtThisDepth = LayerPairsToVisit.size();
 
-		}
+    while (not LayerPairsToVisit.empty()) {
+      auto currentLayerPair = LayerPairsToVisit.front();
+      auto & currentLayerPairRef  = theLayerGraph.theLayerPairs[currentLayerPair];
+      auto & currentInnerLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[0]];
+      auto & currentOuterLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[1]];
+      bool allInnerLayerPairsAlreadyVisited{true};
 
-		unsigned int numberOfLayerPairsToVisitAtThisDepth =
-				LayerPairsToVisit.size();
+      for (auto innerLayerPair : currentInnerLayerRef.theInnerLayerPairs) {
+        allInnerLayerPairsAlreadyVisited &= alreadyVisitedLayerPairs[innerLayerPair];
+      }
 
-		while (!LayerPairsToVisit.empty())
-		{
-			auto currentLayerPair = LayerPairsToVisit.front();
-			auto & currentLayerPairRef = theLayerGraph.theLayerPairs[currentLayerPair];
-			auto & currentInnerLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[0]];
-			auto & currentOuterLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[1]];
-			bool allInnerLayerPairsAlreadyVisited	{ true };
+      if (alreadyVisitedLayerPairs[currentLayerPair] == false and allInnerLayerPairsAlreadyVisited) {
+        const HitDoublets *doubletLayerPairId = hitDoublets[currentLayerPair];
+        auto numberOfDoublets = doubletLayerPairId->size();
+        currentLayerPairRef.theFoundCells[0] = cellId;
+        currentLayerPairRef.theFoundCells[1] = cellId + numberOfDoublets;
+        for (unsigned int i = 0; i < numberOfDoublets; ++i) {
+          allCells.emplace_back(doubletLayerPairId, i,
+                                doubletLayerPairId->innerHitId(i),
+                                doubletLayerPairId->outerHitId(i));
 
-			for (auto innerLayerPair : currentInnerLayerRef.theInnerLayerPairs)
-			{
-				allInnerLayerPairsAlreadyVisited &=
-						alreadyVisitedLayerPairs[innerLayerPair];
-			}
+          currentOuterLayerRef.isOuterHitOfCell[doubletLayerPairId->outerHitId(i)].push_back(cellId);
 
-			if (alreadyVisitedLayerPairs[currentLayerPair] == false
-					&& allInnerLayerPairsAlreadyVisited)
-			{
+          cellId++;
 
-				const HitDoublets* doubletLayerPairId =
-						hitDoublets[currentLayerPair];
-				auto numberOfDoublets = doubletLayerPairId->size();
-				currentLayerPairRef.theFoundCells[0] = cellId;
-				currentLayerPairRef.theFoundCells[1] = cellId+numberOfDoublets;
-				for (unsigned int i = 0; i < numberOfDoublets; ++i)
-				{
-				  allCells.emplace_back(doubletLayerPairId, i,
-							doubletLayerPairId->innerHitId(i),
-							doubletLayerPairId->outerHitId(i));
-				  
-										  
-				  currentOuterLayerRef.isOuterHitOfCell[doubletLayerPairId->outerHitId(i)].push_back(cellId);
-														     
-				  cellId++;
+          auto & neigCells = currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)];
+          allCells.back().checkAlignmentAndTag(
+              allCells, neigCells, ptmin, region_origin_x, region_origin_y,
+              region_origin_radius, thetaCut, phiCut, hardPtCut);
+        }
+        assert(cellId == currentLayerPairRef.theFoundCells[1]);
+        for (auto outerLayerPair : currentOuterLayerRef.theOuterLayerPairs) {
+          LayerPairsToVisit.push(outerLayerPair);
+        }
 
-				  auto & neigCells = currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)];
-				  allCells.back().checkAlignmentAndTag(allCells,
-								       neigCells, ptmin, region_origin_x,
-								       region_origin_y, region_origin_radius, thetaCut,
-								       phiCut, hardPtCut
-								       );
-				  
-
-				}
-				assert(cellId==currentLayerPairRef.theFoundCells[1]);
-				for (auto outerLayerPair : currentOuterLayerRef.theOuterLayerPairs)
-				{
-					LayerPairsToVisit.push(outerLayerPair);
-				}
-
-				alreadyVisitedLayerPairs[currentLayerPair] = true;
-			}
-			LayerPairsToVisit.pop();
-			numberOfLayerPairsToVisitAtThisDepth--;
-			if (numberOfLayerPairsToVisitAtThisDepth == 0)
-			{
-				numberOfLayerPairsToVisitAtThisDepth = LayerPairsToVisit.size();
-			}
-
-		}
-
-	}
-
+        alreadyVisitedLayerPairs[currentLayerPair] = true;
+      }
+      LayerPairsToVisit.pop();
+      numberOfLayerPairsToVisitAtThisDepth--;
+      if (numberOfLayerPairsToVisitAtThisDepth == 0) {
+        numberOfLayerPairsToVisitAtThisDepth = LayerPairsToVisit.size();
+      }
+    }
+  }
 }
 
 void CellularAutomaton::evolve(const unsigned int minHitsPerNtuplet)
 {
   allStatus.resize(allCells.size());
-  
-  
+
   unsigned int numberOfIterations = minHitsPerNtuplet - 2;
   // keeping the last iteration for later
-  for (unsigned int iteration = 0; iteration < numberOfIterations - 1;
-       ++iteration)
-    {
-      for (auto& layerPair : theLayerGraph.theLayerPairs)
-	{
-	  for (auto i =layerPair.theFoundCells[0]; i<layerPair.theFoundCells[1]; ++i)
-	    {
-	      allCells[i].evolve(i,allStatus);
-	    }
-	}
-      
-      for (auto& layerPair : theLayerGraph.theLayerPairs)
-	{
-	  for (auto i =layerPair.theFoundCells[0]; i<layerPair.theFoundCells[1]; ++i)
-	    {
-	      allStatus[i].updateState();
-	    }
-	}
-      
+  for (unsigned int iteration = 0; iteration < numberOfIterations - 1; ++iteration) {
+    for (auto & layerPair : theLayerGraph.theLayerPairs) {
+      for (auto i = layerPair.theFoundCells[0]; i < layerPair.theFoundCells[1]; ++i) {
+        allCells[i].evolve(i, allStatus);
+      }
     }
 
-  //last iteration
-  
-  
-  for(int rootLayerId : theLayerGraph.theRootLayers)
-    {
-      for(int rootLayerPair: theLayerGraph.theLayers[rootLayerId].theOuterLayerPairs)
-	{
-	  auto foundCells = theLayerGraph.theLayerPairs[rootLayerPair].theFoundCells;
-	  for (auto i =foundCells[0]; i<foundCells[1]; ++i)
-	    {
-	      auto & cell =  allStatus[i];
-	      allCells[i].evolve(i,allStatus);
-	      cell.updateState();
-	      if (cell.isRootCell(minHitsPerNtuplet - 2))
-		{
-		  theRootCells.push_back(i);
-		}
-	    }
-	}
+    for (auto & layerPair : theLayerGraph.theLayerPairs) {
+      for (auto i = layerPair.theFoundCells[0]; i < layerPair.theFoundCells[1]; ++i) {
+        allStatus[i].updateState();
+      }
     }
-  
+  }
+
+  // last iteration
+
+  for (int rootLayerId : theLayerGraph.theRootLayers) {
+    for (int rootLayerPair : theLayerGraph.theLayers[rootLayerId].theOuterLayerPairs) {
+      auto foundCells = theLayerGraph.theLayerPairs[rootLayerPair].theFoundCells;
+      for (auto i = foundCells[0]; i < foundCells[1]; ++i) {
+        auto & cell = allStatus[i];
+        allCells[i].evolve(i, allStatus);
+        cell.updateState();
+        if (cell.isRootCell(minHitsPerNtuplet - 2)) {
+          theRootCells.push_back(i);
+        }
+      }
+    }
+  }
 }
 
-void CellularAutomaton::findNtuplets(
-		std::vector<CACell::CAntuplet>& foundNtuplets,
-		const unsigned int minHitsPerNtuplet)
+void CellularAutomaton::findNtuplets(std::vector<CACell::CAntuplet> & foundNtuplets, const unsigned int minHitsPerNtuplet)
 {
-	CACell::CAntuple tmpNtuplet;
-	tmpNtuplet.reserve(minHitsPerNtuplet);
+  CACell::CAntuple tmpNtuplet;
+  tmpNtuplet.reserve(minHitsPerNtuplet);
 
-	for (auto root_cell : theRootCells)
-	{
-	  tmpNtuplet.clear();
-	  tmpNtuplet.push_back(root_cell);
-	  allCells[root_cell].findNtuplets(allCells,foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
-	}
-
+  for (auto root_cell : theRootCells)
+  {
+    tmpNtuplet.clear();
+    tmpNtuplet.push_back(root_cell);
+    allCells[root_cell].findNtuplets(allCells, foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+  }
 }
 
-
-void CellularAutomaton::findTriplets(const std::vector<const HitDoublets*>& hitDoublets,std::vector<CACell::CAntuplet>& foundTriplets, const TrackingRegion& region,
-		const float thetaCut, const float phiCut, const float hardPtCut)
+void CellularAutomaton::findTriplets(
+    std::vector<const HitDoublets *> const& hitDoublets,
+    std::vector<CACell::CAntuplet> & foundTriplets, TrackingRegion const& region,
+    const float thetaCut,
+    const float phiCut,
+    const float hardPtCut)
 {
-        int tsize=0;
-        for ( auto hd :  hitDoublets) tsize+=hd->size();
-        allCells.reserve(tsize);
+  int tsize = 0;
+  for (auto hd : hitDoublets) {
+    tsize += hd->size();
+  }
+  allCells.reserve(tsize);
 
-        unsigned int cellId = 0;
-	float ptmin = region.ptMin();
-	float region_origin_x = region.origin().x();
-	float region_origin_y = region.origin().y();
-	float region_origin_radius = region.originRBound();
+  unsigned int cellId = 0;
+  float ptmin = region.ptMin();
+  float region_origin_x = region.origin().x();
+  float region_origin_y = region.origin().y();
+  float region_origin_radius = region.originRBound();
 
-	std::vector<bool> alreadyVisitedLayerPairs;
-	alreadyVisitedLayerPairs.resize(theLayerGraph.theLayerPairs.size());
-	for (auto visited : alreadyVisitedLayerPairs)
-	{
-		visited = false;
-	}
-	for (int rootVertex : theLayerGraph.theRootLayers)
-	{
+  std::vector<bool> alreadyVisitedLayerPairs;
+  alreadyVisitedLayerPairs.resize(theLayerGraph.theLayerPairs.size());
+  for (auto visited : alreadyVisitedLayerPairs) {
+    visited = false;
+  }
+  for (int rootVertex : theLayerGraph.theRootLayers) {
+    std::queue<int> LayerPairsToVisit;
 
-		std::queue<int> LayerPairsToVisit;
+    for (int LayerPair : theLayerGraph.theLayers[rootVertex].theOuterLayerPairs) {
+      LayerPairsToVisit.push(LayerPair);
+    }
 
-		for (int LayerPair : theLayerGraph.theLayers[rootVertex].theOuterLayerPairs)
-		{
-			LayerPairsToVisit.push(LayerPair);
+    unsigned int numberOfLayerPairsToVisitAtThisDepth = LayerPairsToVisit.size();
 
-		}
+    while (not LayerPairsToVisit.empty()) {
+      auto currentLayerPair = LayerPairsToVisit.front();
+      auto & currentLayerPairRef  = theLayerGraph.theLayerPairs[currentLayerPair];
+      auto & currentInnerLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[0]];
+      auto & currentOuterLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[1]];
+      bool allInnerLayerPairsAlreadyVisited{true};
 
-		unsigned int numberOfLayerPairsToVisitAtThisDepth =
-				LayerPairsToVisit.size();
+      for (auto innerLayerPair : currentInnerLayerRef.theInnerLayerPairs) {
+        allInnerLayerPairsAlreadyVisited &= alreadyVisitedLayerPairs[innerLayerPair];
+      }
 
-		while (!LayerPairsToVisit.empty())
-		{
-			auto currentLayerPair = LayerPairsToVisit.front();
-			auto & currentLayerPairRef = theLayerGraph.theLayerPairs[currentLayerPair];
-			auto & currentInnerLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[0]];
-			auto & currentOuterLayerRef = theLayerGraph.theLayers[currentLayerPairRef.theLayers[1]];
-			bool allInnerLayerPairsAlreadyVisited	{ true };
+      if (alreadyVisitedLayerPairs[currentLayerPair] == false and allInnerLayerPairsAlreadyVisited) {
+        const HitDoublets *doubletLayerPairId = hitDoublets[currentLayerPair];
+        auto numberOfDoublets = doubletLayerPairId->size();
+        currentLayerPairRef.theFoundCells[0] = cellId;
+        currentLayerPairRef.theFoundCells[1] = cellId + numberOfDoublets;
+        for (unsigned int i = 0; i < numberOfDoublets; ++i) {
+          allCells.emplace_back(doubletLayerPairId, i,
+                                doubletLayerPairId->innerHitId(i),
+                                doubletLayerPairId->outerHitId(i));
 
-			for (auto innerLayerPair : currentInnerLayerRef.theInnerLayerPairs)
-			{
-				allInnerLayerPairsAlreadyVisited &=
-						alreadyVisitedLayerPairs[innerLayerPair];
-			}
+          currentOuterLayerRef.isOuterHitOfCell[doubletLayerPairId->outerHitId(i)].push_back(cellId);
 
-			if (alreadyVisitedLayerPairs[currentLayerPair] == false
-					&& allInnerLayerPairsAlreadyVisited)
-			{
+          cellId++;
 
-				const HitDoublets* doubletLayerPairId =
-						hitDoublets[currentLayerPair];
-				auto numberOfDoublets = doubletLayerPairId->size();
-				currentLayerPairRef.theFoundCells[0] = cellId;
-				currentLayerPairRef.theFoundCells[1] = cellId+numberOfDoublets;
-				for (unsigned int i = 0; i < numberOfDoublets; ++i)
-				{
-				  allCells.emplace_back(doubletLayerPairId, i,
-							doubletLayerPairId->innerHitId(i),
-							doubletLayerPairId->outerHitId(i));
-				  
-										  
-				  currentOuterLayerRef.isOuterHitOfCell[doubletLayerPairId->outerHitId(i)].push_back(cellId);
-														     
-				  cellId++;
+          auto & neigCells = currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)];
+          allCells.back().checkAlignmentAndPushTriplet(
+              allCells, neigCells, foundTriplets, ptmin, region_origin_x, region_origin_y,
+              region_origin_radius, thetaCut, phiCut, hardPtCut);
+        }
+        assert(cellId == currentLayerPairRef.theFoundCells[1]);
+        for (auto outerLayerPair : currentOuterLayerRef.theOuterLayerPairs) {
+          LayerPairsToVisit.push(outerLayerPair);
+        }
 
-				  auto & neigCells = currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)];
-				  allCells.back().checkAlignmentAndPushTriplet(allCells,
-									       neigCells, foundTriplets, ptmin, region_origin_x,
-									       region_origin_y, region_origin_radius, thetaCut,
-									       phiCut, hardPtCut
-									       );
-				}
-				assert(cellId==currentLayerPairRef.theFoundCells[1]);
-
-
-				for (auto outerLayerPair : currentOuterLayerRef.theOuterLayerPairs)
-				{
-					LayerPairsToVisit.push(outerLayerPair);
-				}
-
-				alreadyVisitedLayerPairs[currentLayerPair] = true;
-			}
-			LayerPairsToVisit.pop();
-			numberOfLayerPairsToVisitAtThisDepth--;
-			if (numberOfLayerPairsToVisitAtThisDepth == 0)
-			{
-				numberOfLayerPairsToVisitAtThisDepth = LayerPairsToVisit.size();
-			}
-
-		}
-
-	}
-
+        alreadyVisitedLayerPairs[currentLayerPair] = true;
+      }
+      LayerPairsToVisit.pop();
+      numberOfLayerPairsToVisitAtThisDepth--;
+      if (numberOfLayerPairsToVisitAtThisDepth == 0) {
+        numberOfLayerPairsToVisitAtThisDepth = LayerPairsToVisit.size();
+      }
+    }
+  }
 }

--- a/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.h
@@ -1,20 +1,22 @@
-#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_PLUGINS_CELLULARAUTOMATON_H_
-#define RECOPIXELVERTEXING_PIXELTRIPLETS_PLUGINS_CELLULARAUTOMATON_H_
+#ifndef RecoPixelVertexing_PixelTriplets_src_CellularAutomaton_h
+#define RecoPixelVertexing_PixelTriplets_src_CellularAutomaton_h
+
 #include <array>
-#include "CACell.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+
+#include "CACell.h"
 #include "CAGraph.h"
+
 class CellularAutomaton
 {
 public:
   CellularAutomaton(CAGraph& graph)
     : theLayerGraph(graph)
-  {
-    
-  }
+  { }
   
-  std::vector<CACell> & getAllCells() { return allCells;}
+  std::vector<CACell> & getAllCells() { return allCells; }
   
   void createAndConnectCells(const std::vector<const HitDoublets *>&,
 			     const TrackingRegion&, const float, const float, const float);
@@ -35,4 +37,4 @@ private:
   
 };
 
-#endif 
+#endif // RecoPixelVertexing_PixelTriplets_src_CellularAutomaton_h


### PR DESCRIPTION
Clean up some non-GPU-related pixel tracking code: clean up whitespaces and indenttion, plugin definitions, includes, and file names.

Add a customize function to provide a minimal pixel-tracking only configuration for profiling, removing validation, DQM, and output modules. Can be included in the configuration with
```python
from RecoPixelVertexing.Configuration.customizePixelTracksForProfiling import customizePixelTracksForProfiling
process = customizePixelTracksForProfiling(process)
```

Backport from the Patatrack fork: cms-patatrack#49, cms-patatrack#122, cms-patatrack#134.