### PR TITLE
Remove inappropriate use of provenance in EcalDeadCellTriggerPrimitiveFilter

### DIFF
--- a/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
@@ -143,6 +143,8 @@ private:
 
   bool useTPmethod_, useHITmethod_;
 
+  edm::EDPutTokenT<bool> putToken_;
+
   void loadEventInfoForFilter(const edm::Event& iEvent);
 
 // Only for EB since the dead front-end has one-to-one map to TT
@@ -179,12 +181,12 @@ EcalDeadCellTriggerPrimitiveFilter::EcalDeadCellTriggerPrimitiveFilter(const edm
   , tpDigiCollectionToken_(consumes<EcalTrigPrimDigiCollection>(tpDigiCollection_))
   , useTTsum_ (iConfig.getParameter<bool>("useTTsum") )
   , usekTPSaturated_ (iConfig.getParameter<bool>("usekTPSaturated") )
+  , putToken_ ( produces<bool>() )
 {
   getEventInfoForFilterOnce_ = false;
   hastpDigiCollection_ = 0; hasReducedRecHits_ = 0;
   useTPmethod_ = true; useHITmethod_ = false;
 
-  produces<bool>();
 
   callWhenNewProductsRegistered([this](edm::BranchDescription const& iBranch) {
     if( iBranch.moduleLabel() ==  tpDigiCollection_.label() ){ hastpDigiCollection_ = 1; }
@@ -312,7 +314,7 @@ bool EcalDeadCellTriggerPrimitiveFilter::filter(edm::Event& iEvent, const edm::E
      printf("\nrun : %8u  event : %10llu  lumi : %4u  evtTPstatus  ABS : %d  13 : % 2d\n", run, event, ls, evtstatusABS, evtTagged);
   }
 
-  iEvent.put(std::make_unique<bool>(pass));
+  iEvent.emplace(putToken_, pass);
 
   if (taggingMode_) return true;
   else return pass;

--- a/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
@@ -93,8 +93,7 @@ private:
   edm::ESHandle<CaloGeometry>       geometry;
 
   void loadEcalDigis(edm::Event& iEvent,
-                     edm::Handle<EcalTrigPrimDigiCollection>& pTPDigis
-);
+                     edm::Handle<EcalTrigPrimDigiCollection>& pTPDigis);
   void loadEcalRecHits(edm::Event& iEvent,
                        edm::Handle<EcalRecHitCollection>& barrelReducedRecHitsHandle,
                        edm::Handle<EcalRecHitCollection>& endcapReducedRecHitsHandle);


### PR DESCRIPTION
The code was calling edm::Event::getAllStableProvenance to try to determine if some data products were available in the Event. This did not help performance since the consumes calls would already prefetch all the data. To try to keep the same functionality, I switched to using callWhenNewProductsRegistered.

The logic which changed the movule's behavior for data older than CMSSW_4_2 was also removed.