### PR TITLE
Run2-sim25 Attempt to change warning and important energy for G4Trasportation

### DIFF
--- a/Alignment/LaserAlignmentSimulation/plugins/LaserOpticalPhysics.cc
+++ b/Alignment/LaserAlignmentSimulation/plugins/LaserOpticalPhysics.cc
@@ -26,12 +26,15 @@ LaserOpticalPhysics::LaserOpticalPhysics(const edm::ParameterSet & p)
 : PhysicsList(p)
 {
   int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   G4DataQuestionaire it(photon);
   std::cout << "You are using the simulation engine: QGSP together with optical physics" 
 	    << std::endl;
   
   // EM Physics
-  RegisterPhysics(new CMSEmStandardPhysics(ver));
+  RegisterPhysics(new CMSEmStandardPhysics(ver,ntrials,wEnergy,iEnergy));
   // Synchroton Radiation & GN Physics
   RegisterPhysics(new G4EmExtraPhysics(ver));
   // Decays

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -154,8 +154,11 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         ElectronStepLimit         = cms.bool(False),
         ElectronRangeTest         = cms.bool(False),
         PositronStepLimit         = cms.bool(False),
-        MinStepLimit              = cms.double(1.0)
-    ),
+        MinStepLimit              = cms.double(1.0),
+        ThresholdWarningEnergy    = cms.untracked.double(100.0),
+        ThresholdImportantEnergy  = cms.untracked.double(250.0),
+        ThresholdTrials           = cms.untracked.int32(10)
+     ),
     Generator = cms.PSet(
         HectorEtaCut,
         HepMCProductLabel = cms.InputTag('generatorSmeared'),

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -3,6 +3,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "globals.hh"
 #include <sstream>
 
 ExceptionHandler::ExceptionHandler() 

--- a/SimG4Core/CustomPhysics/src/CustomPhysics.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysics.cc
@@ -24,12 +24,15 @@ CustomPhysics::CustomPhysics(const edm::ParameterSet & p)
   bool tracking= p.getParameter<bool>("TrackingCut");
   bool ssPhys  = p.getUntrackedParameter<bool>("ExoticaPhysicsSS",false);
   double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "FTFP_BERT_EMM for regular particles \n"
 			      << "CustomPhysicsList " << ssPhys << " for exotics; "
                               << " tracking cut " << tracking << "  t(ns)= " << timeLimit/ns;
   // EM Physics
-  RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
+  RegisterPhysics(new CMSEmStandardPhysicsLPM(ver,ntrials,wEnergy,iEnergy));
 
   // Synchroton Radiation & GN Physics
   RegisterPhysics(new G4EmExtraPhysics(ver));

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h
@@ -7,14 +7,15 @@
 class CMSEmStandardPhysics : public G4VPhysicsConstructor {
 
 public: 
-  CMSEmStandardPhysics(G4int ver);
+  CMSEmStandardPhysics(G4int ver, G4int ntr, G4double wEn, G4double iEn);
   ~CMSEmStandardPhysics() override;
 
   void ConstructParticle() override;
   void ConstructProcess() override;
 
 private:
-  G4int               verbose;
+  const G4int         verbose_, ntrials_;
+  const G4double      wEnergy_, iEnergy_;
 };
 
 #endif

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h
@@ -8,14 +8,15 @@
 class CMSEmStandardPhysicsLPM : public G4VPhysicsConstructor {
 
 public: 
-  CMSEmStandardPhysicsLPM(G4int ver);
+  CMSEmStandardPhysicsLPM(G4int ver, G4int ntr, G4double wEn, G4double iEn);
   ~CMSEmStandardPhysicsLPM() override;
 
   void ConstructParticle() override;
   void ConstructProcess() override;
 
 private:
-  G4int               verbose;
+  const G4int         verbose_, ntrials_;
+  const G4double      wEnergy_, iEnergy_;
 };
 
 #endif

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.cc
@@ -23,15 +23,21 @@ FTFPCMS_BERT_ATL_EMM::FTFPCMS_BERT_ATL_EMM(const edm::ParameterSet & p)
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
   double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "FTFP_BERT_ATL_EMM \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+			      << "   t(ns)= " << timeLimit/CLHEP::ns
+                              << " Thresholds (warning) " << wEnergy
+                              << " (important) " << iEnergy << " trials "
+                              << ntrials;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver,ntrials,wEnergy,iEnergy));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
@@ -23,15 +23,21 @@ FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(const edm::ParameterSet & p)
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
   double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "FTFP_BERT_EML: \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+			      << "   t(ns)= " << timeLimit/CLHEP::ns
+                              << " Thresholds (warning) " << wEnergy
+                              << " (important) " << iEnergy << " trials "
+                              << ntrials;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysics(ver));
+    RegisterPhysics( new CMSEmStandardPhysics(ver,ntrials,wEnergy,iEnergy));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
@@ -23,15 +23,21 @@ FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet & p)
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
   double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "FTFP_BERT_EMM \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+			      << "   t(ns)= " << timeLimit/CLHEP::ns
+                              << " Thresholds (warning) " << wEnergy
+                              << " (important) " << iEnergy << " trials "
+                              << ntrials;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver,ntrials,wEnergy,iEnergy));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
@@ -23,15 +23,21 @@ FTFPCMS_BERT_EMM_TRK::FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet & p)
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
   double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "FTFP_BERT_EMM_TRK \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+			      << "   t(ns)= " << timeLimit/CLHEP::ns
+                              << " Thresholds (warning) " << wEnergy
+                              << " (important) " << iEnergy << " trials "
+                              << ntrials;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver,ntrials,wEnergy,iEnergy));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
@@ -22,14 +22,20 @@ QGSPCMS_BERT_EML::QGSPCMS_BERT_EML(const edm::ParameterSet & p)
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "QGSP_BERT_EMY with Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+			      << hadPhys << " and tracking cut " << tracking
+                              << " Thresholds (warning) " << wEnergy
+                              << " (important) " << iEnergy << " trials "
+                              << ntrials;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysics(ver));
+    RegisterPhysics( new CMSEmStandardPhysics(ver,ntrials,wEnergy,iEnergy));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
@@ -22,14 +22,20 @@ QGSPCMS_BERT_HP_EML::QGSPCMS_BERT_HP_EML(const edm::ParameterSet & p)
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "QGSP_BERT_HP_EML \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+			      << hadPhys << " and tracking cut " << tracking
+                              << " Thresholds (warning) " << wEnergy
+                              << " (important) " << iEnergy << " trials "
+                              << ntrials;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysics(ver));
+    RegisterPhysics( new CMSEmStandardPhysics(ver,ntrials,wEnergy,iEnergy));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
@@ -23,15 +23,21 @@ QGSPCMS_FTFP_BERT_EML::QGSPCMS_FTFP_BERT_EML(const edm::ParameterSet & p)
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
   double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "QGSP_FTFP_BERT_EML \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+			      << "   t(ns)= " << timeLimit/CLHEP::ns
+                              << " Thresholds (warning) " << wEnergy
+                              << " (important) " << iEnergy << " trials "
+                              << ntrials;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics(new CMSEmStandardPhysics(ver));
+    RegisterPhysics(new CMSEmStandardPhysics(ver,ntrials,wEnergy,iEnergy));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.cc
@@ -23,15 +23,21 @@ QGSPCMS_FTFP_BERT_EMM::QGSPCMS_FTFP_BERT_EMM(const edm::ParameterSet & p)
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
   double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double wEnergy = p.getUntrackedParameter<double>("ThresholdWarningEnergy");
+  double iEnergy = p.getUntrackedParameter<double>("ThresholdImportantEnergy");
+  int    ntrials = p.getUntrackedParameter<int>("ThresholdTrials");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "QGSP_FTFP_BERT_EMM \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+			      << "   t(ns)= " << timeLimit/CLHEP::ns
+                              << " Thresholds (warning) " << wEnergy
+                              << " (important) " << iEnergy << " trials "
+                              << ntrials;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsLPM(ver,ntrials,wEnergy,iEnergy));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -69,14 +69,18 @@
 
 #include "G4PhysicsListHelper.hh"
 #include "G4BuilderType.hh"
+#include "G4ProcessManager.hh"
+#include "G4Transportation.hh"
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver) :
-  G4VPhysicsConstructor("CMSEmStandard_opt1"), verbose(ver) {
+CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver,G4int ntr,
+					   G4double wEn,G4double iEn) :
+  G4VPhysicsConstructor("CMSEmStandard_opt1"), verbose_(ver), ntrials_(ntr),
+  wEnergy_(wEn), iEnergy_(iEn) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
-  param->SetVerbose(verbose);
+  param->SetVerbose(verbose_);
   param->SetApplyCuts(true);
   param->SetStepFunction(0.8, 1*CLHEP::mm);
   param->SetMscRangeFactor(0.2);
@@ -134,7 +138,7 @@ void CMSEmStandardPhysics::ConstructParticle() {
 
 void CMSEmStandardPhysics::ConstructProcess() {
 
-  if(verbose > 0) {
+  if(verbose_ > 0) {
     G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
   }
 
@@ -345,6 +349,18 @@ void CMSEmStandardPhysics::ConstructProcess() {
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
+    }
+    
+    if ((particleName == "e-") || (particleName == "e+")) {
+      /*          Uncomment when GetProcess() is available
+      auto pme = particle->GetProcessManager();
+      G4Transportation* transPe = static_cast<G4Transportation*>(pme->GetProcess("Transportation"));
+      if (transPe != nullptr) {
+        transPe->SetThresholdWarningEnergy(wEnergy_);
+	transPe->SetThresholdImportantEnergy(iEnergy_);
+        transPe->SetThresholdTrials(ntrials_);
+      }
+      */
     }
   }
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -71,14 +71,18 @@
 #include "G4BuilderType.hh"
 #include "G4RegionStore.hh"
 #include "G4Region.hh"
+#include "G4ProcessManager.hh"
+#include "G4Transportation.hh"
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) :
-  G4VPhysicsConstructor("CMSEmStandard_emm"), verbose(ver) {
+CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver,G4int ntr,
+                                                 G4double wEn,G4double iEn) :
+  G4VPhysicsConstructor("CMSEmStandard_emm"), verbose_(ver), ntrials_(ntr),
+  wEnergy_(wEn), iEnergy_(iEn) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
-  param->SetVerbose(verbose);
+  param->SetVerbose(verbose_);
   param->SetApplyCuts(true);
   param->SetStepFunction(0.8, 1*CLHEP::mm);
   param->SetMscRangeFactor(0.2);
@@ -136,7 +140,7 @@ void CMSEmStandardPhysicsLPM::ConstructParticle() {
 
 void CMSEmStandardPhysicsLPM::ConstructProcess() {
 
-  if(verbose > 0) {
+  if(verbose_ > 0) {
     G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
   }
 
@@ -362,6 +366,18 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
+    }
+    
+    if ((particleName == "e-") || (particleName == "e+")) {
+      /*          Uncomment when GetProcess() is available
+      auto pme = particle->GetProcessManager();
+      G4Transportation* transPe = static_cast<G4Transportation*>(pme->GetProcess("Transportation"));
+      if (transPe != nullptr) {
+        transPe->SetThresholdWarningEnergy(wEnergy_);
+	transPe->SetThresholdImportantEnergy(iEnergy_);
+        transPe->SetThresholdTrials(ntrials_);
+      }
+      */
     }
   }
 }


### PR DESCRIPTION
This is an attempt to control this for e-/e+. Vladimir - please take a look if it can be improved. Also this needs geant4.10.5.beta or original for a missing method in existing geant4.10.4