### PR TITLE
add 2018 HI MC with pp-like reco to the limited matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -65,6 +65,7 @@ if __name__ == '__main__':
                      136.85, #2018A Egamma data
                      140.53, #2011 HI data
                      150.0, #2018 HI MC
+                     158.0, #2018 HI MC with pp-like reco
                      1306.0, #SingleMu Pt1 UP15
                      1325.7, #test NanoAOD from existing MINI
                      1330, #Run2 MC Zmm


### PR DESCRIPTION
wf 158.0 is now the primary target for the reco configuration of HI reco in 2018.
We need to have this tested regularly.
