### PR TITLE
Removed unnecessary using declaration in DataFormats/L1DTTrackFinder

### DIFF
--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhDigi.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhDigi.cc
@@ -23,7 +23,6 @@
 //---------------
 // C++ Headers --
 //---------------
-using namespace std;
 
 //-------------------
 // Initializations --

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambThDigi.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambThDigi.cc
@@ -23,7 +23,6 @@
 //---------------
 // C++ Headers --
 //---------------
-using namespace std;
 
 //-------------------
 // Initializations --

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTTrackCand.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTTrackCand.cc
@@ -23,7 +23,6 @@
 //---------------
 // C++ Headers --
 //---------------
-using namespace std;
 
 //-------------------
 // Initializations --


### PR DESCRIPTION
This fixes a clang warning.