### PR TITLE
Removed unused variable in Geometry/HcalCommonData

### DIFF
--- a/Geometry/HcalCommonData/src/HcalHitRelabeller.cc
+++ b/Geometry/HcalCommonData/src/HcalHitRelabeller.cc
@@ -100,7 +100,6 @@ DetId HcalHitRelabeller::relabel(const uint32_t testId, const HcalDDDRecConstant
 
 double HcalHitRelabeller::energyWt(const uint32_t testId) const {
 
-  HcalDetId hid;
   int       det, z, depth, eta, phi, layer;
   HcalTestNumbering::unpackHcalIndex(testId,det,z,depth,eta,phi,layer);
   int       zside = (z==0) ? (-1) : (1);


### PR DESCRIPTION
This fixes a clang warning.