### PR TITLE
modify electron track seeding regions for pp_on_AA era

### DIFF
--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -100,7 +100,7 @@ pp_on_AA_2018.toReplaceWith(tripletElectronTrackingRegions,
     _globalTrackingRegionWithVertices.clone(
         RegionPSet = dict(
             fixedError = 0.5,
-            ptMin = 4.0,
+            ptMin = 8.0,
             originRadius = 0.02)))
 
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
@@ -172,7 +172,7 @@ pixelPairElectronTrackingRegions = _globalTrackingRegionWithVertices.clone(Regio
     originRadius = 0.015,
     fixedError = 0.03,
 ))
-pp_on_AA_2018.toModify(pixelPairElectronTrackingRegions, RegionPSet = dict(ptMin = 4.0))
+pp_on_AA_2018.toModify(pixelPairElectronTrackingRegions, RegionPSet = dict(ptMin = 8.0))
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 pixelPairElectronHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "pixelPairElectronSeedLayers",
@@ -222,7 +222,7 @@ pp_on_AA_2018.toReplaceWith(stripPairElectronTrackingRegions,
     _globalTrackingRegionWithVertices.clone(
         RegionPSet = dict(
             fixedError = 0.5,
-            ptMin = 4.0,
+            ptMin = 8.0,
             originRadius = 0.4)))
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 stripPairElectronHitDoublets = _hitPairEDProducer.clone(

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -93,6 +93,16 @@ tripletElectronTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionP
     originRadius = 0.02,
     nSigmaZ = 4.0
 ))
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
+pp_on_AA_2018.toReplaceWith(tripletElectronTrackingRegions,
+    _globalTrackingRegionWithVertices.clone(
+        RegionPSet = dict(
+            fixedError = 0.5,
+            ptMin = 4.0,
+            originRadius = 0.02)))
+
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 tripletElectronHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "tripletElectronSeedLayers",
@@ -162,6 +172,7 @@ pixelPairElectronTrackingRegions = _globalTrackingRegionWithVertices.clone(Regio
     originRadius = 0.015,
     fixedError = 0.03,
 ))
+pp_on_AA_2018.toModify(pixelPairElectronTrackingRegions, RegionPSet = dict(ptMin = 4.0))
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 pixelPairElectronHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "pixelPairElectronSeedLayers",
@@ -207,6 +218,12 @@ stripPairElectronTrackingRegions = _globalTrackingRegionFromBeamSpotFixedZ.clone
     originHalfLength = 12.0,
     originRadius = 0.4,
 ))
+pp_on_AA_2018.toReplaceWith(stripPairElectronTrackingRegions,
+    _globalTrackingRegionWithVertices.clone(
+        RegionPSet = dict(
+            fixedError = 0.5,
+            ptMin = 4.0,
+            originRadius = 0.4)))
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 stripPairElectronHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "stripPairElectronSeedLayers",


### PR DESCRIPTION
this PR switches the tracking regions for the pixel pair/triplet and strip pair electron track seeding modules to regions centred on vertices. the ptmin threshold in the seeding regions for all three modules are also raised to 8 GeV. this improves the timing of the stripPairElectronSeeds module by a factor of 6-7, while also slightly improving the efficiency and fake rate. a short set of slides comparing the performance before/after this change can be found at [1].

[[1]]: https://twiki.cern.ch/twiki/pub/CMS/HiEgamma2018/electron-strippair-seeding.pdf

@mandrenguyen