### PR TITLE
Explicitly allow ParameterSet and its internals to be moveable

### DIFF
--- a/FWCore/ParameterSet/interface/Entry.h
+++ b/FWCore/ParameterSet/interface/Entry.h
@@ -160,7 +160,11 @@ namespace edm {
     Entry(std::string const& name, std::string const& type,
           std::vector<std::string> const& value, bool is_tracked);
 
-    ~Entry();
+    ~Entry() = default;
+    Entry(Entry const&) = default;
+    Entry(Entry&&) = default;
+    Entry& operator=(Entry const&) = default;
+    Entry& operator=(Entry&&) = default;
     // encode
 
     std::string toString() const;

--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -48,12 +48,11 @@ namespace edm {
     // construct from coded string.
     explicit ParameterSet(std::string const& rep);
 
-    ~ParameterSet();
-
-    // instantiate in this library, so these methods don't cause code bloat
-    ParameterSet(ParameterSet const& other);
-
-    ParameterSet& operator=(ParameterSet const& other);
+    ~ParameterSet() = default;
+    ParameterSet(ParameterSet const& other) = default;
+    ParameterSet(ParameterSet&& other) = default;
+    ParameterSet& operator=(ParameterSet const& other) = default;
+    ParameterSet& operator=(ParameterSet&& other) = default;
 
     void swap(ParameterSet& other);
 

--- a/FWCore/ParameterSet/interface/ParameterSetEntry.h
+++ b/FWCore/ParameterSet/interface/ParameterSetEntry.h
@@ -27,7 +27,11 @@ namespace edm {
     ParameterSetEntry(ParameterSetID const& id, bool isTracked);
     explicit ParameterSetEntry(std::string const& rep);
 
-    ~ParameterSetEntry();
+    ~ParameterSetEntry() = default;
+    ParameterSetEntry(ParameterSetEntry const&) = default;
+    ParameterSetEntry(ParameterSetEntry&&) = default;
+    ParameterSetEntry& operator=(ParameterSetEntry const&) = default;
+    ParameterSetEntry& operator=(ParameterSetEntry&&) = default;
 
     std::string toString() const;
     void toString(std::string& result) const;

--- a/FWCore/ParameterSet/interface/VParameterSetEntry.h
+++ b/FWCore/ParameterSet/interface/VParameterSetEntry.h
@@ -27,7 +27,11 @@ namespace edm {
     VParameterSetEntry(std::vector<ParameterSet> const& vpset, bool isTracked);
     VParameterSetEntry(std::string const& rep);
 
-    ~VParameterSetEntry();
+    ~VParameterSetEntry() = default;
+    VParameterSetEntry(VParameterSetEntry const&) = default;
+    VParameterSetEntry(VParameterSetEntry&&) = default;
+    VParameterSetEntry& operator=(VParameterSetEntry const&) = default;
+    VParameterSetEntry& operator=(VParameterSetEntry&&) = default;
 
     std::string toString() const;
     void toString(std::string& result) const;

--- a/FWCore/ParameterSet/src/Entry.cc
+++ b/FWCore/ParameterSet/src/Entry.cc
@@ -78,8 +78,6 @@ namespace edm {
   static pset::TypeTrans const sTypeTranslations;
   typedef std::map<std::string, char> Type2Code;
 
-  Entry::~Entry() {}
-
 // ----------------------------------------------------------------------
 // consistency-checker
 // ----------------------------------------------------------------------

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -89,8 +89,6 @@ namespace edm {
     }
   }
 
-  ParameterSet::~ParameterSet() {}
-
   void
   ParameterSet::registerFromString(std::string const& rep) {
     // from coded string.  Will cause registration
@@ -105,19 +103,6 @@ namespace edm {
     cms::Digest newDigest;
     ParameterSet().toDigest(newDigest);
     return ParameterSetID(newDigest.digest().toString());
-  }
-
-  ParameterSet::ParameterSet(ParameterSet const& other)
-  : tbl_(other.tbl_),
-    psetTable_(other.psetTable_),
-    vpsetTable_(other.vpsetTable_),
-    id_(other.id_) {
-  }
-
-  ParameterSet& ParameterSet::operator=(ParameterSet const& other) {
-    ParameterSet temp(other);
-    swap(temp);
-    return *this;
   }
 
   void ParameterSet::copyForModify(ParameterSet const& other) {

--- a/FWCore/ParameterSet/src/ParameterSetEntry.cc
+++ b/FWCore/ParameterSet/src/ParameterSetEntry.cc
@@ -44,8 +44,6 @@ namespace edm {
     theID_.swap(newID);
   }
     
-  ParameterSetEntry::~ParameterSetEntry() {}
-
   void
   ParameterSetEntry::toString(std::string& result) const {
     result += isTracked() ? "+Q(" : "-Q(";

--- a/FWCore/ParameterSet/src/VParameterSetEntry.cc
+++ b/FWCore/ParameterSet/src/VParameterSetEntry.cc
@@ -39,8 +39,6 @@ namespace edm {
     }
   }
 
-  VParameterSetEntry::~VParameterSetEntry() {}
-
   void
   VParameterSetEntry::toString(std::string& result) const {
     assert(theIDs_);

--- a/FWCore/Utilities/interface/atomic_value_ptr.h
+++ b/FWCore/Utilities/interface/atomic_value_ptr.h
@@ -71,7 +71,7 @@ namespace edm {
     }
 
     atomic_value_ptr(atomic_value_ptr&& orig) :
-      myP(orig.myP) { orig.myP.store(nullptr); }
+      myP(orig.myP.load()) { orig.myP.store(nullptr); }
 
     atomic_value_ptr& operator=(atomic_value_ptr&& orig) {
       atomic_value_ptr<T> local(orig);


### PR DESCRIPTION
The previous code did not allow the compiler to create the default move related functions.