### PR TITLE
Added a possibility to customise G4Transportation parameters

### DIFF
--- a/SimG4Core/Application/interface/ParametrisedEMPhysics.h
+++ b/SimG4Core/Application/interface/ParametrisedEMPhysics.h
@@ -14,6 +14,7 @@
 class GFlashEMShowerModel;
 class GFlashHadronShowerModel;
 class ElectronLimiter;
+class G4FastSimulationManagerProcess;
 
 class ParametrisedEMPhysics : public G4VPhysicsConstructor
 {
@@ -29,13 +30,15 @@ private:
 
   edm::ParameterSet theParSet;
 
-  GFlashEMShowerModel *theEcalEMShowerModel;
-  GFlashEMShowerModel *theHcalEMShowerModel;
-  GFlashHadronShowerModel *theEcalHadShowerModel;
-  GFlashHadronShowerModel *theHcalHadShowerModel;
+  static G4ThreadLocal std::unique_ptr<GFlashEMShowerModel> theEcalEMShowerModel;
+  static G4ThreadLocal std::unique_ptr<GFlashEMShowerModel> theHcalEMShowerModel;
+  static G4ThreadLocal std::unique_ptr<GFlashHadronShowerModel> theEcalHadShowerModel;
+  static G4ThreadLocal std::unique_ptr<GFlashHadronShowerModel> theHcalHadShowerModel;
 
-  ElectronLimiter *theElectronLimiter;
-  ElectronLimiter *thePositronLimiter;
+  static G4ThreadLocal std::unique_ptr<ElectronLimiter> theElectronLimiter;
+  static G4ThreadLocal std::unique_ptr<ElectronLimiter> thePositronLimiter;
+
+  static G4ThreadLocal std::unique_ptr<G4FastSimulationManagerProcess> theFastSimulationManagerProcess; 
 
 };
 

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -154,7 +154,11 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         ElectronStepLimit         = cms.bool(False),
         ElectronRangeTest         = cms.bool(False),
         PositronStepLimit         = cms.bool(False),
-        MinStepLimit              = cms.double(1.0)
+        MinStepLimit              = cms.double(1.0),
+        ModifyTransportation      = cms.bool(False),
+        ThresholdWarningEnergy    = cms.untracked.double(100.0),
+        ThresholdImportantEnergy  = cms.untracked.double(250.0),
+        ThresholdTrials           = cms.untracked.int32(10)
     ),
     Generator = cms.PSet(
         HectorEtaCut,

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -3,6 +3,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "globals.hh"
 #include <sstream>
 
 ExceptionHandler::ExceptionHandler() 

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -109,7 +109,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 {
   if (m_managerInitialized) return;
 
-  edm::LogInfo("SimG4CoreApplication") 
+  edm::LogVerbatim("SimG4CoreApplication") 
     << "RunManagerMT: start initialisation of geometry";
   
   // DDDWorld: get the DDCV from the ES and use it to build the World
@@ -118,7 +118,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   m_registry.dddWorldSignal_(m_world.get());
 
   // setup the magnetic field
-  edm::LogInfo("SimG4CoreApplication") 
+  edm::LogVerbatim("SimG4CoreApplication") 
     << "RunManagerMT: start initialisation of magnetic field";
 
   if (m_pUseMagneticField && !m_FieldFile.empty())
@@ -134,7 +134,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
     }
 
   // Create physics list
-  edm::LogInfo("SimG4CoreApplication") 
+  edm::LogVerbatim("SimG4CoreApplication") 
     << "RunManagerMT: create PhysicsList";
 
   std::unique_ptr<PhysicsListMakerBase>
@@ -168,7 +168,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   if (m_RestorePhysicsTables) {
     m_physicsList->SetPhysicsTableRetrieved(m_PhysicsTablesDir);
   }
-  edm::LogInfo("SimG4CoreApplication") 
+  edm::LogVerbatim("SimG4CoreApplication") 
     << "RunManagerMT: start initialisation of PhysicsList for master";
 
   int verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity",0),


### PR DESCRIPTION
Depending on value of G4Transportation parameters different levels of warning/exceptions are produced. With this PR:

1) G4Transportation parameters may be customized by values from g4SimHits
2) ParameterisedEMPhysics class was updated (printout, usage of std::unique_ptr, cleaned up initialisation for newer Geant4)
3) In several places LogInfo substituted by LogVerbatim

This PR substitutes #24425  (att. @bsunanda ) 