### PR TITLE
 Remove smartME1aME1b in ME1/1. Make ME1/1 upgrade TMB inherit from CSCUpgradeMotherboard

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -87,7 +87,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
   if (h_gem.isValid()) {
     streamCache(iID)->setGEMGeometry(&*h_gem);
   } else {
-    edm::LogInfo("L1CSCTPEmulatorNoGEMGeometry")
+    edm::LogInfo("CSCTriggerPrimitivesProducer|NoGEMGeometry")
       << "+++ Info: GEM geometry is unavailable. Running CSC-only trigger algorithm. +++\n";
   }
 
@@ -102,7 +102,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
     edm::ESHandle<CSCDBL1TPParameters> conf;
     setup.get<CSCDBL1TPParametersRcd>().get(conf);
     if (conf.product() == nullptr) {
-      edm::LogError("L1CSCTPEmulatorConfigError")
+      edm::LogError("CSCTriggerPrimitivesProducer|ConfigError")
         << "+++ Failed to find a CSCDBL1TPParametersRcd in EventSetup! +++\n"
         << "+++ Cannot continue emulation without these parameters +++\n";
       return;
@@ -143,14 +143,14 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
   std::unique_ptr<GEMCoPadDigiCollection> oc_gemcopad(new GEMCoPadDigiCollection);
 
   if (!wireDigis.isValid()) {
-    edm::LogWarning("L1CSCTPEmulatorNoInputCollection")
+    edm::LogWarning("CSCTriggerPrimitivesProducer|NoInputCollection")
       << "+++ Warning: Collection of wire digis with label "
       << wireDigiProducer_.label()
       << " requested in configuration, but not found in the event..."
       << " Skipping production of CSC TP digis +++\n";
   }
   if (!compDigis.isValid()) {
-    edm::LogWarning("L1CSCTPEmulatorNoInputCollection")
+    edm::LogWarning("CSCTriggerPrimitivesProducer|NoInputCollection")
       << "+++ Warning: Collection of comparator digis with label "
       << compDigiProducer_.label()
       << " requested in configuration, but not found in the event..."

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -22,17 +22,10 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         # Flag for SLHC studies (upgraded ME11, MPC)
         isSLHC = cms.bool(False),
 
-        # ME1a configuration:
-        # smartME1aME1b=f, gangedME1a=t
-        #   default logic for current HW
-        # smartME1aME1b=t, gangedME1a=f
-        #   realistic upgrade scenario:
-        #   one ALCT finder and two CLCT finders per ME11
-        #   with additional logic for A/CLCT matching with ME1a unganged
-        # smartME1aME1b=t, gangedME1a=t
-        #   the previous case with ME1a still being ganged
-        # Note: gangedME1a has effect only if smartME1aME1b=t
-        smartME1aME1b = cms.bool(False),
+        ## During Run-1, ME1a strips were triple-ganged
+        ## Effectively, this means there were only 16 strips
+        ## As of Run-2, ME1a strips are unganged,
+        ## which increased the number of strips to 48
         gangedME1a = cms.bool(True),
 
         # flags to optionally disable finding stubs in ME42 or ME1a
@@ -124,7 +117,7 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         # whether to store the "corrected" ALCT stub time
         # (currently it is median time of particular hits in a pattern) into the ASCCLCTDigi bx,
         # and temporary store the regular "key layer hit" time into the CSCCLCTDigi fullBX:
-        alctUseCorrectedBx = cms.bool(True)
+        alctUseCorrectedBx = cms.bool(True),
     ),
 
     # Parameters for CLCT processors: 2007 and later
@@ -256,11 +249,11 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 
         # For CLCT-centric matching in ME11, break after finding
         # the first BX with matching ALCT
-        matchEarliestAlctME11Only = cms.bool(False),
+        matchEarliestAlctOnly = cms.bool(False),
 
         # For ALCT-centric matching in ME11, break after finding
         # the first BX with matching CLCT
-        matchEarliestClctME11Only = cms.bool(False),
+        matchEarliestClctOnly = cms.bool(False),
 
         # 0 = default "non-X-BX" sorting algorithm,
         #     where the first BX with match goes first
@@ -271,7 +264,12 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 
         # How many maximum LCTs per whole chamber per BX to keep
         # (supposedly, 1b and 1a can have max 2 each)
-        maxME11LCTs = cms.uint32(2)
+        maxLCTs = cms.uint32(2),
+
+        # True: allow construction of unphysical LCTs
+        # in ME11 for which WG and HS do not intersect
+        # False: do not build unphysical LCTs
+        ignoreAlctCrossClct = cms.bool(True)
     ),
 
     # MPC sorter config for Run2 and beyond
@@ -430,9 +428,7 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscTriggerPrimitiveDigis,
                    GEMPadDigiProducer = cms.InputTag("simMuonGEMPadDigis"),
                    GEMPadDigiClusterProducer = cms.InputTag("simMuonGEMPadDigiClusters"),
-                   commonParam = dict(isSLHC = cms.bool(True),
-                                      smartME1aME1b = cms.bool(True),
-                                      runME11ILT = cms.bool(True),
+                   commonParam = dict(runME11ILT = cms.bool(True),
                                       useClusters = cms.bool(False)),
                    clctSLHC = dict(clctNplanesHitPattern = 3),
                    me11tmbSLHCGEM = me11tmbSLHCGEM,

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -269,7 +269,12 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         # True: allow construction of unphysical LCTs
         # in ME11 for which WG and HS do not intersect
         # False: do not build unphysical LCTs
-        ignoreAlctCrossClct = cms.bool(True)
+        ignoreAlctCrossClct = cms.bool(True),
+
+        ## run in debug mode
+        debugLUTs = cms.bool(False),
+        debugMatching = cms.bool(False),
+
     ),
 
     # MPC sorter config for Run2 and beyond
@@ -428,7 +433,8 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscTriggerPrimitiveDigis,
                    GEMPadDigiProducer = cms.InputTag("simMuonGEMPadDigis"),
                    GEMPadDigiClusterProducer = cms.InputTag("simMuonGEMPadDigiClusters"),
-                   commonParam = dict(runME11ILT = cms.bool(True),
+                   commonParam = dict(isSLHC = True,
+                                      runME11ILT = cms.bool(True),
                                       useClusters = cms.bool(False)),
                    clctSLHC = dict(clctNplanesHitPattern = 3),
                    me11tmbSLHCGEM = me11tmbSLHCGEM,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -66,17 +66,6 @@ const int CSCAnodeLCTProcessor::pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS
            0, -1, -2}
 };
 
-// time averaging weights for pattern (used for SLHC version)
-const int CSCAnodeLCTProcessor::time_weights[CSCConstants::MAX_WIRES_IN_PATTERN] =
-  //Layer
-  { 0,  1,  1,
-        1,  2,
-            2,
-            2,  1,
-            2,  1,  0,
-            1,  1,  0};
-
-
 // Since the test beams in 2003, both collision patterns are "completely
 // open".  This is our current default.
 const int CSCAnodeLCTProcessor::pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN] = {
@@ -183,7 +172,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor(unsigned endcap, unsigned station,
   // Other parameters.
 
   // Flag for SLHC studies
-  isSLHC       = comm.getParameter<bool>("isSLHC");
+  isSLHC_       = comm.getParameter<bool>("isSLHC");
 
   // special configuration parameters for ME11 treatment
   disableME1a = comm.getParameter<bool>("disableME1a");
@@ -206,7 +195,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor(unsigned endcap, unsigned station,
 
   // Check and print configuration parameters.
   checkConfigParameters();
-  if ((infoV > 0 || isSLHC) && !config_dumped) {
+  if ((infoV > 0 || isSLHC_) && !config_dumped) {
     //std::cout<<"**** ALCT constructor parameters dump ****"<<std::endl;
     dumpConfigParams();
     config_dumped = true;
@@ -225,7 +214,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor(unsigned endcap, unsigned station,
 
   // whether to calculate bx as corrected_bx instead of pretrigger one
   use_corrected_bx = false;
-  if (isSLHC && isME11) {
+  if (isSLHC_ && isME11) {
     use_corrected_bx = conf.getParameter<bool>("alctUseCorrectedBx");
   }
 
@@ -251,7 +240,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor() :
   setDefaultConfigParameters();
   infoV = 2;
 
-  isSLHC = false;
+  isSLHC_ = false;
   disableME1a = false;
 
   early_tbins = 4;
@@ -452,7 +441,7 @@ CSCAnodeLCTProcessor::run(const CSCWireDigiCollection* wiredc) {
   // from the wire digis and then passes them on to another run() function.
 
   static std::atomic<bool> config_dumped{false};
-  if ((infoV > 0 || isSLHC) && !config_dumped) {
+  if ((infoV > 0 || isSLHC_) && !config_dumped) {
     //std::cout<<"**** ALCT run parameters dump ****"<<std::endl;
     dumpConfigParams();
     config_dumped = true;
@@ -578,7 +567,7 @@ void CSCAnodeLCTProcessor::run(const std::vector<int> wire[CSCConstants::NUM_LAY
 
   // Do the rest only if there is at least one trigger candidate.
   if (trigger) {
-    if (isSLHC) ghostCancellationLogicSLHC();
+    if (isSLHC_) ghostCancellationLogicSLHC();
     else ghostCancellationLogic();
     lctSearch();
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
@@ -36,9 +36,9 @@ class CSCAnodeLCTProcessor
  public:
   /** Normal constructor. */
   CSCAnodeLCTProcessor(unsigned endcap, unsigned station, unsigned sector,
-		       unsigned subsector, unsigned chamber,
-		       const edm::ParameterSet& conf,
-		       const edm::ParameterSet& comm);
+                       unsigned subsector, unsigned chamber,
+                       const edm::ParameterSet& conf,
+                       const edm::ParameterSet& comm);
 
   /** Default constructor. Used for testing. */
   CSCAnodeLCTProcessor();
@@ -79,14 +79,10 @@ class CSCAnodeLCTProcessor
   /** Returns vector of all found ALCTs, if any. */
   std::vector<CSCALCTDigi> getALCTs();
 
-  /** set ring number. Important only for ME1a */
-  void setRing(unsigned r) {theRing = r;}
-
   /** Pre-defined patterns. */
   static const int pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
   static const int pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
   static const int pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
-  static const int time_weights[CSCConstants::MAX_WIRES_IN_PATTERN];
 
  private:
   /** Verbosity level: 0: no print (default).
@@ -121,7 +117,7 @@ class CSCAnodeLCTProcessor
   unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES];
 
   /** Flag for SLHC studies. */
-  bool isSLHC;
+  bool isSLHC_;
 
   /** Configuration parameters. */
   unsigned int fifo_tbins, fifo_pretrig, drift_delay;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -143,12 +143,6 @@ const unsigned int CSCCathodeLCTProcessor::def_pid_thresh_pretrig  =  2;
 const unsigned int CSCCathodeLCTProcessor::def_min_separation      = 10;
 const unsigned int CSCCathodeLCTProcessor::def_tmb_l1a_window_size =  7;
 
-// Number of di-strips/half-strips per CFEB.
-const int CSCCathodeLCTProcessor::cfeb_strips[2] = {
-  CSCConstants::NUM_DISTRIPS_PER_CFEB, //8
-  CSCConstants::NUM_HALF_STRIPS_PER_CFEB//32
-};
-
 //----------------
 // Constructors --
 //----------------
@@ -190,13 +184,8 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
   alctClctOffset = comm.getParameter<unsigned int>("alctClctOffset");
 
   // special configuration parameters for ME11 treatment
-  smartME1aME1b = comm.getParameter<bool>("smartME1aME1b");
   disableME1a = comm.getParameter<bool>("disableME1a");
   gangedME1a = comm.getParameter<bool>("gangedME1a");
-
-  if (isSLHC && !smartME1aME1b) edm::LogError("L1CSCTPEmulatorConfigError")
-    << "+++ SLHC upgrade configuration is used (isSLHC=True) but smartME1aME1b=False!\n"
-    << "Only smartME1aME1b algorithm is so far supported for upgrade! +++\n";
 
   pid_thresh_pretrig =
     conf.getParameter<unsigned int>("clctPidThreshPretrig");
@@ -205,7 +194,7 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
 
   start_bx_shift = conf.getParameter<int>("clctStartBxShift");
 
-  if (smartME1aME1b) {
+  if (isSLHC) {
     // use of localized dead-time zones
     use_dead_time_zoning = conf.existsAs<bool>("useDeadTimeZoning")?conf.getParameter<bool>("useDeadTimeZoning"):true;
     clct_state_machine_zone = conf.existsAs<unsigned int>("clctStateMachineZone")?conf.getParameter<unsigned int>("clctStateMachineZone"):8;
@@ -268,7 +257,7 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor() :
   setDefaultConfigParameters();
   infoV =  2;
 
-  smartME1aME1b = false;
+  isSLHC = false;
   disableME1a = false;
   gangedME1a = true;
 
@@ -436,7 +425,8 @@ void CSCCathodeLCTProcessor::clear() {
 }
 
 std::vector<CSCCLCTDigi>
-CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
+CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc)
+{
   // This is the version of the run() function that is called when running
   // over the entire detector.  It gets the comparator & timing info from the
   // comparator digis and then passes them on to another run() function.
@@ -467,26 +457,30 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
       // to them.
       // For SLHC ME1/1 is set to have 4 CFEBs in ME1/b and 3 CFEBs in ME1/a
       if (isME11) {
-	if (!smartME1aME1b && !disableME1a && theRing == 1 && !gangedME1a) numStrips = 112;
-	if (!smartME1aME1b && !disableME1a && theRing == 1 && gangedME1a) numStrips = 80;
-	if (!smartME1aME1b &&  disableME1a && theRing == 1 ) numStrips = 64;
-	if ( smartME1aME1b && !disableME1a && theRing == 1 ) numStrips = 64;
-	if ( smartME1aME1b && !disableME1a && theRing == 4 ) {
-	  if (gangedME1a) numStrips = 16;
-	  else numStrips = 48;
-	}
+        if (theRing == 4) {
+          if (infoV >= 0) {
+            edm::LogError("L1CSCTPEmulatorSetupError")
+              << "+++ Invalid ring number for this processor " << theRing
+              << " was set in the config."
+              << " +++\n"
+              << "+++ CSC geometry looks garbled; no emulation possible +++\n";
+          }
+        }
+        if (!disableME1a && theRing == 1 && !gangedME1a) numStrips = 112;
+        if (!disableME1a && theRing == 1 && gangedME1a) numStrips = 80;
+        if (disableME1a && theRing == 1 ) numStrips = 64;
       }
 
       if (numStrips > CSCConstants::MAX_NUM_STRIPS_7CFEBS) {
-	if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
-	  << "+++ Number of strips, " << numStrips
-    << " found in " << detid.chamberName()
-	  << " (sector " << theSector << " subsector " << theSubsector
-	  << " trig id. " << theTrigChamber << ")"
-	  << " exceeds max expected, " << CSCConstants::MAX_NUM_STRIPS_7CFEBS
-	  << " +++\n"
-	  << "+++ CSC geometry looks garbled; no emulation possible +++\n";
-	numStrips = -1;
+        if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
+                          << "+++ Number of strips, " << numStrips
+                          << " found in " << detid.chamberName()
+                          << " (sector " << theSector << " subsector " << theSubsector
+                          << " trig id. " << theTrigChamber << ")"
+                          << " exceeds max expected, " << CSCConstants::MAX_NUM_STRIPS_7CFEBS
+                          << " +++\n"
+                          << "+++ CSC geometry looks garbled; no emulation possible +++\n";
+        numStrips = -1;
       }
       // The strips for a given layer may be offset from the adjacent layers.
       // This was done in order to improve resolution.  We need to find the
@@ -502,8 +496,8 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
       // negative half-strip numbers.  This will necessitate a
       // subtraction of 1 half-strip for TMB-07 later on. -SV.
       for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
-	stagger[i_layer] =
-	  (chamber->layer(i_layer+1)->geometry()->stagger() + 1) / 2;
+        stagger[i_layer] =
+          (chamber->layer(i_layer+1)->geometry()->stagger() + 1) / 2;
       }
     }
     else {
@@ -545,8 +539,8 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
     unsigned int layersHit = 0;
     for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
       for (int i_hstrip = 0; i_hstrip < CSCConstants::NUM_HALF_STRIPS_7CFEBS;
-	   i_hstrip++) {
-	if (!halfstrip[i_layer][i_hstrip].empty()) {layersHit++; break;}
+           i_hstrip++) {
+        if (!halfstrip[i_layer][i_hstrip].empty()) {layersHit++; break;}
       }
     }
     // Run the algorithm only if the probability for the pre-trigger
@@ -582,7 +576,7 @@ void CSCCathodeLCTProcessor::run(const std::vector<int> halfstrip[CSCConstants::
   std::vector<CSCCLCTDigi> CLCTlist;
 
   // Upgrade version for ME11 with better dead-time handling
-  if (isSLHC && smartME1aME1b && isME11 && use_dead_time_zoning) CLCTlist = findLCTsSLHC(halfstrip);
+  if (isSLHC && isME11 && use_dead_time_zoning) CLCTlist = findLCTsSLHC(halfstrip);
   // TMB07 version of the CLCT algorithm.
   else CLCTlist = findLCTs(halfstrip);
 
@@ -639,28 +633,19 @@ bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc)
     CSCDetId detid(theEndcap, theStation, theRing, theChamber, i_layer+1);
     getDigis(compdc, detid);
 
-    // If this is ME1/1, fetch digis in corresponding ME1/A (ring=4) as well.
-    if (theStation == 1 && theRing == 1 && !disableME1a && !smartME1aME1b) {
+    if (theStation == 1 && theRing == 1 && !disableME1a) {
       CSCDetId detid_me1a(theEndcap, theStation, 4, theChamber, i_layer+1);
       getDigis(compdc, detid_me1a);
-    }
-
-    // If this is ME1/1, fetch digis in corresponding ME1/B (ring=1) as well.
-    // needed only for the "smart" A/B case; and, actually, only for data
-    if (theStation == 1 && theRing == 4 && !disableME1a && smartME1aME1b
-	&& digiV[i_layer].empty()) {
-      CSCDetId detid_me1b(theEndcap, theStation, 1, theChamber, i_layer+1);
-      getDigis(compdc, detid_me1b);
     }
 
     if (!digiV[i_layer].empty()) {
       noDigis = false;
       if (infoV > 1) {
-	LogTrace("CSCCathodeLCTProcessor")
-	  << "found " << digiV[i_layer].size()
-	  << " comparator digi(s) in layer " << i_layer << " of " <<
-    detid.chamberName() << " (trig. sector " << theSector
-	  << " subsector " << theSubsector << " id " << theTrigChamber << ")";
+        LogTrace("CSCCathodeLCTProcessor")
+          << "found " << digiV[i_layer].size()
+          << " comparator digi(s) in layer " << i_layer << " of " <<
+          detid.chamberName() << " (trig. sector " << theSector
+          << " subsector " << theSubsector << " id " << theTrigChamber << ")";
       }
     }
   }
@@ -669,38 +654,23 @@ bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc)
 }
 
 void CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc,
-				      const CSCDetId& id) {
-  bool me1bProc = theStation == 1 && theRing == 1;
-  bool me1aProc = theStation == 1 && theRing == 4;
-  bool me1b = (id.station() == 1) && (id.ring() == 1);
-  bool me1a = (id.station() == 1) && (id.ring() == 4);
+                                      const CSCDetId& id)
+{
+  const bool me1a = (id.station() == 1) && (id.ring() == 4);
   const CSCComparatorDigiCollection::Range rcompd = compdc->get(id);
   for (CSCComparatorDigiCollection::const_iterator digiIt = rcompd.first;
        digiIt != rcompd.second; ++digiIt) {
-    unsigned int origStrip = digiIt->getStrip();
-    unsigned int maxStripsME1a = gangedME1a ? 16 : 48;
-    if (me1a && origStrip <= maxStripsME1a && !disableME1a && !smartME1aME1b) {
+    const unsigned int origStrip = digiIt->getStrip();
+    const unsigned int maxStripsME1a = gangedME1a ? 16 : 48;
+    // this special case can only be reached in MC
+    // in real data, the comparator digis have always ring==1
+    if (me1a && origStrip <= maxStripsME1a && !disableME1a) {
       // Move ME1/A comparators from CFEB=0 to CFEB=4 if this has not
       // been done already.
       CSCComparatorDigi digi_corr(origStrip+64,
-				  digiIt->getComparator(),
-				  digiIt->getTimeBinWord());
+                                  digiIt->getComparator(),
+                                  digiIt->getTimeBinWord());
       digiV[id.layer()-1].push_back(digi_corr);
-    }
-    else if (smartME1aME1b && (me1bProc || me1aProc)){
-      //stay within bounds; in data all comps are in ME11B DetId
-
-      if (me1aProc && me1b && origStrip > 64){//this is data
-	//shift back to start from 1
-	CSCComparatorDigi digi_corr(origStrip-64,
-				    digiIt->getComparator(),
-				    digiIt->getTimeBinWord());
-	digiV[id.layer()-1].push_back(digi_corr);
-      } else if ((me1bProc && me1b && origStrip <= 64)
-		 || ((me1aProc && me1a))//this is MC for ME11a
-		 ){
-	digiV[id.layer()-1].push_back(*digiIt);
-      }
     }
     else {
       digiV[id.layer()-1].push_back(*digiIt);
@@ -735,7 +705,8 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
       int thisComparator = pld->getComparator();
       if (thisComparator != 0 && thisComparator != 1) {
 	if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongInput")
-	  << "+++ Found comparator digi with wrong comparator value = "
+	  << "+++ station "<< theStation<<" ring "<< theRing<<" chamber "<< theChamber
+	  << " Found comparator digi with wrong comparator value = "
 	  << thisComparator << "; skipping it... +++\n";
 	continue;
       }
@@ -744,7 +715,8 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
       int thisStrip = pld->getStrip() - 1; // count from 0
       if (thisStrip < 0 || thisStrip >= numStrips) {
 	if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongInput")
-	  << "+++ Found comparator digi with wrong strip number = "
+	  << "+++ station "<< theStation<<" ring "<< theRing<<" chamber "<< theChamber
+	  <<" Found comparator digi with wrong strip number = "
 	  << thisStrip
 	  << " (max strips = " << numStrips << "); skipping it... +++\n";
 	continue;
@@ -755,7 +727,8 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
       int thisHalfstrip = 2*thisStrip + thisComparator + stagger[i_layer];
       if (thisHalfstrip >= 2*numStrips + 1) {
 	if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorWrongInput")
-	  << "+++ Found wrong halfstrip number = " << thisHalfstrip
+	  << "+++ station "<< theStation<<" ring "<< theRing<<" chamber "<< theChamber
+	  << " Found wrong halfstrip number = " << thisHalfstrip
 	  << "; skipping this digi... +++\n";
 	continue;
       }
@@ -789,6 +762,7 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
 	  }
 	  else if (i > 0) {
 	    if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
+	      << "+++ station "<< theStation<<" ring "<< theRing<<" chamber "<< theChamber
 	      << " Skipping comparator digi: strip = " << thisStrip
 	      << ", layer = " << i_layer+1 << ", bx = " << bx_times[i]
 	      << ", bx of previous hit = " << bx_times[i-1];
@@ -796,6 +770,7 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
 	}
 	else {
 	  if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
+	    << "+++ station "<< theStation<<" ring "<< theRing<<" chamber "<< theChamber
 	    << "+++ Skipping comparator digi: strip = " << thisStrip
 	    << ", layer = " << i_layer+1 << ", bx = " << bx_times[i] << " +++";
 	}
@@ -818,7 +793,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
   // Max. number of half-strips for this chamber.
   const int maxHalfStrips = 2*numStrips + 1;
 
-  if (infoV > 1) dumpDigis(halfstrip, 1, maxHalfStrips);
+  if (infoV > 1) dumpDigis(halfstrip, maxHalfStrips);
 
   // 2 possible LCTs per CSC x 7 LCT quantities
   int keystrip_data[CSCConstants::MAX_CLCTS_PER_PROCESSOR][CLCT_NUM_QUANTITIES] = {{0}};
@@ -1270,7 +1245,7 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
   // Max. number of half-strips for this chamber.
   const int maxHalfStrips = 2 * numStrips + 1;
 
-  if (infoV > 1) dumpDigis(halfstrip, 1, maxHalfStrips);
+  if (infoV > 1) dumpDigis(halfstrip, maxHalfStrips);
 
   // keeps dead-time zones around key halfstrips of triggered CLCTs
   bool busyMap[CSCConstants::NUM_HALF_STRIPS_7CFEBS][CSCConstants::MAX_CLCT_TBINS];
@@ -1552,12 +1527,12 @@ void CSCCathodeLCTProcessor::dumpConfigParams() const {
   //std::cerr<<strm.str()<<std::endl;
 }
 
-// Reasonably nice dump of digis on half-strips and di-strips.
-void CSCCathodeLCTProcessor::dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS], const int stripType, const int nStrips) const
+// Reasonably nice dump of digis on half-strips.
+void CSCCathodeLCTProcessor::dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS], const int nStrips) const
 {
   LogDebug("CSCCathodeLCTProcessor")
     << CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber)
-    << " strip type " << stripType << " nStrips " << nStrips;
+    << " strip type: half-strip,  nStrips " << nStrips;
 
   std::ostringstream strstrm;
   for (int i_strip = 0; i_strip < nStrips; i_strip++) {
@@ -1566,25 +1541,25 @@ void CSCCathodeLCTProcessor::dumpDigis(const std::vector<int> strip[CSCConstants
       else               strstrm << (i_strip-100)/10;
     }
     else                 strstrm << " ";
-    if ((i_strip+1)%cfeb_strips[stripType] == 0) strstrm << " ";
+    if ((i_strip+1)%CSCConstants::NUM_HALF_STRIPS_PER_CFEB == 0) strstrm << " ";
   }
   strstrm << "\n";
   for (int i_strip = 0; i_strip < nStrips; i_strip++) {
     strstrm << i_strip%10;
-    if ((i_strip+1)%cfeb_strips[stripType] == 0) strstrm << " ";
+    if ((i_strip+1)%CSCConstants::NUM_HALF_STRIPS_PER_CFEB == 0) strstrm << " ";
   }
   for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
     strstrm << "\n";
     for (int i_strip = 0; i_strip < nStrips; i_strip++) {
       if (!strip[i_layer][i_strip].empty()) {
-	std::vector<int> bx_times = strip[i_layer][i_strip];
-	// Dump only the first in time.
-	strstrm << std::hex << bx_times[0] << std::dec;
+        std::vector<int> bx_times = strip[i_layer][i_strip];
+        // Dump only the first in time.
+        strstrm << std::hex << bx_times[0] << std::dec;
       }
       else {
-	strstrm << "-";
+        strstrm << "-";
       }
-      if ((i_strip+1)%cfeb_strips[stripType] == 0) strstrm << " ";
+      if ((i_strip+1)%CSCConstants::NUM_HALF_STRIPS_PER_CFEB == 0) strstrm << " ";
     }
   }
   LogTrace("CSCCathodeLCTProcessor") << strstrm.str();
@@ -1669,6 +1644,58 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs() {
   return tmpV;
 }
 
+// Returns vector of read-out CLCTs, if any.  Starts with the vector
+// of all found CLCTs and selects the ones in the read-out time window.
+std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTsME1a() {
+  std::vector<CSCCLCTDigi> tmpV;
+  if (not (theStation == 1 and  (theRing == 1 or theRing == 4)) )
+    return tmpV;
+  std::vector<CSCCLCTDigi>  allCLCTs = readoutCLCTs();
+  for (auto clct : allCLCTs)
+    if (clct.getCFEB() >= 4 )
+      tmpV.push_back(clct);
+  return tmpV;
+}
+
+
+// Returns vector of read-out CLCTs, if any.  Starts with the vector
+// of all found CLCTs and selects the ones in the read-out time window.
+std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTsME1b() {
+  std::vector<CSCCLCTDigi> tmpV;
+  if (not (theStation == 1 and  (theRing == 1 or theRing == 4)) )
+    return tmpV;
+  std::vector<CSCCLCTDigi>  allCLCTs = readoutCLCTs();
+  for (auto clct : allCLCTs)
+    if (clct.getCFEB() < 4 )
+      tmpV.push_back(clct);
+  return tmpV;
+}
+
+
+std::vector<CSCCLCTPreTriggerDigi> CSCCathodeLCTProcessor::preTriggerDigisME1a(){
+  std::vector<CSCCLCTPreTriggerDigi> tmpV;
+  if (not (theStation == 1 and  (theRing == 1 or theRing == 4)) )
+    return tmpV;
+  std::vector<CSCCLCTPreTriggerDigi>  allPretriggerdigis = preTriggerDigis();
+  for (auto preclct : allPretriggerdigis)
+    if (preclct.getCFEB() >= 4 )
+      tmpV.push_back(preclct);
+  return tmpV;
+}
+
+
+std::vector<CSCCLCTPreTriggerDigi> CSCCathodeLCTProcessor::preTriggerDigisME1b(){
+  std::vector<CSCCLCTPreTriggerDigi> tmpV;
+  if (not (theStation == 1 and  (theRing == 1 or theRing == 4)) )
+    return tmpV;
+  std::vector<CSCCLCTPreTriggerDigi>  allPretriggerdigis = preTriggerDigis();
+  for (auto preclct : allPretriggerdigis)
+    if (preclct.getCFEB() < 4 )
+      tmpV.push_back(preclct);
+  return tmpV;
+}
+
+
 // Returns vector of all found CLCTs, if any.  Used for ALCT-CLCT matching.
 std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::getCLCTs() {
   std::vector<CSCCLCTDigi> tmpV;
@@ -1677,51 +1704,4 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::getCLCTs() {
     if (secondCLCT[bx].isValid()) tmpV.push_back(secondCLCT[bx]);
   }
   return tmpV;
-}
-
-
-
-void CSCCathodeLCTProcessor::testLCTs() {
-  // test to make sure what goes into an LCT is what comes out.
-  for (int ptn = 0; ptn < 8; ptn++) {
-    for (int bend = 0; bend < 2; bend++) {
-      for (int cfeb = 0; cfeb < CSCConstants::MAX_CFEBS; cfeb++) {
-	for (int key_strip = 0; key_strip < CSCConstants::NUM_HALF_STRIPS_PER_CFEB; key_strip++) {
-	  for (int bx = 0; bx < 7; bx++) {
-	    for (int stripType = 0; stripType < 2; stripType++) {
-	      for (int quality = 3; quality < 6; quality++) {
-		CSCCLCTDigi thisLCT(1, quality, ptn, stripType, bend,
-				    key_strip, cfeb, bx);
-		if (ptn != thisLCT.getPattern())
-		  LogTrace("CSCCathodeLCTProcessor")
-		    << "pattern mismatch: " << ptn << " "
-		    << thisLCT.getPattern();
-		if (bend != thisLCT.getBend())
-		  LogTrace("CSCCathodeLCTProcessor")
-		    << "bend mismatch: " << bend << " " << thisLCT.getBend();
-		if (cfeb != thisLCT.getCFEB())
-		  LogTrace("CSCCathodeLCTProcessor")
-		    << "cfeb mismatch: " << cfeb << " " << thisLCT.getCFEB();
-		if (key_strip != thisLCT.getKeyStrip())
-		  LogTrace("CSCCathodeLCTProcessor")
-		    << "strip mismatch: " << key_strip << " "
-		    << thisLCT.getKeyStrip();
-		if (bx != thisLCT.getBX())
-		  LogTrace("CSCCathodeLCTProcessor")
-		    << "bx mismatch: " << bx << " " << thisLCT.getBX();
-		if (stripType != thisLCT.getStripType())
-		  LogTrace("CSCCathodeLCTProcessor")
-		    << "Strip Type mismatch: " << stripType << " "
-		    << thisLCT.getStripType();
-		if (quality != thisLCT.getQuality())
-		  LogTrace("CSCCathodeLCTProcessor")
-		    << "quality mismatch: " << quality << " "
-		    << thisLCT.getQuality();
-	      }
-	    }
-	  }
-	}
-      }
-    }
-  }
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -466,8 +466,8 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc)
               << "+++ CSC geometry looks garbled; no emulation possible +++\n";
           }
         }
-        if (!disableME1a && theRing == 1 && !gangedME1a) numStrips = 112;
-        if (!disableME1a && theRing == 1 && gangedME1a) numStrips = 80;
+        if (!disableME1a && theRing == 1 && !gangedME1a) numStrips = CSCConstants::MAX_NUM_STRIPS_7CFEBS;
+        if (!disableME1a && theRing == 1 && gangedME1a) numStrips = CSCConstants::MAX_NUM_STRIPS;
         if (disableME1a && theRing == 1 ) numStrips = 64;
       }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
@@ -46,10 +46,10 @@ class CSCCathodeLCTProcessor
  public:
   /** Normal constructor. */
   CSCCathodeLCTProcessor(unsigned endcap, unsigned station, unsigned sector,
-			 unsigned subsector, unsigned chamber,
-			 const edm::ParameterSet& conf,
-			 const edm::ParameterSet& comm,
-			 const edm::ParameterSet& ctmb);
+                         unsigned subsector, unsigned chamber,
+                         const edm::ParameterSet& conf,
+                         const edm::ParameterSet& comm,
+                         const edm::ParameterSet& ctmb);
 
   /** Default constructor. Used for testing. */
   CSCCathodeLCTProcessor();
@@ -83,6 +83,10 @@ class CSCCathodeLCTProcessor
   /** Returns vector of CLCTs in the read-out time window, if any. */
   std::vector<CSCCLCTDigi> readoutCLCTs();
 
+  /** read out CLCTs in ME1a , ME1b */
+  std::vector<CSCCLCTDigi> readoutCLCTsME1a();
+  std::vector<CSCCLCTDigi> readoutCLCTsME1b();
+
   /** Returns vector of all found CLCTs, if any. */
   std::vector<CSCCLCTDigi> getCLCTs();
 
@@ -90,10 +94,9 @@ class CSCCathodeLCTProcessor
 
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigis() const {return thePreTriggerDigis; }
 
-  /** Set ring number
-   * Has to be done for upgrade ME1a!
-   **/
-  void setRing(unsigned r) {theRing = r;}
+  /** read out CLCTs in ME1a , ME1b */
+  std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1a();
+  std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1b();
 
   /** Pre-defined patterns. */
   static const int pattern2007_offset[CSCConstants::MAX_HALFSTRIPS_IN_PATTERN];
@@ -157,7 +160,7 @@ class CSCCathodeLCTProcessor
   int start_bx_shift;
 
   /** VK: special configuration parameters for ME1a treatment */
-  bool smartME1aME1b, disableME1a, gangedME1a;
+  bool disableME1a, gangedME1a;
 
   /** VK: separate handle for early time bins */
   int early_tbins;
@@ -190,9 +193,6 @@ class CSCCathodeLCTProcessor
   /** Make sure that the parameter values are within the allowed range. */
   void checkConfigParameters();
 
-  /** Number of di-strips/half-strips per CFEB. */
-  static const int cfeb_strips[2];
-
   //---------------- Methods common to all firmware versions ------------------
   void readComparatorDigis(std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
   void pulseExtension(const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
@@ -221,12 +221,9 @@ class CSCCathodeLCTProcessor
   /** Dump CLCT configuration parameters. */
   void dumpConfigParams() const;
 
-  /** Dump digis on half-strips */
+  /** Dump half-strip digis */
   void dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-                 const int stripType, const int nStrips) const;
-
-  //--------------------------- Methods for tests -----------------------------
-  void testLCTs();
+                 const int nStrips) const;
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.h
@@ -78,101 +78,94 @@ protected:
 
   float getPad(const GEMPadDigi&) const;
   float getPad(const GEMCoPadDigi&) const;
-  float getPad(const CSCCLCTDigi&, enum CSCPart part) const;
+  float getPad(const CSCCLCTDigi&,  enum CSCPart par) const;
 
   // match ALCT to GEM Pad/CoPad
   // the template is GEMPadDigi or GEMCoPadDigi
   template <class T>
   void matchingPads(const CSCALCTDigi& alct,
-                    enum CSCPart part, matches<T>&) const;
+                    matches<T>&) const;
 
   // match CLCT to GEM Pad/CoPad
   // the template is GEMPadDigi or GEMCoPadDigi
   template <class T>
   void matchingPads(const CSCCLCTDigi& alct,
-                    enum CSCPart part, matches<T>&) const;
+                    matches<T>&) const;
 
   // find the matching pads to a pair of ALCT/CLCT
   // the first template is ALCT or CLCT
   // the second template is GEMPadDigi or GEMCoPadDigi
   template <class S, class T>
   void matchingPads(const S& d1, const S& d2,
-                    enum CSCPart part, matches<T>&) const;
+                    matches<T>&) const;
 
   // find common matches between an ALCT and CLCT
   // the template is GEMPadDigi or GEMCoPadDigi
   template <class T>
   void matchingPads(const CSCCLCTDigi& clct1, const CSCALCTDigi& alct1,
-                    enum CSCPart part, matches<T>&) const;
+                    matches<T>&) const;
 
   // find all matching pads to a pair of ALCT and a pair of CLCT
   // the template is GEMPadDigi or GEMCoPadDigi
   template <class T>
   void matchingPads(const CSCCLCTDigi& clct1, const CSCCLCTDigi& clct2,
                     const CSCALCTDigi& alct1, const CSCALCTDigi& alct2,
-                    enum CSCPart part, matches<T>&) const;
+                    matches<T>&) const;
 
   // find the best matching pad to an ALCT
   // the template is GEMPadDigi or GEMCoPadDigi
   template <class T>
-  T bestMatchingPad(const CSCALCTDigi&, const matches<T>&, enum CSCPart) const;
+  T bestMatchingPad(const CSCALCTDigi&, const matches<T>&) const;
 
   // find the best matching pad to an ALCT
   // the template is GEMPadDigi or GEMCoPadDigi
   template <class T>
-  T bestMatchingPad(const CSCCLCTDigi&, const matches<T>&, enum CSCPart) const;
+  T bestMatchingPad(const CSCCLCTDigi&, const matches<T>&) const;
 
   // find the best matching pad to an ALCT and CLCT
   // the template is GEMPadDigi or GEMCoPadDigi
   template <class T>
   T bestMatchingPad(const CSCALCTDigi&, const CSCCLCTDigi&,
-		    const matches<T>&, enum CSCPart) const;
+                    const matches<T>&) const;
 
   // correlate ALCTs/CLCTs with a set of matching GEM copads
   // use this function when the best matching copads are not clear yet
   // the template is ALCT or CLCT
   template <class T>
   void correlateLCTsGEM(T& best, T& second, const GEMCoPadDigiIds& coPads,
-			CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2,
-			enum CSCPart) const;
+                        CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2) const;
 
   // correlate ALCTs/CLCTs with their best matching GEM copads
   // the template is ALCT or CLCT
   template <class T>
   void correlateLCTsGEM(const T& best, const T& second,
-			const GEMCoPadDigi&, const GEMCoPadDigi&,
-			CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2,
-			enum CSCPart) const;
+                        const GEMCoPadDigi&, const GEMCoPadDigi&,
+                        CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2) const;
 
   // construct LCT from ALCT and GEM copad
-  // third argument is the CSC 'partition'
   // fourth argument is the LCT number (1 or 2)
   CSCCorrelatedLCTDigi constructLCTsGEM(const CSCALCTDigi& alct,
-					const GEMCoPadDigi& gem,
-					enum CSCPart, int i) const;
+                                        const GEMCoPadDigi& gem, int i) const;
 
   // construct LCT from CLCT and GEM copad
-  // third argument is the CSC 'partition'
   // fourth argument is the LCT number (1 or 2)
   CSCCorrelatedLCTDigi constructLCTsGEM(const CSCCLCTDigi& clct,
-					const GEMCoPadDigi& gem,
-					enum CSCPart, int i) const;
+                                        const GEMCoPadDigi& gem,
+                                        int i) const;
 
   // construct LCT from ALCT,CLCT and GEM copad
-  // fourth argument is the CSC 'partition'
-  // fifth argument is the LCT number (1 or 2)
+  // last argument is the LCT number (1 or 2)
   CSCCorrelatedLCTDigi constructLCTsGEM(const CSCALCTDigi& alct,
-					const CSCCLCTDigi& clct,
-					const GEMCoPadDigi& gem,
-					enum CSCPart p, int i) const;
+                                        const CSCCLCTDigi& clct,
+                                        const GEMCoPadDigi& gem,
+                                        int i) const;
 
   // construct LCT from ALCT,CLCT and a single GEM pad
-  // fourth argument is the CSC 'partition'
-  // fifth argument is the LCT number (1 or 2)
+  // last argument is the LCT number (1 or 2)
   CSCCorrelatedLCTDigi constructLCTsGEM(const CSCALCTDigi& alct,
-					const CSCCLCTDigi& clct,
-					const GEMPadDigi& gem,
-					enum CSCPart p, int i) const;
+                                        const CSCCLCTDigi& clct,
+                                        const GEMPadDigi& gem,
+                                        int i) const;
   /*
    * General function to construct integrated stubs from CSC and GEM information.
    * Options are:
@@ -181,13 +174,12 @@ protected:
    * 3. ALCT-GEMCoPad
    * 4. CLCT-GEMCoPad
    */
-  // fifth argument is the CSC 'partition'
-  // sixth argument is the LCT number (1 or 2)
+  // last argument is the LCT number (1 or 2)
   CSCCorrelatedLCTDigi constructLCTsGEM(const CSCALCTDigi& alct,
                                         const CSCCLCTDigi& clct,
                                         const GEMPadDigi& gem1,
                                         const GEMCoPadDigi& gem2,
-                                        enum CSCPart p, int i) const;
+                                        int i) const;
 
   // get the pads/copads from the digi collection and store in handy containers
   void retrieveGEMPads(const GEMPadDigiCollection* pads, unsigned id);
@@ -195,8 +187,8 @@ protected:
 
   // quality of the LCT when you take into account max 2 GEM layers
   unsigned int findQualityGEM(const CSCALCTDigi&,
-			      const CSCCLCTDigi&,
-			      int gemlayer) const;
+                              const CSCCLCTDigi&,
+                              int gemlayer) const;
 
   // print available trigger pads
   void printGEMTriggerPads(int bx_start, int bx_stop, enum CSCPart);
@@ -251,7 +243,6 @@ protected:
 
 template<class T>
 void CSCGEMMotherboard::matchingPads(const CSCALCTDigi& alct,
-                                     enum CSCPart part,
                                      matches<T>& result) const
 {
   result.clear();
@@ -270,9 +261,6 @@ void CSCGEMMotherboard::matchingPads(const CSCALCTDigi& alct,
 
   for (const auto& p: lut.at(alct.getBX())){
     auto padRoll(getRoll(p));
-
-    // only pads in overlap are good for ME1A
-    if (part==CSCPart::ME1A and !isPadInOverlap(padRoll)) continue;
 
     // pad bx needs to match to ALCT bx
     int pad_bx = getBX(p.second)+CSCConstants::LCT_CENTRAL_BX;
@@ -297,13 +285,13 @@ void CSCGEMMotherboard::matchingPads(const CSCALCTDigi& alct,
 
 template<class T>
 void CSCGEMMotherboard::matchingPads(const CSCCLCTDigi& clct,
-                                     enum CSCPart part,
                                      matches<T>& result) const
 {
   result.clear();
   // Invalid ALCTs have no matching pads
   if (not clct.isValid()) return;
 
+  auto part(getCSCPart(clct.getKeyStrip()));
   // Get the corresponding pad numbers for a given CLCT
   const auto& mymap = (getLUT()->get_csc_hs_to_gem_pad(par, part));
   const int lowPad(mymap[clct.getKeyStrip()].first);
@@ -333,16 +321,15 @@ void CSCGEMMotherboard::matchingPads(const CSCCLCTDigi& clct,
 
 template <class S, class T>
 void CSCGEMMotherboard::matchingPads(const S& d1, const S& d2,
-                                     enum CSCPart part,
                                      matches<T>& result) const
 {
   matches<T> p1, p2;
 
   // pads matching to the CLCT/ALCT
-  matchingPads<T>(d1, part, p1);
+  matchingPads<T>(d1, p1);
 
   // pads matching to the CLCT/ALCT
-  matchingPads<T>(d2, part, p2);
+  matchingPads<T>(d2, p2);
 
   // collect *all* matching pads
   result.reserve(p1.size() + p2.size());
@@ -353,16 +340,15 @@ void CSCGEMMotherboard::matchingPads(const S& d1, const S& d2,
 template <class T>
 void CSCGEMMotherboard::matchingPads(const CSCCLCTDigi& clct1,
                                      const CSCALCTDigi& alct1,
-                                     enum CSCPart part,
                                      matches<T>& result) const
 {
   matches<T> padsClct, padsAlct;
 
   // pads matching to the CLCT
-  matchingPads<T>(clct1, part, padsClct);
+  matchingPads<T>(clct1, padsClct);
 
   // pads matching to the ALCT
-  matchingPads<T>(alct1, part, padsAlct);
+  matchingPads<T>(alct1, padsAlct);
 
   // collect all *common* pads
   intersection(padsClct, padsAlct, result);
@@ -373,16 +359,15 @@ void CSCGEMMotherboard::matchingPads(const CSCCLCTDigi& clct1,
                                      const CSCCLCTDigi& clct2,
                                      const CSCALCTDigi& alct1,
                                      const CSCALCTDigi& alct2,
-                                     enum CSCPart part,
                                      matches<T>& result) const
 {
   matches<T> padsClct, padsAlct;
 
   // pads matching to CLCTs
-  matchingPads<CSCCLCTDigi, T>(clct1, clct2, part, padsClct);
+  matchingPads<CSCCLCTDigi, T>(clct1, clct2, padsClct);
 
   // pads matching to ALCTs
-  matchingPads<CSCALCTDigi, T>(alct1, alct2, part, padsAlct);
+  matchingPads<CSCALCTDigi, T>(alct1, alct2, padsAlct);
 
   // collect *all* matching pads
   result.reserve(padsClct.size() + padsAlct.size());
@@ -393,8 +378,7 @@ void CSCGEMMotherboard::matchingPads(const CSCCLCTDigi& clct1,
 
 template <class S>
 S CSCGEMMotherboard::bestMatchingPad(const CSCALCTDigi& alct1,
-                                     const matches<S>& pads,
-                                     enum CSCPart) const
+                                     const matches<S>& pads) const
 {
   S result;
   // no matching pads for invalid stub
@@ -416,12 +400,13 @@ S CSCGEMMotherboard::bestMatchingPad(const CSCALCTDigi& alct1,
 
 template <class S>
 S CSCGEMMotherboard::bestMatchingPad(const CSCCLCTDigi& clct,
-                                     const matches<S>& pads,
-                                     enum CSCPart part) const
+                                     const matches<S>& pads) const
 {
   S result;
   // no matching pads for invalid stub
   if (not clct.isValid()) return result;
+
+  auto part(getCSCPart(clct.getKeyStrip()));
 
   // return the pad with the smallest bending angle
   float averagePadNumberCSC = getPad(clct, part);
@@ -444,12 +429,13 @@ S CSCGEMMotherboard::bestMatchingPad(const CSCCLCTDigi& clct,
 template <class S>
 S CSCGEMMotherboard::bestMatchingPad(const CSCALCTDigi& alct1,
                                      const CSCCLCTDigi& clct1,
-                                     const matches<S>& pads,
-                                     enum CSCPart part) const
+                                     const matches<S>& pads) const
 {
   S result;
   // no matching pads for invalid stub
   if (not alct1.isValid() or not clct1.isValid()) return result;
+
+  auto part(getCSCPart(clct1.getKeyStrip()));
 
   // return the pad with the smallest bending angle
   float averagePadNumberCSC = getPad(clct1, part);
@@ -475,8 +461,7 @@ void CSCGEMMotherboard::correlateLCTsGEM(T& bestLCT,
                                          T& secondLCT,
                                          const GEMCoPadDigiIds& coPads,
                                          CSCCorrelatedLCTDigi& lct1,
-                                         CSCCorrelatedLCTDigi& lct2,
-                                         enum CSCPart p) const
+                                         CSCCorrelatedLCTDigi& lct2) const
 {
   // Check which LCTs are valid
   bool bestValid     = bestLCT.isValid();
@@ -488,10 +473,10 @@ void CSCGEMMotherboard::correlateLCTsGEM(T& bestLCT,
   if (!bestValid and secondValid) bestLCT   = secondLCT;
 
   // get best matching copad1
-  const GEMCoPadDigi& bestCoPad = bestMatchingPad<GEMCoPadDigi>(bestLCT, coPads, p);
-  const GEMCoPadDigi& secondCoPad = bestMatchingPad<GEMCoPadDigi>(secondLCT, coPads, p);
+  const GEMCoPadDigi& bestCoPad = bestMatchingPad<GEMCoPadDigi>(bestLCT, coPads);
+  const GEMCoPadDigi& secondCoPad = bestMatchingPad<GEMCoPadDigi>(secondLCT, coPads);
 
-  correlateLCTsGEM(bestLCT, secondLCT, bestCoPad, secondCoPad, lct1, lct2, p);
+  correlateLCTsGEM(bestLCT, secondLCT, bestCoPad, secondCoPad, lct1, lct2);
 }
 
 
@@ -501,21 +486,20 @@ void CSCGEMMotherboard::correlateLCTsGEM(const T& bestLCT,
                                          const GEMCoPadDigi& bestCoPad,
                                          const GEMCoPadDigi& secondCoPad,
                                          CSCCorrelatedLCTDigi& lct1,
-                                         CSCCorrelatedLCTDigi& lct2,
-                                         enum CSCPart p) const
+                                         CSCCorrelatedLCTDigi& lct2) const
 {
   // construct the first LCT from ALCT(CLCT) and a GEM Copad
   if ((getLctTrigEnable<T>()  and bestLCT.isValid()) or
       (match_trig_enable and bestLCT.isValid()))
     {
-      lct1 = constructLCTsGEM(bestLCT, bestCoPad, p, 1);
+      lct1 = constructLCTsGEM(bestLCT, bestCoPad, 1);
     }
 
   // construct the second LCT from ALCT(CLCT) and a GEM Copad
   if ((getLctTrigEnable<T>()  and secondLCT.isValid()) or
       (match_trig_enable and secondLCT.isValid() and secondLCT != bestLCT))
     {
-      lct2 = constructLCTsGEM(secondLCT, secondCoPad, p, 2);
+      lct2 = constructLCTsGEM(secondLCT, secondCoPad, 2);
     }
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -1,19 +1,11 @@
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
 #include "L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.h"
-#include "Geometry/GEMGeometry/interface/GEMEtaPartitionSpecs.h"
 
 CSCGEMMotherboardME11::CSCGEMMotherboardME11(unsigned endcap, unsigned station,
-					     unsigned sector, unsigned subsector,
-					     unsigned chamber,
-					     const edm::ParameterSet& conf)
+                                             unsigned sector, unsigned subsector,
+                                             unsigned chamber,
+                                             const edm::ParameterSet& conf)
   : CSCGEMMotherboard(endcap, station, sector, subsector, chamber, conf)
-  , allLCTs1b(match_trig_window_size)
-  , allLCTs1a(match_trig_window_size)
-  // special configuration parameters for ME11 treatment
-  , smartME1aME1b(commonParams_.getParameter<bool>("smartME1aME1b"))
-  , disableME1a(commonParams_.getParameter<bool>("disableME1a"))
-  , gangedME1a(commonParams_.getParameter<bool>("gangedME1a"))
+   // special configuration parameters for ME11 treatment
   , dropLowQualityCLCTsNoGEMs_ME1a_(tmbParams_.getParameter<bool>("dropLowQualityCLCTsNoGEMs_ME1a"))
   , dropLowQualityCLCTsNoGEMs_ME1b_(tmbParams_.getParameter<bool>("dropLowQualityCLCTsNoGEMs_ME1b"))
   , dropLowQualityALCTsNoGEMs_ME1a_(tmbParams_.getParameter<bool>("dropLowQualityALCTsNoGEMs_ME1a"))
@@ -25,49 +17,26 @@ CSCGEMMotherboardME11::CSCGEMMotherboardME11(unsigned endcap, unsigned station,
   , promoteCLCTGEMquality_ME1a_(tmbParams_.getParameter<bool>("promoteCLCTGEMquality_ME1a"))
   , promoteCLCTGEMquality_ME1b_(tmbParams_.getParameter<bool>("promoteCLCTGEMquality_ME1b"))
 {
-  if (!smartME1aME1b) edm::LogError("L1CSCTPEmulatorConfigError")
-    << "+++ Upgrade CSCGEMMotherboardME11 constructed while smartME1aME1b is not set! +++\n";
-
-  const edm::ParameterSet clctParams(conf.getParameter<edm::ParameterSet>("clctSLHC"));
-  clct1a.reset( new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams_, tmbParams_) );
-  clct1a->setRing(4);
+  if (!isSLHC_) edm::LogError("CSCGEMMotherboardME11|ConfigError")
+    << "+++ Upgrade CSCGEMMotherboardME11 constructed while isSLHC is not set! +++\n";
 
   // set LUTs
   tmbLUT_.reset(new CSCGEMMotherboardLUTME11());
+  cscTmbLUT_.reset(new CSCMotherboardLUTME11());
 }
 
 
 CSCGEMMotherboardME11::CSCGEMMotherboardME11() :
   CSCGEMMotherboard()
-  , allLCTs1b(match_trig_window_size)
-  , allLCTs1a(match_trig_window_size)
 {
   // Constructor used only for testing.
-
-  clct1a.reset( new CSCCathodeLCTProcessor() );
-  clct1a->setRing(4);
+  if (!isSLHC_) edm::LogError("CSCGEMMotherboardME11|ConfigError")
+    << "+++ Upgrade CSCGEMMotherboardME11 constructed while isSLHC is not set! +++\n";
 }
 
 
 CSCGEMMotherboardME11::~CSCGEMMotherboardME11()
 {
-}
-
-
-void CSCGEMMotherboardME11::clear()
-{
-  CSCMotherboard::clear();
-  CSCGEMMotherboard::clear();
-
-  if (clct1a) clct1a->clear();
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
-    for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++) {
-      for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++) {
-        allLCTs1b(bx,mbx,i).clear();
-        allLCTs1a(bx,mbx,i).clear();
-      }
-    }
-  }
 }
 
 
@@ -82,49 +51,53 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
 				const CSCComparatorDigiCollection* compdc,
 				const GEMPadDigiCollection* gemPads)
 {
-  clear();
+  CSCGEMMotherboard::clear();
   setupGeometry();
   debugLUTs();
 
   if (gem_g != nullptr) {
-    if (infoV >= 0) edm::LogInfo("L1CSCTPEmulatorSetupInfo")
+    if (infoV >= 0) edm::LogInfo("CSCGEMMotherboardME11|SetupInfo")
 		      << "+++ run() called for GEM-CSC integrated trigger! +++ \n";
     gemGeometryAvailable = true;
   }
 
   // check for GEM geometry
   if (not gemGeometryAvailable){
-    if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
+    if (infoV >= 0) edm::LogError("CSCGEMMotherboardME11|SetupError")
 		      << "+++ run() called for GEM-CSC integrated trigger without valid GEM geometry! +++ \n";
     return;
   }
   gemCoPadV = coPadProcessor->run(gemPads); // run copad processor in GE1/1
 
-  if (!( alct and clct and  clct1a and smartME1aME1b))
+  if (!( alctProc and clctProc and isSLHC_))
   {
-    if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
+    if (infoV >= 0) edm::LogError("CSCGEMMotherboardME11|SetupError")
       << "+++ run() called for non-existing ALCT/CLCT processor! +++ \n";
     return;
   }
 
-  alct->setCSCGeometry(csc_g);
-  clct->setCSCGeometry(csc_g);
-  clct1a->setCSCGeometry(csc_g);
+  alctProc->setCSCGeometry(csc_g);
+  clctProc->setCSCGeometry(csc_g);
 
-  alctV = alct->run(wiredc); // run anodeLCT
-  clctV1b = clct->run(compdc); // run cathodeLCT in ME1/b
-  clctV1a = clct1a->run(compdc); // run cathodeLCT in ME1/a
+  alctV = alctProc->run(wiredc); // run anodeLCT
+  clctV = clctProc->run(compdc); // run cathodeLCT
 
   // if there are no ALCTs and no CLCTs, it does not make sense to run this TMB
-  if (alctV.empty() and clctV1b.empty() and clctV1a.empty()) return;
+  if (alctV.empty() and clctV.empty()) return;
 
-  int used_clct_mask[20], used_clct_mask_1a[20];
+  LogTrace("CSCGEMCMotherboardME11") <<"ALL ALCTs from ME11 "<< std::endl;
+  for (const auto& alct : alctV)
+    if (alct.isValid())
+      LogTrace("CSCGEMCMotherboardME11") << alct << std::endl;
+
+  LogTrace("CSCGEMCMotherboardME11") <<"ALL CLCTs from ME11 "<< std::endl;
+  for (const auto& clct : clctV)
+    if (clct.isValid())
+      LogTrace("CSCGEMCMotherboardME11") << clct << std::endl;
+
+  int used_clct_mask[20];
   for (int b=0;b<20;b++)
-    used_clct_mask[b] = used_clct_mask_1a[b] = 0;
-
-  // retrieve CSCChamber geometry
-  const CSCDetId me1aId(theEndcap, 1, 4, theChamber);
-  const CSCChamber* cscChamberME1a(csc_g->chamber(me1aId));
+    used_clct_mask[b] = 0;
 
   retrieveGEMPads(gemPads, gemId);
   retrieveGEMCoPads();
@@ -135,7 +108,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   // ALCT-centric matching
   for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++)
   {
-    if (alct->bestALCT[bx_alct].isValid())
+    if (alctProc->bestALCT[bx_alct].isValid())
     {
       const int bx_clct_start(bx_alct - match_trig_window_size/2 - alctClctOffset);
       const int bx_clct_stop(bx_alct + match_trig_window_size/2 - alctClctOffset);
@@ -146,8 +119,8 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
         LogTrace("CSCGEMCMotherboardME11") << "========================================================================\n"
                                            << "ALCT-CLCT matching in ME1/1 chamber: " << cscChamber->id() << "\n"
                                            << "------------------------------------------------------------------------\n"
-                                           << "+++ Best ALCT Details: " << alct->bestALCT[bx_alct]  << "\n"
-                                           << "+++ Second ALCT Details: " << alct->secondALCT[bx_alct] << std::endl;
+                                           << "+++ Best ALCT Details: " << alctProc->bestALCT[bx_alct]  << "\n"
+                                           << "+++ Second ALCT Details: " << alctProc->secondALCT[bx_alct] << std::endl;
 
         printGEMTriggerPads(bx_clct_start, bx_clct_stop, CSCPart::ME11);
         printGEMTriggerCoPads(bx_clct_start, bx_clct_stop, CSCPart::ME11);
@@ -162,24 +135,24 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       {
         if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
         if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
-        if (clct->bestCLCT[bx_clct].isValid())
+        if (clctProc->bestCLCT[bx_clct].isValid())
         {
-          const int quality(clct->bestCLCT[bx_clct].getQuality());
-          if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "++Valid ME1b CLCT: " << clct->bestCLCT[bx_clct] << std::endl;
+          const int quality(clctProc->bestCLCT[bx_clct].getQuality());
+          if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "++Valid ME1b CLCT: " << clctProc->bestCLCT[bx_clct] << std::endl;
 
 	  // pick the pad that corresponds
 	  matches<GEMPadDigi> mPads;
-	  matchingPads<GEMPadDigi>(clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
-				   alct->bestALCT[bx_alct], alct->secondALCT[bx_alct], ME1B, mPads);
+	  matchingPads<GEMPadDigi>(clctProc->bestCLCT[bx_clct], clctProc->secondCLCT[bx_clct],
+				   alctProc->bestALCT[bx_alct], alctProc->secondALCT[bx_alct], mPads);
 	  matches<GEMCoPadDigi> mCoPads;
-	  matchingPads<GEMCoPadDigi>(clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
-				     alct->bestALCT[bx_alct], alct->secondALCT[bx_alct], ME1B, mCoPads);
+	  matchingPads<GEMCoPadDigi>(clctProc->bestCLCT[bx_clct], clctProc->secondCLCT[bx_clct],
+				     alctProc->bestALCT[bx_alct], alctProc->secondALCT[bx_alct], mCoPads);
 
     // Low quality LCTs have at most 3 layers. Check if there is a matching GEM pad to keep the CLCT
     if (dropLowQualityCLCTsNoGEMs_ME1b_ and quality < 4 and hasPads){
       int nFound(mPads.size());
       // these halfstrips (1,2,3,4) and (125,126,127,128) do not have matching GEM pads because GEM chambers are slightly wider than CSCs
-      const bool clctInEdge(clct->bestCLCT[bx_clct].getKeyStrip() < 5 or clct->bestCLCT[bx_clct].getKeyStrip() > 124);
+      const bool clctInEdge(clctProc->bestCLCT[bx_clct].getKeyStrip() < 5 or clctProc->bestCLCT[bx_clct].getKeyStrip() > 124);
             if (clctInEdge){
               if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "\tInfo: low quality CLCT in CSC chamber edge, don't care about GEM pads" << std::endl;
             }
@@ -198,25 +171,25 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
 
           //	    if (infoV > 1) LogTrace("CSCMotherboard")
           int mbx = bx_clct-bx_clct_start;
-	  correlateLCTsGEM(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-			   clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
-			   mPads, mCoPads,
-			   allLCTs1b(bx_alct,mbx,0), allLCTs1b(bx_alct,mbx,1), ME1B);
+          correlateLCTsGEM(alctProc->bestALCT[bx_alct], alctProc->secondALCT[bx_alct],
+                           clctProc->bestCLCT[bx_clct], clctProc->secondCLCT[bx_clct],
+                           mPads, mCoPads,
+                           allLCTs(bx_alct,mbx,0), allLCTs(bx_alct,mbx,1));
           if (debug_matching ) {
             LogTrace("CSCGEMCMotherboardME11") << "Successful ALCT-CLCT match in ME1b: bx_alct = " << bx_alct
                                                << "; match window: [" << bx_clct_start << "; " << bx_clct_stop
                                                << "]; bx_clct = " << bx_clct << "\n"
-                                               << "+++ Best CLCT Details: " << clct->bestCLCT[bx_clct] << "\n"
-                                               << "+++ Second CLCT Details: " << clct->secondCLCT[bx_clct] << std::endl;
-	    if (allLCTs1b(bx_alct,mbx,0).isValid())
-		LogTrace("CSCGEMCMotherboardME11") << "LCT #1 "<< allLCTs1b(bx_alct,mbx,0) << std::endl;
-	    else
-		LogTrace("CSCGEMCMotherboardME11") << "No valid LCT is built from ALCT-CLCT matching in ME1b"  << std::endl;
-	    if (allLCTs1b(bx_alct,mbx,1).isValid())
-		LogTrace("CSCGEMCMotherboardME11") << "LCT #2 "<< allLCTs1b(bx_alct,mbx,1) << std::endl;
+                                               << "+++ Best CLCT Details: " << clctProc->bestCLCT[bx_clct] << "\n"
+                                               << "+++ Second CLCT Details: " << clctProc->secondCLCT[bx_clct] << std::endl;
+            if (allLCTs(bx_alct,mbx,0).isValid())
+              LogTrace("CSCGEMCMotherboardME11") << "LCT #1 "<< allLCTs(bx_alct,mbx,0) << std::endl;
+            else
+              LogTrace("CSCGEMCMotherboardME11") << "No valid LCT is built from ALCT-CLCT matching in ME1b"  << std::endl;
+            if (allLCTs(bx_alct,mbx,1).isValid())
+              LogTrace("CSCGEMCMotherboardME11") << "LCT #2 "<< allLCTs(bx_alct,mbx,1) << std::endl;
           }
 
-          if (allLCTs1b(bx_alct,mbx,0).isValid()) {
+          if (allLCTs(bx_alct,mbx,0).isValid()) {
             used_clct_mask[bx_clct] += 1;
             if (match_earliest_clct_only) break;
           }
@@ -234,28 +207,28 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
 
           // find the best matching copad
 	  matches<GEMCoPadDigi> copads;
-	  matchingPads<CSCALCTDigi, GEMCoPadDigi>(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct], ME1B, copads);
+	  matchingPads<CSCALCTDigi, GEMCoPadDigi>(alctProc->bestALCT[bx_alct], alctProc->secondALCT[bx_alct], copads);
 
           if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "\t++Number of matching GEM CoPads in BX " << bx_alct << " : "<< copads.size() << std::endl;
           if (copads.empty()) {
             continue;
           }
 
-	  CSCGEMMotherboard::correlateLCTsGEM(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-					      copads, allLCTs1b(bx_alct,0,0), allLCTs1b(bx_alct,0,1), ME1B);
+	  CSCGEMMotherboard::correlateLCTsGEM(alctProc->bestALCT[bx_alct], alctProc->secondALCT[bx_alct],
+                                        copads, allLCTs(bx_alct,0,0), allLCTs(bx_alct,0,1));
 
           if (debug_matching) {
             LogTrace("CSCGEMCMotherboardME11") << "Successful ALCT-GEM CoPad match in ME1b: bx_alct = " << bx_alct << "\n\n"
                                                << "------------------------------------------------------------------------" << std::endl << std::endl;
-	    if (allLCTs1b(bx_alct,0,0).isValid())
-		LogTrace("CSCGEMCMotherboardME11") << "LCT #1 "<< allLCTs1b(bx_alct,0,0) << std::endl;
-	    else
-		LogTrace("CSCGEMCMotherboardME11") << "No valid LCT is built from ALCT-GEM matching in ME1b"  << std::endl;
-	    if (allLCTs1b(bx_alct,0,1).isValid())
-		LogTrace("CSCGEMCMotherboardME11") << "LCT #2 "<< allLCTs1b(bx_alct,0,1) << std::endl;
+            if (allLCTs(bx_alct,0,0).isValid())
+              LogTrace("CSCGEMCMotherboardME11") << "LCT #1 "<< allLCTs(bx_alct,0,0) << std::endl;
+            else
+              LogTrace("CSCGEMCMotherboardME11") << "No valid LCT is built from ALCT-GEM matching in ME1b"  << std::endl;
+            if (allLCTs(bx_alct,0,1).isValid())
+              LogTrace("CSCGEMCMotherboardME11") << "LCT #2 "<< allLCTs(bx_alct,0,1) << std::endl;
           }
 
-          if (allLCTs1b(bx_alct,0,0).isValid()) {
+          if (allLCTs(bx_alct,0,0).isValid()) {
             ++nSuccesFulGEMMatches;
             if (match_earliest_clct_only) break;
           }
@@ -289,132 +262,6 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
         LogTrace("CSCGEMCMotherboardME11") << "------------------------------------------------------------------------" << std::endl
                                            << "Attempt ALCT-CLCT matching in ME1/a in bx range: [" << bx_clct_start << "," << bx_clct_stop << "]" << std::endl;
       }
-
-      // ALCT-to-CLCT matching in ME1a
-      nSuccesFulMatches = 0;
-      for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
-      {
-        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
-        if (drop_used_clcts and used_clct_mask_1a[bx_clct]) continue;
-        if (clct1a->bestCLCT[bx_clct].isValid())
-        {
-          const int quality(clct1a->bestCLCT[bx_clct].getQuality());
-          if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "++Valid ME1a CLCT: " << clct1a->bestCLCT[bx_clct] << std::endl;
-
-	  // pick the pad that corresponds
-	  matches<GEMPadDigi> mPads;
-	  matchingPads<GEMPadDigi>(clct1a->bestCLCT[bx_clct], clct1a->secondCLCT[bx_clct],
-				   alct->bestALCT[bx_alct], alct->secondALCT[bx_alct], ME1A, mPads);
-	  matches<GEMCoPadDigi> mCoPads;
-	  matchingPads<GEMCoPadDigi>(clct1a->bestCLCT[bx_clct], clct1a->secondCLCT[bx_clct],
-				     alct->bestALCT[bx_alct], alct->secondALCT[bx_alct], ME1A, mCoPads);
-
-          if (dropLowQualityCLCTsNoGEMs_ME1a_ and quality < 4 and hasPads){
-            int nFound(mPads.size());
-            const bool clctInEdge(clct1a->bestCLCT[bx_clct].getKeyStrip() < 4 or clct1a->bestCLCT[bx_clct].getKeyStrip() > 93);
-            if (clctInEdge){
-              if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "\tInfo: low quality CLCT in CSC chamber edge, don't care about GEM pads" << std::endl;
-            }
-            else {
-              if (nFound != 0){
-                if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "\tInfo: low quality CLCT with " << nFound << " matching GEM trigger pads" << std::endl;
-              }
-              else {
-                if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "\tWarning: low quality CLCT without matching GEM trigger pad" << std::endl;
-                continue;
-              }
-            }
-          }
-          ++nSuccesFulMatches;
-          int mbx = bx_clct-bx_clct_start;
-          correlateLCTsGEM(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-			   clct1a->bestCLCT[bx_clct], clct1a->secondCLCT[bx_clct],
-			   mPads, mCoPads,
-			   allLCTs1a(bx_alct,mbx,0), allLCTs1a(bx_alct,mbx,1), ME1A);
-          if (debug_matching) {
-            LogTrace("CSCGEMCMotherboardME11") << "Successful ALCT-CLCT match in ME1a: bx_alct = " << bx_alct
-                                               << "; match window: [" << bx_clct_start << "; " << bx_clct_stop
-                                               << "]; bx_clct = " << bx_clct << "\n"
-                                               << "+++ Best CLCT Details: " << clct1a->bestCLCT[bx_clct] << "\n"
-                                               << "+++ Second CLCT Details: " << clct1a->secondCLCT[bx_clct] << std::endl;
-	    if (allLCTs1a(bx_alct,mbx,0).isValid())
-		LogTrace("CSCGEMCMotherboardME11") << "LCT #1 "<< allLCTs1a(bx_alct,mbx,0) << std::endl;
-	    else
-		LogTrace("CSCGEMCMotherboardME11") << "No valid LCT is built from ALCT-CLCT matching in ME1a"  << std::endl;
-	    if (allLCTs1a(bx_alct,mbx,1).isValid())
-		LogTrace("CSCGEMCMotherboardME11") << "LCT #2 "<< allLCTs1a(bx_alct,mbx,1) << std::endl;
-          }
-          if (allLCTs1a(bx_alct,mbx,0).isValid()){
-            used_clct_mask_1a[bx_clct] += 1;
-            if (match_earliest_clct_only) break;
-          }
-        }
-      }
-
-      // ALCT-to-GEM matching in ME1a
-      nSuccesFulGEMMatches = 0;
-      if (nSuccesFulMatches==0 and buildLCTfromALCTandGEM_ME1a_){
-        if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "++No valid ALCT-CLCT matches in ME1a" << std::endl;
-        for (int bx_gem = bx_copad_start; bx_gem <= bx_copad_stop; bx_gem++) {
-          if (not hasCoPads) {
-            continue;
-          }
-
-          // find the best matching copad
-	  matches<GEMCoPadDigi> copads;
-	  matchingPads<CSCALCTDigi, GEMCoPadDigi>(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct], ME1A, copads);
-
-          if (debug_matching) LogTrace("CSCGEMCMotherboardME11") << "\t++Number of matching GEM CoPads in BX " << bx_alct << " : "<< copads.size() << std::endl;
-          if (copads.empty()) {
-            continue;
-          }
-
-	  CSCGEMMotherboard::correlateLCTsGEM(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-					      copads, allLCTs1a(bx_alct,0,0), allLCTs1a(bx_alct,0,1), ME1A);
-
-          if (debug_matching) {
-            LogTrace("CSCGEMCMotherboardME11") << "Successful ALCT-GEM CoPad match in ME1a: bx_alct = " << bx_alct << "\n\n"
-                                               << "------------------------------------------------------------------------" << std::endl << std::endl;
-	    if (allLCTs1a(bx_alct,0,0).isValid())
-		LogTrace("CSCGEMCMotherboardME11") << "LCT #1 "<< allLCTs1a(bx_alct,0,0) << std::endl;
-	    else
-		LogTrace("CSCGEMCMotherboardME11") << "No valid LCT is built from ALCT-GEM matching in ME1a"  << std::endl;
-	    if (allLCTs1a(bx_alct,0,1).isValid())
-		LogTrace("CSCGEMCMotherboardME11") << "LCT #2 "<< allLCTs1a(bx_alct,0,1) << std::endl;
-          }
-
-          if (allLCTs1a(bx_alct,0,0).isValid()) {
-             ++nSuccesFulGEMMatches;
-            if (match_earliest_clct_only) break;
-          }
-        }
-      }
-
-      if (debug_matching) {
-        LogTrace("CSCGEMCMotherboardME11") << "======================================================================== \n"
-                                           << "Summary: " << std::endl;
-        if (nSuccesFulMatches>1)
-          LogTrace("CSCGEMCMotherboardME11") << "Too many successful ALCT-CLCT matches in ME1a: " << nSuccesFulMatches
-					     << ", CSCDetId " << cscChamberME1a->id()
-					     << ", bx_alct = " << bx_alct
-					     << "; match window: [" << bx_clct_start << "; " << bx_clct_stop << "]" << std::endl;
-        else if (nSuccesFulMatches==1)
-          LogTrace("CSCGEMCMotherboardME11") << "1 successful ALCT-CLCT match in ME1a: "
-					     << " CSCDetId " << cscChamberME1a->id()
-					     << ", bx_alct = " << bx_alct
-					     << "; match window: [" << bx_clct_start << "; " << bx_clct_stop << "]" << std::endl;
-        else if (nSuccesFulGEMMatches==1)
-          LogTrace("CSCGEMCMotherboardME11") << "1 successful ALCT-GEM match in ME1a: "
-					     << " CSCDetId " << cscChamberME1a->id()
-					     << ", bx_alct = " << bx_alct
-					     << "; match window: [" << bx_clct_start << "; " << bx_clct_stop << "]" << std::endl;
-        else
-          LogTrace("CSCGEMCMotherboardME11") << "Unsuccessful ALCT-CLCT match in ME1a: "
-					     << "CSCDetId " << cscChamberME1a->id()
-					     << ", bx_alct = " << bx_alct
-					     << "; match window: [" << bx_clct_start << "; " << bx_clct_stop << "]" << std::endl;
-      }
-
     } // end of ALCT valid block
     else {
       auto coPads(coPads_[bx_alct]);
@@ -428,155 +275,42 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
           for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++) {
             if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
             if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
-            if (clct->bestCLCT[bx_clct].isValid()) {
-              const int quality(clct->bestCLCT[bx_clct].getQuality());
+            if (clctProc->bestCLCT[bx_clct].isValid()) {
+              const int quality(clctProc->bestCLCT[bx_clct].getQuality());
               // only use high-Q stubs for the time being
               if (quality < 4) continue;
               int mbx = bx_clct-bx_clct_start;
-              CSCGEMMotherboard::correlateLCTsGEM(clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct], coPads,
-                                                  allLCTs1b(bx_alct,mbx,0), allLCTs1b(bx_alct,mbx,1), ME1B);
+              CSCGEMMotherboard::correlateLCTsGEM(clctProc->bestCLCT[bx_clct], clctProc->secondCLCT[bx_clct], coPads,
+                                                  allLCTs(bx_alct,mbx,0), allLCTs(bx_alct,mbx,1));
               if (debug_matching) {
                 //	    if (infoV > 1) LogTrace("CSCMotherboard")
                 LogTrace("CSCGEMCMotherboardME11") << "Successful GEM-CLCT match in ME1b: bx_alct = " << bx_alct
                                                    << "; match window: [" << bx_clct_start << "; " << bx_clct_stop
                                                    << "]; bx_clct = " << bx_clct << "\n"
-                                                   << "+++ Best CLCT Details: " << clct->bestCLCT[bx_clct] << "\n"
-                                                   << "+++ Second CLCT Details: " << clct->secondCLCT[bx_clct] << std::endl;
+                                                   << "+++ Best CLCT Details: " << clctProc->bestCLCT[bx_clct] << "\n"
+                                                   << "+++ Second CLCT Details: " << clctProc->secondCLCT[bx_clct] << std::endl;
               }
-              if (allLCTs1b(bx_alct,mbx,0).isValid()) {
+              if (allLCTs(bx_alct,mbx,0).isValid()) {
                 used_clct_mask[bx_clct] += 1;
                 if (match_earliest_clct_only) break;
               }
             }
-          }
+          } //end of clct loop
         }
-
-        // matching in ME1a
-        if (buildLCTfromCLCTandGEM_ME1a_) {
-          for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++) {
-            if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
-            if (drop_used_clcts && used_clct_mask_1a[bx_clct]) continue;
-            if (clct1a->bestCLCT[bx_clct].isValid()){
-              const int quality(clct1a->bestCLCT[bx_clct].getQuality());
-              // only use high-Q stubs for the time being
-              if (quality < 4) continue;
-              int mbx = bx_clct-bx_clct_start;
-	      CSCGEMMotherboard::correlateLCTsGEM(clct1a->bestCLCT[bx_clct], clct1a->secondCLCT[bx_clct], coPads,
-						  allLCTs1a(bx_alct,mbx,0), allLCTs1a(bx_alct,mbx,1), ME1A);
-              if (debug_matching) {
-                //	    if (infoV > 1) LogTrace("CSCMotherboard")
-                LogTrace("CSCGEMCMotherboardME11") << "Successful GEM-CLCT match in ME1a: bx_alct = " << bx_alct
-                                                   << "; match window: [" << bx_clct_start << "; " << bx_clct_stop
-                                                   << "]; bx_clct = " << bx_clct << "\n"
-                                                   << "+++ Best CLCT Details: " << clct1a->bestCLCT[bx_clct] << "\n"
-                                                   << "+++ Second CLCT Details: " << clct1a->secondCLCT[bx_clct] << std::endl;
-              }
-              if (allLCTs1a(bx_alct,mbx,0).isValid()){
-                used_clct_mask_1a[bx_clct] += 1;
-                if (match_earliest_clct_only) break;
-              }
-            }
-          }
-        }
-      }
+      } // if (!coPads.empty())
     }
   } // end of ALCT-centric matching
 
   if (debug_matching){
     LogTrace("CSCGEMCMotherboardME11") << "======================================================================== \n"
-                                       << "Counting the LCTs \n"
+                                       << "Counting the LCTs in CSCGEMMotherboard ME11 \n"
                                        << "========================================================================" << std::endl;
   }
 
-  // reduction of nLCTs per each BX
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
-  {
-    // counting
-    unsigned int n1a=0, n1b=0;
-    for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
-      for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
-      {
-        int cbx = bx + mbx - match_trig_window_size/2;
-        if (allLCTs1b(bx,mbx,i).isValid())
-        {
-          n1b++;
-	    if (infoV > 0) LogDebug("CSCGEMMotherboardME11")
-			     << "1b LCT"<<i+1<<" "<<bx<<"/"<<cbx<<": "<<allLCTs1b(bx,mbx,i)<<std::endl;
-        }
-        if (allLCTs1a(bx,mbx,i).isValid())
-        {
-          n1a++;
-	    if (infoV > 0) LogDebug("CSCGEMMotherboardME11")
-			     << "1a LCT"<<i+1<<" "<<bx<<"/"<<cbx<<": "<<allLCTs1a(bx,mbx,i)<<std::endl;
-        }
-      }
-    if (infoV > 0 and n1a+n1b>0) LogDebug("CSCGEMMotherboardME11")
-				   <<"bx "<<bx<<" nLCT:"<<n1a<<" "<<n1b<<" "<<n1a+n1b<<std::endl;
-
-    // some simple cross-bx sorting algorithms
-    if (tmb_cross_bx_algo == 1 and (n1a>2 or n1b>2) )
-    {
-      n1a=0, n1b=0;
-      for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
-        for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
-        {
-          if (allLCTs1b(bx,pref[mbx],i).isValid())
-          {
-            n1b++;
-            if (n1b>2) allLCTs1b(bx,pref[mbx],i).clear();
-          }
-          if (allLCTs1a(bx,pref[mbx],i).isValid())
-          {
-            n1a++;
-            if (n1a>2) allLCTs1a(bx,pref[mbx],i).clear();
-          }
-        }
-
-      n1a=0, n1b=0;
-      for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
-        for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
-        {
-          int cbx = bx + mbx - match_trig_window_size/2;
-          if (allLCTs1b(bx,mbx,i).isValid())
-          {
-            n1b++;
-           if (infoV > 0) LogDebug("CSCGEMMotherboardME11")
-			    << "1b LCT"<<i+1<<" "<<bx<<"/"<<cbx<<": "<<allLCTs1b(bx,mbx,i)<< std::endl;
-          }
-          if (allLCTs1a(bx,mbx,i).isValid())
-          {
-            n1a++;
-            if (infoV > 0) LogDebug("CSCGEMMotherboardME11")
-			     << "1a LCT"<<i+1<<" "<<bx<<"/"<<cbx<<": "<<allLCTs1a(bx,mbx,i)<< std::endl;
-          }
-        }
-      if (infoV > 0 and n1a+n1b>0) LogDebug("CSCGEMMotherboardME11")
-				     <<"bx "<<bx<<" nnLCT:"<<n1a<<" "<<n1b<<" "<<n1a+n1b<<std::endl;
-    } // x-bx sorting
-
-    // Maximum 2 per whole ME11 per BX case:
-    // (supposedly, now we should have max 2 per bx in each 1a and 1b)
-    if (n1a+n1b > max_lcts and tmb_cross_bx_algo == 1)
-    {
-      // do it simple so far: take all low eta 1/b stubs
-      unsigned int nLCT=n1b;
-      n1a=0;
-      // right now nLCT<=2; cut 1a if necessary
-      for (unsigned int mbx=0; mbx<match_trig_window_size; mbx++)
-        for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
-          if (allLCTs1a(bx,mbx,i).isValid()) {
-            nLCT++;
-            if (nLCT>max_lcts) allLCTs1a(bx,mbx,i).clear();
-            else n1a++;
-          }
-      if (infoV > 0 and nLCT>0) LogDebug("CSCGEMMotherboardME11")
-				  <<"bx "<<bx<<" nnnLCT: "<<n1a<<" "<<n1b<<" "<<n1a+n1b<< std::endl;
-    }
-  }// reduction per bx
 
   unsigned int n1b=0, n1a=0;
   LogTrace("CSCGEMCMotherboardME11") << "======================================================================== \n"
-                                     << "Counting the final LCTs \n"
+                                     << "Counting the final LCTs in CSCGEMMotherboard ME11\n"
                                      << "======================================================================== \n"
                                      << "tmb_cross_bx_algo: " << tmb_cross_bx_algo << std::endl;
 
@@ -627,16 +361,12 @@ std::vector<CSCCorrelatedLCTDigi> CSCGEMMotherboardME11::readoutLCTs(enum CSCPar
   int bx_readout = -1;
   std::vector<CSCCorrelatedLCTDigi> all_lcts;
   switch(tmb_cross_bx_algo){
-  case 1:
-	  if (me1ab == ME1A and not (mpc_block_me1a or disableME1a)) {
-	    allLCTs1a.getMatched(all_lcts);
-	  }else if (me1ab == ME1B) {
-	    allLCTs1b.getMatched(all_lcts);
-	  }
-	  break;
-  case 2: sortLCTs(all_lcts, me1ab, CSCUpgradeMotherboard::sortLCTsByQuality);
+  case 0:  case 1:
+    allLCTs.getMatched(all_lcts);
     break;
-  case 3: sortLCTs(all_lcts, me1ab, CSCUpgradeMotherboard::sortLCTsByGEMDphi);
+  case 2: sortLCTs(all_lcts, CSCUpgradeMotherboard::sortLCTsByQuality);
+    break;
+  case 3: sortLCTs(all_lcts, CSCUpgradeMotherboard::sortLCTsByGEMDphi);
     break;
   default: LogTrace("CSCGEMCMotherboardME11")<<"tmb_cross_bx_algo error" <<std::endl;
     break;
@@ -653,6 +383,9 @@ std::vector<CSCCorrelatedLCTDigi> CSCGEMMotherboardME11::readoutLCTs(enum CSCPar
     // Skip LCTs found too late relative to L1Accept.
     if (bx > late_tbins) continue;
 
+    if ((me1ab == CSCPart::ME1B and lct.getStrip() >  CSCConstants::MAX_HALF_STRIP_ME1B  ) or (me1ab == CSCPart::ME1A and lct.getStrip() <=  CSCConstants::MAX_HALF_STRIP_ME1B))
+	continue;
+
     // If (readout_earliest_2) take only LCTs in the earliest bx in the read-out window:
     // in digi->raw step, LCTs have to be packed into the TMB header, and
     // currently there is room just for two.
@@ -667,11 +400,10 @@ std::vector<CSCCorrelatedLCTDigi> CSCGEMMotherboardME11::readoutLCTs(enum CSCPar
 }
 
 //sort LCTs in each BX
-void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs, int bx, enum CSCPart me,
+//
+void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs, int bx,
                                      bool (*sorter)(const CSCCorrelatedLCTDigi&, const CSCCorrelatedLCTDigi&)) const
 {
-  const auto& allLCTs(me==ME1A ? allLCTs1a : allLCTs1b);
-
   allLCTs.getTimeMatched(bx, LCTs);
 
   CSCUpgradeMotherboard::sortLCTs(LCTs, *sorter);
@@ -680,86 +412,26 @@ void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs, in
 }
 
 //sort LCTs in whole LCTs BX window
-void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs_final, enum CSCPart me,
+void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs_final,
                                      bool (*sorter)(const CSCCorrelatedLCTDigi&, const CSCCorrelatedLCTDigi&)) const
 {
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
-    {
-      // get sorted LCTs per subchamber
-      std::vector<CSCCorrelatedLCTDigi> LCTs1a;
-      std::vector<CSCCorrelatedLCTDigi> LCTs1b;
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
+    // temporary collection with all LCTs in the whole chamber
+    std::vector<CSCCorrelatedLCTDigi> LCTs_tmp;
+    CSCGEMMotherboardME11::sortLCTs(LCTs_tmp, bx, *sorter);
 
-      CSCGEMMotherboardME11::sortLCTs(LCTs1a, bx, ME1A, *sorter);
-      CSCGEMMotherboardME11::sortLCTs(LCTs1b, bx, ME1B, *sorter);
-
-      // temporary collection with all LCTs in the whole chamber
-      std::vector<CSCCorrelatedLCTDigi> LCTs_tmp;
-      LCTs_tmp.insert(LCTs_tmp.begin(), LCTs1b.begin(), LCTs1b.end());
-      LCTs_tmp.insert(LCTs_tmp.end(), LCTs1a.begin(), LCTs1a.end());
-
-      // sort the selected LCTs
-      CSCUpgradeMotherboard::sortLCTs(LCTs_tmp, *sorter);
-
-      //LCTs reduction per BX
-      if (max_lcts > 0)
-        {
-	  if (LCTs_tmp.size() > max_lcts) LCTs_tmp.erase(LCTs_tmp.begin()+max_lcts, LCTs_tmp.end());//double check
-          // loop on all the selected LCTs
-          for (const auto& p: LCTs_tmp){
-            // case when you only want to readout ME1A
-            if (me==ME1A and std::find(LCTs1a.begin(), LCTs1a.end(), p) != LCTs1a.end()){
-              LCTs_final.push_back(p);
-            }
-            // case when you only want to readout ME1B
-            else if(me==ME1B and std::find(LCTs1b.begin(), LCTs1b.end(), p) != LCTs1b.end()){
-              LCTs_final.push_back(p);
-            }
-          }
-        }
-      else {
-        if (!LCTs1a.empty() and !LCTs1b.empty() and me==ME1A)
-          LCTs_final.push_back(*LCTs1a.begin());
-        else if (!LCTs1a.empty() and !LCTs1b.empty() and me==ME1B)
-          LCTs_final.push_back(*LCTs1b.begin());
-        else if (!LCTs1a.empty() and LCTs1b.empty() and me==ME1A)
-          LCTs_final.insert(LCTs_final.end(), LCTs1a.begin(), LCTs1a.end());
-        else if (!LCTs1b.empty() and LCTs1a.empty() and me==ME1B)
-          LCTs_final.insert(LCTs_final.end(), LCTs1b.begin(), LCTs1b.end());
-      }
+    //LCTs reduction per BX
+    if (max_lcts > 0) {
+      if (LCTs_tmp.size() > max_lcts)
+        LCTs_tmp.erase(LCTs_tmp.begin()+max_lcts, LCTs_tmp.end());//double check
     }
+  }
 }
 
 
-bool CSCGEMMotherboardME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c, int me) const
+bool CSCGEMMotherboardME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c) const
 {
-  if ( !c.isValid() or !a.isValid() ) return false;
-  int key_hs = c.getKeyStrip();
-  int key_wg = a.getKeyWG();
-  if ( me == ME1A )
-  {
-    if ( !gangedME1a )
-    {
-      // wrap around ME11 HS number for -z endcap
-      if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_UNGANGED - key_hs;
-      if ( key_hs >= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1A))[key_wg][0] and
-	   key_hs <= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1A))[key_wg][1]    ) return true;
-      return false;
-    }
-    else
-    {
-      if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_GANGED - key_hs;
-      if ( key_hs >= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1Ag))[key_wg][0] and
-	   key_hs <= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1Ag))[key_wg][1]    ) return true;
-      return false;
-    }
-  }
-  if ( me == ME1B)
-  {
-    if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1B - key_hs;
-    if ( key_hs >= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1B))[key_wg][0] and
-         key_hs <= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1B))[key_wg][1]      ) return true;
-  }
-  return false;
+  return cscTmbLUT_->doesALCTCrossCLCT(a, c, theEndcap, gangedME1a);
 }
 
 
@@ -770,8 +442,7 @@ void CSCGEMMotherboardME11::correlateLCTsGEM(const CSCALCTDigi& bALCT,
                                              const GEMPadDigiIds& pads,
                                              const GEMCoPadDigiIds& copads,
                                              CSCCorrelatedLCTDigi& lct1,
-                                             CSCCorrelatedLCTDigi& lct2,
-                                             enum CSCPart p) const
+                                             CSCCorrelatedLCTDigi& lct2) const
 {
   CSCALCTDigi bestALCT = bALCT;
   CSCALCTDigi secondALCT = sALCT;
@@ -787,17 +458,16 @@ void CSCGEMMotherboardME11::correlateLCTsGEM(const CSCALCTDigi& bALCT,
   const bool ok_sb = secondALCT.isValid() and bestCLCT.isValid();
   const bool ok_ss = secondALCT.isValid() and secondCLCT.isValid();
 
-  const int ok11 = doesALCTCrossCLCT( bestALCT, bestCLCT, p);
-  const int ok12 = doesALCTCrossCLCT( bestALCT, secondCLCT, p);
-  const int ok21 = doesALCTCrossCLCT( secondALCT, bestCLCT, p);
-  const int ok22 = doesALCTCrossCLCT( secondALCT, secondCLCT, p);
+  const int ok11 = doesALCTCrossCLCT( bestALCT, bestCLCT);
+  const int ok12 = doesALCTCrossCLCT( bestALCT, secondCLCT);
+  const int ok21 = doesALCTCrossCLCT( secondALCT, bestCLCT);
+  const int ok22 = doesALCTCrossCLCT( secondALCT, secondCLCT);
   const int code = (ok11<<3) | (ok12<<2) | (ok21<<1) | (ok22);
 
   int dbg=0;
-  int ring = p;
   int chamb= CSCTriggerNumbering::chamberFromTriggerLabels(theSector,theSubsector, theStation, theTrigChamber);
-  CSCDetId did(theEndcap, theStation, ring, chamb, 0);
-  if (dbg) LogTrace("CSCGEMMotherboardME11")<<"debug correlateLCTs in "<<did<< "\n"
+  CSCDetId did(theEndcap, theStation, 1, chamb, 0);
+  if (dbg) LogTrace("CSCGEMMotherboardME11")<<"debug correlateLCTs in ME11"<<did<< "\n"
 	   <<"ALCT1: "<<bestALCT<<"\n"
 	   <<"ALCT2: "<<secondALCT<<"\n"
 	   <<"CLCT1: "<<bestCLCT<<"\n"
@@ -831,16 +501,16 @@ void CSCGEMMotherboardME11::correlateLCTsGEM(const CSCALCTDigi& bALCT,
   if (dbg) LogTrace("CSCGEMMotherboardME11")<<"lut 0 1 = "<<lut[code][0]<<" "<<lut[code][1]<<std::endl;
 
   // check matching copads
-  const GEMCoPadDigi& bb_copad = bestMatchingPad<GEMCoPadDigi>(bestALCT,   bestCLCT,   copads, p);
-  const GEMCoPadDigi& bs_copad = bestMatchingPad<GEMCoPadDigi>(bestALCT,   secondCLCT, copads, p);
-  const GEMCoPadDigi& sb_copad = bestMatchingPad<GEMCoPadDigi>(secondALCT, bestCLCT,   copads, p);
-  const GEMCoPadDigi& ss_copad = bestMatchingPad<GEMCoPadDigi>(secondALCT, secondCLCT, copads, p);
+  const GEMCoPadDigi& bb_copad = bestMatchingPad<GEMCoPadDigi>(bestALCT,   bestCLCT,   copads);
+  const GEMCoPadDigi& bs_copad = bestMatchingPad<GEMCoPadDigi>(bestALCT,   secondCLCT, copads);
+  const GEMCoPadDigi& sb_copad = bestMatchingPad<GEMCoPadDigi>(secondALCT, bestCLCT,   copads);
+  const GEMCoPadDigi& ss_copad = bestMatchingPad<GEMCoPadDigi>(secondALCT, secondCLCT, copads);
 
   // check matching pads
-  const GEMPadDigi& bb_pad = bestMatchingPad<GEMPadDigi>(bestALCT,   bestCLCT,   pads, p);
-  const GEMPadDigi& bs_pad = bestMatchingPad<GEMPadDigi>(bestALCT,   secondCLCT, pads, p);
-  const GEMPadDigi& sb_pad = bestMatchingPad<GEMPadDigi>(secondALCT, bestCLCT,   pads, p);
-  const GEMPadDigi& ss_pad = bestMatchingPad<GEMPadDigi>(secondALCT, secondCLCT, pads, p);
+  const GEMPadDigi& bb_pad = bestMatchingPad<GEMPadDigi>(bestALCT,   bestCLCT,   pads);
+  const GEMPadDigi& bs_pad = bestMatchingPad<GEMPadDigi>(bestALCT,   secondCLCT, pads);
+  const GEMPadDigi& sb_pad = bestMatchingPad<GEMPadDigi>(secondALCT, bestCLCT,   pads);
+  const GEMPadDigi& ss_pad = bestMatchingPad<GEMPadDigi>(secondALCT, secondCLCT, pads);
 
   // evaluate possible combinations
   const bool ok_bb_copad = ok11==1 and ok_bb and bb_copad.isValid();
@@ -855,20 +525,20 @@ void CSCGEMMotherboardME11::correlateLCTsGEM(const CSCALCTDigi& bALCT,
 
   switch (lut[code][0]) {
   case 11:
-    if (ok_bb_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, bestCLCT, bb_copad, p, 1);
-    if (ok_bb_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, bestCLCT, bb_pad, p, 1);
+    if (ok_bb_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, bestCLCT, bb_copad, 1);
+    if (ok_bb_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, bestCLCT, bb_pad, 1);
     break;
   case 12:
-    if (ok_bs_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_copad, p, 1);
-    if (ok_bs_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_pad, p, 1);
+    if (ok_bs_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_copad, 1);
+    if (ok_bs_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_pad, 1);
     break;
   case 21:
-    if (ok_sb_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_copad, p, 1);
-    if (ok_sb_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_pad, p, 1);
+    if (ok_sb_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_copad, 1);
+    if (ok_sb_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_pad, 1);
     break;
   case 22:
-    if (ok_ss_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, ss_copad, p, 1);
-    if (ok_ss_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, ss_pad, p, 1);
+    if (ok_ss_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, ss_copad, 1);
+    if (ok_ss_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, ss_pad, 1);
     break;
   default:
     return;
@@ -878,16 +548,16 @@ void CSCGEMMotherboardME11::correlateLCTsGEM(const CSCALCTDigi& bALCT,
 
   switch (lut[code][1]){
   case 12:
-    if (ok_bs_copad) lct2 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_copad, p, 2);
-    if (ok_bs_pad)   lct2 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_pad, p, 2);
+    if (ok_bs_copad) lct2 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_copad, 2);
+    if (ok_bs_pad)   lct2 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_pad, 2);
     break;
   case 21:
-    if (ok_sb_copad) lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_copad, p, 2);
-    if (ok_sb_pad)   lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_pad, p, 2);
+    if (ok_sb_copad) lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_copad, 2);
+    if (ok_sb_pad)   lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_pad, 2);
     break;
   case 22:
-    if (ok_bb_copad) lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, bb_copad, p, 2);
-    if (ok_bb_pad)   lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, bb_pad, p, 2);
+    if (ok_bb_copad) lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, bb_copad, 2);
+    if (ok_bb_pad)   lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, bb_pad, 2);
     break;
   default:
     return;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -412,7 +412,7 @@ void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs, in
 }
 
 //sort LCTs in whole LCTs BX window
-void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs_final,
+void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs,
                                      bool (*sorter)(const CSCCorrelatedLCTDigi&, const CSCCorrelatedLCTDigi&)) const
 {
   for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -420,10 +420,9 @@ void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs_fin
     std::vector<CSCCorrelatedLCTDigi> LCTs_tmp;
     CSCGEMMotherboardME11::sortLCTs(LCTs_tmp, bx, *sorter);
 
-    //LCTs reduction per BX
-    if (max_lcts > 0) {
-      if (LCTs_tmp.size() > max_lcts)
-        LCTs_tmp.erase(LCTs_tmp.begin()+max_lcts, LCTs_tmp.end());//double check
+    // Add the LCTs
+    for (const auto& p: LCTs_tmp){
+      LCTs.push_back(p);
     }
   }
 }
@@ -525,20 +524,24 @@ void CSCGEMMotherboardME11::correlateLCTsGEM(const CSCALCTDigi& bALCT,
 
   switch (lut[code][0]) {
   case 11:
-    if (ok_bb_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, bestCLCT, bb_copad, 1);
-    if (ok_bb_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, bestCLCT, bb_pad, 1);
+    if (ok_bb_copad)    lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, bestCLCT, bb_copad, 1);
+    else if (ok_bb_pad) lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, bestCLCT, bb_pad, 1);
+    else                lct1 = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
     break;
   case 12:
-    if (ok_bs_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_copad, 1);
-    if (ok_bs_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_pad, 1);
+    if (ok_bs_copad)    lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_copad, 1);
+    else if (ok_bs_pad) lct1 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_pad, 1);
+    else                lct1 = constructLCTs(bestALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
     break;
   case 21:
-    if (ok_sb_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_copad, 1);
-    if (ok_sb_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_pad, 1);
+    if (ok_sb_copad)    lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_copad, 1);
+    else if (ok_sb_pad) lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_pad, 1);
+    else                lct1 = constructLCTs(secondALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
     break;
   case 22:
-    if (ok_ss_copad) lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, ss_copad, 1);
-    if (ok_ss_pad)   lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, ss_pad, 1);
+    if (ok_ss_copad)    lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, ss_copad, 1);
+    else if (ok_ss_pad) lct1 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, ss_pad, 1);
+    else                lct1 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
     break;
   default:
     return;
@@ -548,16 +551,19 @@ void CSCGEMMotherboardME11::correlateLCTsGEM(const CSCALCTDigi& bALCT,
 
   switch (lut[code][1]){
   case 12:
-    if (ok_bs_copad) lct2 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_copad, 2);
-    if (ok_bs_pad)   lct2 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_pad, 2);
+    if (ok_bs_copad)    lct2 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_copad, 2);
+    else if (ok_bs_pad) lct2 = CSCGEMMotherboard::constructLCTsGEM(bestALCT, secondCLCT, bs_pad, 2);
+    else                lct2 = constructLCTs(bestALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 2);
     break;
   case 21:
-    if (ok_sb_copad) lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_copad, 2);
-    if (ok_sb_pad)   lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_pad, 2);
+    if (ok_sb_copad)    lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_copad, 2);
+    else if (ok_sb_pad) lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, bestCLCT, sb_pad, 2);
+    else                lct2 = constructLCTs(secondALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 2);
     break;
   case 22:
-    if (ok_bb_copad) lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, bb_copad, 2);
-    if (ok_bb_pad)   lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, bb_pad, 2);
+    if (ok_bb_copad)    lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, bb_copad, 2);
+    else if (ok_bb_pad) lct2 = CSCGEMMotherboard::constructLCTsGEM(secondALCT, secondCLCT, bb_pad, 2);
+    else                lct2 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 2);
     break;
   default:
     return;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.h
@@ -28,10 +28,6 @@ class CSCGEMMotherboardME11 : public CSCGEMMotherboard
   /** Default destructor. */
   ~CSCGEMMotherboardME11() override;
 
-  /** Clears correlated LCT and passes clear signal on to cathode and anode
-      LCT processors. */
-  void clear();
-
   /** Run function for normal usage.  Runs cathode and anode LCT processors,
       takes results and correlates into CorrelatedLCT. */
   void run(const CSCWireDigiCollection* wiredc,
@@ -42,33 +38,24 @@ class CSCGEMMotherboardME11 : public CSCGEMMotherboard
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs1a() const;
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs1b() const;
 
-  /** additional Cathode LCT processor for ME1a */
-  std::unique_ptr<CSCCathodeLCTProcessor> clct1a;
-
  private:
 
   /* access to the LUTs needed for matching */
   const CSCGEMMotherboardLUTME11* getLUT() const override {return tmbLUT_.get();}
   std::unique_ptr<CSCGEMMotherboardLUTME11> tmbLUT_;
-
-  /** Returns vectors of found ALCTs in ME1a and ME1b, if any. */
-  std::vector<CSCALCTDigi> getALCTs1b() const {return alctV;}
-
-  /** Returns vectors of found CLCTs in ME1a and ME1b, if any. */
-  std::vector<CSCCLCTDigi> getCLCTs1a() const {return clctV1a;}
-  std::vector<CSCCLCTDigi> getCLCTs1b() const {return clctV1b;}
+  std::unique_ptr<CSCMotherboardLUTME11> cscTmbLUT_;
 
   /* readout the LCTs in a sector of ME11 */
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs(enum CSCPart me1ab) const;
 
   /** Methods to sort the LCTs */
-  void sortLCTs(std::vector<CSCCorrelatedLCTDigi>&, int bx, enum CSCPart,
+  void sortLCTs(std::vector<CSCCorrelatedLCTDigi>&, int bx,
                 bool (*sorter)(const CSCCorrelatedLCTDigi&, const CSCCorrelatedLCTDigi&)) const;
-  void sortLCTs(std::vector<CSCCorrelatedLCTDigi>&, enum CSCPart,
+  void sortLCTs(std::vector<CSCCorrelatedLCTDigi>&,
                 bool (*sorter)(const CSCCorrelatedLCTDigi&, const CSCCorrelatedLCTDigi&)) const;
 
   /* check if an ALCT cross a CLCT in an ME11 sector */
-  bool doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c, int me) const;
+  bool doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c) const;
 
   /* correlate a pair of ALCTs and a pair of CLCTs with matched pads or copads
      the output is up to two LCTs in a sector of ME11 */
@@ -79,19 +66,10 @@ class CSCGEMMotherboardME11 : public CSCGEMMotherboard
                         const GEMPadDigiIds& pads,
                         const GEMCoPadDigiIds& copads,
                         CSCCorrelatedLCTDigi& lct1,
-                        CSCCorrelatedLCTDigi& lct2,
-                        enum CSCPart p) const;
-
-  /* store the LCTs found separately in ME1a and ME1b */
-  LCTContainer allLCTs1b;
-  LCTContainer allLCTs1a;
-
-  /** SLHC: special configuration parameters for ME11 treatment. */
-  bool smartME1aME1b, disableME1a, gangedME1a;
+                        CSCCorrelatedLCTDigi& lct2) const;
 
   /* store the CLCTs found separately in ME1a and ME1b */
-  std::vector<CSCCLCTDigi> clctV1a;
-  std::vector<CSCCLCTDigi> clctV1b;
+  std::vector<CSCCLCTDigi> clctV;
 
   // Drop low quality stubs if they don't have GEMs
   bool dropLowQualityCLCTsNoGEMs_ME1a_;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.h
@@ -28,10 +28,6 @@ class CSCGEMMotherboardME21 : public CSCGEMMotherboard
   /** Default destructor. */
   ~CSCGEMMotherboardME21() override;
 
-  /** Clears correlated LCT and passes clear signal on to cathode and anode
-      LCT processors. */
-  void clear();
-
   /** Run function for normal usage.  Runs cathode and anode LCT processors,
       takes results and correlates into CorrelatedLCT. */
   void run(const CSCWireDigiCollection* wiredc,
@@ -56,15 +52,7 @@ class CSCGEMMotherboardME21 : public CSCGEMMotherboard
                         const GEMPadDigiIds& pads,
                         const GEMCoPadDigiIds& copads,
                         CSCCorrelatedLCTDigi& lct1,
-                        CSCCorrelatedLCTDigi& lct2,
-                        enum CSCPart p) const;
-
-  /** for the case when more than 2 LCTs/BX are allowed;
-      maximum match window = 15 */
-  LCTContainer allLCTs;
-
-  /* store the CLCTs found earlier */
-  std::vector<CSCCLCTDigi> clctV;
+                        CSCCorrelatedLCTDigi& lct2) const;
 
   // drop low quality stubs if they don't have GEMs
   bool dropLowQualityCLCTsNoGEMs_;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.h
@@ -7,8 +7,6 @@ class CSCMotherboardME3141 : public CSCUpgradeMotherboard
 {
 public:
 
-  enum Default_values{DEFAULT_MATCHING_VALUE = -99};
-
   // standard constructor
   CSCMotherboardME3141(unsigned endcap, unsigned station, unsigned sector,
                     unsigned subsector, unsigned chamber,
@@ -18,9 +16,6 @@ public:
   CSCMotherboardME3141();
 
   ~CSCMotherboardME3141() override;
-
-  // clear stored pads and copads
-  void clear();
 
   // run TMB with GEM pad clusters as input
   void run(const CSCWireDigiCollection* wiredc,
@@ -32,14 +27,6 @@ public:
 
   /* readout the two best LCTs in this CSC */
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs() const;
-
-  /* store the CLCTs found earlier */
-  std::vector<CSCCLCTDigi> clctV;
-
- private:
-  /** for the case when more than 2 LCTs/BX are allowed;
-      maximum match window = 15 */
-  LCTContainer allLCTs;
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -50,9 +50,9 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
 
   // special configuration parameters for ME11 treatment
   edm::ParameterSet commonParams = conf.getParameter<edm::ParameterSet>("commonParam");
-  smartME1aME1b = commonParams.getParameter<bool>("smartME1aME1b");
-  disableME1a = commonParams.getParameter<bool>("disableME1a");
-  disableME42 = commonParams.getParameter<bool>("disableME42");
+  isSLHC_ = commonParams.getParameter<bool>("isSLHC");
+  disableME1a_ = commonParams.getParameter<bool>("disableME1a");
+  disableME42_ = commonParams.getParameter<bool>("disableME42");
 
   checkBadChambers_ = conf.getParameter<bool>("checkBadChambers");
 
@@ -79,7 +79,7 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
                 (subs <= 0 || subs > MAX_SUBSECTORS) ||
                 (cham <= 0 || cham > MAX_CHAMBERS))
             {
-              edm::LogError("L1CSCTPEmulatorSetupError")
+              edm::LogError("CSCTriggerPrimitivesBuilder|SetupError")
                 << "+++ trying to instantiate TMB of illegal CSC id ["
                 << " endcap = "  << endc << " station = "   << stat
                 << " sector = "  << sect << " subsector = " << subs
@@ -89,9 +89,9 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
             int ring = CSCTriggerNumbering::ringFromTriggerLabels(stat, cham);
             // When the motherboard is instantiated, it instantiates ALCT
             // and CLCT processors.
-            if (stat==1 && ring==1 && smartME1aME1b && !runME11ILT_)
+            if (stat==1 && ring==1 && isSLHC_ && !runME11ILT_)
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCMotherboardME11(endc, stat, sect, subs, cham, conf) );
-            else if (stat==1 && ring==1 && smartME1aME1b && runME11ILT_)
+            else if (stat==1 && ring==1 && isSLHC_ && runME11ILT_)
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCGEMMotherboardME11(endc, stat, sect, subs, cham, conf) );
             else if (stat==2 && ring==1 && runME21ILT_)
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCGEMMotherboardME21(endc, stat, sect, subs, cham, conf) );
@@ -106,8 +106,8 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
   }
 
   // Get min and max BX to sort LCTs in MPC.
-  m_minBX = conf.getParameter<int>("MinBX");
-  m_maxBX = conf.getParameter<int>("MaxBX");
+  m_minBX_ = conf.getParameter<int>("MinBX");
+  m_maxBX_ = conf.getParameter<int>("MaxBX");
 
   // Init MPC
   m_muonportcard.reset( new CSCMuonPortCard(conf) );
@@ -185,7 +185,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
             int ring = CSCTriggerNumbering::ringFromTriggerLabels(stat, cham);
 
             // case when you want to ignore ME42
-            if (disableME42 && stat==4 && ring==2) continue;
+            if (disableME42_ && stat==4 && ring==2) continue;
 
             CSCMotherboard* tmb = tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].get();
 
@@ -206,7 +206,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 
 
             // running upgraded ME1/1 TMBs
-            if (stat==1 && ring==1 && smartME1aME1b && !runME11ILT_)
+            if (stat==1 && ring==1 && isSLHC_ && !runME11ILT_)
             {
               // run the TMB
               CSCMotherboardME11* tmb11 = static_cast<CSCMotherboardME11*>(tmb);
@@ -214,28 +214,19 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               tmb11->run(wiredc,compdc);
 
               // get all collections
+              // all ALCTs, CLCTs, LCTs are written with detid ring = 1, as data did
+              // but CLCTs and LCTs are written sperately in ME1a and ME1b, considering whether ME1a is disabled or not
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb11->readoutLCTs1b();
               const std::vector<CSCCorrelatedLCTDigi>& lctV1a = tmb11->readoutLCTs1a();
-              std::vector<CSCALCTDigi> alctV1a, alctV = tmb11->alct->readoutALCTs();
-              const std::vector<CSCCLCTDigi>& clctV = tmb11->clct->readoutCLCTs();
-              const std::vector<int> preTriggerBXs = tmb11->clct->preTriggerBXs();
-              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11->clct->preTriggerDigis();
-              const std::vector<CSCCLCTDigi>& clctV1a = tmb11->clct1a->readoutCLCTs();
-              const std::vector<int> preTriggerBXs1a = tmb11->clct1a->preTriggerBXs();
-              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV1a = tmb11->clct1a->preTriggerDigis();
-
-              // perform simple separation of ALCTs into 1/a and 1/b
-              // for 'smart' case. Some duplication occurs for WG [10,15]
-              std::vector<CSCALCTDigi> tmpV(alctV);
-              alctV.clear();
-              for (unsigned int al=0; al < tmpV.size(); al++)
-              {
-                if (tmpV[al].getKeyWG()<=15) alctV1a.push_back(tmpV[al]);
-                if (tmpV[al].getKeyWG()>=10) alctV.push_back(tmpV[al]);
-              }
+              const std::vector<CSCALCTDigi>& alctV = tmb11->alctProc->readoutALCTs();
+              const std::vector<CSCCLCTDigi>& clctV = tmb11->clctProc->readoutCLCTsME1b();
+              const std::vector<int> preTriggerBXs = tmb11->clctProc->preTriggerBXs();
+              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11->clctProc->preTriggerDigisME1b();
+              const std::vector<CSCCLCTDigi>& clctV1a = tmb11->clctProc->readoutCLCTsME1a();
+              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV1a = tmb11->clctProc->preTriggerDigisME1a();
 
               LogTrace("CSCTriggerPrimitivesBuilder")<<"CSCTriggerPrimitivesBuilder:: a="<<alctV.size()<<" c="<<clctV.size()<<" l="<<lctV.size()
-                                                     <<"   1a: a="<<alctV1a.size()<<" c="<<clctV1a.size()<<" l="<<lctV1a.size();
+                                                     <<" c="<<clctV1a.size()<<" l="<<lctV1a.size();
 
               // ME1/b
 
@@ -253,24 +244,23 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 
               // ME1/a
 
-              if (disableME1a) continue;
+              if (disableME1a_) continue;
 
               CSCDetId detid1a(endc, stat, 4, chid, 0);
 
-              if (!(lctV1a.empty()&&alctV1a.empty()&&clctV1a.empty())){
+              //if (!(lctV1a.empty()&&alctV1a.empty()&&clctV1a.empty())){
+              if (!(lctV1a.empty() && clctV1a.empty())){
                 LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder results in " <<detid1a;
               }
 
-              // put collections in event
-              put(lctV1a, oc_lct, detid1a, " ME1a LCT digi");
-              put(alctV1a, oc_alct, detid1a, " ME1a ALCT digi");
-              put(clctV1a, oc_clct, detid1a, " ME1a CLCT digi");
-              put(pretriggerV1a, oc_pretrigger, detid1a, " ME1a CLCT pre-trigger digi");
-              put(preTriggerBXs1a, oc_pretrig, detid1a, " ME1a CLCT pre-trigger BX");
+              // put collections in event, still use detid ring =1
+              put(lctV1a, oc_lct, detid, " ME1a LCT digi");
+              put(clctV1a, oc_clct, detid, " ME1a CLCT digi");
+              put(pretriggerV1a, oc_pretrigger, detid, " ME1a CLCT pre-trigger digi");
             } // upgraded TMB
 
             // running upgraded ME1/1 TMBs with GEMs
-            else if (stat==1 && ring==1 && smartME1aME1b && runME11ILT_)
+            else if (stat==1 && ring==1 && isSLHC_ && runME11ILT_)
             {
               // run the TMB
               CSCGEMMotherboardME11* tmb11GEM = static_cast<CSCGEMMotherboardME11*>(tmb);
@@ -285,26 +275,13 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb11GEM->readoutLCTs1b();
               const std::vector<CSCCorrelatedLCTDigi>& lctV1a = tmb11GEM->readoutLCTs1a();
-              std::vector<CSCALCTDigi> alctV1a, alctV = tmb11GEM->alct->readoutALCTs();
-              const std::vector<CSCCLCTDigi>& clctV = tmb11GEM->clct->readoutCLCTs();
-              const std::vector<int>& preTriggerBXs = tmb11GEM->clct->preTriggerBXs();
-              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11GEM->clct->preTriggerDigis();
-              const std::vector<CSCCLCTDigi>& clctV1a = tmb11GEM->clct1a->readoutCLCTs();
-              const std::vector<int>& preTriggerBXs1a = tmb11GEM->clct1a->preTriggerBXs();
-              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV1a = tmb11GEM->clct1a->preTriggerDigis();
+              const std::vector<CSCALCTDigi> alctV = tmb11GEM->alctProc->readoutALCTs();
+              const std::vector<CSCCLCTDigi>& clctV = tmb11GEM->clctProc->readoutCLCTsME1b();
+              const std::vector<int>& preTriggerBXs = tmb11GEM->clctProc->preTriggerBXs();
+              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11GEM->clctProc->preTriggerDigisME1b();
+              const std::vector<CSCCLCTDigi>& clctV1a = tmb11GEM->clctProc->readoutCLCTsME1a();
+              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV1a = tmb11GEM->clctProc->preTriggerDigisME1a();
               const std::vector<GEMCoPadDigi>& copads = tmb11GEM->coPadProcessor->readoutCoPads();
-
-              // perform simple separation of ALCTs into 1/a and 1/b
-              // for 'smart' case. Some duplication occurs for WG [10,15]
-              std::vector<CSCALCTDigi> tmpV(alctV);
-              alctV.clear();
-              for (unsigned int al=0; al < tmpV.size(); al++)
-                {
-                  if (tmpV[al].getKeyWG()<=15) alctV1a.push_back(tmpV[al]);
-                  if (tmpV[al].getKeyWG()>=10) alctV.push_back(tmpV[al]);
-                }
-              //LogTrace("CSCTriggerPrimitivesBuilder")<<"CSCTriggerPrimitivesBuilder:: a="<<alctV.size()<<" c="<<clctV.size()<<" l="<<lctV.size()
-              //  <<"   1a: a="<<alctV1a.size()<<" c="<<clctV1a.size()<<" l="<<lctV1a.size();
 
               // ME1/b
               if (!(lctV.empty()&&alctV.empty()&&clctV.empty())) {
@@ -321,20 +298,18 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(copads, oc_gemcopad, gemId, " GEM coincidence pad");
 
               // ME1/a
-              if (disableME1a) continue;
+              if (disableME1a_) continue;
 
               CSCDetId detid1a(endc, stat, 4, chid, 0);
 
-              if (!(lctV1a.empty()&&alctV1a.empty()&&clctV1a.empty())){
+              if (!(lctV1a.empty() && clctV1a.empty())){
                 LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder results in " <<detid1a;
               }
 
-              // put collections in event
-              put(lctV1a, oc_lct, detid1a, " ME1a LCT digi");
-              put(alctV1a, oc_alct, detid1a, " ME1a ALCT digi");
-              put(clctV1a, oc_clct, detid1a, " ME1a CLCT digi");
-              put(pretriggerV1a, oc_pretrigger, detid1a, " ME1a CLCT pre-trigger digi");
-              put(preTriggerBXs1a, oc_pretrig, detid1a, " ME1a CLCT pre-trigger BX");
+              // put collections in event, still use detid ring =1
+              put(lctV1a, oc_lct, detid, " ME1a LCT digi");
+              put(clctV1a, oc_clct, detid, " ME1a CLCT digi");
+              put(pretriggerV1a, oc_pretrigger, detid, " ME1a CLCT pre-trigger digi");
             }
 
             // running upgraded ME2/1 TMBs
@@ -351,10 +326,10 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb21GEM->readoutLCTs();
-              const std::vector<CSCALCTDigi>& alctV = tmb21GEM->alct->readoutALCTs();
-              const std::vector<CSCCLCTDigi>& clctV = tmb21GEM->clct->readoutCLCTs();
-              const std::vector<int>& preTriggerBXs = tmb21GEM->clct->preTriggerBXs();
-              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb21GEM->clct->preTriggerDigis();
+              const std::vector<CSCALCTDigi>& alctV = tmb21GEM->alctProc->readoutALCTs();
+              const std::vector<CSCCLCTDigi>& clctV = tmb21GEM->clctProc->readoutCLCTs();
+              const std::vector<int>& preTriggerBXs = tmb21GEM->clctProc->preTriggerBXs();
+              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb21GEM->clctProc->preTriggerDigis();
               const std::vector<GEMCoPadDigi>& copads = tmb21GEM->coPadProcessor->readoutCoPads();
 
               if (!(alctV.empty() && clctV.empty() && lctV.empty())) {
@@ -380,10 +355,10 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb3141->readoutLCTs();
-              const std::vector<CSCALCTDigi>& alctV = tmb3141->alct->readoutALCTs();
-              const std::vector<CSCCLCTDigi>& clctV = tmb3141->clct->readoutCLCTs();
-              const std::vector<int>& preTriggerBXs = tmb3141->clct->preTriggerBXs();
-              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb3141->clct->preTriggerDigis();
+              const std::vector<CSCALCTDigi>& alctV = tmb3141->alctProc->readoutALCTs();
+              const std::vector<CSCCLCTDigi>& clctV = tmb3141->clctProc->readoutCLCTs();
+              const std::vector<int>& preTriggerBXs = tmb3141->clctProc->preTriggerBXs();
+              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb3141->clctProc->preTriggerDigis();
 
               if (!(alctV.empty() && clctV.empty() && lctV.empty())) {
                 LogTrace("L1CSCTrigger")
@@ -406,10 +381,10 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb->readoutLCTs();
-              const std::vector<CSCALCTDigi>& alctV = tmb->alct->readoutALCTs();
-              const std::vector<CSCCLCTDigi>& clctV = tmb->clct->readoutCLCTs();
-              const std::vector<int>& preTriggerBXs = tmb->clct->preTriggerBXs();
-              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb->clct->preTriggerDigis();
+              const std::vector<CSCALCTDigi>& alctV = tmb->alctProc->readoutALCTs();
+              const std::vector<CSCCLCTDigi>& clctV = tmb->clctProc->readoutCLCTs();
+              const std::vector<int>& preTriggerBXs = tmb->clctProc->preTriggerBXs();
+              const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb->clctProc->preTriggerDigis();
 
               if (!(alctV.empty() && clctV.empty() && lctV.empty())) {
                 LogTrace("L1CSCTrigger")
@@ -436,7 +411,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
   // sort the LCTs per sector
   // insert them into the result vector
   std::vector<csctf::TrackStub> result;
-  for(int bx = m_minBX; bx <= m_maxBX; ++bx)
+  for(int bx = m_minBX_; bx <= m_maxBX_; ++bx)
     for(int e = min_endcap; e <= max_endcap; ++e)
       for(int st = min_station; st <= max_station; ++st)
         for(int se = min_sector; se <= max_sector; ++se)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -275,7 +275,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb11GEM->readoutLCTs1b();
               const std::vector<CSCCorrelatedLCTDigi>& lctV1a = tmb11GEM->readoutLCTs1a();
-              const std::vector<CSCALCTDigi> alctV = tmb11GEM->alctProc->readoutALCTs();
+              const std::vector<CSCALCTDigi>& alctV = tmb11GEM->alctProc->readoutALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb11GEM->clctProc->readoutCLCTsME1b();
               const std::vector<int>& preTriggerBXs = tmb11GEM->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11GEM->clctProc->preTriggerDigisME1b();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -93,9 +93,9 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCMotherboardME11(endc, stat, sect, subs, cham, conf) );
             else if (stat==1 && ring==1 && isSLHC_ && runME11ILT_)
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCGEMMotherboardME11(endc, stat, sect, subs, cham, conf) );
-            else if (stat==2 && ring==1 && runME21ILT_)
+            else if (stat==2 && ring==1 && isSLHC_ && runME21ILT_)
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCGEMMotherboardME21(endc, stat, sect, subs, cham, conf) );
-            else if ((stat==3 || stat==4) && ring==1 && runME3141ILT_)
+            else if ((stat==3 || stat==4) && ring==1 && isSLHC_ && runME3141ILT_)
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCMotherboardME3141(endc, stat, sect, subs, cham, conf) );
             else
               tmb_[endc-1][stat-1][sect-1][subs-1][cham-1].reset( new CSCMotherboard(endc, stat, sect, subs, cham, conf) );
@@ -313,7 +313,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
             }
 
             // running upgraded ME2/1 TMBs
-            else if (stat==2 && ring==1 && runME21ILT_)
+            else if (stat==2 && ring==1 && isSLHC_ && runME21ILT_)
             {
               // run the TMB
               CSCGEMMotherboardME21* tmb21GEM = static_cast<CSCGEMMotherboardME21*>(tmb);
@@ -346,7 +346,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(copads, oc_gemcopad, gemId, " GEM coincidence pad");
             }
             // running upgraded ME3/1-ME4/1 TMBs
-            else if ((stat==3 or stat==4) && ring==1 && runME3141ILT_)
+            else if ((stat==3 or stat==4) && ring==1 && isSLHC_ && runME3141ILT_)
             {
               // run the TMB
               CSCMotherboardME3141* tmb3141 = static_cast<CSCMotherboardME3141*>(tmb);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
@@ -101,10 +101,13 @@ class CSCTriggerPrimitivesBuilder
   bool checkBadChambers_;
 
   /** SLHC: special configuration parameters for ME11 treatment. */
-  bool smartME1aME1b, disableME1a;
+  bool isSLHC_;
 
   /** SLHC: special switch for disabling ME42 */
-  bool disableME42;
+  bool disableME1a_;
+
+  /** SLHC: special switch for disabling ME42 */
+  bool disableME42_;
 
   /** SLHC: special switch for the upgrade ME1/1 TMB */
   bool runME11ILT_;
@@ -118,7 +121,7 @@ class CSCTriggerPrimitivesBuilder
   /** SLHC: special switch to use gem clusters */
   bool useClusters_;
 
-  int m_minBX, m_maxBX; // min and max BX to sort.
+  int m_minBX_, m_maxBX_; // min and max BX to sort.
 
   /** Pointers to TMB processors for all possible chambers. */
   std::unique_ptr<CSCMotherboard>

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -18,10 +18,13 @@ CSCUpgradeMotherboard::LCTContainer::getTimeMatched(const int bx,
 {
   for (unsigned int mbx = 0; mbx < match_trig_window_size_; mbx++) {
     for (int i=0;i<2;i++) {
-      //remove duplicated LCTs
-      if (data[bx][mbx][i].isValid() and std::find(lcts.begin(), lcts.end(), data[bx][mbx][i]) == lcts.end()) {
-        lcts.push_back(data[bx][mbx][i]);
-      }
+      // consider only valid LCTs
+      if (not data[bx][mbx][i].isValid()) continue;
+
+      // remove duplicated LCTs
+      if (std::find(lcts.begin(), lcts.end(), data[bx][mbx][i]) != lcts.end()) continue;
+
+      lcts.push_back(data[bx][mbx][i]);
     }
   }
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -2,7 +2,7 @@
 #include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
 
 CSCUpgradeMotherboard::LCTContainer::LCTContainer(unsigned int trig_window_size)
-  : match_trig_window_size(trig_window_size)
+  : match_trig_window_size_(trig_window_size)
 {
 }
 
@@ -14,12 +14,16 @@ CSCUpgradeMotherboard::LCTContainer::operator()(int bx, int match_bx, int lct)
 
 void
 CSCUpgradeMotherboard::LCTContainer::getTimeMatched(const int bx,
-						    std::vector<CSCCorrelatedLCTDigi>& lcts) const
+                                                    std::vector<CSCCorrelatedLCTDigi>& lcts) const
 {
-  for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
-    for (int i=0;i<2;i++)
-      if (data[bx][mbx][i].isValid())
+  for (unsigned int mbx = 0; mbx < match_trig_window_size_; mbx++) {
+    for (int i=0;i<2;i++) {
+      //remove duplicated LCTs
+      if (data[bx][mbx][i].isValid() and std::find(lcts.begin(), lcts.end(), data[bx][mbx][i]) == lcts.end()) {
         lcts.push_back(data[bx][mbx][i]);
+      }
+    }
+  }
 }
 
 void
@@ -32,24 +36,40 @@ CSCUpgradeMotherboard::LCTContainer::getMatched(std::vector<CSCCorrelatedLCTDigi
   }
 }
 
-CSCUpgradeMotherboard::CSCUpgradeMotherboard(unsigned endcap, unsigned station,
-						   unsigned sector, unsigned subsector,
-						   unsigned chamber,
-						   const edm::ParameterSet& conf) :
-  CSCMotherboard(endcap, station, sector, subsector, chamber, conf)
+void
+CSCUpgradeMotherboard::LCTContainer::clear()
 {
-  if (!isSLHC) edm::LogError("L1CSCTPEmulatorConfigError")
-    << "+++ Upgrade CSCUpgradeMotherboard constructed while isSLHC is not set! +++\n";
+  // Loop over all time windows
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
+    // Loop over all matched trigger windows
+    for (unsigned int mbx = 0; mbx < match_trig_window_size_; mbx++) {
+      // Loop over all stubs
+      for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++) {
+        data[bx][mbx][i].clear();
+      }
+    }
+  }
+}
+
+CSCUpgradeMotherboard::CSCUpgradeMotherboard(unsigned endcap, unsigned station,
+                                             unsigned sector, unsigned subsector,
+                                             unsigned chamber,
+                                             const edm::ParameterSet& conf) :
+  // special configuration parameters for ME11 treatment
+  CSCMotherboard(endcap, station, sector, subsector, chamber, conf)
+  , allLCTs(match_trig_window_size)
+  // special configuration parameters for ME11 treatment
+  , disableME1a(commonParams_.getParameter<bool>("disableME1a"))
+  , gangedME1a(commonParams_.getParameter<bool>("gangedME1a"))
+{
+  if (!isSLHC_) edm::LogError("CSCUpgradeMotherboard|ConfigError")
+    << "+++ Upgrade CSCUpgradeMotherboard constructed while isSLHC_ is not set! +++\n";
 
   theRegion = (theEndcap == 1) ? 1: -1;
   theChamber = CSCTriggerNumbering::chamberFromTriggerLabels(theSector,theSubsector,theStation,theTrigChamber);
   par = theChamber%2==0 ? Parity::Even : Parity::Odd;
 
-  commonParams_ = conf.getParameter<edm::ParameterSet>("commonParam");
-  if (theStation==1) tmbParams_ = conf.getParameter<edm::ParameterSet>("me11tmbSLHCGEM");
-  else if (theStation==2) tmbParams_ = conf.getParameter<edm::ParameterSet>("me21tmbSLHCGEM");
-  else if (theStation==3 or theStation==4) tmbParams_ = conf.getParameter<edm::ParameterSet>("me3141tmbSLHC");
-
+  // generate the LUTs
   generator_.reset(new CSCUpgradeMotherboardLUTGenerator());
 
   match_earliest_alct_only = tmbParams_.getParameter<bool>("matchEarliestAlctOnly");
@@ -61,26 +81,45 @@ CSCUpgradeMotherboard::CSCUpgradeMotherboard(unsigned endcap, unsigned station,
   debug_matching = tmbParams_.getParameter<bool>("debugMatching");
   debug_luts = tmbParams_.getParameter<bool>("debugLUTs");
 
-  pref[0] = match_trig_window_size/2;
-  for (unsigned int m=2; m<match_trig_window_size; m+=2)
-  {
-    pref[m-1] = pref[0] - m/2;
-    pref[m]   = pref[0] + m/2;
-  }
+  setPrefIndex();
 }
 
-CSCUpgradeMotherboard::CSCUpgradeMotherboard() : CSCMotherboard()
+CSCUpgradeMotherboard::CSCUpgradeMotherboard()
+  : CSCMotherboard()
+  , allLCTs(match_trig_window_size)
 {
-  pref[0] = match_trig_window_size/2;
-  for (unsigned int m=2; m<match_trig_window_size; m+=2)
-  {
-    pref[m-1] = pref[0] - m/2;
-    pref[m]   = pref[0] + m/2;
-  }
+  if (!isSLHC_) edm::LogError("CSCUpgradeMotherboard|ConfigError")
+    << "+++ Upgrade CSCUpgradeMotherboard constructed while isSLHC_ is not set! +++\n";
+
+  setPrefIndex();
 }
 
 CSCUpgradeMotherboard::~CSCUpgradeMotherboard()
 {
+}
+
+enum CSCPart CSCUpgradeMotherboard::getCSCPart(int keystrip) const
+{
+  if (theStation == 1 and (theRing ==1 or theRing == 4)){
+    if (keystrip > CSCConstants::MAX_HALF_STRIP_ME1B){
+      if ( !gangedME1a )
+        return CSCPart::ME1Ag;
+      else
+        return CSCPart::ME1A;
+    }else if (keystrip <= CSCConstants::MAX_HALF_STRIP_ME1B and keystrip >= 0)
+      return CSCPart::ME1B;
+    else
+      return CSCPart::ME11;
+  }else if (theStation == 2 and theRing == 1 )
+    return CSCPart::ME21;
+  else if  (theStation == 3 and theRing == 1 )
+    return CSCPart::ME31;
+  else if (theStation == 4 and theRing == 1 )
+    return CSCPart::ME41;
+  else{
+    edm::LogError("CSCUpgradeMotherboard|Error") <<" ++ getCSCPart() failed to find the CSC chamber for in case ";
+    return  CSCPart::ME11;// return ME11 by default
+  }
 }
 
 void CSCUpgradeMotherboard::debugLUTs()
@@ -113,4 +152,22 @@ void CSCUpgradeMotherboard::setupGeometry()
   const CSCDetId csc_id(theEndcap, theStation, theStation, chid, 0);
   cscChamber = csc_g->chamber(csc_id);
   generator_->setCSCGeometry(csc_g);
+}
+
+
+void CSCUpgradeMotherboard::setPrefIndex()
+{
+  pref[0] = match_trig_window_size/2;
+  for (unsigned int m=2; m<match_trig_window_size; m+=2)
+  {
+    pref[m-1] = pref[0] - m/2;
+    pref[m]   = pref[0] + m/2;
+  }
+}
+
+
+void CSCUpgradeMotherboard::clear()
+{
+  CSCMotherboard::clear();
+  allLCTs.clear();
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.h
@@ -56,11 +56,14 @@ public:
     // get all LCTs in the 16 BX readout window
     void getMatched(std::vector<CSCCorrelatedLCTDigi>&) const;
 
+    // clear the array with stubs
+    void clear();
+
     // array with stored LCTs
     CSCCorrelatedLCTDigi data[CSCConstants::MAX_LCT_TBINS][15][2];
 
     // matching trigger window
-    const unsigned int match_trig_window_size;
+    const unsigned int match_trig_window_size_;
   };
 
   // standard constructor
@@ -72,6 +75,9 @@ public:
   CSCUpgradeMotherboard();
 
   ~CSCUpgradeMotherboard() override;
+
+  // Empty the LCT container
+  void clear();
 
   // Compare two matches of type <ID,DIGI>
   // The template is match<GEMPadDigi> or match<GEMCoPadDigi>
@@ -94,25 +100,36 @@ public:
                 bool (*sorter)(const CSCCorrelatedLCTDigi&,
                                const CSCCorrelatedLCTDigi&)) const;
 
+  /** get CSCPart from HS, station, ring number **/
+  enum CSCPart getCSCPart(int keystrip) const;
+
   // functions to setup geometry and LUTs
-  void setCSCGeometry(const CSCGeometry *g) { csc_g = g; }
   void setupGeometry();
   void debugLUTs();
 
  protected:
+
+  void setPrefIndex();
+
+  /** for the case when more than 2 LCTs/BX are allowed;
+      maximum match window = 15 */
+  LCTContainer allLCTs;
 
   /** Chamber id (trigger-type labels). */
   unsigned theRegion;
   unsigned theChamber;
   Parity par;
 
+  /** SLHC: special configuration parameters for ME11 treatment. */
+  bool disableME1a, gangedME1a;
+
+  /* Parameters for the TMB */
   edm::ParameterSet tmbParams_;
+
+  /* Parameters common to TMB and processors */
   edm::ParameterSet commonParams_;
 
-  const CSCGeometry* csc_g;
   const CSCChamber* cscChamber;
-
-  std::vector<CSCALCTDigi> alctV;
 
   std::unique_ptr<CSCUpgradeMotherboardLUTGenerator> generator_;
 
@@ -122,14 +139,7 @@ public:
   bool match_earliest_alct_only;
   bool match_earliest_clct_only;
 
-  /** if true: use regular CLCT-to-ALCT matching in TMB
-      if false: do ALCT-to-CLCT matching */
-  bool clct_to_alct;
-
-  /** whether to not reuse CLCTs that were used by previous matching ALCTs
-      in ALCT-to-CLCT algorithm */
-  bool drop_used_clcts;
-
+  /* type of algorithm to sort the stubs */
   unsigned int tmb_cross_bx_algo;
 
   /** maximum lcts per BX in MEX1: 2, 3, 4 or 999 */

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.h
@@ -123,12 +123,6 @@ public:
   /** SLHC: special configuration parameters for ME11 treatment. */
   bool disableME1a, gangedME1a;
 
-  /* Parameters for the TMB */
-  edm::ParameterSet tmbParams_;
-
-  /* Parameters common to TMB and processors */
-  edm::ParameterSet commonParams_;
-
   const CSCChamber* cscChamber;
 
   std::unique_ptr<CSCUpgradeMotherboardLUTGenerator> generator_;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.cc
@@ -1,5 +1,83 @@
 #include "L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.h"
 
+CSCMotherboardLUTME11::CSCMotherboardLUTME11()
+{
+  // Keep in mind that ME1A is considered an extension of ME1B
+  // This means that ME1A half-strips start at 128 and end at 223
+  lut_wg_vs_hs_me1a  =  {
+    {128,223},{128,223},{128,223},{128,223},{128,223},
+    {128,223},{128,223},{128,223},{128,223},{128,223},
+    {128,223},{128,223},{128,205},{128,189},{128,167},
+    {128,150},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1}
+  };
+  // When the half-strips are triple-ganged, (Run-1)
+  // ME1A half-strips go from 128 to 159
+  lut_wg_vs_hs_me1ag =  {
+    {128,159},{128,159},{128,159},{128,159},{128,159},
+    {128,159},{128,159},{128,159},{128,159},{128,159},
+    {128,159},{128,159},{128,159},{128,159},{128,159},
+    {128,150},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1}
+  };
+  // ME1B half-strips start at 0 and end at 127
+  lut_wg_vs_hs_me1b  =  {
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
+    {100, 127},{73, 127},{47, 127},{22, 127},{0, 127},
+    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
+    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
+    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
+    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
+    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
+    {0, 127},{0, 127},{0, 127},{0, 127},{0, 105},
+    {0, 93},{0, 78},{0, 63}
+  };
+}
+ bool
+ CSCMotherboardLUTME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c,
+                                          int theEndcap, bool gangedME1a) const
+ {
+   if ( !c.isValid() || !a.isValid() ) return false;
+   int key_hs = c.getKeyStrip();
+   int key_wg = a.getKeyWG();
+   if ( key_hs >= CSCConstants::MAX_HALF_STRIP_ME1B )
+     {
+       if ( !gangedME1a )
+         {
+           // wrap around ME11 HS number for -z endcap
+           if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_UNGANGED - key_hs;
+           if ( key_hs >= lut_wg_vs_hs_me1a[key_wg][0] &&
+                key_hs <= lut_wg_vs_hs_me1a[key_wg][1]    ) return true;
+           return false;
+         }
+       else
+         {
+           if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_GANGED - key_hs;
+           if ( key_hs >= lut_wg_vs_hs_me1ag[key_wg][0] &&
+                key_hs <= lut_wg_vs_hs_me1ag[key_wg][1]    ) return true;
+           return false;
+         }
+     }
+   if ( key_hs < CSCConstants::MAX_HALF_STRIP_ME1B )
+     {
+       if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1B - key_hs;
+       if ( key_hs >= lut_wg_vs_hs_me1b[key_wg][0] &&
+            key_hs <= lut_wg_vs_hs_me1b[key_wg][1]      ) return true;
+     }
+   return false;
+ }
+
 CSCGEMMotherboardLUT::CSCGEMMotherboardLUT()
   : lut_wg_eta_odd(0)
   , lut_wg_eta_even(0)
@@ -57,14 +135,6 @@ CSCGEMMotherboardLUTME11::get_csc_hs_to_gem_pad(Parity par, enum CSCPart p) cons
   else                  { return par==Parity::Even ? csc_hs_to_gem_pad_me1b_even : csc_hs_to_gem_pad_me1b_odd; }
 }
 
-std::vector<std::vector<double> >
-CSCGEMMotherboardLUTME11::get_lut_wg_vs_hs(enum CSCPart p) const
-{
-  if (p==CSCPart::ME1A)      { return lut_wg_vs_hs_me1a;  }
-  else if (p==CSCPart::ME1B) { return lut_wg_vs_hs_me1b;  }
-  else                       { return lut_wg_vs_hs_me1ag; }
-}
-
 CSCGEMMotherboardLUT::~CSCGEMMotherboardLUT()
 {
 }
@@ -104,45 +174,6 @@ CSCGEMMotherboardLUTME11::CSCGEMMotherboardLUTME11()
     {20, 0.00535176, 0.00276152},
     {30, 0.00389050, 0.00224959},
     {40, 0.00329539, 0.00204670}
-  };
-
-  lut_wg_vs_hs_me1a  =  {
-    {0, 95},{0, 95},{0, 95},{0, 95},{0, 95},
-    {0, 95},{0, 95},{0, 95},{0, 95},{0, 95},
-    {0, 95},{0, 95},{0, 77},{0, 61},{0, 39},
-    {0, 22},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1}
-  };
-
-  lut_wg_vs_hs_me1ag =  {
-    {0, 31},{0, 31},{0, 31},{0, 31},{0, 31},
-    {0, 31},{0, 31},{0, 31},{0, 31},{0, 31},
-    {0, 31},{0, 31},{0, 31},{0, 31},{0, 31},
-    {0, 22},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1}
-  };
-
-  lut_wg_vs_hs_me1b  =  {
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
-    {100, 127},{73, 127},{47, 127},{22, 127},{0, 127},
-    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
-    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
-    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
-    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
-    {0, 127},{0, 127},{0, 127},{0, 127},{0, 127},
-    {0, 127},{0, 127},{0, 127},{0, 127},{0, 105},
-    {0, 93},{0, 78},{0, 63}
   };
 
   gem_roll_eta_limits_odd_l1 = {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.cc
@@ -44,14 +44,16 @@ CSCMotherboardLUTME11::CSCMotherboardLUTME11()
     {0, 93},{0, 78},{0, 63}
   };
 }
- bool
- CSCMotherboardLUTME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c,
-                                          int theEndcap, bool gangedME1a) const
+
+bool
+CSCMotherboardLUTME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c,
+                                         int theEndcap, bool gangedME1a) const
  {
    if ( !c.isValid() || !a.isValid() ) return false;
    int key_hs = c.getKeyStrip();
    int key_wg = a.getKeyWG();
-   if ( key_hs >= CSCConstants::MAX_HALF_STRIP_ME1B )
+   // ME1/a half-strip starts at 128
+   if ( key_hs > CSCConstants::MAX_HALF_STRIP_ME1B )
      {
        if ( !gangedME1a )
          {
@@ -69,7 +71,8 @@ CSCMotherboardLUTME11::CSCMotherboardLUTME11()
            return false;
          }
      }
-   if ( key_hs < CSCConstants::MAX_HALF_STRIP_ME1B )
+   // ME1/b half-strip ends at 127
+   if ( key_hs <= CSCConstants::MAX_HALF_STRIP_ME1B )
      {
        if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1B - key_hs;
        if ( key_hs >= lut_wg_vs_hs_me1b[key_wg][0] &&

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.cc
@@ -58,14 +58,29 @@ CSCMotherboardLUTME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi
        if ( !gangedME1a )
          {
            // wrap around ME11 HS number for -z endcap
-           if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_UNGANGED - key_hs;
+           if (theEndcap==2) {
+             // first subtract 128
+             key_hs -= 1 + CSCConstants::MAX_HALF_STRIP_ME1B;
+             // flip the HS
+             key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_UNGANGED - key_hs;
+             // then add 128 again
+             key_hs += 1 + CSCConstants::MAX_HALF_STRIP_ME1B;
+           }
            if ( key_hs >= lut_wg_vs_hs_me1a[key_wg][0] &&
                 key_hs <= lut_wg_vs_hs_me1a[key_wg][1]    ) return true;
            return false;
          }
        else
          {
-           if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_GANGED - key_hs;
+           // wrap around ME11 HS number for -z endcap
+           if (theEndcap==2) {
+             // first subtract 128
+             key_hs -= 1 + CSCConstants::MAX_HALF_STRIP_ME1B;
+             // flip the HS
+             key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_GANGED - key_hs;
+             // then add 128 again
+             key_hs += 1 + CSCConstants::MAX_HALF_STRIP_ME1B;
+           }
            if ( key_hs >= lut_wg_vs_hs_me1ag[key_wg][0] &&
                 key_hs <= lut_wg_vs_hs_me1ag[key_wg][1]    ) return true;
            return false;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.h
@@ -1,12 +1,36 @@
 #ifndef L1Trigger_CSCTriggerPrimitives_CSCUpgradeMotherboardLUT_h
 #define L1Trigger_CSCTriggerPrimitives_CSCUpgradeMotherboardLUT_h
 
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
+
 #include <vector>
 #include <map>
 
 /** labels for ME1a and ME1B */
 enum CSCPart {ME1B = 1, ME1A=4, ME21=21, ME1Ag, ME11, ME31, ME41};
 enum Parity {Even=0, Odd=1};
+
+class CSCMotherboardLUTME11
+{
+ public:
+  CSCMotherboardLUTME11();
+  ~CSCMotherboardLUTME11() {}
+  bool doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c,
+                         int theEndcap, bool gangedME1a = false) const;
+ private:
+  // LUT for which ME1/1 wire group can cross which ME1/a halfstrip
+  // 1st index: WG number
+  // 2nd index: inclusive HS range
+  //with "ag" a modified LUT for ganged ME1a
+  std::vector<std::vector<double> > lut_wg_vs_hs_me1a;
+  std::vector<std::vector<double> > lut_wg_vs_hs_me1ag;
+  // LUT for which ME1/1 wire group can cross which ME1/b halfstrip
+  // 1st index: WG number
+  // 2nd index: inclusive HS range
+  std::vector<std::vector<double> > lut_wg_vs_hs_me1b;
+};
 
 class CSCGEMMotherboardLUT
 {
@@ -66,15 +90,6 @@ class CSCGEMMotherboardLUTME11 : public CSCGEMMotherboardLUT
 
   std::vector<int> get_gem_pad_to_csc_hs(Parity par, enum CSCPart) const override;
   std::vector<std::pair<int,int> > get_csc_hs_to_gem_pad(Parity par, enum CSCPart) const override;
-  std::vector<std::vector<double> > get_lut_wg_vs_hs(enum CSCPart) const;
-
-  // LUT for which ME1/1 wire group can cross which ME1/a halfstrip
-  // 1st index: WG number
-  // 2nd index: inclusive HS range
-  //with "ag" a modified LUT for ganged ME1a
-  std::vector<std::vector<double> > lut_wg_vs_hs_me1a;
-  std::vector<std::vector<double> > lut_wg_vs_hs_me1ag;
-  std::vector<std::vector<double> > lut_wg_vs_hs_me1b;
 
   // map of GEM pad to CSC HS for ME1a chambers
   std::vector<int> gem_pad_to_csc_hs_me1a_odd;


### PR DESCRIPTION
This PR removes the option `smartME1aME1b` which would split up the ME1/1 cathode region in an ME1/a and an ME1/b region. The feature was developed several years ago in simulation intended for the SLHC version of the CSC local trigger algorithm. However, it was not developed in the Verilog firmware for data taking. In all likelihood it will not be developed in the future either. Because certain features in the SLHC algorithm are currently being tested on 2018D pp collision data, we decided to remove the `smartME1aME1b` feature in simulation to allow for accurate data vs emulator studies. 

In addition, I modified `CSCMotherboardME11` so that it inherits from `CSCUpgradeMotherboard`.  A redundant LUT (called `time_weights`) was also removed. 

In the near future I plan to enable the upgrade algorithm for all ME1/1 trigger motherboards and CLCT processors. Since the ALCT processor firmware code has not been developed, the ALCT upgrade simulation will not be deployed during Run-2 (most likely during LS2).

This PR must be included after #24402 and #24403 (rebase will be required).  

@tahuang1991 @lpernie 