### PR TITLE
Improvements to APE tool: Usability and error fixes

### DIFF
--- a/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
+++ b/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
@@ -58,7 +58,7 @@ isMc = False
 if "iov" in  options.sample:
     isMultiIOV = True
     isData = True
-if options.sample == 'data1':
+elif options.sample == 'data1':
     isData1 = True
     isData = True
 elif options.sample == 'data2':

--- a/Alignment/APEEstimation/test/autoSubmitter/config.ini
+++ b/Alignment/APEEstimation/test/autoSubmitter/config.ini
@@ -2,13 +2,11 @@
 [dataset:exampleDataset]
 # directory where to look, probably starting with /eos/cms/store/caf/user/<username>
 baseDirectory=/some/directory
-# without _ or .root at the end
-baseFileName=filename 
-# number of files in base directory
-nFiles=6
+# define input files, separate files with " ", use ranges for multiple files. [1-6,8,10] will be replaced by files with 1,2,3,4,5,6,8, and 10 in its place
+fileNames=filename.root otherFile_[1-6,8,10].root
 # optional, events per file, not total maxEvents
 maxEvents=-1
-# set to True for MC samples, False by default
+# optional, set to True for MC samples, False by default
 isMC=False
 
 #define alignments like this
@@ -24,14 +22,12 @@ alignmentName=alignmentObjectName
 baselineDir=Design
 # is this a baseline measurement? False by default
 isDesign=False
-# normally, 15 iterations are done for a measurement. If isDesign is True, 
-# this will be automatically set to 0 as only one iteration needs to be run
-# 15 by default
-maxIterations=15
 
 # define measurements like this
 [measurements]
 # name: dataset alignment
 # unique names are important as this name will be used as a folder name
 # where all relevant files are stored
-exampleName: exampleDataset alignmentObjectName
+# firstIteration and maxIterations are optional, 0 and 15 by default. 
+# maxIterations is forced to 0 if alignmentObject has isDesign=True
+exampleName: exampleDataset alignmentObjectName firstIteration=0 maxIterations=15

--- a/Alignment/APEEstimation/test/batch/startSkim.py
+++ b/Alignment/APEEstimation/test/batch/startSkim.py
@@ -104,7 +104,11 @@ def main(argv):
     finalSamples = []
     for sample in args.samples:
         if "[" in sample and "]" in sample:
-            sampleName = sample[:sample.find("[")]
+            posS = sample.find("[")
+            posE = sample.find("]")
+            nums = sample[posS+1:posE].split(",")
+            expression = sample[posS:posE+1]
+            
             nums = sample[sample.find("[")+1:sample.find("]")]
             for interval in nums.split(","):
                 interval = interval.strip()
@@ -112,15 +116,15 @@ def main(argv):
                     lowNum = int(interval.split("-")[0])
                     upNum = int(interval.split("-")[1])
                     for i in range(lowNum, upNum+1):
-                        finalSamples.append("%s%d"%(sampleName, i))
+                        finalSamples.append("%s"%(sample.replace(expression,str(i))))
                 else:
-                    finalSamples.append("%s%d"%(sampleName, int(interval)))
+                    finalSamples.append("%s"%(sample.replace(expression,interval)))
         else:
             finalSamples.append(sample)
     
     args.samples = finalSamples
     print(args.samples)
-    return
+
     if len(args.samples) == 1 or args.consecutive:
         for sample in args.samples:
             doSkim(sample) 

--- a/Alignment/APEEstimation/test/batch/startSkim.py
+++ b/Alignment/APEEstimation/test/batch/startSkim.py
@@ -19,7 +19,7 @@ def doSkim(sample):
     outFilePath = None
     
     # start cmsRun
-    proc = subprocess.Popen(toExec, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(toExec, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     
     def get_output(proc):
         while True:
@@ -27,6 +27,7 @@ def doSkim(sample):
             if not line:
                 break
             yield line
+
     
     # print output in shell while program runs, also extract output filename
     try:
@@ -35,7 +36,7 @@ def doSkim(sample):
                 outFileName = line.split("output name ")[1].split(".root")[0]
             if "Using output path" in line:
                 outFilePath = line.split("output path ")[1]
-            print(line)
+            print(sample+": "+line)
     except KeyboardInterrupt:
         #this way, the current file is closed and the skimming is finished in a way that the last opened file is actually usable
         
@@ -61,7 +62,7 @@ def doSkim(sample):
                     try:
                         fileNo = int(fileNoString)
                         # For (most) weird naming conventions to not mess up renaming
-                        if len(fileNoString) != 3 or fileNo == 1:
+                        if len(fileNoString) != 3:
                             continue
                         
                         newFileName = "%s_%d.root"%(outFileName, fileNo+1)
@@ -80,7 +81,8 @@ def doSkim(sample):
         if not os.path.isdir(outFilePath):
             os.makedirs(outFilePath)
         for fi in targetFiles:
-            subprocess.call("xrdcp %s %s/"%(fi, outFilePath), shell=True)
+            if not subprocess.call("xrdcp %s %s/"%(fi, outFilePath), shell=True):
+                os.remove(fi)    
 
 def main(argv):
     if not 'CMSSW_BASE' in os.environ:
@@ -99,6 +101,26 @@ def main(argv):
         print("Usage: python startSkim.py -s <sample>")
         sys.exit()
     
+    finalSamples = []
+    for sample in args.samples:
+        if "[" in sample and "]" in sample:
+            sampleName = sample[:sample.find("[")]
+            nums = sample[sample.find("[")+1:sample.find("]")]
+            for interval in nums.split(","):
+                interval = interval.strip()
+                if "-" in interval:
+                    lowNum = int(interval.split("-")[0])
+                    upNum = int(interval.split("-")[1])
+                    for i in range(lowNum, upNum+1):
+                        finalSamples.append("%s%d"%(sampleName, i))
+                else:
+                    finalSamples.append("%s%d"%(sampleName, int(interval)))
+        else:
+            finalSamples.append(sample)
+    
+    args.samples = finalSamples
+    print(args.samples)
+    return
     if len(args.samples) == 1 or args.consecutive:
         for sample in args.samples:
             doSkim(sample) 

--- a/Alignment/APEEstimation/test/cfgTemplate/apeEstimator_cfg.py
+++ b/Alignment/APEEstimation/test/cfgTemplate/apeEstimator_cfg.py
@@ -56,6 +56,7 @@ process.MessageLogger.categories.append('CalculateAPE')
 process.MessageLogger.categories.append('ApeEstimator')
 process.MessageLogger.categories.append('TrackRefitter')
 process.MessageLogger.categories.append('AlignmentTrackSelector')
+process.MessageLogger.cerr.threshold = 'WARNING'
 process.MessageLogger.cerr.INFO.limit = 0
 process.MessageLogger.cerr.default.limit = -1
 process.MessageLogger.cerr.SectorBuilder = cms.untracked.PSet(limit = cms.untracked.int32(-1))
@@ -64,7 +65,6 @@ process.MessageLogger.cerr.CalculateAPE = cms.untracked.PSet(limit = cms.untrack
 process.MessageLogger.cerr.ApeEstimator = cms.untracked.PSet(limit = cms.untracked.int32(-1))
 process.MessageLogger.cerr.AlignmentTrackSelector = cms.untracked.PSet(limit = cms.untracked.int32(-1))
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000 ## really show only every 1000th
-
 
 
 ##

--- a/Alignment/APEEstimation/test/cfgTemplate/apeLocalSetting_cfg.py
+++ b/Alignment/APEEstimation/test/cfgTemplate/apeLocalSetting_cfg.py
@@ -67,7 +67,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     statistics = cms.untracked.vstring('cout', 'alignment'),
     categories = cms.untracked.vstring('Alignment'),
     cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
+        threshold = cms.untracked.string('WARNING'),
         noLineBreaks = cms.untracked.bool(True)
     ),
     alignment = cms.untracked.PSet(


### PR DESCRIPTION
This commit includes changes that were found neccessary while doing a multi-IOV APE measurement for the ReReco campaign. The changes include:

1. Reduced verbosity of some modules ( b467869 5b714bb  ) 
This makes the stderr files procuded by plugins/ApeEstimator.cc shorter and consume disk less space (was: 9mb per file per iteration per measurement). Now, these files can be searched for fatal errors that would not be caught otherwise, which helps tracing back job failures. test/cfgTemplate/apeLocalSetting_cfg.py produced a lot of unneccessary output which flooded the terminal.

2. Improved skimming tool ( fae3000 ccd3aca  ) 
Fixed a few errors. Also made starting a large number of skims easier.

3. More natural configuration of the automated submission tool, improved error detection ( 0357460 )
The way that a config file is built was changed. The input file name definition is now more dynamic and easier. Finished or failed measurements are now logged. One can now specify the name of the file in which the current measurements are stored in case on wants to run multiple instances of autoSubmitter and cancel/resume any of them.