### PR TITLE
Fix invalid PF jet collection for L1T offline jets and sums DQM - 102x

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
@@ -173,3 +173,17 @@ l1tEtSumJetOfflineDQMEmu = l1tEtSumJetOfflineDQM.clone(
     histFolderEtSum=cms.string('L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco'),
     histFolderJet=cms.string('L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco'),
 )
+
+# sequences
+l1tEtSumJetOfflineDQMSeq = cms.Sequence(
+    goodPFJetsForL1T
+    + l1tPFMetNoMuForDQM
+    + l1tEtSumJetOfflineDQM
+)
+
+l1tEtSumJetOfflineDQMEmuSeq = cms.Sequence(
+    goodPFJetsForL1T
+    + l1tPFMetNoMuForDQM
+    + l1tEtSumJetOfflineDQMEmu
+)
+

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -338,7 +338,7 @@ Stage2l1tEgOffline = cms.Sequence(
 
 # sequence to run only for modules requiring a muon dataset
 Stage2l1tMuonOffline = cms.Sequence(
-                                l1tEtSumJetOfflineDQM *
+                                l1tEtSumJetOfflineDQMSeq *
                                 l1tTauOfflineDQM *
                                 l1tMuonDQMOffline
                                 )
@@ -367,7 +367,7 @@ Stage2l1tEgEmulatorOffline = cms.Sequence(
 
 # sequence to run only for modules requiring a muon dataset
 Stage2l1tMuonEmulatorOffline = cms.Sequence(
-                                #l1tEtSumJetOfflineDQMEmu +
+                                #l1tEtSumJetOfflineDQMEmuSeq +
                                 #l1tTauOfflineDQMEmu
                                 )
 


### PR DESCRIPTION
backport of #24333 

This PR fixes the empty efficiency and resolution plots for L1T jets and ET sums in the offline DQM.
The plots were empty since the move to the 10_2 release.