### PR TITLE
HCALDQM: Add quality test for LED misfires (10_3_X)

### DIFF
--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -1,0 +1,15 @@
+<TESTSCONFIGURATION>
+
+  <QTEST name="LEDMisfireThreshold">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="warning">0.</PARAM>
+      <PARAM name="error">1.</PARAM>
+      <PARAM name="ymin">0.0</PARAM>
+      <PARAM name="ymax">0.0</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+  </QTEST>
+  <LINK name="*Hcal/DigiTask/LED/LEDEventCount*">
+      <TestName activate="true">LEDMisfireThreshold</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/HcalTasks/python/HcalQualityTests.py
+++ b/DQM/HcalTasks/python/HcalQualityTests.py
@@ -1,0 +1,15 @@
+# quality tests for HCAL TPG trigger
+ 
+import FWCore.ParameterSet.Config as cms
+
+hcalQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/HcalTasks/data/HcalQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -122,6 +122,7 @@ process.load('DQM.HcalTasks.NoCQTask')
 #process.load('DQM.HcalTasks.ZDCTask')
 #process.load('DQM.HcalTasks.QIE11Task') # 2018: integrate QIE11Task into DigiTask
 process.load('DQM.HcalTasks.HcalOnlineHarvesting')
+process.load('DQM.HcalTasks.HcalQualityTests')
 
 #-------------------------------------
 #	To force using uTCA
@@ -193,10 +194,12 @@ process.dqmPath = cms.EndPath(
 process.dqmPath1 = cms.EndPath(
 		process.dqmSaver
 )
+process.qtPath = cms.Path(process.hcalQualityTests)
 
 process.schedule = cms.Schedule(
 	process.preRecoPath,
 	process.tasksPath,
+	process.qtPath,
 	process.harvestingPath,
 	process.dqmPath,
 	process.dqmPath1


### PR DESCRIPTION
Adds a quality test for Hcal/DigiTask/LED/LEDEventCount (>=1 events in the histogram indicates that an LED misfired in physics data).