### PR TITLE
Fix CkfTrackCandidates_cfi.py (10_1)

### DIFF
--- a/RecoTracker/CkfPattern/python/CkfTrackCandidates_cfi.py
+++ b/RecoTracker/CkfPattern/python/CkfTrackCandidates_cfi.py
@@ -7,6 +7,7 @@ ckfTrackCandidates = cms.EDProducer("CkfTrackCandidateMaker",
     TrajectoryCleaner = cms.string('TrajectoryCleanerBySharedHits'),
 # Run cleaning after in-out tracking in addition to at end of tracking ?
     cleanTrajectoryAfterInOut = cms.bool(True),
+    reverseTrajectories  =cms.bool(False),
 # Split matched strip tracker hits into mono/stereo components.
     useHitsSplitting = cms.bool(True),
 # After in-out tracking, do out-in tracking through the seeding


### PR DESCRIPTION
Fix CkfTrackCandidates_cfi.py (10_1)
Based on 10_0_0
Add missing parameter explicitly with default set to reproduce old behaviour.
Needed for ConfDB parsing.