### PR TITLE
DD: Current Namespace is a Singleton, so make it one

### DIFF
--- a/DetectorDescription/Core/interface/DDCurrentNamespace.h
+++ b/DetectorDescription/Core/interface/DDCurrentNamespace.h
@@ -1,12 +1,19 @@
-#ifndef DDCurrentNamespace_h
-#define DDCurrentNamespace_h
+#ifndef DETECTOR_DESCRIPTION_DD_CURRENT_NAMESPACE_H
+#define DETECTOR_DESCRIPTION_DD_CURRENT_NAMESPACE_H
 
+#include "DetectorDescription/Core/interface/DDSingleton.h"
+#include <iostream>
 #include <string>
 
-class DDCurrentNamespace
+struct DDCurrentNamespace;
+
+std::ostream & operator<<( std::ostream &, const DDCurrentNamespace & );
+
+struct DDCurrentNamespace : public dd::DDSingleton<std::string, DDCurrentNamespace>
 {
-public:
-  static std::string & ns();
+  DDCurrentNamespace() : DDSingleton(1) {}
+  static std::unique_ptr<std::string> init() {
+    return std::make_unique<std::string>( "GLOBAL" ); }
 };
 
 #endif

--- a/DetectorDescription/Core/interface/DDName.h
+++ b/DetectorDescription/Core/interface/DDName.h
@@ -7,8 +7,6 @@
 #include <utility>
 #include <vector>
 
-class DDCurrentNamespace;
-
 //! DDName is used to identify DDD entities uniquely.
 /** A DDName consists of a \a name and a \a namespace. Both are represented as std::string.
 */

--- a/DetectorDescription/Core/interface/DDSingleton.h
+++ b/DetectorDescription/Core/interface/DDSingleton.h
@@ -1,0 +1,40 @@
+#ifndef DETECTOR_DESCRIPTION_DD_SINGLETON_H
+#define DETECTOR_DESCRIPTION_DD_SINGLETON_H
+
+#include <memory>
+
+namespace dd {
+
+  template< typename T, typename CONTEXT >
+    class DDSingleton
+  {
+  public:
+    T* operator->() { return m_instance.get(); }
+    const T* operator->() const { return m_instance; }
+    T& operator*() { return *m_instance; }
+    const T& operator*() const { return *m_instance; }
+    
+  protected:
+    DDSingleton() {
+      static bool static_init __attribute__(( unused )) = []()->bool {
+	m_instance = std::make_unique<T>();
+	return true;
+      }();
+    }
+
+    DDSingleton( int ) {
+      static bool static_init __attribute__(( unused )) = []()->bool {
+	m_instance = CONTEXT::init();
+	return true;
+      }();
+    }
+    
+  private:
+    static std::unique_ptr<T> m_instance;
+  };
+}
+
+template < typename T, typename CONTEXT >
+  std::unique_ptr<T> dd::DDSingleton< T, CONTEXT >::m_instance;
+  
+#endif

--- a/DetectorDescription/Core/plugins/DDAngular.cc
+++ b/DetectorDescription/Core/plugins/DDAngular.cc
@@ -120,11 +120,11 @@ DDAngular::initialize( const DDNumericArguments & nArgs,
     LogDebug( "DDAlgorithm" ) << "  rotsolid[" << i <<  "] axis=" << temp.Axis() << " rot.angle=" << CONVERT_TO( temp.Angle(), deg );
     m_solidRot = temp * m_solidRot;			  
   }
-
-  m_idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  m_idNameSpace = *ns;
   m_childNmNs 	= DDSplit( sArgs["ChildName"] );
   if( m_childNmNs.second.empty())
-    m_childNmNs.second = DDCurrentNamespace::ns();
+    m_childNmNs.second = *ns;
 
   DDName parentName = parent().name();
   LogDebug( "DDAlgorithm" ) << "DDAngular: Parent " << parentName 

--- a/DetectorDescription/Core/plugins/DDLinear.cc
+++ b/DetectorDescription/Core/plugins/DDLinear.cc
@@ -76,7 +76,7 @@ DDLinear::initialize( const DDNumericArguments & nArgs,
   
   m_childNmNs 	= DDSplit( sArgs["ChildName"] );
   if( m_childNmNs.second.empty())
-    m_childNmNs.second = DDCurrentNamespace::ns();
+    m_childNmNs.second = DDCurrentNamespace()->c_str();
   
   DDName parentName = parent().name();
   LogDebug( "DDAlgorithm" ) << "DDLinear: Parent " << parentName 

--- a/DetectorDescription/Core/plugins/DDLinear.cc
+++ b/DetectorDescription/Core/plugins/DDLinear.cc
@@ -76,7 +76,7 @@ DDLinear::initialize( const DDNumericArguments & nArgs,
   
   m_childNmNs 	= DDSplit( sArgs["ChildName"] );
   if( m_childNmNs.second.empty())
-    m_childNmNs.second = DDCurrentNamespace()->c_str();
+    m_childNmNs.second = *DDCurrentNamespace();
   
   DDName parentName = parent().name();
   LogDebug( "DDAlgorithm" ) << "DDLinear: Parent " << parentName 

--- a/DetectorDescription/Core/src/DDCurrentNamespace.cc
+++ b/DetectorDescription/Core/src/DDCurrentNamespace.cc
@@ -1,8 +1,5 @@
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
 
-std::string & 
-DDCurrentNamespace::ns()
-{
-  static std::string ns_ = "GLOBAL";
-  return ns_;
+std::ostream & operator<<( std::ostream & os, const DDCurrentNamespace & ns ) {
+  return os << *ns;
 }

--- a/DetectorDescription/Core/src/DDName.cc
+++ b/DetectorDescription/Core/src/DDName.cc
@@ -22,7 +22,7 @@ DDName::DDName( const std::string & name )
 { 
   std::pair<std::string, std::string> result = DDSplit( name );
   if( result.second.empty()) {
-    id_ = registerName( std::make_pair( result.first, DDCurrentNamespace::ns()))->second;
+    id_ = registerName( std::make_pair( result.first, DDCurrentNamespace()->c_str()))->second;
   }  
   else {
     id_ = registerName( result )->second;
@@ -34,7 +34,7 @@ DDName::DDName( const char* name )
 { 
   std::pair< std::string, std::string > result = DDSplit( name );
   if( result.second.empty()) {
-    id_ = registerName( std::make_pair( result.first, DDCurrentNamespace::ns()))->second;
+    id_ = registerName( std::make_pair( result.first, DDCurrentNamespace()->c_str()))->second;
   }  
   else {
     id_ = registerName( result )->second;

--- a/DetectorDescription/Core/test/BuildFile.xml
+++ b/DetectorDescription/Core/test/BuildFile.xml
@@ -14,6 +14,8 @@
 </bin>
 <bin   name="testUnits" file="testRunner.cpp,DDUnits.cppunit.cc">
 </bin>
+<bin   name="testDDCurrentNamespace" file="testRunner.cpp,DDCurrentNamespace.cppunit.cc">
+</bin>
 <bin   file="clhepToROOTMath.cpp">
 </bin>
 <bin   file="test_DDRotation.cpp">

--- a/DetectorDescription/Core/test/DDCurrentNamespace.cppunit.cc
+++ b/DetectorDescription/Core/test/DDCurrentNamespace.cppunit.cc
@@ -1,0 +1,49 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
+
+#include "cppunit/TestAssert.h"
+#include "cppunit/TestFixture.h"
+
+class testDDCurrentNamespace : public CppUnit::TestFixture {
+  
+  CPPUNIT_TEST_SUITE( testDDCurrentNamespace );
+  CPPUNIT_TEST( checkNamespace );
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void setUp() override{}
+  void tearDown() override {}
+  void checkNamespace();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testDDCurrentNamespace);
+
+void testDDCurrentNamespace::checkNamespace()
+{
+  std::cout << "\nDefault namespace is GLOBAL.\n";
+  {
+    DDCurrentNamespace ns1;
+    std::cout << *ns1 << "\n";
+    std::cout << DDCurrentNamespace() << "\n";
+    CPPUNIT_ASSERT( DDCurrentNamespace()->c_str() == std::string{"GLOBAL"});
+  }
+  {
+    std::cout << DDCurrentNamespace()->c_str() << "\n";
+    CPPUNIT_ASSERT( DDCurrentNamespace()->c_str() == std::string{"GLOBAL"});
+  }
+  {
+    DDCurrentNamespace ns;
+    std::cout << *ns << "\n";
+    CPPUNIT_ASSERT( *ns == std::string{"GLOBAL"});
+  }
+  {
+    DDCurrentNamespace ns;
+    *ns = "New namespace";
+    std::cout << *ns << "\n";
+    CPPUNIT_ASSERT( *ns == std::string{"New namespace"});
+  }
+  std::cout << DDCurrentNamespace() << "\n";
+  CPPUNIT_ASSERT( DDCurrentNamespace()->c_str() == std::string{"New namespace"});
+}

--- a/DetectorDescription/Parser/src/DDLSAX2FileHandler.cc
+++ b/DetectorDescription/Parser/src/DDLSAX2FileHandler.cc
@@ -75,16 +75,16 @@ DDLSAX2FileHandler::endElement( const XMLCh* const uri,
   // The need for processElement to have the nmspace so that it can 
   // do the necessary gymnastics made things more complicated in the
   // effort to allow fully user-controlled namespaces.  So the "magic"
-  // trick of setting nmspace to "!" is used :(... I don't like this magic trick
-  // -- Michael Case 2008-11-06
-  // OPTIMISE in the near future, like the current nmspace_ impl. 
+  // trick of setting nmspace to "!" is used
+  // FIXME:
   // just set nmspace_ to "!" from Parser based on userNS_ so 
-  // userNS_ is set by parser ONCE and no if nec. here. MEC: 2009-06-22
+  // userNS_ is set by parser ONCE and no if nec. here.
   if ( userNS_ ) {
     nmspace = "!";
   } 
 
-  DDCurrentNamespace::ns() = nmspace;
+  DDCurrentNamespace ns;
+  *ns = nmspace;
   // tell the element it's parent name for recording/reporting purposes
   myElement->setParent(parent());
   myElement->setSelf(self());

--- a/Geometry/EcalCommonData/src/DDEcalBarrelAlgo.cc
+++ b/Geometry/EcalCommonData/src/DDEcalBarrelAlgo.cc
@@ -339,7 +339,8 @@ void DDEcalBarrelAlgo::initialize(const DDNumericArguments      & nArgs,
 				  const DDStringVectorArguments & vsArgs) {
 
    LogDebug("EcalGeom") << "DDEcalBarrelAlgo info: Initialize" ;
-   m_idNameSpace = DDCurrentNamespace::ns();
+   DDCurrentNamespace ns;
+   m_idNameSpace = *ns;
    // TRICK!
    m_idNameSpace = parent().name().ns();
    // barrel parent volume

--- a/Geometry/EcalCommonData/src/DDEcalBarrelNewAlgo.cc
+++ b/Geometry/EcalCommonData/src/DDEcalBarrelNewAlgo.cc
@@ -373,7 +373,8 @@ void DDEcalBarrelNewAlgo::initialize(const DDNumericArguments      & nArgs,
 				     const DDStringVectorArguments & vsArgs) {
 
    LogDebug("EcalGeom") << "DDEcalBarrelAlgo info: Initialize" ;
-   m_idNameSpace = DDCurrentNamespace::ns();
+   DDCurrentNamespace ns;
+   m_idNameSpace = *ns;
    // TRICK!
    m_idNameSpace = parent().name().ns();
    // barrel parent volume

--- a/Geometry/EcalCommonData/src/DDEcalEndcapAlgo.cc
+++ b/Geometry/EcalCommonData/src/DDEcalEndcapAlgo.cc
@@ -79,10 +79,10 @@ void DDEcalEndcapAlgo::initialize(const DDNumericArguments      & nArgs,
 				  const DDVectorArguments       & vArgs,
 				  const DDMapArguments          & /*mArgs*/,
 				  const DDStringArguments       & sArgs,
-				  const DDStringVectorArguments & /*vsArgs*/) {
-
-//   edm::LogInfo("EcalGeom") << "DDEcalEndcapAlgo info: Initialize" ;
-   m_idNameSpace = DDCurrentNamespace::ns();
+				  const DDStringVectorArguments & /*vsArgs*/)
+{
+  DDCurrentNamespace ns;
+   m_idNameSpace = *ns;
    // TRICK!
    m_idNameSpace = parent().name().ns();
    // barrel parent volume

--- a/Geometry/EcalTestBeam/plugins/DDTBH4Algo.cc
+++ b/Geometry/EcalTestBeam/plugins/DDTBH4Algo.cc
@@ -87,7 +87,8 @@ void DDTBH4Algo::initialize(const DDNumericArguments&      nArgs,
 			    const DDStringArguments&       sArgs,
 			    const DDStringVectorArguments& vsArgs )
 {
-   m_idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  m_idNameSpace = *ns;
    m_BLZBeg      = nArgs["BLZBeg"];	
    m_BLZEnd      = nArgs["BLZEnd"];	
    m_BLZPiv      = nArgs["BLZPiv"];	

--- a/Geometry/HGCalCommonData/plugins/DDAHcalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDAHcalModuleAlgo.cc
@@ -87,7 +87,8 @@ void DDAHcalModuleAlgo::initialize(const DDNumericArguments & nArgs,
   std::cout << std::endl;
 #endif
   zMinBlock     = nArgs["zMinBlock"];
-  idNameSpace   = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace   = *ns;
 #ifdef EDM_ML_DEBUG
   std::cout << "DDAHcalModuleAlgo: NameSpace " << idNameSpace << std::endl;
 #endif

--- a/Geometry/HGCalCommonData/plugins/DDHGCalCell.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalCell.cc
@@ -38,7 +38,8 @@ void DDHGCalCell::initialize(const DDNumericArguments & nArgs,
   extenSensN_  = vsArgs["ExtendedSensitive"];
   cornrCN_     = vsArgs["CornerCell"];
   cornrSensN_  = vsArgs["CornerSensitive"];
-  nameSpace_   = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  nameSpace_   = *ns;
   if ((truncCN_.size() != truncSensN_.size()) ||
       (extenCN_.size() != extenSensN_.size()) ||
       (cornrCN_.size() != cornrSensN_.size()))

--- a/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.cc
@@ -126,7 +126,8 @@ void DDHGCalEEAlgo::initialize(const DDNumericArguments & nArgs,
 				  << " Rmax " << rMaxFront_[i] << " Slope " 
 				  << slopeT_[i];
 #endif
-  nameSpace_    = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  nameSpace_    = *ns;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "DDHGCalEEAlgo: NameSpace " << nameSpace_;
 #endif

--- a/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.cc
@@ -170,7 +170,8 @@ void DDHGCalHEAlgo::initialize(const DDNumericArguments & nArgs,
 				  << " Rmax " << rMaxFront_[i] << " Slope " 
 				  << slopeT_[i];
 #endif
-  nameSpace_    = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  nameSpace_    = *ns;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "DDHGCalHEAlgo: NameSpace " << nameSpace_;
 #endif

--- a/Geometry/HGCalCommonData/plugins/DDHGCalModule.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalModule.cc
@@ -91,7 +91,8 @@ void DDHGCalModule::initialize(const DDNumericArguments & nArgs,
     std::cout << "Block [" << i << "] Zmin " << zFront[i] << " Rmax "
 	      << rMaxFront[i] << " Slope " << slopeT[i] << std::endl;
 #endif
-  idNameSpace   = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace   = *ns;
 #ifdef EDM_ML_DEBUG
   std::cout << "DDHGCalModule: NameSpace " << idNameSpace << std::endl;
 #endif

--- a/Geometry/HGCalCommonData/plugins/DDHGCalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalModuleAlgo.cc
@@ -92,7 +92,8 @@ void DDHGCalModuleAlgo::initialize(const DDNumericArguments & nArgs,
     std::cout << "Block [" << i << "] Zmin " << zFront[i] << " Rmax "
 	      << rMaxFront[i] << " Slope " << slopeT[i] << std::endl;
 #endif
-  idNameSpace   = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace   = *ns;
 #ifdef EDM_ML_DEBUG
   std::cout << "DDHGCalModuleAlgo: NameSpace " << idNameSpace << std::endl;
 #endif

--- a/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.cc
@@ -35,7 +35,8 @@ void DDHGCalNoTaperEndcap::initialize(const DDNumericArguments & nArgs,
   m_startCopyNo = int( nArgs["startCopyNo"] );
   m_incrCopyNo  = int( nArgs["incrCopyNo"] );
   m_childName   = sArgs["ChildName"];
-  m_idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  m_idNameSpace = *ns;
   edm::LogInfo("HGCalGeom") << "DDHGCalNoTaperEndcap: NameSpace " << m_idNameSpace 
 			    << "\tParent " << parent().name();
 }

--- a/Geometry/HGCalCommonData/plugins/DDHGCalTBModule.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalTBModule.cc
@@ -96,7 +96,8 @@ void DDHGCalTBModule::initialize(const DDNumericArguments & nArgs,
     std::cout << "Block [" << i << "] Zmin " << zFront_[i] << " Rmax "
 	      << rMaxFront_[i] << " Slope " << slopeT_[i] << std::endl;
 #endif
-  idNameSpace_  = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace_  = *ns;
 #ifdef EDM_ML_DEBUG
   std::cout << "DDHGCalTBModule: NameSpace " << idNameSpace_ << std::endl;
 #endif

--- a/Geometry/HGCalCommonData/plugins/DDHGCalWafer.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalWafer.cc
@@ -33,7 +33,8 @@ void DDHGCalWafer::initialize(const DDNumericArguments & nArgs,
   nCellsRow_   = dbl_to_int(vArgs["NCellsRow"]);
   angleEdges_ = dbl_to_int(vArgs["AngleEdges"]);
   detectorType_= dbl_to_int(vArgs["DetectorType"]);
-  idNameSpace_ = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace_ = *ns;
   parentName_  = parent().name(); 
 #ifdef EDM_ML_DEBUG
   std::cout << childNames_.size() << " children: " << childNames_[0] << "; "

--- a/Geometry/HGCalCommonData/plugins/DDHGCalWafer8.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalWafer8.cc
@@ -32,7 +32,8 @@ void DDHGCalWafer8::initialize(const DDNumericArguments & nArgs,
   cellType_    = (int)(nArgs["CellType"]);
   material_    = sArgs["Material"];
   cellNames_   = vsArgs["CellNames"];
-  nameSpace_   = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  nameSpace_   = *ns;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "DDHGCalWafer8: Wafer 2r " << waferSize_
 				<< " T " << waferT_ << " Half Separation " 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalWaferAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalWaferAlgo.cc
@@ -46,7 +46,8 @@ void DDHGCalWaferAlgo::initialize(const DDNumericArguments & nArgs,
 	      << std::endl;
 #endif
   rotns       = sArgs["RotNameSpace"];
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   parentName  = parent().name(); 
 #ifdef EDM_ML_DEBUG
   std::cout << "DDHGCalWaferAlgo debug: Parent " << parentName << " NameSpace "

--- a/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
@@ -41,7 +41,8 @@ void DDHCalAngular::initialize(const DDNumericArguments & nArgs,
 		       << ", " << incrCopyNo;
 
   rotns       = sArgs["RotNameSpace"];
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name(); 
   LogDebug("HCalGeom") << "DDHCalAngular debug: Parent " << parentName 

--- a/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.cc
@@ -173,9 +173,9 @@ void DDHCalBarrelAlgo::initialize(const DDNumericArguments & nArgs,
 			 << detWidth2[i] << "\t" << detPosY[i];
   }
 
-  //  idName = parentName.name();
   idName      = sArgs["MotherName"];
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   idOffset = int (nArgs["IdOffset"]); 
   DDName parentName = parent().name(); 
   LogDebug("HCalGeom") << "DDHCalBarrelAlgo debug: Parent " << parentName

--- a/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.cc
@@ -313,7 +313,8 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
 #endif
 
   idName      = sArgs["MotherName"];
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   idOffset = int (nArgs["IdOffset"]); 
 
 #ifdef EDM_ML_DEBUG

--- a/Geometry/HcalAlgo/plugins/DDHCalEndcapModuleAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalEndcapModuleAlgo.cc
@@ -96,7 +96,8 @@ void DDHCalEndcapModuleAlgo::initialize(const DDNumericArguments & nArgs,
     edm::LogInfo("HCalGeom") << "LayerName[" << i << "] = " << layerName[i];
 
   idName      = sArgs["MotherName"];
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   idOffset    = int (nArgs["IdOffset"]); 
   DDName parentName = parent().name(); 
   modName     = sArgs["ModName"];

--- a/Geometry/HcalAlgo/plugins/DDHCalFibreBundle.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalFibreBundle.cc
@@ -37,8 +37,9 @@ void DDHCalFibreBundle::initialize(const DDNumericArguments & nArgs,
   rEnd        = vArgs["RadiusEnd"];
   bundle      = dbl_to_int(vArgs["Bundles"]);
   tilt        = nArgs["TiltAngle"];
-  
-  idNameSpace = DDCurrentNamespace::ns();
+
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childPrefix = sArgs["Child"]; 
   DDName parentName = parent().name();
   LogDebug("HCalGeom") << "DDHCalFibreBundle debug: Parent " << parentName

--- a/Geometry/HcalAlgo/plugins/DDHCalForwardAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalForwardAlgo.cc
@@ -51,7 +51,8 @@ void DDHCalForwardAlgo::initialize(const DDNumericArguments & nArgs,
 			 << " occurence " << number[i] << " first child index "
 			 << type[i];
 
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   DDName parentName = parent().name(); 
   LogDebug("HCalGeom") << "DDHCalForwardAlgo debug: Parent " << parentName
 		       << " NameSpace " << idNameSpace;

--- a/Geometry/HcalAlgo/plugins/DDHCalLinearXY.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalLinearXY.cc
@@ -29,9 +29,7 @@ void DDHCalLinearXY::initialize(const DDNumericArguments & nArgs,
   numberY   = int(nArgs["NumberY"]);
   deltaY    = nArgs["DeltaY"];
   centre    = vArgs["Center"];
-  
-  idNameSpace = DDCurrentNamespace::ns();
-  childName   = vsArgs["Child"]; 
+  childName = vsArgs["Child"]; 
   DDName parentName = parent().name();
   LogDebug("HCalGeom") << "DDHCalLinearXY debug: Parent " << parentName
 		       << "\twith " << childName.size() << " children";
@@ -39,7 +37,7 @@ void DDHCalLinearXY::initialize(const DDNumericArguments & nArgs,
     LogDebug("HCalGeom") << "DDHCalLinearXY debug: Child[" << i << "] = "
 			 << childName[i];
   LogDebug("HCalGeom") << "DDHCalLinearXY debug: NameSpace " 
-		       << idNameSpace << "\tNumber along X/Y " << numberX
+		       << DDCurrentNamespace() << "\tNumber along X/Y " << numberX
 		       << "/" << numberY << "\tDelta along X/Y " << deltaX
 		       << "/" << deltaY << "\tCentre " << centre[0] << ", " 
 		       << centre[1] << ", "	<< centre[2];

--- a/Geometry/HcalAlgo/plugins/DDHCalLinearXY.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalLinearXY.h
@@ -24,7 +24,6 @@ public:
 
 private:
 
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
   std::vector<std::string> childName;   //Child name
   int                      numberX;     //Number of positioning along X-axis
   double                   deltaX;      //Increment               .........

--- a/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.cc
@@ -60,7 +60,8 @@ void DDHCalTBCableAlgo::initialize(const DDNumericArguments & nArgs,
 		       << " Gap " << gap2;
 
   idName      = sArgs["MotherName"];
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   rotns       = sArgs["RotNameSpace"];
   DDName parentName = parent().name(); 
   LogDebug("HCalGeom") << "DDHCalTBCableAlgo debug: Parent " << parentName

--- a/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
@@ -42,7 +42,8 @@ void DDHCalTBZposAlgo::initialize(const DDNumericArguments & nArgs,
 		       << "\tRadial Distance " << dist << "\tTilt angle "
 		       << tilt/CLHEP::deg << "\tcopyNumber " << copyNumber;
 
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name(); 
   LogDebug("HCalGeom") << "DDHCalTBZposAlgo debug: Parent " << parentName

--- a/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
@@ -38,8 +38,8 @@ void DDHCalTestBeamAlgo::initialize(const DDNumericArguments & nArgs,
 		       << phi/CLHEP::deg << "\tTheta " << theta/CLHEP::deg 
 		       << "\tDistance " << distance << "/" << distanceZ << "/"
 		       << dist <<"\tDz " << dz <<"\tcopyNumber " << copyNumber;
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name(); 
   LogDebug("HCalGeom") << "DDHCalTestBeamAlgo debug: Parent " << parentName

--- a/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
@@ -41,7 +41,8 @@ void DDHCalXtalAlgo::initialize(const DDNumericArguments & nArgs,
   for (unsigned int i = 0; i < names.size(); i++)
     LogDebug("HCalGeom") << "\tnames[" << i << "] = " << names[i];
 
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   idName      = sArgs["ChildName"]; 
   DDName parentName = parent().name(); 
   LogDebug("HCalGeom") << "DDHCalXtalAlgo debug: Parent " << parentName 

--- a/Geometry/HcalTestBeamData/plugins/DDEcalPreshowerAlgoTB.cc
+++ b/Geometry/HcalTestBeamData/plugins/DDEcalPreshowerAlgoTB.cc
@@ -70,7 +70,8 @@ void DDEcalPreshowerAlgoTB::initialize(const DDNumericArguments & nArgs,
   LogDebug("HCalGeom") << "DDEcalPreshowerAlgoTB Dummy Material = "
 		       << dummyMaterial;
 
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
 
   LogDebug("HCalGeom") << "DDEcalPreshowerAlgoTB info: end initialize" ;
 }

--- a/Geometry/MTCCTrackerCommonData/plugins/DDTIBLayerAlgo_MTCC.cc
+++ b/Geometry/MTCCTrackerCommonData/plugins/DDTIBLayerAlgo_MTCC.cc
@@ -27,8 +27,8 @@ void DDTIBLayerAlgo_MTCC::initialize(const DDNumericArguments & nArgs,
 				     const DDMapArguments & ,
 				     const DDStringArguments & sArgs,
 				     const DDStringVectorArguments & ) {
-  
-  idNameSpace  = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace  = *ns;
   genMat       = sArgs["GeneralMaterial"];
   DDName parentName = parent().name(); 
   LogDebug("TIBGeom") << "DDTIBLayerAlgo_MTCC debug: Parent " << parentName 

--- a/Geometry/MTCCTrackerCommonData/plugins/DDTIBRadCableAlgo_MTCC.cc
+++ b/Geometry/MTCCTrackerCommonData/plugins/DDTIBRadCableAlgo_MTCC.cc
@@ -27,8 +27,8 @@ void DDTIBRadCableAlgo_MTCC::initialize(const DDNumericArguments & nArgs,
 					const DDMapArguments & ,
 					const DDStringArguments & sArgs,
 					const DDStringVectorArguments & vsArgs) {
-
-  idNameSpace  = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace  = *ns;
   unsigned int i;
   DDName parentName = parent().name();
   LogDebug("TIBGeom") << "DDTIBRadCableAlgo_MTCC debug: Parent " << parentName 

--- a/Geometry/MuonCommonData/plugins/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/DDGEMAngular.cc
@@ -47,7 +47,8 @@ void DDGEMAngular::initialize(const DDNumericArguments & nArgs,
 #endif
 
   rotns       = sArgs["RotNameSpace"];
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
 #ifdef EDM_ML_DEBUG
   DDName parentName = parent().name(); 

--- a/Geometry/MuonCommonData/plugins/DDMuonAngular.cc
+++ b/Geometry/MuonCommonData/plugins/DDMuonAngular.cc
@@ -42,7 +42,8 @@ void DDMuonAngular::initialize(const DDNumericArguments & nArgs,
 			   << startCopyNo << ", " << incrCopyNo;
 #endif
   rotns       = sArgs["RotNameSpace"];
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
 #ifdef EDM_ML_DEBUG
   DDName parentName = parent().name(); 

--- a/Geometry/TrackerCommonData/plugins/DDCutTubsFromPoints.cc
+++ b/Geometry/TrackerCommonData/plugins/DDCutTubsFromPoints.cc
@@ -50,11 +50,10 @@ void DDCutTubsFromPoints::initialize(const DDNumericArguments & nArgs,
 
   solidOutput = DDName(sArgs["SolidName"]);
   
-  std::string idNameSpace = DDCurrentNamespace::ns();
   DDName parentName = parent().name();
   LogDebug("TrackerGeom") << "DDCutTubsFromPoints debug: Parent " << parentName
                           << "\tSolid " << solidOutput << " NameSpace " 
-                          << idNameSpace 
+                          << DDCurrentNamespace()
                           << "\tnumber of sections " << sections.size();
 }
 

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerAlgo.cc
@@ -28,8 +28,8 @@ void DDPixBarLayerAlgo::initialize(const DDNumericArguments & nArgs,
 				   const DDMapArguments & ,
 				   const DDStringArguments & sArgs,
 				   const DDStringVectorArguments & vsArgs) {
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   DDName parentName = parent().name();
 
   genMat    = sArgs["GeneralMaterial"];

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.cc
@@ -28,8 +28,8 @@ void DDPixBarLayerUpgradeAlgo::initialize(const DDNumericArguments & nArgs,
 				   const DDMapArguments & ,
 				   const DDStringArguments & sArgs,
 				   const DDStringVectorArguments & vsArgs) {
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   DDName parentName = parent().name();
 
   genMat    = sArgs["GeneralMaterial"];

--- a/Geometry/TrackerCommonData/plugins/DDPixFwdBlades.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixFwdBlades.cc
@@ -69,8 +69,8 @@ void DDPixFwdBlades::initialize(const DDNumericArguments & nArgs,
   } else {
     childRotationName = "";
   }
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
 
   // -- Input geometry parameters :  -----------------------------------------------------
 

--- a/Geometry/TrackerCommonData/plugins/DDPixFwdDiskAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixFwdDiskAlgo.cc
@@ -32,15 +32,13 @@ void DDPixFwdDiskAlgo::initialize(const DDNumericArguments & nArgs,
   zPlane      = nArgs["BladeCommonZ"];
   bladeZShift = vArgs["BladeZShift"];
   anchorR     = nArgs["AnchorRadius"];
- 
-  idNameSpace = DDCurrentNamespace::ns();
   childName   = sArgs["ChildName"]; 
   rotName     = sArgs["RotationName"]; 
   flagString  = sArgs["FlagString"];
   DDName parentName = parent().name();
   LogDebug("TrackerGeom") << "DDPixFwdDiskAlgo debug: Parent " << parentName 
 			  << "\tChild " << childName << " NameSpace " 
-			  << idNameSpace << "\tRot Name " << rotName
+			  << DDCurrentNamespace() << "\tRot Name " << rotName
 			  << "\tCopyNo (Start/Total) " << startCopyNo << ", " 
 			  << nBlades << "\tAngles " << bladeAngle/CLHEP::deg 
 			  << ", " << bladeTilt/CLHEP::deg << "\tZshifts " 

--- a/Geometry/TrackerCommonData/plugins/DDPixFwdDiskAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixFwdDiskAlgo.h
@@ -23,7 +23,6 @@ class DDPixFwdDiskAlgo : public DDAlgorithm {
 
 private:
 
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
   std::string              childName;   //Child name
   std::string              rotName;     //Name of the base rotation matrix
   std::string              flagString;  //Flag if a blade is present

--- a/Geometry/TrackerCommonData/plugins/DDPixPhase1FwdDiskAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDPixPhase1FwdDiskAlgo.cc
@@ -33,15 +33,13 @@ void DDPixPhase1FwdDiskAlgo::initialize(const DDNumericArguments & nArgs,
   zPlane      = nArgs["BladeCommonZ"];
   bladeZShift = vArgs["BladeZShift"];
   anchorR     = nArgs["AnchorRadius"];
- 
-  idNameSpace = DDCurrentNamespace::ns();
   childName   = sArgs["ChildName"]; 
   rotName     = sArgs["RotationName"]; 
   flagString  = sArgs["FlagString"];
   DDName parentName = parent().name();
   LogDebug("TrackerGeom") << "DDPixPhase1FwdDiskAlgo debug: Parent " << parentName 
 			  << "\tChild " << childName << " NameSpace " 
-			  << idNameSpace << "\tRot Name " << rotName
+			  << DDCurrentNamespace() << "\tRot Name " << rotName
 			  << "\tCopyNo (Start/Total) " << startCopyNo << ", " 
 			  << nBlades << "\tAngles " << bladeAngle/CLHEP::deg 
 			  << ", " << bladeTilt/CLHEP::deg << "\tZshifts " 

--- a/Geometry/TrackerCommonData/plugins/DDPixPhase1FwdDiskAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixPhase1FwdDiskAlgo.h
@@ -23,7 +23,6 @@ class DDPixPhase1FwdDiskAlgo : public DDAlgorithm {
 
 private:
 
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
   std::string              childName;   //Child name
   std::string              rotName;     //Name of the base rotation matrix
   std::string              flagString;  //Flag if a blade is present

--- a/Geometry/TrackerCommonData/plugins/DDTECAxialCableAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTECAxialCableAlgo.cc
@@ -64,7 +64,8 @@ void DDTECAxialCableAlgo::initialize(const DDNumericArguments & nArgs,
     LogDebug("TECGeom") << "                          Cable " << i 
 			<< " from Z " << zPos[i] << " startAngle " 
 			<< startAngle[i]/CLHEP::deg;
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
   matName     = sArgs["Material"]; 
 

--- a/Geometry/TrackerCommonData/plugins/DDTECCoolAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTECCoolAlgo.cc
@@ -30,13 +30,12 @@ void DDTECCoolAlgo::initialize(const DDNumericArguments & nArgs,
 			       const DDStringArguments & sArgs,
 			       const DDStringVectorArguments & vsArgs) {
 
-  idNameSpace    = DDCurrentNamespace::ns();
   startCopyNo    = int(nArgs["StartCopyNo"]);
 
   DDName parentName = parent().name(); 
   rPosition       = nArgs["RPosition"];
   LogDebug("TECGeom") << "DDTECCoolAlgo debug: Parent " << parentName 
-		      <<" NameSpace " << idNameSpace << " at radial Position " 
+		      <<" NameSpace " << DDCurrentNamespace() << " at radial Position " 
 		      << rPosition ;
   phiPosition    = vArgs["PhiPosition"]; 
   coolInsert     = vsArgs["CoolInsert"];

--- a/Geometry/TrackerCommonData/plugins/DDTECCoolAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTECCoolAlgo.h
@@ -22,7 +22,6 @@ class DDTECCoolAlgo : public DDAlgorithm {
   void execute(DDCompactView& cpv) override;
 
 private:
-  std::string              idNameSpace;    //Namespace of this and ALL parts
   int                      startCopyNo;    //Start copy number
   double                   rPosition;      // Position of the Inserts in R
   std::vector<double>      phiPosition;    // Position of the Inserts in Phi

--- a/Geometry/TrackerCommonData/plugins/DDTECModuleAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTECModuleAlgo.cc
@@ -31,8 +31,8 @@ void DDTECModuleAlgo::initialize(const DDNumericArguments & nArgs,
 				 const DDMapArguments & ,
 				 const DDStringArguments & sArgs,
 				 const DDStringVectorArguments & vsArgs) {
-
-  idNameSpace  = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace  = *ns;
   genMat       = sArgs["GeneralMaterial"];
 
   DDName parentName = parent().name(); 

--- a/Geometry/TrackerCommonData/plugins/DDTECOptoHybAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTECOptoHybAlgo.cc
@@ -25,8 +25,8 @@ void DDTECOptoHybAlgo::initialize(const DDNumericArguments & nArgs,
 				  const DDMapArguments & ,
 				  const DDStringArguments & sArgs,
 				  const DDStringVectorArguments & ) {
-
-  idNameSpace  = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace  = *ns;
   childName    = sArgs["ChildName"];
 
   DDName parentName = parent().name(); 

--- a/Geometry/TrackerCommonData/plugins/DDTECPhiAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTECPhiAlgo.cc
@@ -41,8 +41,8 @@ void DDTECPhiAlgo::initialize(const DDNumericArguments & nArgs,
 		      << zOut 	      << "\tCopy Numbers " << number 
 		      << " Start/Increment " << startCopyNo << ", " 
 		      << incrCopyNo;
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name();
   LogDebug("TECGeom") << "DDTECPhiAlgo debug: Parent " << parentName 

--- a/Geometry/TrackerCommonData/plugins/DDTECPhiAltAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTECPhiAltAlgo.cc
@@ -42,8 +42,8 @@ void DDTECPhiAltAlgo::initialize(const DDNumericArguments & nArgs,
 		      << "\tZ in/out " << zIn << ", " << zOut 
 		      << "\tCopy Numbers " << number  << " Start/Increment " 
 		      << startCopyNo << ", " << incrCopyNo;
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name();
   LogDebug("TECGeom") << "DDTECPhiAltAlgo debug: Parent " << parentName 

--- a/Geometry/TrackerCommonData/plugins/DDTIBLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTIBLayerAlgo.cc
@@ -28,8 +28,8 @@ void DDTIBLayerAlgo::initialize(const DDNumericArguments & nArgs,
 				const DDMapArguments & ,
 				const DDStringArguments & sArgs,
 				const DDStringVectorArguments & ) {
-
-  idNameSpace  = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace  = *ns;
   genMat       = sArgs["GeneralMaterial"];
   DDName parentName = parent().name(); 
   LogDebug("TIBGeom") << "DDTIBLayerAlgo debug: Parent " << parentName 

--- a/Geometry/TrackerCommonData/plugins/DDTIDAxialCableAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTIDAxialCableAlgo.cc
@@ -58,7 +58,8 @@ void DDTIDAxialCableAlgo::initialize(const DDNumericArguments & nArgs,
   for (int i=0; i<(int)(zposRing.size()); i++)
     LogDebug("TIDGeom") << "\tzposRing[" << i <<"] = " << zposRing[i];
 
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
   matIn       = sArgs["MaterialIn"]; 
   matOut      = sArgs["MaterialOut"]; 

--- a/Geometry/TrackerCommonData/plugins/DDTIDRingAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTIDRingAlgo.cc
@@ -27,8 +27,8 @@ void DDTIDRingAlgo::initialize(const DDNumericArguments & nArgs,
 			       const DDMapArguments & ,
 			       const DDStringArguments & sArgs,
 			       const DDStringVectorArguments & vsArgs) {
-
-  idNameSpace        = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace        = *ns;
   moduleName         = vsArgs["ModuleName"]; 
   iccName            = sArgs["ICCName"]; 
   DDName parentName = parent().name();

--- a/Geometry/TrackerCommonData/plugins/DDTOBAxCableAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTOBAxCableAlgo.cc
@@ -29,8 +29,8 @@ void DDTOBAxCableAlgo::initialize(const DDNumericArguments & nArgs,
 				  const DDMapArguments &,
 				  const DDStringArguments & sArgs,
 				  const DDStringVectorArguments & vsArgs) {
-  
-  idNameSpace  = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace  = *ns;
   LogDebug("TOBGeom") << "DDTOBAxCableAlgo debug: Parent " << parent().name()
 		      << " NameSpace " << idNameSpace;
   

--- a/Geometry/TrackerCommonData/plugins/DDTOBRadCableAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTOBRadCableAlgo.cc
@@ -33,8 +33,8 @@ void DDTOBRadCableAlgo::initialize(const DDNumericArguments & nArgs,
 				   const DDMapArguments &,
 				   const DDStringArguments & sArgs,
 				   const DDStringVectorArguments & vsArgs) {
-
-  idNameSpace  = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace  = *ns;
   DDName parentName = parent().name();
   LogDebug("TOBGeom") << "DDTOBRadCableAlgo debug: Parent " << parentName
 		      << " NameSpace " << idNameSpace;

--- a/Geometry/TrackerCommonData/plugins/DDTOBRodAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTOBRodAlgo.cc
@@ -35,11 +35,10 @@ void DDTOBRodAlgo::initialize(const DDNumericArguments & nArgs,
 
   central      = sArgs["CentralName"];
   shift        = nArgs["Shift"];
-  idNameSpace  = DDCurrentNamespace::ns();
   DDName parentName = parent().name();
   LogDebug("TOBGeom") << "DDTOBRodAlgo debug: Parent " << parentName 
 		      << " Central " << central << " NameSpace "
-		      << idNameSpace << "\tShift " << shift;
+		      << DDCurrentNamespace() << "\tShift " << shift;
 
   sideRod      = vsArgs["SideRodName"];     
   sideRodX     = vArgs["SideRodX"];    

--- a/Geometry/TrackerCommonData/plugins/DDTOBRodAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTOBRodAlgo.h
@@ -24,7 +24,6 @@ class DDTOBRodAlgo : public DDAlgorithm {
 private:
 
   std::string              central;        // Name of the central piece
-  std::string              idNameSpace;    // Namespace of this and ALL sub-parts
 					      
   double                   shift;          // Shift in z
   std::vector<std::string> sideRod;        // Name of the Side Rod

--- a/Geometry/TrackerCommonData/plugins/DDTrackerAngular.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerAngular.cc
@@ -50,8 +50,8 @@ void DDTrackerAngular::initialize(const DDNumericArguments & nArgs,
 			  << rangeAngle/CLHEP::deg << " " << delta/CLHEP::deg
 			  << " Radius " << radius << " Centre " << center[0] 
 			  << ", " << center[1] << ", "<<center[2];
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
 
   DDName parentName = parent().name();

--- a/Geometry/TrackerCommonData/plugins/DDTrackerAngularV1.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerAngularV1.cc
@@ -50,8 +50,8 @@ void DDTrackerAngularV1::initialize(const DDNumericArguments & nArgs,
 			  << rangeAngle/CLHEP::deg << " " << delta/CLHEP::deg
 			  << " Radius " << radius << " Centre " << center[0] 
 			  << ", " << center[1] << ", "<<center[2];
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
 
   DDName parentName = parent().name();

--- a/Geometry/TrackerCommonData/plugins/DDTrackerLinear.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerLinear.cc
@@ -44,12 +44,11 @@ void DDTrackerLinear::initialize(const DDNumericArguments & nArgs,
     incrcn = 1;
   }
   
-  idNameSpace = DDCurrentNamespace::ns();
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name();
   LogDebug("TrackerGeom") << "DDTrackerLinear debug: Parent " << parentName 
 			  << "\tChild " << childName << " NameSpace " 
-			  << idNameSpace << "\tNumber " << number 
+			  << DDCurrentNamespace() << "\tNumber " << number 
 			  << "\tAxis (theta/phi) " << theta/CLHEP::deg << ", "
 			  << phi/CLHEP::deg << "\t(Offset/Delta) " << offset 
 			  << ", "  << delta << "\tCentre " << centre[0] << ", "

--- a/Geometry/TrackerCommonData/plugins/DDTrackerLinear.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerLinear.h
@@ -23,7 +23,6 @@ class DDTrackerLinear : public DDAlgorithm {
 
 private:
 
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
   std::string              childName;   //Child name
   int                      number;      //Number of positioning
   int                      startcn;     //Start copy no index

--- a/Geometry/TrackerCommonData/plugins/DDTrackerLinearXY.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerLinearXY.cc
@@ -31,13 +31,11 @@ void DDTrackerLinearXY::initialize(const DDNumericArguments & nArgs,
   numberY   = int(nArgs["NumberY"]);
   deltaY    = nArgs["DeltaY"];
   centre    = vArgs["Center"];
-  
-  idNameSpace = DDCurrentNamespace::ns();
-  childName   = sArgs["ChildName"]; 
+  childName = sArgs["ChildName"]; 
   DDName parentName = parent().name();
   LogDebug("TrackerGeom") << "DDTrackerLinearXY debug: Parent " << parentName
 			  << "\tChild " << childName << " NameSpace " 
-			  << idNameSpace << "\tNumber along X/Y " << numberX
+			  << DDCurrentNamespace() << "\tNumber along X/Y " << numberX
 			  << "/" << numberY << "\tDelta along X/Y " << deltaX
 			  << "/" << deltaY << "\tCentre " << centre[0] << ", " 
 			  << centre[1] << ", "	<< centre[2];

--- a/Geometry/TrackerCommonData/plugins/DDTrackerLinearXY.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerLinearXY.h
@@ -23,7 +23,6 @@ class DDTrackerLinearXY : public DDAlgorithm {
 
 private:
 
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
   std::string              childName;   //Child name
   int                      numberX;     //Number of positioning along X-axis
   double                   deltaX;      //Increment               .........

--- a/Geometry/TrackerCommonData/plugins/DDTrackerPhiAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerPhiAlgo.cc
@@ -63,8 +63,8 @@ void DDTrackerPhiAlgo::initialize(const DDNumericArguments & nArgs,
   for (int i=0; i<(int)(phi.size()); i++)
     LogDebug("TrackerGeom") << "\t[" << i << "] phi = " << phi[i]/CLHEP::deg 
 			    << " z = " << zpos[i];
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name();
   LogDebug("TrackerGeom") <<  "DDTrackerPhiAlgo debug: Parent " << parentName

--- a/Geometry/TrackerCommonData/plugins/DDTrackerPhiAltAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerPhiAltAlgo.cc
@@ -44,8 +44,8 @@ void DDTrackerPhiAltAlgo::initialize(const DDNumericArguments & nArgs,
 			  << "\t ZPos " << zpos << "\tCopy Numbers " << number 
 			  << " Start/Increment " << startCopyNo << ", " 
 			  << incrCopyNo;
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name();
   LogDebug("TrackerGeom") << "DDTrackerPhiAltAlgo debug: Parent " << parentName

--- a/Geometry/TrackerCommonData/plugins/DDTrackerRingAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerRingAlgo.cc
@@ -57,8 +57,8 @@ void DDTrackerRingAlgo::initialize(const DDNumericArguments & nArgs,
 			  << rangeAngle/CLHEP::deg << " " << delta/CLHEP::deg
 			  << " Radius " << radius << " Centre " << center[0]
 			  << ", " << center[1] << ", "<<center[2];
-
-  idNameSpace = DDCurrentNamespace::ns();
+  DDCurrentNamespace ns;
+  idNameSpace = *ns;
   childName   = sArgs["ChildName"];
 
   DDName parentName = parent().name();

--- a/Geometry/TrackerCommonData/plugins/DDTrackerXYZPosAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerXYZPosAlgo.cc
@@ -32,13 +32,11 @@ void DDTrackerXYZPosAlgo::initialize(const DDNumericArguments & nArgs,
   yvec        = vArgs["YPositions"];
   zvec        = vArgs["ZPositions"];
   rotMat      = vsArgs["Rotations"];
-  
-  idNameSpace = DDCurrentNamespace::ns();
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name();
   LogDebug("TrackerGeom") << "DDTrackerXYZPosAlgo debug: Parent " << parentName 
 			  << "\tChild " << childName << " NameSpace " 
-			  << idNameSpace << "\tCopyNo (Start/Increment) " 
+			  << DDCurrentNamespace() << "\tCopyNo (Start/Increment) " 
 			  << startCopyNo << ", " << incrCopyNo << "\tNumber " 
 			  << xvec.size() << ", " << yvec.size() << ", " << zvec.size();
   for (int i = 0; i < (int)(zvec.size()); i++) {

--- a/Geometry/TrackerCommonData/plugins/DDTrackerXYZPosAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerXYZPosAlgo.h
@@ -28,7 +28,6 @@ private:
   std::vector<double>      zvec;   //Z positions
   std::vector<std::string> rotMat; //Names of rotation matrices
 
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
   std::string              childName;   //Child name
   int                      startCopyNo; //Start Copy number
   int                      incrCopyNo;  //Increment in Copy number

--- a/Geometry/TrackerCommonData/plugins/DDTrackerZPosAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerZPosAlgo.cc
@@ -30,13 +30,11 @@ void DDTrackerZPosAlgo::initialize(const DDNumericArguments & nArgs,
   incrCopyNo  = int(nArgs["IncrCopyNo"]);
   zvec        = vArgs["ZPositions"];
   rotMat      = vsArgs["Rotations"];
-  
-  idNameSpace = DDCurrentNamespace::ns();
   childName   = sArgs["ChildName"]; 
   DDName parentName = parent().name();
   LogDebug("TrackerGeom") << "DDTrackerZPosAlgo debug: Parent " << parentName 
 			  << "\tChild " << childName << " NameSpace " 
-			  << idNameSpace << "\tCopyNo (Start/Increment) " 
+			  << DDCurrentNamespace() << "\tCopyNo (Start/Increment) " 
 			  << startCopyNo << ", " << incrCopyNo << "\tNumber " 
 			  << zvec.size();
   for (int i = 0; i < (int)(zvec.size()); i++) {

--- a/Geometry/TrackerCommonData/plugins/DDTrackerZPosAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerZPosAlgo.h
@@ -25,8 +25,6 @@ private:
 
   std::vector<double>      zvec;   //Z positions
   std::vector<std::string> rotMat; //Names of rotation matrices
-
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
   std::string              childName;   //Child name
   int                      startCopyNo; //Start Copy number
   int                      incrCopyNo;  //Increment in Copy number


### PR DESCRIPTION
* DD current namespace is set by the DD Parser at the end of an element: https://github.com/cms-sw/cmssw/compare/master...ianna:dd-current-namespace-singleton?expand=1#diff-51ff922ad1d158611046bba4ee32b399R86

@cvuosalo - Could you, please, check during the DD Algorithms code review if they do need to use a current namespace or they would be ok with using their parent's namespace? If the latter works, we can remove this class entirely. Thanks.