### PR TITLE
Add HI jet histograms to offline DQM for pp_on_AA_2018 era

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -187,16 +187,8 @@ phase2_hcal.toReplaceWith( PostDQMOfflineMiniAOD, PostDQMOfflineMiniAOD.copyAndE
     pfMetDQMAnalyzerMiniAOD, pfPuppiMetDQMAnalyzerMiniAOD # No hcalnoise yet
 ]))
 
-# Import the heavy ion JetMET sequence
-from DQMOffline.JetMET.jetMETDQMOfflineSourceHI_cff import jetMETDQMOfflineSource as jetMETDQMOfflineSourceHI
-
-# Define a new offline sequence for heavy ions
-DQMOfflineHI = cms.Sequence(DQMOffline.copyAndExclude([pfTauRunDQMValidation,jetMETDQMOfflineSource]) * jetMETDQMOfflineSourceHI)
-
-# For pp_on_AA_2018 era, replace the pp sequence with PbPb sequence
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toReplaceWith(DQMOffline, DQMOfflineHI)
-
+pp_on_AA_2018.toReplaceWith(DQMOffline, DQMOffline.copyAndExclude([pfTauRunDQMValidation]))
 
 from PhysicsTools.NanoAOD.nanoDQM_cff import nanoDQM
 DQMOfflineNanoAOD = cms.Sequence(nanoDQM)

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -187,8 +187,16 @@ phase2_hcal.toReplaceWith( PostDQMOfflineMiniAOD, PostDQMOfflineMiniAOD.copyAndE
     pfMetDQMAnalyzerMiniAOD, pfPuppiMetDQMAnalyzerMiniAOD # No hcalnoise yet
 ]))
 
+# Import the heavy ion JetMET sequence
+from DQMOffline.JetMET.jetMETDQMOfflineSourceHI_cff import jetMETDQMOfflineSource as jetMETDQMOfflineSourceHI
+
+# Define a new offline sequence for heavy ions
+DQMOfflineHI = cms.Sequence(DQMOffline.copyAndExclude([pfTauRunDQMValidation,jetMETDQMOfflineSource]) * jetMETDQMOfflineSourceHI)
+
+# For pp_on_AA_2018 era, replace the pp sequence with PbPb sequence
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toReplaceWith(DQMOffline, DQMOffline.copyAndExclude([pfTauRunDQMValidation]))
+pp_on_AA_2018.toReplaceWith(DQMOffline, DQMOfflineHI)
+
 
 from PhysicsTools.NanoAOD.nanoDQM_cff import nanoDQM
 DQMOfflineNanoAOD = cms.Sequence(nanoDQM)

--- a/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons.h
@@ -102,6 +102,7 @@ class JetAnalyzer_HeavyIons : public DQMEDAnalyzer {
   static constexpr int nedge_pseudorapidity = etaBins_ + 1; 
  
   edm::InputTag   mInputCollection;
+  edm::InputTag   mInputVtxCollection;
   edm::InputTag   mInputPFCandCollection;
   edm::InputTag   mInputCsCandCollection; 
  

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -13,13 +13,33 @@ jetDQMAnalyzerSequenceCosmics = cms.Sequence(jetDQMAnalyzerAk4CaloUncleaned)
 
 jetDQMAnalyzerSequenceMiniAOD = cms.Sequence(jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD*jetDQMAnalyzerAk4PFCHSCleanedMiniAOD*jetDQMAnalyzerAk8PFPUPPICleanedMiniAOD*jetDQMAnalyzerAk4PFCHSPuppiCleanedMiniAOD)
 
-jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMMatchAkPu4CaloAkPu4PF
+jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMAnalyzerIC5CaloHIUncleaned
+                                        * jetDQMMatchAkPu3CaloAkPu3PF
+                                        * jetDQMMatchAkPu4CaloAkPu4PF
+                                        * jetDQMMatchAkPu5CaloAkPu5PF
 
+                                        * jetDQMAnalyzerAkPU3Calo
                                         * jetDQMAnalyzerAkPU4Calo
+                                        * jetDQMAnalyzerAkPU5Calo
                                         
                                         * jetDQMAnalyzerAkPU3PF
                                         * jetDQMAnalyzerAkPU4PF
+                                        * jetDQMAnalyzerAkPU5PF
                                      
+                                        * jetDQMAnalyzerAkCs3PF
                                         * jetDQMAnalyzerAkCs4PF
 )
+
+_jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMMatchAkPu4CaloAkPu4PF
+        * jetDQMAnalyzerAkPU4Calo
+        * jetDQMAnalyzerAkPU3PF
+        * jetDQMAnalyzerAkPU4PF
+        * jetDQMAnalyzerAkCs4PF
+)
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith( jetDQMAnalyzerSequence, _jetDQMAnalyzerSequenceHI )
+pp_on_AA_2018.toModify( jetDQMAnalyzerAkPU4Calo, srcVtx = cms.untracked.InputTag("offlinePrimaryVertices") )
+pp_on_AA_2018.toModify( jetDQMAnalyzerAkPU3PF, srcVtx = cms.untracked.InputTag("offlinePrimaryVertices") )
+pp_on_AA_2018.toModify( jetDQMAnalyzerAkPU4PF, srcVtx = cms.untracked.InputTag("offlinePrimaryVertices") )
+pp_on_AA_2018.toModify( jetDQMAnalyzerAkCs4PF, srcVtx = cms.untracked.InputTag("offlinePrimaryVertices") )
 

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -13,20 +13,13 @@ jetDQMAnalyzerSequenceCosmics = cms.Sequence(jetDQMAnalyzerAk4CaloUncleaned)
 
 jetDQMAnalyzerSequenceMiniAOD = cms.Sequence(jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD*jetDQMAnalyzerAk4PFCHSCleanedMiniAOD*jetDQMAnalyzerAk8PFPUPPICleanedMiniAOD*jetDQMAnalyzerAk4PFCHSPuppiCleanedMiniAOD)
 
-jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMAnalyzerIC5CaloHIUncleaned
-                                        * jetDQMMatchAkPu3CaloAkPu3PF
-                                        * jetDQMMatchAkPu4CaloAkPu4PF
-                                        * jetDQMMatchAkPu5CaloAkPu5PF
+jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMMatchAkPu4CaloAkPu4PF
 
-                                        * jetDQMAnalyzerAkPU3Calo
                                         * jetDQMAnalyzerAkPU4Calo
-                                        * jetDQMAnalyzerAkPU5Calo
                                         
                                         * jetDQMAnalyzerAkPU3PF
                                         * jetDQMAnalyzerAkPU4PF
-                                        * jetDQMAnalyzerAkPU5PF
                                      
-                                        * jetDQMAnalyzerAkCs3PF
                                         * jetDQMAnalyzerAkCs4PF
 )
 

--- a/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons.cc
@@ -17,6 +17,7 @@ using namespace std;
 
 JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
   mInputCollection               (iConfig.getParameter<edm::InputTag>       ("src")),
+  mInputVtxCollection            (iConfig.getUntrackedParameter<edm::InputTag>("srcVtx", edm::InputTag("hiSelectedVertex"))),
   mInputPFCandCollection         (iConfig.getParameter<edm::InputTag>       ("PFcands")),
   mInputCsCandCollection         (iConfig.exists("CScands") ? iConfig.getParameter<edm::InputTag>("CScands") : edm::InputTag()),
   mOutputFile                    (iConfig.getUntrackedParameter<std::string>("OutputFile","")),
@@ -53,7 +54,7 @@ JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
 
   centralityBinToken = mayConsume<int>(iConfig.exists("centralitybincollection") ? iConfig.getParameter<edm::InputTag> ("centralitybincollection"): edm::InputTag());
 
-  hiVertexToken_ = consumes<std::vector<reco::Vertex> >(edm::InputTag("offlinePrimaryVertices"));
+  hiVertexToken_ = consumes<std::vector<reco::Vertex> >(mInputVtxCollection);
 
   etaToken_ = mayConsume<std::vector<double>>(iConfig.exists("etaMap") ? iConfig.getParameter<edm::InputTag>( "etaMap" ) : edm::InputTag());
   rhoToken_ = mayConsume<std::vector<double>>(iConfig.exists("rho") ? iConfig.getParameter<edm::InputTag>( "rho" ) : edm::InputTag());

--- a/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons.cc
@@ -53,7 +53,7 @@ JetAnalyzer_HeavyIons::JetAnalyzer_HeavyIons(const edm::ParameterSet& iConfig) :
 
   centralityBinToken = mayConsume<int>(iConfig.exists("centralitybincollection") ? iConfig.getParameter<edm::InputTag> ("centralitybincollection"): edm::InputTag());
 
-  hiVertexToken_ = consumes<std::vector<reco::Vertex> >(edm::InputTag("hiSelectedVertex"));
+  hiVertexToken_ = consumes<std::vector<reco::Vertex> >(edm::InputTag("offlinePrimaryVertices"));
 
   etaToken_ = mayConsume<std::vector<double>>(iConfig.exists("etaMap") ? iConfig.getParameter<edm::InputTag>( "etaMap" ) : edm::InputTag());
   rhoToken_ = mayConsume<std::vector<double>>(iConfig.exists("rho") ? iConfig.getParameter<edm::InputTag>( "rho" ) : edm::InputTag());


### PR DESCRIPTION
In this PR the JetMET pp offline DMQ sequence is replaced by HI JetMET sequence if the era is pp_on_AA_2018. There are also small updates on JetMET files to make things work in this new era.