### PR TITLE
VBF & HWJ gridpack patch

### DIFF
--- a/Configuration/Generator/python/VBFToH_Pow_JHU4l_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/VBFToH_Pow_JHU4l_LHE_13TeV_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 # https://github.com/cms-sw/genproductions/blob/060e6d3363a78ecfae90f7f5c46c968992820a56/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/VBFH/VBF_H_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_VBF_new.tgz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/VBFH/VBF_H_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_VBF_new_reducedPdf.tgz'),
     nEvents = cms.untracked.uint32(1000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/VHToH_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/VHToH_Pow_LHE_13TeV_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # https://github.com/cms-sw/genproductions/blob/329fda9f8d07c2d4d4e75c9a00279dcd6e78cda7/bin/Powheg/production/VH_from_Hbb/HWplusJ_HanythingJ_NNPDF30_13TeV_M125.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/VH/HWJ_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_VH_new.tgz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/VH/HWJ_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_VH_new_reducedPdf.tgz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),


### PR DESCRIPTION
Backport of #24208, in a response of JIRA ticket [CMSCOMPPR-3394](https://its.cern.ch/jira/browse/CMSCOMPPR-3394) to resolve using too much wall clock time issue in possible future relval sample production using 10_2_X.