### PR TITLE
L1T DQM - Add uGT board comparison quality tests - 102x

### DIFF
--- a/DQM/L1TMonitorClient/data/L1TStage2uGTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGTQualityTests.xml
@@ -2,7 +2,20 @@
 
   <!-- uGT Muon Quality Tests -->
 
-  <!-- uGT Mismatch Summary QTest -->
+  <!-- uGT Board 2-6 Comparisons -->
+
+  <QTEST name="uGTBoardComparison_MismatchRatioMax0">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+
+  <LINK name="*/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard*/*/mismatchRatio">
+      <TestName activate="true">uGTBoardComparison_MismatchRatioMax0</TestName>
+  </LINK>
 
   <!-- Calo Layer2 Output uGT Input -->
 
@@ -14,7 +27,7 @@
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
-  
+
   <LINK name="*/L1TStage2uGT/calol2ouput_vs_uGTinput/mismatchRatio">
     <TestName activate="true">caloLayer2vsuGT_MismatchRatioMax0</TestName>
   </LINK>
@@ -30,7 +43,7 @@
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
-  
+
   <LINK name="*/L1TStage2uGT/uGMToutput_vs_uGTinput/mismatchRatio">
       <TestName activate="true">uGMTvsuGT_MismatchRatioMax0</TestName>
   </LINK>

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -339,6 +339,56 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard2/CaloLayer2/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/CaloLayer2/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/CaloLayer2/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/CaloLayer2/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/CaloLayer2/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard2/Muons/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/Muons/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/Muons/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/Muons/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGTBoardComparison_MismatchRatioMax0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/Muons/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
                                 QualityTestName = cms.string("uGMTvsuGT_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGT/uGMToutput_vs_uGTinput/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)


### PR DESCRIPTION
backport of #24352 

Add uGT board 2-6 comparison quality tests to the L1T online DQM.