### PR TITLE
Raised nPix threshhold on pp_on_AA_2018 era track cluster checker

### DIFF
--- a/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
@@ -13,10 +13,15 @@ peripheralPbPb.toModify(trackerClusterCheck,
                         cut = "strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)"
                         )
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toModify(trackerClusterCheck,
+    pp_on_XeXe_2017.toModify(trackerClusterCheck,
                doClusterCheck=True, #FIXMETOO
                cut = "strip < 1000000 && pixel < 100000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/2.)",
                MaxNumberOfPixelClusters = 100000
+               )
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+    pp_on_AA_2018.toModify(trackerClusterCheck,
+               doClusterCheck=True, 
+               cut = "strip < 1000000 && pixel < 150000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/2.)",
+               MaxNumberOfPixelClusters = 150000
                )

--- a/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
@@ -13,14 +13,14 @@ peripheralPbPb.toModify(trackerClusterCheck,
                         cut = "strip < 400000 && pixel < 40000 && (strip < 60000 + 7.0*pixel) && (pixel < 8000 + 0.14*strip)"
                         )
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
-    pp_on_XeXe_2017.toModify(trackerClusterCheck,
+pp_on_XeXe_2017.toModify(trackerClusterCheck,
                doClusterCheck=True, #FIXMETOO
                cut = "strip < 1000000 && pixel < 100000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/2.)",
                MaxNumberOfPixelClusters = 100000
                )
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-    pp_on_AA_2018.toModify(trackerClusterCheck,
+pp_on_AA_2018.toModify(trackerClusterCheck,
                doClusterCheck=True, 
                cut = "strip < 1000000 && pixel < 150000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/2.)",
                MaxNumberOfPixelClusters = 150000


### PR DESCRIPTION
The thresholds used for the track cluster checker were previously copied from what was used in XeXe collisions in 2017.  However, PbPb collisions are expected to have more hits, so we checked if these cuts were appropriate for 2018 data.  Based on the plot at [1], we determined that it would be best if we slightly raised the threshold on the number of pixels.

[1] https://indico.cern.ch/event/754818/contributions/3127986/attachments/1709774/2757318/clusterCheck.pdf

@mandrenguyen 