### PR TITLE
2018_pp_on_AA era HI jet sequences

### DIFF
--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -48,21 +48,14 @@ kt4PFJetsForRho = cms.EDProducer(
     jetAlgorithm = cms.string("Kt"),
     rParam       = cms.double(0.4)
 )
+
 kt4PFJetsForRho.src = cms.InputTag('particleFlow')
 kt4PFJetsForRho.doAreaFastjet = cms.bool(True)
 kt4PFJetsForRho.jetPtMin      = cms.double(0.0)
 kt4PFJetsForRho.GhostArea     = cms.double(0.005)
 
-hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
-                                 jetSource = cms.InputTag('kt4PFJetsForRho'),
-                                 nExcl = cms.int32(2),
-                                 etaMaxExcl = cms.double(2.),
-                                 ptMinExcl = cms.double(20.),
-                                 nExcl2 = cms.int32(1),
-                                 etaMaxExcl2 = cms.double(3.),
-                                 ptMinExcl2 = cms.double(20.),
-                                 etaRanges = cms.vdouble(-5., -3., -2.1, -1.3, 1.3, 2.1, 3., 5.)
-)
+from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
+hiFJRhoProducer.etaRanges = cms.vdouble(-5., -3., -2.1, -1.3, 1.3, 2.1, 3., 5.)
 
 akCs4PFJets = cms.EDProducer(
     "CSJetProducer",

--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -55,7 +55,6 @@ kt4PFJetsForRho.jetPtMin      = cms.double(0.0)
 kt4PFJetsForRho.GhostArea     = cms.double(0.005)
 
 from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
-hiFJRhoProducer.etaRanges = cms.vdouble(-5., -3., -2.1, -1.3, 1.3, 2.1, 3., 5.)
 
 akCs4PFJets = cms.EDProducer(
     "CSJetProducer",

--- a/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
+++ b/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
@@ -14,3 +14,6 @@ hiFJGridEmptyAreaCalculator = cms.EDProducer('HiFJGridEmptyAreaCalculator',
 					     keepGridInfo = cms.bool(False),
 )
 
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+pA_2016.toModify(hiFJGridEmptyAreaCalculator, doCentrality = False)
+

--- a/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
+++ b/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
@@ -8,5 +8,8 @@ hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
                                  nExcl2 = cms.int32(1),
                                  etaMaxExcl2 = cms.double(3.),
                                  ptMinExcl2 = cms.double(20.),
-     				 etaRanges = cms.vdouble(-5., -3., -2., -1.5, -1., 1., 1.5, 2., 3., 5.)
+     				 etaRanges = cms.vdouble(-5., -3., -2.1, -1.3, 1.3, 2.1, 3., 5.)
 )
+
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+pA_2016.toModify(hiFJRhoProducer, etaRanges = cms.vdouble(-5., -3., -2., -1.5, -1., 1., 1.5, 2., 3., 5.))

--- a/RecoJets/Configuration/python/RecoJetsGlobal_cff.py
+++ b/RecoJets/Configuration/python/RecoJetsGlobal_cff.py
@@ -15,6 +15,7 @@ from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaC
 from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
 from RecoHI.HiJetAlgos.HiRecoPFJets_cff import kt4PFJetsForRho
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoHI.HiCentralityAlgos.pACentrality_cfi import pACentrality
 pA_2016.toModify(pACentrality, producePixelTracks = False)
 
@@ -24,3 +25,9 @@ _jetHighLevelReco_pA += hiFJRhoProducer
 _jetHighLevelReco_pA += hiFJGridEmptyAreaCalculator
 _jetHighLevelReco_pA += pACentrality
 pA_2016.toReplaceWith(jetHighLevelReco, _jetHighLevelReco_pA)
+
+_jetGlobalReco_HI = cms.Sequence(recoJetsHI*recoJetIds)
+_jetHighLevelReco_HI = cms.Sequence(recoPFJetsHI*jetCorrectorsForReco*recoJetAssociations)
+
+pp_on_AA_2018.toReplaceWith(jetGlobalReco,_jetGlobalReco_HI)
+pp_on_AA_2018.toReplaceWith(jetHighLevelReco,_jetHighLevelReco_HI)

--- a/RecoJets/Configuration/python/RecoJetsGlobal_cff.py
+++ b/RecoJets/Configuration/python/RecoJetsGlobal_cff.py
@@ -13,15 +13,11 @@ jetHighLevelReco = cms.Sequence(recoPFJets*jetCorrectorsForReco*recoJetAssociati
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 #HI-specific algorithms needed in pp scenario special configurations
-from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
-
 from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
 pA_2016.toModify(hiFJGridEmptyAreaCalculator, doCentrality = False)
 
-kt4PFJetsForRho = kt4PFJets.clone(doAreaFastjet = True,
-                                  jetPtMin = 0.0,
-                                  GhostArea = 0.005)
-
+from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
+from RecoHI.HiJetAlgos.HiRecoPFJets_cff import kt4PFJetsForRho
 from RecoHI.HiCentralityAlgos.pACentrality_cfi import pACentrality
 pA_2016.toModify(pACentrality, producePixelTracks = False)
 

--- a/RecoJets/Configuration/python/RecoJetsGlobal_cff.py
+++ b/RecoJets/Configuration/python/RecoJetsGlobal_cff.py
@@ -11,13 +11,10 @@ from JetMETCorrections.Configuration.JetCorrectorsForReco_cff import *
 jetGlobalReco = cms.Sequence(recoJets*recoJetIds*recoTrackJets)
 jetHighLevelReco = cms.Sequence(recoPFJets*jetCorrectorsForReco*recoJetAssociations*recoJetAssociationsExplicit*recoJPTJets)
 
-from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
-#HI-specific algorithms needed in pp scenario special configurations
 from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
-pA_2016.toModify(hiFJGridEmptyAreaCalculator, doCentrality = False)
-
 from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
 from RecoHI.HiJetAlgos.HiRecoPFJets_cff import kt4PFJetsForRho
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from RecoHI.HiCentralityAlgos.pACentrality_cfi import pACentrality
 pA_2016.toModify(pACentrality, producePixelTracks = False)
 

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -175,12 +175,10 @@ for ec in [RecoJetsAOD.outputCommands, RecoJetsRECO.outputCommands, RecoJetsFEVT
                                                                                       'keep *_hiFJRhoProducer_*_*',
                                                                                       'keep *_akPu3PFJets_*_*',
                                                                                       'keep *_akPu4PFJets_*_*',
-                                                                                      'keep *_akPu5PFJets_*_*',
-                                                                                      'keep *_kt4PFJetsForRhoHI_*_*',
-                                                                                      'keep *_akCs3PFJets_*_*',
+                                                                                      'keep *_kt4PFJetsForRho_*_*',
                                                                                       'keep *_akCs4PFJets_*_*',
-                                                                                      'keep *_akPu3CaloJets_*_*',
                                                                                       'keep *_akPu4CaloJets_*_*',
-                                                                                      'keep *_akPu5CaloJets_*_*'
+                                                                                      'drop *_caloTowers_*_*'
+
                                                                          ])
     )    

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -168,4 +168,19 @@ for ec in [RecoJetsAOD.outputCommands, RecoJetsRECO.outputCommands, RecoJetsFEVT
     peripheralPbPb.toModify( ec, 
                              func=lambda outputCommands: outputCommands.extend(['keep recoCentrality*_pACentrality_*_*'])
                              )
-    
+
+for ec in [RecoJetsAOD.outputCommands, RecoJetsRECO.outputCommands, RecoJetsFEVT.outputCommands]:
+    pp_on_AA_2018.toModify( ec, 
+                                   func=lambda outputCommands: outputCommands.extend(['keep *_hiCentrality_*_*',
+                                                                                      'keep *_hiFJRhoProducer_*_*',
+                                                                                      'keep *_akPu3PFJets_*_*',
+                                                                                      'keep *_akPu4PFJets_*_*',
+                                                                                      'keep *_akPu5PFJets_*_*',
+                                                                                      'keep *_kt4PFJetsForRhoHI_*_*',
+                                                                                      'keep *_akCs3PFJets_*_*',
+                                                                                      'keep *_akCs4PFJets_*_*',
+                                                                                      'keep *_akPu3CaloJets_*_*',
+                                                                                      'keep *_akPu4CaloJets_*_*',
+                                                                                      'keep *_akPu5CaloJets_*_*'
+                                                                         ])
+    )    

--- a/RecoJets/Configuration/python/RecoJets_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_cff.py
@@ -28,3 +28,20 @@ recoAllJets=cms.Sequence(fixedGridRhoFastjetAllCalo+
 recoAllJetsPUOffsetCorr=cms.Sequence(fixedGridRhoFastjetAllCalo+
                                      fixedGridRhoFastjetCentralCalo+
                                      ak4CaloJetsPUCorr)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+
+from RecoHI.HiJetAlgos.HiRecoJets_cff import caloTowersRec, caloTowers, akPu3CaloJets, akPu4CaloJets, akPu5CaloJets
+
+recoJetsHI =cms.Sequence(fixedGridRhoFastjetAllCalo+
+                         fixedGridRhoFastjetCentralCalo+
+                         ak4CaloJets+
+			 caloTowersRec+
+			 caloTowers+
+			 akPu3CaloJets+
+			 akPu4CaloJets+
+			 akPu5CaloJets
+                         )
+
+for e in [pp_on_AA_2018]:
+ e.toReplaceWith(recoJets, recoJetsHI)

--- a/RecoJets/Configuration/python/RecoJets_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_cff.py
@@ -36,11 +36,11 @@ from RecoHI.HiJetAlgos.HiRecoJets_cff import caloTowersRec, caloTowers, akPu3Cal
 recoJetsHI =cms.Sequence(fixedGridRhoFastjetAllCalo+
                          fixedGridRhoFastjetCentralCalo+
                          ak4CaloJets+
-			 caloTowersRec+
-			 caloTowers+
-			 akPu3CaloJets+
-			 akPu4CaloJets+
-			 akPu5CaloJets
+                         caloTowersRec+
+                         caloTowers+
+                         akPu3CaloJets+
+                         akPu4CaloJets+
+                         akPu5CaloJets
                          )
 
 for e in [pp_on_AA_2018]:

--- a/RecoJets/Configuration/python/RecoJets_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_cff.py
@@ -29,19 +29,12 @@ recoAllJetsPUOffsetCorr=cms.Sequence(fixedGridRhoFastjetAllCalo+
                                      fixedGridRhoFastjetCentralCalo+
                                      ak4CaloJetsPUCorr)
 
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-
-from RecoHI.HiJetAlgos.HiRecoJets_cff import caloTowersRec, caloTowers, akPu3CaloJets, akPu4CaloJets, akPu5CaloJets
+from RecoHI.HiJetAlgos.HiRecoJets_cff import caloTowersRec, caloTowers, akPu4CaloJets
 
 recoJetsHI =cms.Sequence(fixedGridRhoFastjetAllCalo+
                          fixedGridRhoFastjetCentralCalo+
                          ak4CaloJets+
                          caloTowersRec+
                          caloTowers+
-                         akPu3CaloJets+
-                         akPu4CaloJets+
-                         akPu5CaloJets
+                         akPu4CaloJets
                          )
-
-for e in [pp_on_AA_2018]:
- e.toReplaceWith(recoJets, recoJetsHI)

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -105,3 +105,32 @@ recoPFJetsWithSubstructureTask=cms.Task(
                            ak4PFJetsSK
     )
 recoPFJetsWithSubstructure=cms.Sequence(recoPFJetsWithSubstructureTask)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+
+from RecoHI.HiJetAlgos.HiRecoPFJets_cff import PFTowers, akPu3PFJets, akPu4PFJets, akPu5PFJets, kt4PFJetsForRho, hiFJRhoProducer, akCs3PFJets, akCs4PFJets
+
+recoPFJetsHITask =cms.Task(fixedGridRhoAll,
+                           fixedGridRhoFastjetAll,
+                           fixedGridRhoFastjetCentral,
+                           fixedGridRhoFastjetCentralChargedPileUp,
+                           fixedGridRhoFastjetCentralNeutral,
+			   ak4PFJets,
+			   ak4PFJetsCHS,
+                           ak8PFJetsCHS,
+                           PFTowers,			   
+			   akPu3PFJets,
+			   akPu4PFJets,
+			   akPu5PFJets,
+			   kt4PFJetsForRho,
+			   hiFJRhoProducer,
+			   akCs3PFJets,
+			   akCs4PFJets
+
+   )
+recoPFJetsHI   = cms.Sequence(recoPFJetsHITask)
+
+
+for e in [pp_on_AA_2018]:
+ e.toReplaceWith(recoPFJets, recoPFJetsHI)
+

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -106,9 +106,7 @@ recoPFJetsWithSubstructureTask=cms.Task(
     )
 recoPFJetsWithSubstructure=cms.Sequence(recoPFJetsWithSubstructureTask)
 
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-
-from RecoHI.HiJetAlgos.HiRecoPFJets_cff import PFTowers, akPu3PFJets, akPu4PFJets, akPu5PFJets, kt4PFJetsForRho, hiFJRhoProducer, akCs3PFJets, akCs4PFJets
+from RecoHI.HiJetAlgos.HiRecoPFJets_cff import PFTowers, akPu3PFJets, akPu4PFJets, kt4PFJetsForRho, hiFJRhoProducer, akCs4PFJets
 
 recoPFJetsHITask =cms.Task(fixedGridRhoAll,
                            fixedGridRhoFastjetAll,
@@ -121,16 +119,9 @@ recoPFJetsHITask =cms.Task(fixedGridRhoAll,
                            PFTowers,			   
                            akPu3PFJets,
                            akPu4PFJets,
-                           akPu5PFJets,
                            kt4PFJetsForRho,
                            hiFJRhoProducer,
-                           akCs3PFJets,
                            akCs4PFJets
 
    )
 recoPFJetsHI   = cms.Sequence(recoPFJetsHITask)
-
-
-for e in [pp_on_AA_2018]:
- e.toReplaceWith(recoPFJets, recoPFJetsHI)
-

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -115,17 +115,17 @@ recoPFJetsHITask =cms.Task(fixedGridRhoAll,
                            fixedGridRhoFastjetCentral,
                            fixedGridRhoFastjetCentralChargedPileUp,
                            fixedGridRhoFastjetCentralNeutral,
-			   ak4PFJets,
-			   ak4PFJetsCHS,
+                           ak4PFJets,
+                           ak4PFJetsCHS,
                            ak8PFJetsCHS,
                            PFTowers,			   
-			   akPu3PFJets,
-			   akPu4PFJets,
-			   akPu5PFJets,
-			   kt4PFJetsForRho,
-			   hiFJRhoProducer,
-			   akCs3PFJets,
-			   akCs4PFJets
+                           akPu3PFJets,
+                           akPu4PFJets,
+                           akPu5PFJets,
+                           kt4PFJetsForRho,
+                           hiFJRhoProducer,
+                           akCs3PFJets,
+                           akCs4PFJets
 
    )
 recoPFJetsHI   = cms.Sequence(recoPFJetsHITask)


### PR DESCRIPTION
This pull request is for having a proper set of heavy-ion specific jet algorithms within pp_on_AA_2018 era. Also,definition of kt4PFJetsForRho is removed from RecoJets/Configuration/RecoJetsGlobal and now kept in the RecoHI area.

Compared to the previous attempt:
https://github.com/cms-sw/cmssw/pull/24349
This PR passes both 150 and 158 workflow tests and avoid any duplication.

@mverwe @mandrenguyen @cfmcginn @FHead