### PR TITLE
Removed unnused variable in lambda capture

### DIFF
--- a/FWCore/Integration/test/ESTestProducers.cc
+++ b/FWCore/Integration/test/ESTestProducers.cc
@@ -90,7 +90,7 @@ namespace edmtest {
     }
 
     host->ifRecordChanges<ESTestRecordC>(record,
-                                         [this, h=host.get()](auto const& rec) {
+                                         [h=host.get()](auto const& rec) {
       ++h->value();
     });
 


### PR DESCRIPTION
This fixes a clang warning.