### PR TITLE
Bugfix in HcalDumpConditions

### DIFF
--- a/CondTools/Hcal/plugins/CastorDumpConditions.cc
+++ b/CondTools/Hcal/plugins/CastorDumpConditions.cc
@@ -135,7 +135,7 @@ CastorDumpConditions::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
    // dumpIt called for all possible ValueMaps. The function checks if the dump is actually requested.
    dumpIt<CastorElectronicsMap , CastorElectronicsMapRcd> (mDumpRequest, iEvent,iSetup,"ElectronicsMap" );
-   dumpIt<CastorQIEData        , CastorQIEDataRcd>        (mDumpRequest, iEvent,iSetup,"ElectronicsMap" );
+   dumpIt<CastorQIEData        , CastorQIEDataRcd>        (mDumpRequest, iEvent,iSetup,"QIEData"        );
    dumpIt<CastorPedestals      , CastorPedestalsRcd>      (mDumpRequest, iEvent,iSetup,"Pedestals"      );
    dumpIt<CastorPedestalWidths , CastorPedestalWidthsRcd> (mDumpRequest, iEvent,iSetup,"PedestalWidths" );
    dumpIt<CastorGains          , CastorGainsRcd>          (mDumpRequest, iEvent,iSetup,"Gains"          );

--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -77,17 +77,19 @@ namespace edmtest
                                   const HcalTopology * topo,
                                   const std::string label)
   {
-    edm::ESHandle<S> p;
-    if(!label.empty()) context.get<SRcd>().get(label, p);
-    else context.get<SRcd>().get(p);
-    S myobject(*p.product());
-    if( topo ) myobject.setTopo(topo);
-    
-    writeToFile(myobject, e, name);
-    
-    if ( context.get<SRcd>().validityInterval().first() == edm::IOVSyncValue::invalidIOVSyncValue() )
-      std::cout << "error: invalid IOV sync value !" << std::endl;
-
+    if (std::find (mDumpRequest.begin(), mDumpRequest.end(), name) != mDumpRequest.end())
+    {
+        edm::ESHandle<S> p;
+        if(!label.empty()) context.get<SRcd>().get(label, p);
+        else context.get<SRcd>().get(p);
+        S myobject(*p.product());
+        if( topo ) myobject.setTopo(topo);
+        
+        writeToFile(myobject, e, name);
+        
+        if ( context.get<SRcd>().validityInterval().first() == edm::IOVSyncValue::invalidIOVSyncValue() )
+          std::cout << "error: invalid IOV sync value !" << std::endl;
+    }
   }
 
 
@@ -108,7 +110,6 @@ namespace edmtest
         if ( context.get<SRcd>().validityInterval().first() == edm::IOVSyncValue::invalidIOVSyncValue() )
           std::cout << "error: invalid IOV sync value !" << std::endl;
     }
-
   }
 
   template<class S> void HcalDumpConditions::writeToFile(const S& myS, const edm::Event& e, const std::string name){


### PR DESCRIPTION
Hi,

this is the PR which addresses the bug referred to in https://github.com/cms-sw/cmssw/pull/24146#issuecomment-419729141.

When moving the __if(dumpRequest)__ snippet to the dumpIt function I overlooked a second overloaded version of that function, which tried to dump things which were not requested/produced.

Also, I fixed a copy-pase artefact of mine in the CastorDumpConditions.