### PR TITLE
Trigger Object Tag and Probe DQM source

### DIFF
--- a/DQM/HLTEvF/plugins/BuildFile.xml
+++ b/DQM/HLTEvF/plugins/BuildFile.xml
@@ -32,7 +32,6 @@
   <use   name="MagneticField/Records"/>
   <use   name="MagneticField/Engine"/>
   <use   name="TrackingTools/TrajectoryState"/>
-  <use   name="CommonTools/TriggerUtils"/>
   <use   name="DQMOffline/Trigger"/>
   <use   name="rootcore"/>
   <flags   EDM_PLUGIN="1"/>

--- a/DQM/HLTEvF/plugins/BuildFile.xml
+++ b/DQM/HLTEvF/plugins/BuildFile.xml
@@ -32,6 +32,8 @@
   <use   name="MagneticField/Records"/>
   <use   name="MagneticField/Engine"/>
   <use   name="TrackingTools/TrajectoryState"/>
+  <use   name="CommonTools/TriggerUtils"/>
+  <use   name="DQMOffline/Trigger"/>
   <use   name="rootcore"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/DQM/HLTEvF/plugins/TrigObjTnPHistColl.cc
+++ b/DQM/HLTEvF/plugins/TrigObjTnPHistColl.cc
@@ -4,9 +4,7 @@
 
 namespace{
   std::vector<float> convertToFloat(const std::vector<double>& vecD){
-    std::vector<float> vecF;
-    for(double x : vecD) vecF.push_back(x);
-    return vecF;
+    return std::vector<float>(vecD.begin(),vecD.end());
   }
 }
 
@@ -20,7 +18,8 @@ TrigObjTnPHistColl::TrigObjTnPHistColl(const edm::ParameterSet& config):
   evtTrigSel_(config.getParameter<edm::ParameterSet>("evtTrigSel"))
   
 {
-  for(auto probeFilter : config.getParameter<std::vector<std::string> >("probeFilters")){
+  auto probeFilters = config.getParameter<std::vector<std::string> >("probeFilters");
+  for(auto& probeFilter : probeFilters){
     probeHists_.emplace_back(ProbeData(std::move(probeFilter)));
   }
 }

--- a/DQM/HLTEvF/plugins/TrigObjTnPHistColl.cc
+++ b/DQM/HLTEvF/plugins/TrigObjTnPHistColl.cc
@@ -1,0 +1,305 @@
+#include "TrigObjTnPHistColl.h"
+
+namespace{
+  std::vector<float> convertToFloat(const std::vector<double>& vecD){
+    std::vector<float> vecF;
+    for(double x : vecD) vecF.push_back(x);
+    return vecF;
+  }
+}
+
+TrigObjTnPHistColl::TrigObjTnPHistColl(const edm::ParameterSet& config,edm::ConsumesCollector&& cc):
+  tagCuts_(config.getParameter<std::vector<edm::ParameterSet>>("tagCuts")),
+  probeCuts_(config.getParameter<std::vector<edm::ParameterSet>>("probeCuts")),
+  tagFilters_(config.getParameter<edm::ParameterSet>("tagFilters")),
+  collName_(config.getParameter<std::string>("collName")),
+  folderName_(config.getParameter<std::string>("folderName")),
+  histDefs_(config.getParameter<edm::ParameterSet>("histDefs")),
+  evtTrigSel_(config.getParameter<edm::ParameterSet>("evtTrigSel"),cc)
+{
+  for(auto probeFilter : config.getParameter<std::vector<std::string> >("probeFilters")){
+    probeHists_.emplace_back(ProbeData(std::move(probeFilter)));
+  }
+}
+
+edm::ParameterSetDescription TrigObjTnPHistColl::makePSetDescription()
+{
+  edm::ParameterSetDescription desc;
+  desc.addVPSet("tagCuts",VarRangeCut<trigger::TriggerObject>::makePSetDescription(),std::vector<edm::ParameterSet>());
+  desc.addVPSet("probeCuts",VarRangeCut<trigger::TriggerObject>::makePSetDescription(),std::vector<edm::ParameterSet>());
+  desc.add<edm::ParameterSetDescription>("tagFilters",FilterSelector::makePSetDescription());
+  desc.add<std::string>("collName","stdTag");
+  desc.add<std::string>("folderName","HLT/EGM/TrigObjTnP");
+  desc.add<edm::ParameterSetDescription>("histDefs",HistDefs::makePSetDescription());
+  desc.add<std::vector<std::string>>("probeFilters",std::vector<std::string>());  
+
+  edm::ParameterSetDescription trigEvtFlagDesc;
+  trigEvtFlagDesc.add<bool>("andOr",false);
+  trigEvtFlagDesc.add<unsigned int>("verbosityLevel",1);
+  trigEvtFlagDesc.add<bool>("andOrDcs", false);  
+  trigEvtFlagDesc.add<edm::InputTag>("dcsInputTag", edm::InputTag("scalersRawToDigi") );
+  trigEvtFlagDesc.add<std::vector<int> >("dcsPartitions",{24,25,26,27,28,29});
+  trigEvtFlagDesc.add<bool>("errorReplyDcs", true);
+  trigEvtFlagDesc.add<std::string>("dbLabel","");
+  trigEvtFlagDesc.add<bool>("andOrHlt", true); //true = OR, false = and
+  trigEvtFlagDesc.add<edm::InputTag>("hltInputTag", edm::InputTag("TriggerResults::HLT") );
+  trigEvtFlagDesc.add<std::vector<std::string> >("hltPaths",{});
+  trigEvtFlagDesc.add<std::string>("hltDBKey","");
+  trigEvtFlagDesc.add<bool>("errorReplyHlt",false);
+  desc.add<edm::ParameterSetDescription>("evtTrigSel",trigEvtFlagDesc);
+  
+  return desc;
+}
+
+void TrigObjTnPHistColl::bookHists(DQMStore::IBooker& iBooker)
+{
+  iBooker.setCurrentFolder(folderName_);
+  for(auto& probe : probeHists_){
+    probe.bookHists(collName_,iBooker,histDefs_);
+  }
+}
+
+void TrigObjTnPHistColl::fill(const trigger::TriggerEvent& trigEvt,
+			      const edm::Event& event,const edm::EventSetup& setup)
+{
+  if(evtTrigSel_.accept(event,setup)==false) return;
+
+  auto tagTrigKeys = tagFilters_.getPassingKeys(trigEvt);
+  for(auto& tagKey : tagTrigKeys){
+    const trigger::TriggerObject& tagObj = trigEvt.getObjects()[tagKey];
+    if(tagCuts_(tagObj)){
+      for(auto& probeColl : probeHists_) probeColl.fill(tagKey,trigEvt,probeCuts_);
+    }
+  }
+}
+
+//trigger::Keys is likely a vector containing 0-3 short ints (probably 10 max),
+// passing by value makes this much  easier code wise (otherwise would have to 
+//create a dummy empty vector) and shouldnt be too much of a performance hit
+const trigger::Keys TrigObjTnPHistColl::getKeys(const trigger::TriggerEvent& trigEvt,const std::string& filterName)
+{
+  edm::InputTag filterTag(filterName,"",trigEvt.usedProcessName());
+  trigger::size_type filterIndex = trigEvt.filterIndex(filterTag); 
+  if(filterIndex<trigEvt.sizeFilters()) return trigEvt.filterKeys(filterIndex);
+  else return trigger::Keys();
+}
+
+TrigObjTnPHistColl::FilterSelector::FilterSelector(const edm::ParameterSet& config):
+  isAND_(config.getParameter<bool>("isAND"))
+{
+  auto filterSetConfigs = config.getParameter<std::vector<edm::ParameterSet>>("filterSets");
+  for(auto& filterSetConfig : filterSetConfigs) filterSets_.emplace_back(FilterSet(filterSetConfig));
+}
+
+edm::ParameterSetDescription TrigObjTnPHistColl::FilterSelector::makePSetDescription()
+{
+  edm::ParameterSetDescription desc;
+  desc.addVPSet("filterSets",FilterSet::makePSetDescription(),std::vector<edm::ParameterSet>());
+  desc.add<bool>("isAND",false);
+  return desc;
+}
+
+const trigger::Keys TrigObjTnPHistColl::FilterSelector::getPassingKeys(const trigger::TriggerEvent& trigEvt)const
+{
+  trigger::Keys passingKeys;
+  bool isFirstFilterSet = true;
+  for(const auto& filterSet : filterSets_){
+    auto keysOfFilterSet = filterSet.getPassingKeys(trigEvt);
+    if(isFirstFilterSet) passingKeys = keysOfFilterSet;
+    else mergeTrigKeys(passingKeys,keysOfFilterSet,isAND_);
+    isFirstFilterSet = false;
+  }
+  cleanTrigKeys(passingKeys);
+  return passingKeys;
+}
+
+void TrigObjTnPHistColl::FilterSelector::mergeTrigKeys(trigger::Keys& keys,const trigger::Keys& keysToMerge,bool isAND)
+{
+  if(isAND){
+    for(auto& key : keys) {
+      if(std::count(keysToMerge.begin(),keysToMerge.end(),key)==0){
+	key=std::numeric_limits<trigger::size_type>::max();
+      }
+    }
+  }else{
+    for(const auto key : keysToMerge){
+      keys.push_back(key);
+    }
+  }  
+}
+
+void TrigObjTnPHistColl::FilterSelector::cleanTrigKeys(trigger::Keys& keys)
+{
+  std::sort(keys.begin(),keys.end());
+  std::unique(keys.begin(),keys.end());
+  while(!keys.empty() && keys.back()==std::numeric_limits<trigger::size_type>::max()){
+    keys.pop_back();
+  }
+}
+
+TrigObjTnPHistColl::FilterSelector::FilterSet::FilterSet(const edm::ParameterSet& config):
+  filters_(config.getParameter<std::vector<std::string>>("filters")),
+  isAND_(config.getParameter<bool>("isAND"))
+{
+  
+}
+
+edm::ParameterSetDescription TrigObjTnPHistColl::FilterSelector::FilterSet::makePSetDescription()
+{
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<std::string> >("filters",std::vector<std::string>());
+  desc.add<bool>("isAND",true);
+  return desc;
+}
+
+const trigger::Keys TrigObjTnPHistColl::FilterSelector::FilterSet::getPassingKeys(const trigger::TriggerEvent& trigEvt)const
+{
+  trigger::Keys passingKeys;
+  bool firstFilter = true;
+  for(const auto& filterName : filters_){
+    const trigger::Keys& trigKeys = getKeys(trigEvt,filterName);
+    if(firstFilter) {
+      passingKeys = trigKeys;
+      firstFilter = false;
+    }else mergeTrigKeys(passingKeys,trigKeys,isAND_);
+  }
+  cleanTrigKeys(passingKeys);
+  
+  return passingKeys;
+}
+
+TrigObjTnPHistColl::TrigObjVarF::TrigObjVarF(std::string varName):isAbs_(false)
+{
+  //first look for "Abs" at the end of the string
+  auto absPos = varName.rfind("Abs");
+  if(absPos != std::string::npos && absPos+3 == varName.size() ) {
+    isAbs_ = true;
+    varName = varName.erase(absPos);
+  }
+  if(varName=="pt") varFunc_ = &trigger::TriggerObject::pt;
+  else if(varName=="eta") varFunc_ = &trigger::TriggerObject::eta;
+  else if(varName=="phi") varFunc_ = &trigger::TriggerObject::phi;
+  else{
+    std::ostringstream msg;
+    msg<<"var "<<varName<<" not recognised (use pt or p rather than et or e for speed!) ";
+    if(isAbs_) msg<<" varName was \"Abs\" suffex cleaned where it tried to remove \"Abs\" at the end of the variable name ";
+    msg <<__FILE__<<","<<__LINE__<<std::endl;
+    throw cms::Exception("ConfigError") <<msg.str();
+  }
+}
+
+TrigObjTnPHistColl::HistFiller::HistFiller(const edm::ParameterSet& config):
+  localCuts_(config.getParameter<std::vector<edm::ParameterSet> >("localCuts")),
+  var_(config.getParameter<std::string>("var"))
+{
+  
+}
+
+edm::ParameterSetDescription TrigObjTnPHistColl::HistFiller::makePSetDescription()
+{
+  edm::ParameterSetDescription desc;
+  desc.addVPSet("localCuts",VarRangeCut<trigger::TriggerObject>::makePSetDescription());
+  desc.add<std::string>("var","pt");
+  return desc;
+}
+
+void TrigObjTnPHistColl::HistFiller::operator()(const trigger::TriggerObject& probe,float mass,
+						MonitorElement* hist)
+{
+  if(localCuts_(probe)) hist->Fill(var_(probe),mass);
+}
+
+
+
+TrigObjTnPHistColl::HistDefs::HistDefs(const edm::ParameterSet& config):
+  massBins_(convertToFloat(config.getParameter<std::vector<double> >("massBins")))
+{
+  const auto histConfigs = config.getParameter<std::vector<edm::ParameterSet> >("configs");
+  for(const auto& histConfig : histConfigs){
+    histData_.emplace_back(Data(histConfig));
+  }
+}
+
+edm::ParameterSetDescription TrigObjTnPHistColl::HistDefs::makePSetDescription()
+{
+  edm::ParameterSetDescription desc;
+  desc.addVPSet("configs",Data::makePSetDescription(),std::vector<edm::ParameterSet>()); 
+  std::vector<double> massBins;
+  for(float mass = 60;mass<=120;mass+=1) massBins.push_back(mass);
+  desc.add<std::vector<double>>("massBins",massBins);
+  return desc;
+}
+
+std::vector<std::pair<TrigObjTnPHistColl::HistFiller,MonitorElement*> > TrigObjTnPHistColl::HistDefs::bookHists(DQMStore::IBooker& iBooker,const std::string& name,const std::string& title)const
+{
+  std::vector<std::pair<HistFiller,MonitorElement*> > hists;
+  for(const auto& data : histData_){
+    hists.push_back({data.filler(),data.book(iBooker,name,title,massBins_)});
+  }
+  return hists;
+}
+
+TrigObjTnPHistColl::HistDefs::Data::Data(const edm::ParameterSet& config):
+  histFiller_(config.getParameter<edm::ParameterSet>("filler")),
+  bins_(convertToFloat(config.getParameter<std::vector<double> >("bins"))),
+  nameSuffex_(config.getParameter<std::string>("nameSuffex")),
+  titleSuffex_(config.getParameter<std::string>("titleSuffex"))
+{ 
+
+}
+
+edm::ParameterSetDescription TrigObjTnPHistColl::HistDefs::Data::makePSetDescription()
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::ParameterSetDescription>("filler",TrigObjTnPHistColl::HistFiller::makePSetDescription());
+  desc.add<std::vector<double> >("bins",{-2.5,-1.5,0,1.5,2.5});
+  desc.add<std::string>("nameSuffex","_eta");
+  desc.add<std::string>("titleSuffex",";#eta;mass [GeV]");
+  return desc;
+}
+
+MonitorElement* TrigObjTnPHistColl::HistDefs::Data::book(DQMStore::IBooker& iBooker,
+					      const std::string& name,const std::string& title,
+					      const std::vector<float>& massBins)const
+{
+  return iBooker.book2D((name+nameSuffex_).c_str(),(title+titleSuffex_).c_str(),
+			bins_.size()-1,bins_.data(),massBins.size()-1,massBins.data());
+}
+
+void TrigObjTnPHistColl::HistColl::bookHists(DQMStore::IBooker& iBooker,
+					     const std::string& name,const std::string& title,
+					     const HistDefs& histDefs)
+{
+  hists_ = histDefs.bookHists(iBooker,name,title);
+}
+
+void TrigObjTnPHistColl::HistColl::fill(const trigger::TriggerObject& probe,float mass)
+{
+  for(auto& hist : hists_){
+    hist.first(probe,mass,hist.second);
+  }
+}
+
+void TrigObjTnPHistColl::ProbeData::bookHists(const std::string& tagName,
+					      DQMStore::IBooker& iBooker,
+					      const HistDefs& histDefs)
+{
+  hists_.bookHists(iBooker,tagName+"_"+probeFilter_,tagName+"_"+probeFilter_,histDefs);
+}
+
+void TrigObjTnPHistColl::ProbeData::fill(const trigger::size_type tagKey,const trigger::TriggerEvent& trigEvt,const VarRangeCutColl<trigger::TriggerObject>& probeCuts)
+{
+  auto probeKeys = getKeys(trigEvt,probeFilter_);
+  for(auto probeKey : probeKeys){
+    const trigger::TriggerObject& probe = trigEvt.getObjects()[probeKey];
+    if(tagKey != probeKey && probeCuts(probe) ){
+      const trigger::TriggerObject& tag = trigEvt.getObjects()[tagKey];
+      auto massFunc = [](float pt1,float eta1,float phi1,float pt2,float eta2,float phi2){
+	return std::sqrt( 2*pt1*pt2*( std::cosh(eta1-eta2) - std::cos(phi1-phi2) ) );
+      };
+      float mass = massFunc(tag.pt(),tag.eta(),tag.phi(),probe.pt(),probe.eta(),probe.phi());
+      hists_.fill(probe,mass);
+    }
+  }
+}
+

--- a/DQM/HLTEvF/plugins/TrigObjTnPHistColl.h
+++ b/DQM/HLTEvF/plugins/TrigObjTnPHistColl.h
@@ -189,7 +189,7 @@ public:
 		   const std::string& title,const HistDefs& histDefs);
     void fill(const trigger::TriggerObject& probe,float mass)const;
   private:
-    std::vector<std::pair<HistFiller,ConcurrentMonitorElement> > hists_; //we do not own the MonitorElement*
+    std::vector<std::pair<HistFiller,ConcurrentMonitorElement> > hists_;
   };
 
 

--- a/DQM/HLTEvF/plugins/TrigObjTnPHistColl.h
+++ b/DQM/HLTEvF/plugins/TrigObjTnPHistColl.h
@@ -1,0 +1,202 @@
+#ifndef DQM_HLTEvF_TrigObjTnPHistColl_h
+#define DQM_HLTEvF_TrigObjTnPHistColl_h
+
+//********************************************************************************
+//
+// Description:
+//   Manages a set of histograms intended for tag and probe efficiency measurements
+//   using TriggerObjects stored in TriggerEvent as the input 
+//   selection is limited to basic et/eta/phi cuts and trigger filter requirements
+//   The idea that this can run on any of the following data formats RAW,RECO,AOD
+//   or even as part of the HLT job
+//
+//   All histograms in a TrigObjTnPHistColl share the same tag defination and 
+//   currently the same probe et/eta/phi cuts. The tag trigger requirements may be
+//   to pass multiple triggers anded or ored together
+//
+//   The TrigObjTnPHistColl then has a series of histograms which are filled for 
+//   probes which pass a specified filter. For each specified filter, a set of 
+//   2D histograms are produced, <var> vs mass where var is configuable via python
+//   These histograms may have additional cuts, eg eta cuts which limit them to barrel
+//   or endcap
+
+//   This allows us to get the mass spectrum in each bin to allow signal & bkg fits 
+//
+// Class Structure
+//   TrigObjTnPHistColl : master object which manages a series of histograms which 
+//                        share a common tag defination. It selects tag and probe pairs
+//                        and then sends selected probes to fill the relavent histograms
+//
+//   FilterSelector : specifies and cuts on the trigger filters an object has to pass.
+//                    It allows ANDed and ORing of trigger filter requirements.
+//                    It acheives this by grouping the filters in sets of filters (FilterSet)
+//                    and an object either has to pass all of those filters in the sets or 
+//                    any of those filters in the set.
+//                    An object can then be required to pass all defined FilterSets or any of them
+//
+//   TrigObjVarF : allows arbitary access to a given float variable of trigger::TriggerObject
+//                 it can also return the abs value of that variable if so requested
+//  
+//   HistFiller : stores the variable a histogram is to be filled with and any cuts the object
+//                must additional pass. It then can fill/not fill a histogram using this information
+//
+//   HistDefs : has all the information necesary to define a histograms to be produced. 
+//              The Data sub struct containts the HistFiller object, the binning of the 
+//              histogram and name /title suffexs. There is one set of histogram definations
+//              for a TrigObjTnPHistColl so each probe filter has identical binning
+//              Each booked histogram contains a local copy of the approprate HistFiller
+//              
+//   HistColl : a collection of histograms to be filled by a probe passing a particular trigger 
+//              and kinematic selection. Histograms may have additional further selection on the 
+//              probe (eg limiting to the barrel etc). Each histogram is booked using the central 
+//              histogram definations and contains a copy of the approprate HistFiller
+//
+//   ProbeData : a specific filter for a probe object to pass with a collection of histograms to
+//               fill managed by HistColl. The filter is not measured by FilterSelector as it is
+//               intentionally limited to only a single filter
+//
+//   TrigObjTnPHistColl : single tag selection and generic requirements for a probe
+//      |
+//      |--> collection of ProbeData : a set of histos to fill for probes passing a given filter
+//              |
+//              |--> ProbeData : filter to pass to fill histograms + histograms
+//                    |
+//                    |--> HistColl : hists for it to be filled
+//                           | 
+//                           |--> collection of HistFillters+their hists, histfillter fills the hist
+//
+// Author : Sam Harper , RAL, Aug 2018
+//
+//***********************************************************************************
+
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+#include "DQMOffline/Trigger/interface/VarRangeCutColl.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+
+
+class TrigObjTnPHistColl {
+public:
+  
+  class FilterSelector {
+  public:
+    class FilterSet {
+    public:
+      explicit FilterSet(const edm::ParameterSet& config);
+      static edm::ParameterSetDescription makePSetDescription();
+      const trigger::Keys getPassingKeys(const trigger::TriggerEvent& trigEvt)const;
+					 
+    private: 
+      std::vector<std::string> filters_;
+      bool isAND_;
+    };
+    
+  public:
+    explicit FilterSelector(const edm::ParameterSet& config); 
+    static edm::ParameterSetDescription makePSetDescription();
+    const trigger::Keys getPassingKeys(const trigger::TriggerEvent& trigEvt)const;
+  private:
+    //helper functions
+    static void mergeTrigKeys(trigger::Keys& keys,const trigger::Keys& keysToMerge,bool isAND);
+    static void cleanTrigKeys(trigger::Keys& keys);
+    
+    std::vector<FilterSet> filterSets_;
+    bool isAND_;
+    
+  };
+
+  class TrigObjVarF {
+  public:
+    explicit TrigObjVarF(std::string varName);
+    float operator()(const trigger::TriggerObject& obj)const{
+      return isAbs_ ? std::abs((obj.*varFunc_)()) : (obj.*varFunc_)();
+    }
+  private:
+    float (trigger::TriggerObject::*varFunc_)()const;
+    bool isAbs_;
+  };
+
+  class HistFiller { 
+  public:
+    explicit HistFiller(const edm::ParameterSet& config);
+    static edm::ParameterSetDescription makePSetDescription();
+    void operator()(const trigger::TriggerObject& probe,float mass,MonitorElement* hist);    
+  private:
+    VarRangeCutColl<trigger::TriggerObject> localCuts_;
+    TrigObjVarF var_;
+  };
+
+  //Histogram Defination, defines the histogram (name,title,bins,how its filled)
+  class HistDefs { 
+  private:
+    class Data { 
+    public:
+      explicit Data(const edm::ParameterSet& config); 
+      static edm::ParameterSetDescription makePSetDescription();
+      MonitorElement* book(DQMStore::IBooker& iBooker,const std::string& name,const std::string& title,const std::vector<float>& massBins)const;
+      const HistFiller& filler()const{return histFiller_;}
+    private:
+      HistFiller histFiller_;
+      std::vector<float> bins_;
+      std::string nameSuffex_;
+      std::string titleSuffex_;
+    };  
+  public:
+    explicit HistDefs(const edm::ParameterSet& config);  
+    static edm::ParameterSetDescription makePSetDescription();
+    std::vector<std::pair<HistFiller,MonitorElement*> > bookHists(DQMStore::IBooker& iBooker,const std::string& name,const std::string& title)const;
+  private:
+    std::vector<Data> histData_;
+    std::vector<float> massBins_;
+  };
+
+  class HistColl {
+  public:
+    HistColl(){}
+    void bookHists(DQMStore::IBooker& iBooker,const std::string& name,
+		   const std::string& title,const HistDefs& histDefs);
+    void fill(const trigger::TriggerObject& probe,float mass);
+  private:
+    std::vector<std::pair<HistFiller,MonitorElement*> > hists_; //we do not own the MonitorElement*
+  };
+
+
+  class ProbeData {
+  public:
+    explicit ProbeData(std::string probeFilter):probeFilter_(std::move(probeFilter)){}
+    void bookHists(const std::string& tagName,DQMStore::IBooker& iBooker,const HistDefs& histDefs);
+    void fill(const trigger::size_type tagKey,const trigger::TriggerEvent& trigEvt,const VarRangeCutColl<trigger::TriggerObject>& probeCuts);
+
+  private:
+    std::string probeFilter_;
+    HistColl hists_;
+  };
+  
+public:
+  TrigObjTnPHistColl(const edm::ParameterSet& config,edm::ConsumesCollector&& cc);
+  static edm::ParameterSetDescription makePSetDescription();
+  void bookHists(DQMStore::IBooker& iBooker);
+  void fill(const trigger::TriggerEvent& trigEvt,
+	    const edm::Event& event,const edm::EventSetup& setup);
+
+private: 
+  //helper function, probably should go in a utilty class
+  static const trigger::Keys getKeys(const trigger::TriggerEvent& trigEvt,const std::string& filterName);
+  
+  VarRangeCutColl<trigger::TriggerObject> tagCuts_,probeCuts_;
+  FilterSelector tagFilters_;
+  std::string collName_;
+  std::string folderName_;
+  HistDefs histDefs_;
+  std::vector<ProbeData> probeHists_; 
+  GenericTriggerEventFlag evtTrigSel_;
+
+};
+
+
+#endif

--- a/DQM/HLTEvF/plugins/TrigObjTnPSource.cc
+++ b/DQM/HLTEvF/plugins/TrigObjTnPSource.cc
@@ -1,0 +1,66 @@
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+
+#include "TrigObjTnPHistColl.h"
+
+class TrigObjTnPSource : public DQMEDAnalyzer {
+public:
+  explicit TrigObjTnPSource(const edm::ParameterSet&);
+  ~TrigObjTnPSource() override = default;
+  TrigObjTnPSource(const TrigObjTnPSource&) = delete; 
+  TrigObjTnPSource& operator=(const TrigObjTnPSource&) = delete; 
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const & run, edm::EventSetup const & c) override;
+  void dqmBeginRun(edm::Run const& run, edm::EventSetup const& c) override{}
+
+private:
+  edm::EDGetTokenT<trigger::TriggerEvent> trigEvtToken_;
+  std::vector<TrigObjTnPHistColl> tnpHistColls_;
+  
+};
+
+TrigObjTnPSource::TrigObjTnPSource(const edm::ParameterSet& config):
+  trigEvtToken_(consumes<trigger::TriggerEvent>(config.getParameter<edm::InputTag>("triggerEvent")))
+{
+  auto histCollConfigs = config.getParameter<std::vector<edm::ParameterSet>>("histColls");
+  for(auto& histCollConfig : histCollConfigs) tnpHistColls_.emplace_back(TrigObjTnPHistColl(histCollConfig,consumesCollector()));
+    
+}
+
+
+void TrigObjTnPSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("triggerEvent", edm::InputTag("hltTriggerSummaryAOD"));
+  desc.addVPSet("histColls",
+		TrigObjTnPHistColl::makePSetDescription(),
+		std::vector<edm::ParameterSet>());  
+  descriptions.add("trigObjTnPSource",desc);
+}
+
+void TrigObjTnPSource::bookHistograms(DQMStore::IBooker& iBooker,const edm::Run& run,
+						 const edm::EventSetup& setup)
+{
+  for(auto& histColl : tnpHistColls_) histColl.bookHists(iBooker);
+}
+
+
+void TrigObjTnPSource::analyze(const edm::Event& event,const edm::EventSetup& setup)
+{
+  edm::Handle<trigger::TriggerEvent> trigEvtHandle;
+  event.getByToken(trigEvtToken_,trigEvtHandle);
+  for(auto& histColl: tnpHistColls_) histColl.fill(*trigEvtHandle,event,setup);
+}
+
+DEFINE_FWK_MODULE(TrigObjTnPSource);

--- a/DQM/HLTEvF/plugins/TrigObjTnPSource.cc
+++ b/DQM/HLTEvF/plugins/TrigObjTnPSource.cc
@@ -30,6 +30,8 @@ private:
   edm::EDGetTokenT<trigger::TriggerEvent> trigEvtToken_;
   edm::EDGetTokenT<edm::TriggerResults> trigResultsToken_;
   std::string hltProcess_;
+  //it would be more memory efficient to save this as a vector of TrigTnPHistColls and then use this to instance
+  //the TrigTnPHistColls for each run, something to do for the future
   std::vector<edm::ParameterSet> histCollConfigs_;
  
 };

--- a/DQM/HLTEvF/python/trigObjTnPSource_cfi.py
+++ b/DQM/HLTEvF/python/trigObjTnPSource_cfi.py
@@ -34,7 +34,7 @@ _phiEBHist = cms.PSet(
     )
 _phiEEHist = cms.PSet(
     nameSuffex = cms.string("_phiEE"),
-    titleSuffex = cms.string(" (Barrel);#phi [rad];mass [GeV]"),
+    titleSuffex = cms.string(" (Endcap);#phi [rad];mass [GeV]"),
     bins = cms.vdouble(-3.14,-1.57,0,1.57,3.14),
     filler = cms.PSet(var = cms.string("phi"),localCuts = cms.VPSet(_ecalEndcapEtaCut))
     )
@@ -45,8 +45,9 @@ _etaHist = cms.PSet(
     filler = cms.PSet(var = cms.string("eta"),localCuts = cms.VPSet())
     )
 
-trigObjTnPSource = cms.EDProducer('TrigObjTnPSource',
+trigObjTnPSource = cms.EDAnalyzer('TrigObjTnPSource',
   triggerEvent = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
+  triggerResults = cms.InputTag('TriggerResults','','HLT'),
   histColls = cms.VPSet(cms.PSet(
     tagCuts = cms.VPSet(_ecalBarrelEtaCut),
     probeCuts = cms.VPSet(_ecalEtaCut),
@@ -64,8 +65,9 @@ trigObjTnPSource = cms.EDProducer('TrigObjTnPSource',
     collName = cms.string("stdTag"),
     folderName = cms.string("HLT/EGM/TrigObjTnP"),
     evtTrigSel = cms.PSet(
-      hltInputTag = cms.InputTag('TriggerResults','','HLT'),
-      hltPaths = cms.vstring("HLT_Ele32_WPTight_Gsf_v*")
+      selectionStr = cms.string("HLT_Ele32_WPTight_Gsf_v*"),
+      isANDForExpandedPaths = cms.bool(False),
+      verbose = cms.int32(1)
     ),
     histDefs = cms.PSet(
       massBins = cms.vdouble(i for i in range(60,120+1)),

--- a/DQM/HLTEvF/python/trigObjTnPSource_cfi.py
+++ b/DQM/HLTEvF/python/trigObjTnPSource_cfi.py
@@ -1,0 +1,87 @@
+import FWCore.ParameterSet.Config as cms
+
+_ecalBarrelEtaCut = cms.PSet(
+    rangeVar = cms.string("eta"),
+    allowedRanges=cms.vstring("-1.4442:1.4442")
+    )
+_ecalEndcapEtaCut = cms.PSet(
+    rangeVar = cms.string("eta"),
+    allowedRanges=cms.vstring("-2.5:-1.556","1.556:2.5")
+    )
+
+_ecalEtaCut = cms.PSet(
+    rangeVar = cms.string("eta"),
+    allowedRanges=cms.vstring("-2.5:-1.556","-1.4442:1.4442","1.556:2.5")
+    )
+
+_ptEBHist = cms.PSet(
+    nameSuffex = cms.string("_ptEB"),
+    titleSuffex = cms.string(" (Barrel);p_{T} [GeV];mass [GeV]"),
+    bins = cms.vdouble(32,40,50,100),
+    filler = cms.PSet(var = cms.string("pt"),localCuts = cms.VPSet(_ecalBarrelEtaCut))
+    )
+_ptEEHist = cms.PSet(
+    nameSuffex = cms.string("_ptEE"),
+    titleSuffex = cms.string(" (Endcap);p_{T} [GeV];mass [GeV]"),
+    bins = cms.vdouble(32,40,50,100),
+    filler = cms.PSet(var = cms.string("pt"),localCuts = cms.VPSet(_ecalEndcapEtaCut))
+    )
+_phiEBHist = cms.PSet(
+    nameSuffex = cms.string("_phiEB"),
+    titleSuffex = cms.string(" (Barrel);#phi [rad];mass [GeV]"),
+    bins = cms.vdouble(-3.14,-1.57,0,1.57,3.14),
+    filler = cms.PSet(var = cms.string("phi"),localCuts = cms.VPSet(_ecalBarrelEtaCut))
+    )
+_phiEEHist = cms.PSet(
+    nameSuffex = cms.string("_phiEE"),
+    titleSuffex = cms.string(" (Barrel);#phi [rad];mass [GeV]"),
+    bins = cms.vdouble(-3.14,-1.57,0,1.57,3.14),
+    filler = cms.PSet(var = cms.string("phi"),localCuts = cms.VPSet(_ecalEndcapEtaCut))
+    )
+_etaHist = cms.PSet(
+    nameSuffex = cms.string("_eta"),
+    titleSuffex = cms.string(";#eta;mass [GeV]"),
+    bins = cms.vdouble(-2.5,-1.5,0,1.5,2.5),
+    filler = cms.PSet(var = cms.string("eta"),localCuts = cms.VPSet())
+    )
+
+trigObjTnPSource = cms.EDProducer('TrigObjTnPSource',
+  triggerEvent = cms.InputTag('hltTriggerSummaryAOD','','HLT'),
+  histColls = cms.VPSet(cms.PSet(
+    tagCuts = cms.VPSet(_ecalBarrelEtaCut),
+    probeCuts = cms.VPSet(_ecalEtaCut),
+    tagFilters = cms.PSet(
+      filterSets = cms.VPSet(
+        cms.PSet( 
+           filters = cms.vstring(
+             "hltEle32WPTightGsfTrackIsoFilter"
+           ),
+           isAND = cms.bool(False)
+        ),
+      ),
+      isAND = cms.bool(False)
+    ),
+    collName = cms.string("stdTag"),
+    folderName = cms.string("HLT/EGM/TrigObjTnP"),
+    evtTrigSel = cms.PSet(
+      hltInputTag = cms.InputTag('TriggerResults','','HLT'),
+      hltPaths = cms.vstring("HLT_Ele32_WPTight_Gsf_v*")
+    ),
+    histDefs = cms.PSet(
+      massBins = cms.vdouble(i for i in range(60,120+1)),
+      configs = cms.VPSet(_ptEBHist,_ptEEHist,_phiEBHist,_phiEEHist,_etaHist)
+    ),
+    probeFilters = cms.vstring("hltEG32L1SingleEGOrEtFilter",
+                               "hltEle32WPTightClusterShapeFilter",
+                               "hltEle32WPTightHEFilter",
+                               "hltEle32WPTightEcalIsoFilter",
+                               "hltEle32WPTightHcalIsoFilter",
+                               "hltEle32WPTightPixelMatchFilter",
+                               "hltEle32WPTightPMS2Filter",
+                               "hltEle32WPTightGsfOneOEMinusOneOPFilter",
+                               "hltEle32WPTightGsfMissingHitsFilter",
+                               "hltEle32WPTightGsfDetaFilter",
+                               "hltEle32WPTightGsfDphiFilter",
+                               "hltEle32WPTightGsfTrackIsoFilter")           
+  ))
+)

--- a/DQM/HLTEvF/test/trigObjTnPSource.py
+++ b/DQM/HLTEvF/test/trigObjTnPSource.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DQM")
+
+# DQM service
+process.load("DQMServices.Core.DQMStore_cfi")
+
+# MessageLogger
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing ('analysis') 
+options.register('dqmTag','/HLT/TrigObjTnpSource/All',options.multiplicity.singleton,options.varType.string," whether we are running on miniAOD or not")
+options.parseArguments()
+
+# Source
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring(options.inputFiles)
+)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.load("DQM.HLTEvF.trigObjTnPSource_cfi")
+
+process.load('DQMServices.Components.DQMFileSaver_cfi')
+process.dqmSaver.workflow = options.dqmTag
+
+process.endp = cms.EndPath( process.trigObjTnPSource + process.dqmSaver )

--- a/DQM/HLTEvF/test/trigObjTnPSource.py
+++ b/DQM/HLTEvF/test/trigObjTnPSource.py
@@ -8,17 +8,24 @@ process.load("DQMServices.Core.DQMStore_cfi")
 # MessageLogger
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-
+#process.MessageLogger.cerr.INFO.limit = 1000
 import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing ('analysis') 
 options.register('dqmTag','/HLT/TrigObjTnpSource/All',options.multiplicity.singleton,options.varType.string," whether we are running on miniAOD or not")
 options.parseArguments()
 
+
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool( True ),
+    numberOfThreads = cms.untracked.uint32( 4 ),
+    numberOfStreams = cms.untracked.uint32( 4 ),
+)
+
 # Source
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(options.inputFiles)
 )
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
 
 process.load("DQM.HLTEvF.trigObjTnPSource_cfi")
 

--- a/DQMOffline/Trigger/BuildFile.xml
+++ b/DQMOffline/Trigger/BuildFile.xml
@@ -31,4 +31,6 @@
 
 <use   name="root"/>
 <use   name="boost"/>
-<flags   EDM_PLUGIN="1"/>
+<export>
+  <lib   name="1"/>
+ </export>

--- a/DQMOffline/Trigger/interface/FunctionDefs.h
+++ b/DQMOffline/Trigger/interface/FunctionDefs.h
@@ -61,23 +61,12 @@ namespace hltdqm {
     }
     return varFunc;
   }
- 
-  
+
   template<>
-  std::function<float(const reco::GsfElectron&)> getUnaryFuncExtraFloat<reco::GsfElectron>(const std::string& varName){
-    std::function<float(const reco::GsfElectron&)> varFunc;
-    if(varName=="scEta") varFunc = scEtaFunc<reco::GsfElectron>;
-    else if(varName=="hOverE") varFunc = &reco::GsfElectron::hcalOverEcal;
-    return varFunc;
-  }
+  std::function<float(const reco::GsfElectron&)> getUnaryFuncExtraFloat<reco::GsfElectron>(const std::string& varName);
   template<>
-  std::function<float(const reco::Photon&)> getUnaryFuncExtraFloat<reco::Photon>(const std::string& varName){
-    std::function<float(const reco::Photon&)> varFunc;
-    if(varName=="scEta") varFunc = scEtaFunc<reco::Photon>;
-    else if(varName=="hOverE") varFunc = &reco::Photon::hadTowOverEm;
-    return varFunc;
-  }
-  
+  std::function<float(const reco::Photon&)> getUnaryFuncExtraFloat<reco::Photon>(const std::string& varName);
+
 }
 
 

--- a/DQMOffline/Trigger/plugins/BuildFile.xml
+++ b/DQMOffline/Trigger/plugins/BuildFile.xml
@@ -21,6 +21,7 @@
 <use   name="CommonTools/Utils"/>
 <use   name="CommonTools/TriggerUtils"/>
 <use   name="DataFormats/VertexReco"/>
+<use   name="DQMOffline/Trigger"/>
 <use   name="root"/>
 <use   name="roofit"/>
 <use   name="boost"/>

--- a/DQMOffline/Trigger/src/FunctionDefs.cc
+++ b/DQMOffline/Trigger/src/FunctionDefs.cc
@@ -1,0 +1,17 @@
+#include "DQMOffline/Trigger/interface/VarRangeCutColl.h"
+
+template<>
+std::function<float(const reco::GsfElectron&)> hltdqm::getUnaryFuncExtraFloat<reco::GsfElectron>(const std::string& varName){
+  std::function<float(const reco::GsfElectron&)> varFunc;
+  if(varName=="scEta") varFunc = scEtaFunc<reco::GsfElectron>;
+  else if(varName=="hOverE") varFunc = &reco::GsfElectron::hcalOverEcal;
+  return varFunc;
+}
+
+template<>
+std::function<float(const reco::Photon&)> hltdqm::getUnaryFuncExtraFloat<reco::Photon>(const std::string& varName){
+  std::function<float(const reco::Photon&)> varFunc;
+  if(varName=="scEta") varFunc = scEtaFunc<reco::Photon>;
+  else if(varName=="hOverE") varFunc = &reco::Photon::hadTowOverEm;
+  return varFunc;
+}

--- a/DQMOffline/Trigger/src/FunctionDefs.cc
+++ b/DQMOffline/Trigger/src/FunctionDefs.cc
@@ -1,4 +1,4 @@
-#include "DQMOffline/Trigger/interface/VarRangeCutColl.h"
+#include "DQMOffline/Trigger/interface/FunctionDefs.h"
 
 template<>
 std::function<float(const reco::GsfElectron&)> hltdqm::getUnaryFuncExtraFloat<reco::GsfElectron>(const std::string& varName){


### PR DESCRIPTION
Dear All,

This PR adds a DQM module which aims to monitor trigger efficiencies using only information calculated by the trigger.  In principle it is completely agnostic of the particle type, in practice it is probably only applicable to electrons. 

It is intended that this module is run as part of the HLT job, hence why its not include in any "DQM" sequence. Running in the HLT was seen as the optimal solution as 

1. it needs the full stats (excludes online DQM, express) 
1. it requires a short latency (excludes offline DQM)  
1. it has no need for any quantities calculated outside the HLT. 

This module just provides the source histograms. The client will be run outside of the CMSSW framework and will be maintained in a separate git repo.  The client will acquire the histograms via the DQM gui api. 

The goal of this DQM is to allow fast feedback of current E/gamma data taking efficiency with a latency of ~30-60mins from the fill ending. 

Finally, it is reasonable to ask, why bother? Two reasons. I am still paranoid about possible pixel issues causing efficiency losses and this will reduce the latency of finding them from <1 week> to <1 day>. More importantly, I want this up and running before the end of the Run so it doesn't get forgotten about for the start of RunIII where it will be extremely useful. 

We will need this running at P5 so expect backports to 10_2 and 10_1.

@Martin-Grunewald @silviodonato 