### PR TITLE
Prepare for concurrent IOVs, HcalDbProducer 

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
@@ -22,76 +22,116 @@
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-
-class HcalDbService;
-class HcalDbRecord;
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include "CondFormats/DataRecord/interface/HcalAllRcds.h"
+#include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
-
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 
 class HcalDbProducer : public edm::ESProducer {
- public:
+public:
   HcalDbProducer( const edm::ParameterSet& );
   ~HcalDbProducer() override;
-  
+
   std::shared_ptr<HcalDbService> produce( const HcalDbRecord& );
 
-  std::shared_ptr<HcalChannelQuality> produceChannelQualityWithTopo( const HcalChannelQualityRcd&);
+  std::unique_ptr<HcalPedestals> producePedestalsWithTopo(const HcalPedestalsRcd&);
+  std::unique_ptr<HcalPedestalWidths> producePedestalWidthsWithTopo(const HcalPedestalWidthsRcd&);
+  std::unique_ptr<HcalPedestals> produceEffectivePedestalsWithTopo(const HcalPedestalsRcd&);
+  std::unique_ptr<HcalPedestalWidths> produceEffectivePedestalWidthsWithTopo(const HcalPedestalWidthsRcd&);
+  std::unique_ptr<HcalGains> produceGainsWithTopo(const HcalGainsRcd&);
+  std::unique_ptr<HcalGainWidths> produceGainWidthsWithTopo(const HcalGainWidthsRcd&);
+  std::unique_ptr<HcalQIEData> produceQIEDataWithTopo(const HcalQIEDataRcd&);
+  std::unique_ptr<HcalQIETypes> produceQIETypesWithTopo(const HcalQIETypesRcd&);
+  std::unique_ptr<HcalChannelQuality> produceChannelQualityWithTopo( const HcalChannelQualityRcd&);
+  std::unique_ptr<HcalZSThresholds> produceZSThresholdsWithTopo(const HcalZSThresholdsRcd&);
+  std::unique_ptr<HcalRespCorrs> produceRespCorrsWithTopo(const HcalRespCorrsRcd&);
+  std::unique_ptr<HcalL1TriggerObjects> produceL1triggerObjectsWithTopo(const HcalL1TriggerObjectsRcd&);
+  std::unique_ptr<HcalTimeCorrs> produceTimeCorrsWithTopo(const HcalTimeCorrsRcd&);
+  std::unique_ptr<HcalLUTCorrs> produceLUTCorrsWithTopo(const HcalLUTCorrsRcd&);
+  std::unique_ptr<HcalPFCorrs> producePFCorrsWithTopo(const HcalPFCorrsRcd&);
+  std::unique_ptr<HcalLutMetadata> produceLUTMetadataWithTopo(const HcalLutMetadataRcd&);
+  std::unique_ptr<HcalSiPMParameters> produceSiPMParametersWithTopo(const HcalSiPMParametersRcd&);
+  std::unique_ptr<HcalTPChannelParameters> produceTPChannelParametersWithTopo(const HcalTPChannelParametersRcd&);
+  std::unique_ptr<HcalMCParams> produceMCParamsWithTopo(const HcalMCParamsRcd&);
+  std::unique_ptr<HcalRecoParams> produceRecoParamsWithTopo(const HcalRecoParamsRcd&);
 
-  // callbacks
-  void pedestalsCallback (const HcalPedestalsRcd& fRecord);
-  void pedestalWidthsCallback (const HcalPedestalWidthsRcd& fRecord);
-  void effectivePedestalsCallback (const HcalPedestalsRcd& fRecord);
-  void effectivePedestalWidthsCallback (const HcalPedestalWidthsRcd& fRecord);
-  void gainsCallback (const HcalGainsRcd& fRecord);
-  void gainWidthsCallback (const HcalGainWidthsRcd& fRecord);
-  void QIEDataCallback (const HcalQIEDataRcd& fRecord);
-  void QIETypesCallback (const HcalQIETypesRcd& fRecord);
-  void channelQualityCallback (const HcalChannelQualityRcd& fRecord);
-  void zsThresholdsCallback (const HcalZSThresholdsRcd& fRecord);
-  void respCorrsCallback (const HcalRespCorrsRcd& fRecord);
-  void L1triggerObjectsCallback (const HcalL1TriggerObjectsRcd& fRecord);
-  void electronicsMapCallback (const HcalElectronicsMapRcd& fRecord);
-  void frontEndMapCallback (const HcalFrontEndMapRcd& fRecord);
-  void timeCorrsCallback (const HcalTimeCorrsRcd& fRecord);
-  void LUTCorrsCallback (const HcalLUTCorrsRcd& fRecord);
-  void PFCorrsCallback (const HcalPFCorrsRcd& fRecord);
-  void lutMetadataCallback (const HcalLutMetadataRcd& fRecord);
-  void SiPMParametersCallback (const HcalSiPMParametersRcd& fRecord);
-  void SiPMCharacteristicsCallback (const HcalSiPMCharacteristicsRcd& fRecord);
-  void TPChannelParametersCallback (const HcalTPChannelParametersRcd& fRecord);
-  void TPParametersCallback (const HcalTPParametersRcd& fRecord);
-  void MCParamsCallback (const HcalMCParamsRcd& fRecord);
-  void RecoParamsCallback (const HcalRecoParamsRcd& fRecord);
+  void setupPedestals(const HcalPedestalsRcd&, HcalDbService&);
+  void setupPedestalWidths(const HcalPedestalWidthsRcd&, HcalDbService&);
+  void setupEffectivePedestals(const HcalPedestalsRcd&, HcalDbService&);
+  void setupEffectivePedestalWidths(const HcalPedestalWidthsRcd&, HcalDbService&);
 
 private:
-      // ----------member data ---------------------------
-  std::shared_ptr<HcalDbService> mService;
+
+  using HostType = edm::ESProductHost<HcalDbService,
+                                      HcalPedestalsRcd,
+                                      HcalPedestalWidthsRcd,
+                                      HcalGainsRcd,
+                                      HcalGainWidthsRcd,
+                                      HcalQIEDataRcd,
+                                      HcalQIETypesRcd,
+                                      HcalChannelQualityRcd,
+                                      HcalZSThresholdsRcd,
+                                      HcalRespCorrsRcd,
+                                      HcalL1TriggerObjectsRcd,
+                                      HcalTimeCorrsRcd,
+                                      HcalLUTCorrsRcd,
+                                      HcalPFCorrsRcd,
+                                      HcalLutMetadataRcd,
+                                      HcalSiPMParametersRcd,
+                                      HcalTPChannelParametersRcd,
+                                      HcalMCParamsRcd,
+                                      HcalRecoParamsRcd,
+                                      HcalElectronicsMapRcd,
+                                      HcalFrontEndMapRcd,
+                                      HcalSiPMCharacteristicsRcd,
+                                      HcalTPParametersRcd>;
+
+  template <typename ProductType, typename RecordType>
+  static std::unique_ptr<ProductType> produceWithTopology(RecordType const& record) {
+
+    edm::ESTransientHandle<ProductType> item;
+    record.get(item);
+
+    auto productWithTopology = std::make_unique<ProductType>(*item);
+
+    edm::ESHandle<HcalTopology> htopo;
+    record. template getRecord<HcalRecNumberingRecord>().get(htopo);
+    const HcalTopology* topo=&(*htopo);
+    productWithTopology->setTopo(topo);
+
+    return productWithTopology;
+  }
+
+  template <typename ProductType, typename RecordType>
+  void setupHcalDbService(HostType& host,
+                          const HcalDbRecord& record,
+                          const char* label,
+                          const char* dumpName,
+                          const char* dumpHeader) {
+
+    host.ifRecordChanges<RecordType>(record,
+                                     [this, &host, label, dumpName, dumpHeader](auto const& rec) {
+      edm::ESHandle<ProductType> item;
+      rec.get(label, item);
+      host.setData(item.product());
+
+      if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string (dumpName)) != mDumpRequest.end()) {
+        *mDumpStream << dumpHeader << std::endl;
+        HcalDbASCIIIO::dumpObject(*mDumpStream, *item);
+      }
+    });
+  }
+
+  // ----------member data ---------------------------
+  edm::ReusableObjectHolder<HostType> holder_;
+
   std::vector<std::string> mDumpRequest;
   std::ostream* mDumpStream;
-
-  std::unique_ptr<HcalPedestals> mPedestals;
-  std::unique_ptr<HcalPedestalWidths> mPedestalWidths;
-  std::unique_ptr<HcalPedestals> mEffectivePedestals;
-  std::unique_ptr<HcalPedestalWidths> mEffectivePedestalWidths;
-  std::unique_ptr<HcalGains> mGains;
-  std::unique_ptr<HcalGainWidths> mGainWidths;
-  std::unique_ptr<HcalQIEData> mQIEData;
-  std::unique_ptr<HcalQIETypes> mQIETypes;
-  std::unique_ptr<HcalRespCorrs> mRespCorrs;
-  std::unique_ptr<HcalLUTCorrs> mLUTCorrs;
-  std::unique_ptr<HcalPFCorrs> mPFCorrs;
-  std::unique_ptr<HcalTimeCorrs> mTimeCorrs;
-  std::unique_ptr<HcalZSThresholds> mZSThresholds;
-  std::unique_ptr<HcalL1TriggerObjects> mL1TriggerObjects;
-  std::unique_ptr<HcalLutMetadata> mLutMetadata;
-  std::unique_ptr<HcalSiPMParameters> mSiPMParameters;
-  std::unique_ptr<HcalSiPMCharacteristics> mSiPMCharacteristics;
-  std::unique_ptr<HcalTPChannelParameters> mTPChannelParameters;
-  std::unique_ptr<HcalTPParameters> mTPParameters;
-  std::unique_ptr<HcalMCParams> mMCParams;
-  std::unique_ptr<HcalRecoParams> mRecoParams;
-
 };

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -1,10 +1,9 @@
+#ifndef CalibFormats_HcalObjects_HcalDbService_h
+#define CalibFormats_HcalObjects_HcalDbService_h
 
 //
 // F.Ratnikov (UMd), Aug. 9, 2005
 //
-
-#ifndef HcalDbService_h
-#define HcalDbService_h
 
 #include <memory>
 #include <map>
@@ -133,3 +132,4 @@ class HcalDbService {
 };
 
 #endif
+

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -26,7 +26,7 @@ class HcalTopology;
 
 class HcalDbService {
  public:
-  HcalDbService (const edm::ParameterSet&);
+  HcalDbService();
   ~HcalDbService();
 
   const HcalTopology* getTopologyUsed() const;

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -30,7 +30,7 @@ class HcalDbService {
   ~HcalDbService();
 
   const HcalTopology* getTopologyUsed() const;
-  
+
   const HcalCalibrations& getHcalCalibrations(const HcalGenericDetId& fId) const;
   const HcalCalibrationWidths& getHcalCalibrationWidths(const HcalGenericDetId& fId) const;
   const HcalCalibrationsSet* getHcalCalibrationsSet() const;
@@ -95,10 +95,10 @@ class HcalDbService {
   void setData (const HcalRecoParams* fItem) {mRecoParams = fItem;}
 
  private:
-  bool makeHcalCalibration (const HcalGenericDetId& fId, HcalCalibrations* fObject, 
+  bool makeHcalCalibration (const HcalGenericDetId& fId, HcalCalibrations* fObject,
 			    bool pedestalInADC, bool effPedestalInADC) const;
   void buildCalibrations() const;
-  bool makeHcalCalibrationWidth (const HcalGenericDetId& fId, HcalCalibrationWidths* fObject, 
+  bool makeHcalCalibrationWidth (const HcalGenericDetId& fId, HcalCalibrationWidths* fObject,
 				 bool pedestalInADC, bool effPedestalInADC) const;
   void buildCalibWidths() const;
   bool convertPedestals(const HcalGenericDetId& fId, const HcalPedestal* pedestal, float* pedTrue, bool inADC) const;

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -13,7 +13,7 @@
 
 #include <cmath>
 
-HcalDbService::HcalDbService (const edm::ParameterSet& cfg):
+HcalDbService::HcalDbService() :
   mPedestals (nullptr), mPedestalWidths (nullptr),
   mEffectivePedestals (nullptr), mEffectivePedestalWidths (nullptr),
   mGains (nullptr), mGainWidths (nullptr),

--- a/CalibFormats/HcalObjects/src/HcalDbService.cc
+++ b/CalibFormats/HcalObjects/src/HcalDbService.cc
@@ -13,10 +13,10 @@
 
 #include <cmath>
 
-HcalDbService::HcalDbService (const edm::ParameterSet& cfg): 
+HcalDbService::HcalDbService (const edm::ParameterSet& cfg):
   mPedestals (nullptr), mPedestalWidths (nullptr),
   mEffectivePedestals (nullptr), mEffectivePedestalWidths (nullptr),
-  mGains (nullptr), mGainWidths (nullptr),  
+  mGains (nullptr), mGainWidths (nullptr),
   mQIEData(nullptr),
   mQIETypes(nullptr),
   mElectronicsMap(nullptr), mFrontEndMap(nullptr),
@@ -49,26 +49,26 @@ const HcalTopology* HcalDbService::getTopologyUsed() const {
 }
 
 
-const HcalCalibrations& HcalDbService::getHcalCalibrations(const HcalGenericDetId& fId) const 
-{ 
+const HcalCalibrations& HcalDbService::getHcalCalibrations(const HcalGenericDetId& fId) const
+{
   buildCalibrations();
   return (*mCalibSet.load(std::memory_order_acquire)).getCalibrations(fId);
 }
 
-const HcalCalibrationWidths& HcalDbService::getHcalCalibrationWidths(const HcalGenericDetId& fId) const 
-{ 
+const HcalCalibrationWidths& HcalDbService::getHcalCalibrationWidths(const HcalGenericDetId& fId) const
+{
   buildCalibWidths();
   return (*mCalibWidthSet.load(std::memory_order_acquire)).getCalibrationWidths(fId);
 }
 
-const HcalCalibrationsSet* HcalDbService::getHcalCalibrationsSet() const 
-{ 
+const HcalCalibrationsSet* HcalDbService::getHcalCalibrationsSet() const
+{
   buildCalibrations();
   return mCalibSet.load(std::memory_order_acquire);
 }
 
-const HcalCalibrationWidthsSet* HcalDbService::getHcalCalibrationWidthsSet() const 
-{ 
+const HcalCalibrationWidthsSet* HcalDbService::getHcalCalibrationWidthsSet() const
+{
   buildCalibWidths();
   return mCalibWidthSet.load(std::memory_order_acquire);
 }
@@ -173,10 +173,10 @@ bool HcalDbService::makeHcalCalibration (const HcalGenericDetId& fId, HcalCalibr
 
     float effPedTrue[4];
     bool effconverted = convertPedestals(fId,effpedestal,effPedTrue,effPedestalInADC);
-	
+
     if (pedestal && effpedestal && converted && effconverted && gain && respcorr && timecorr && lutcorr) {
       *fObject = HcalCalibrations (gain->getValues(), pedTrue, effPedTrue, respcorr->getValue(), timecorr->getValue(), lutcorr->getValue() );
-      return true; 
+      return true;
     }
   }
   return false;
@@ -207,7 +207,7 @@ bool HcalDbService::convertPedestalWidths(const HcalGenericDetId& fId, const Hca
 }
 
 
-bool HcalDbService::makeHcalCalibrationWidth (const HcalGenericDetId& fId, 
+bool HcalDbService::makeHcalCalibrationWidth (const HcalGenericDetId& fId,
 					      HcalCalibrationWidths* fObject, bool pedestalInADC, bool effPedestalInADC) const {
   if (fObject) {
     const HcalPedestalWidth* pedestalwidth = getPedestalWidth (fId);
@@ -221,11 +221,11 @@ bool HcalDbService::makeHcalCalibrationWidth (const HcalGenericDetId& fId,
     bool effconverted = convertPedestalWidths(fId,effpedestalwidth,effPedTrueWidth,effPedestalInADC);
     if (pedestalwidth && effpedestalwidth&& gainwidth && converted && effconverted) {
       *fObject = HcalCalibrationWidths (gainwidth->getValues (), pedTrueWidth, effPedTrueWidth);
-      return true; 
-    } 
+      return true;
+    }
   }
   return false;
-}  
+}
 
 const HcalQIEType* HcalDbService::getHcalQIEType (const HcalGenericDetId& fId) const {
   if (mQIETypes) {

--- a/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
@@ -223,9 +223,8 @@ void HcalDigitizerTest::analyze(const edm::Event& iEvent,
   //std::cout << "ZDC pedestal width " << pedestalWidths.getWidth(zdcDetId,  1) << std::endl;
   //std::cout << "ZDC gain " << gains.getValue(zdcDetId,  1) << std::endl;
   //std::cout << "ZDC gain width " << gainWidths.getValue(zdcDetId,  1) << std::endl;
-  
-  edm::ParameterSet emptyPSet;
-  HcalDbService calibratorHandle(emptyPSet);
+
+  HcalDbService calibratorHandle;
   calibratorHandle.setData(&pedestals);
   calibratorHandle.setData(&pedestalWidths);
   calibratorHandle.setData(&gains);


### PR DESCRIPTION
Note this PR contains 2 commits. The first commit just changes the line endings of HcalDbService from DOS to UNIX. The second commit contains the more substantive changes. Only 2 lines changed in HcalDbService, removing an unused constructor argument. Almost all the substantive changes are in HcalDbProducer. The intent is that it should behave identically when there is only one IOV processed at a time and its behavior is changed so that it will work also with concurrent IOVs.

I tested by turning on the debug print option for the many different callbacks and compared the output with and without my changes and it was identical. This is enabled with the "dump" configuration parameter of the HcalDbProducer. With one exception, for LutMetadata the debug print option throws a fatal exception both before and after my changes. I didn't fix this, but I didn't break it either.
