### PR TITLE
Removed self assignment in Geometry/TrackerNumberingBuilder

### DIFF
--- a/Geometry/TrackerNumberingBuilder/test/ModuleNumbering.cc
+++ b/Geometry/TrackerNumberingBuilder/test/ModuleNumbering.cc
@@ -891,7 +891,7 @@ ModuleNumbering::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetu
 			// TEC+
 		      case 2:
 			{
-			  phiRad = phiRad;
+                          //do not change phiRad
 			  break;
 			}
 			// TEC-


### PR DESCRIPTION
This fixes a clang warning.