### PR TITLE
Phase2-hgx140 Change the ieta field to radius field for scintillator part

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
@@ -7,7 +7,7 @@
 
 /* \brief description of the bit assigment
    [0:8]   iphi index wrt x-axis on +z side
-   [9:16]  |ieta| index (starting from |etamin|)
+   [9:16]  |radius| index (starting from a minimum radius depending on type)
    [17:21] Layer #
    [22:24] Reserved for future extension
    [25:25] z-side (0 for +z; 1 for -z)
@@ -25,14 +25,14 @@ public:
   /** Create cellid from raw id (0=invalid tower id) */
   HGCScintillatorDetId(uint32_t rawid);
   /** Constructor from subdetector, zplus, layer, module, cell numbers */
-  HGCScintillatorDetId(int type, int layer, int ieta, int iphi);
+  HGCScintillatorDetId(int type, int layer, int iradius, int iphi);
   /** Constructor from a generic cell id */
   HGCScintillatorDetId(const DetId& id);
   /** Assignment from a generic cell id */
   HGCScintillatorDetId& operator=(const DetId& id);
   
   /** Converter for a geometry cell id */
-  HGCScintillatorDetId geometryCell () const {return HGCScintillatorDetId (0, layer(), ieta(), iphi());}
+  HGCScintillatorDetId geometryCell () const {return HGCScintillatorDetId (0, layer(), iradius(), iphi());}
 
   /// get the subdetector
   DetId::Detector subdet() const { return det(); }
@@ -47,12 +47,15 @@ public:
   int layer() const { return (id_>>kHGCalLayerOffset)&kHGCalLayerMask; }
 
   /// get the eta index
-  int ietaAbs() const { return (id_>>kHGCalEtaOffset)&kHGCalEtaMask; }
-  int ieta()    const { return zside()*ietaAbs(); }
+  int iradiusAbs() const { return (id_>>kHGCalRadiusOffset)&kHGCalRadiusMask; }
+  int iradius()    const { return zside()*iradiusAbs(); }
+  int ietaAbs()    const { return (id_>>kHGCalRadiusOffset)&kHGCalRadiusMask; }
+  int ieta()       const { return zside()*ietaAbs(); }
 
   /// get the phi index
   int iphi() const { return (id_>>kHGCalPhiOffset)&kHGCalPhiMask; }
   std::pair<int,int> ietaphi() const { return std::pair<int,int>(ieta(),iphi()); }
+  std::pair<int,int> iradiusphi() const { return std::pair<int,int>(iradius(),iphi()); }
 
   /// consistency check : no bits left => no overhead
   bool isEE()      const { return false; }
@@ -65,8 +68,8 @@ private:
 
   static const int kHGCalPhiOffset      = 0;
   static const int kHGCalPhiMask        = 0x1FF;
-  static const int kHGCalEtaOffset      = 9;
-  static const int kHGCalEtaMask        = 0xFF;
+  static const int kHGCalRadiusOffset   = 9;
+  static const int kHGCalRadiusMask     = 0xFF;
   static const int kHGCalLayerOffset    = 17;
   static const int kHGCalLayerMask      = 0x1F;
   static const int kHGCalZsideOffset    = 25;

--- a/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
@@ -11,15 +11,15 @@ HGCScintillatorDetId::HGCScintillatorDetId() : DetId() {
 HGCScintillatorDetId::HGCScintillatorDetId(uint32_t rawid) : DetId(rawid) {
 }
 
-HGCScintillatorDetId::HGCScintillatorDetId(int type, int layer, int eta,
+HGCScintillatorDetId::HGCScintillatorDetId(int type, int layer, int radius,
 					   int phi) : DetId(HGCalHSc,ForwardEmpty) {
 
-  int zside      = (eta < 0) ? 1 : 0;
-  int etaAbs     = std::abs(eta);
+  int zside      = (radius < 0) ? 1 : 0;
+  int radiusAbs  = std::abs(radius);
   id_ |= (((type&kHGCalTypeMask)<<kHGCalTypeOffset) | 
 	  ((zside&kHGCalZsideMask)<<kHGCalZsideOffset) |
 	  ((layer&kHGCalLayerMask)<<kHGCalLayerOffset) |
-	  ((etaAbs&kHGCalEtaMask)<<kHGCalEtaOffset) |
+	  ((radiusAbs&kHGCalRadiusMask)<<kHGCalRadiusOffset) |
 	  ((phi&kHGCalPhiMask)<<kHGCalPhiOffset));
 }
 
@@ -45,7 +45,5 @@ HGCScintillatorDetId& HGCScintillatorDetId::operator=(const DetId& gen) {
 std::ostream& operator<<(std::ostream& s,const HGCScintillatorDetId& id) {
   return s << " EE:HE= " << id.isEE() << ":" << id.isHE()
 	   << " type= " << id.type()  << " layer= " << id.layer() 
-	   << " eta= "  << id.ieta() << " phi= " << id.iphi();
+	   << " radius= "  << id.iradius() << " phi= " << id.iphi();
 }
-
-


### PR DESCRIPTION
Maintain the ieta() method to keep up backward compatibility. But it is better to remove this in future after verifying the downstream codes.