### PR TITLE
Fix pfpu assomap construction

### DIFF
--- a/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
@@ -100,7 +100,7 @@ class PF_PU_AssoMapAlgos{
    std::auto_ptr<VertexToTrackAssMap> CreateVertexToTrackMap(edm::Handle<reco::TrackCollection>, const edm::EventSetup&);
 
    //function to sort the vertices in the AssociationMap by the sum of (pT - pT_Error)**2
-   std::unique_ptr<TrackToVertexAssMap> SortAssociationMap(TrackToVertexAssMap*);
+   std::unique_ptr<TrackToVertexAssMap> SortAssociationMap(TrackToVertexAssMap*,edm::Handle<reco::TrackCollection>);
 
  protected:
   //protected functions

--- a/CommonTools/RecoUtils/plugins/PF_PU_AssoMap.cc
+++ b/CommonTools/RecoUtils/plugins/PF_PU_AssoMap.cc
@@ -87,7 +87,7 @@ PF_PU_AssoMap::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 	if ( ( asstype == "TracksToVertex" ) || ( asstype == "Both" ) ) {
 	  unique_ptr<TrackToVertexAssMap> Track2Vertex = CreateTrackToVertexMap(trkcollH, iSetup);
-  	  iEvent.put( SortAssociationMap( &(*Track2Vertex) ) );
+  	  iEvent.put( SortAssociationMap( &(*Track2Vertex) , trkcollH ) );
 	}
 
 	if ( ( asstype == "VertexToTracks" ) || ( asstype == "Both" ) ) {

--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -210,10 +210,12 @@ PF_PU_AssoMapAlgos::CreateVertexToTrackMap(edm::Handle<reco::TrackCollection> tr
 /*****************************************************************************************/
 
 unique_ptr<TrackToVertexAssMap>
-PF_PU_AssoMapAlgos::SortAssociationMap(TrackToVertexAssMap* trackvertexassInput)
+PF_PU_AssoMapAlgos::SortAssociationMap(TrackToVertexAssMap* trackvertexassInput, edm::Handle<reco::TrackCollection> trkcollH)
 {
 	//create a new TrackVertexAssMap for the Output which will be sorted
-	unique_ptr<TrackToVertexAssMap> trackvertexassOutput(new TrackToVertexAssMap() );
+	std::cout<<"blah blah blah blah"<<std::endl;
+	//unique_ptr<TrackToVertexAssMap> trackvertexassOutput(new TrackToVertexAssMap() );
+	unique_ptr<TrackToVertexAssMap> trackvertexassOutput(new TrackToVertexAssMap(vtxcollH, trkcollH));
 
 	//Create and fill a vector of pairs of vertex and the summed (pT-pT_Error)**2 of the tracks associated to the vertex
 	VertexPtsumVector vertexptsumvector;

--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -213,8 +213,6 @@ unique_ptr<TrackToVertexAssMap>
 PF_PU_AssoMapAlgos::SortAssociationMap(TrackToVertexAssMap* trackvertexassInput, edm::Handle<reco::TrackCollection> trkcollH)
 {
 	//create a new TrackVertexAssMap for the Output which will be sorted
-	std::cout<<"blah blah blah blah"<<std::endl;
-	//unique_ptr<TrackToVertexAssMap> trackvertexassOutput(new TrackToVertexAssMap() );
 	unique_ptr<TrackToVertexAssMap> trackvertexassOutput(new TrackToVertexAssMap(vtxcollH, trkcollH));
 
 	//Create and fill a vector of pairs of vertex and the summed (pT-pT_Error)**2 of the tracks associated to the vertex


### PR DESCRIPTION
Update constructor to work for > CMSSW_7_5_X. Before fix one would obtain a runtime error [1].

[1] Begin processing the 2nd record. Run 319347, Event 31972000, LumiSection 43 on stream 0 at 10-Aug-2018 16:57:16.339 CEST
----- Begin Fatal Exception 10-Aug-2018 16:57:17 CEST-----------------------
An exception of category 'LogicError' occurred while
 [0] Processing  Event run: 319347 lumi: 43 event: 31972000 stream: 0
 [1] Running path 'all'
 [2] Calling method for module PF_PU_AssoMap/'Tracks2Vertex'
Exception Message:
Can't insert into AssociationMap unless it was properly initialized.
The most common fix for this is to add arguments to the call to the
AssociationMap constructor that are valid Handle's to the containers.
If you don't have valid handles or either template parameter to the
AssociationMap is a View, then see the comments in AssociationMap.h.
(note this was a new requirement added in the 7_5_X release series)