### PR TITLE
Implementation of the dual slope in the clusterizer for Phase2 IT 

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -236,8 +236,18 @@ def customiseForPR24339HybridFormatSiStripZS(process):
     return process  
 
 
+# Adding some parameters to the pixel clusterizer
+def customiseFor24329(process):
+    for producer in producers_by_type(process, "SiPixelClusterProducer"):
+        producer.AdcFullScaleStack = cms.int32(255)
+        producer.FirstStackLayer = cms.int32(5)
+        producer.ElectronPerADCGain = cms.double(135.)
+        producer.Phase2Calibration = cms.bool(False)
+        producer.Phase2ReadoutMode = cms.int32(-1)
+        producer.Phase2DigiBaseline = cms.double(1200.)
+        producer.Phase2KinkADC = cms.int32(8)
 
-
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
@@ -248,5 +258,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = customiseForPR24339HybridFormatSiStripZS(process)
     # process = customizeHLTForL3OIPR24267(process)
+
+    process = customiseFor24329(process)
 
     return process

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -88,10 +88,14 @@ PixelThresholdClusterizer::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<int>("ClusterThreshold_L1", 4000);
   desc.add<int>("ClusterThreshold", 4000);
   desc.add<int>("maxNumberOfClusters", -1);
+  desc.add<int>("AdcFullScaleStack", 255);
+  desc.add<int>("FirstStackLayer", 5);
+  desc.add<double>("ElectronPerADCGain", 135.);
   desc.add<bool>("Phase2Calibration", false);
   desc.add<int>("Phase2ReadoutMode", -1);
-  desc.add<double>("Phase2DigiBaseline", 0.);
-  descriptions.add("siPixelClusters", desc);
+  desc.add<double>("Phase2DigiBaseline", 1200.);
+  desc.add<int>("Phase2KinkADC", 8);
+  descriptions.add("siPixClusters", desc);
 }
 
 //----------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -261,13 +261,13 @@ void PixelThresholdClusterizer::copy_to_buffer( DigiIterator begin, DigiIterator
         const float pedestal = 0.; //
         electron[i] = int(adc * gain + pedestal);
         if (layer_>=theFirstStack_) {
-      if (theStackADC_==1&&adc==1) {
-        electron[i] = int(255*135); // Arbitrarily use overflow value.
-      }
-      if (theStackADC_>1&&theStackADC_!=255&&adc>=1){
-        const float gain = theElectronPerADCGain_; // default: 1 ADC = 135 electrons
-        electron[i] = int((adc-1) * gain * 255/float(theStackADC_-1));
-      }
+        if (theStackADC_==1&&adc==1) {
+          electron[i] = int(255*135); // Arbitrarily use overflow value.
+        }
+        if (theStackADC_>1&&theStackADC_!=255&&adc>=1){
+          const float gain = theElectronPerADCGain_; // default: 1 ADC = 135 electrons
+          electron[i] = int((adc-1) * gain * 255/float(theStackADC_-1));
+        }
         }
         ++i;
       }

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -56,7 +56,7 @@ PixelThresholdClusterizer::PixelThresholdClusterizer
     theFirstStack_( conf.exists("FirstStackLayer") ? conf.getParameter<int>("FirstStackLayer") : 5 ),
     theElectronPerADCGain_( conf.exists("ElectronPerADCGain") ? conf.getParameter<double>("ElectronPerADCGain") : 135. ),
     doPhase2Calibration( conf.exists("Phase2Calibration") ? conf.getParameter<bool>("Phase2Calibration") : false),
-    phase2ReadoutMethod( conf.exists("Phase2ReadoutMethod") ? conf.getParameter<int>("Phase2ReadoutMethod") : -1),
+    phase2ReadoutMode( conf.exists("Phase2ReadoutMode") ? conf.getParameter<int>("Phase2ReadoutMode") : -1),
     phase2DigiBaseline( conf.exists("Phase2DigiBaseline") ? conf.getParameter<double>("Phase2DigiBaseline") : 0.),
     phase2KinkADC( conf.exists("Phase2KinkADC") ? conf.getParameter<int>("Phase2KinkADC") : 8),
     theNumOfRows(0), theNumOfCols(0), detid_(0),
@@ -333,7 +333,7 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
   if (doPhase2Calibration) {
 
     const float gain = theElectronPerADCGain_;
-    int p2rm = (phase2ReadoutMethod < -1 ? -1 : phase2ReadoutMethod);
+    int p2rm = (phase2ReadoutMode < -1 ? -1 : phase2ReadoutMode);
     if (p2rm > 10) p2rm = 10;
     const int dualslopeparam = abs(p2rm);
     const int dualslope = int(dualslopeparam <= 1 ? 1. : pow(2, dualslopeparam-1));
@@ -346,7 +346,7 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
         electrons = int(adc * gain - 0.5 * gain * dualslope);
     }
 
-    if (phase2ReadoutMethod > 0) electrons += int(phase2DigiBaseline);
+    if (phase2ReadoutMode > 0) electrons += int(phase2DigiBaseline);
 
     return electrons;
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -339,16 +339,17 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
 
     const float gain = theElectronPerADCGain;
     int p2rm = (thePhase2ReadoutMode < -1 ? -1 : thePhase2ReadoutMode);
-    if (p2rm > 10) p2rm = 10;
-    const int dualslopeparam = abs(p2rm);
-    const int dualslope = int(dualslopeparam <= 1 ? 1. : pow(2, dualslopeparam-1));
 
     if (p2rm == -1) {
         electrons = int(adc * gain);
     }
     else {
-        if (adc < thePhase2KinkADC) electrons = int((adc - 0.5) * gain);
+        if (adc < thePhase2KinkADC) {
+            electrons = int((adc - 0.5) * gain);
+        }
         else {
+            const int dualslopeparam = (thePhase2ReadoutMode < 10 ? thePhase2ReadoutMode : 10);
+            const int dualslope = int(dualslopeparam <= 1 ? 1. : pow(2, dualslopeparam-1));
             adc -= (thePhase2KinkADC-1);
             adc *= dualslope;
             adc += (thePhase2KinkADC-1);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -87,7 +87,6 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
 
   //! Data storage
   SiPixelArrayBuffer               theBuffer;         // internal nrow * ncol matrix
-  bool                             bufferAlreadySet;  // status of the buffer array
   std::vector<SiPixelCluster::PixelPos>  theSeeds;          // cached seed pixels
   std::vector<SiPixelCluster>            theClusters;       // resulting clusters  
   
@@ -105,21 +104,20 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   const int theOffset;              // adc to electron conversion offset
   const int theOffset_L1;           // adc to electron conversion offset for Layer 1
 
-  const int   theStackADC_;          // The maximum ADC count for the stack layers
-  const int   theFirstStack_;        // The index of the first stack layer
-  const double theElectronPerADCGain_;  //  ADC to electrons conversion
+  const int   theStackADC;          // The maximum ADC count for the stack layers
+  const int   theFirstStack;        // The index of the first stack layer
+  const double theElectronPerADCGain;  //  ADC to electrons conversion
 
   const bool doPhase2Calibration;    // The ADC --> electrons calibration is for phase-2 tracker
-  const int  phase2ReadoutMode;      // Readout mode of the phase-2 IT digitizer
-  const double phase2DigiBaseline;   // Threshold above which digis are measured in the phase-2 IT
-  const int  phase2KinkADC;          // ADC count at which the kink in the dual slop kicks in
+  const int  thePhase2ReadoutMode;   // Readout mode of the phase-2 IT digitizer
+  const double thePhase2DigiBaseline;// Threshold above which digis are measured in the phase-2 IT
+  const int  thePhase2KinkADC;       // ADC count at which the kink in the dual slop kicks in
 
   //! Geometry-related information
   int  theNumOfRows;
   int  theNumOfCols;
-  uint32_t detid_;
-  int layer_;
-  bool dead_flag;
+  uint32_t theDetid;
+  int theLayer;
   const bool doMissCalibrate; // Use calibration or not
   const bool doSplitClusters;
   //! Private helper methods:

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -109,6 +109,11 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   const int   theFirstStack_;        // The index of the first stack layer
   const double theElectronPerADCGain_;  //  ADC to electrons conversion
 
+  const bool doPhase2Calibration;    // The ADC --> electrons calibration is for phase-2 tracker
+  const int  phase2ReadoutMethod;    // Readout mode of the phase-2 IT digitizer
+  const double phase2DigiBaseline;   // Threshold above which digis are measured in the phase-2 IT
+  const int  phase2KinkADC;          // ADC count at which the kink in the dual slop kicks in
+
   //! Geometry-related information
   int  theNumOfRows;
   int  theNumOfCols;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -110,7 +110,7 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   const double theElectronPerADCGain_;  //  ADC to electrons conversion
 
   const bool doPhase2Calibration;    // The ADC --> electrons calibration is for phase-2 tracker
-  const int  phase2ReadoutMethod;    // Readout mode of the phase-2 IT digitizer
+  const int  phase2ReadoutMode;      // Readout mode of the phase-2 IT digitizer
   const double phase2DigiBaseline;   // Threshold above which digis are measured in the phase-2 IT
   const int  phase2KinkADC;          // ADC count at which the kink in the dual slop kicks in
 

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -47,7 +47,7 @@ phase2_tracker.toModify(siPixelClusters, # FIXME
   src = cms.InputTag('simSiPixelDigis', "Pixel"),
   MissCalibrate = False,
   Phase2Calibration = cms.bool(True),
-  Phase2ReadoutMethod = cms.int32(1),
+  Phase2ReadoutMethod = cms.int32(-1),
   Phase2DigiBaseline = cms.double(1200.), 
   ElectronPerADCGain = cms.double(600.) # it can be changed to something else (e.g. 135e) if needed
 )

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -25,6 +25,13 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     ClusterThreshold_L1 = cms.int32(4000),
     # **************************************
     maxNumberOfClusters = cms.int32(-1), # -1 means no limit.
+    ElectronPerADCGain = cms.double(135.0),
+    AdcFullScaleStack = cms.int32(255),
+    FirstStackLayer = cms.int32(5),
+    Phase2Calibration = cms.bool(False),
+    Phase2ReadoutMode = cms.int32(-1),
+    Phase2DigiBaseline = cms.double(1200.),
+    Phase2KinkADC = cms.int32(8),
 )
 
 # phase1 pixel

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -47,7 +47,7 @@ phase2_tracker.toModify(siPixelClusters, # FIXME
   src = cms.InputTag('simSiPixelDigis', "Pixel"),
   MissCalibrate = False,
   Phase2Calibration = cms.bool(True),
-  Phase2ReadoutMethod = cms.int32(1),
+  Phase2ReadoutMode = cms.int32(-1), # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction
   Phase2DigiBaseline = cms.double(1200.), 
   ElectronPerADCGain = cms.double(600.) # it can be changed to something else (e.g. 135e) if needed
 )

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -46,6 +46,9 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(siPixelClusters, # FIXME
   src = cms.InputTag('simSiPixelDigis', "Pixel"),
   MissCalibrate = False,
+  Phase2Calibration = cms.bool(True),
+  Phase2ReadoutMethod = cms.int32(1),
+  Phase2DigiBaseline = cms.double(1200.), 
   ElectronPerADCGain = cms.double(600.) # it can be changed to something else (e.g. 135e) if needed
 )
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -56,6 +56,7 @@ phase2_tracker.toModify(siPixelClusters, # FIXME
   Phase2Calibration = cms.bool(True),
   Phase2ReadoutMode = cms.int32(-1), # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction
   Phase2DigiBaseline = cms.double(1200.), 
+  Phase2KinkADC = cms.int32(8),
   ElectronPerADCGain = cms.double(600.) # it can be changed to something else (e.g. 135e) if needed
 )
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -47,7 +47,7 @@ phase2_tracker.toModify(siPixelClusters, # FIXME
   src = cms.InputTag('simSiPixelDigis', "Pixel"),
   MissCalibrate = False,
   Phase2Calibration = cms.bool(True),
-  Phase2ReadoutMethod = cms.int32(-1),
+  Phase2ReadoutMethod = cms.int32(1),
   Phase2DigiBaseline = cms.double(1200.), 
   ElectronPerADCGain = cms.double(600.) # it can be changed to something else (e.g. 135e) if needed
 )


### PR DESCRIPTION
The dual slope feature in the phase2 inner tracker digitizer has been implemented in the clusterizer code. Studies of this implementation have been reported in several presentation within the Tracker DPG. 

https://indico.cern.ch/event/688846/
https://indico.cern.ch/event/688869/

Note that a corresponding PR for the implementation of the dual slope in the digitizer code has also been submitted : 
https://github.com/cms-sw/cmssw/pull/24325

These are to be taken together. 

People closely following these developments are : 
@suchandradutta , @emiglior , @boudoul 