### PR TITLE
Move from tinyxml to tinyxml2 in FWCore-MessageLogger

### DIFF
--- a/FWCore/MessageLogger/BuildFile.xml
+++ b/FWCore/MessageLogger/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
-<use   name="tinyxml"/>
+<use   name="tinyxml2"/>
 <use name="tbb"/>
 <export>
   <lib   name="1"/>

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -23,7 +23,7 @@
 
 // The part of tinyxml used in JobReport was reviewed and
 // determined to be threadsafe.
-#include "tinyxml.h"
+#include "tinyxml2.h"
 #include <fstream>
 #include <iomanip>
 #include <ostream>
@@ -35,23 +35,23 @@ namespace edm {
    * If something outside these classes requires access to the
    * same formatting then we need to refactor it into a common library
    */
+
   template <typename S, typename T>
   S& formatFile(T const& f, S& os) {
-
+    tinyxml2::XMLDocument doc;
     if(f.fileHasBeenClosed) {
       os << "\n<State  Value=\"closed\"/>";
     } else {
       os << "\n<State  Value=\"open\"/>";
     }
-
-    os << "\n<LFN>" << TiXmlText(f.logicalFileName) << "</LFN>";
-    os << "\n<PFN>" << TiXmlText(f.physicalFileName) << "</PFN>";
-    os << "\n<Catalog>" << TiXmlText(f.catalog) << "</Catalog>";
-    os << "\n<ModuleLabel>" << TiXmlText(f.moduleLabel) << "</ModuleLabel>";
+    os << "\n<LFN>" << doc.NewText(f.logicalFileName.c_str())->Value() << "</LFN>";
+    os << "\n<PFN>" << doc.NewText(f.physicalFileName.c_str())->Value() << "</PFN>";
+    os << "\n<Catalog>" << doc.NewText(f.catalog.c_str())->Value() << "</Catalog>";
+    os << "\n<ModuleLabel>" << doc.NewText(f.moduleLabel.c_str())->Value() << "</ModuleLabel>";
     os << "\n<GUID>" << f.guid << "</GUID>";
     os << "\n<Branches>";
     for(auto const& branch : f.branchNames) {
-      os << "\n  <Branch>" << TiXmlText(branch) << "</Branch>";
+      os << "\n  <Branch>" << doc.NewText(branch.c_str())->Value() << "</Branch>";
     }
     os << "\n</Branches>";
     return os;
@@ -63,11 +63,11 @@ namespace edm {
    */
   template <typename S>
   S& print(S& os, JobReport::InputFile const& f) {
-
+    tinyxml2::XMLDocument doc;
     os << "\n<InputFile>";
     formatFile(f, os);
     os << "\n<InputType>" << f.inputType << "</InputType>";
-    os << "\n<InputSourceClass>" << TiXmlText(f.inputSourceClassName)
+    os << "\n<InputSourceClass>" << doc.NewText(f.inputSourceClassName.c_str())->Value()
        << "</InputSourceClass>";
     os << "\n<EventsRead>" << f.numEventsRead << "</EventsRead>";
     return os;
@@ -75,18 +75,19 @@ namespace edm {
 
   template <typename S>
   S& print(S& os, JobReport::OutputFile const& f) {
+    tinyxml2::XMLDocument doc;
     formatFile(f, os);
     os << "\n<OutputModuleClass>"
-       << TiXmlText(f.outputModuleClassName)
+       << doc.NewText(f.outputModuleClassName.c_str())->Value()
        << "</OutputModuleClass>";
     os << "\n<TotalEvents>"
        << f.numEventsWritten
        << "</TotalEvents>\n";
     os << "\n<DataType>"
-       << TiXmlText(f.dataType)
+       << doc.NewText(f.dataType.c_str())->Value()
        << "</DataType>\n";
     os << "\n<BranchHash>"
-       << TiXmlText(f.branchHash)
+       << doc.NewText(f.branchHash.c_str())->Value()
        << "</BranchHash>\n";
     return os;
   }
@@ -222,6 +223,7 @@ namespace edm {
    *
    */
   void JobReport::JobReportImpl::writeOutputFile(JobReport::OutputFile const& f) {
+    tinyxml2::XMLDocument doc;
     if(ost_) {
       *ost_ << "\n<File>";
       *ost_ << f;
@@ -236,16 +238,16 @@ namespace edm {
       for(auto token : f.contributingInputs) {
         JobReport::InputFile inpFile = inputFiles_.at(token);
         *ost_ << "\n<Input>";
-        *ost_ << "\n  <LFN>" << TiXmlText(inpFile.logicalFileName) << "</LFN>";
-        *ost_ << "\n  <PFN>" << TiXmlText(inpFile.physicalFileName) << "</PFN>";
+        *ost_ << "\n  <LFN>" << doc.NewText(inpFile.logicalFileName.c_str())->Value() << "</LFN>";
+        *ost_ << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
         *ost_ << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
         *ost_ << "\n</Input>";
       }
       for(auto token : f.contributingInputsSecSource) {
         JobReport::InputFile inpFile = inputFilesSecSource_.at(token);
         *ost_ << "\n<Input>";
-        *ost_ << "\n  <LFN>" << TiXmlText(inpFile.logicalFileName) << "</LFN>";
-        *ost_ << "\n  <PFN>" << TiXmlText(inpFile.physicalFileName) << "</PFN>";
+        *ost_ << "\n  <LFN>" << doc.NewText(inpFile.logicalFileName.c_str())->Value() << "</LFN>";
+        *ost_ << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
         *ost_ << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
         *ost_ << "\n</Input>";
       }
@@ -505,12 +507,13 @@ namespace edm {
 
   void
   JobReport::reportAnalysisFile(std::string const& fileName, std::map<std::string, std::string> const& fileData) {
+    tinyxml2::XMLDocument doc;
     if(impl_->ost_) {
       std::ostream& msg = *(impl_->ost_);
       {
         std::lock_guard<std::mutex> lock(write_mutex);
         msg << "<AnalysisFile>\n"
-            << "  <FileName>" << TiXmlText(fileName) << "</FileName>\n";
+            << "  <FileName>" << doc.NewText(fileName.c_str())->Value() << "</FileName>\n";
 
         typedef std::map<std::string, std::string>::const_iterator const_iterator;
         for(const_iterator pos = fileData.begin(), posEnd = fileData.end(); pos != posEnd; ++pos) {
@@ -546,12 +549,15 @@ namespace edm {
                                std::string const& lfn) {
     if(impl_->ost_) {
       std::ostream& msg = *(impl_->ost_);
-      TiXmlElement skipped("SkippedFile");
-      skipped.SetAttribute("Pfn", pfn);
-      skipped.SetAttribute("Lfn", lfn);
+      tinyxml2::XMLDocument doc;
+      tinyxml2::XMLPrinter printer;
+      tinyxml2::XMLElement * skipped = doc.NewElement("SkippedFile");
+      skipped->SetAttribute("Pfn", pfn.c_str());
+      skipped->SetAttribute("Lfn", lfn.c_str());
       {
         std::lock_guard<std::mutex> lock(write_mutex);
-        msg << skipped << "\n";
+	skipped->Accept(&printer);
+        msg << printer.CStr() ;
         msg << std::flush;
       }
     }
@@ -561,12 +567,15 @@ namespace edm {
   JobReport::reportFallbackAttempt(std::string const& pfn, std::string const& lfn, std::string const& err) {
     if(impl_->ost_) {
       std::ostream& msg = *(impl_->ost_);
-      TiXmlElement fallback("FallbackAttempt");
-      fallback.SetAttribute("Pfn", pfn);
-      fallback.SetAttribute("Lfn", lfn);
+      tinyxml2::XMLDocument doc;
+      tinyxml2::XMLPrinter printer;
+      tinyxml2::XMLElement * fallback = doc.NewElement("FallbackAttempt");
+      fallback->SetAttribute("Pfn", pfn.c_str());
+      fallback->SetAttribute("Lfn", lfn.c_str());
       {
         std::lock_guard<std::mutex> lock(write_mutex);
-        msg << fallback << "\n";
+	fallback->Accept(&printer);
+        msg << printer.CStr() ;
         msg << "<![CDATA[\n" << err << "\n]]>\n";
         msg << std::flush;
       }
@@ -611,26 +620,33 @@ namespace edm {
     if(impl_->ost_) {
       std::ostream& ost = *(impl_->ost_);
       ost << "<ReadBranches>\n";
+      tinyxml2::XMLDocument doc;
       for(auto const& iBranch : impl_->readBranches_) {
-        TiXmlElement branch("Branch");
-        branch.SetAttribute("Name", iBranch.first);
-        branch.SetAttribute("ReadCount", iBranch.second);
-        ost << branch << "\n";
+	tinyxml2::XMLPrinter printer;
+	tinyxml2::XMLElement * branch = doc.NewElement("Branch");
+        branch->SetAttribute("Name", iBranch.first.c_str());
+        branch->SetAttribute("ReadCount", int64_t(iBranch.second));
+	branch->Accept(&printer);
+        ost << printer.CStr();
       }
       for(auto const& iBranch : impl_->readBranchesSecFile_) {
-        TiXmlElement branch("Branch");
-        branch.SetAttribute("Name", iBranch.first);
-        branch.SetAttribute("ReadCount", iBranch.second);
-        ost << branch << "\n";
+	tinyxml2::XMLPrinter printer;
+	tinyxml2::XMLElement * branch = doc.NewElement("Branch");
+        branch->SetAttribute("Name", iBranch.first.c_str());
+        branch->SetAttribute("ReadCount", int64_t(iBranch.second));
+	branch->Accept(&printer);
+        ost << printer.CStr();
       }
       ost << "</ReadBranches>\n";
       if(!impl_->readBranchesSecSource_.empty()) {
         ost << "<SecondarySourceReadBranches>\n";
         for(auto const& iBranch : impl_->readBranchesSecSource_) {
-          TiXmlElement branch("Branch");
-          branch.SetAttribute("Name", iBranch.first);
-          branch.SetAttribute("ReadCount", iBranch.second.value().load());
-          ost << branch << "\n";
+	  tinyxml2::XMLPrinter printer;
+	  tinyxml2::XMLElement * branch = doc.NewElement("Branch");
+          branch->SetAttribute("Name", iBranch.first.c_str());
+          branch->SetAttribute("ReadCount", int64_t(iBranch.second.value().load()));
+	  branch->Accept(&printer);
+	  ost << printer.CStr();
         }
         ost << "</SecondarySourceReadBranches>\n";
       }
@@ -665,12 +681,13 @@ namespace edm {
   }
 
   void JobReport::reportRandomStateFile(std::string const& name) {
+    tinyxml2::XMLDocument doc;
     if(impl_->ost_) {
       std::ostream& msg = *(impl_->ost_);
       {
         std::lock_guard<std::mutex> lock(write_mutex);
         msg << "<RandomServiceStateFile>\n"
-            << TiXmlText(name) << "\n"
+            << doc.NewText(name.c_str())->Value() << "\n"
             <<  "</RandomServiceStateFile>\n";
         msg << std::flush;
       }
@@ -725,7 +742,7 @@ namespace edm {
   JobReport::dumpFiles(void) {
     std::ostringstream msg;
 
-
+    tinyxml2::XMLDocument doc;
     for(auto const& f :impl_->outputFiles_) {
 
       msg << "\n<File>";
@@ -737,8 +754,8 @@ namespace edm {
       for(auto const& iInput : f.contributingInputs) {
         auto const& inpFile = impl_->inputFiles_[iInput];
         msg << "\n<Input>";
-        msg << "\n  <LFN>" << TiXmlText(inpFile.logicalFileName) << "</LFN>";
-        msg << "\n  <PFN>" << TiXmlText(inpFile.physicalFileName) << "</PFN>";
+        msg << "\n  <LFN>" << doc.NewText(inpFile.logicalFileName.c_str())->Value() << "</LFN>";
+        msg << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
         msg << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
         msg << "\n</Input>";
       }

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -243,7 +243,7 @@ namespace edm {
         *ost_ << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
         *ost_ << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
         *ost_ << "\n</Input>";
-	doc.DeleteChildren();
+        doc.DeleteChildren();
       }
       for(auto token : f.contributingInputsSecSource) {
         JobReport::InputFile inpFile = inputFilesSecSource_.at(token);
@@ -252,7 +252,7 @@ namespace edm {
         *ost_ << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
         *ost_ << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
         *ost_ << "\n</Input>";
-	doc.DeleteChildren();
+        doc.DeleteChildren();
       }
       *ost_ << "\n</Inputs>";
       *ost_ << "\n</File>\n";
@@ -762,7 +762,7 @@ namespace edm {
         msg << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
         msg << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
         msg << "\n</Input>";
-	doc.DeleteChildren();
+        doc.DeleteChildren();
       }
       msg << "\n</Inputs>";
       msg << "\n</File>";

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -556,7 +556,7 @@ namespace edm {
       skipped->SetAttribute("Lfn", lfn.c_str());
       {
         std::lock_guard<std::mutex> lock(write_mutex);
-	skipped->Accept(&printer);
+        skipped->Accept(&printer);
         msg << printer.CStr() ;
         msg << std::flush;
       }
@@ -574,7 +574,7 @@ namespace edm {
       fallback->SetAttribute("Lfn", lfn.c_str());
       {
         std::lock_guard<std::mutex> lock(write_mutex);
-	fallback->Accept(&printer);
+        fallback->Accept(&printer);
         msg << printer.CStr() ;
         msg << "<![CDATA[\n" << err << "\n]]>\n";
         msg << std::flush;
@@ -621,32 +621,33 @@ namespace edm {
       std::ostream& ost = *(impl_->ost_);
       ost << "<ReadBranches>\n";
       tinyxml2::XMLDocument doc;
+      tinyxml2::XMLPrinter printer;
       for(auto const& iBranch : impl_->readBranches_) {
-	tinyxml2::XMLPrinter printer;
-	tinyxml2::XMLElement * branch = doc.NewElement("Branch");
+        tinyxml2::XMLElement * branch = doc.NewElement("Branch");
         branch->SetAttribute("Name", iBranch.first.c_str());
         branch->SetAttribute("ReadCount", int64_t(iBranch.second));
-	branch->Accept(&printer);
+        branch->Accept(&printer);
         ost << printer.CStr();
+        printer.ClearBuffer();
       }
       for(auto const& iBranch : impl_->readBranchesSecFile_) {
-	tinyxml2::XMLPrinter printer;
-	tinyxml2::XMLElement * branch = doc.NewElement("Branch");
+        tinyxml2::XMLElement * branch = doc.NewElement("Branch");
         branch->SetAttribute("Name", iBranch.first.c_str());
         branch->SetAttribute("ReadCount", int64_t(iBranch.second));
-	branch->Accept(&printer);
+        branch->Accept(&printer);
         ost << printer.CStr();
+        printer.ClearBuffer();
       }
       ost << "</ReadBranches>\n";
       if(!impl_->readBranchesSecSource_.empty()) {
         ost << "<SecondarySourceReadBranches>\n";
         for(auto const& iBranch : impl_->readBranchesSecSource_) {
-	  tinyxml2::XMLPrinter printer;
-	  tinyxml2::XMLElement * branch = doc.NewElement("Branch");
+          tinyxml2::XMLElement * branch = doc.NewElement("Branch");
           branch->SetAttribute("Name", iBranch.first.c_str());
           branch->SetAttribute("ReadCount", int64_t(iBranch.second.value().load()));
-	  branch->Accept(&printer);
-	  ost << printer.CStr();
+          branch->Accept(&printer);
+          ost << printer.CStr();
+          printer.ClearBuffer();
         }
         ost << "</SecondarySourceReadBranches>\n";
       }

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -52,6 +52,7 @@ namespace edm {
     os << "\n<Branches>";
     for(auto const& branch : f.branchNames) {
       os << "\n  <Branch>" << doc.NewText(branch.c_str())->Value() << "</Branch>";
+      doc.DeleteChildren();
     }
     os << "\n</Branches>";
     return os;
@@ -242,6 +243,7 @@ namespace edm {
         *ost_ << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
         *ost_ << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
         *ost_ << "\n</Input>";
+	doc.DeleteChildren();
       }
       for(auto token : f.contributingInputsSecSource) {
         JobReport::InputFile inpFile = inputFilesSecSource_.at(token);
@@ -250,6 +252,7 @@ namespace edm {
         *ost_ << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
         *ost_ << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
         *ost_ << "\n</Input>";
+	doc.DeleteChildren();
       }
       *ost_ << "\n</Inputs>";
       *ost_ << "\n</File>\n";
@@ -759,6 +762,7 @@ namespace edm {
         msg << "\n  <PFN>" << doc.NewText(inpFile.physicalFileName.c_str())->Value() << "</PFN>";
         msg << "\n  <FastCopying>" << findOrDefault(f.fastCopyingInputs, inpFile.physicalFileName) << "</FastCopying>";
         msg << "\n</Input>";
+	doc.DeleteChildren();
       }
       msg << "\n</Inputs>";
       msg << "\n</File>";

--- a/GeneratorInterface/RivetInterface/BuildFile.xml
+++ b/GeneratorInterface/RivetInterface/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="boost"/>
 <use name="gsl"/>
 <use name="root"/>
-<use name="tinyxml"/>
 <use name="GeneratorInterface/Core"/>
 <use name="GeneratorInterface/Pythia6Interface"/>
 <flags   RIVET_PLUGIN="1"/>

--- a/GeneratorInterface/RivetInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/RivetInterface/plugins/BuildFile.xml
@@ -6,6 +6,7 @@
 <use   name="rivet"/>
 <use   name="yoda"/>
 <use   name="gsl"/>
+<use   name="tinyxml2"/>
 <use   name="DQMServices/Core"/>
 <use   name="SimGeneral/HepPDTRecord"/>
 <use   name="DataFormats/HepMCCandidate"/>

--- a/IOPool/Common/test/proper_fjr_output
+++ b/IOPool/Common/test/proper_fjr_output
@@ -79,8 +79,8 @@
 </Inputs>
 </File>
 <ReadBranches>
-<Branch Name="edmTriggerResults_TriggerResults__TESTPROD." ReadCount="35" />
-<Branch Name="edmtestThings_Thing__TESTPROD." ReadCount="35" />
+<Branch Name="edmTriggerResults_TriggerResults__TESTPROD." ReadCount="35"/>
+<Branch Name="edmtestThings_Thing__TESTPROD." ReadCount="35"/>
 </ReadBranches>
 
 </FrameworkJobReport>

--- a/IOPool/Common/test/proper_fjrx_output
+++ b/IOPool/Common/test/proper_fjrx_output
@@ -85,11 +85,11 @@
 </Inputs>
 </File>
 <ReadBranches>
-<Branch Name="edmTriggerResults_TriggerResults__TESTPROD." ReadCount="35" />
-<Branch Name="edmtestOtherThings_AOtherThing_testUserTag_TESTPROD." ReadCount="10" />
-<Branch Name="edmtestOtherThings_OtherThing_testUserTag_TESTPROD." ReadCount="10" />
-<Branch Name="edmtestOtherThings_ZOtherThing_testUserTag_TESTPROD." ReadCount="10" />
-<Branch Name="edmtestThings_Thing__TESTPROD." ReadCount="35" />
+<Branch Name="edmTriggerResults_TriggerResults__TESTPROD." ReadCount="35"/>
+<Branch Name="edmtestOtherThings_AOtherThing_testUserTag_TESTPROD." ReadCount="10"/>
+<Branch Name="edmtestOtherThings_OtherThing_testUserTag_TESTPROD." ReadCount="10"/>
+<Branch Name="edmtestOtherThings_ZOtherThing_testUserTag_TESTPROD." ReadCount="10"/>
+<Branch Name="edmtestThings_Thing__TESTPROD." ReadCount="35"/>
 </ReadBranches>
 
 </FrameworkJobReport>


### PR DESCRIPTION
Recently we added tinyxml2 external and now we are moving pkgs that were using tinyxml to tinyxml2. 