### PR TITLE
Forward declaration should be struct not class in DataFormats/L1THGCal

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalTowerMap.h
+++ b/DataFormats/L1THGCal/interface/HGCalTowerMap.h
@@ -9,7 +9,7 @@
 namespace l1t {
 
   class HGCalTowerMap;
-  class HGCalTowerCoord;
+  struct HGCalTowerCoord;
   typedef BXVector<HGCalTowerMap> HGCalTowerMapBxCollection;
 
   class HGCalTowerMap {


### PR DESCRIPTION
This fixes a clang warning.