### PR TITLE
Extend the hit pattern class to include MTD hits

### DIFF
--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -461,9 +461,10 @@ private:
     const static unsigned short SubDetectorOffset = 10;
     const static unsigned short SubDetectorMask = 0x3;
 
-    const static unsigned short minTrackerWord = 1<< SubDetectorOffset;
-    const static unsigned short minPixelWord = minTrackerWord |  (1<<SubstrOffset);
-    const static unsigned short minStripWord = minTrackerWord |  (3<<SubstrOffset);
+    const static unsigned short minTrackerWord = 1 << SubDetectorOffset;
+    const static unsigned short maxTrackerWord = (2 << SubDetectorOffset) - 1;
+    const static unsigned short minPixelWord = minTrackerWord | (1<<SubstrOffset);
+    const static unsigned short minStripWord = minTrackerWord | (3<<SubstrOffset);
 
 
     // detector side for tracker modules (mono/stereo)
@@ -699,7 +700,7 @@ inline bool HitPattern::muonME0HitFilter(uint16_t pattern) {
 
 inline bool HitPattern::trackerHitFilter(uint16_t pattern)
 {
-  return pattern > minTrackerWord;
+  return pattern > minTrackerWord && pattern <= maxTrackerWord;
 }
 
 inline bool HitPattern::muonHitFilter(uint16_t pattern)

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -155,6 +155,12 @@ public:
         STEREO = 2
     };
 
+    enum HIT_DETECTOR_TYPE {
+      MUON_HIT = 0,
+      TRACKER_HIT = 1,
+      MTD_HIT = 2
+    };
+
     enum HIT_TYPE {
         VALID = 0,
         MISSING = 1,

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -19,23 +19,25 @@
 // The hits of a track are saved in unit16_t hitPattern[MaxHits].
 //
 //                                            uint16_t
-// +--------+---------------+---------------------------+-----------------+----------------+
-// |  tk/mu | sub-structure |     sub-sub-structure     |     stereo      |    hit type    |
-// +--------+---------------+---------------------------+-----------------+----------------+
-// |   10   | 9   8    7    |  6     5     4     3      |        2        |    1        0  |  bit
-// +--------+---------------+---------------------------+-----------------+----------------|
-// | tk = 1 |    PXB = 1    | layer = 1-3               |                 | hit type = 0-3 |
-// | tk = 1 |    PXF = 2    | disk  = 1-2               |                 | hit type = 0-3 |
-// | tk = 1 |    TIB = 3    | layer = 1-4               | 0=rphi,1=stereo | hit type = 0-3 |
-// | tk = 1 |    TID = 4    | wheel = 1-3               | 0=rphi,1=stereo | hit type = 0-3 |
-// | tk = 1 |    TOB = 5    | layer = 1-6               | 0=rphi,1=stereo | hit type = 0-3 |
-// | tk = 1 |    TEC = 6    | wheel = 1-9               | 0=rphi,1=stereo | hit type = 0-3 |
-// | mu = 0 |    DT  = 1    | 4*(stat-1)+superlayer     |                 | hit type = 0-3 |
-// | mu = 0 |    CSC = 2    | 4*(stat-1)+(ring-1)       |                 | hit type = 0-3 |
-// | mu = 0 |    RPC = 3    | 4*(stat-1)+2*layer+region |                 | hit type = 0-3 |
-// | mu = 0 |    GEM = 4    | 2*(stat-1)+2*(layer-1)    |                 | hit type = 0-3 |
-// |mu = 0  |    ME0 = 5    | roll                      |                 | hit type = 0-3 |
-// +--------+---------------+---------------------------+-----------------+----------------+
+// +------------+---------------+---------------------------+-----------------+----------------+
+// |  tk/mu/mtd | sub-structure |     sub-sub-structure     |     stereo      |    hit type    |
+// +------------+---------------+---------------------------+-----------------+----------------+
+// |    11-10   | 9   8    7    |  6     5     4     3      |        2        |    1        0  |  bit
+// +------------+---------------+---------------------------+-----------------+----------------|
+// | tk  = 1    |    PXB = 1    | layer = 1-3               |                 | hit type = 0-3 |
+// | tk  = 1    |    PXF = 2    | disk  = 1-2               |                 | hit type = 0-3 |
+// | tk  = 1    |    TIB = 3    | layer = 1-4               | 0=rphi,1=stereo | hit type = 0-3 |
+// | tk  = 1    |    TID = 4    | wheel = 1-3               | 0=rphi,1=stereo | hit type = 0-3 |
+// | tk  = 1    |    TOB = 5    | layer = 1-6               | 0=rphi,1=stereo | hit type = 0-3 |
+// | tk  = 1    |    TEC = 6    | wheel = 1-9               | 0=rphi,1=stereo | hit type = 0-3 |
+// | mu  = 0    |    DT  = 1    | 4*(stat-1)+superlayer     |                 | hit type = 0-3 |
+// | mu  = 0    |    CSC = 2    | 4*(stat-1)+(ring-1)       |                 | hit type = 0-3 |
+// | mu  = 0    |    RPC = 3    | 4*(stat-1)+2*layer+region |                 | hit type = 0-3 |
+// | mu  = 0    |    GEM = 4    | 2*(stat-1)+2*(layer-1)    |                 | hit type = 0-3 |
+// | mu  = 0    |    ME0 = 5    | roll                      |                 | hit type = 0-3 |
+// | mtd = 2    |    BTL = 1    | moduleType = 1-3          |                 | hit type = 0-3 | 
+// | mtd = 2    |    ETL = 2    | ring = 1-12               |                 | hit type = 0-3 | 
+// +------------+---------------+---------------------------+-----------------+----------------+
 //
 //  hit type, see DataFormats/TrackingRecHit/interface/TrackingRecHit.h
 //      VALID    = valid hit                                     = 0
@@ -121,6 +123,7 @@
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
+#include "DataFormats/ForwardDetId/interface/MTDDetId.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
@@ -164,8 +167,8 @@ public:
         MISSING_INNER_HITS = 1,
         MISSING_OUTER_HITS = 2
     };
-    const static unsigned short ARRAY_LENGTH = 50;
-    const static unsigned short HIT_LENGTH = 11;
+    const static unsigned short ARRAY_LENGTH = 57;
+    const static unsigned short HIT_LENGTH = 12;
     const static unsigned short MaxHits = (8 * sizeof(uint16_t) * ARRAY_LENGTH) / HIT_LENGTH;
 
     static const uint32_t NULL_RETURN = 999999;
@@ -173,6 +176,7 @@ public:
 
     static bool trackerHitFilter(uint16_t pattern);
     static bool muonHitFilter(uint16_t pattern);
+    static bool timingHitFilter(uint16_t pattern);
 
     static bool validHitFilter(uint16_t pattern);
     static bool missingHitFilter(uint16_t pattern);
@@ -193,6 +197,9 @@ public:
     static bool muonRPCHitFilter(uint16_t pattern);
     static bool muonGEMHitFilter(uint16_t pattern); 
     static bool muonME0HitFilter(uint16_t pattern);
+
+    static bool timingBTLHitFilter(uint16_t pattern);
+    static bool timingETLHitFilter(uint16_t pattern);
 
     static uint32_t getHitType(uint16_t pattern);
 
@@ -223,6 +230,12 @@ public:
 
     /// GEM layer: 1,2. Only valid for muon GEM patterns, of course.
     static uint16_t getGEMLayer(uint16_t pattern);
+
+    /// BTL Module type: 1,2,3. Only valid for BTL patterns of course.
+    static uint16_t getBTLModType(uint16_t pattern);
+
+    /// ETL Ring: 1-12. Only valid for ETL patterns of course.
+    static uint16_t getETLRing(uint16_t pattern);
 
     HitPattern();
 
@@ -281,7 +294,6 @@ public:
     int numberOfValidStripTOBHits() const;                        // not-null, valid, strip TOB
     int numberOfValidStripTECHits() const;                        // not-null, valid, strip TEC
 
-
     int numberOfLostHits(HitCategory category) const;             // not-null, not valid
     int numberOfLostTrackerHits(HitCategory category) const;      // not-null, not valid, tracker
     int numberOfLostPixelHits(HitCategory category) const;        // not-null, not valid, pixel
@@ -293,6 +305,15 @@ public:
     int numberOfLostStripTOBHits(HitCategory category) const;     // not-null, not valid, strip TOB
     int numberOfLostStripTECHits(HitCategory category) const;     // not-null, not valid, strip TEC
 
+    int numberOfTimingHits() const;         // not-null timing
+    int numberOfValidTimingHits() const;    // not-null, valid, timing
+    int numberOfValidTimingBTLHits() const;       // not-null, valid, timing BTL
+    int numberOfValidTimingETLHits() const;       // not-null, valid, timing ETL
+
+    int numberOfLostTimingHits() const;     // not-null, not valid, timing
+    int numberOfLostTimingBTLHits() const;  // not-null, not valid, timing BTL
+    int numberOfLostTimingETLHits() const;  // not-null, not valid, timing ETL
+    
     int numberOfMuonHits() const;             // not-null, muon
     int numberOfValidMuonHits() const;        // not-null, valid, muon
     int numberOfValidMuonDTHits() const;      // not-null, valid, muon DT
@@ -318,6 +339,7 @@ public:
 
     int numberOfInactiveHits() const;         // not-null, inactive
     int numberOfInactiveTrackerHits() const;  // not-null, inactive, tracker
+    int numberOfInactiveTimingHits() const;   // not-null, inactive, timing
 
     // count strip layers that have non-null, valid mono and stereo hits
     int numberOfValidStripLayersWithMonoAndStereo(uint16_t stripdet, uint16_t layer) const;
@@ -435,9 +457,9 @@ private:
     const static unsigned short SubstrOffset = 7;
     const static unsigned short SubstrMask = 0x7;
 
-    // 1 bit to distinguish tracker and muon subsystems
+    // 2 bits to distinguish tracker, muon, mtd subsystems
     const static unsigned short SubDetectorOffset = 10;
-    const static unsigned short SubDetectorMask = 0x1;
+    const static unsigned short SubDetectorMask = 0x3;
 
     const static unsigned short minTrackerWord = 1<< SubDetectorOffset;
     const static unsigned short minPixelWord = minTrackerWord |  (1<<SubstrOffset);
@@ -689,6 +711,27 @@ inline bool HitPattern::muonHitFilter(uint16_t pattern)
     return (((pattern >> SubDetectorOffset) & SubDetectorMask) == 0);
 }
 
+inline bool HitPattern::timingBTLHitFilter(uint16_t pattern) { 
+  if  UNLIKELY(!timingHitFilter(pattern)) return false;
+  uint16_t substructure = getSubStructure(pattern);
+  return (substructure == (uint16_t) MTDDetId::BTL);
+}
+
+inline bool HitPattern::timingETLHitFilter(uint16_t pattern) { 
+  if  UNLIKELY(!timingHitFilter(pattern)) return false;
+  uint16_t substructure = getSubStructure(pattern);
+  return (substructure == (uint16_t) MTDDetId::ETL);
+}
+
+inline bool HitPattern::timingHitFilter(uint16_t pattern)
+{
+    if UNLIKELY(pattern == HitPattern::EMPTY_PATTERN) {
+        return false;
+    }
+
+    return (((pattern >> SubDetectorOffset) & SubDetectorMask) == 2);
+}
+
 inline uint32_t HitPattern::getSubStructure(uint16_t pattern)
 {
     if UNLIKELY(pattern == HitPattern::EMPTY_PATTERN) {
@@ -780,6 +823,15 @@ inline uint16_t HitPattern::getGEMStation(uint16_t pattern)
     return stat + 1;
 }
 
+/// MTD
+inline uint16_t HitPattern::getBTLModType(uint16_t pattern) { 
+  return getSubSubStructure(pattern);
+}
+
+inline uint16_t HitPattern::getETLRing(uint16_t pattern) {
+  return getSubSubStructure(pattern);
+}
+
 inline uint16_t HitPattern::getGEMLayer(uint16_t pattern)
 {
     return (getSubSubStructure(pattern) & 1) + 1;
@@ -821,6 +873,11 @@ inline int HitPattern::numberOfMuonHits() const
     return countHits(TRACK_HITS, muonHitFilter);
 }
 
+inline int HitPattern::numberOfTimingHits() const
+{
+    return countHits(TRACK_HITS, timingHitFilter);
+}
+
 inline int HitPattern::numberOfValidHits() const
 {
     return countHits(TRACK_HITS, validHitFilter);
@@ -834,6 +891,11 @@ inline int HitPattern::numberOfValidTrackerHits() const
 inline int HitPattern::numberOfValidMuonHits() const
 {
     return countTypedHits(TRACK_HITS, validHitFilter, muonHitFilter);
+}
+
+inline int HitPattern::numberOfValidTimingHits() const
+{
+    return countTypedHits(TRACK_HITS, validHitFilter, timingHitFilter);
 }
 
 inline int HitPattern::numberOfValidPixelHits() const
@@ -900,6 +962,16 @@ inline int HitPattern::numberOfValidMuonME0Hits() const {
   return countTypedHits(TRACK_HITS, validHitFilter, muonME0HitFilter);
 }
 
+inline int HitPattern::numberOfValidTimingBTLHits() const
+{
+   return countTypedHits(TRACK_HITS, validHitFilter, timingBTLHitFilter);
+}
+
+inline int HitPattern::numberOfValidTimingETLHits() const
+{
+   return countTypedHits(TRACK_HITS, validHitFilter, timingETLHitFilter);
+}
+
 inline int HitPattern::numberOfLostHits(HitCategory category) const
 {
     return countHits(category, missingHitFilter);
@@ -913,6 +985,21 @@ inline int HitPattern::numberOfLostTrackerHits(HitCategory category) const
 inline int HitPattern::numberOfLostMuonHits() const
 {
     return countTypedHits(TRACK_HITS, missingHitFilter, muonHitFilter);
+}
+
+inline int HitPattern::numberOfLostTimingHits() const
+{
+    return countTypedHits(TRACK_HITS, missingHitFilter, timingHitFilter);
+}
+
+inline int HitPattern::numberOfLostTimingBTLHits() const
+{
+    return countTypedHits(TRACK_HITS, missingHitFilter, timingBTLHitFilter);
+}
+
+inline int HitPattern::numberOfLostTimingETLHits() const
+{
+    return countTypedHits(TRACK_HITS, missingHitFilter, timingETLHitFilter);
 }
 
 inline int HitPattern::numberOfLostPixelHits(HitCategory category) const

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -185,10 +185,12 @@ uint16_t HitPattern::encode(const DetId &id, TrackingRecHit::Type hitType, const
 
     // juggle the detid around to deal with the fact the bitwidth is larger
     // DetId::Muon is 2 and DetId::Forward is 6, must map to 0 and 2 respectively
-    if( detid == DetId::Muon ) {
-      detid = 0; // DetId::Muon is 2 and needs to be reordered to match old encoding where it got masked
+    if( detid == DetId::Tracker ) {
+      detid = TRACKER_HIT;
+    } else if( detid == DetId::Muon ) {
+      detid = MUON_HIT; // DetId::Muon is 2 and needs to be reordered to match old encoding where it got masked
     } else if( detid == DetId::Forward && subdet == FastTime ) {
-      detid = 2; // since DetId::Forward is some other number, reorder it here
+      detid = MTD_HIT; // since DetId::Forward is some other number, reorder it here
     }
 
     return encode(detid, subdet, layer, side, hitType);
@@ -300,7 +302,7 @@ bool HitPattern::appendHit(const uint16_t pattern, TrackingRecHit::Type hitType)
 }
 
 bool HitPattern::appendTrackerHit(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType) {
-    return appendHit(encode(DetId::Tracker, subdet, layer, stereo, hitType), hitType);
+    return appendHit(encode(TRACKER_HIT, subdet, layer, stereo, hitType), hitType);
 }
 
 bool HitPattern::appendMuonHit(const DetId& id, TrackingRecHit::Type hitType) {
@@ -312,10 +314,9 @@ bool HitPattern::appendMuonHit(const DetId& id, TrackingRecHit::Type hitType) {
     if UNLIKELY(id.det() != DetId::Muon) {
         throw cms::Exception("HitPattern") << "Got DetId from det " << id.det() << " that is not Muon in appendMuonHit(), which should only be used for muon hits in the HitPattern IO rule";
     }
-
-    //uint16_t detid = id.det(); // force this to zero, MTD is 2
+    
     uint16_t subdet = id.subdetId();
-    return appendHit(encode(0, subdet, encodeMuonLayer(id), 0, hitType), hitType);
+    return appendHit(encode(MUON_HIT, subdet, encodeMuonLayer(id), 0, hitType), hitType);
 }
 
 uint16_t HitPattern::getHitPatternByAbsoluteIndex(int position) const

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -1,7 +1,8 @@
 <lcgdict>
 
   <class name="reco::TrackBase::AlgoMask"/>
-  <class name="reco::HitPattern" ClassVersion="12">
+  <class name="reco::HitPattern" ClassVersion="13">
+      <version ClassVersion="13" checksum="2211596316"/>
       <version ClassVersion="12" checksum="3922863495"/>
       <version ClassVersion="11" checksum="1621684703"/>
   </class>
@@ -25,6 +26,149 @@
     <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>
+ <ioread
+    sourceClass="reco::HitPattern"
+      source="uint16_t hitPattern[50]"
+      targetClass="reco::HitPattern"
+      target="hitPattern"
+      version="[12]"
+      include="utility,DataFormats/MuonDetId/interface/DTLayerId.h,DataFormats/MuonDetId/interface/CSCDetId.h,DataFormats/MuonDetId/interface/RPCDetId.h,DataFormats/MuonDetId/interface/GEMDetId.h,DataFormats/MuonDetId/interface/ME0DetId.h,"
+      >
+   <![CDATA[
+            using namespace reco;
+
+            const unsigned short HitSize = 11;
+            const unsigned short PatternSize = 50;
+            const int MaxHits = (PatternSize * sizeof(uint16_t) * 8) / HitSize;
+
+            auto getHitFromOldHitPattern = [](const uint16_t hitPattern[], const int position) {
+                uint16_t bitEndOffset = (position + 1) * HitSize;
+                uint8_t secondWord   = (bitEndOffset >> 4);
+                uint8_t secondWordBits = bitEndOffset & (16 - 1); // that is, bitEndOffset % 32
+                if (secondWordBits >= HitSize) {
+                    // full block is in this word
+                    uint8_t lowBitsToTrash = secondWordBits - HitSize;
+                    return (hitPattern[secondWord] >> lowBitsToTrash) & ((1 << HitSize) - 1);
+                } else {
+                    uint8_t  firstWordBits   = HitSize - secondWordBits;
+                    uint16_t firstWordBlock  = hitPattern[secondWord - 1] >> (16 - firstWordBits);
+                    uint16_t secondWordBlock = hitPattern[secondWord] & ((1 << secondWordBits) - 1);
+                    return firstWordBlock + (secondWordBlock << firstWordBits);
+                }
+            };
+
+            auto appendOldHitPattern = [&](const uint16_t pattern) {
+                // value used for those parameters needed by XXXDetId constructors
+                // but that we do not care about because they are not stored in the
+                // HitPattern.
+                const uint8_t DONT_CARE = 1;
+
+                const static unsigned short HitTypeMask = 0x3;
+                const static unsigned short HitTypeOffset = 0;
+                
+                const static unsigned short SideMask = 0x1;
+                const static unsigned short SideOffset = 2;
+                
+                const static unsigned short LayerMask = 0xF;
+                const static unsigned short LayerOffset = 3;
+
+                const static unsigned short SubstrMask = 0x7;
+                const static unsigned short SubstrOffset = 7;
+
+                const static unsigned short SubDetectorMask = 0x1;
+                const static unsigned short SubDetectorOffset = 10;
+
+                const uint16_t VALID_CONST = (uint16_t) TrackingRecHit::valid;
+                const uint16_t MISSING_CONST = (uint16_t) TrackingRecHit::missing;
+                const uint16_t INACTIVE_CONST = (uint16_t) TrackingRecHit::inactive;
+                const uint16_t BAD_CONST = (uint16_t) TrackingRecHit::bad;
+
+                uint16_t rawHitType = (pattern >> HitTypeOffset) & HitTypeMask;
+                uint16_t layer = (pattern >> LayerOffset) & LayerMask;
+                uint16_t subdet = (pattern >> SubstrOffset) & SubstrMask;
+                uint16_t detector = (pattern >> SubDetectorOffset) & SubDetectorMask;
+                uint16_t stereo = (pattern >> SideOffset) & SideMask;
+
+                // DetId::Tracker = 1 and DetId::Muon = 2 but
+                // in HitPattern Tracker = 1 and Muon = 0 so a conversion is needed:
+                if (detector == 0) {
+                    detector = DetId::Muon;
+                }
+
+                TrackingRecHit::Type hitType = TrackingRecHit::valid;
+                switch (rawHitType) {
+                case VALID_CONST:
+                    hitType = TrackingRecHit::valid;
+                    break;
+                case MISSING_CONST:
+                    hitType = TrackingRecHit::missing;
+                    break;
+                case INACTIVE_CONST:
+                    hitType = TrackingRecHit::inactive;
+                    break;
+                case BAD_CONST:
+                    hitType = TrackingRecHit::bad;
+                    break;
+                }
+
+                DetId detId;
+                if (detector == DetId::Tracker) {
+                    return newObj->appendTrackerHit(subdet, layer, stereo, hitType);
+                } else if (detector == DetId::Muon) {
+                    switch (subdet) {
+                    case MuonSubdetId::DT: {
+                        uint16_t station = 1 + ((layer >> 2) & 0x3);
+                        uint16_t superLayer = (layer & 0x3);
+                        detId = DTLayerId(DONT_CARE, station, DONT_CARE, superLayer, DONT_CARE);
+                    }
+                    break;
+                    case MuonSubdetId::CSC: {
+                        uint16_t station = 1 + ((layer >> 2) & 0x3);
+                        uint16_t ring = 1 + (layer & 0x3);
+                        detId = CSCDetId(DONT_CARE, station, ring, DONT_CARE, DONT_CARE);
+                    }
+                    break;
+                    case MuonSubdetId::RPC: {
+                        uint16_t station =  1 + ((layer >> 2) & 0x3);
+                        uint16_t region  = layer & 0x1;
+                        uint16_t layer_muon = 1 + ((station <= 2) ? ((layer >> 1) & 0x1) : 0);
+                        detId = RPCDetId(region, DONT_CARE, station, DONT_CARE, layer_muon, DONT_CARE, DONT_CARE);
+                    }
+                    break;
+                    case MuonSubdetId::GEM: {
+                        uint16_t station =  1 + ((layer >> 2) & 0x3);
+                        uint16_t layer_muon = 1 + (layer & 0x3);
+                        detId = GEMDetId(DONT_CARE, DONT_CARE, station, layer_muon, DONT_CARE, DONT_CARE);
+                    }
+                    break;
+                    case MuonSubdetId::ME0: {
+                        uint16_t roll =  layer & 0xF;
+                        detId = ME0DetId(DONT_CARE, DONT_CARE, DONT_CARE, roll);
+                    }
+                    break;
+                    }
+                    return newObj->appendMuonHit(detId, hitType);
+                }
+                return false;
+            };
+
+            auto fillNewHitPatternWithOldHitPattern = [&](const uint16_t oldHitPattern[]) {
+                newObj->clear();
+                for (int i = 0; i < MaxHits; i++) {
+                    uint16_t pattern = getHitFromOldHitPattern(oldHitPattern, i);
+                    if (pattern == 0) {
+                        break;
+                    }
+                    if(!appendOldHitPattern(pattern)) {
+                        return false;
+                    }
+                }
+                return true;
+            };
+
+            fillNewHitPatternWithOldHitPattern(onfile.hitPattern);
+      ]]>
+ </ioread>
  <ioread
       sourceClass="reco::HitPattern"
       source="uint32_t hitPattern_[25]"

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -32,7 +32,7 @@
       targetClass="reco::HitPattern"
       target="hitPattern"
       version="[12]"
-      include="utility,DataFormats/MuonDetId/interface/DTLayerId.h,DataFormats/MuonDetId/interface/CSCDetId.h,DataFormats/MuonDetId/interface/RPCDetId.h,DataFormats/MuonDetId/interface/GEMDetId.h,DataFormats/MuonDetId/interface/ME0DetId.h,"
+      include="utility"
       >
    <![CDATA[
             using namespace reco;
@@ -90,7 +90,7 @@
             auto fillNewHitPatternWithOldHitPattern = [&](const uint16_t oldHitPattern[]) {
                 newObj->clear();
                 for (int i = 0; i < MaxHits; i++) {
-                    uint32_t pattern = getHitFromOldHitPattern(oldHitPattern, i);
+                    uint16_t pattern = getHitFromOldHitPattern(oldHitPattern, i);
                     if (pattern == 0) {
                         break;
                     }

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -58,42 +58,16 @@
             };
 
             auto appendOldHitPattern = [&](const uint16_t pattern) {
-                // value used for those parameters needed by XXXDetId constructors
-                // but that we do not care about because they are not stored in the
-                // HitPattern.
-                const uint8_t DONT_CARE = 1;
-
+                // for this version we just have to add a 0 bit to the top of the pattern
                 const static unsigned short HitTypeMask = 0x3;
-                const static unsigned short HitTypeOffset = 0;
-                
-                const static unsigned short SideMask = 0x1;
-                const static unsigned short SideOffset = 2;
-                
-                const static unsigned short LayerMask = 0xF;
-                const static unsigned short LayerOffset = 3;
-
-                const static unsigned short SubstrMask = 0x7;
-                const static unsigned short SubstrOffset = 7;
-
-                const static unsigned short SubDetectorMask = 0x1;
-                const static unsigned short SubDetectorOffset = 10;
+                const static unsigned short HitTypeOffset = 0;                
 
                 const uint16_t VALID_CONST = (uint16_t) TrackingRecHit::valid;
                 const uint16_t MISSING_CONST = (uint16_t) TrackingRecHit::missing;
                 const uint16_t INACTIVE_CONST = (uint16_t) TrackingRecHit::inactive;
                 const uint16_t BAD_CONST = (uint16_t) TrackingRecHit::bad;
 
-                uint16_t rawHitType = (pattern >> HitTypeOffset) & HitTypeMask;
-                uint16_t layer = (pattern >> LayerOffset) & LayerMask;
-                uint16_t subdet = (pattern >> SubstrOffset) & SubstrMask;
-                uint16_t detector = (pattern >> SubDetectorOffset) & SubDetectorMask;
-                uint16_t stereo = (pattern >> SideOffset) & SideMask;
-
-                // DetId::Tracker = 1 and DetId::Muon = 2 but
-                // in HitPattern Tracker = 1 and Muon = 0 so a conversion is needed:
-                if (detector == 0) {
-                    detector = DetId::Muon;
-                }
+                uint16_t rawHitType = (pattern >> HitTypeOffset) & HitTypeMask;                
 
                 TrackingRecHit::Type hitType = TrackingRecHit::valid;
                 switch (rawHitType) {
@@ -109,53 +83,14 @@
                 case BAD_CONST:
                     hitType = TrackingRecHit::bad;
                     break;
-                }
-
-                DetId detId;
-                if (detector == DetId::Tracker) {
-                    return newObj->appendTrackerHit(subdet, layer, stereo, hitType);
-                } else if (detector == DetId::Muon) {
-                    switch (subdet) {
-                    case MuonSubdetId::DT: {
-                        uint16_t station = 1 + ((layer >> 2) & 0x3);
-                        uint16_t superLayer = (layer & 0x3);
-                        detId = DTLayerId(DONT_CARE, station, DONT_CARE, superLayer, DONT_CARE);
-                    }
-                    break;
-                    case MuonSubdetId::CSC: {
-                        uint16_t station = 1 + ((layer >> 2) & 0x3);
-                        uint16_t ring = 1 + (layer & 0x3);
-                        detId = CSCDetId(DONT_CARE, station, ring, DONT_CARE, DONT_CARE);
-                    }
-                    break;
-                    case MuonSubdetId::RPC: {
-                        uint16_t station =  1 + ((layer >> 2) & 0x3);
-                        uint16_t region  = layer & 0x1;
-                        uint16_t layer_muon = 1 + ((station <= 2) ? ((layer >> 1) & 0x1) : 0);
-                        detId = RPCDetId(region, DONT_CARE, station, DONT_CARE, layer_muon, DONT_CARE, DONT_CARE);
-                    }
-                    break;
-                    case MuonSubdetId::GEM: {
-                        uint16_t station =  1 + ((layer >> 2) & 0x3);
-                        uint16_t layer_muon = 1 + (layer & 0x3);
-                        detId = GEMDetId(DONT_CARE, DONT_CARE, station, layer_muon, DONT_CARE, DONT_CARE);
-                    }
-                    break;
-                    case MuonSubdetId::ME0: {
-                        uint16_t roll =  layer & 0xF;
-                        detId = ME0DetId(DONT_CARE, DONT_CARE, DONT_CARE, roll);
-                    }
-                    break;
-                    }
-                    return newObj->appendMuonHit(detId, hitType);
-                }
-                return false;
+                }                
+                return newObj->appendHit(pattern,hitType);                
             };
 
             auto fillNewHitPatternWithOldHitPattern = [&](const uint16_t oldHitPattern[]) {
                 newObj->clear();
                 for (int i = 0; i < MaxHits; i++) {
-                    uint16_t pattern = getHitFromOldHitPattern(oldHitPattern, i);
+                    uint32_t pattern = getHitFromOldHitPattern(oldHitPattern, i);
                     if (pattern == 0) {
                         break;
                     }

--- a/DataFormats/TrackReco/test/testHitPattern.cpp
+++ b/DataFormats/TrackReco/test/testHitPattern.cpp
@@ -22,7 +22,10 @@ namespace test {
     				     470131344,//TEC r4
     				     470079661,//TEC r5
     				     470049476,//TEC r6
-    				     470045428}; //TEC r7
+				     470045428,//TEC r7
+				     0x628f3a3c // MTD BTL
+                                     }; 
+                                     
     
        HitPattern hp;
        auto i=0;
@@ -31,11 +34,12 @@ namespace test {
        hp.appendHit(radial_detids[8],TrackingRecHit::missing);
     
     
-       std::cout << hp.numberOfValidTrackerHits() << ' ' << hp.numberOfValidPixelHits() << ' ' <<	hp.numberOfValidStripHits() << std::endl;
+       std::cout << hp.numberOfValidTrackerHits() << ' ' << hp.numberOfValidPixelHits() << ' ' <<	hp.numberOfValidStripHits() << ' ' << hp.numberOfValidTimingHits() << std::endl;
        std::cout << hp.pixelLayersWithMeasurement() << ' ' << hp.stripLayersWithMeasurement() << std::endl;
        std::cout << hp.numberOfValidStripLayersWithMonoAndStereo() << std::endl;
        std::cout <<	hp.pixelLayersWithoutMeasurement(HitPattern::TRACK_HITS) << ' ' << hp.stripLayersWithoutMeasurement(HitPattern::TRACK_HITS) << std::endl;
-    
+       assert(hp.numberOfValidTimingHits() == 1);
+       
     }
     
     

--- a/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
@@ -100,7 +100,7 @@ string printseed(const L3TkMuonProducer::SeedRef & s){
   TrajectorySeed::range r=s->recHits();
   TrajectorySeed::const_iterator it=r.first;
   for (;it!=r.second;++it)
-    ss<<"\n detId: "<<it->geographicalId()<<" position: "<<it->localPosition()<<" and error: "<<it->localPositionError();
+    ss<<"\n detId: " << std::hex <<it->geographicalId().rawId() << std::dec <<" position: "<<it->localPosition()<<" and error: "<<it->localPositionError();
   return ss.str();
 }
 

--- a/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
@@ -175,7 +175,7 @@ float EcalBarrelClusterFastTimer::correctTimeToVertex(const float intime, const 
   auto cellGeometry = ecalGeom->getGeometry(timeDet);
   if( nullptr == cellGeometry ) {
     throw cms::Exception("BadECALBarrelCell")
-      << timeDet << " is not a valid ECAL Barrel DetId!";
+      << std::hex << timeDet.rawId() << std::dec<< " is not a valid ECAL Barrel DetId!";
   }
   //depth in mm in the middle of the layer position;
   GlobalPoint layerPos = cellGeometry->getPosition( ecalDepth_+0.5 ); 

--- a/RecoTracker/TkSeedGenerator/src/SeedFromProtoTrack.cc
+++ b/RecoTracker/TkSeedGenerator/src/SeedFromProtoTrack.cc
@@ -72,7 +72,7 @@ void SeedFromProtoTrack::init(const reco::Track & proto, const edm::EventSetup& 
 
   if (!outerState.isValid()){    
     const Surface & surface = tracker->idToDet(lastHit.geographicalId())->surface();
-    edm::LogError("SeedFromProtoTrack")<<" was trying to create a seed from:\n"<<fts<<"\n propagating to: "<<lastHit.geographicalId()<<surface.position();
+    edm::LogError("SeedFromProtoTrack")<<" was trying to create a seed from:\n"<<fts<<"\n propagating to: " << std::hex <<lastHit.geographicalId().rawId()<< std::dec << ' ' <<surface.position();
     theValid = false;
     return ;
   }


### PR DESCRIPTION
Extends the reco::HitPattern class to understand timing detector hits. 
HitPattern is now 12 bits instead of 11, appropriate iorule added to maintain compatibility.

As discussed with @VinInn and company.

@fabiocos @bendavid @casarsa 