### PR TITLE
Fix SimPFProducer for electrons

### DIFF
--- a/Validation/HGCalValidation/plugins/CaloParticleValidation.cc
+++ b/Validation/HGCalValidation/plugins/CaloParticleValidation.cc
@@ -47,6 +47,7 @@ struct Histogram_CaloParticleSingle {
   ConcurrentMonitorElement pfcandidateEta_;
   ConcurrentMonitorElement pfcandidatePhi_;
   ConcurrentMonitorElement pfcandidateElementsInBlocks_;
+  ConcurrentMonitorElement pfcandidate_vect_sum_pt_; // This is indeed a cumulative istogram
 };
 
 
@@ -200,8 +201,12 @@ CaloParticleValidation::dqmAnalyze(edm::Event const& iEvent, edm::EventSetup con
 
   // simPFCandidates
   int offset = 100000;
+  double ptx_tot = 0.;
+  double pty_tot = 0.;
   for (auto const pfc : simPFCandidates) {
     size_t type = offset + pfc.particleId();
+    ptx_tot += pfc.px();
+    pty_tot += pfc.py();
     histos.at(offset).pfcandidateType_.fill(type - offset);
     auto & histo = histos.at(type);
     histo.pfcandidateEnergy_.fill(pfc.energy());
@@ -210,6 +215,8 @@ CaloParticleValidation::dqmAnalyze(edm::Event const& iEvent, edm::EventSetup con
     histo.pfcandidatePhi_.fill(pfc.phi());
     histo.pfcandidateElementsInBlocks_.fill(pfc.elementsInBlocks().size());
   }
+  auto & histo = histos.at(offset);
+  histo.pfcandidate_vect_sum_pt_.fill(std::sqrt(ptx_tot*ptx_tot+pty_tot*pty_tot));
 }
 
 
@@ -234,6 +241,7 @@ CaloParticleValidation::bookHistograms(DQMStore::ConcurrentBooker & ibook,
   int offset = 100000;
   ibook.setCurrentFolder(folder_ + "PFCandidates");
   histos[offset].pfcandidateType_ = ibook.book1D("PFCandidateType", "PFCandidateType", 10, 0, 10);
+  histos[offset].pfcandidate_vect_sum_pt_ = ibook.book1D("PFCandidatePtVectSum", "PFCandidatePtVectSum", 200, 0., 200.);
   for (size_t type = reco::PFCandidate::h; type <= reco::PFCandidate::egamma_HF; type++) {
     ibook.setCurrentFolder(folder_ + "PFCandidates/" + std::to_string(type));
     auto & histo = histos[offset + type];


### PR DESCRIPTION
Please refer to the commit messages for further information.
There are also useful slides in [here](https://indico.cern.ch/event/748252/contributions/3100081/attachments/1698957/2735366/kunori_20180808_hgcsim_testing2.pdf]) and [here](https://indico.cern.ch/event/747942/contributions/3094699/attachments/1696999/2731800/kunori_20180801_hgcsim_ak4_PFcand.pdf)

Also, a new MonitorElement has been added in order to monitor the issue: the previously added Validation MonitorElements were not able to spot this issue.

I do expect some regression, but it fixes the issue.
The fix is geometry independent.

type bug-fix