### PR TITLE
Prepare CastorDbProducer for concurrent IOVs

### DIFF
--- a/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.h
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.h
@@ -4,6 +4,8 @@
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 class CastorDbService;
 class CastorDbRecord;
@@ -17,24 +19,33 @@ class CastorDbRecord;
 #include "CondFormats/DataRecord/interface/CastorQIEDataRcd.h"
 
 class CastorDbProducer : public edm::ESProducer {
- public:
+public:
   CastorDbProducer( const edm::ParameterSet& );
   ~CastorDbProducer() override;
   
   std::shared_ptr<CastorDbService> produce( const CastorDbRecord& );
 
-  // callbacks
-  void pedestalsCallback (const CastorPedestalsRcd& fRecord);
-  void pedestalWidthsCallback (const CastorPedestalWidthsRcd& fRecord);
-  void gainsCallback (const CastorGainsRcd& fRecord);
-  void gainWidthsCallback (const CastorGainWidthsRcd& fRecord);
-  void QIEDataCallback (const CastorQIEDataRcd& fRecord);
-  void channelQualityCallback (const CastorChannelQualityRcd& fRecord);
-  void electronicsMapCallback (const CastorElectronicsMapRcd& fRecord);
+private:
+  // ----------member data ---------------------------
+  using HostType = edm::ESProductHost<CastorDbService,
+                                      CastorPedestalsRcd,
+                                      CastorPedestalWidthsRcd,
+                                      CastorGainsRcd,
+                                      CastorGainWidthsRcd,
+                                      CastorQIEDataRcd,
+                                      CastorChannelQualityRcd,
+                                      CastorElectronicsMapRcd>;
 
-   private:
-      // ----------member data ---------------------------
-  std::shared_ptr<CastorDbService> mService;
+  void setupPedestals(const CastorPedestalsRcd&, CastorDbService*);
+  void setupPedestalWidths(const CastorPedestalWidthsRcd&, CastorDbService*);
+  void setupGains(const CastorGainsRcd&, CastorDbService*);
+  void setupGainWidths(const CastorGainWidthsRcd&, CastorDbService*);
+  void setupQIEData(const CastorQIEDataRcd&, CastorDbService*);
+  void setupChannelQuality(const CastorChannelQualityRcd&, CastorDbService*);
+  void setupElectronicsMap(const CastorElectronicsMapRcd&, CastorDbService*);
+
+  edm::ReusableObjectHolder<HostType> holder_;
+
   std::vector<std::string> mDumpRequest;
   std::ostream* mDumpStream;
 };

--- a/CalibFormats/CastorObjects/interface/CastorCalibrationWidths.h
+++ b/CalibFormats/CastorObjects/interface/CastorCalibrationWidths.h
@@ -8,7 +8,7 @@
 */
 class CastorCalibrationWidths {
  public:
-  CastorCalibrationWidths () {};
+  CastorCalibrationWidths () : mGain{}, mPedestal{} {};
   CastorCalibrationWidths (const float fGain [4], const float fPedestal [4]);
   /// get gain width for capid=0..3
   double gain (int fCapId) const {return mGain [fCapId];}

--- a/CalibFormats/CastorObjects/interface/CastorCalibrations.h
+++ b/CalibFormats/CastorObjects/interface/CastorCalibrations.h
@@ -8,7 +8,7 @@
 */
 class CastorCalibrations {
  public:
-  CastorCalibrations () {};
+  CastorCalibrations () : mGain{}, mPedestal{} {};
   CastorCalibrations (const float fGain [4], const float fPedestal [4]);
   /// get gain for capid=0..3
   double gain (int fCapId) const {return mGain [fCapId];}

--- a/CalibFormats/CastorObjects/interface/CastorDbService.h
+++ b/CalibFormats/CastorObjects/interface/CastorDbService.h
@@ -27,7 +27,7 @@ class CastorCalibrationWidths;
 
 class CastorDbService {
  public:
-  CastorDbService (const edm::ParameterSet&);
+  CastorDbService ();
 
   const CastorCalibrations& getCastorCalibrations(const HcalGenericDetId& fId) const 
   { return mCalibSet.getCalibrations(fId); }
@@ -43,21 +43,22 @@ class CastorDbService {
   const CastorElectronicsMap* getCastorMapping () const;
   const CastorChannelStatus* getCastorChannelStatus (const HcalGenericDetId& fId) const;
 
-  void setData (const CastorPedestals* fItem) {mPedestals = fItem; buildCalibrations(); }
-  void setData (const CastorPedestalWidths* fItem) {mPedestalWidths = fItem; buildCalibWidths(); }
-  void setData (const CastorGains* fItem) {mGains = fItem; buildCalibrations(); }
+  void setData (const CastorPedestals* fItem) { mPedestals = fItem; }
+  void setData (const CastorPedestalWidths* fItem) { mPedestalWidths = fItem; }
+  void setData (const CastorGains* fItem) { mGains = fItem; }
   void setData (const CastorGainWidths* fItem) {mGainWidths = fItem; }
   void setData (const CastorQIEData* fItem) {mQIEData = fItem; }
   void setData (const CastorChannelQuality* fItem) {mChannelQuality = fItem;}
   void setData (const CastorElectronicsMap* fItem) {mElectronicsMap = fItem;}
 
+  void buildCalibrations();
+  void buildCalibWidths();
+
  private:
   bool makeCastorCalibration (const HcalGenericDetId& fId, CastorCalibrations* fObject, 
 			    bool pedestalInADC) const;
-  void buildCalibrations();
   bool makeCastorCalibrationWidth (const HcalGenericDetId& fId, CastorCalibrationWidths* fObject, 
 				 bool pedestalInADC) const;
-  void buildCalibWidths();
   const CastorPedestals* mPedestals;
   const CastorPedestalWidths* mPedestalWidths;
   const CastorGains* mGains;

--- a/CalibFormats/CastorObjects/src/CastorDbService.cc
+++ b/CalibFormats/CastorObjects/src/CastorDbService.cc
@@ -13,13 +13,14 @@
 
 #include <cmath>
 
-CastorDbService::CastorDbService (const edm::ParameterSet& cfg)
+CastorDbService::CastorDbService ()
   : 
   mPedestals (nullptr),
   mPedestalWidths (nullptr),
   mGains (nullptr),
   mGainWidths (nullptr),
   mQIEData(nullptr),
+  mChannelQuality(nullptr),
   mElectronicsMap(nullptr)
  {}
 

--- a/SimCalorimetry/CastorSim/test/CastorDigitizerTest.cpp
+++ b/SimCalorimetry/CastorSim/test/CastorDigitizerTest.cpp
@@ -153,14 +153,15 @@ int main() {
 
 */
 
-edm::ParameterSet emptyPSet;
-CastorDbService calibratorHandle(emptyPSet);
+  CastorDbService calibratorHandle;
 
 //  CastorDbService calibratorHandle;
   calibratorHandle.setData(&pedestals);
   calibratorHandle.setData(&pedestalWidths);
   calibratorHandle.setData(&gains);
   calibratorHandle.setData(&gainWidths);
+  calibratorHandle.buildCalibrations();
+  calibratorHandle.buildCalibWidths();
   cout << "set data" << std::endl;
   bool addNoise = false;
 


### PR DESCRIPTION
Prior to this PR there was one CastorDbService and the ESProducer held as a data member a shared pointer to this object. This has worked perfectly fine up to now because the Framework has only allowed one IOV to be processed at a time, but we hope in the future to allows multiple IOVs to run concurrently. If there are multiple IOVs being processed concurrently, there must be multiple CastorDbService objects because the contents must be different for different IOVs. In addition, if we want to maximize the concurrency the produce method should be able to run for the different IOVs concurrently and the produce function modifies the CastorDbService. It would create data races for them to work on the same object.

In the modified version, there are multiple CastorDbService objects, one for each concurrent IOV. The ReusableObjectHolder owns and manages those objects in a thread safe manner and replaces the single shared_ptr. 

The dependsOn feature of the EventSetup has difficulty communicating which instance CastorDbService a particular callback and produce function are referring to.  So the usage of the dependsOn function and its callbacks is replaced by usage of the new ESProductHost class. It has a similar purpose, but works better when there are multiple IOVs because its interface allows direct communication between the produce methods and the lambda function that gets called when the record changes via arguments.
