### PR TITLE
activating usage of EcalSimPulseShapeRcd (>= 10_3_X)

### DIFF
--- a/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
+++ b/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
@@ -169,7 +169,7 @@ void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::Eve
 #endif
     
     try{
-      bool useDBShape = false;
+      bool useDBShape = true;
       EBShape ebShape(useDBShape);  
       EEShape eeShape(useDBShape); 
       EcalShapeBase* pShape;      

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.cc
@@ -54,7 +54,7 @@ double oneOverEtResolEt(double *x, double *par) {
 }
 
 EcalTPGParamBuilder::EcalTPGParamBuilder(edm::ParameterSet const& pSet)
-  : xtal_LSB_EB_(0), xtal_LSB_EE_(0), nSample_(5), complement2_(7), useDBShape_(false)
+  : xtal_LSB_EB_(0), xtal_LSB_EE_(0), nSample_(5), complement2_(7), useDBShape_(true)
 {
   ped_conf_id_=0;
   lin_conf_id_=0;

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '103X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '103X_mcRun2_asymptotic_v1',
+    'run2_mc_l1stage1'  :   '103X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '103X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '103X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v4',
+    'run2_mc_l1stage1'  :   '103X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '103X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
@@ -18,7 +18,7 @@
 #include <FWCore/ParameterSet/interface/ParameterSetDescription.h>
 
 EcalUncalibRecHitWorkerGlobal::EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&ps,edm::ConsumesCollector& c) :
-  EcalUncalibRecHitWorkerRunOneDigiBase(ps,c), useDBShape(false), testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape))
+  EcalUncalibRecHitWorkerRunOneDigiBase(ps,c), useDBShape(true), testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape))
 {
         // ratio method parameters
         EBtimeFitParameters_ = ps.getParameter<std::vector<double> >("EBtimeFitParameters"); 
@@ -62,7 +62,7 @@ EcalUncalibRecHitWorkerGlobal::EcalUncalibRecHitWorkerGlobal(const edm::Paramete
 
 
 EcalUncalibRecHitWorkerGlobal::EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&ps) :
-  EcalUncalibRecHitWorkerRunOneDigiBase(ps), useDBShape(false), testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape))
+  EcalUncalibRecHitWorkerRunOneDigiBase(ps), useDBShape(true), testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape))
 {
         // ratio method parameters
         EBtimeFitParameters_ = ps.getParameter<std::vector<double> >("EBtimeFitParameters"); 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
@@ -18,7 +18,7 @@
 #include <FWCore/ParameterSet/interface/ParameterSetDescription.h>
 
 EcalUncalibRecHitWorkerGlobal::EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&ps,edm::ConsumesCollector& c) :
-  EcalUncalibRecHitWorkerRunOneDigiBase(ps,c), useDBShape(true), testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape))
+  EcalUncalibRecHitWorkerRunOneDigiBase(ps,c), testbeamEEShape(EEShape(true)), testbeamEBShape(EBShape(true))
 {
         // ratio method parameters
         EBtimeFitParameters_ = ps.getParameter<std::vector<double> >("EBtimeFitParameters"); 
@@ -62,7 +62,7 @@ EcalUncalibRecHitWorkerGlobal::EcalUncalibRecHitWorkerGlobal(const edm::Paramete
 
 
 EcalUncalibRecHitWorkerGlobal::EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&ps) :
-  EcalUncalibRecHitWorkerRunOneDigiBase(ps), useDBShape(true), testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape))
+  EcalUncalibRecHitWorkerRunOneDigiBase(ps), testbeamEEShape(EEShape(true)), testbeamEBShape(EBShape(true))
 {
         // ratio method parameters
         EBtimeFitParameters_ = ps.getParameter<std::vector<double> >("EBtimeFitParameters"); 
@@ -125,11 +125,8 @@ EcalUncalibRecHitWorkerGlobal::set(const edm::EventSetup& es)
 	es.get<EcalTimeBiasCorrectionsRcd>().get(timeCorrBias_);
   
         // for the DB Ecal Pulse Sim Shape
-        if(useDBShape) 
-	{
-	    testbeamEEShape.setEventSetup(es);
-	    testbeamEBShape.setEventSetup(es);
-	}
+	testbeamEEShape.setEventSetup(es);
+	testbeamEBShape.setEventSetup(es);
 }
 
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.h
@@ -38,7 +38,7 @@ class EcalUncalibRecHitWorkerGlobal : public EcalUncalibRecHitWorkerRunOneDigiBa
         public:
                 EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&, edm::ConsumesCollector& c);
 		EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&);
-		EcalUncalibRecHitWorkerGlobal():useDBShape(false),testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape)){;}
+		EcalUncalibRecHitWorkerGlobal():useDBShape(true),testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape)){;}
                 ~EcalUncalibRecHitWorkerGlobal() override {};
 
                 void set(const edm::EventSetup& es) override;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.h
@@ -38,7 +38,7 @@ class EcalUncalibRecHitWorkerGlobal : public EcalUncalibRecHitWorkerRunOneDigiBa
         public:
                 EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&, edm::ConsumesCollector& c);
 		EcalUncalibRecHitWorkerGlobal(const edm::ParameterSet&);
-		EcalUncalibRecHitWorkerGlobal():useDBShape(true),testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape)){;}
+		EcalUncalibRecHitWorkerGlobal():testbeamEEShape(EEShape(true)), testbeamEBShape(EBShape(true)){;}
                 ~EcalUncalibRecHitWorkerGlobal() override {};
 
                 void set(const edm::EventSetup& es) override;
@@ -66,7 +66,6 @@ class EcalUncalibRecHitWorkerGlobal : public EcalUncalibRecHitWorkerRunOneDigiBa
                 const EcalWeightSet::EcalChi2WeightMatrix* chi2mat[2];
                 EcalUncalibRecHitRecWeightsAlgo<EBDataFrame> weightsMethod_barrel_;
                 EcalUncalibRecHitRecWeightsAlgo<EEDataFrame> weightsMethod_endcap_;
-                bool useDBShape;
                 EEShape testbeamEEShape; // used in the chi2
                 EBShape testbeamEBShape; // can be replaced by simple shape arrays of float in the future
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.cc
@@ -15,7 +15,7 @@
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 
 EcalUncalibRecHitWorkerWeights::EcalUncalibRecHitWorkerWeights(const edm::ParameterSet&ps, edm::ConsumesCollector& c) :
-  EcalUncalibRecHitWorkerRunOneDigiBase(ps,c),useDBShape(true), testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape))
+  EcalUncalibRecHitWorkerRunOneDigiBase(ps,c),testbeamEEShape(EEShape(true)), testbeamEBShape(EBShape(true))
 {
 }
 
@@ -27,11 +27,8 @@ EcalUncalibRecHitWorkerWeights::set(const edm::EventSetup& es)
         es.get<EcalWeightXtalGroupsRcd>().get(grps);
         es.get<EcalTBWeightsRcd>().get(wgts);
 
-        if(useDBShape) 
-        {
-	    testbeamEEShape.setEventSetup(es);
-	    testbeamEBShape.setEventSetup(es);
-	}
+	testbeamEEShape.setEventSetup(es);
+	testbeamEBShape.setEventSetup(es);
 }
 
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.cc
@@ -15,7 +15,7 @@
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 
 EcalUncalibRecHitWorkerWeights::EcalUncalibRecHitWorkerWeights(const edm::ParameterSet&ps, edm::ConsumesCollector& c) :
-  EcalUncalibRecHitWorkerRunOneDigiBase(ps,c),useDBShape(false), testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape))
+  EcalUncalibRecHitWorkerRunOneDigiBase(ps,c),useDBShape(true), testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape))
 {
 }
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.h
@@ -32,7 +32,7 @@ class EcalUncalibRecHitWorkerWeights : public EcalUncalibRecHitWorkerRunOneDigiB
 
         public:
                 EcalUncalibRecHitWorkerWeights(const edm::ParameterSet&, edm::ConsumesCollector& c);
-		EcalUncalibRecHitWorkerWeights():useDBShape(false),testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape)){;}
+		EcalUncalibRecHitWorkerWeights():useDBShape(true),testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape)){;}
                 ~EcalUncalibRecHitWorkerWeights() override {};
 
                 void set(const edm::EventSetup& es) override;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerWeights.h
@@ -32,7 +32,7 @@ class EcalUncalibRecHitWorkerWeights : public EcalUncalibRecHitWorkerRunOneDigiB
 
         public:
                 EcalUncalibRecHitWorkerWeights(const edm::ParameterSet&, edm::ConsumesCollector& c);
-		EcalUncalibRecHitWorkerWeights():useDBShape(true),testbeamEEShape(EEShape(useDBShape)), testbeamEBShape(EBShape(useDBShape)){;}
+		EcalUncalibRecHitWorkerWeights():testbeamEEShape(EEShape(true)), testbeamEBShape(EBShape(true)){;}
                 ~EcalUncalibRecHitWorkerWeights() override {};
 
                 void set(const edm::EventSetup& es) override;
@@ -57,7 +57,6 @@ class EcalUncalibRecHitWorkerWeights : public EcalUncalibRecHitWorkerRunOneDigiB
                 EcalUncalibRecHitRecWeightsAlgo<EBDataFrame> uncalibMaker_barrel_;
                 EcalUncalibRecHitRecWeightsAlgo<EEDataFrame> uncalibMaker_endcap_;
 
-                bool useDBShape;
  		EEShape testbeamEEShape; // used in the chi2
                 EBShape testbeamEBShape; // can be replaced by simple shape arrays of floats in the future (kostas)
 

--- a/SimCalorimetry/EcalSimAlgos/test/testEcalShape.cpp
+++ b/SimCalorimetry/EcalSimAlgos/test/testEcalShape.cpp
@@ -20,7 +20,7 @@ int main()
 
    const EcalSimParameterMap parameterMap ;
 
-   bool useDBShape = false; // this unit test is supposing the phase I hardcoded ECAL shapes
+   bool useDBShape = false; // for the purpose of testing the EcalShape class, doesn't need to (should not) fetch a shape from the DB but just to assume the testbeam one
    const APDShape theAPDShape(useDBShape) ;
    const EBShape theEBShape(useDBShape) ;
    const EEShape theEEShape(useDBShape) ;

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -87,7 +87,6 @@ class EcalDigiProducer : public DigiAccumulatorMixMod {
 
       void checkCalibrations(const edm::Event& event, const edm::EventSetup& eventSetup) ;
 
-      bool useDBShape;
       APDShape m_APDShape ;
       EBShape  m_EBShape  ;
       EEShape  m_EEShape  ;

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -67,10 +67,9 @@ EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::Produc
 // version for Pre-Mixing, for use outside of MixingModule
 EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params,  edm::ConsumesCollector& iC) :
    DigiAccumulatorMixMod(),
-   useDBShape         ( true) ,
-   m_APDShape         ( useDBShape ) ,
-   m_EBShape          ( useDBShape ) ,
-   m_EEShape          ( useDBShape ) ,
+   m_APDShape         ( true ) ,
+   m_EBShape          ( true ) ,
+   m_EEShape          ( true ) ,
    m_ESShape          (   ) ,
    m_EBdigiCollection ( params.getParameter<std::string>("EBdigiCollection") ) ,
    m_EEdigiCollection ( params.getParameter<std::string>("EEdigiCollection") ) ,

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -67,7 +67,7 @@ EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::Produc
 // version for Pre-Mixing, for use outside of MixingModule
 EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params,  edm::ConsumesCollector& iC) :
    DigiAccumulatorMixMod(),
-   useDBShape         ( false) ,
+   useDBShape         ( true) ,
    m_APDShape         ( useDBShape ) ,
    m_EBShape          ( useDBShape ) ,
    m_EEShape          ( useDBShape ) ,
@@ -344,12 +344,15 @@ EcalDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const& eventSe
   // Step A: Get Inputs
   edm::Handle<std::vector<PCaloHit> > ebHandle;
   if(m_doEB) {
+    m_EBShape.setEventSetup(eventSetup);  // need to set the eventSetup here, otherwise pre-mixing module will not wrk
+    m_APDShape.setEventSetup(eventSetup); //
     edm::InputTag ebTag(m_hitsProducerTag, "EcalHitsEB");
     e.getByLabel(ebTag, ebHandle);
   }
 
   edm::Handle<std::vector<PCaloHit> > eeHandle;
   if(m_doEE) {
+    m_EEShape.setEventSetup(eventSetup); // need to set the eventSetup here, otherwise pre-mixing module will not work
     edm::InputTag eeTag(m_hitsProducerTag, "EcalHitsEE");
     e.getByLabel(eeTag, eeHandle);
   }

--- a/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
+++ b/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
@@ -151,7 +151,6 @@ private:
  const EcalSimParameterMap * theParameterMap;
  //const CaloVShape * theEcalShape;
  ESShape * theESShape;
- bool useDBShape;
  EBShape *theEBShape;
  EEShape *theEEShape;
 

--- a/Validation/EcalDigis/src/EcalMixingModuleValidation.cc
+++ b/Validation/EcalDigis/src/EcalMixingModuleValidation.cc
@@ -35,7 +35,7 @@ EcalMixingModuleValidation::EcalMixingModuleValidation(const edm::ParameterSet& 
 										   , ps.getParameter<std::string>( "hitsProducer" ) + std::string( "EcalHitsES" )
 										   )
 								    )
-			       ), useDBShape(true) {
+			       ) {
 
 
   // needed for MixingModule checks
@@ -70,8 +70,8 @@ EcalMixingModuleValidation::EcalMixingModuleValidation(const edm::ParameterSet& 
 */
 
   theESShape = new ESShape();
-  theEBShape = new EBShape(useDBShape); 
-  theEEShape = new EEShape(useDBShape); 
+  theEBShape = new EBShape(true); 
+  theEEShape = new EEShape(true); 
 
   theESResponse = new CaloHitResponse(theParameterMap, theESShape);
   theEBResponse = new CaloHitResponse(theParameterMap, theEBShape);
@@ -136,11 +136,8 @@ EcalMixingModuleValidation::~EcalMixingModuleValidation(){}
 void EcalMixingModuleValidation::dqmBeginRun(edm::Run const&, edm::EventSetup const& c) {
 
   checkCalibrations(c);
-  if(useDBShape)
-  {
-    theEBShape->setEventSetup(c);
-    theEEShape->setEventSetup(c);
-  }
+  theEBShape->setEventSetup(c);
+  theEEShape->setEventSetup(c);
 }
 
 void EcalMixingModuleValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&){

--- a/Validation/EcalDigis/src/EcalMixingModuleValidation.cc
+++ b/Validation/EcalDigis/src/EcalMixingModuleValidation.cc
@@ -35,7 +35,7 @@ EcalMixingModuleValidation::EcalMixingModuleValidation(const edm::ParameterSet& 
 										   , ps.getParameter<std::string>( "hitsProducer" ) + std::string( "EcalHitsES" )
 										   )
 								    )
-			       ), useDBShape(false) {
+			       ), useDBShape(true) {
 
 
   // needed for MixingModule checks


### PR DESCRIPTION
This pull request is a follow-up of PR #23600, activating the usage of the database  EcalSimPulseShapeRcd for constructing the ECAL signal's electronic pulse shape. 

This PR should **not** have any **significant physics** changes for any **Phase-I MC**. In addition, it should be completely **adiabatic** for **DATA** RECO tasks. It is however expected to see some small differences in the MC DIGI production to the level of 10^-5 in the ECAL Digi Pulse Shape.  As a result, some of the rechits in Phase-I MC might slightly change in terms of energy/time but these changes are expected to be very small, numerically noticeable but not important in terms of physics.

the main updates are described here:

    https://indico.cern.ch/event/731948/ (slide 4)
