### PR TITLE
Removed std::move on return to allow compiler optimization

### DIFF
--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
@@ -30,7 +30,7 @@ EcalTBHodoscopeGeometryLoaderFromDDD::load( const DDCompactView* cpv )
 
    std::cout << "[EcalTBHodoscopeGeometryLoaderFromDDD]:: Returning EcalTBHodoscopeGeometry" << std::endl;
 
-   return std::move(ebg);
+   return ebg;
 }
 
 void 


### PR DESCRIPTION
clang gave a warning stating the use of std::move on a returned value prevents a compiler optimization.