### PR TITLE
island clustering can exclude flagged rechits

### DIFF
--- a/Calibration/EcalCalibAlgos/interface/Pi0FixedMassWindowCalibration.h
+++ b/Calibration/EcalCalibAlgos/interface/Pi0FixedMassWindowCalibration.h
@@ -14,6 +14,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -65,6 +66,8 @@ class Pi0FixedMassWindowCalibration :  public edm::ESProducerLooper
   
   /// Destructor
   ~Pi0FixedMassWindowCalibration() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   /// Dummy implementation (job done in duringLoop)
   virtual void produce(edm::Event&, const edm::EventSetup&) {};

--- a/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
@@ -73,9 +73,6 @@ Pi0FixedMassWindowCalibration::Pi0FixedMassWindowCalibration(const edm::Paramete
   selePi0MinvMeanFixed_ = iConfig.getParameter<double>("selePi0MinvMeanFixed");
   selePi0MinvSigmaFixed_ = iConfig.getParameter<double>("selePi0MinvSigmaFixed");
 
-
-
-
   // Parameters for the position calculation:
   edm::ParameterSet posCalcParameters = 
     iConfig.getParameter<edm::ParameterSet>("posCalcParameters");
@@ -112,6 +109,58 @@ Pi0FixedMassWindowCalibration::Pi0FixedMassWindowCalibration(const edm::Paramete
 Pi0FixedMassWindowCalibration::~Pi0FixedMassWindowCalibration()
 {
 
+}
+
+void Pi0FixedMassWindowCalibration::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  edm::ParameterSetDescription desc;
+
+  desc.add<unsigned int>("maxLoops", 0);
+  desc.add<std::string>("ecalRecHitsProducer", "");
+  desc.add<std::string>("barrelHitCollection", "");
+
+  desc.add<std::string>("VerbosityLevel", "");
+  desc.add<std::string>("barrelClusterCollection", "");
+
+  desc.add<double>("IslandBarrelSeedThr", 0);
+  desc.add<double>("IslandEndcapSeedThr", 0);
+
+  desc.add<double>("selePi0PtGammaOneMin", 0);
+  desc.add<double>("selePi0PtGammaTwoMin", 0);
+
+  desc.add<double>("selePi0DRBelt", 0);
+  desc.add<double>("selePi0DetaBelt", 0);
+
+  desc.add<double>("selePi0PtPi0Min", 0);
+
+  desc.add<double>("selePi0S4S9GammaOneMin", 0);
+  desc.add<double>("selePi0S4S9GammaTwoMin", 0);
+  desc.add<double>("selePi0S9S25GammaOneMin", 0);
+  desc.add<double>("selePi0S9S25GammaTwoMin", 0);
+
+  desc.add<double>("selePi0EtBeltIsoRatioMax", 0);
+
+  desc.add<double>("selePi0MinvMeanFixed", 0);
+  desc.add<double>("selePi0MinvSigmaFixed", 0);
+
+  edm::ParameterSetDescription posCalcParameters;
+  posCalcParameters.add<bool>("LogWeighted", true);
+  posCalcParameters.add<double>("T0_barl", 7.4);
+  posCalcParameters.add<double>("T0_endc", 3.1);
+  posCalcParameters.add<double>("T0_endcPresh", 1.2);
+  posCalcParameters.add<double>("W0", 4.2);
+  posCalcParameters.add<double>("X0", 0.89);
+  desc.add<edm::ParameterSetDescription>("posCalcParameters", posCalcParameters);
+
+  desc.add<std::string>("clustershapecollectionEB", "islandBarrelShape");
+  desc.add<std::string>("barrelShapeAssociation", "islandBarrelShapeAssoc");
+
+  desc.add<std::vector<std::string>>("SeedRecHitFlagToBeExcludedEB", {});
+  desc.add<std::vector<std::string>>("SeedRecHitFlagToBeExcludedEE", {});
+  desc.add<std::vector<std::string>>("RecHitFlagToBeExcludedEB", {});
+  desc.add<std::vector<std::string>>("RecHitFlagToBeExcludedEE", {});
+
+  descriptions.add("Pi0FixedMassWindowCalibration", desc);
 }
 
 //_____________________________________________________________________________

--- a/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
@@ -108,7 +108,7 @@ Pi0FixedMassWindowCalibration::Pi0FixedMassWindowCalibration(const edm::Paramete
 
 Pi0FixedMassWindowCalibration::~Pi0FixedMassWindowCalibration()
 {
-
+  delete island_p;
 }
 
 void Pi0FixedMassWindowCalibration::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
@@ -4,7 +4,6 @@
 
 // Framework
 
-
 // Conditions database
 
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
@@ -24,6 +23,8 @@
 // EgammaCoreTools
 #include "DataFormats/EgammaReco/interface/ClusterShape.h"
 #include "DataFormats/EgammaReco/interface/ClusterShapeFwd.h"
+
+#include "CommonTools/Utils/interface/StringToEnumValue.h"
 
 //const double Pi0Calibration::PDGPi0Mass =  0.1349766;
 
@@ -85,7 +86,19 @@ Pi0FixedMassWindowCalibration::Pi0FixedMassWindowCalibration(const edm::Paramete
   //AssociationMap
   barrelClusterShapeAssociation_ = iConfig.getParameter<std::string>("barrelShapeAssociation");
 
-  island_p = new IslandClusterAlgo(barrelSeedThreshold, endcapSeedThreshold, posCalculator_,verbosity);
+  const std::vector<std::string> seedflagnamesEB = iConfig.getParameter<std::vector<std::string> >("SeedRecHitFlagToBeExcludedEB");
+  const std::vector<int> seedflagsexclEB = StringToEnumValue<EcalRecHit::Flags>(seedflagnamesEB);
+
+  const std::vector<std::string> seedflagnamesEE = iConfig.getParameter<std::vector<std::string> >("SeedRecHitFlagToBeExcludedEE");
+  const std::vector<int> seedflagsexclEE = StringToEnumValue<EcalRecHit::Flags>(seedflagnamesEE);
+
+  const std::vector<std::string> flagnamesEB = iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB");
+  const std::vector<int> flagsexclEB = StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
+
+  const std::vector<std::string> flagnamesEE = iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE");
+  const std::vector<int> flagsexclEE = StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
+
+  island_p = new IslandClusterAlgo(barrelSeedThreshold, endcapSeedThreshold, posCalculator_, seedflagsexclEB, seedflagsexclEE, flagsexclEB, flagsexclEE, verbosity);
 
   theParameterSet=iConfig;
 

--- a/RecoEcal/EgammaClusterAlgos/interface/IslandClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/IslandClusterAlgo.h
@@ -34,8 +34,14 @@ class IslandClusterAlgo
   IslandClusterAlgo() {
   }
 
-  IslandClusterAlgo(double ebst, double ecst, const PositionCalc& posCalc, VerbosityLevel the_verbosity = pERROR) : 
-    ecalBarrelSeedThreshold(ebst), ecalEndcapSeedThreshold(ecst), verbosity(the_verbosity) {
+  IslandClusterAlgo(double ebst, double ecst, const PositionCalc& posCalc,
+                    const std::vector<int>& v_chstatusSeed_Barrel, const std::vector<int>& v_chstatusSeed_Endcap,
+                    const std::vector<int>& v_chstatus_Barrel, const std::vector<int>& v_chstatus_Endcap,
+                    VerbosityLevel the_verbosity = pERROR) :
+    ecalBarrelSeedThreshold(ebst), ecalEndcapSeedThreshold(ecst),
+    v_chstatusSeed_Barrel_(v_chstatusSeed_Barrel), v_chstatusSeed_Endcap_(v_chstatusSeed_Endcap),
+    v_chstatus_Barrel_(v_chstatus_Barrel), v_chstatus_Endcap_(v_chstatus_Endcap),
+    verbosity(the_verbosity) {
     posCalculator_ = posCalc;
   }
 
@@ -84,6 +90,17 @@ class IslandClusterAlgo
 
   // The vector of clusters
   std::vector<reco::BasicCluster> clusters_v;
+
+  // channels not to be used for seeding
+  std::vector<int> v_chstatusSeed_Barrel_;
+  std::vector<int> v_chstatusSeed_Endcap_;
+
+  // channels not to be used for clustering
+  std::vector<int> v_chstatus_Barrel_;
+  std::vector<int> v_chstatus_Endcap_;
+
+  std::vector<int> v_chstatusSeed_;
+  std::vector<int> v_chstatus_;
 
   // The verbosity level
   VerbosityLevel verbosity;

--- a/RecoEcal/EgammaClusterProducers/interface/IslandClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/IslandClusterProducer.h
@@ -31,7 +31,7 @@ class IslandClusterProducer : public edm::stream::EDProducer<>
       IslandClusterProducer(const edm::ParameterSet& ps);
 
       ~IslandClusterProducer() override;
-
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
       void produce(edm::Event&, const edm::EventSetup&) override;
 
    private:

--- a/RecoEcal/EgammaClusterProducers/python/islandBasicClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/islandBasicClusters_cfi.py
@@ -19,7 +19,33 @@ islandBasicClusters = cms.EDProducer("IslandClusterProducer",
                                   LogWeighted  = cms.bool(True),
                                   W0           = cms.double(4.2),
                                   X0           = cms.double(0.89)
-                                 )
+                                 ),
+    # recHit flags to be excluded from seeding
+    SeedRecHitFlagToBeExcludedEB = cms.vstring(
+        'kFaultyHardware',
+        'kTowerRecovered',
+        'kDead'
+        ),
+    SeedRecHitFlagToBeExcludedEE = cms.vstring(
+        'kFaultyHardware',
+        'kNeighboursRecovered',
+        'kTowerRecovered',
+        'kDead',
+        'kWeird'
+        ),
+    # recHit flags to be excluded from clustering
+    RecHitFlagToBeExcludedEB = cms.vstring(
+        'kWeird',
+        'kDiWeird',
+        'kOutOfTime',
+        'kTowerRecovered'
+        ),
+    RecHitFlagToBeExcludedEE = cms.vstring(
+        'kWeird',
+        'kDiWeird',
+        'kOutOfTime',
+        'kTowerRecovered'
+        )
 )
 
 

--- a/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "CommonTools/Utils/interface/StringToEnumValue.h"
 
 // Reconstruction Classes
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
@@ -72,6 +73,18 @@ IslandClusterProducer::IslandClusterProducer(const edm::ParameterSet& ps)
   barrelClusterShapeAssociation_ = ps.getParameter<std::string>("barrelShapeAssociation");
   endcapClusterShapeAssociation_ = ps.getParameter<std::string>("endcapShapeAssociation");
 
+  const std::vector<std::string> seedflagnamesEB = ps.getParameter<std::vector<std::string> >("SeedRecHitFlagToBeExcludedEB");
+  const std::vector<int> seedflagsexclEB = StringToEnumValue<EcalRecHit::Flags>(seedflagnamesEB);
+
+  const std::vector<std::string> seedflagnamesEE = ps.getParameter<std::vector<std::string> >("SeedRecHitFlagToBeExcludedEE");
+  const std::vector<int> seedflagsexclEE = StringToEnumValue<EcalRecHit::Flags>(seedflagnamesEE);
+
+  const std::vector<std::string> flagnamesEB = ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB");
+  const std::vector<int> flagsexclEB = StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
+
+  const std::vector<std::string> flagnamesEE = ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE");
+  const std::vector<int> flagsexclEE = StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
+
   // Produces a collection of barrel and a collection of endcap clusters
 
   produces< reco::ClusterShapeCollection>(clustershapecollectionEE_);
@@ -81,7 +94,7 @@ IslandClusterProducer::IslandClusterProducer(const edm::ParameterSet& ps)
   produces< reco::BasicClusterShapeAssociationCollection >(barrelClusterShapeAssociation_);
   produces< reco::BasicClusterShapeAssociationCollection >(endcapClusterShapeAssociation_);
 
-  island_p = new IslandClusterAlgo(barrelSeedThreshold, endcapSeedThreshold, posCalculator_,verbosity);
+  island_p = new IslandClusterAlgo(barrelSeedThreshold, endcapSeedThreshold, posCalculator_, seedflagsexclEB, seedflagsexclEE, flagsexclEB, flagsexclEE, verbosity);
 
   nEvt_ = 0;
 }

--- a/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
@@ -9,6 +9,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "CommonTools/Utils/interface/StringToEnumValue.h"
 
@@ -105,6 +106,36 @@ IslandClusterProducer::~IslandClusterProducer()
   delete island_p;
 }
 
+void IslandClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("VerbosityLevel", "ERROR");
+  desc.add<edm::InputTag>("barrelHits", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+  desc.add<edm::InputTag>("endcapHits", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
+  desc.add<std::string>("barrelClusterCollection", "islandBarrelBasicClusters");
+  desc.add<std::string>("endcapClusterCollection", "islandEndcapBasicClusters");
+  desc.add<double>("IslandBarrelSeedThr", 0.5);
+  desc.add<double>("IslandEndcapSeedThr", 0.18);
+
+  edm::ParameterSetDescription posCalcParameters;
+  posCalcParameters.add<bool>("LogWeighted", true);
+  posCalcParameters.add<double>("T0_barl", 7.4);
+  posCalcParameters.add<double>("T0_endc", 3.1);
+  posCalcParameters.add<double>("T0_endcPresh", 1.2);
+  posCalcParameters.add<double>("W0", 4.2);
+  posCalcParameters.add<double>("X0", 0.89);
+  desc.add<edm::ParameterSetDescription>("posCalcParameters", posCalcParameters);
+
+  desc.add<std::string>("clustershapecollectionEE", "islandEndcapShape");
+  desc.add<std::string>("clustershapecollectionEB", "islandBarrelShape");
+  desc.add<std::string>("barrelShapeAssociation", "islandBarrelShapeAssoc");
+  desc.add<std::string>("endcapShapeAssociation", "islandEndcapShapeAssoc");
+  desc.add<std::vector<std::string>>("SeedRecHitFlagToBeExcludedEB", {});
+  desc.add<std::vector<std::string>>("SeedRecHitFlagToBeExcludedEE", {});
+  desc.add<std::vector<std::string>>("RecHitFlagToBeExcludedEB", {});
+  desc.add<std::vector<std::string>>("RecHitFlagToBeExcludedEE", {});
+  descriptions.add("IslandClusterProducer", desc);
+}
 
 void IslandClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 {

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
@@ -33,6 +33,8 @@
 // Class header file
 #include "RecoEgamma/EgammaHLTProducers/interface/EgammaHLTIslandClusterProducer.h"
 
+#include "CommonTools/Utils/interface/StringToEnumValue.h"
+
 EgammaHLTIslandClusterProducer::EgammaHLTIslandClusterProducer(const edm::ParameterSet& ps)
   : doBarrel_   (ps.getParameter<bool>("doBarrel"))
   , doEndcaps_  (ps.getParameter<bool>("doEndcaps"))
@@ -65,6 +67,10 @@ EgammaHLTIslandClusterProducer::EgammaHLTIslandClusterProducer(const edm::Parame
   , island_p (new IslandClusterAlgo(ps.getParameter<double>("IslandBarrelSeedThr"),
                                      ps.getParameter<double>("IslandEndcapSeedThr"),
                                      posCalculator_,
+                                     StringToEnumValue<EcalRecHit::Flags>(ps.getParameter<std::vector<std::string> >("SeedRecHitFlagToBeExcludedEB")),
+                                     StringToEnumValue<EcalRecHit::Flags>(ps.getParameter<std::vector<std::string> >("SeedRecHitFlagToBeExcludedEE")),
+                                     StringToEnumValue<EcalRecHit::Flags>(ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB")),
+                                     StringToEnumValue<EcalRecHit::Flags>(ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE")),
                                      verb_ == "DEBUG" ? IslandClusterAlgo::pDEBUG :
                                      (verb_ == "WARNING" ? IslandClusterAlgo::pWARNING :
                                       (verb_ == "INFO" ? IslandClusterAlgo::pINFO :

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTIslandClusterProducer.cc
@@ -107,6 +107,10 @@ void EgammaHLTIslandClusterProducer::fillDescriptions(edm::ConfigurationDescript
   desc.add<double>("regionEtaMargin", 0.3);
   desc.add<double>("regionPhiMargin", 0.4);
   //desc.add<edm::ParameterSet>("posCalcParameters"), edm::ParameterSet());
+  desc.add<std::vector<std::string>>("SeedRecHitFlagToBeExcludedEB", {});
+  desc.add<std::vector<std::string>>("SeedRecHitFlagToBeExcludedEE", {});
+  desc.add<std::vector<std::string>>("RecHitFlagToBeExcludedEB", {});
+  desc.add<std::vector<std::string>>("RecHitFlagToBeExcludedEE", {});
   descriptions.add("hltEgammaHLTIslandClusterProducer", desc);  
 }
 


### PR DESCRIPTION
Add option to remove flagged rechits from island clustering. Use separate flags for rechits to be excluded from seeding and those to be excluded from a cluster. These changes have very little impact in MC. In PbPb data, this should prevent fake photons being reconstructed from flagged rechits. In 2015, these were removed using offline selections. Flags to be excluded from seeding are chosen to be same as the ones from hybrid [1] and multi5x5 [2] clustering. Flags to excluded from clustering are chosen to match the ones for PF rechits [3],[4].

Needed for 2018 pbpb data. Tests pass workflows 150.1,2,3 and 158.
@mandrenguyen, @bi-ran, @ikucher

[1] : https://github.com/cms-sw/cmssw/blob/master/RecoEcal/EgammaClusterProducers/python/hybridSuperClusters_cfi.py#L35-L39

[2] : https://github.com/cms-sw/cmssw/blob/master/RecoEcal/EgammaClusterProducers/python/multi5x5BasicClusters_cfi.py#L28-L33

[3] : https://github.com/cms-sw/cmssw/blob/master/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h#L554-L572

[4] : https://github.com/cms-sw/cmssw/blob/master/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py#L27-L29
