### PR TITLE
CLCTs are offset by 1 BX in matching

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -215,7 +215,7 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         #         take CLCTs in BX look for matching ALCTs in window)
         #  False = ALCT-centric matching (recommended for SLHC,
         #         take ALCTs in BX look for matching CLCTs in window)
-        clctToAlct = cms.bool(True),
+        clctToAlct = cms.bool(False),
     ),
 
     # to be used by ME11 chambers with upgraded TMB and ALCT

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -137,8 +137,8 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
-      const int bx_clct_start(bx_alct - match_trig_window_size/2);
-      const int bx_clct_stop(bx_alct + match_trig_window_size/2);
+      const int bx_clct_start(bx_alct - match_trig_window_size/2 - alctClctOffset);
+      const int bx_clct_stop(bx_alct + match_trig_window_size/2 - alctClctOffset);
       const int bx_copad_start(bx_alct - maxDeltaBXCoPad_);
       const int bx_copad_stop(bx_alct + maxDeltaBXCoPad_);
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -100,8 +100,8 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
-      const int bx_clct_start(bx_alct - match_trig_window_size/2);
-      const int bx_clct_stop(bx_alct + match_trig_window_size/2);
+      const int bx_clct_start(bx_alct - match_trig_window_size/2 - alctClctOffset);
+      const int bx_clct_stop(bx_alct + match_trig_window_size/2 - alctClctOffset);
       const int bx_copad_start(bx_alct - maxDeltaBXCoPad_);
       const int bx_copad_stop(bx_alct + maxDeltaBXCoPad_);
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -54,10 +54,6 @@ class CSCMotherboard
   /** Default destructor. */
   virtual ~CSCMotherboard() = default;
 
-  /** Test version of run function. */
-  void run(const std::vector<int> w_time[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES],
-           const std::vector<int> hs_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
-
   /** Run function for normal usage.  Runs cathode and anode LCT processors,
       takes results and correlates into CorrelatedLCT. */
   void run(const CSCWireDigiCollection* wiredc, const CSCComparatorDigiCollection* compdc);
@@ -126,6 +122,8 @@ class CSCMotherboard
   /** if true: use regular CLCT-to-ALCT matching in TMB
       if false: do ALCT-to-CLCT matching */
   bool clct_to_alct;
+
+  unsigned int alctClctOffset;
 
   /** Default values of configuration parameters. */
   static const unsigned int def_mpc_block_me1a;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -190,8 +190,8 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
     // matching in ME1b
     if (clct->bestCLCT[bx_clct].isValid())
     {
-      int bx_alct_start = bx_clct - match_trig_window_size/2;
-      int bx_alct_stop  = bx_clct + match_trig_window_size/2;
+      const int bx_alct_start = bx_clct - match_trig_window_size/2 + alctClctOffset;
+      const int bx_alct_stop  = bx_clct + match_trig_window_size/2 + alctClctOffset;
       for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++)
       {
         if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS) continue;
@@ -218,8 +218,8 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
     // matching in ME1a
     if (clct1a->bestCLCT[bx_clct].isValid())
     {
-      int bx_alct_start = bx_clct - match_trig_window_size/2;
-      int bx_alct_stop  = bx_clct + match_trig_window_size/2;
+      const int bx_alct_start = bx_clct - match_trig_window_size/2 + alctClctOffset;
+      const int bx_alct_stop  = bx_clct + match_trig_window_size/2 + alctClctOffset;
       for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++)
       {
         if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS) continue;
@@ -251,8 +251,8 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
-      int bx_clct_start = bx_alct - match_trig_window_size/2;
-      int bx_clct_stop  = bx_alct + match_trig_window_size/2;
+      const int bx_clct_start = bx_alct - match_trig_window_size/2 - alctClctOffset;
+      const int bx_clct_stop  = bx_alct + match_trig_window_size/2 - alctClctOffset;
 
       // matching in ME1b
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
@@ -64,8 +64,8 @@ CSCMotherboardME3141::run(const CSCWireDigiCollection* wiredc,
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
-      const int bx_clct_start(bx_alct - match_trig_window_size/2);
-      const int bx_clct_stop(bx_alct + match_trig_window_size/2);
+      const int bx_clct_start(bx_alct - match_trig_window_size/2 - alctClctOffset);
+      const int bx_clct_stop(bx_alct + match_trig_window_size/2 - alctClctOffset);
 
       if (debug_matching){
         LogTrace("CSCMotherboardME3141") << "========================================================================" << std::endl;


### PR DESCRIPTION
Recent data vs emulator studies using 2018C data (in particular data from the ME+1/1/9 OTMB) have shown that the CLCT BX are not shifted in the ALCT-CLCT matching algorithms. They are shifted when the CLCTs are written to EDM ROOT files however. Because the ALCT-CLCT matching windows are quite wide (7BX) in the current CSC local trigger firmware and emulator, it has a negligible effect. However, it does start playing a role when the ALCT-CLCT matching window is reduced to 5BX and ultimately 3BX. That is foreseen in the "SLHC" version of the CSC local trigger.

In addition, the matching algorithm type was changed from CLCT-centric to ALCT-centric. This as always been the case in firmware. 

A redundant test TMB run function was also removed.

This PR addresses these issues.

@tahuang1991 @lpernie @ptcox 
