### PR TITLE
GEM strip definition change

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMDigi.h
@@ -22,7 +22,7 @@ public:
   bool operator!=(const GEMDigi& digi) const;
   bool operator<(const GEMDigi& digi) const;
 
-  // return the strip number. counts from 1.
+  // return the strip number. counts from 0.
   int strip() const { return strip_; }
   int bx() const {return bx_; }
 

--- a/DataFormats/GEMDigi/interface/GEMPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigi.h
@@ -23,7 +23,7 @@ public:
   bool operator<(const GEMPadDigi& digi) const;
   bool isValid() const;
 
-  // return the pad number. counts from 1.
+  // return the pad number. counts from 0.
   int pad() const { return pad_; }
   int bx() const { return bx_; }
 

--- a/Geometry/GEMGeometry/interface/GEMEtaPartition.h
+++ b/Geometry/GEMGeometry/interface/GEMEtaPartition.h
@@ -55,14 +55,14 @@ public:
   int npads() const;
 
   /// returns center of pad position for INTEGER pad number
-  /// that has a value range of [1, npads]
+  /// that has a value range of [0, npads-1]
   LocalPoint  centreOfPad(int pad) const;
 
   /// returns center of pad position for FRACTIONAL pad number
-  /// that has a value range of [0., npads]
+  /// that has a value range of [0., npads)
   LocalPoint  centreOfPad(float pad) const;
 
-  /// returns FRACTIONAL pad number [0.,npads] for a point
+  /// returns FRACTIONAL pad number [0.,npads) for a point
   float pad(const LocalPoint& lp) const;
 
   /// pad pitch in a center
@@ -73,13 +73,13 @@ public:
 
   // relations between strips and pads:
   
-  /// returns FRACTIONAL pad number [0.,npads] for an integer strip [1,nstrip]
+  /// returns FRACTIONAL pad number [0.,npads) for an integer strip [0,nstrip-1]
   float padOfStrip(int strip) const;
 
-  /// returns first strip (INT number [1,nstrip]) for pad (an integer [1,npads])
+  /// returns first strip (INT number [0,nstrip-1]) for pad (an integer [0,npads-1])
   int firstStripInPad(int pad) const;
 
-  /// returns last strip (INT number [1,nstrip]) for pad (an integer [1,npads])
+  /// returns last strip (INT number [0,nstrip-1]) for pad (an integer [0,npads-1])
   int lastStripInPad(int pad) const;
 
 private:

--- a/Geometry/GEMGeometry/interface/GEMEtaPartition.h
+++ b/Geometry/GEMGeometry/interface/GEMEtaPartition.h
@@ -33,16 +33,16 @@ public:
   int nstrips() const;
 
   /// returns center of strip position for INTEGER strip number
-  /// that has a value range of [1, nstrip]
+  /// that has a value range of [0, nstrip-1]
   LocalPoint  centreOfStrip(int strip) const;
 
   /// returns center of strip position for FRACTIONAL strip number
-  /// that has a value range of [0., nstrip]
+  /// that has a value range of [0.0, nstrip)
   LocalPoint  centreOfStrip(float strip) const;
   LocalError  localError(float strip, float cluster_size= 1.) const;
-  /// returns fractional strip number [0..nstrips] for a LocalPoint
+  /// returns fractional strip number [0.0, nstrips) for a LocalPoint
   /// E.g., if local point hit strip #2, the fractional strip number would be
-  /// somewhere in the (1., 2] interval
+  /// somewhere in the [2.0, 3.0) interval
   float strip(const LocalPoint& lp) const;
 
   float pitch() const;

--- a/Geometry/GEMGeometry/src/GEMEtaPartition.cc
+++ b/Geometry/GEMGeometry/src/GEMEtaPartition.cc
@@ -53,7 +53,7 @@ GEMEtaPartition::nstrips() const
 LocalPoint
 GEMEtaPartition::centreOfStrip(int strip) const
 {
-  float s = static_cast<float>(strip) + 0.5;
+  float s = static_cast<float>(strip) + 0.5f;
   return this->specificTopology().localPosition(s);
 }
 
@@ -97,7 +97,7 @@ GEMEtaPartition::npads() const
 LocalPoint
 GEMEtaPartition::centreOfPad(int pad) const
 {
-  float p = static_cast<float>(pad) + 0.5;
+  float p = static_cast<float>(pad) + 0.5f;
   return specificPadTopology().localPosition(p);
 }
 
@@ -136,7 +136,7 @@ GEMEtaPartition::padOfStrip(int strip) const
 int
 GEMEtaPartition::firstStripInPad(int pad) const
 {
-  float p = static_cast<float>(pad) - 0.9999;
+  float p = static_cast<float>(pad) - 0.9999f;
   LocalPoint lp = specificPadTopology().localPosition(p);
   return static_cast<int>(strip(lp));
 }
@@ -144,7 +144,7 @@ GEMEtaPartition::firstStripInPad(int pad) const
 int
 GEMEtaPartition::lastStripInPad(int pad) const
 {
-  float p = static_cast<float>(pad) - 0.0001;
+  float p = static_cast<float>(pad) - 0.0001f;
   LocalPoint lp = specificPadTopology().localPosition(p);
   return static_cast<int>(strip(lp));
 }

--- a/Geometry/GEMGeometry/src/GEMEtaPartition.cc
+++ b/Geometry/GEMGeometry/src/GEMEtaPartition.cc
@@ -97,7 +97,7 @@ GEMEtaPartition::npads() const
 LocalPoint
 GEMEtaPartition::centreOfPad(int pad) const
 {
-  float p = static_cast<float>(pad) - 0.5;
+  float p = static_cast<float>(pad) + 0.5;
   return specificPadTopology().localPosition(p);
 }
 
@@ -138,7 +138,7 @@ GEMEtaPartition::firstStripInPad(int pad) const
 {
   float p = static_cast<float>(pad) - 0.9999;
   LocalPoint lp = specificPadTopology().localPosition(p);
-  return static_cast<int>(strip(lp)) + 1;
+  return static_cast<int>(strip(lp));
 }
 
 int
@@ -146,6 +146,6 @@ GEMEtaPartition::lastStripInPad(int pad) const
 {
   float p = static_cast<float>(pad) - 0.0001;
   LocalPoint lp = specificPadTopology().localPosition(p);
-  return static_cast<int>(strip(lp)) + 1;
+  return static_cast<int>(strip(lp));
 }
 

--- a/Geometry/GEMGeometry/src/GEMEtaPartition.cc
+++ b/Geometry/GEMGeometry/src/GEMEtaPartition.cc
@@ -53,7 +53,7 @@ GEMEtaPartition::nstrips() const
 LocalPoint
 GEMEtaPartition::centreOfStrip(int strip) const
 {
-  float s = static_cast<float>(strip) - 0.5;
+  float s = static_cast<float>(strip) + 0.5;
   return this->specificTopology().localPosition(s);
 }
 

--- a/SimMuon/GEMDigitizer/src/GEMPadDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMPadDigiProducer.cc
@@ -62,7 +62,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection &det_digis, GEMPadDig
     auto digis = det_digis.get(p->id());
     for (auto d = digis.first; d != digis.second; ++d)
     {
-      int pad_num = 1 + static_cast<int>( p->padOfStrip(d->strip()) );
+      int pad_num = static_cast<int>(p->padOfStrip(d->strip()));
       proto_pads.emplace(pad_num, d->bx());
     }
 

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -293,11 +293,8 @@ std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(
   LocalPoint smeared_start_point(smeared_start_x, start_point.y(), start_point.z());
   LocalPoint smeared_end_point(smeared_end_x, end_point.y(), end_point.z());
 
-  // Round up for preventing truncation caused by typecasting.
-  // If local point hit strip #2, the fractional strip number would be somewhere
-  // in the (1., 2] interval. (ref. GEMGeometry/interface/GEMEtaPartition.h)
-  int cluster_start = std::ceil(roll->strip(smeared_start_point));
-  int cluster_end = std::ceil(roll->strip(smeared_end_point));
+  int cluster_start = roll->strip(smeared_start_point);
+  int cluster_end = roll->strip(smeared_end_point);
 
   std::vector< std::pair<int, int> > cluster;
   for (int strip = cluster_start; strip <= cluster_end; strip++) {

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -283,11 +283,11 @@ std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(
   // Add Gaussian noise to the points towards outside. 
   float smeared_entry_x, smeared_exit_x;
   if(hit_entry_x > hit_exit_x) {
-    smeard_entry_x = hit_entry_x + std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
-    smeard_exit_x = hit_exit_x - std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+    smeared_entry_x = hit_entry_x + std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+    smeared_exit_x = hit_exit_x - std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
   } else {
-    smeard_entry_x = hit_entry_x - std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
-    smeard_exit_x = hit_exit_x + std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+    smeared_entry_x = hit_entry_x - std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+    smeared_exit_x = hit_exit_x + std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
   }
 
   LocalPoint smeared_entry(smeared_entry_x, hit_entry.y(), hit_entry.z());
@@ -302,10 +302,10 @@ std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(
   int cluster_start, cluster_end;
   if(smeared_entry_strip <= smeared_exit_strip) {
     cluster_start = smeared_entry_strip;
-    cluster_end = smeared_exit_strip
+    cluster_end = smeared_exit_strip;
   } else {
     cluster_start = smeared_exit_strip;
-    cluster_end = smeared_entry_strip
+    cluster_end = smeared_entry_strip;
   }
 
   std::vector< std::pair<int, int> > cluster;

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -282,7 +282,7 @@ std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(
 
   // Add Gaussian noise to the points towards outside. 
   float smeared_entry_x, smeared_exit_x;
-  if(hit_entry_x > hit_exit_entry) {
+  if(hit_entry_x > hit_exit_x) {
     smeard_entry_x = hit_entry_x + std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
     smeard_exit_x = hit_exit_x - std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
   } else {

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -278,7 +278,7 @@ std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(
   const LocalPoint & hit_exit(simHit->exitPoint());
 
   LocalPoint start_point, end_point;
-  if(hit_entry.x() < hit_entry.x()) {
+  if(hit_entry.x() < hit_exit.x()) {
     start_point = hit_entry;
     end_point = hit_exit;
   } else {

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -277,36 +277,27 @@ std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(
   const LocalPoint & hit_entry(simHit->entryPoint());
   const LocalPoint & hit_exit(simHit->exitPoint());
 
-  float hit_entry_x = hit_entry.x();
-  float hit_exit_x = hit_exit.x();
-
-  // Add Gaussian noise to the points towards outside. 
-  float smeared_entry_x, smeared_exit_x;
-  if(hit_entry_x > hit_exit_x) {
-    smeared_entry_x = hit_entry_x + std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
-    smeared_exit_x = hit_exit_x - std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+  LocalPoint start_point, end_point;
+  if(hit_entry.x() < hit_entry.x()) {
+    start_point = hit_entry;
+    end_point = hit_exit;
   } else {
-    smeared_entry_x = hit_entry_x - std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
-    smeared_exit_x = hit_exit_x + std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+    start_point = hit_exit;
+    end_point = hit_entry;
   }
 
-  LocalPoint smeared_entry(smeared_entry_x, hit_entry.y(), hit_entry.z());
-  LocalPoint smeared_exit(smeared_exit_x, hit_exit.y(), hit_exit.z());
+  // Add Gaussian noise to the points towards outside. 
+  float smeared_start_x = start_point.x() - std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+  float smeared_end_x = end_point.x() + std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+
+  LocalPoint smeared_start_point(smeared_start_x, start_point.y(), start_point.z());
+  LocalPoint smeared_end_point(smeared_end_x, end_point.y(), end_point.z());
 
   // Round up for preventing truncation caused by typecasting.
   // If local point hit strip #2, the fractional strip number would be somewhere
   // in the (1., 2] interval. (ref. GEMGeometry/interface/GEMEtaPartition.h)
-  int smeared_entry_strip = std::ceil(roll->strip(smeared_entry));
-  int smeared_exit_strip = std::ceil(roll->strip(smeared_exit));
-
-  int cluster_start, cluster_end;
-  if(smeared_entry_strip <= smeared_exit_strip) {
-    cluster_start = smeared_entry_strip;
-    cluster_end = smeared_exit_strip;
-  } else {
-    cluster_start = smeared_exit_strip;
-    cluster_end = smeared_entry_strip;
-  }
+  int cluster_start = std::ceil(roll->strip(smeared_start_point));
+  int cluster_end = std::ceil(roll->strip(smeared_end_point));
 
   std::vector< std::pair<int, int> > cluster;
   for (int strip = cluster_start; strip <= cluster_end; strip++) {

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -267,35 +267,41 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll, CLHEP::HepRandom
   return;
 }
 
-std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(const GEMEtaPartition* roll,
-								     const PSimHit* simHit, const int bx, 
-								     CLHEP::HepRandomEngine* engine)
-{
-  const LocalPoint& hit_entry(simHit->entryPoint());
-  const LocalPoint& hit_exit(simHit->exitPoint());
 
-  float hit_entry_smeardX;
-  float hit_exit_smeardX;
-  if (hit_entry.x()>hit_exit.x()) {
-    hit_entry_smeardX = hit_entry.x()+std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
-    hit_exit_smeardX = hit_exit.x()-std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+std::vector<std::pair<int, int> > GEMSimpleModel::simulateClustering(
+    const GEMEtaPartition* roll,
+    const PSimHit* simHit,
+    const int bx,
+    CLHEP::HepRandomEngine* engine) {
+
+  const LocalPoint & hit_entry(simHit->entryPoint());
+  const LocalPoint & hit_exit(simHit->exitPoint());
+
+  float hit_entry_x = hit_entry.x();
+  float hit_exit_x = hit_exit.x();
+
+  if (hit_entry_x > hit_exit_x) {
+    hit_entry_x = hit_exit.x();
+    hit_exit_x = hit_entry.x();
   }
-  else {
-    hit_entry_smeardX = hit_entry.x()-std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
-    hit_exit_smeardX = hit_exit.x()+std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
-  }
+
+  float hit_entry_smeardX = hit_entry_x - std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
+  float hit_exit_smeardX = hit_exit_x + std::abs(CLHEP::RandGaussQ::shoot(engine, 0, resolutionX_));
 
   LocalPoint inPoint(hit_entry_smeardX, hit_entry.y(), hit_entry.z());
   LocalPoint outPoint(hit_exit_smeardX, hit_exit.y(), hit_exit.z());
 
-  int clusterStart = roll->strip(inPoint);
-  int clusterEnd = roll->strip(outPoint);
+  int clusterStart = static_cast<int>(std::ceil(roll->strip(inPoint)));
+  int clusterEnd = static_cast<int>(std::ceil(roll->strip(outPoint)));
 
-  std::vector < std::pair<int, int> > cluster_;
+  std::vector< std::pair<int, int> > cluster_;
   cluster_.clear();
+
   for (int i = clusterStart; i<= clusterEnd ; i++) {
     cluster_.emplace_back(i, bx);
   }
 
   return cluster_;
 }
+
+


### PR DESCRIPTION
To make all strip/channel definitions unify with HW it was suggested that we change all definitions for strips and channels to start from 0.

Bug in gem digitizer which was causing low efficiency (https://indico.cern.ch/event/748857/contributions/3097829/attachments/1699357/2736224/180809_GEMSimpleModel_bug_fix.pdf)

@dildick @kpedro88 @watson-ij @slowmoyang