### PR TITLE
Process only 10 plugins per process for AARCH64

### DIFF
--- a/FWCore/PluginManager/bin/refresh.cc
+++ b/FWCore/PluginManager/bin/refresh.cc
@@ -38,7 +38,7 @@ using namespace edmplugin;
 #ifdef __APPLE__
 #define PER_PROCESS_DSO 20
 #elif defined(__aarch64__)
-#define PER_PROCESS_DSO 20
+#define PER_PROCESS_DSO 10
 #else
 #define PER_PROCESS_DSO 2000
 #endif


### PR DESCRIPTION
For AARCH64 builds we often see error [a]. This should reduce the static TLS block usage and let build complete successfully.

[a]
```
@@@@ Refreshing Plugins:edmPluginRefresh
>> All python modules compiled
Caught exception An exception of category 'PluginLibraryLoadError' occurred.
Exception Message:
unable to load lib/slc7_aarch64_gcc700/pluginFireworksCaloPlugins.so because /lib64/libGL.so.1: cannot allocate memory in static TLS block
 will ignore pluginFireworksCaloPlugins.so and continue.

 *** Break *** segmentation violation
```