### PR TITLE
Hide testing functions within appropriate CPP macros

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
@@ -134,7 +134,7 @@ private:
 
 #ifdef VI_DEBUG
   void check() const { assert(det());}
-#elif EDM_LM_DEBUG
+#elif DO_THROW_UNINITIALIZED
   void check() const;
 #else 
   static void check(){}

--- a/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
@@ -8,8 +8,8 @@
 #include "DataFormats/GeometrySurface/interface/Surface.h" 
 
 
-
-// #define VI_DEBUG
+//#define DO_INTERNAL_CHECKS_BTR
+//#define VI_DEBUG
 
 class OmniClusterRef;
 
@@ -134,7 +134,7 @@ private:
 
 #ifdef VI_DEBUG
   void check() const { assert(det());}
-#elif DO_THROW_UNINITIALIZED
+#elif defined(DO_INTERNAL_CHECKS_BTR)
   void check() const;
 #else 
   static void check(){}

--- a/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
@@ -1,3 +1,4 @@
+//#define DO_THROW_UNINITIALIZED
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/KfComponentsHolder.h"
 #include "DataFormats/Math/interface/ProjectMatrix.h"
@@ -6,7 +7,7 @@
 
 
 namespace {
-#ifdef EDM_LM_DEBUG
+#ifdef DO_THROW_UNINITIALIZED
   inline void
   throwExceptionUninitialized(const char *where)
   {
@@ -21,7 +22,7 @@ namespace {
   }
 }
 
-#ifdef EDM_LM_DEBUG
+#if !defined(VI_DEBUG) && defined(DO_THROW_UNINITIALIZED)
 void BaseTrackerRecHit::check() const {
   if (!hasPositionAndError()) throwExceptionUninitialized("localPosition or Error");
 }
@@ -39,7 +40,9 @@ bool BaseTrackerRecHit::hasPositionAndError() const {
 void
 BaseTrackerRecHit::getKfComponents1D( KfComponentsHolder & holder ) const 
 {
-  // if (!hasPositionAndError()) throwExceptionUninitialized("getKfComponents");
+#if defined(DO_THROW_UNINITIALIZED)
+  if (!hasPositionAndError()) throwExceptionUninitialized("getKfComponents");
+#endif
   AlgebraicVector1 & pars = holder.params<1>();
   pars[0] = pos_.x(); 
   
@@ -56,7 +59,9 @@ BaseTrackerRecHit::getKfComponents1D( KfComponentsHolder & holder ) const
 void
 BaseTrackerRecHit::getKfComponents2D( KfComponentsHolder & holder ) const 
 {
-  //if (!hasPositionAndError()) throwExceptionUninitialized("getKfComponents");
+#if defined(DO_THROW_UNINITIALIZED)
+  if (!hasPositionAndError()) throwExceptionUninitialized("getKfComponents");
+#endif
    AlgebraicVector2 & pars = holder.params<2>();
    pars[0] = pos_.x(); 
    pars[1] = pos_.y();

--- a/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
@@ -6,6 +6,7 @@
 
 
 namespace {
+#ifdef EDM_LM_DEBUG
   inline void
   throwExceptionUninitialized(const char *where)
   {
@@ -14,7 +15,7 @@ namespace {
       "If you want to get coarse position/error estimation from disk, please set: ComputeCoarseLocalPositionFromDisk = True \n " <<
       " to the TransientTrackingRecHitBuilder you are using from RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py";
   }
-  
+#endif
   void obsolete() {
     throw cms::Exception("BaseTrackerRecHit") << "CLHEP is obsolete for Tracker Hits";
   }

--- a/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
@@ -7,7 +7,7 @@
 
 
 namespace {
-#ifdef DO_THROW_UNINITIALIZED
+#if defined(DO_THROW_UNINITIALIZED) || defined(DO_INTERNAL_CHECKS_BTR)
   inline void
   throwExceptionUninitialized(const char *where)
   {
@@ -22,7 +22,7 @@ namespace {
   }
 }
 
-#if !defined(VI_DEBUG) && defined(DO_THROW_UNINITIALIZED)
+#if !defined(VI_DEBUG) && defined(DO_INTERNAL_CHECKS_BTR)
 void BaseTrackerRecHit::check() const {
   if (!hasPositionAndError()) throwExceptionUninitialized("localPosition or Error");
 }

--- a/DataFormats/TrackerRecHit2D/src/TrackerSingleRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/TrackerSingleRecHit.cc
@@ -7,6 +7,8 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 
+//#define DO_INTERNAL_CHECKS
+#if defined(DO_INTERNAL_CHECKS)
 namespace {
   
   void verify(OmniClusterRef const ref) {
@@ -84,7 +86,7 @@ namespace {
     verify(thit);
 
   }
-  
+
   bool doingCheck = false;
   inline void checkSelf(const TrackingRecHit* one,const TrackingRecHit* two) {
     doingCheck=true;
@@ -94,16 +96,17 @@ namespace {
     if (!two->sharesInput(two,TrackingRecHit::some)) problem(two,"some");
     doingCheck=false;
   }
-
 }
+#endif
 
 bool 
 TrackerSingleRecHit::sharesInput( const TrackingRecHit* other, 
 			      SharedInputType what) const
 {
-  //  verify(this); verify(other);
-  // if (!doingCheck && (other!=this)) checkSelf(this,other);
-
+#if defined(DO_INTERNAL_CHECKS)
+  verify(this); verify(other);
+  if (!doingCheck && (other!=this)) checkSelf(this,other);
+#endif
 
   if (!sameDetModule(*other)) return false;
 


### PR DESCRIPTION
Functions which are only used during debugging were being reported
by a clang warning as unused. Moving them into the same CPP macros
as their calling code makes them only available if they will be
called.