### PR TITLE
[10.3.X] miscellaneous fixes to Strip CondDB monitoring

### DIFF
--- a/DQM/SiStripMonitorSummary/interface/SiStripMonitorCondData.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripMonitorCondData.h
@@ -70,15 +70,15 @@ class SiStripMonitorCondData : public edm::EDAnalyzer {
      
    std::string outPutFileName;
 
-   SiStripPedestalsDQM*           pedestalsDQM_;
-   SiStripNoisesDQM*                 noisesDQM_; 
-   SiStripThresholdDQM*        lowthresholdDQM_; 
-   SiStripThresholdDQM*       highthresholdDQM_; 
-   SiStripQualityDQM*               qualityDQM_; 
-   SiStripApvGainsDQM*             apvgainsDQM_;  
-   SiStripLorentzAngleDQM*     lorentzangleDQM_; 
-   SiStripBackPlaneCorrectionDQM*     bpcorrectionDQM_; 
-   SiStripCablingDQM*               cablingDQM_;  
+   std::unique_ptr<SiStripPedestalsDQM>                  pedestalsDQM_;
+   std::unique_ptr<SiStripNoisesDQM>                        noisesDQM_; 
+   std::unique_ptr<SiStripThresholdDQM>               lowthresholdDQM_; 
+   std::unique_ptr<SiStripThresholdDQM>              highthresholdDQM_; 
+   std::unique_ptr<SiStripQualityDQM>                      qualityDQM_; 
+   std::unique_ptr<SiStripApvGainsDQM>                    apvgainsDQM_;  
+   std::unique_ptr<SiStripLorentzAngleDQM>            lorentzangleDQM_; 
+   std::unique_ptr<SiStripBackPlaneCorrectionDQM>     bpcorrectionDQM_; 
+   std::unique_ptr<SiStripCablingDQM>                      cablingDQM_;  
   
 };
 

--- a/DQM/SiStripMonitorSummary/src/SiStripMonitorCondData.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripMonitorCondData.cc
@@ -71,17 +71,6 @@ SiStripMonitorCondData::SiStripMonitorCondData(edm::ParameterSet const& iConfig)
 // ----- Destructor
 // 
 SiStripMonitorCondData::~SiStripMonitorCondData(){
-
-  if(monitorPedestals_)   { delete pedestalsDQM_   ;}
-  if(monitorNoises_)      { delete noisesDQM_      ;}
-  if(monitorLowThreshold_) { delete lowthresholdDQM_ ;}
-  if(monitorHighThreshold_){ delete highthresholdDQM_;}
-  if(monitorQuality_)     { delete qualityDQM_     ;}
-  if(monitorApvGains_)    { delete apvgainsDQM_    ;}
-  if(monitorLorentzAngle_){ delete lorentzangleDQM_;}
-  if(monitorBackPlaneCorrection_){ delete bpcorrectionDQM_;}
-  if(monitorCabling_)     { delete cablingDQM_;}
-
 }
 // -----
 
@@ -93,69 +82,69 @@ SiStripMonitorCondData::~SiStripMonitorCondData(){
 void SiStripMonitorCondData::beginRun(edm::Run const& run, edm::EventSetup const& eSetup) {
 
   if(monitorPedestals_){
-    pedestalsDQM_ = new SiStripPedestalsDQM(eSetup,
-                                            run.run(),
-                                            conf_.getParameter<edm::ParameterSet>("SiStripPedestalsDQM_PSet"),
-                                            conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    pedestalsDQM_ = std::make_unique<SiStripPedestalsDQM>(eSetup,
+							  run.run(),
+							  conf_.getParameter<edm::ParameterSet>("SiStripPedestalsDQM_PSet"),
+							  conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   
   
   if(monitorNoises_){
-    noisesDQM_ = new SiStripNoisesDQM(eSetup,
-                                      run.run(),
-                                      conf_.getParameter<edm::ParameterSet>("SiStripNoisesDQM_PSet"),
-                                      conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    noisesDQM_ = std::make_unique<SiStripNoisesDQM>(eSetup,
+						    run.run(),
+						    conf_.getParameter<edm::ParameterSet>("SiStripNoisesDQM_PSet"),
+						    conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   
   
   if(monitorLowThreshold_){
-    lowthresholdDQM_ = new SiStripThresholdDQM(eSetup,
-                                               run.run(),
-                                               conf_.getParameter<edm::ParameterSet>("SiStripLowThresholdDQM_PSet"),
-                                               conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    lowthresholdDQM_ = std::make_unique<SiStripThresholdDQM>(eSetup,
+							     run.run(),
+							     conf_.getParameter<edm::ParameterSet>("SiStripLowThresholdDQM_PSet"),
+							     conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if(monitorHighThreshold_){
-    highthresholdDQM_ = new SiStripThresholdDQM(eSetup,
-                                                run.run(),
-                                                conf_.getParameter<edm::ParameterSet>("SiStripHighThresholdDQM_PSet"),
-                                                conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    highthresholdDQM_ = std::make_unique<SiStripThresholdDQM>(eSetup,
+							      run.run(),
+							      conf_.getParameter<edm::ParameterSet>("SiStripHighThresholdDQM_PSet"),
+							      conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if(monitorQuality_){
-    qualityDQM_ = new SiStripQualityDQM(eSetup,
-                                        run.run(),
-                                        conf_.getParameter<edm::ParameterSet>("SiStripQualityDQM_PSet"),
-                                        conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    qualityDQM_ = std::make_unique<SiStripQualityDQM>(eSetup,
+						      run.run(),
+						      conf_.getParameter<edm::ParameterSet>("SiStripQualityDQM_PSet"),
+						      conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   } 
   
  
   if(monitorApvGains_){
-    apvgainsDQM_ = new SiStripApvGainsDQM(eSetup,
-                                          run.run(),
-                                          conf_.getParameter<edm::ParameterSet>("SiStripApvGainsDQM_PSet"),
-                                          conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    apvgainsDQM_ = std::make_unique<SiStripApvGainsDQM>(eSetup,
+							run.run(),
+							conf_.getParameter<edm::ParameterSet>("SiStripApvGainsDQM_PSet"),
+							conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   
   
   if(monitorLorentzAngle_){
-    lorentzangleDQM_ = new SiStripLorentzAngleDQM(eSetup,
-                                                  run.run(),
-                                                 conf_.getParameter<edm::ParameterSet>("SiStripLorentzAngleDQM_PSet"),
-                                                 conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    lorentzangleDQM_ = std::make_unique<SiStripLorentzAngleDQM>(eSetup,
+								run.run(),
+								conf_.getParameter<edm::ParameterSet>("SiStripLorentzAngleDQM_PSet"),
+								conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if(monitorBackPlaneCorrection_){
-    bpcorrectionDQM_ = new SiStripBackPlaneCorrectionDQM(eSetup,
-                                                         run.run(),
-                                                 conf_.getParameter<edm::ParameterSet>("SiStripBackPlaneCorrectionDQM_PSet"),
-                                                 conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    bpcorrectionDQM_ = std::make_unique<SiStripBackPlaneCorrectionDQM>(eSetup,
+								       run.run(),
+								       conf_.getParameter<edm::ParameterSet>("SiStripBackPlaneCorrectionDQM_PSet"),
+								       conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   if(monitorCabling_){
-    cablingDQM_ = new SiStripCablingDQM(eSetup,
-                                        run.run(),
-					conf_.getParameter<edm::ParameterSet>("SiStripCablingDQM_PSet"),
-					conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    cablingDQM_ = std::make_unique<SiStripCablingDQM>(eSetup,
+						      run.run(),
+						      conf_.getParameter<edm::ParameterSet>("SiStripCablingDQM_PSet"),
+						      conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 } // beginRun
 // -----

--- a/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_generic_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_generic_cfg.py
@@ -178,7 +178,7 @@ process.source = cms.Source("EmptyIOVSource",
 )
 
 #process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
-process.load('Configuration.Geometry.GeometryExtended_cff')
+process.load('Configuration.Geometry.GeometryExtended2018_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
 process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
@@ -323,10 +323,11 @@ if options.QualityMon == True:
                                                       )
 
 # this module is almost useless since SiStripQualityDQM does all the job. If we want to remove it the log file has to be filled with SiStripQualityDQM
-    process.stat = cms.EDAnalyzer("SiStripQualityStatistics",
-                                  TkMapFileName = cms.untracked.string(''),
-                                  dataLabel = cms.untracked.string('')
-                                  )
+    from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+    process.stat = DQMEDAnalyzer("SiStripQualityStatistics",
+                                 TkMapFileName = cms.untracked.string(''),
+                                 dataLabel = cms.untracked.string('')
+                                 )
 
     process.e = cms.EndPath(process.stat)
 


### PR DESCRIPTION
Greetings,
this PR fixes the Strip CondDB monitoring validation suite, which is used by the Tracker Offline shift crew to check the conditions changes during data-taking. 
The code changes include some minor configuration fixes taking into account the correct geometry for 2018 + the DQM migration to `DQMEDAnalyzer` for `SiStripQualityStatistics` and the usage of smart pointers in `SiStripMonitorCondData`.
No change in the any central workflow is expected.
@jandrea @arossi83 FYI