### PR TITLE
Tracker alignment: fixing space at beginning of line in auto-created python scripts

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_splice.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_splice.py
@@ -72,9 +72,9 @@ for j in xrange(numberOfExtends):
         i+=1
 
     for line in fileinput.input(outCfg, inplace=1):
-        print(line, end=' ')
+        print(line,end='')
         if re.match('readFiles\s*=\s*cms.untracked.vstring()',line):
-            print(insertBlock, end=' ')
+            print(insertBlock,end='')
 
 if args.skip_events is not None:
     with open(outCfg, "a") as f:


### PR DESCRIPTION
With the new style print() statement something like this:
```
print("SomeText\n",end=' ')
print("SomeOtherText\n",end=' ')
```
Will add the space specified as separation character at the beginning of the next line of printed text. This PR fixes one instance in the MillePede code where such statements are used to generate python scripts, which means the additional space at the beginning of every line (except for the first) leads to an indentation error.