### PR TITLE
Pixel code cleanup 10_3

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -39,9 +39,9 @@ std::shared_ptr<SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProducer::
 	GlobalPoint center(0.0, 0.0, 0.0);
 	float theMagField = magfield.product()->inTesla(center).mag();
 
-	//  std::string label = "numerator";   // &&& Temporary: matches Barrel Layer1 for 2017 data
-	//  std::string label = "denominator"; // &&& Temporary: matches Barrel Layer1 fullsim MC
-	std::string label = "";      // the correct default
+    std::string label = "numerator";   // The correct default
+	//  std::string label = "denominator"; // Outdated. Used for MC in older GT's
+	//  std::string label = "";      // Outdated. Old default 
 
 	if(     theMagField>=-0.1 && theMagField<1.0 ) label = "0T";
 	else if(theMagField>=1.0  && theMagField<2.5 ) label = "2T";

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -271,7 +271,6 @@ protected:
    LocalVector driftDirection       (DetParam & theDetParam, LocalVector bfield ) const ;
    void computeLorentzShifts(DetParam &) const ;
    
-   bool isFlipped(DetParam const & theDetParam) const;              // is the det flipped or not?
    
    //---------------------------------------------------------------------------
    //  Cluster-level services.

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -201,7 +201,6 @@ void PixelCPEBase::fillDetParams()
       p.thePitchX = pitchxy.first;	     // pitch along x
       p.thePitchY = pitchxy.second;	     // pitch along y
       
-      //p.theSign = isFlipped(&p) ? -1 : 1; //Not used, AH.  PM: leave commented out.
       
       LocalVector Bfield = p.theDet->surface().toLocal(magfield_->inTesla(p.theDet->surface().position()));
       p.bz = Bfield.z();
@@ -277,21 +276,6 @@ void PixelCPEBase::
 computeAnglesFromTrajectory( DetParam const & theDetParam, ClusterParam & theClusterParam,
                             const LocalTrajectoryParameters & ltp) const
 {
-  // &&& PM: this comment is a candidate for deletion, but ask around first.
-   //cout<<" in PixelCPEBase:computeAnglesFromTrajectory - "<<endl; //dk
-   /*
-   //theClusterParam.loc_traj_param = ltp;   
-   LocalVector localDir = ltp.momentum();
-   float locx = localDir.x();
-   float locy = localDir.y();
-   float locz = localDir.z();
-    // Danek's definition
-    alpha_ = acos(locx/sqrt(locx*locx+locz*locz));
-    if ( isFlipped() )                    // &&& check for FPIX !!!
-    alpha_ = PI - alpha_ ;
-    beta_ = acos(locy/sqrt(locy*locy+locz*locz));
-    */
-   
    
    theClusterParam.cotalpha = ltp.dxdz();
    theClusterParam.cotbeta  = ltp.dydz();
@@ -333,60 +317,7 @@ computeAnglesFromTrajectory( DetParam const & theDetParam, ClusterParam & theClu
 void PixelCPEBase::
 computeAnglesFromDetPosition(DetParam const & theDetParam, ClusterParam & theClusterParam ) const
 {
-  // &&& PM: darn, we have a lot of junk here.  Need to clean up.
    
-   /*
-    // get cluster center of gravity (of charge)
-    float xcenter = cl.x();
-    float ycenter = cl.y();
-    
-    // get the cluster position in local coordinates (cm)
-    
-    // ggiurgiu@jhu.edu 12/09/2010 : This function is called without track info, therefore there are no track
-    // angles to provide here. Call the default localPosition (without track info)
-    LocalPoint lp = theTopol->localPosition( MeasurementPoint(xcenter, ycenter) );
-    
-    
-    // get the cluster position in global coordinates (cm)
-    GlobalPoint gp = theDet->surface().toGlobal( lp );
-    float gp_mod = sqrt( gp.x()*gp.x() + gp.y()*gp.y() + gp.z()*gp.z() );
-    
-    // normalize
-    float gpx = gp.x()/gp_mod;
-    float gpy = gp.y()/gp_mod;
-    float gpz = gp.z()/gp_mod;
-    
-    // make a global vector out of the global point; this vector will point from the
-    // origin of the detector to the cluster
-    GlobalVector gv(gpx, gpy, gpz);
-    
-    // make local unit vector along local X axis
-    const Local3DVector lvx(1.0, 0.0, 0.0);
-    
-    // get the unit X vector in global coordinates/
-    GlobalVector gvx = theDet->surface().toGlobal( lvx );
-    
-    // make local unit vector along local Y axis
-    const Local3DVector lvy(0.0, 1.0, 0.0);
-    
-    // get the unit Y vector in global coordinates
-    GlobalVector gvy = theDet->surface().toGlobal( lvy );
-    
-    // make local unit vector along local Z axis
-    const Local3DVector lvz(0.0, 0.0, 1.0);
-    
-    // get the unit Z vector in global coordinates
-    GlobalVector gvz = theDet->surface().toGlobal( lvz );
-    
-    // calculate the components of gv (the unit vector pointing to the cluster)
-    // in the local coordinate system given by the basis {gvx, gvy, gvz}
-    // note that both gv and the basis {gvx, gvy, gvz} are given in global coordinates
-    float gv_dot_gvx = gv.x()*gvx.x() + gv.y()*gvx.y() + gv.z()*gvx.z();
-    float gv_dot_gvy = gv.x()*gvy.x() + gv.y()*gvy.y() + gv.z()*gvy.z();
-    float gv_dot_gvz = gv.x()*gvz.x() + gv.y()*gvz.y() + gv.z()*gvz.z();
-    */
-   
-   // all the above is equivalent to
    LocalPoint lp = theDetParam.theTopol->localPosition( MeasurementPoint(theClusterParam.theCluster->x(), theClusterParam.theCluster->y()) );
    auto gvx = lp.x()-theDetParam.theOrigin.x();
    auto gvy = lp.y()-theDetParam.theOrigin.y();
@@ -419,26 +350,6 @@ computeAnglesFromDetPosition(DetParam const & theDetParam, ClusterParam & theClu
 
 
 
-//-----------------------------------------------------------------------------
-// The isFlipped() is a silly way to determine which detectors are inverted.
-// In the barrel for every 2nd ladder the E field direction is in the
-// global r direction (points outside from the z axis), every other
-// ladder has the E field inside. Something similar is in the
-// forward disks (2 sides of the blade). This has to be recognised
-// because the charge sharing effect is different.
-//
-// The isFliped does it by looking and the relation of the local (z always
-// in the E direction) to global coordinates. There is probably a much
-// better way.
-//-----------------------------------------------------------------------------
-bool PixelCPEBase::isFlipped(DetParam const & theDetParam) const
-{
-   // Check the relative position of the local +/- z in global coordinates.
-   float tmp1 = theDetParam.theDet->surface().toGlobal(Local3DPoint(0.,0.,0.)).perp2();
-   float tmp2 = theDetParam.theDet->surface().toGlobal(Local3DPoint(0.,0.,1.)).perp2();
-   if ( tmp2 < tmp1 ) return true;
-   else return false;
-}
 //------------------------------------------------------------------------
 PixelCPEBase::DetParam const & PixelCPEBase::detParam(const GeomDetUnit & det) const 
 {

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -178,14 +178,6 @@ void PixelCPEBase::fillDetParams()
          p.detTemplateId = templateDBobject_->getTemplateID(p.theDet->geographicalId());
       }
       
-      // &&& PM: I'm not sure what this does. Ask around.
-      // just for testing
-      //int i1 = 0;
-      //if(theFlag_==0) i1 = genErrorDBObject_->getGenErrorID(p.theDet->geographicalId().rawId());
-      //int i2= templateDBobject_->getTemplateID(p.theDet->geographicalId().rawId());
-      //int i3= templateDBobject_->getTemplateID(p.theDet->geographicalId());
-      //if(i2!=i3) cout<<i2<<" != "<<i3<<endl;
-      //cout<<i<<" "<<p.detTemplateId<<" "<<i1<<" "<<i2<<" "<<i3<<endl;
       
       auto topol = &(p.theDet->specificTopology());
       p.theTopol=topol;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -251,21 +251,6 @@ PixelCPEClusterRepair::localPosition(DetParam const & theDetParam, ClusterParam 
      //--- Did we find a cluster which has bad probability and not enough charge?
      if ( theClusterParam.recommended2D_ ) {
        //--- Yes. So run Template Reco 2d with cluster repair.
-       
-       // //--- Once again (!) copy clust's pixels (calibrated in electrons) into 
-       // //    clustMatrix.  We need to do that because the vanilla template reco
-       // //    will modify the ADC counts in situ (during decapitation)
-       // memset( clustMatrix, 0, sizeof(float)*mrow*mcol );   // Wipe it clean.
-       // for (int i=0 ; i!=theClusterParam.theCluster->size(); ++i )
-       // 	 {
-       // 	   auto pix = theClusterParam.theCluster->pixel(i);
-       // 	   int irow = int(pix.x) - row_offset;
-       // 	   int icol = int(pix.y) - col_offset;
-       // 	   // &&& Do we ever get pixels that are out of bounds ???  Need to check.
-       // 	   if ( (irow<mrow) & (icol<mcol) ) clustMatrix[irow][icol] =  float(pix.adc);
-       // 	 }
-       // // fillClustMatrix( float * clustMatrix );
-       
 
        //--- Call the Template Reco 2d with cluster repair
        callTempReco2D( theDetParam, theClusterParam, clusterPayload2d, ID, lp );
@@ -381,7 +366,7 @@ PixelCPEClusterRepair::callTempReco1D( DetParam const & theDetParam,
 
       //--- templ.clsleny() is the expected length of the cluster along y axis.
       if ( (theClusterParam.probabilityY_ < minProbY_ ) && (templ.clsleny() - nypix > 1) ) {
-	theClusterParam.recommended2D_ = true;
+	     theClusterParam.recommended2D_ = true;
       }
       
       //--- Go from microns to centimeters


### PR DESCRIPTION
Small cleanup for pixel code. Mostly just removing blocks of commented out code that are old and not used. Removed one unused function (isFlipped). Also set the 2D template label is ESProducer to the correct default for current and future GT's. Tested on pixeltrees to produce exactly the same output. 


@pmaksim1  @perrotta @slava77 @fabiocos @makortel @tvami @tsusa @cmantill @schuetzepaul