### PR TITLE
Puppi pileupjetID

### DIFF
--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -34,7 +34,7 @@ public:
 	~PileupJetIdAlgo(); 
 	
 	PileupJetIdentifier computeIdVariables(const reco::Jet * jet, 
-					       float jec, const reco::Vertex *, const reco::VertexCollection &, double rho);
+					       float jec, const reco::Vertex *, const reco::VertexCollection &, double rho, bool usePuppi);
 
 	void set(const PileupJetIdentifier &);
         float getMVAval(const std::vector<std::string> &, const std::unique_ptr<const GBRForest> &);

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -24,7 +24,8 @@ GBRForestsAndConstants::GBRForestsAndConstants(edm::ParameterSet const& iConfig)
   inputIsCorrected_(iConfig.getParameter<bool>("inputIsCorrected")),
   applyJec_(iConfig.getParameter<bool>("applyJec")),
   jec_(iConfig.getParameter<std::string>("jec")),
-  residualsFromTxt_(iConfig.getParameter<bool>("residualsFromTxt")) {
+  residualsFromTxt_(iConfig.getParameter<bool>("residualsFromTxt")),
+  usePuppi_(iConfig.getParameter<bool>("usePuppi")) {
 
   if (residualsFromTxt_) {
     residualsTxt_ = iConfig.getParameter<edm::FileInPath>("residualsTxt");
@@ -167,7 +168,7 @@ PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		PileupJetIdentifier puIdentifier;
 		if( gc->produceJetIds() ) {
 		        // Compute the input variables
-		        puIdentifier = ialgo->computeIdVariables(theJet, jec,  &(*vtx), vertexes, rho);
+		        puIdentifier = ialgo->computeIdVariables(theJet, jec,  &(*vtx), vertexes, rho,gc->usePuppi());
 			ids.push_back( puIdentifier );
 		} else {
 		        // Or read it from the value map

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
@@ -63,6 +63,7 @@ public:
   std::string const& jec() const { return jec_; }
   bool residualsFromTxt() const { return residualsFromTxt_; }
   edm::FileInPath const& residualsTxt() const { return residualsTxt_; }
+  bool usePuppi() const { return usePuppi_; }
 
 private:
 
@@ -75,6 +76,7 @@ private:
   std::string jec_;
   bool residualsFromTxt_;
   edm::FileInPath residualsTxt_;
+  bool usePuppi_;
 };
 
 class PileupJetIdProducer : public edm::stream::EDProducer<edm::GlobalCache<GBRForestsAndConstants>> {

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -27,6 +27,7 @@ pileupJetId = cms.EDProducer('PileupJetIdProducer',
      applyJec = cms.bool(True),
      inputIsCorrected = cms.bool(False),
      residualsFromTxt = cms.bool(False),
+     usePuppi = cms.bool(False),
 #     residualsTxt     = cms.FileInPath("RecoJets/JetProducers/data/download.url") # must be an existing file
 )
 

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -506,8 +506,8 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	 internalId_.neuEMfrac_   = patjet->neutralEmEnergy()    /jet->energy();
 	 internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy()/jet->energy();
 	 internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy()/jet->energy();
-         if (patjet->hasUserFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity"))
-           internalId_.nNeutrals_ = patjet->userFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity");
+	 if (patjet->hasUserFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity"))
+	   internalId_.nNeutrals_ = patjet->userFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity");
 	} else {
 	 internalId_.nCharged_    = pfjet->chargedMultiplicity();
 	 internalId_.nNeutrals_   = pfjet->neutralMultiplicity();
@@ -528,7 +528,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
             continue;
 	  }
 
-          float partPuppiWeight=1.0;
+	  float partPuppiWeight=1.0;
 	  if (usePuppi){
 	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part.get() );
 	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();
@@ -554,7 +554,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
             continue;
           }
  
-          float partPuppiWeight=1.0;
+	  float partPuppiWeight=1.0;
 	  if (usePuppi){
 	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part.get() );
 	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -553,7 +553,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	  if (!(part.isAvailable() && part.isNonnull()) ){
             continue;
           }
-
+ 
           float partPuppiWeight=1.0;
 	  if (usePuppi){
 	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part.get() );

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -299,6 +299,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	TMatrixDSym covMatrix(2); covMatrix = 0.;
 	float jetPt = jet->pt() / jec; // use uncorrected pt for shape variables
 	float sumPt = 0., sumPt2 = 0., sumTkPt = 0.,sumPtCh=0,sumPtNe = 0;
+	float multNeut = 0.0;
 	setPtEtaPhi(*jet,internalId_.jetPt_,internalId_.jetEta_,internalId_.jetPhi_); // use corrected pt for jet kinematics
 	internalId_.jetM_ = jet->mass(); 
 	internalId_.nvtx_ = allvtx.size();
@@ -359,6 +360,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 			if( icone < ncones ) { *coneNeutFracs[icone] += candPt; }
 			internalId_.ptDNe_    += candPt*candPt;
 			sumPtNe               += candPt;
+			multNeut += candPuppiWeight;
 		}
 		// EM candidated
 		if( icand->pdgId() == 22 ) {
@@ -368,7 +370,10 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 			if( icone < ncones ) { *coneEmFracs[icone] += candPt; }
 			internalId_.ptDNe_    += candPt*candPt;
 			sumPtNe               += candPt;
+			multNeut += candPuppiWeight;
 		}
+		if((abs(icand->pdgId()) == 1) || (abs(icand->pdgId()) == 2)) multNeut += candPuppiWeight;
+
 		// Charged  particles
 		if(  icand->charge() != 0 ) {
 		        if (lLeadCh == nullptr || candPt > lLeadCh->pt()) { 
@@ -484,6 +489,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 				}
 			}
 		}
+
 		// trailing candidate
 		if( lTrail == nullptr || candPt < lTrail->pt() ) {
 			lTrail = icand; 
@@ -506,8 +512,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	 internalId_.neuEMfrac_   = patjet->neutralEmEnergy()    /jet->energy();
 	 internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy()/jet->energy();
 	 internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy()/jet->energy();
-	 if (patjet->hasUserFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity"))
-	   internalId_.nNeutrals_ = patjet->userFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity");
+	 if (usePuppi) internalId_.nNeutrals_ = multNeut;
 	} else {
 	 internalId_.nCharged_    = pfjet->chargedMultiplicity();
 	 internalId_.nNeutrals_   = pfjet->neutralMultiplicity();

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -506,6 +506,8 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	 internalId_.neuEMfrac_   = patjet->neutralEmEnergy()    /jet->energy();
 	 internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy()/jet->energy();
 	 internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy()/jet->energy();
+         if (patjet->hasUserFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity"))
+           internalId_.nNeutrals_ = patjet->userFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity");
 	} else {
 	 internalId_.nCharged_    = pfjet->chargedMultiplicity();
 	 internalId_.nNeutrals_   = pfjet->neutralMultiplicity();

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -305,6 +305,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	internalId_.rho_ = rho;
 
 	float dRmin(1000);
+
 	for ( unsigned i = 0; i < jet->numberOfSourceCandidatePtrs(); ++i ) {
 	  reco::CandidatePtr pfJetConstituent = jet->sourceCandidatePtr(i);
   
@@ -597,13 +598,12 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	internalId_.dRMeanEm_   /= jetPt;
 	internalId_.dRMeanCh_   /= jetPt;
 	internalId_.dR2Mean_    /= sumPt2;
-	float conesum=0.0;
+
 	for(size_t ic=0; ic<ncones; ++ic){
 		*coneFracs[ic]     /= jetPt;
 		*coneEmFracs[ic]   /= jetPt;
 		*coneNeutFracs[ic] /= jetPt;
 		*coneChFracs[ic]   /= jetPt;
-		conesum+=*coneFracs[ic];
 	}
 	//http://jets.physics.harvard.edu/qvg/
 	double ptMean = sumPt/internalId_.nParticles_;

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -526,7 +526,13 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
             continue;
 	  }
 
-	  float weight = part->pt();
+          float partPuppiWeight=1.0;
+	  if (usePuppi){
+	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part );
+	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();
+	  }
+
+	  float weight = (part->pt())*partPuppiWeight;
 	  float weight2 = weight * weight;
 	  sumW2        += weight2;
 	  float deta = part->eta() - jet->eta();
@@ -545,7 +551,15 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 	  if (!(part.isAvailable() && part.isNonnull()) ){
             continue;
           }
-	  float weight =part->pt()*part->pt();
+
+          float partPuppiWeight=1.0;
+	  if (usePuppi){
+	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part );
+	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();
+	  }
+
+
+	  float weight = partPuppiWeight*(part->pt())*partPuppiWeight*(part->pt());
 	  float deta = part->eta() - jet->eta();
 	  float dphi = reco::deltaPhi(*part, *jet);
 	  float ddeta, ddphi, ddR;

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -528,7 +528,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 
           float partPuppiWeight=1.0;
 	  if (usePuppi){
-	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part );
+	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part.get() );
 	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();
 	  }
 
@@ -554,10 +554,9 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 
           float partPuppiWeight=1.0;
 	  if (usePuppi){
-	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part );
+	    const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate *>( part.get() );
 	    if (partpack!=nullptr)  partPuppiWeight = partpack->puppiWeight();
 	  }
-
 
 	  float weight = partPuppiWeight*(part->pt())*partPuppiWeight*(part->pt());
 	  float deta = part->eta() - jet->eta();

--- a/RecoJets/JetProducers/test/testJetTools_onMiniAOD_cfg.py
+++ b/RecoJets/JetProducers/test/testJetTools_onMiniAOD_cfg.py
@@ -22,22 +22,10 @@ updateJetCollection(
     jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
     )
 
-
-updateJetCollection(
-    process,
-    labelName = 'AK4PFPUPPI',
-    jetSource = cms.InputTag('slimmedJetsPuppi'),
-    algo = 'ak4',
-    rParam = 0.4,
-    jetCorrections = ('AK4PFPuppi', cms.vstring(['L2Relative', 'L3Absolute']), 'None'),
-    )
-
-
 patJetsAK4 = process.updatedPatJetsAK4PFCHS
-patJetsAK4Puppi = process.updatedPatJetsAK4PFPUPPI
 patJetsAK8 = process.updatedPatJetsAK8PFCHS
 
-process.out.outputCommands += ['keep *_updatedPatJetsAK4PFCHS_*_*','keep *_updatedPatJetsAK4PFPUPPI_*_*',
+process.out.outputCommands += ['keep *_updatedPatJetsAK4PFCHS_*_*',
                                'keep *_updatedPatJetsAK8PFCHS_*_*']
 
 ####################################################################################################
@@ -50,18 +38,16 @@ process.out.outputCommands += ['keep *_updatedPatJetsAK4PFCHS_*_*','keep *_updat
 
 process.load('RecoJets.JetProducers.PileupJetID_cfi')
 patAlgosToolsTask.add(process.pileUpJetIDTask)
-process.pileupJetIdCalculator.jets=cms.InputTag("slimmedJetsPuppi")
+process.pileupJetIdCalculator.jets=cms.InputTag("slimmedJets")
 process.pileupJetIdCalculator.inputIsCorrected=True
 process.pileupJetIdCalculator.applyJec=True
-process.pileupJetIdCalculator.usePuppi=True
 process.pileupJetIdCalculator.vertexes=cms.InputTag("offlineSlimmedPrimaryVertices")
 process.pileupJetIdEvaluator.jets=process.pileupJetIdCalculator.jets
 process.pileupJetIdEvaluator.inputIsCorrected=process.pileupJetIdCalculator.inputIsCorrected
 process.pileupJetIdEvaluator.applyJec=process.pileupJetIdCalculator.applyJec
-process.pileupJetIdEvaluator.usePuppi=process.pileupJetIdCalculator.usePuppi
 process.pileupJetIdEvaluator.vertexes=process.pileupJetIdCalculator.vertexes
-patJetsAK4Puppi.userData.userFloats.src += ['pileupJetIdEvaluator:fullDiscriminant']
-patJetsAK4Puppi.userData.userInts.src += ['pileupJetIdEvaluator:cutbasedId','pileupJetIdEvaluator:fullId']
+patJetsAK4.userData.userFloats.src += ['pileupJetIdEvaluator:fullDiscriminant']
+patJetsAK4.userData.userInts.src += ['pileupJetIdEvaluator:cutbasedId','pileupJetIdEvaluator:fullId']
 process.out.outputCommands += ['keep *_pileupJetIdEvaluator_*_*']
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -179,14 +165,11 @@ import PhysicsTools.PatAlgos.patInputFiles_cff
 from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
 process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
 #                                         ##
-process.maxEvents.input = 5000
-
-process.load("FWCore.MessageLogger.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 10000
-
+process.maxEvents.input = 5
 #                                         ##
 #   process.out.outputCommands = [ ... ]  ##  (e.g. taken from PhysicsTools/PatAlgos/python/patEventContent_cff.py)
 #                                         ##
-process.out.fileName = 'testJetTools_PON.root'
+process.out.fileName = 'testJetTools.root'
 #                                         ##
 #   process.options.wantSummary = False   ##  (to suppress the long output at the end of the job)
+


### PR DESCRIPTION
Update to pileupjetID algorithm to include an option to calculate the discriminator variables using Puppi weights.

There are a few effects, but one visible change is the fractional pt variables. previously these were calculated using the Puppi jet pt in the denominator and and the unweighted constituent sum in the numerator which leads to an undesirable >1 tail in the total pt fraction. See below

OFF

![image](https://user-images.githubusercontent.com/5091580/44106668-498ab736-9fc3-11e8-8992-4c1ab228658b.png)

ON

![image](https://user-images.githubusercontent.com/5091580/44106695-571aa230-9fc3-11e8-8857-149de90952ff.png)

There was no additional implementation beyond the feature addition (ie no standard workflows should change). 

I think the changes in RecoJets/JetProducers/src/PileupJetIdAlgo.cc, Line 509-510 are appropriate but would like a second opinion @ahinzmann .

This was tested only using a modified version of the script:
RecoJets/JetProducers/test/testJetTools_onMiniAOD_cfg.py
There were a few small changes required for this script to run in 10_3_X which I am also pushing.