### PR TITLE
[10.3.X] Introduce RelVal wf for testing SiStrip hybrid emulation and Hybrid ZeroSuppression of 2015 PbPb VirginRaw data

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -115,6 +115,8 @@ workflows[140.52] = ['',['RunHI2010','RECOHID10','RECOHIR10D11','HARVESTDHI']]
 workflows[140.53] = ['',['RunHI2011','RECOHID11','HARVESTDHI']]
 workflows[140.54] = ['',['RunPA2013','RECO_PPbData','HARVEST_PPbData']]
 
+workflows[140.55] = ['',['RunHI2015VR','HYBRIDRepackHI2015VR','HYBRIDZSHI2015','RECOHID15','HARVESTDHI15']]
+
 ### run2 2015B 50ns ###
 workflows[134.701] = ['',['RunHLTPhy2015B','HLTDR2_50ns','RECODR2_50nsreHLT_HIPM','HARVESTDR2']]
 workflows[134.702] = ['',['RunDoubleEG2015B','HLTDR2_50ns','RECODR2_50nsreHLT_HIPM','HARVESTDR2']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -93,6 +93,9 @@ steps['RunHI2010']={'INPUT':InputInfo(dataSet='/HIAllPhysics/HIRun2010-v1/RAW',l
 steps['RunHI2011']={'INPUT':InputInfo(dataSet='/HIMinBiasUPC/HIRun2011-v1/RAW',label='hi2011',run=[182124],events=10000,location='STD')}
 steps['RunPA2013']={'INPUT':InputInfo(dataSet='/PAMinBiasUPC/HIRun2013-v1/RAW',label='pa2013',run=[211313],events=10000,location='STD')}
 
+Run2015HI={263400: [[65,904]]}
+steps['RunHI2015VR']={'INPUT':InputInfo(dataSet='/HITrackerVirginRaw/HIRun2015-v1/RAW',label='hi2015vr',events=10000,location='STD',ls=Run2015HI)}
+
 Run2012A=[191226]
 Run2012ASk=Run2012A+[]
 steps['RunMinBias2012A']={'INPUT':InputInfo(dataSet='/MinimumBias/Run2012A-v1/RAW',label='mb2012A',run=Run2012A, events=100000,location='STD')}
@@ -1544,6 +1547,30 @@ steps['RECOHID10']['-s']+=',REPACK'
 steps['RECOHID10']['--datatier']+=',RAW'
 steps['RECOHID10']['--eventcontent']+=',REPACKRAW'
 
+steps['HYBRIDRepackHI2015VR']={'--eventcontent':'RAW',
+                               '--datatier':'RAW',
+                               '--conditions':'auto:run2_data',
+                               '--step':'RAW2DIGI,REPACK:DigiToHybridRawRepack',
+                               '--scenario':'HeavyIons',                     
+                               '--data':'',
+                               '--era':'Run2_HI',
+                               '--customise':'RecoLocalTracker/SiStripZeroSuppression/customiseHybrid.addHybridEmulationBeforeRepack',
+                               '--processName':'EMULATEHYBRID',    
+                               #'--customise_commands':'\'process.RAWoutput.outputCommands.append(\"drop *_*_*_HLT*\")\'',
+                               '-n':100
+                               }
+
+steps['HYBRIDZSHI2015']=merge([{'--step': 'RAW2DIGI,REPACK:DigiToRawRepack',
+                                '--processName':'REHLT',
+                                '--customise': 'RecoLocalTracker/SiStripZeroSuppression/customiseHybrid.runOnHybridZS,RecoLocalTracker/SiStripZeroSuppression/customiseHybrid.repackZSHybrid',
+                                '--customise_commands':'\'from Configuration.Applications.ConfigBuilder import MassReplaceInputTag; MassReplaceInputTag(process, new="hybridRawDataRepacker")\'' ,
+                                },steps['HYBRIDRepackHI2015VR']])
+
+steps['RECOHID15']=merge([{ '--runUnscheduled':'',
+                            '--conditions':'auto:run2_data',
+                            '--era':'Run2_HI'
+                            },steps['RECOHID11']])
+                           
 steps['TIER0']=merge([{'--customise':'Configuration/DataProcessing/RecoTLR.customisePrompt',
                        '-s':'RAW2DIGI,L1Reco,RECO,EI,ALCAPRODUCER:@allForPrompt,DQM:@allForPrompt,ENDJOB',
                        '--datatier':'RECO,AOD,ALCARECO,DQMIO',
@@ -2232,6 +2259,9 @@ steps['HARVESTDHI']={'-s':'HARVESTING:dqmHarvesting',
                    '--data':'',
                    '--scenario':'HeavyIons'}
 
+steps['HARVESTDHI15']=merge([{ '--conditions':'auto:run2_data',
+                               '--era':'Run2_HI',
+                               '-n':-1},steps['HARVESTDHI']])
 
 #MC
 steps['HARVEST']={'-s':'HARVESTING:validationHarvestingNoHLT+dqmHarvestingFakeHLT',


### PR DESCRIPTION
Greetings,
as https://github.com/cms-sw/cmssw/pull/24339, adding the Hybrid Format SiStrip Zero Suppression algorithms for 2018 PbPb data-taking, has recently been merged in the 10.3.X branch, this PR packages into a RelVal wofkflow the steps for:
   * taking as input the 2015 PbPb `VirginRaw` data;
   * hybrid emulation (with ZS10 repacking);
   * HLT-like zero-suppression of hybridized input (with normal ZS repacking);
   * standard RECO of the repacked out;

The 3 steps have been taken from https://github.com/cms-sw/cmssw/pull/24339#issuecomment-418740678.

FYI @echabert @pieterdavid @icali @CesarBernardes 