### PR TITLE
New CSCBaseboard class and helper function in CSCDetId

### DIFF
--- a/DataFormats/MuonDetId/interface/CSCDetId.h
+++ b/DataFormats/MuonDetId/interface/CSCDetId.h
@@ -244,6 +244,13 @@ public:
    static int minLayerId()   { return MIN_LAYER; }
    static int maxLayerId()   { return MAX_LAYER; }
 
+   /**
+    * Returns the chamber name in the format
+    * ME$sign$station/$ring/$chamber. Example: ME+1/1/9
+    */
+   static std::string chamberName(int endcap, int station, int ring, int chamber);
+   std::string chamberName() const;
+
 private:
  
   /**

--- a/DataFormats/MuonDetId/src/CSCDetId.cc
+++ b/DataFormats/MuonDetId/src/CSCDetId.cc
@@ -62,6 +62,16 @@ unsigned short CSCDetId::iChamberType( unsigned short istation, unsigned short i
   return i;
 }
 
+std::string CSCDetId::chamberName(int endcap, int station, int ring, int chamber)
+{
+  const std::string eSign = endcap==1 ? "+" : "-";
+  return "ME" + eSign + std::to_string(station) + "/" + std::to_string(ring) + "/" + std::to_string(chamber);
+}
+
+std::string CSCDetId::chamberName() const
+{
+  return chamberName(endcap(), station(), ring(), chamber());
+}
 
 std::ostream& operator<<( std::ostream& os, const CSCDetId& id )
 {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -471,8 +471,7 @@ CSCAnodeLCTProcessor::run(const CSCWireDigiCollection* wiredc) {
       if (numWireGroups > CSCConstants::MAX_NUM_WIRES) {
         if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
           << "+++ Number of wire groups, " << numWireGroups
-          << " found in ME" << ((theEndcap == 1) ? "+" : "-")
-          << theStation << "/" << theRing << "/" << theChamber
+          << " found in " << detid.chamberName()
           << " (sector " << theSector << " subsector " << theSubsector
           << " trig id. " << theTrigChamber << ")"
           << " exceeds max expected, " << CSCConstants::MAX_NUM_WIRES
@@ -483,8 +482,7 @@ CSCAnodeLCTProcessor::run(const CSCWireDigiCollection* wiredc) {
     }
     else {
       if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
-        << "+++ ME" << ((theEndcap == 1) ? "+" : "-")
-        << theStation << "/" << theRing << "/" << theChamber
+        << "+++ " << detid.chamberName()
         << " (sector " << theSector << " subsector " << theSubsector
         << " trig id. " << theTrigChamber << ")"
         << " is not defined in current geometry! +++\n"
@@ -495,8 +493,7 @@ CSCAnodeLCTProcessor::run(const CSCWireDigiCollection* wiredc) {
 
   if (numWireGroups < 0) {
     if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
-      << "+++ ME" << ((theEndcap == 1) ? "+" : "-")
-      << theStation << "/" << theRing << "/" << theChamber
+      << "+++ " << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
       << " (sector " << theSector << " subsector " << theSubsector
       << " trig id. " << theTrigChamber << "):"
       << " numWireGroups = " << numWireGroups
@@ -609,9 +606,8 @@ bool CSCAnodeLCTProcessor::getDigis(const CSCWireDigiCollection* wiredc) {
       if (infoV > 1) {
         LogTrace("CSCAnodeLCTProcessor")
           << "found " << digiV[i_layer].size()
-          << " wire digi(s) in layer " << i_layer << " of ME"
-          << ((theEndcap == 1) ? "+" : "-") << theStation << "/" << theRing
-          << "/" << theChamber << " (trig. sector " << theSector
+          << " wire digi(s) in layer " << i_layer << " of " << detid.chamberName()
+          << " (trig. sector " << theSector
           << " subsector " << theSubsector << " id " << theTrigChamber << ")";
         for (std::vector<CSCWireDigi>::iterator pld = digiV[i_layer].begin();
              pld != digiV[i_layer].end(); pld++) {
@@ -1255,9 +1251,7 @@ void CSCAnodeLCTProcessor::lctSearch() {
       if (infoV > 0) {
         LogDebug("CSCAnodeLCTProcessor")
           << "\n" << bestALCT[bx] << " fullBX = "<<bestALCT[bx].getFullBX()
-          << " found in ME"
-          << ((theEndcap == 1) ? "+" : "-")
-          << theStation << "/" << theRing << "/" << theChamber
+          << " found in " << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
           << " (sector " << theSector << " subsector " << theSubsector
           << " trig id. " << theTrigChamber << ")" << "\n";
       }
@@ -1266,9 +1260,7 @@ void CSCAnodeLCTProcessor::lctSearch() {
         if (infoV > 0) {
           LogDebug("CSCAnodeLCTProcessor")
             << secondALCT[bx] << " fullBX = "<<secondALCT[bx].getFullBX()
-            << " found in ME"
-            << ((theEndcap == 1) ? "+" : "-")
-            << theStation << "/" << theRing << "/" << theChamber
+            << " found in " << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
             << " (sector " << theSector << " subsector " << theSubsector
             << " trig id. " << theTrigChamber << ")" << "\n";
         }
@@ -1525,8 +1517,7 @@ void CSCAnodeLCTProcessor::dumpConfigParams() const {
 // Dump of digis on wire groups.
 void CSCAnodeLCTProcessor::dumpDigis(const std::vector<int> wire[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES]) const {
   LogDebug("CSCAnodeLCTProcessor")
-    << "ME" << ((theEndcap == 1) ? "+" : "-")
-    << theStation << "/" << theRing << "/" << theChamber
+    << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
     << " nWiregroups " << numWireGroups;
 
   std::ostringstream strstrm;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
@@ -1,0 +1,105 @@
+#include "L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.h"
+
+CSCBaseboard::CSCBaseboard(unsigned endcap, unsigned station,
+                           unsigned sector, unsigned subsector,
+                           unsigned chamber,
+                           const edm::ParameterSet& conf) :
+  theEndcap(endcap),
+  theStation(station),
+  theSector(sector),
+  theSubsector(subsector),
+  theTrigChamber(chamber)
+{
+  theRegion = (theEndcap == 1) ? 1: -1;
+
+  // Ring number
+  theRing = CSCTriggerNumbering::ringFromTriggerLabels(theStation, theTrigChamber);
+
+  // actual chamber number
+  theChamber = CSCTriggerNumbering::chamberFromTriggerLabels(theSector, theSubsector,
+                                                             theStation, theTrigChamber);
+  // is this an ME11 chamber?
+  isME11_ = (theStation == 1 && theRing == 1);
+
+  // CSCDetId for this chamber
+  cscId_ = CSCDetId(theEndcap, theStation, theRing, theChamber, 0);
+
+  // Parameters common for all boards
+  commonParams_ = conf.getParameter<edm::ParameterSet>("commonParam");
+
+  // Flag for SLHC studies
+  isSLHC_       = commonParams_.getParameter<bool>("isSLHC");
+
+  // run the upgrade for the Phase-II ME1/1 integrated local trigger
+  runME11ILT_ = commonParams_.existsAs<bool>("runME11ILT") ?
+    commonParams_.getParameter<bool>("runME11ILT"):false;
+
+  // run the upgrade for the Phase-II ME2/1 integrated local trigger
+  runME21ILT_ = commonParams_.existsAs<bool>("runME21ILT")?
+    commonParams_.getParameter<bool>("runME21ILT"):false;
+
+  // run the upgrade for the Phase-II ME3/1-ME4/1 local trigger
+  runME3141ILT_ = commonParams_.existsAs<bool>("runME3141ILT")?
+    commonParams_.getParameter<bool>("runME3141ILT"):false;
+
+  // chamber name, e.g. ME+1/1/9
+  theCSCName_ = CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber);
+
+  upgradeChambers_ = commonParams_.existsAs< std::vector<std::string> >("upgradeChambers") ?
+    commonParams_.getParameter< std::vector<std::string> >("upgradeChambers"):std::vector<std::string>();
+
+  // is this particular board (ALCT processor, TMB or CLCT processor) running the upgrade algorithm?
+  runUpgradeBoard_ = false;
+  if (isSLHC_ and std::find(upgradeChambers_.begin(), upgradeChambers_.end(), theCSCName_) != upgradeChambers_.end()){
+    runUpgradeBoard_ = true;
+  }
+
+  // run upgrade scenarios for all MEX/1 stations
+  if (isSLHC_ and theRing == 1 and runUpgradeBoard_){
+    if (theStation == 1) {
+      tmbParams_ = conf.getParameter<edm::ParameterSet>("tmbSLHC");
+      alctParams_ = conf.getParameter<edm::ParameterSet>("alctParam07");
+      clctParams_ = conf.getParameter<edm::ParameterSet>("clctSLHC");
+      if (runME11ILT_) {
+        tmbParams_ = conf.getParameter<edm::ParameterSet>("me11tmbSLHCGEM");
+      }
+    }
+    else if (theStation == 2 and runME21ILT_) {
+      tmbParams_ = conf.getParameter<edm::ParameterSet>("me21tmbSLHCGEM");
+      alctParams_ = conf.getParameter<edm::ParameterSet>("alctSLHCME21");
+      clctParams_ = conf.getParameter<edm::ParameterSet>("clctSLHCME21");
+    }
+    else if ((theStation == 3 or theStation == 4) and runME3141ILT_) {
+      tmbParams_ = conf.getParameter<edm::ParameterSet>("me3141tmbSLHC");
+      alctParams_ = conf.getParameter<edm::ParameterSet>("alctSLHCME3141");
+      clctParams_ = conf.getParameter<edm::ParameterSet>("clctSLHCME3141");
+    }
+  } else {
+    tmbParams_ = conf.getParameter<edm::ParameterSet>("tmbParam");
+    alctParams_ = conf.getParameter<edm::ParameterSet>("alctParam07");
+    clctParams_ = conf.getParameter<edm::ParameterSet>("clctParam07");
+  }
+
+  // special configuration parameters for ME11 treatment
+  disableME1a_ = commonParams_.getParameter<bool>("disableME1a");
+
+  // special configuration parameters for ME11 treatment
+  gangedME1a_ = commonParams_.getParameter<bool>("gangedME1a");
+}
+
+CSCBaseboard::CSCBaseboard() :
+                   theEndcap(1), theStation(1), theSector(1),
+                   theSubsector(1), theTrigChamber(1)
+{
+  theRing = 1;
+  theChamber = 1;
+  isSLHC_ = false;
+  disableME1a_ = false;
+  gangedME1a_ = false;
+}
+
+void CSCBaseboard::setCSCGeometry(const CSCGeometry *g)
+{
+  cscGeometry_ = g;
+  cscChamber_ = cscGeometry_->chamber(cscId_);
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.h
@@ -1,0 +1,77 @@
+#ifndef L1Trigger_CSCTriggerPrimitives_CSCBaseboard_h
+#define L1Trigger_CSCTriggerPrimitives_CSCBaseboard_h
+
+#include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.h"
+#include "L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUTGenerator.h"
+
+class CSCBaseboard
+{
+ public:
+  /** Normal constructor. */
+  CSCBaseboard(unsigned endcap, unsigned station, unsigned sector,
+                 unsigned subsector, unsigned chamber,
+                 const edm::ParameterSet& conf);
+
+  /** Constructor for use during testing. */
+  CSCBaseboard();
+
+  /** Default destructor. */
+  virtual ~CSCBaseboard() = default;
+
+  void setCSCGeometry(const CSCGeometry *g);
+
+ protected:
+  // Parameters common for all boards
+  edm::ParameterSet commonParams_;
+
+  // Motherboard parameters:
+  edm::ParameterSet tmbParams_;
+
+  // Motherboard parameters:
+  edm::ParameterSet alctParams_;
+
+  // Motherboard parameters:
+  edm::ParameterSet clctParams_;
+
+  /** Chamber id (trigger-type labels). */
+  const unsigned theEndcap;
+  const unsigned theStation;
+  const unsigned theSector;
+  const unsigned theSubsector;
+  const unsigned theTrigChamber;
+  unsigned theRegion;
+  unsigned theRing;
+  unsigned theChamber;
+
+  bool isME11_;
+
+  CSCDetId cscId_;
+  const CSCGeometry* cscGeometry_;
+  const CSCChamber* cscChamber_;
+
+  std::vector<std::string> upgradeChambers_;
+  std::string theCSCName_;
+  bool runUpgradeBoard_;
+
+  /** Flag for SLHC studies. */
+  bool isSLHC_;
+
+  /** SLHC: special configuration parameters for ME1a treatment */
+  bool disableME1a_, gangedME1a_;
+
+  /** SLHC: run the upgrade for the Phase-II ME1/1 integrated local trigger */
+  bool runME11ILT_;
+
+  /** SLHC: run the upgrade for the Phase-II ME2/1 integrated local trigger */
+  bool runME21ILT_;
+
+  /** SLHC: run the upgrade for the Phase-II ME3/1(ME4/1) integrated local trigger */
+  bool runME3141ILT_;
+};
+#endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -480,8 +480,7 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
       if (numStrips > CSCConstants::MAX_NUM_STRIPS_7CFEBS) {
 	if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
 	  << "+++ Number of strips, " << numStrips
-	  << " found in ME" << ((theEndcap == 1) ? "+" : "-")
-	  << theStation << "/" << theRing << "/" << theChamber
+    << " found in " << detid.chamberName()
 	  << " (sector " << theSector << " subsector " << theSubsector
 	  << " trig id. " << theTrigChamber << ")"
 	  << " exceeds max expected, " << CSCConstants::MAX_NUM_STRIPS_7CFEBS
@@ -509,23 +508,21 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
     }
     else {
       if (infoV >= 0) edm::LogError("L1CSCTPEmulatorConfigError")
-	<< " ME" << ((theEndcap == 1) ? "+" : "-")
-        << theStation << "/" << theRing << "/" << theChamber
-	<< " (sector " << theSector << " subsector " << theSubsector
-	<< " trig id. " << theTrigChamber << ")"
-	<< " is not defined in current geometry! +++\n"
-	<< "+++ CSC geometry looks garbled; no emulation possible +++\n";
+                        << " " << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
+                        << " (sector " << theSector << " subsector " << theSubsector
+                        << " trig id. " << theTrigChamber << ")"
+                        << " is not defined in current geometry! +++\n"
+                        << "+++ CSC geometry looks garbled; no emulation possible +++\n";
       numStrips = -1;
     }
   }
 
   if (numStrips < 0) {
     if (infoV >= 0) edm::LogError("L1CSCTPEmulatorConfigError")
-      << " ME" << ((theEndcap == 1) ? "+" : "-")
-      << theStation << "/" << theRing << "/" << theChamber
-      << " (sector " << theSector << " subsector " << theSubsector
-      << " trig id. " << theTrigChamber << "):"
-      << " numStrips = " << numStrips << "; CLCT emulation skipped! +++";
+                        << " " << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
+                        << " (sector " << theSector << " subsector " << theSubsector
+                        << " trig id. " << theTrigChamber << "):"
+                        << " numStrips = " << numStrips << "; CLCT emulation skipped! +++";
     std::vector<CSCCLCTDigi> emptyV;
     return emptyV;
   }
@@ -614,16 +611,16 @@ void CSCCathodeLCTProcessor::run(const std::vector<int> halfstrip[CSCConstants::
     if (bestCLCT[bx].isValid()) {
       bestCLCT[bx].setTrknmb(1);
       if (infoV > 0) LogDebug("CSCCathodeLCTProcessor")
-                       << bestCLCT[bx] << " found in ME" << ((theEndcap == 1) ? "+" : "-")
-                       << theStation << "/" << theRing << "/" << theChamber
+                       << bestCLCT[bx] << " found in " <<
+                       CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
                        << " (sector " << theSector << " subsector " << theSubsector
                        << " trig id. " << theTrigChamber << ")" << "\n";
     }
     if (secondCLCT[bx].isValid()) {
       secondCLCT[bx].setTrknmb(2);
       if (infoV > 0) LogDebug("CSCCathodeLCTProcessor")
-                       << secondCLCT[bx] << " found in ME" << ((theEndcap == 1) ? "+" : "-")
-                       << theStation << "/" << theRing << "/" << theChamber
+                       << secondCLCT[bx] << " found in " <<
+                       CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
                        << " (sector " << theSector << " subsector " << theSubsector
                        << " trig id. " << theTrigChamber << ")" << "\n";
     }
@@ -661,9 +658,8 @@ bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc)
       if (infoV > 1) {
 	LogTrace("CSCCathodeLCTProcessor")
 	  << "found " << digiV[i_layer].size()
-	  << " comparator digi(s) in layer " << i_layer << " of ME"
-	  << ((theEndcap == 1) ? "+" : "-") << theStation << "/" << theRing
-	  << "/" << theChamber << " (trig. sector " << theSector
+	  << " comparator digi(s) in layer " << i_layer << " of " <<
+    detid.chamberName() << " (trig. sector " << theSector
 	  << " subsector " << theSubsector << " id " << theTrigChamber << ")";
       }
     }
@@ -1560,8 +1556,7 @@ void CSCCathodeLCTProcessor::dumpConfigParams() const {
 void CSCCathodeLCTProcessor::dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS], const int stripType, const int nStrips) const
 {
   LogDebug("CSCCathodeLCTProcessor")
-    << "ME" << ((theEndcap == 1) ? "+" : "-")
-    << theStation << "/" << theRing << "/" << theChamber
+    << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
     << " strip type " << stripType << " nStrips " << nStrips;
 
   std::ostringstream strstrm;


### PR DESCRIPTION
Addition of a helper function in CSCDetId that returns the name of a CSC, e.g. ME+1/1/9, the 9th chamber on the positive endcap of the ME1/1 ring. 

This function will replace half a dozen snippets that look like:  
```
    if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
      << "+++ ME" << ((theEndcap == 1) ? "+" : "-")
      << theStation << "/" << theRing << "/" << theChamber
```

The second addition is a new base class `CSCBaseboard` which will contain members common to all TMBs and processors. While there is no physical equivalent of a `CSCBaseboard`, it will reduce a lot of code duplication. The TMBs and processors do not inherit from the base class yet. I will change that very soon.

@tahuang1991 @lpernie 