### PR TITLE
Change mask to be an unsigned long long to avoid compiler warning

### DIFF
--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModule.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModule.h
@@ -75,6 +75,6 @@ class SiPixelRawDataErrorModule {
   static const int LINK_bits,  ROC_bits,  DCOL_bits,  PXID_bits,  ADC_bits, DataBit_bits, TRLRBGN_bits, EVTLGT_bits, TRLREND_bits;
   static const int LINK_shift, ROC_shift, DCOL_shift, PXID_shift, ADC_shift, DB0_shift, DB1_shift, DB2_shift, DB3_shift, DB4_shift, DB5_shift, DB6_shift, DB7_shift, TRLRBGN_shift, EVTLGT_shift, TRLREND_shift;
   static const uint32_t LINK_mask, ROC_mask, DCOL_mask, PXID_mask, ADC_mask, DataBit_mask;
-  static const long long TRLRBGN_mask, EVTLGT_mask, TRLREND_mask;
+  static const unsigned long long TRLRBGN_mask, EVTLGT_mask, TRLREND_mask;
 };
 #endif

--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorModule.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorModule.cc
@@ -57,9 +57,9 @@ const int SiPixelRawDataErrorModule::TRLRBGN_shift = 0;
 const int SiPixelRawDataErrorModule::EVTLGT_shift  = TRLRBGN_shift + TRLRBGN_bits;
 const int SiPixelRawDataErrorModule::TRLREND_shift = EVTLGT_shift + EVTLGT_bits;
  
-const long long SiPixelRawDataErrorModule::TRLREND_mask = ~(~(long long)(0) << TRLREND_bits);
-const long long SiPixelRawDataErrorModule::EVTLGT_mask  = ~(~(long long)(0) << EVTLGT_bits);
-const long long SiPixelRawDataErrorModule::TRLRBGN_mask = ~(~(long long)(0) << TRLRBGN_bits);
+const unsigned long long SiPixelRawDataErrorModule::TRLREND_mask = ~(~0ULL << TRLREND_bits);
+const unsigned long long SiPixelRawDataErrorModule::EVTLGT_mask  = ~(~0ULL << EVTLGT_bits);
+const unsigned long long SiPixelRawDataErrorModule::TRLRBGN_mask = ~(~0ULL << TRLRBGN_bits);
 //
 // Constructors
 //


### PR DESCRIPTION
The clang compiler warned that doing bit shift operations on a
signed type is undefined.