### PR TITLE
[10.3.X][Update GTs] new JEC MC TAGs + 2D Pixel Templates + EcalSimPulseShape + L1 menu

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '103X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '103X_dataRun2_v1',
+    'run1_data'         :   '103X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '103X_dataRun2_v1',
+    'run2_data'         :   '103X_dataRun2_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '103X_dataRun2_relval_v3',
+    'run2_data_relval'  :   '103X_dataRun2_relval_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '103X_dataRun2_PromptLike_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
@@ -36,7 +36,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '103X_dataRun2_HLT_relval_v2',
+    'run2_hlt_relval'   :   '103X_dataRun2_HLT_relval_v3',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -12,7 +12,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '103X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'Run2_relval_v4run2_mc_50ns'      :   '103X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '103X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '103X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,63 +2,63 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '102X_mcRun1_design_v1',
+    'run1_design'       :   '103X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '102X_mcRun1_realistic_v1',
+    'run1_mc'           :   '103X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '102X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '103X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '102X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '103X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '102X_mcRun2_design_v2',
+    'run2_design'       :   '103X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '102X_mcRun2_startup_v2',
+    'Run2_relval_v4run2_mc_50ns'      :   '103X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '102X_mcRun2_asymptotic_v3',
+    'run2_mc'           :   '103X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '102X_mcRun2cosmics_startup_deco_v2',
+    'run2_mc_cosmics'   :   '103X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '102X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '103X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '102X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '103X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '102X_dataRun2_v3',
+    'run1_data'         :   '103X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '102X_dataRun2_v3',
+    'run2_data'         :   '103X_dataRun2_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '103X_dataRun2_relval_v2',
+    'run2_data_relval'  :   '103X_dataRun2_relval_v3',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '102X_dataRun2_PromptLike_v4',
+    'run2_data_promptlike' : '103X_dataRun2_PromptLike_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '103X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'   :   '103X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '102X_mc2017_design_IdealBS_v3',
+    'phase1_2017_design'       :  '103X_mc2017_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '102X_mc2017_realistic_v3',
+    'phase1_2017_realistic'    : '103X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '102X_mc2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      : '103X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v3',
+    'phase1_2017_cosmics_peak' : '103X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '103X_upgrade2018_design_v1',
+    'phase1_2018_design'       : '103X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '103X_postLS2_design_v1', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '103X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '103X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '103X_postLS2_realistic_v2', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '103X_upgrade2023_realistic_v1'
+    'phase2_realistic'         : '103X_upgrade2023_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
## **Added JEC MC and EcalSimPulseShape to the following **MC GTs****
### RunI simulation 
 
   * **RunI Heavy Ions scenario** : [103X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun1_HeavyIon_v1) as [102X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun1_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun1_HeavyIon_v1/102X_mcRun1_HeavyIon_v1): 

   * **RunI Ideal scenario** : [103X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun1_design_v1) as [102X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun1_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun1_design_v1/102X_mcRun1_design_v1): 

   * **RunI Proton-Lead scenario** : [103X_mcRun1_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun1_pA_v2) as [102X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun1_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun1_pA_v2/102X_mcRun1_pA_v1): 

   * **RunI Realistic scenario** : [103X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun1_realistic_v1) as [102X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun1_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun1_realistic_v1/102X_mcRun1_realistic_v1): 

### RunII simulation 
 
   * **RunII Asymptotic scenario** : [103X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun2_asymptotic_v1) as [102X_mcRun2_asymptotic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_asymptotic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun2_asymptotic_v1/102X_mcRun2_asymptotic_v3): 

   * **RunII CRAFT scenario** : [103X_mcRun2cosmics_startup_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun2cosmics_startup_deco_v1) as [102X_mcRun2cosmics_startup_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2cosmics_startup_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun2cosmics_startup_deco_v1/102X_mcRun2cosmics_startup_deco_v2): 

   * **RunII Heavy Ions scenario** : [103X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun2_HeavyIon_v1) as [102X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun2_HeavyIon_v1/102X_mcRun2_HeavyIon_v2): 

   * **RunII Ideal scenario** : [103X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun2_design_v1) as [102X_mcRun2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun2_design_v1/102X_mcRun2_design_v2): 

   * **RunII Proton-Lead scenario** : [103X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun2_pA_v1) as [102X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_pA_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun2_pA_v1/102X_mcRun2_pA_v2): 

   * **RunII Startup scenario** : [103X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_mcRun2_startup_v1) as [102X_mcRun2_startup_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_mcRun2_startup_v1/102X_mcRun2_startup_v2): 

### Upgrade 
 
   * **PhaseII realistic scenario** : [103X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_upgrade2023_realistic_v2) as [103X_upgrade2023_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_upgrade2023_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2023_realistic_v2/103X_upgrade2023_realistic_v1): 

   * **PostLS2 design scenario** : [103X_postLS2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_postLS2_design_v2) as [103X_postLS2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_postLS2_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_postLS2_design_v2/103X_postLS2_design_v1): 

   * **PostLS2 realistic scenario** : [103X_postLS2_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_postLS2_realistic_v2) as [103X_postLS2_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_postLS2_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_postLS2_realistic_v2/103X_postLS2_realistic_v1): 

### 2017_MC 
 
   * **PhaseI 2017 cosmics peak scenario** : [103X_upgrade2017cosmics_realistic_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_upgrade2017cosmics_realistic_peak_v1) as [102X_upgrade2017cosmics_realistic_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2017cosmics_realistic_peak_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2017cosmics_realistic_peak_v1/102X_upgrade2017cosmics_realistic_peak_v3): 

   * **PhaseI 2017 cosmics scenario** : [103X_upgrade2017cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_upgrade2017cosmics_realistic_deco_v1) as [102X_upgrade2017cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2017cosmics_realistic_deco_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2017cosmics_realistic_deco_v1/102X_upgrade2017cosmics_realistic_deco_v3): 

   * **PhaseI 2017 design scenario** : [103X_upgrade2017_design_IdealBS_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_upgrade2017_design_IdealBS_v1) as [102X_upgrade2017_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2017_design_IdealBS_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2017_design_IdealBS_v1/102X_upgrade2017_design_IdealBS_v3): 

   * **PhaseI 2017 realistic scenario** : [103X_upgrade2017_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_upgrade2017_realistic_v1) as [102X_upgrade2017_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2017_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2017_realistic_v1/102X_upgrade2017_realistic_v3): 


## **Added EcalSimPulseShape and new L1 menu to the following **data GTs****

### RunII data 
 
   * **RunII HLT relval processing** : [103X_dataRun2_HLT_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_dataRun2_HLT_relval_v3) as [103X_dataRun2_HLT_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_dataRun2_HLT_relval_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_HLT_relval_v3/103X_dataRun2_HLT_relval_v1): 

**Added EcalSimPulseShape, Pixel2DTemplate and correct CTPPS geometry to the following **data GTs****

### RunI data 
 
   * **RunI Offline processing** : [103X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_dataRun2_v2) as [102X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_dataRun2_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_v2/102X_dataRun2_v3): 

### RunII data 

   * **RunII Offline processing** : [103X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_dataRun2_v2) as [102X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_dataRun2_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_v2/102X_dataRun2_v3): 

   * **RunII Prompt processing** : [103X_dataRun2_PromptLike_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_dataRun2_PromptLike_v3) as [102X_dataRun2_PromptLike_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_dataRun2_PromptLike_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_PromptLike_v3/102X_dataRun2_PromptLike_v4): 

## **Added EcalSimPulseShape, Pixel2DTemplate, new L1 menu and correct CTPPS geometry to the following **data GTs****

### RunII data 

   * **RunII Offline relval processing** : [103X_dataRun2_relval_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_dataRun2_relval_v4) as [103X_dataRun2_relval_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/103X_dataRun2_relval_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_relval_v4/103X_dataRun2_relval_v2): 