### PR TITLE
Prepare HcalTPGCoderULUT for concurrent IOVs

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
@@ -14,7 +14,7 @@ public:
   const HcalPulseContainmentCorrection * get(const HcalDetId & detId, int toAdd, float fixedphase_ns);
 
   void beginRun(edm::EventSetup const & es);
-  void beginRun(const HcalDbService* conditions, const edm::ESHandle<HcalTimeSlew>& delay);
+  void beginRun(const HcalDbService* conditions, const HcalTimeSlew* delay);
 
   void setTimeSlew(const HcalTimeSlew* timeSlew) {
     hcalTimeSlew_delay_ = timeSlew;

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
@@ -21,9 +21,9 @@ void HcalPulseContainmentManager::beginRun(edm::EventSetup const & es)
   shapes_.beginRun(es);
 }
 
-void HcalPulseContainmentManager::beginRun(const HcalDbService* conditions, const edm::ESHandle<HcalTimeSlew>& delay)
+void HcalPulseContainmentManager::beginRun(const HcalDbService* conditions, const HcalTimeSlew* delay)
 {
-  hcalTimeSlew_delay_ = &*delay;
+  hcalTimeSlew_delay_ = delay;
 
   shapes_.beginRun(conditions);
 }

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -33,8 +33,12 @@ class HcaluLUTTPGCoder : public HcalTPGCoder {
 public:
   static const float  lsb_;
 
-  HcaluLUTTPGCoder(const HcalTopology* topo, const edm::ESHandle<HcalTimeSlew>& delay);
+  HcaluLUTTPGCoder();
+  HcaluLUTTPGCoder(const HcalTopology* topo, const HcalTimeSlew* delay);
   ~HcaluLUTTPGCoder() override;
+
+  void init(const HcalTopology* top, const HcalTimeSlew* delay);
+
   void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const override;
   void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const override;
   void adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const override;
@@ -83,7 +87,7 @@ private:
   
   // member variables
   const HcalTopology* topo_;
-  const edm::ESHandle<HcalTimeSlew>& delay_;
+  const HcalTimeSlew* delay_;
   bool LUTGenerationMode_;
   unsigned int FG_HF_threshold_;
   int  bitToMask_;

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -13,7 +13,6 @@
 #include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -38,7 +37,51 @@ const int HcaluLUTTPGCoder::QIE11_LUT_BITMASK;
 
 constexpr double MaximumFractionalError = 0.002; // 0.2% error allowed from this source
 
-HcaluLUTTPGCoder::HcaluLUTTPGCoder(const HcalTopology* top, const edm::ESHandle<HcalTimeSlew>& delay) : topo_(top),  delay_(delay), LUTGenerationMode_(true), bitToMask_(0), allLinear_(false), linearLSB_QIE8_(1.), linearLSB_QIE11_(1.), pulseCorr_(std::make_unique<HcalPulseContainmentManager>(MaximumFractionalError)) {
+HcaluLUTTPGCoder::HcaluLUTTPGCoder() :
+  topo_{},
+  delay_{},
+  LUTGenerationMode_{},
+  FG_HF_threshold_{},
+  bitToMask_{},
+  firstHBEta_{},
+  lastHBEta_{},
+  nHBEta_{},
+  maxDepthHB_{},
+  sizeHB_{},
+  firstHEEta_{},
+  lastHEEta_{},
+  nHEEta_{},
+  maxDepthHE_{},
+  sizeHE_{},
+  firstHFEta_{},
+  lastHFEta_{},
+  nHFEta_{},
+  maxDepthHF_{},
+  sizeHF_{},
+  cosh_ieta_28_HE_low_depths_{},
+  cosh_ieta_28_HE_high_depths_{},
+  cosh_ieta_29_HE_{},
+  allLinear_{},
+  linearLSB_QIE8_{},
+  linearLSB_QIE11_{},
+  linearLSB_QIE11Overlap_{} {
+}
+
+HcaluLUTTPGCoder::HcaluLUTTPGCoder(const HcalTopology* top, const HcalTimeSlew* delay) {
+  init(top, delay);
+}
+
+void HcaluLUTTPGCoder::init(const HcalTopology* top, const HcalTimeSlew* delay) {
+  topo_ = top;
+  delay_ = delay;
+  LUTGenerationMode_ = true;
+  FG_HF_threshold_ = 0;
+  bitToMask_ = 0;
+  allLinear_ = false;
+  linearLSB_QIE8_ = 1.;
+  linearLSB_QIE11_ = 1.;
+  linearLSB_QIE11Overlap_ = 1.;
+  pulseCorr_ = std::make_unique<HcalPulseContainmentManager>(MaximumFractionalError);
   firstHBEta_ = topo_->firstHBRing();      
   lastHBEta_  = topo_->lastHBRing();
   nHBEta_     = (lastHBEta_-firstHBEta_+1);

--- a/DataFormats/HcalRecHit/src/HFQIE10Info.cc
+++ b/DataFormats/HcalRecHit/src/HFQIE10Info.cc
@@ -1,1 +1,3 @@
 #include "DataFormats/HcalRecHit/interface/HFQIE10Info.h"
+
+const unsigned HFQIE10Info::N_RAW_MAX;


### PR DESCRIPTION
Currently the Framework only allows one EventSetup IOV (Interval of Validity) to be processed at a time, but we are preparing to change this in the future and allow multiple concurrent IOVs. This PR modifies the ESProducer of type HcalTPGCoderULUT in preparation for this change.

Prior to this, the ESProducer held a pointer to a single HcaluLUTTPGCoder object. After this PR it will use the ReusableObjectHolder class to manage multiple objects of this type, one for each concurrent IOV. The objects needs to hold different content for different IOVs and the ESProducer needs to modify them during its produce call in a thread safe manner.

The dependsOn feature of the EventSetup has difficulty communicating with these different objects in the callbacks and produce function calls. The usage of the dependsOn feature is replaced by usage of the new ESProductHost class. It has a similar purpose, but works better when there are multiple IOVs because its interface allows direct communication via arguments between the produce methods and the lambda function that gets called when the dependent record changes.

Note that the one very minor change in DataFormats/HcalRecHit is a bug fix. It was failing to compile with debug flags because a static member variable which needed to be defined was not defined.