### PR TITLE
Changed CSC binary examiner mask to enable ALCT CRC checks - CMSSW master

### DIFF
--- a/EventFilter/CSCRawToDigi/python/cscUnpacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscUnpacker_cfi.py
@@ -9,7 +9,7 @@ muonCSCDigis.InputObjects = cms.InputTag("rawDataCollector")
 # Use CSC examiner to check for corrupt or semi-corrupt data & avoid unpacker crashes
 muonCSCDigis.UseExaminer = cms.bool(True)
 # This mask is needed by the examiner 
-muonCSCDigis.ExaminerMask = cms.uint32(0x1FEBF3F6)
+muonCSCDigis.ExaminerMask = cms.uint32(0x1FEBF7F6)
 # Use Examiner to unpack good chambers and skip only bad ones
 muonCSCDigis.UseSelectiveUnpacking = cms.bool(True)
 # This mask simply reduces error reporting


### PR DESCRIPTION
EventFilter/CSCRawToDigi - Changed CSC binary examiner mask to enable ALCT CRC checks.
It should prevent passing of corrupted (bad ALCT) CSC event data to main CSC data unpacking code.
Related to request from HLT group, which was investigating random HLT crashes in run 320917