### PR TITLE
Prepare CSCGeometryESModule for concurrent IOVs 

### DIFF
--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -87,6 +87,7 @@ recordsWithALooperProxy_(new std::set<EventSetupRecordKey>)
 
 EventSetupProvider::~EventSetupProvider()
 {
+  forceCacheClear();
 }
 
 //

--- a/Geometry/CSCGeometry/interface/CSCGeometry.h
+++ b/Geometry/CSCGeometry/interface/CSCGeometry.h
@@ -44,6 +44,9 @@ class CSCGeometry : public TrackingGeometry {
   /// Destructor
   ~CSCGeometry() override;
 
+  // Clear containers and deallocate managed memory
+  void clear();
+
   //---- Base class' interface
 
   // Return a vector of all det types
@@ -133,7 +136,18 @@ class CSCGeometry : public TrackingGeometry {
   /// Dump parameters for overall strip and wire modelling
   void queryModelling() const;
 
+  unsigned long long muonNumberingCacheID() const { return muonNumberingCacheID_; }
+  unsigned long long geometryCacheID() const { return geometryCacheID_; }
+  unsigned long long digiParametersCacheID() const { return digiParametersCacheID_; }
+
+  void setMuonNumberingCacheID(unsigned long long v) { muonNumberingCacheID_ = v; }
+  void setGeometryCacheID(unsigned long long v) { geometryCacheID_ = v; }
+  void setDigiParametersCacheID(unsigned long long v) { digiParametersCacheID_ = v; }
+
  private:
+
+  // deallocate managed memory
+  void deallocate();
 
   /// Add a chamber with given DetId.
   void addChamber(CSCChamber* ch);
@@ -179,7 +193,9 @@ class CSCGeometry : public TrackingGeometry {
   // Store pointers to Specs objects as we build them.
   CSCSpecsContainer specsContainer;
 
+  unsigned long long muonNumberingCacheID_ = 0;
+  unsigned long long geometryCacheID_ = 0;
+  unsigned long long digiParametersCacheID_ = 0;
 };
 
 #endif
-

--- a/Geometry/CSCGeometry/src/CSCGeometry.cc
+++ b/Geometry/CSCGeometry/src/CSCGeometry.cc
@@ -19,7 +19,24 @@ CSCGeometry::CSCGeometry( bool dbgv, bool gangedstripsME1a, bool onlywiresME1a, 
 }
 
 CSCGeometry::~CSCGeometry(){
+  deallocate();
+}
 
+void CSCGeometry::clear() {
+  deallocate();
+
+  theChambers.clear();
+  theMap.clear();
+  theDetTypes.clear();
+  theDets.clear();
+  theDetUnits.clear();
+  theDetIds.clear();
+  theDetUnitIds.clear();
+  theLayers.clear();
+  specsContainer.clear();
+}
+
+void CSCGeometry::deallocate() {
   // delete all the chambers (which will delete the layers)
   for (ChamberContainer::const_iterator ich=theChambers.begin();
        ich!=theChambers.end(); ++ich) delete (*ich);
@@ -29,9 +46,7 @@ CSCGeometry::~CSCGeometry(){
 	   specsContainer.begin(); it!=specsContainer.end(); ++it) {
     delete (*it).second; // they are never shared per chamber type so should be no possible double deletion.
   }
-
-}  
-
+}
 
 void CSCGeometry::addChamber(CSCChamber* ch){
   theChambers.emplace_back(ch);

--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
@@ -10,6 +10,7 @@
 
 #include <FWCore/Framework/interface/ESProducer.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 #include <Geometry/CSCGeometry/interface/CSCGeometry.h>
 
@@ -29,14 +30,9 @@ public:
 
 private:  
 
-  /// Called when geometry description changes
-  void muonNumberingChanged_( const MuonNumberingRecord& );
-  void cscRecoGeometryChanged_( const CSCRecoGeometryRcd& );
-  void cscRecoDigiParametersChanged_( const CSCRecoDigiParametersRcd& );
+  void initCSCGeometry_(const MuonGeometryRecord&, std::shared_ptr<CSCGeometry>&);
 
-  void initCSCGeometry_(const MuonGeometryRecord& );
-  std::shared_ptr<CSCGeometry> cscGeometry;
-  bool recreateGeometry_;
+  edm::ReusableObjectHolder<CSCGeometry> cscGeometryHolder_;
 
   // Flags for controlling geometry modelling during build of CSCGeometry
   bool useRealWireGeometry;
@@ -48,12 +44,5 @@ private:
   bool useDDD_; // whether to build from DDD or DB
   const std::string alignmentsLabel_;
   const std::string myLabel_;
-
 };
 #endif
-
-
-
-
-
-


### PR DESCRIPTION
Main issue is replacing the shared_ptr data member
and its usage. Multiple threads cannot access the same
one concurrently.

Also add Framework change to clear the caches before
destroying the EventSetupProvider.
