### PR TITLE
Extend DQMGlobalEDAnalyzer to allow additional template options

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
@@ -10,6 +10,8 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include <numeric>
@@ -24,78 +26,65 @@ using namespace edm;
 //
 // constructors and destructor
 //
-BeamConditionsMonitor::BeamConditionsMonitor( const ParameterSet& ps ) :
-  countEvt_(0),countLumi_(0) {
+BeamConditionsMonitor::BeamConditionsMonitor( const ParameterSet& ps ):
+  bsSrc_{ps.getUntrackedParameter<InputTag>("beamSpot")}
 
-  parameters_     = ps;
-  monitorName_    = parameters_.getUntrackedParameter<string>("monitorName","YourSubsystemName");
-  bsSrc_          = parameters_.getUntrackedParameter<InputTag>("beamSpot");
-  debug_          = parameters_.getUntrackedParameter<bool>("Debug");
-  
-  dbe_            = Service<DQMStore>().operator->();
+  {
+
+  monitorName_    = ps.getUntrackedParameter<string>("monitorName","YourSubsystemName");
   
   if (monitorName_ != "" ) monitorName_ = monitorName_+"/" ;
 }
 
 
-BeamConditionsMonitor::~BeamConditionsMonitor() {
-}
-
-
 //--------------------------------------------------------
-void BeamConditionsMonitor::beginJob() {
+void BeamConditionsMonitor::bookHistograms(DQMStore::ConcurrentBooker& i, const edm::Run& r, const edm::EventSetup& c, 
+                                           beamcond::RunCache& cache) const {
   
   // book some histograms here
   // create and cd into new folder
-  dbe_->setCurrentFolder(monitorName_+"Conditions");
+  i.setCurrentFolder(monitorName_+"Conditions");
   
-  h_x0_lumi = dbe_->book1D("x0_lumi_cond","x coordinate of beam spot vs lumi (Cond)",10,0,10);
-  h_x0_lumi->setAxisTitle("Lumisection",1);
-  h_x0_lumi->setAxisTitle("x_{0} (cm)",2);
-  h_x0_lumi->getTH1()->SetOption("E1");
+  cache.h_x0_lumi = i.book1D("x0_lumi_cond","x coordinate of beam spot vs lumi (Cond)",10,0,10);
+  cache.h_x0_lumi.setAxisTitle("Lumisection",1);
+  cache.h_x0_lumi.setAxisTitle("x_{0} (cm)",2);
+  cache.h_x0_lumi.setOption("E1");
 
-  h_y0_lumi = dbe_->book1D("y0_lumi_cond","y coordinate of beam spot vs lumi (Cond)",10,0,10);
-  h_y0_lumi->setAxisTitle("Lumisection",1);
-  h_y0_lumi->setAxisTitle("y_{0} (cm)",2);
-  h_y0_lumi->getTH1()->SetOption("E1");
+  cache.h_y0_lumi = i.book1D("y0_lumi_cond","y coordinate of beam spot vs lumi (Cond)",10,0,10);
+  cache.h_y0_lumi.setAxisTitle("Lumisection",1);
+  cache.h_y0_lumi.setAxisTitle("y_{0} (cm)",2);
+  cache.h_y0_lumi.setOption("E1");
   
 }
 
-//--------------------------------------------------------
-void BeamConditionsMonitor::beginRun(const edm::Run& r, const EventSetup& context) {
-}
 
-//--------------------------------------------------------
-void BeamConditionsMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg,
-						 const EventSetup& context) {
-  countLumi_++;
+std::shared_ptr<void> 
+BeamConditionsMonitor::globalBeginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+                                                  const edm::EventSetup& c) const {
+  ESHandle< BeamSpotObjects > beamhandle;
+  c.get<BeamSpotObjectsRcd>().get(beamhandle);
+  auto const& condBeamSpot = *beamhandle;
+
+  auto cache = runCache(lumiSeg.getRun().index() );
+  LogInfo("BeamConditions") << "[BeamConditionsMonitor]:" << condBeamSpot << endl;
+  cache->h_x0_lumi.shiftFillLast( condBeamSpot.GetX(), condBeamSpot.GetXError(), 1 );
+  cache->h_y0_lumi.shiftFillLast( condBeamSpot.GetY(), condBeamSpot.GetYError(), 1 );
+
+  return std::shared_ptr<void>{};
 }
 
 // ----------------------------------------------------------
-void BeamConditionsMonitor::analyze(const Event& iEvent, const EventSetup& iSetup ) {
-
-  countEvt_++;  
-  ESHandle< BeamSpotObjects > beamhandle;
-  iSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
-  condBeamSpot = *beamhandle;
+void BeamConditionsMonitor::dqmAnalyze(const Event& iEvent, const EventSetup& iSetup, 
+                                       beamcond::RunCache const&) const {
 
 }
 
 
 //--------------------------------------------------------
-void BeamConditionsMonitor::endLuminosityBlock(const LuminosityBlock& lumiSeg, 
-					       const EventSetup& iSetup) {
+void BeamConditionsMonitor::globalEndLuminosityBlock(const LuminosityBlock& lumiSeg, 
+                                                     const EventSetup& iSetup) const {
 
-  LogInfo("BeamConditions") << "[BeamConditionsMonitor]:" << condBeamSpot << endl;
-  h_x0_lumi->ShiftFillLast( condBeamSpot.GetX(), condBeamSpot.GetXError(), 1 );
-  h_y0_lumi->ShiftFillLast( condBeamSpot.GetY(), condBeamSpot.GetYError(), 1 );
 
-}
-//--------------------------------------------------------
-void BeamConditionsMonitor::endRun(const Run& r, const EventSetup& context) {  
-}
-//--------------------------------------------------------
-void BeamConditionsMonitor::endJob() {
 }
 
 DEFINE_FWK_MODULE(BeamConditionsMonitor);

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
@@ -33,7 +33,7 @@ BeamConditionsMonitor::BeamConditionsMonitor( const ParameterSet& ps ):
 
   monitorName_    = ps.getUntrackedParameter<string>("monitorName","YourSubsystemName");
   
-  if (monitorName_ != "" ) monitorName_ = monitorName_+"/" ;
+  if (!monitorName_.empty() ) monitorName_ = monitorName_+"/" ;
 }
 
 

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
@@ -11,65 +11,45 @@
 #include <string>
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "DQMServices/Core/interface/ConcurrentMonitorElement.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 //
 // class declaration
 //
+namespace beamcond {
+  struct RunCache {
+    // MonitorElements
+    ConcurrentMonitorElement h_x0_lumi;
+    ConcurrentMonitorElement h_y0_lumi;
+  };
+};
 
-class BeamConditionsMonitor : public edm::EDAnalyzer {
+class BeamConditionsMonitor : public DQMGlobalEDAnalyzer<beamcond::RunCache, edm::LuminosityBlockCache<void>> {
  public:
   BeamConditionsMonitor( const edm::ParameterSet& );
-  ~BeamConditionsMonitor() override;
+  ~BeamConditionsMonitor() override = default;
 
  protected:
    
-  // BeginJob
-  void beginJob() override;
-
-  // BeginRun
-  void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
+  // Book Histograms
+  void bookHistograms(DQMStore::ConcurrentBooker& i, const edm::Run& r, const edm::EventSetup& c, beamcond::RunCache& ) const override;
   
   // Fake Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  void dqmAnalyze(const edm::Event& e, const edm::EventSetup& c, beamcond::RunCache const& ) const override;
   
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-			    const edm::EventSetup& context) override;
-  
-  // DQM Client Diagnostic
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-			  const edm::EventSetup& c) override;
-  
-  // EndRun
-  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
-  
-  // Endjob
-  void endJob() override;
-  
+  // DQM Client Diagnostic (come from edm::LuminosityBlockCache use)
+  std::shared_ptr<void> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+                                                   const edm::EventSetup& c) const override;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override;
+
  private:
   
-  edm::ParameterSet parameters_;
   std::string monitorName_;
-  edm::InputTag bsSrc_; // beam spot
-  bool debug_;
-  
-  DQMStore* dbe_;
-  
-  int countEvt_;      //counter
-  int countLumi_;      //counter
-  
-  // ----------member data ---------------------------
-  BeamSpotObjects condBeamSpot;
-  
-  // MonitorElements
-  MonitorElement * h_x0_lumi;
-  MonitorElement * h_y0_lumi;
+  const edm::InputTag bsSrc_; // beam spot
   
 };
 

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
@@ -15,7 +15,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/ConcurrentMonitorElement.h"
-#include "FWCore/Utilities/interface/propagate_const.h"
 
 //
 // class declaration

--- a/DQM/BeamMonitor/python/BeamConditionsMonitor_cff.py
+++ b/DQM/BeamMonitor/python/BeamConditionsMonitor_cff.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
-dqmBeamCondMonitor = DQMEDAnalyzer("BeamConditionsMonitor",
+dqmBeamCondMonitor = cms.EDAnalyzer("BeamConditionsMonitor",
                               monitorName = cms.untracked.string('BeamMonitor'),
                               beamSpot = cms.untracked.InputTag('offlineBeamSpot') ## hltOfflineBeamSpot for HLTMON
                               )

--- a/DQM/BeamMonitor/python/BeamConditionsMonitor_cff.py
+++ b/DQM/BeamMonitor/python/BeamConditionsMonitor_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
-dqmBeamCondMonitor = cms.EDAnalyzer("BeamConditionsMonitor",
+dqmBeamCondMonitor = DQMEDAnalyzer("BeamConditionsMonitor",
                               monitorName = cms.untracked.string('BeamMonitor'),
-                              beamSpot = cms.untracked.InputTag('offlineBeamSpot'), ## hltOfflineBeamSpot for HLTMON
-                              Debug = cms.untracked.bool(False)
+                              beamSpot = cms.untracked.InputTag('offlineBeamSpot') ## hltOfflineBeamSpot for HLTMON
                               )

--- a/DQMServices/Core/interface/ConcurrentMonitorElement.h
+++ b/DQMServices/Core/interface/ConcurrentMonitorElement.h
@@ -146,6 +146,10 @@ public:
     me_->getTH1()->GetXaxis()->SetNoAlphanumeric(false);
     me_->getTH1()->GetYaxis()->SetNoAlphanumeric(false);
   }
+
+  void setOption(const char* option) {
+    me_->getTH1()->SetOption(option);
+  }
 };
 
 #endif // DQMServices_Core_ConcurrentMonitorElement_h

--- a/DQMServices/Core/interface/DQMGlobalEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMGlobalEDAnalyzer.h
@@ -7,8 +7,8 @@
 #include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-template <typename H>
-class DQMGlobalEDAnalyzer : public edm::global::EDAnalyzer<edm::RunCache<H>>
+template <typename H, typename... Args>
+class DQMGlobalEDAnalyzer : public edm::global::EDAnalyzer<edm::RunCache<H>, Args...>
 {
 private:
   std::shared_ptr<H>
@@ -31,9 +31,9 @@ private:
   dqmAnalyze(edm::Event const&, edm::EventSetup const&, H const&) const = 0;
 };
 
-template <typename H>
+template <typename H, typename... Args>
 std::shared_ptr<H>
-DQMGlobalEDAnalyzer<H>::globalBeginRun(edm::Run const& run, edm::EventSetup const& setup) const
+DQMGlobalEDAnalyzer<H, Args...>::globalBeginRun(edm::Run const& run, edm::EventSetup const& setup) const
 {
   auto h = std::make_shared<H>();
   dqmBeginRun(run, setup, *h);
@@ -46,15 +46,15 @@ DQMGlobalEDAnalyzer<H>::globalBeginRun(edm::Run const& run, edm::EventSetup cons
   return h;
 }
 
-template <typename H>
+template <typename H, typename... Args>
 void
-DQMGlobalEDAnalyzer<H>::globalEndRun(edm::Run const&, edm::EventSetup const&) const
+DQMGlobalEDAnalyzer<H, Args...>::globalEndRun(edm::Run const&, edm::EventSetup const&) const
 {
 }
 
-template <typename H>
+template <typename H, typename... Args>
 void
-DQMGlobalEDAnalyzer<H>::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const
+DQMGlobalEDAnalyzer<H, Args...>::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const
 {
   //auto& h = const_cast<H&>(* this->runCache(event.getRun().index()));
   auto const& h = * this->runCache(event.getRun().index());


### PR DESCRIPTION
The BeamConditionsMonitor module was a prime candidate to become a DQMGlobalEDAnalyzer. To make that happen, the module wanted to see the beginLuminosityBlock callback from the framework. This required the use of the edm::LuminosityBlockCache<> option. This could be accomodated by a simple extension to DQMGlobalEDAnalyzer to allow addition template arguments to be passed on to the base class.