### PR TITLE
Update CondDBESSource to match recent EventSetup changes

### DIFF
--- a/CondCore/CalibPlugins/src/plugin.cc
+++ b/CondCore/CalibPlugins/src/plugin.cc
@@ -50,7 +50,7 @@ namespace cond {
 
 
 namespace {
-  struct InitEfficiency {void operator()(condex::Efficiency& e){ e.initialize();}};
+  struct InitEfficiency {void operator()(condex::Efficiency& e) const { e.initialize();}};
 }
 
 REGISTER_PLUGIN(PedestalsRcd,Pedestals);

--- a/CondCore/CondDB/interface/PayloadProxy.h
+++ b/CondCore/CondDB/interface/PayloadProxy.h
@@ -13,8 +13,8 @@ namespace cond {
      */
     class CondGetter {
     public:
-      virtual ~CondGetter(){}
-      virtual IOVProxy get(std::string name) const=0;
+      virtual ~CondGetter() = default;
+      virtual IOVProxy get(std::string const& name) const=0;
       
     };
     
@@ -81,7 +81,7 @@ namespace cond {
       explicit PayloadProxy( const char * source=nullptr ) :
 	BasePayloadProxy() {}
       
-      ~PayloadProxy() override{}
+      ~PayloadProxy() override = default;
       
       // dereference 
       const DataT & operator()() const {

--- a/CondCore/DTPlugins/src/plugin.cc
+++ b/CondCore/DTPlugins/src/plugin.cc
@@ -65,43 +65,43 @@ namespace cond {
 
 
 namespace {
-  struct InitDTCCBConfig {void operator()(DTCCBConfig& e){ e.initialize();}};
+  struct InitDTCCBConfig {void operator()(DTCCBConfig& e) const { e.initialize();}};
 }
 
 namespace {
-  struct InitDTDeadFlag {void operator()(DTDeadFlag& e){ e.initialize();}};
+  struct InitDTDeadFlag {void operator()(DTDeadFlag& e) const { e.initialize();}};
 }
 
 namespace {
-  struct InitDTHVStatus {void operator()(DTHVStatus& e){ e.initialize();}};
+  struct InitDTHVStatus {void operator()(DTHVStatus& e) const { e.initialize();}};
 }
 
 namespace {
-  struct InitDTLVStatus {void operator()(DTLVStatus& e){ e.initialize();}};
+  struct InitDTLVStatus {void operator()(DTLVStatus& e) const { e.initialize();}};
 }
 
 namespace {
-  struct InitDTMtime {void operator()(DTMtime& e){ e.initialize();}};
+  struct InitDTMtime {void operator()(DTMtime& e) const { e.initialize();}};
 }
 
 namespace {
-  struct InitDTPerformance {void operator()(DTPerformance& e){ e.initialize();}};
+  struct InitDTPerformance {void operator()(DTPerformance& e) const { e.initialize();}};
 }
 
 namespace {
-  struct InitDTRangeT0 {void operator()(DTRangeT0& e){ e.initialize();}};
+  struct InitDTRangeT0 {void operator()(DTRangeT0& e) const { e.initialize();}};
 }
 
 namespace {
-  struct InitDTStatusFlag {void operator()(DTStatusFlag& e){ e.initialize();}};
+  struct InitDTStatusFlag {void operator()(DTStatusFlag& e) const { e.initialize();}};
 }
 
 namespace {
-  struct InitDTTPGParameters {void operator()(DTTPGParameters& e){ e.initialize();}};
+  struct InitDTTPGParameters {void operator()(DTTPGParameters& e) const { e.initialize();}};
 }
 
 namespace {
-  struct InitDTTtrig {void operator()(DTTtrig& e){ e.initialize();}};
+  struct InitDTTtrig {void operator()(DTTtrig& e) const { e.initialize();}};
 }
 
 REGISTER_PLUGIN(DTReadOutMappingRcd,DTReadOutMapping);

--- a/CondCore/ESSources/interface/DataProxy.h
+++ b/CondCore/ESSources/interface/DataProxy.h
@@ -56,7 +56,7 @@ class DataProxy : public edm::eventsetup::DataProxy{
   // ---------- member data --------------------------------
 
   std::shared_ptr<cond::persistency::PayloadProxy<DataT>>  m_data;
-  Initializer m_initializer;
+  Initializer const  m_initializer;
 };
 
 namespace cond {

--- a/CondCore/ESSources/interface/DataProxy.h
+++ b/CondCore/ESSources/interface/DataProxy.h
@@ -131,7 +131,9 @@ public:
     
   edm::eventsetup::TypeTag type() const override { return m_type;}
   ProxyP proxy() const override { return m_proxy.get();}
-  edmProxyP makeEdmProxy() const override { return std::make_shared<DataProxy>(*m_proxy);}
+  edmProxyP makeEdmProxy() const override { 
+    assert(m_proxy.get() != nullptr);
+    return std::make_shared<DataProxy>(*m_proxy);}
  
 private:
   // late initialize (to allow to load ALL library first)

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -246,7 +246,7 @@ CondDBESSource::CondDBESSource( const edm::ParameterSet& iConfig ) :
       tagSnapshotTime = boost::posix_time::ptime();
 
     auto& proxy =proxyWrappers[ipb++];
-    proxy->lateInit(nsess, tag, tagSnapshotTime, tagInfo.second.recordLabel(), connStr);
+    proxy->lateInit(nsess, std::move(tag), tagSnapshotTime, tagInfo.second.recordLabel(), std::move(connStr));
     //  instert in the map
     m_proxies.emplace(tagInfo.second.recordName(), std::move(proxy));
   }

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -13,6 +13,7 @@
 // system include files
 #include <string>
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <set>
 // user include files
@@ -33,8 +34,8 @@ namespace cond{
 class CondDBESSource : public edm::eventsetup::DataProxyProvider,
 		       public edm::EventSetupRecordIntervalFinder{
  public:
-  using ProxyP = std::shared_ptr<cond::DataProxyWrapperBase>;
-  using ProxyMap = std::multimap< std::string,  ProxyP>;
+  using ProxyP = std::unique_ptr<cond::DataProxyWrapperBase>;
+  using ProxyMap = std::unordered_multimap< std::string,  ProxyP>;
 
   enum RefreshPolicy { NOREFRESH, REFRESH_ALWAYS, REFRESH_OPEN_IOVS, REFRESH_EACH_RUN, RECONNECT_EACH_RUN };
   
@@ -62,11 +63,11 @@ class CondDBESSource : public edm::eventsetup::DataProxyProvider,
   ProxyMap m_proxies;
 
 
-  using TagCollection = std::map< std::string, cond::GTEntry_t >;
+  using TagCollection = std::unordered_map< std::string, cond::GTEntry_t >;
   // the collections of tag, record/label used in this ESSource
   TagCollection m_tagCollection;
-  std::map<std::string,std::pair<cond::persistency::Session,std::string> > m_sessionPool;
-  std::map<std::string,unsigned int> m_lastRecordRuns;
+  std::unordered_map<std::string,std::pair<cond::persistency::Session,std::string> > m_sessionPool;
+  std::unordered_map<std::string,unsigned int> m_lastRecordRuns;
   
   struct Stats {
     int nData;

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -33,10 +33,10 @@ namespace cond{
 class CondDBESSource : public edm::eventsetup::DataProxyProvider,
 		       public edm::EventSetupRecordIntervalFinder{
  public:
-  typedef std::shared_ptr<cond::DataProxyWrapperBase > ProxyP;
-  typedef std::multimap< std::string,  ProxyP> ProxyMap;
+  using ProxyP = std::shared_ptr<cond::DataProxyWrapperBase>;
+  using ProxyMap = std::multimap< std::string,  ProxyP>;
 
-  typedef enum { NOREFRESH, REFRESH_ALWAYS, REFRESH_OPEN_IOVS, REFRESH_EACH_RUN, RECONNECT_EACH_RUN } RefreshPolicy;
+  enum RefreshPolicy { NOREFRESH, REFRESH_ALWAYS, REFRESH_OPEN_IOVS, REFRESH_EACH_RUN, RECONNECT_EACH_RUN };
   
 
   explicit CondDBESSource( const edm::ParameterSet& );
@@ -62,7 +62,7 @@ class CondDBESSource : public edm::eventsetup::DataProxyProvider,
   ProxyMap m_proxies;
 
 
-  typedef std::map< std::string, cond::GTEntry_t > TagCollection;
+  using TagCollection = std::map< std::string, cond::GTEntry_t >;
   // the collections of tag, record/label used in this ESSource
   TagCollection m_tagCollection;
   std::map<std::string,std::pair<cond::persistency::Session,std::string> > m_sessionPool;

--- a/CondCore/ESSources/src/ProxyFactory.cc
+++ b/CondCore/ESSources/src/ProxyFactory.cc
@@ -22,8 +22,8 @@ cond::DataProxyWrapperBase::DataProxyWrapperBase(std::string const & il) : m_lab
 
 cond::DataProxyWrapperBase::~DataProxyWrapperBase(){}
 
-void cond::DataProxyWrapperBase::addInfo(std::string const & il, std::string const & cs, std::string const & tag) { 
-  m_label=il; m_connString = cs; m_tag=tag;
+void cond::DataProxyWrapperBase::addInfo(std::string const il, std::string cs, std::string tag) { 
+  m_label=std::move(il); m_connString = std::move(cs); m_tag=std::move(tag);
 }
 
 EDM_REGISTER_PLUGINFACTORY(cond::ProxyFactory, cond::pluginCategory());

--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -43,16 +43,16 @@ namespace cond {
 }
 
 namespace {
-  struct InitHcalElectronicsMap {void operator()(HcalElectronicsMap& e){ e.initialize();}};
+  struct InitHcalElectronicsMap {void operator()(HcalElectronicsMap& e) const { e.initialize();}};
 }
 namespace {
-  struct InitHcalDcsMap {void operator()(HcalDcsMap& e){ e.initialize();}};
+  struct InitHcalDcsMap {void operator()(HcalDcsMap& e) const { e.initialize();}};
 }
 namespace {
-  struct InitHcalFrontEndMap {void operator()(HcalFrontEndMap& e){ e.initialize();}};
+  struct InitHcalFrontEndMap {void operator()(HcalFrontEndMap& e) const { e.initialize();}};
 }
 namespace {
-  struct InitHcalSiPMCharacteristics {void operator()(HcalSiPMCharacteristics& e){ e.initialize();}};
+  struct InitHcalSiPMCharacteristics {void operator()(HcalSiPMCharacteristics& e) const { e.initialize();}};
 }
 
 REGISTER_PLUGIN(HcalPedestalsRcd,HcalPedestals);

--- a/CondCore/L1TPlugins/src/GTRecords3.cc
+++ b/CondCore/L1TPlugins/src/GTRecords3.cc
@@ -3,7 +3,7 @@
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 
 namespace {
-  struct L1GtTriggerMenuInitializer { void operator()(L1GtTriggerMenu & _) { _.buildGtConditionMap(); } };
+  struct L1GtTriggerMenuInitializer { void operator()(L1GtTriggerMenu & _) const { _.buildGtConditionMap(); } };
 }
 REGISTER_PLUGIN_INIT(L1GtTriggerMenuRcd, L1GtTriggerMenu, L1GtTriggerMenuInitializer);
 

--- a/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
+++ b/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
@@ -28,7 +28,7 @@ namespace cond {
 }
 
 namespace {
-  struct InitPerformancePayload {void operator()(PerformancePayload& e){ e.initialize();}};
+  struct InitPerformancePayload {void operator()(PerformancePayload& e) const { e.initialize();}};
 }
 
 REGISTER_PLUGIN_INIT(PerformancePayloadRecord, PerformancePayload, InitPerformancePayload);

--- a/CondCore/SiPixelPlugins/src/plugin.cc
+++ b/CondCore/SiPixelPlugins/src/plugin.cc
@@ -44,8 +44,8 @@
 #include "CondFormats/DataRecord/interface/SiPixelLorentzAngleSimRcd.h"
 
 namespace {
- struct InitRocs {void operator()(SiPixelFedCablingMap& m){ m.initializeRocs();}};
- template<typename G> struct InitGains {void operator()(G& g){ g.initialize();}}; 
+ struct InitRocs {void operator()(SiPixelFedCablingMap& m) const { m.initializeRocs();}};
+ template<typename G> struct InitGains {void operator()(G& g) const { g.initialize();}}; 
 }
 
 

--- a/CondCore/SiStripPlugins/plugins/plugin.cc
+++ b/CondCore/SiStripPlugins/plugins/plugin.cc
@@ -67,6 +67,6 @@ REGISTER_PLUGIN(SiStripConfObjectRcd, SiStripConfObject);
 
 #include "CondFormats/SiStripObjects/interface/Phase2TrackerCabling.h"
 namespace {
-  struct initializeCabling {void operator()(Phase2TrackerCabling& c){ c.initializeCabling();}};
+  struct initializeCabling {void operator()(Phase2TrackerCabling& c) const { c.initializeCabling();}};
   }
 REGISTER_PLUGIN_INIT(Phase2TrackerCablingRcd, Phase2TrackerCabling, initializeCabling);

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -245,7 +245,7 @@ class JetCorrectorParametersCollection {
 };
 
 struct JetCorrectorParametersInitializeTransients {
-  void operator()(JetCorrectorParametersCollection& jcpc) {
+  void operator() (JetCorrectorParametersCollection& jcpc) const {
     for (auto & ptype : jcpc.getCorrections())   {ptype.second.init();}
     for (auto & ptype : jcpc.getCorrectionsL5()) {ptype.second.init();}
     for (auto & ptype : jcpc.getCorrectionsL7()) {ptype.second.init();}


### PR DESCRIPTION
-Changed to directly inherit from edm::eventsetup::DataProxy since the intermediate DataProxyTemplate was not adding anything useful.
-Switched to modern C++ constructs
-Moved to single memory ownership to reduce use of std::shared_ptr
-Made Initializer be explicitly const