### PR TITLE
Removed unnecessary std::move from Geometry/ForwardGeometry

### DIFF
--- a/Geometry/ForwardGeometry/src/CastorHardcodeGeometryLoader.cc
+++ b/Geometry/ForwardGeometry/src/CastorHardcodeGeometryLoader.cc
@@ -43,7 +43,7 @@ CastorHardcodeGeometryLoader::load( DetId::Detector /*det*/,
       fill( HcalCastorDetId::EM,  hg.get() ) ;
       fill( HcalCastorDetId::HAD, hg.get() ) ;
    }
-   return std::move(hg);
+   return hg;
 }
 
 std::unique_ptr<CaloSubdetectorGeometry> 
@@ -53,7 +53,7 @@ CastorHardcodeGeometryLoader::load()
       ( new CastorGeometry( extTopology ) ) ;
    fill( HcalCastorDetId::EM,  hg.get() ) ;
    fill( HcalCastorDetId::HAD, hg.get() ) ;
-   return std::move(hg);
+   return hg;
 }
 
 void 


### PR DESCRIPTION
clang gave a warning stating the use of std::move on a returned
value prevents a compiler optimization.