### PR TITLE
sync OMTF code (as in tag omtfdev_mk20) with CMSSW_2_1_0.

### DIFF
--- a/EventFilter/L1TRawToDigi/interface/OmtfRpcPacker.h
+++ b/EventFilter/L1TRawToDigi/interface/OmtfRpcPacker.h
@@ -6,6 +6,8 @@
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "DataFormats/L1TMuon/interface/OMTF/OmtfDataWord64.h"
 #include "EventFilter/L1TRawToDigi/interface/OmtfLinkMappingRpc.h"
+#include "CondFormats/RPCObjects/interface/RPCReadOutMapping.h"  
+
 
 namespace edm { class EventSetup; }
 
@@ -14,7 +16,7 @@ namespace omtf {
 class RpcPacker {
 
 public:
-  RpcPacker() : thePactCabling(nullptr) {}
+  RpcPacker(){}
 
   void init(const edm::EventSetup & es);
   void init(const edm::EventSetup & es, const std::string & connectionFile);
@@ -24,7 +26,8 @@ private:
   void initCabling(const edm::EventSetup & es);
 
   MapLBIndex2EleIndex      thePact2Omtf;
-  const RPCReadOutMapping* thePactCabling;
+  std::unique_ptr<const RPCReadOutMapping> thePactCabling;
+
 };
 }
 #endif

--- a/EventFilter/L1TRawToDigi/interface/OmtfRpcUnpacker.h
+++ b/EventFilter/L1TRawToDigi/interface/OmtfRpcUnpacker.h
@@ -2,10 +2,12 @@
 #define EventFilter_L1TRawToDigi_Omtf_RpcUnpacker_H
 
 #include <string>
+#include <memory>
 
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "DataFormats/L1TMuon/interface/OMTF/OmtfDataWord64.h"
 #include "EventFilter/L1TRawToDigi/interface/OmtfLinkMappingRpc.h"
+#include "CondFormats/RPCObjects/interface/RPCReadOutMapping.h" 
 
 namespace edm { class EventSetup; }
 namespace omtf { class RpcDataWord64; }
@@ -15,7 +17,7 @@ namespace omtf {
 class RpcUnpacker {
 
 public:
-  RpcUnpacker() : thePactCabling(nullptr) {}
+  RpcUnpacker() {}
 
   void init(const edm::EventSetup & es);
   void init(const edm::EventSetup & es, const std::string & connectionFile);
@@ -25,7 +27,7 @@ private:
   void initCabling(const edm::EventSetup & es);
 
   MapEleIndex2LBIndex      theOmtf2Pact;
-  const RPCReadOutMapping* thePactCabling;
+  std::unique_ptr<const RPCReadOutMapping> thePactCabling;
 };
 }
 #endif

--- a/EventFilter/L1TRawToDigi/src/OmtfCscPacker.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfCscPacker.cc
@@ -2,6 +2,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/L1TMuon/interface/OMTF/OmtfCscDataWord64.h"
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
 
 namespace omtf {
 
@@ -19,7 +20,7 @@ void CscPacker::pack(const CSCCorrelatedLCTDigiCollection* prod, FedAmcRawsMap &
       CscDataWord64 data;
       data.hitNum_ = digi->getTrknmb();
       data.vp_ = digi->isValid();
-      data.bxNum_ = digi->getBX()-3;
+      data.bxNum_ = digi->getBX()-(CSCConstants::LCT_CENTRAL_BX-3);
       data.halfStrip_ = digi->getStrip();
       data.clctPattern_ = digi->getPattern();
       data.keyWG_ = digi->getKeyWG();

--- a/EventFilter/L1TRawToDigi/src/OmtfCscUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfCscUnpacker.cc
@@ -4,6 +4,7 @@
 
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
 
 #include "DataFormats/L1TMuon/interface/OMTF/OmtfCscDataWord64.h"
 
@@ -31,7 +32,7 @@ void CscUnpacker::unpack(unsigned int fed, unsigned int amc, const CscDataWord64
                                     data.halfStrip(),
                                     data.clctPattern(),
                                     data.bend(),
-                                    data.bxNum()+3) ;
+                                    data.bxNum()+(CSCConstants::LCT_CENTRAL_BX-3) );
           LogTrace("") << digi << std::endl;
           //producedCscLctDigis->insertDigi( cscId, digi);
           prod->insertDigi( cscId, digi);

--- a/EventFilter/L1TRawToDigi/src/OmtfRpcPacker.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfRpcPacker.cc
@@ -17,7 +17,7 @@ namespace omtf {
 void RpcPacker::initCabling(const edm::EventSetup & es) {
   edm::ESTransientHandle<RPCEMap> readoutMapping;
   es.get<RPCEMapRcd>().get(readoutMapping);
-  thePactCabling = readoutMapping->convert();
+  thePactCabling.reset(readoutMapping->convert());
   LogDebug("OmtfPacker") <<" Has PACT readout map, VERSION: " << thePactCabling->version() << std::endl;
 }
 
@@ -26,7 +26,7 @@ void RpcPacker::init(const edm::EventSetup & es)
   initCabling(es);
   RpcLinkMap omtfLink2Ele;
   omtfLink2Ele.init(es);
-  thePact2Omtf = translatePact2Omtf(omtfLink2Ele,thePactCabling);
+  thePact2Omtf = translatePact2Omtf(omtfLink2Ele,thePactCabling.get());
 }
 
 void RpcPacker::init(const edm::EventSetup & es, const std::string & connectionFile)
@@ -34,14 +34,14 @@ void RpcPacker::init(const edm::EventSetup & es, const std::string & connectionF
   initCabling(es);
   RpcLinkMap omtfLink2Ele;
   omtfLink2Ele.init(connectionFile);
-  thePact2Omtf = translatePact2Omtf(omtfLink2Ele,thePactCabling);
+  thePact2Omtf = translatePact2Omtf(omtfLink2Ele,thePactCabling.get());
 }
 
 void RpcPacker::pack(const RPCDigiCollection * digis, FedAmcRawsMap & raws) 
 {
   LogTrace("")<<" HERE HERE !!! RPC PACKER" << rpcrawtodigi::DebugDigisPrintout()(digis);
   for (int dcc=790; dcc <= 792; dcc++) {
-    RPCRecordFormatter formatter(dcc, thePactCabling);
+    RPCRecordFormatter formatter(dcc, thePactCabling.get());
     const std::vector<rpcrawtodigi::EventRecords> & merged = RPCPackingModule::eventRecords(dcc,200, digis ,formatter);
     LogTrace("") << " SIZE OF MERGED, for DCC="<<dcc<<" is: "<<merged.size()<<std::endl;
     for (const auto & rpcEvent : merged) {

--- a/L1Trigger/L1TMuonOverlap/interface/AlgoMuon.h
+++ b/L1Trigger/L1TMuonOverlap/interface/AlgoMuon.h
@@ -15,6 +15,8 @@ class AlgoMuon{
               m_hits(hits), m_q(q), m_bx(bx), m_pt(pt), m_charge(charge), 
               m_patNumb(999), m_rhitNumb(999) {}
 
+  virtual ~AlgoMuon() {}
+
   int getDisc() const { return m_disc; }
   int getPhi()  const { return m_phi; }
   int getEta()  const { return m_eta; }

--- a/L1Trigger/L1TMuonOverlap/interface/OMTFReconstruction.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFReconstruction.h
@@ -69,6 +69,7 @@ class OMTFReconstruction {
 
 
     bool dumpResultToXML, dumpDetailedResultToXML;
+    int bxMin, bxMax;
 
   ///OMTF objects
     OMTFConfiguration   *m_OMTFConfig;

--- a/L1Trigger/L1TMuonOverlap/interface/OMTFSorter.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFSorter.h
@@ -12,10 +12,13 @@
 #include "L1Trigger/L1TMuonOverlap/interface/AlgoMuon.h"
 #include "L1Trigger/L1TMuonOverlap/interface/GhostBuster.h"
 
+class OMTFConfiguration;
+
 class OMTFSorter{
 
  public:
 
+  void initialize(const OMTFConfiguration* cfg) { myOmtfConfig=cfg; }
   void setNphiBins(unsigned int phiBins) { nPhiBins = phiBins;}
 
   void sortRefHitResults(const std::vector<OMTFProcessor::resultsMap> & procResults,
@@ -55,6 +58,7 @@ class OMTFSorter{
 
 
   unsigned int nPhiBins;
+  const OMTFConfiguration   *myOmtfConfig; 
 };
 
 #endif

--- a/L1Trigger/L1TMuonOverlap/interface/OMTFinput.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFinput.h
@@ -21,7 +21,7 @@ class OMTFinput{
   ///iInput marks input number (max 14 per layer)
   bool addLayerHit(unsigned int iLayer,
 		   unsigned int iInput,
-		   int iPhi, int iEta);
+		   int iPhi, int iEta, bool allowOverwrite=true);
 
   ///Reset vectors with data.
   void clear();

--- a/L1Trigger/L1TMuonOverlap/interface/OMTFinputMaker.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFinputMaker.h
@@ -35,7 +35,8 @@ class OMTFinputMaker {
 				   const CSCCorrelatedLCTDigiCollection *cscDigis,
 				   const RPCDigiCollection *rpcDigis,
 				   unsigned int iProcessor,
-				   l1t::tftype type=l1t::tftype::omtf_pos);
+				   l1t::tftype type=l1t::tftype::omtf_pos,
+                           int bx=0);
   
 
  void setFlag(int aFlag) {flag = aFlag; }
@@ -49,21 +50,21 @@ class OMTFinputMaker {
   OMTFinput processDT(const L1MuDTChambPhContainer *dtPhDigis,
 		 const L1MuDTChambThContainer *dtThDigis,
 		 unsigned int iProcessor,
-		 l1t::tftype type);
+		 l1t::tftype type, int bx);
 
   ///Take the CSC digis, select chambers connected to given
   ///processor, convers logal angles to global scale.
   ///For CSC do NOT take the bending angle.
   OMTFinput processCSC(const CSCCorrelatedLCTDigiCollection *cscDigis,
 		  unsigned int iProcessor,
-		  l1t::tftype type);
+		  l1t::tftype type, int bx);
 
   ///Decluster nearby hits in single chamber, by taking
   ///average cluster position, expressed in half RPC strip:
   ///pos = (cluster_begin + cluster_end)
   OMTFinput processRPC(const RPCDigiCollection *rpcDigis,
 		  unsigned int iProcessor,
-		  l1t::tftype type);
+		  l1t::tftype type, int bx);
 
   ///Check if digis are within a give processor input.
   ///Simply checks sectors range.

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.cc
@@ -61,10 +61,6 @@ void L1TMuonOverlapTrackProducer::produce(edm::Event& iEvent, const edm::EventSe
   
   std::unique_ptr<l1t::RegionalMuonCandBxCollection > candidates = m_Reconstruction.reconstruct(iEvent, evSetup);
 
-  int bx = 0;
-  str<<" Number of candidates: "<<candidates->size(bx);
-  edm::LogInfo("OMTFOMTFProducer")<<str.str();
-
   iEvent.put(std::move(candidates), "OMTF");
 }
 /////////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/python/fakeOmtfParams_cff.py
+++ b/L1Trigger/L1TMuonOverlap/python/fakeOmtfParams_cff.py
@@ -13,7 +13,7 @@ omtfParams = cms.ESProducer(
     patternsXMLFiles = cms.VPSet(
         cms.PSet(patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_0x0003.xml")),
     ),
-    configXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/hwToLogicLayer_0x0004.xml"),
+    configXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/hwToLogicLayer_0x0005.xml"),
 )
 
 

--- a/L1Trigger/L1TMuonOverlap/python/simOmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonOverlap/python/simOmtfDigis_cfi.py
@@ -2,20 +2,24 @@ import FWCore.ParameterSet.Config as cms
 
 ###OMTF emulator configuration
 simOmtfDigis = cms.EDProducer("L1TMuonOverlapTrackProducer",
-                              srcDTPh = cms.InputTag('simDtTriggerPrimitiveDigis'),
-                              srcDTTh = cms.InputTag('simDtTriggerPrimitiveDigis'),
-                              srcCSC = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
-                              srcRPC = cms.InputTag('simMuonRPCDigis'),                              
-                              dumpResultToXML = cms.bool(False),
-                              dumpDetailedResultToXML = cms.bool(False),
-                              XMLDumpFileName = cms.string("TestEvents.xml"),                                     
-                              dumpGPToXML = cms.bool(False),  
-                              readEventsFromXML = cms.bool(False),
-                              eventsXMLFiles = cms.vstring("TestEvents.xml"),
-                              dropRPCPrimitives = cms.bool(False),                                    
-                              dropDTPrimitives = cms.bool(False),                                    
-                              dropCSCPrimitives = cms.bool(False),
-                              #ghostBusterType = cms.string("GhostBusterPreferRefDt")
+
+  srcDTPh = cms.InputTag('simDtTriggerPrimitiveDigis'),
+  srcDTTh = cms.InputTag('simDtTriggerPrimitiveDigis'),
+  srcCSC = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
+  srcRPC = cms.InputTag('simMuonRPCDigis'),                              
+
+  dumpResultToXML = cms.bool(False),
+  dumpDetailedResultToXML = cms.bool(False),
+  XMLDumpFileName = cms.string("TestEvents.xml"),                                     
+  dumpGPToXML = cms.bool(False),  
+  readEventsFromXML = cms.bool(False),
+  eventsXMLFiles = cms.vstring("TestEvents.xml"),
+
+  dropRPCPrimitives = cms.bool(False),                                    
+  dropDTPrimitives = cms.bool(False),                                    
+  dropCSCPrimitives = cms.bool(False),
+
+#  bxMin = cms.int32(-3),
+#  bxMax = cms.int32(4)
+
 )
-
-

--- a/L1Trigger/L1TMuonOverlap/src/GhostBusterPreferRefDt.cc
+++ b/L1Trigger/L1TMuonOverlap/src/GhostBusterPreferRefDt.cc
@@ -6,10 +6,19 @@
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFConfiguration.h"
 
 namespace { 
+
   int phiGMT(int phiAlgo) { return phiAlgo*437/pow(2,12); }
+
+  struct AlgoMuonEtaFix : public AlgoMuon {
+    AlgoMuonEtaFix(const AlgoMuon & mu) : AlgoMuon(mu), fixedEta(mu.getEta()) {}
+    unsigned int fixedEta;
+  };
+
 }
 
-std::vector<AlgoMuon> GhostBusterPreferRefDt::select(std::vector<AlgoMuon> refHitCands, int charge) {
+std::vector<AlgoMuon> GhostBusterPreferRefDt::select(std::vector<AlgoMuon> muonsIN, int charge) {
+
+  // sorting within GB.
   auto customLess = [&](const AlgoMuon& a, const AlgoMuon& b)->bool {
     int aRefLayerLogicNum = omtfConfig->getRefToLogicNumber()[a.getRefLayer()];
     int bRefLayerLogicNum = omtfConfig->getRefToLogicNumber()[b.getRefLayer()];
@@ -26,72 +35,54 @@ std::vector<AlgoMuon> GhostBusterPreferRefDt::select(std::vector<AlgoMuon> refHi
       return false;
     else
       return true;
-    //TODO check if the firmware really includes the pattern number and refHit number here
   };
 
-/*  auto customLess = [&](const AlgoMuon& a, const AlgoMuon& b)->bool {
-    int aRefLayerLogicNum = omtfConfig->getRefToLogicNumber()[a.getRefLayer()];
-    int bRefLayerLogicNum = omtfConfig->getRefToLogicNumber()[b.getRefLayer()];
-    if(a.getQ() > b.getQ())
-      return false;
-    else if(a.getQ()==b.getQ() && aRefLayerLogicNum < bRefLayerLogicNum) {
-      return false;
-    }
-    else if (a.getQ()==b.getQ() && aRefLayerLogicNum == bRefLayerLogicNum && a.getPatternNumber() > b.getPatternNumber() )
-      return false;
-    else if (a.getQ()==b.getQ() && aRefLayerLogicNum == bRefLayerLogicNum && a.getPatternNumber() == b.getPatternNumber() && a.getRefHitNumber() < b.getRefHitNumber())
-      return false;
-    else
-      return true;
-    //TODO check if the firmware really includes the pattern number and refHit number here
-  };*/
+  std::sort( muonsIN.rbegin(), muonsIN.rend(), customLess);
 
-  std::vector<AlgoMuon> refHitCleanCands;
-  // Sort candidates with decreased goodness,
-  // where goodness definied in < operator of AlgoMuon
-  std::sort( refHitCands.rbegin(), refHitCands.rend(), customLess );
+  // actual GhostBusting. Overwrite eta in case of no DT info.
+  std::vector<AlgoMuonEtaFix> refHitCleanCandsFixedEta;
+  for (const auto & muIN : muonsIN) {
+    refHitCleanCandsFixedEta.push_back(muIN);
+    auto killIt = refHitCleanCandsFixedEta.end();
 
-  for(std::vector<AlgoMuon>::iterator it1 = refHitCands.begin();
-      it1 != refHitCands.end(); ++it1){
-    bool isGhost=false;
-    for(std::vector<AlgoMuon>::iterator it2 = refHitCleanCands.begin();
-    it2 != refHitCleanCands.end(); ++it2){
-      //do not accept candidates with similar phi (any charge combination)
-      //veto window 5deg(=half of logic cone)=5/360*5760=80"logic strips" 
-      //veto window 5 degree in GMT scale is 5/360*576=8 units
-      if (std::abs( phiGMT(it1->getPhi()) - phiGMT(it2->getPhi()) ) < 8 ) { 
-//      if(std::abs(it1->getPhi() - it2->getPhi())<5/360.0*nPhiBins){
-        isGhost=true;
-        break;
-        //which one candidate is killed depends only on the order in the refHitCands (the one with smaller index is taken), and this order is assured by the sort above
-        //TODO here the candidate that is killed does not kill other candidates - check if the firmware does the same (KB)
+    //do not accept candidates with similar phi (any charge combination)
+    //veto window 5 degree in GMT scale is 5/360*576=8 units
+    for (auto it1 = refHitCleanCandsFixedEta.begin(); it1 != refHitCleanCandsFixedEta.end(); ++it1) {
+      for (auto it2 = std::next(it1); it2 != refHitCleanCandsFixedEta.end(); ++it2) {
+        if (std::abs( phiGMT(it1->getPhi()) - phiGMT(it2->getPhi()) ) < 8 ) { 
+          killIt = it2;
+          if (    (omtfConfig->fwVersion() >= 6)
+               && ((abs(it1->getEta())==75 || abs(it1->getEta())==79 || abs(it1->getEta())==92))
+               && ((abs(it2->getEta())!=75 && abs(it2->getEta())!=79 && abs(it2->getEta())!=92)) ) it1->fixedEta=it2->getEta();
+        }
       }
-    }
-    if(it1->getQ()>0 && !isGhost) refHitCleanCands.push_back(*it1);
+    } 
+    if (killIt != refHitCleanCandsFixedEta.end()) refHitCleanCandsFixedEta.erase(killIt);
   }
 
-  refHitCleanCands.resize( 3, AlgoMuon(0,999,9999,0,0,0,0,0) ); //FIXME
-  //refHitCleanCands.resize( 3, AlgoMuon() );
+  // fill outgoing collection 
+  std::vector<AlgoMuon> refHitCleanCands;
+  for (const auto & mu : refHitCleanCandsFixedEta) {
+    AlgoMuon fixed = mu;
+    fixed.setEta(mu.fixedEta);
+    refHitCleanCands.push_back(fixed);
+  } 
 
-
+  refHitCleanCands.resize( 3, AlgoMuon(0,999,9999,0,0,0,0,0) ); 
+/*
   std::stringstream myStr;
   bool hasCandidates = false;
-  for(unsigned int iRefHit=0;iRefHit<refHitCands.size();++iRefHit){
-    if(refHitCands[iRefHit].getQ()){
+  for(unsigned int iRefHit=0;iRefHit<refHitCleanCands.size();++iRefHit){
+    if(refHitCleanCands[iRefHit].getQ()){
       hasCandidates=true;
       break;
     }
   }
-  for(unsigned int iRefHit=0;iRefHit<refHitCands.size();++iRefHit){
-    if(refHitCands[iRefHit].getQ()) myStr<<"Ref hit: "<<iRefHit<<" "<<refHitCands[iRefHit]<<std::endl;
+  for(unsigned int iRefHit=0;iRefHit<refHitCleanCands.size();++iRefHit){
+    if(refHitCleanCands[iRefHit].getQ()) myStr<<"Ref hit: "<<iRefHit<<" "<<refHitCleanCands[iRefHit]<<std::endl;
   }
-  myStr<<"Selected Candidates with charge: "<<charge<<std::endl;
-  for(unsigned int iCand=0; iCand<refHitCleanCands.size(); ++iCand){
-    myStr<<"Cand: "<<iCand<<" "<<refHitCleanCands[iCand]<<std::endl;
-  }
-
   if(hasCandidates) edm::LogInfo("OMTF Sorter")<<myStr.str();
+*/
 
-  // update refHitCands with refHitCleanCands 
   return refHitCleanCands;
 }

--- a/L1Trigger/L1TMuonOverlap/src/OMTFProcessor.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFProcessor.cc
@@ -103,7 +103,7 @@ bool OMTFProcessor::addGP(GoldenPattern *aGP){
       <<" Reading two Golden Patterns with the same key: "
       <<aGP->key()<<std::endl;
   }
-  else theGPs[aGP->key()] = new GoldenPattern(*aGP);
+  else theGPs[aGP->key()] = aGP;
 
   for(auto & itRegion: myResults){
     OMTFResult aResult;

--- a/L1Trigger/L1TMuonOverlap/src/OMTFReconstruction.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFReconstruction.cc
@@ -26,7 +26,9 @@ OMTFReconstruction::OMTFReconstruction(const edm::ParameterSet& theConfig) :
 
   dumpResultToXML = m_Config.getParameter<bool>("dumpResultToXML");
   dumpDetailedResultToXML = m_Config.getParameter<bool>("dumpDetailedResultToXML");
-  m_Config.getParameter<std::string>("XMLDumpFileName");  
+  //m_Config.getParameter<std::string>("XMLDumpFileName");  
+  bxMin = m_Config.exists("bxMin") ? m_Config.getParameter<int>("bxMin") : 0;
+  bxMax = m_Config.exists("bxMax") ? m_Config.getParameter<int>("bxMax") : 0;
 }
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
@@ -74,13 +76,16 @@ void OMTFReconstruction::beginRun(edm::Run const& run, edm::EventSetup const& iS
   m_OMTF->configure(m_OMTFConfig, omtfParams);
   //m_GhostBuster.setNphiBins(m_OMTFConfig->nPhiBins());
 
-  if(m_Config.exists("ghostBusterType") ) {
-    if(m_Config.getParameter<std::string>("ghostBusterType") == "GhostBusterPreferRefDt")
+  if (m_OMTFConfig->fwVersion() >= 5) {
+//  if(m_Config.exists("ghostBusterType") ) {
+//    if(m_Config.getParameter<std::string>("ghostBusterType") == "GhostBusterPreferRefDt")
     	m_GhostBuster.reset(new GhostBusterPreferRefDt(m_OMTFConfig) );
   }
-  else
+  else {
 	  m_GhostBuster.reset(new GhostBuster() );
+  }
 
+  m_Sorter.initialize(m_OMTFConfig);
   m_Sorter.setNphiBins(m_OMTFConfig->nPhiBins());
 
   m_InputMaker.initialize(iSetup, m_OMTFConfig);
@@ -99,17 +104,21 @@ std::unique_ptr<l1t::RegionalMuonCandBxCollection> OMTFReconstruction::reconstru
 
   if(dumpResultToXML) aTopElement = m_Writer->writeEventHeader(iEvent.id().event());
 
-  // NOTE: assuming all is for bx 0
-  int bx = 0;
-  std::unique_ptr<l1t::RegionalMuonCandBxCollection> candidates(new l1t::RegionalMuonCandBxCollection);
+  std::unique_ptr<l1t::RegionalMuonCandBxCollection> candidates(new l1t::RegionalMuonCandBxCollection );
+  candidates->setBXRange(bxMin, bxMax);
 
   ///The order is important: first put omtf_pos candidates, then omtf_neg.
-  for(unsigned int iProcessor=0; iProcessor<m_OMTFConfig->nProcessors(); ++iProcessor)
-    getProcessorCandidates(iProcessor, l1t::tftype::omtf_pos, bx, *candidates);
+  for(int bx = bxMin; bx<= bxMax; bx++) {
 
-  for(unsigned int iProcessor=0; iProcessor<m_OMTFConfig->nProcessors(); ++iProcessor)
-    getProcessorCandidates(iProcessor, l1t::tftype::omtf_neg, bx, *candidates);
+    for(unsigned int iProcessor=0; iProcessor<m_OMTFConfig->nProcessors(); ++iProcessor)
+      getProcessorCandidates(iProcessor, l1t::tftype::omtf_pos, bx, *candidates);
+
+    for(unsigned int iProcessor=0; iProcessor<m_OMTFConfig->nProcessors(); ++iProcessor)
+      getProcessorCandidates(iProcessor, l1t::tftype::omtf_neg, bx, *candidates);
     
+    edm::LogInfo("OMTFReconstruction") <<"OMTF:  Number of candidates in BX="<<bx<<": "<<candidates->size(bx) << std::endl;;
+  }
+
   return candidates;
 }
 
@@ -138,7 +147,7 @@ void OMTFReconstruction::getProcessorCandidates(unsigned int iProcessor, l1t::tf
                 dtThDigis.product(),
                 cscDigis.product(),
                 rpcDigis.product(),
-                iProcessor, mtfType);
+                iProcessor, mtfType, bx);
   int flag = m_InputMaker.getFlag();
   
   const std::vector<OMTFProcessor::resultsMap> & results = m_OMTF->processInput(iProcessor,input);
@@ -160,7 +169,7 @@ void OMTFReconstruction::getProcessorCandidates(unsigned int iProcessor, l1t::tf
   }
   
   //dump to XML
-  writeResultToXML(iProcessor, mtfType,  input, results, candMuons);
+  if(bx==0)writeResultToXML(iProcessor, mtfType,  input, results, candMuons);
 }
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/src/OMTFResult.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFResult.cc
@@ -57,8 +57,14 @@ void OMTFResult::finalise(){
       unsigned int val = results[connectedLayer][iRefLayer]>0 ? results[iLogicLayer][iRefLayer]: 0;
       results1D[iRefLayer]+=val;
       hitsBits[iRefLayer]+=(val>0)*std::pow(2,iLogicLayer);
-      ///Do not count bending layers in hit count
-      if(!myOmtfConfig->getBendingLayers().count(iLogicLayer)) hits1D[iRefLayer]+=(val>0);
+
+      if (myOmtfConfig->fwVersion() <= 4) {
+        ///Do not count bending layers in hit count
+        if(!myOmtfConfig->getBendingLayers().count(iLogicLayer)) hits1D[iRefLayer]+=(val>0);
+      } else {
+        hits1D[iRefLayer]+=(val>0);
+      }
+
     }      
   }
 }

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -169,9 +169,8 @@ std::vector<l1t::RegionalMuonCand> OMTFSorter::candidates(unsigned int iProcesso
 
     int phiValue = myCand.getPhi();
     if(phiValue>= int(nPhiBins) ) phiValue-=nPhiBins;
-    ///conversion factor from OMTF to uGMT scale: 5400/576
-//    phiValue/=9.375;
-    phiValue *= (437./pow(2,12));    // ie. use as in hw: 9.3729977 
+    ///conversion factor from OMTF to uGMT scale is  5400/576 i.e. phiValue/=9.375;
+    phiValue = floor(phiValue*437./pow(2,12));    // ie. use as in hw: 9.3729977 
     candidate.setHwPhi(phiValue);
     
     candidate.setHwSign(myCand.getCharge()<0 ? 1:0  );

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -186,7 +186,34 @@ std::vector<l1t::RegionalMuonCand> OMTFSorter::candidates(unsigned int iProcesso
              || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000001100000000").to_ulong()
              || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000001010000000").to_ulong()
            )
-       ) quality =4;
+       ) quality = 4;
+    if( myOmtfConfig->fwVersion() >= 5 ) {
+      if (    static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000000010000000011").to_ulong() 
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000000100000000011").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000001000000000011").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000010000000000011").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000100000000000011").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("001000000000000011").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("010000000000000011").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000000000000011").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000000010000001100").to_ulong() 
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000000100000001100").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000001000000001100").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000010000000001100").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000100000000001100").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("001000000000001100").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("010000000000001100").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000000000001100").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000000010000110000").to_ulong() 
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000000100000110000").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000001000000110000").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000010000000110000").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("000100000000110000").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("001000000000110000").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("010000000000110000").to_ulong()
+           || static_cast<unsigned int>(myCand.getHits()) == std::bitset<18>("100000000000110000").to_ulong()
+         ) quality = 1;
+    }
 
 //  if (abs(myCand.getEta()) == 121) quality = 4;
     if (abs(myCand.getEta()) == 121) quality = 0; // changed on request from HI

--- a/L1Trigger/L1TMuonOverlap/src/OMTFinput.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFinput.cc
@@ -45,29 +45,25 @@ std::bitset<128> OMTFinput::getRefHits(unsigned int iProcessor) const{
 ///////////////////////////////////////////////////
 bool OMTFinput::addLayerHit(unsigned int iLayer,
 			    unsigned int iInput,
-			    int iPhi, int iEta){
+			    int iPhi, int iEta, bool allowOverwrite){
 
   bool overwrite = false;
   assert(iLayer<myOmtfConfig->nLayers());
   assert(iInput<14);
 
   if(iPhi>=(int)myOmtfConfig->nPhiBins()) return true;
-//  unsigned int origInput = iInput;
 
-  if (measurementsPhi[iLayer][iInput]==iPhi && measurementsEta[iLayer][iInput]==iEta) return true;
+  if(allowOverwrite && measurementsPhi[iLayer][iInput]==iPhi && measurementsEta[iLayer][iInput]==iEta) return true;
 
   if(measurementsPhi[iLayer][iInput]!=(int)myOmtfConfig->nPhiBins()) ++iInput;
   if(measurementsPhi[iLayer][iInput]!=(int)myOmtfConfig->nPhiBins()) overwrite = true;
-
-//  std::cout <<" addLayerHit :"<<iLayer<<" input orig :"<<inputorig<<" now:  "<< iInput <<" phi: "<<iPhi<< std::endl;
   
-  if(iInput>13) return false;
+  if(iInput>13) return true;
   
   measurementsPhi[iLayer][iInput] = iPhi;
   measurementsEta[iLayer][iInput] = iEta;
 
-//  return (origInput==iInput);				      
-  return (!overwrite);				      
+  return overwrite;				      
 }
 ///////////////////////////////////////////////////
 ///////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
@@ -217,7 +217,7 @@ unsigned int OMTFinputMaker::getInputNumber(unsigned int rawId,
 OMTFinput OMTFinputMaker::processDT(const L1MuDTChambPhContainer *dtPhDigis,
 	       const L1MuDTChambThContainer *dtThDigis,
 	       unsigned int iProcessor,
-	       l1t::tftype type)
+	       l1t::tftype type, int bxTrg)
 {
 
   OMTFinput result(myOmtfConfig);
@@ -236,8 +236,14 @@ OMTFinput OMTFinputMaker::processDT(const L1MuDTChambPhContainer *dtPhDigis,
     ///code()>=3     - take only double layer hits, HH, HL and LL
     // FIXME (MK): at least Ts2Tag selection is not correct! Check it
 //    if (digiIt.bxNum()!= 0 || digiIt.BxCnt()!= 0 || digiIt.Ts2Tag()!= 0 || digiIt.code()<4) continue;
-    if (digiIt.bxNum()!= 0) continue;
-    if (digiIt.code() != 4 && digiIt.code() != 5 && digiIt.code() != 6) continue;
+
+    if (digiIt.bxNum()!= bxTrg) continue;
+    
+    if (myOmtfConfig->fwVersion() <= 4) {
+      if (digiIt.code() != 4 && digiIt.code() != 5 && digiIt.code() != 6) continue;
+    } else {
+      if (digiIt.code() != 2 && digiIt.code() != 3 && digiIt.code() != 4 && digiIt.code() != 5 && digiIt.code() != 6) continue;
+    }
 
     unsigned int hwNumber = myOmtfConfig->getLayerNumber(detid.rawId());
     if(myOmtfConfig->getHwToLogicLayer().find(hwNumber)==myOmtfConfig->getHwToLogicLayer().end()) continue;
@@ -258,7 +264,7 @@ OMTFinput OMTFinputMaker::processDT(const L1MuDTChambPhContainer *dtPhDigis,
 ////////////////////////////////////////////
 OMTFinput OMTFinputMaker::processCSC(const CSCCorrelatedLCTDigiCollection *cscDigis,
 	       unsigned int iProcessor,
-	       l1t::tftype type){
+	       l1t::tftype type, int bxTrg){
 
   OMTFinput result(myOmtfConfig);
   if(!cscDigis) return result;
@@ -275,7 +281,7 @@ OMTFinput OMTFinputMaker::processCSC(const CSCCorrelatedLCTDigiCollection *cscDi
     for( ; digi != dend; ++digi ) {
 
       ///Check if LCT trigger primitive has the right BX.
-      if (abs(digi->getBX()- CSCConstants::LCT_CENTRAL_BX)>0) continue;
+      if (digi->getBX()-CSCConstants::LCT_CENTRAL_BX != bxTrg) continue;
 
       unsigned int hwNumber = myOmtfConfig->getLayerNumber(rawid);
       if(myOmtfConfig->getHwToLogicLayer().find(hwNumber)==myOmtfConfig->getHwToLogicLayer().end()) continue;
@@ -302,7 +308,7 @@ bool rpcPrimitiveCmp(const  RPCDigi &a, const  RPCDigi &b) { return a.strip() < 
 ////////////////////////////////////////////
 OMTFinput OMTFinputMaker::processRPC(const RPCDigiCollection *rpcDigis,
 				unsigned int iProcessor,
-				l1t::tftype type){
+				l1t::tftype type, int bxTrg){
 
   OMTFinput result(myOmtfConfig); 
   if(!rpcDigis) return result;
@@ -318,10 +324,11 @@ OMTFinput OMTFinputMaker::processRPC(const RPCDigiCollection *rpcDigis,
     if(!acceptDigi(rawid, iProcessor, type)) continue;    
     ///Find clusters of consecutive fired strips.
     ///Have to copy the digis in chamber to sort them (not optimal).
-    ///NOTE: when copying I select only digis with bx==0       //FIXME: find a better place/way to filtering digi against quality/BX etc.
-//    for (auto tdigi = rollDigis.second.first; tdigi != rollDigis.second.second; tdigi++) { std::cout << "RPC DIGIS: " << roll.rawId()<< " "<<roll<<" digi: " << tdigi->strip() <<" bx: " << tdigi->bx() << std::endl; }
+    ///NOTE: when copying I select only digis with bx==       //FIXME: find a better place/way to filtering digi against quality/BX etc.
+//  for (auto tdigi = rollDigis.second.first; tdigi != rollDigis.second.second; tdigi++) { std::cout << "RPC DIGIS: " << roll.rawId()<< " "<<roll<<" digi: " << tdigi->strip() <<" bx: " << tdigi->bx() << std::endl; }
     std::vector<RPCDigi> digisCopy;
-    std::copy_if(rollDigis.second.first, rollDigis.second.second, std::back_inserter(digisCopy), [](const RPCDigi & aDigi){return (aDigi.bx()==0);});
+//  std::copy_if(rollDigis.second.first, rollDigis.second.second, std::back_inserter(digisCopy), [](const RPCDigi & aDigi){return (aDigi.bx()==0);} );
+    for (auto pDigi=rollDigis.second.first; pDigi != rollDigis.second.second; pDigi++) { if (pDigi->bx()==bxTrg) digisCopy.push_back( *pDigi); }
     std::sort(digisCopy.begin(),digisCopy.end(),rpcPrimitiveCmp);
     typedef std::pair<unsigned int, unsigned int> Cluster;
     std::vector<Cluster> clusters;
@@ -373,11 +380,12 @@ OMTFinput OMTFinputMaker::buildInputForProcessor(const L1MuDTChambPhContainer *d
 							 const CSCCorrelatedLCTDigiCollection *cscDigis,
 							 const RPCDigiCollection *rpcDigis,
 							 unsigned int iProcessor,
-							 l1t::tftype type){
+							 l1t::tftype type,
+                                           int bx){
   OMTFinput result(myOmtfConfig);
-  result += processDT(dtPhDigis, dtThDigis, iProcessor, type);
-  result += processCSC(cscDigis, iProcessor, type);
-  result += processRPC(rpcDigis, iProcessor, type);
+  result += processDT(dtPhDigis, dtThDigis, iProcessor, type, bx);
+  result += processCSC(cscDigis, iProcessor, type, bx);
+  result += processRPC(rpcDigis, iProcessor, type, bx);
   return result;
 }
 ////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
@@ -253,8 +253,9 @@ OMTFinput OMTFinputMaker::processDT(const L1MuDTChambPhContainer *dtPhDigis,
     int iPhi =  myAngleConverter.getProcessorPhi(iProcessor, type, digiIt);
     int iEta =  myAngleConverter.getGlobalEta(detid.rawId(), digiIt, dtThDigis);
     unsigned int iInput= getInputNumber(detid.rawId(), iProcessor, type);    
-    result.addLayerHit(iLayer,iInput,iPhi,iEta);
-    result.addLayerHit(iLayer+1,iInput,digiIt.phiB(),iEta);    
+    bool allowOverwrite = false;
+    result.addLayerHit(iLayer,iInput,iPhi,iEta, allowOverwrite);
+    result.addLayerHit(iLayer+1,iInput,digiIt.phiB(),iEta, allowOverwrite);    
   }
 
   return result;
@@ -296,7 +297,8 @@ OMTFinput OMTFinputMaker::processCSC(const CSCCorrelatedLCTDigiCollection *cscDi
       //if (abs(iEta) > 115) continue;
       unsigned int iInput= getInputNumber(rawid, iProcessor, type);      
 //    std::cout <<" ADDING CSC hit, proc: "<<iProcessor<<" iPhi : " << iPhi <<" iEta: "<< iEta << std::endl; 
-      result.addLayerHit(iLayer,iInput,iPhi,iEta);     
+      bool allowOverwrite = false;
+      result.addLayerHit(iLayer,iInput,iPhi,iEta,allowOverwrite);     
     }
   }      
   return result;


### PR DESCRIPTION
Changes includes:
 - fix for missing CSC offset in raw to digi
 - fixed mem leaks
 - allow for emulator reconstruction in bx other than 0.
 - new omtf algorithm (sc-called v5, compatible with the one prepared for P5 running);
   the new algo is planned to be enabled by o2o with omtf algo key 'omtf_algo_base/v4';
   until then old algorithm is enabled.