### PR TITLE
[10.2.X][Update GTs] new JEC MC TAGs + 2D Pixel Templates

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,19 +40,19 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '102X_mc2017_design_IdealBS_v3',
+    'phase1_2017_design'       :  '102X_mc2017_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '102X_mc2017_realistic_v3',
+    'phase1_2017_realistic'    : '102X_mc2017_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '102X_mc2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      : '102X_mc2017cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v3',
+    'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '102X_upgrade2018_design_v6',
+    'phase1_2018_design'       : '102X_upgrade2018_design_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v11',
+    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v12',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v10',
+    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '102X_postLS2_design_v5', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '102X_dataRun2_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '102X_dataRun2_relval_v4',
+    'run2_data_relval'  :   '102X_dataRun2_relval_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '102X_dataRun2_PromptLike_v7',
     # GlobalTag for Run1 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,9 +24,9 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '102X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '102X_dataRun2_v3',
+    'run1_data'         :   '102X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '102X_dataRun2_v3',
+    'run2_data'         :   '102X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '102X_dataRun2_relval_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -30,7 +30,7 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '102X_dataRun2_relval_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '102X_dataRun2_PromptLike_v4',
+    'run2_data_promptlike' : '102X_dataRun2_PromptLike_v7',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
Added JEC MC Tags to:
## 2018 MC GT
.  [102X_upgrade2018_design_v7](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_design_v7/102X_upgrade2018_design_v6)
.  [102X_upgrade2018_realistic_v12](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_realistic_v12/102X_upgrade2018_realistic_v11)
.  [102X_upgrade2018cosmics_realistic_deco_v11](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018cosmics_realistic_deco_v11/102X_upgrade2018cosmics_realistic_deco_v10)

## 2017 MC GT
.  [102X_mc2017_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017_design_IdealBS_v3/102X_mc2017_design_IdealBS_v4)
.  [102X_mc2017_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017_realistic_v4/102X_mc2017_realistic_v3)
.  [102X_mc2017cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017cosmics_realistic_deco_v4/102X_mc2017cosmics_realistic_deco_v3)
.  [102X_mc2017cosmics_realistic_peak_v4](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017cosmics_realistic_peak_v4/102X_mc2017cosmics_realistic_peak_v3)

Pixel Template + HEFilter add to:
## DataRun2 GT
.  [102X_dataRun2_v4](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_v4/102X_dataRun2_v3)
.  [102X_dataRun2_relval_v5](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_relval_v5/102X_dataRun2_relval_v4)
.  [102X_dataRun2_PromptLike_v7](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_PromptLike_v7/102X_dataRun2_PromptLike_v4)