### PR TITLE
FastSim: make two parameters of the KineParticleFilter configurable

### DIFF
--- a/FastSimulation/Event/python/ParticleFilter_cfi.py
+++ b/FastSimulation/Event/python/ParticleFilter_cfi.py
@@ -10,8 +10,12 @@ ParticleFilterBlock = cms.PSet(
         chargedPtMin = cms.double(0.1),
         # Particles must have energy greater than EMin [GeV]
         EMin = cms.double(0.1),
+        # the two following variables define the volume enclosed by the calorimeters
+        # radius of the ECAL barrel inner surface
+        rMax = cms.double(129.),
+        # half-length of the ECAL endcap inner surface
+        zMax = cms.double(317.),
         # List of invisible particles (abs of pdgid)
         invisibleParticles = cms.vint32()
         )
     )
-

--- a/FastSimulation/Event/src/KineParticleFilter.cc
+++ b/FastSimulation/Event/src/KineParticleFilter.cc
@@ -2,26 +2,28 @@
 #include "FastSimulation/Particle/interface/RawParticle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-KineParticleFilter::KineParticleFilter(const edm::ParameterSet & cfg) 
+KineParticleFilter::KineParticleFilter(const edm::ParameterSet & cfg)
 {
     // Charged particles must have pt greater than chargedPtMin [GeV]
     double chargedPtMin  = cfg.getParameter<double>("chargedPtMin");
     chargedPtMin2  = chargedPtMin*chargedPtMin;
-    
+
     // Particles must have energy greater than EMin [GeV]
     EMin   = cfg.getParameter<double>("EMin");
-    
+
     // Allow *ALL* protons with energy > protonEMin
     protonEMin   = cfg.getParameter<double>("protonEMin");
-    
+
     // Particles must have abs(eta) < etaMax (if close enough to 0,0,0)
     double etaMax = cfg.getParameter<double>("etaMax");
     cos2ThetaMax = (std::exp(2.*etaMax)-1.) / (std::exp(2.*etaMax)+1.);
     cos2ThetaMax *= cos2ThetaMax;
 
     // Particles must have vertex inside the volume enclosed by ECAL
-    vertexRMax2 = 129.0*129.0; 
-    vertexZMax = 317;
+    double vertexRMax = cfg.getParameter<double>("rMax");
+    vertexRMax2 = vertexRMax*vertexRMax;
+    vertexZMax = cfg.getParameter<double>("zMax");
+
 }
 
 bool KineParticleFilter::acceptParticle(const RawParticle & particle) const
@@ -34,36 +36,36 @@ bool KineParticleFilter::acceptParticle(const RawParticle & particle) const
     {
 	return false;
     }
-    
+
     // keep all high-energy protons
     else if(pId == 2212 && particle.E() >= protonEMin)
     {
 	return true;
     }
-    
+
     // cut on the energy
     else if( particle.E() < EMin)
     {
 	return false;
     }
-    
+
     // cut on pt of charged particles
     else if( particle.charge()!=0 && particle.Perp2()<chargedPtMin2)
     {
 	return false;
     }
-    
+
     // cut on eta if the origin vertex is close to the beam
     else if( particle.vertex().Perp2() < 25. && particle.cos2Theta() > cos2ThetaMax)
     {
 	return false;
     }
-    
+
 
 
     // particles must have vertex in volume enclosed by ECAL
     return acceptVertex(particle.vertex());
-} 
+}
 
 
 bool KineParticleFilter::acceptVertex(const XYZTLorentzVector & vertex) const


### PR DESCRIPTION
This PR aims at removing two hard-coded parameters related to the geometry of the detector in the particle filter of the FastSim. (The particle filter is used to select the generated particles that are in the acceptance of the detector)
Thus, it will be possible to use the same facility for the upgrade studies. At the moment, the FSimEvent, which uses this KineParticleFilter, is used in [the HGCAL ntuplizer](https://github.com/CMS-HGCAL/reco-ntuples).

I performed a validation using the 250402.0 workflow from runTheMatrix (ttbar events with premixing). To do so, I checked the generalTracks. Indeed, in the FastSim the tracks are derived from the MC tracks, therefore if a different set of generated particles selected, it should reflect in the collection of tracks. 

I find that the number of tracks and their pT spectrum are strictly identical in the two cases.
![canvas_1_new](https://user-images.githubusercontent.com/4553043/45094575-0243d280-b11c-11e8-996b-49f2f478d7c7.png)
![canvas_1_default](https://user-images.githubusercontent.com/4553043/45094605-12f44880-b11c-11e8-900e-4a8d2e1bedaf.png)

