### PR TITLE
Backport of #24379 to 10_2_X, missing EGM ID modules for DQM

### DIFF
--- a/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
@@ -979,7 +979,8 @@ egmGsfElectronIDsForDQM.physicsObjectSrc == cms.InputTag('gedGsfElectrons')
 #note: be careful here to when selecting new ids that the vid tools dont do extra setup for them
 #for example the HEEP cuts need an extra producer which vid tools automatically handles
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import setupVIDSelection
-my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff']
+my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff',
+                 'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_cff']
 for id_module_name in my_id_modules: 
     idmod= __import__(id_module_name, globals(), locals(), ['idName','cutFlow'])
     for name in dir(idmod):


### PR DESCRIPTION
Backport of #24379 to 10_2_X branch