### PR TITLE
Fix GCC 8 compiler warning, catch by const reference

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -457,7 +457,7 @@ try { // edmNew::CapacityExaustedException
           rawAlgos.suppressHybridData(id, ipair*2, workRawDigis, suppDigis);
           std::copy(std::begin(suppDigis), std::end(suppDigis), perStripAdder);
         }
-      } catch (edmNew::CapacityExaustedException) {
+      } catch (edmNew::CapacityExaustedException const&) {
         throw;
       } catch (const cms::Exception& e) {
         if (edm::isDebugEnabled()) {


### PR DESCRIPTION
(A new GCC 8 compiler warning from a recent commit, after I fixed them all)