### PR TITLE
SiPixelDigitizerAlgorithm uninitialized variables

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
@@ -155,7 +155,8 @@ public:
    void sideload(SiPixelTemplateEntry2D* entry, int iDtype, float locBx, float locBz, float lorwdy, float lorwdx, float q50, float fbin[3], float xsize, float ysize, float zsize);
    
    //  Initialize things before interpolating
-   
+   bool getid(int id);
+
    bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx);
    
    // Interpolate input alpha and beta angles to produce a working template for each individual hit.

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -142,7 +142,7 @@ void SiPixelDigitizerAlgorithm::init(const edm::EventSetup& es) {
     SiPixelTemplate2D::pushfile(*dbobject_den, templateStores_);
     SiPixelTemplate2D::pushfile(*dbobject_num, templateStores_);
     
-    track.reserve(6);
+    track.resize(6);
   }
 }
 
@@ -2345,6 +2345,7 @@ int SiPixelDigitizerAlgorithm::PixelTempRewgt2D(int id_in, int id_rewgt, array_2
   array_2d clust(cluster);
 
   // Take the pixel dimensions from the 2D template
+  templ2D.getid(id_in);
   xsize = templ2D.xsize();
   ysize = templ2D.ysize();
   
@@ -2369,7 +2370,7 @@ int SiPixelDigitizerAlgorithm::PixelTempRewgt2D(int id_in, int id_rewgt, array_2
   } else {
     xhit2D = track[0] - cotalpha*track[2] + 0.5f*xsize;
   }
-  
+
   // Zero the input and output templates
   for(i=0; i<BYM2; ++i) {
     for(j=0; j<BXM2; ++j) {


### PR DESCRIPTION
This PR addresses two uninitialized variable issues with SiPixelDigitizerAlgorithm.

1) SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc line 145 vector::reserve() is used where vector::resize() should have been used.  Since this is always a fixed size of 6, in principle std::vector could have been replaced with std::array here.  The only practical effect of this bug is an exception if std::vector bounds checking is enabled.

2) SiPixelDigitizerAlgorithm::PixelTempRewgt2D() calls templ2D methods before templ2D.interpolate() is called.  This is problematic because SiPixelTemplate2D::interpolate() sets the cached values for the current template that PixelTempRewgt2D() is accessing, so the calls to xsize() and ysize() around line 2348 are either accessing uninitialized values (first time) or stale values from the previous call to interpolate().  To fix this I refactored the caching of the current template values into a separated getid() method, modifying interpolate() and PixelTempRewgt2D() to use the new call.  (There are certainly other ways to address this if there are strong preferences for something else.)

These were found while chasing issue #23715 in valgrind.  (2) has pretty far-reaching consequences, but it isn't clear yet whether it is actually responsible for the crashes documented in that issue.