### PR TITLE
Extend TrackBase and Track to include time and velocity

### DIFF
--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -24,7 +24,8 @@
   <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
-  <class name="reco::GsfTrack" ClassVersion="19">
+  <class name="reco::GsfTrack" ClassVersion="20">
+   <version ClassVersion="20" checksum="3090385640"/>
    <version ClassVersion="19" checksum="2111870580"/>
    <version ClassVersion="18" checksum="1193413886"/>
    <version ClassVersion="17" checksum="2463004588"/>

--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -39,7 +39,9 @@ public:
     /// constructor from fit parameters and error matrix
     Track(double chi2, double ndof, const Point & referencePoint,
           const Vector & momentum, int charge, const CovarianceMatrix &,
-          TrackAlgorithm = undefAlgorithm, TrackQuality quality = undefQuality);
+          TrackAlgorithm = undefAlgorithm, TrackQuality quality = undefQuality,
+	  double t0 = 0, double beta = 0, 
+	  double covt0t0 = -1., double covbetabeta = -1.);
 
     /// return true if the outermost hit is valid
     bool outerOk() const {
@@ -50,7 +52,7 @@ public:
     bool innerOk() const {
         return extra_->innerOk();
     }
-   
+    
     /// position of the innermost hit
     const math::XYZPoint & innerPosition()  const {
         return extra_->innerPosition();

--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -40,8 +40,8 @@ public:
     Track(double chi2, double ndof, const Point & referencePoint,
           const Vector & momentum, int charge, const CovarianceMatrix &,
           TrackAlgorithm = undefAlgorithm, TrackQuality quality = undefQuality,
-	  double t0 = 0, double beta = 0, 
-	  double covt0t0 = -1., double covbetabeta = -1.);
+	  float t0 = 0, float beta = 0, 
+	  float covt0t0 = -1., float covbetabeta = -1.);
 
     /// return true if the outermost hit is valid
     bool outerOk() const {
@@ -52,7 +52,7 @@ public:
     bool innerOk() const {
         return extra_->innerOk();
     }
-    
+
     /// position of the innermost hit
     const math::XYZPoint & innerPosition()  const {
         return extra_->innerPosition();

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -171,8 +171,8 @@ public:
               const Vector &momentum, int charge, const CovarianceMatrix &cov,
               TrackAlgorithm = undefAlgorithm, TrackQuality quality = undefQuality,
               signed char nloops = 0, uint8_t stopReason = 0,
-	      double t0 = 0, double beta = 0, 
-	      double covt0t0 = -1., double covbetabeta = -1.);
+	      float t0 = 0.f, float beta = 0., 
+	      float covt0t0 = -1.f, float covbetabeta = -1.f);
 
     /// virtual destructor
     virtual ~TrackBase();
@@ -252,7 +252,7 @@ public:
     /// time at the reference point
     double t0() const;
 
-    /// velocity at the reference point
+    /// velocity at the reference point in natural units
     double beta() const;
 
     /// reference point on the track. This method is DEPRECATED, please use referencePoint() instead
@@ -282,6 +282,12 @@ public:
     
     /// (i,j)-th element of covariance matrix (i, j = 0, ... 4)
     double covariance(int i, int j) const;
+
+    /// error on t0
+    double covt0t0() const;
+    
+    /// error on beta
+    double covBetaBeta() const;
 
     /// error on specified element
     double error(int i) const;
@@ -716,7 +722,7 @@ inline double TrackBase::t0() const
     return t0_;
 }
 
-// Velocity at the reference point on the track
+// Velocity at the reference point on the track in natural units
 inline double TrackBase::beta() const
 {
     return beta_;
@@ -853,6 +859,18 @@ inline double TrackBase::dszError() const
 inline double TrackBase::dzError() const
 {
     return error(i_dsz) * p() / pt();
+}
+
+// covariance of t0
+inline double TrackBase::covt0t0() const
+{
+    return covt0t0_;
+}
+
+// covariance of beta
+inline double TrackBase::covBetaBeta() const
+{
+    return covbetabeta_;
 }
 
 // error on t0

--- a/DataFormats/TrackReco/src/Track.cc
+++ b/DataFormats/TrackReco/src/Track.cc
@@ -4,11 +4,11 @@ using namespace reco;
 
 Track::Track(double chi2, double ndof, const Point &vertex, const Vector &momentum,
              int charge, const CovarianceMatrix &cov, TrackAlgorithm algo,
-             TrackQuality quality, double t0, double beta, 
-	     double covt0t0, double covbetabeta) :
-  TrackBase(chi2, ndof, vertex, momentum, charge, cov, algo, quality,
-	    0,0, // nloops and stop reason
-	    t0,beta,covt0t0,covbetabeta)
+             TrackQuality quality, float t0, float beta, 
+	     float covt0t0, float covbetabeta) :
+             TrackBase(chi2, ndof, vertex, momentum, charge, cov, algo, quality,
+		       0,0, // nloops and stop reason
+		       t0,beta,covt0t0,covbetabeta)
 {
     ;
 }

--- a/DataFormats/TrackReco/src/Track.cc
+++ b/DataFormats/TrackReco/src/Track.cc
@@ -4,8 +4,11 @@ using namespace reco;
 
 Track::Track(double chi2, double ndof, const Point &vertex, const Vector &momentum,
              int charge, const CovarianceMatrix &cov, TrackAlgorithm algo,
-             TrackQuality quality) :
-    TrackBase(chi2, ndof, vertex, momentum, charge, cov, algo, quality)
+             TrackQuality quality, double t0, double beta, 
+	     double covt0t0, double covbetabeta) :
+  TrackBase(chi2, ndof, vertex, momentum, charge, cov, algo, quality,
+	    0,0, // nloops and stop reason
+	    t0,beta,covt0t0,covbetabeta)
 {
     ;
 }

--- a/DataFormats/TrackReco/src/TrackBase.cc
+++ b/DataFormats/TrackReco/src/TrackBase.cc
@@ -67,9 +67,13 @@ std::string const TrackBase::qualityNames[] = {
 };
 
 TrackBase::TrackBase() :
+    covt0t0_(-1.f),
+    covbetabeta_(-1.f),
     chi2_(0),
     vertex_(0, 0, 0),
+    t0_(0),
     momentum_(0, 0, 0),
+    beta_(0),
     ndof_(0),
     charge_(0),
     algorithm_(undefAlgorithm),
@@ -90,7 +94,7 @@ TrackBase::TrackBase() :
 TrackBase::TrackBase(double chi2, double ndof, const Point &vertex, const Vector &momentum,
                      int charge, const CovarianceMatrix &cov, TrackAlgorithm algorithm,
                      TrackQuality quality, signed char nloops, uint8_t stopReason,
-		     double t0, double beta, double covt0t0, double covbetabeta):
+		     float t0, float beta, float covt0t0, float covbetabeta):
     covt0t0_(covt0t0),
     covbetabeta_(covbetabeta),
     chi2_(chi2),

--- a/DataFormats/TrackReco/src/TrackBase.cc
+++ b/DataFormats/TrackReco/src/TrackBase.cc
@@ -89,10 +89,15 @@ TrackBase::TrackBase() :
 
 TrackBase::TrackBase(double chi2, double ndof, const Point &vertex, const Vector &momentum,
                      int charge, const CovarianceMatrix &cov, TrackAlgorithm algorithm,
-                     TrackQuality quality, signed char nloops, uint8_t stopReason):
+                     TrackQuality quality, signed char nloops, uint8_t stopReason,
+		     double t0, double beta, double covt0t0, double covbetabeta):
+    covt0t0_(covt0t0),
+    covbetabeta_(covbetabeta),
     chi2_(chi2),
     vertex_(vertex),
+    t0_(t0),
     momentum_(momentum),
+    beta_(beta),
     ndof_(ndof),
     charge_(charge),
     algorithm_(algorithm),

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -9,7 +9,8 @@
    <version ClassVersion="11" checksum="639174599"/>
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
-  <class name="reco::TrackBase" ClassVersion="19">
+  <class name="reco::TrackBase" ClassVersion="20">
+   <version ClassVersion="20" checksum="1589774059"/>
    <version ClassVersion="19" checksum="4090229239"/>
    <version ClassVersion="18" checksum="1935215297"/>
    <version ClassVersion="17" checksum="1774167599"/>
@@ -318,7 +319,8 @@
   <class name="edm::Ref<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
-  <class name="reco::Track" ClassVersion="19">
+  <class name="reco::Track" ClassVersion="20">
+   <version ClassVersion="20" checksum="2864582648"/>
    <version ClassVersion="19" checksum="362503460"/>
    <version ClassVersion="18" checksum="3235158110"/>
    <version ClassVersion="17" checksum="3387867292"/>


### PR DESCRIPTION
Add time, velocity, and corresponding diagonal covariance terms to reco::TrackBase.
These (in addition to #24419) are the minimal changes needed for MTD development.

This is purely technical, getting it in place so that we can ease development.