### PR TITLE
Make L1T object comparison fillDescriptions compatible with ConfDB parsing

### DIFF
--- a/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
@@ -146,7 +146,7 @@ template <typename T>
 void
 L1TComparisonResultFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("objComparisonColl")->setComment("Object comparison collection");
+  desc.add<edm::InputTag>("objComparisonColl", edm::InputTag("objComparisonColl"))->setComment("Object comparison collection");
   desc.add<int>("maxBxRangeDiff", -1)->setComment("Maximal BX range difference");
   desc.add<int>("maxExcess", -1)->setComment("Maximal allowed excess objects per BX");
   desc.add<int>("maxSize", -1)->setComment("Maximal allowed mismatches");

--- a/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
@@ -151,7 +151,7 @@ L1TComparisonResultFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<int>("maxExcess", -1)->setComment("Maximal allowed excess objects per BX");
   desc.add<int>("maxSize", -1)->setComment("Maximal allowed mismatches");
   desc.add<bool>("invert", false)->setComment("Invert final result");
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 //define plugins for different L1T objects

--- a/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
@@ -46,9 +46,9 @@ class L1TComparisonResultFilter : public edm::stream::EDFilter<> {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginStream(edm::StreamID) override { };
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endStream() override { };
+      void beginStream(edm::StreamID) override { };
+      bool filter(edm::Event&, const edm::EventSetup&) override;
+      void endStream() override { };
 
       // ----------member data ---------------------------
       edm::InputTag inputTag_;

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -57,11 +57,11 @@ template <typename T>
 void L1TStage2ObjectComparison<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("collection1")->setComment("L1T object collection 1");
-  desc.add<edm::InputTag>("collection2")->setComment("L1T object collection 2");
-  desc.add<bool>("checkBxRange")->setComment("Check if BX ranges match");
-  desc.add<bool>("checkCollSizePerBx")->setComment("Check if collection sizes within one BX match");
-  desc.add<bool>("checkObject")->setComment("Check if objects match");
+  desc.add<edm::InputTag>("collection1", edm::InputTag("collection1"))->setComment("L1T object collection 1");
+  desc.add<edm::InputTag>("collection2", edm::InputTag("collection2"))->setComment("L1T object collection 2");
+  desc.add<bool>("checkBxRange", true)->setComment("Check if BX ranges match");
+  desc.add<bool>("checkCollSizePerBx", true)->setComment("Check if collection sizes within one BX match");
+  desc.add<bool>("checkObject", true)->setComment("Check if objects match");
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -62,7 +62,7 @@ void L1TStage2ObjectComparison<T>::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<bool>("checkBxRange")->setComment("Check if BX ranges match");
   desc.add<bool>("checkCollSizePerBx")->setComment("Check if collection sizes within one BX match");
   desc.add<bool>("checkObject")->setComment("Check if objects match");
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 template <typename T>


### PR DESCRIPTION
In order to have the framework modules appear in the ConfDB GUI it is needed to replace object comparison and filter fillDescriptions addDefault with addWithDefaultLabel.