### PR TITLE
Fix imaging algo for post tdr geometries

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
@@ -49,10 +49,10 @@ public:
 
 enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
-HGCalImagingAlgo() : vecDeltas(), kappa(1.), ecut(0.),
-        sigma2(1.0),
-        algoId(reco::CaloCluster::undefined),
-        verbosity(pERROR),initialized(false){
+HGCalImagingAlgo() : vecDeltas_(), kappa_(1.), ecut_(0.),
+        sigma2_(1.0),
+        algoId_(reco::CaloCluster::undefined),
+        verbosity_(pERROR),initialized_(false){
 }
 
 HGCalImagingAlgo(const std::vector<double>& vecDeltas_in, double kappa_in, double ecut_in,
@@ -65,24 +65,24 @@ HGCalImagingAlgo(const std::vector<double>& vecDeltas_in, double kappa_in, doubl
                  const std::vector<double>& nonAgedNoises_in,
                  double noiseMip_in,
                  VerbosityLevel the_verbosity = pERROR) :
-        vecDeltas(vecDeltas_in), kappa(kappa_in),
-        ecut(ecut_in),
-        sigma2(1.0),
-        algoId(algoId_in),
-        dependSensor(dependSensor_in),
-        dEdXweights(dEdXweights_in),
-        thicknessCorrection(thicknessCorrection_in),
-        fcPerMip(fcPerMip_in),
-        fcPerEle(fcPerEle_in),
-        nonAgedNoises(nonAgedNoises_in),
-        noiseMip(noiseMip_in),
-        verbosity(the_verbosity),
-        initialized(false),
-        points(2*(maxlayer+1)),
-        minpos(2*(maxlayer+1),{
+        vecDeltas_(vecDeltas_in), kappa_(kappa_in),
+        ecut_(ecut_in),
+        sigma2_(1.0),
+        algoId_(algoId_in),
+        dependSensor_(dependSensor_in),
+        dEdXweights_(dEdXweights_in),
+        thicknessCorrection_(thicknessCorrection_in),
+        fcPerMip_(fcPerMip_in),
+        fcPerEle_(fcPerEle_in),
+        nonAgedNoises_(nonAgedNoises_in),
+        noiseMip_(noiseMip_in),
+        verbosity_(the_verbosity),
+        initialized_(false),
+        points_(2*(maxlayer+1)),
+        minpos_(2*(maxlayer+1),{
                 {0.0f,0.0f}
         }),
-        maxpos(2*(maxlayer+1),{ {0.0f,0.0f} })
+        maxpos_(2*(maxlayer+1),{ {0.0f,0.0f} })
 {
 }
 
@@ -96,24 +96,24 @@ HGCalImagingAlgo(const std::vector<double>& vecDeltas_in, double kappa_in, doubl
                  double fcPerEle_in,
                  const std::vector<double>& nonAgedNoises_in,
                  double noiseMip_in,
-                 VerbosityLevel the_verbosity = pERROR) : vecDeltas(vecDeltas_in), kappa(kappa_in),
-        ecut(ecut_in),
-        sigma2(std::pow(showerSigma,2.0)),
-        algoId(algoId_in),
-        dependSensor(dependSensor_in),
-        dEdXweights(dEdXweights_in),
-        thicknessCorrection(thicknessCorrection_in),
-        fcPerMip(fcPerMip_in),
-        fcPerEle(fcPerEle_in),
-        nonAgedNoises(nonAgedNoises_in),
-        noiseMip(noiseMip_in),
-        verbosity(the_verbosity),
-        initialized(false),
-        points(2*(maxlayer+1)),
-	minpos(2*(maxlayer+1),{
+                 VerbosityLevel the_verbosity = pERROR) : vecDeltas_(vecDeltas_in), kappa_(kappa_in),
+        ecut_(ecut_in),
+        sigma2_(std::pow(showerSigma,2.0)),
+        algoId_(algoId_in),
+        dependSensor_(dependSensor_in),
+        dEdXweights_(dEdXweights_in),
+        thicknessCorrection_(thicknessCorrection_in),
+        fcPerMip_(fcPerMip_in),
+        fcPerEle_(fcPerEle_in),
+        nonAgedNoises_(nonAgedNoises_in),
+        noiseMip_(noiseMip_in),
+        verbosity_(the_verbosity),
+        initialized_(false),
+        points_(2*(maxlayer+1)),
+	minpos_(2*(maxlayer+1),{
                 {0.0f,0.0f}
         }),
-	maxpos(2*(maxlayer+1),{ {0.0f,0.0f} })
+	maxpos_(2*(maxlayer+1),{ {0.0f,0.0f} })
 {
 }
 
@@ -123,7 +123,7 @@ virtual ~HGCalImagingAlgo()
 
 void setVerbosity(VerbosityLevel the_verbosity)
 {
-        verbosity = the_verbosity;
+        verbosity_ = the_verbosity;
 }
 
 void populate(const HGCRecHitCollection &hits);
@@ -138,17 +138,17 @@ void getEventSetup(const edm::EventSetup& es){
 }
 // use this if you want to reuse the same cluster object but don't want to accumulate clusters (hardly useful?)
 void reset(){
-        clusters_v.clear();
-        layerClustersPerLayer.clear();
-        for( auto& it: points)
+        clusters_v_.clear();
+        layerClustersPerLayer_.clear();
+        for( auto& it: points_)
         {
                 it.clear();
                 std::vector<KDNode>().swap(it);
         }
-        for(unsigned int i = 0; i < minpos.size(); i++)
+        for(unsigned int i = 0; i < minpos_.size(); i++)
         {
-                minpos[i][0]=0.; minpos[i][1]=0.;
-                maxpos[i][0]=0.; maxpos[i][1]=0.;
+                minpos_[i][0]=0.; minpos_[i][1]=0.;
+                maxpos_[i][0]=0.; maxpos_[i][1]=0.;
         }
 }
 void computeThreshold();
@@ -166,39 +166,39 @@ static const unsigned int lastLayerEE = 28;
 static const unsigned int lastLayerFH = 40;
 
 // The two parameters used to identify clusters
-std::vector<double> vecDeltas;
-double kappa;
+std::vector<double> vecDeltas_;
+double kappa_;
 
 // The hit energy cutoff
-double ecut;
+double ecut_;
 
 // for energy sharing
-double sigma2;   // transverse shower size
+double sigma2_;   // transverse shower size
 
 // The vector of clusters
-std::vector<reco::BasicCluster> clusters_v;
+std::vector<reco::BasicCluster> clusters_v_;
 
 hgcal::RecHitTools rhtools_;
 
 // The algo id
-reco::CaloCluster::AlgoId algoId;
+reco::CaloCluster::AlgoId algoId_;
 
 // various parameters used for calculating the noise levels for a given sensor (and whether to use them)
-bool dependSensor;
-std::vector<double> dEdXweights;
-std::vector<double> thicknessCorrection;
-std::vector<double> fcPerMip;
-double fcPerEle;
-std::vector<double> nonAgedNoises;
-double noiseMip;
-std::vector<std::vector<double> > thresholds;
-std::vector<std::vector<double> > v_sigmaNoise;
+bool dependSensor_;
+std::vector<double> dEdXweights_;
+std::vector<double> thicknessCorrection_;
+std::vector<double> fcPerMip_;
+double fcPerEle_;
+std::vector<double> nonAgedNoises_;
+double noiseMip_;
+std::vector<std::vector<double> > thresholds_;
+std::vector<std::vector<double> > v_sigmaNoise_;
 
 // The verbosity level
-VerbosityLevel verbosity;
+VerbosityLevel verbosity_;
 
 // initialization bool
-bool initialized;
+bool initialized_;
 
 struct Hexel {
 
@@ -252,7 +252,7 @@ typedef KDTreeLinkerAlgo<Hexel,2> KDTree;
 typedef KDTreeNodeInfoT<Hexel,2> KDNode;
 
 
-std::vector<std::vector<std::vector< KDNode> > > layerClustersPerLayer;
+std::vector<std::vector<std::vector< KDNode> > > layerClustersPerLayer_;
 
 std::vector<size_t> sort_by_delta(const std::vector<KDNode> &v) const {
         std::vector<size_t> idx(v.size());
@@ -264,11 +264,11 @@ std::vector<size_t> sort_by_delta(const std::vector<KDNode> &v) const {
         return idx;
 }
 
-std::vector<std::vector<KDNode> > points;   //a vector of vectors of hexels, one for each layer
+std::vector<std::vector<KDNode> > points_;   //a vector of vectors of hexels, one for each layer
 //@@EM todo: the number of layers should be obtained programmatically - the range is 1-n instead of 0-n-1...
 
-std::vector<std::array<float,2> > minpos;
-std::vector<std::array<float,2> > maxpos;
+std::vector<std::array<float,2> > minpos_;
+std::vector<std::array<float,2> > maxpos_;
 
 
 //these functions should be in a helper class.

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -15,7 +15,7 @@
 void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
   // loop over all hits and create the Hexel structure, skip energies below ecut
 
-  if (dependSensor) {
+  if (dependSensor_) {
     // for each layer and wafer calculate the thresholds (sigmaNoise and energy)
     // once
     computeThreshold();
@@ -31,19 +31,19 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
     // set sigmaNoise default value 1 to use kappa value directly in case of
     // sensor-independent thresholds
     float sigmaNoise = 1.f;
-    if (dependSensor) {
+    if (dependSensor_) {
       thickness = rhtools_.getSiThickness(detid);
       int thickness_index = rhtools_.getSiThickIndex(detid);
       if (thickness_index == -1)
         thickness_index = 3;
-      double storedThreshold = thresholds[layer - 1][thickness_index];
-      sigmaNoise = v_sigmaNoise[layer - 1][thickness_index];
+      double storedThreshold = thresholds_[layer - 1][thickness_index];
+      sigmaNoise = v_sigmaNoise_[layer - 1][thickness_index];
 
       if (hgrh.energy() < storedThreshold)
         continue; // this sets the ZS threshold at ecut times the sigma noise
                   // for the sensor
     }
-    if (!dependSensor && hgrh.energy() < ecut)
+    if (!dependSensor_ && hgrh.energy() < ecut_)
       continue;
 
     // map layers from positive endcap (z) to layer + maxlayer+1 to prevent
@@ -56,23 +56,23 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
 
     // here's were the KDNode is passed its dims arguments - note that these are
     // *copied* from the Hexel
-    points[layer].emplace_back(
+    points_[layer].emplace_back(
         Hexel(hgrh, detid, isHalf, sigmaNoise, thickness, &rhtools_),
         position.x(), position.y());
 
     // for each layer, store the minimum and maximum x and y coordinates for the
     // KDTreeBox boundaries
     if (firstHit[layer]) {
-      minpos[layer][0] = position.x();
-      minpos[layer][1] = position.y();
-      maxpos[layer][0] = position.x();
-      maxpos[layer][1] = position.y();
+      minpos_[layer][0] = position.x();
+      minpos_[layer][1] = position.y();
+      maxpos_[layer][0] = position.x();
+      maxpos_[layer][1] = position.y();
       firstHit[layer] = false;
     } else {
-      minpos[layer][0] = std::min((float)position.x(), minpos[layer][0]);
-      minpos[layer][1] = std::min((float)position.y(), minpos[layer][1]);
-      maxpos[layer][0] = std::max((float)position.x(), maxpos[layer][0]);
-      maxpos[layer][1] = std::max((float)position.y(), maxpos[layer][1]);
+      minpos_[layer][0] = std::min((float)position.x(), minpos_[layer][0]);
+      minpos_[layer][1] = std::min((float)position.y(), minpos_[layer][1]);
+      maxpos_[layer][0] = std::max((float)position.x(), maxpos_[layer][0]);
+      maxpos_[layer][1] = std::max((float)position.y(), maxpos_[layer][1]);
     }
 
   } // end loop hits
@@ -82,13 +82,13 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
 // this method can be invoked multiple times for the same event with different
 // input (reset should be called between events)
 void HGCalImagingAlgo::makeClusters() {
-  layerClustersPerLayer.resize(2 * maxlayer + 2);
+  layerClustersPerLayer_.resize(2 * maxlayer + 2);
   // assign all hits in each layer to a cluster core or halo
   tbb::this_task_arena::isolate([&] {
     tbb::parallel_for(size_t(0), size_t(2 * maxlayer + 2), [&](size_t i) {
-      KDTreeBox bounds(minpos[i][0], maxpos[i][0], minpos[i][1], maxpos[i][1]);
+      KDTreeBox bounds(minpos_[i][0], maxpos_[i][0], minpos_[i][1], maxpos_[i][1]);
       KDTree hit_kdtree;
-      hit_kdtree.build(points[i], bounds);
+      hit_kdtree.build(points_[i], bounds);
 
       unsigned int actualLayer =
           i > maxlayer
@@ -96,13 +96,13 @@ void HGCalImagingAlgo::makeClusters() {
               : i; // maps back from index used for KD trees to actual layer
 
       double maxdensity = calculateLocalDensity(
-          points[i], hit_kdtree, actualLayer); // also stores rho (energy
+          points_[i], hit_kdtree, actualLayer); // also stores rho (energy
                                                // density) for each point (node)
       // calculate distance to nearest point with higher density storing
       // distance (delta) and point's index
-      calculateDistanceToHigher(points[i]);
-      findAndAssignClusters(points[i], hit_kdtree, maxdensity, bounds,
-                            actualLayer, layerClustersPerLayer[i]);
+      calculateDistanceToHigher(points_[i]);
+      findAndAssignClusters(points_[i], hit_kdtree, maxdensity, bounds,
+                            actualLayer, layerClustersPerLayer_[i]);
     });
   });
 }
@@ -111,7 +111,7 @@ std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
 
   reco::CaloID caloID = reco::CaloID::DET_HGCAL_ENDCAP;
   std::vector<std::pair<DetId, float>> thisCluster;
-  for (auto &clsOnLayer : layerClustersPerLayer) {
+  for (auto &clsOnLayer : layerClustersPerLayer_) {
     for (unsigned int i = 0; i < clsOnLayer.size(); ++i) {
       double energy = 0;
       Point position;
@@ -144,7 +144,7 @@ std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
             }
           }
 
-          if (verbosity < pINFO) {
+          if (verbosity_ < pINFO) {
             std::cout << "\t******** NEW CLUSTER (SHARING) ********"
                       << std::endl;
             std::cout << "\tEff. No. of cells = " << effective_hits
@@ -156,8 +156,8 @@ std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
                       << std::endl;
             std::cout << "\t*****************************" << std::endl;
           }
-          clusters_v.emplace_back(energy, position, caloID, thisCluster,
-                                  algoId);
+          clusters_v_.emplace_back(energy, position, caloID, thisCluster,
+                                  algoId_);
           thisCluster.clear();
         }
       } else {
@@ -168,7 +168,7 @@ std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
           // use fraction to store whether this is a Halo hit or not
           thisCluster.emplace_back(it.data.detid, (it.data.isHalo ? 0.f : 1.f));
         }
-        if (verbosity < pINFO) {
+        if (verbosity_ < pINFO) {
           std::cout << "******** NEW CLUSTER (HGCIA) ********" << std::endl;
           std::cout << "Index          " << i << std::endl;
           std::cout << "No. of cells = " << clsOnLayer[i].size() << std::endl;
@@ -177,12 +177,12 @@ std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
           std::cout << "     Eta        = " << position.eta() << std::endl;
           std::cout << "*****************************" << std::endl;
         }
-        clusters_v.emplace_back(energy, position, caloID, thisCluster, algoId);
+        clusters_v_.emplace_back(energy, position, caloID, thisCluster, algoId_);
         thisCluster.clear();
       }
     }
   }
-  return clusters_v;
+  return clusters_v_;
 }
 
 math::XYZPoint
@@ -236,11 +236,11 @@ double HGCalImagingAlgo::calculateLocalDensity(std::vector<KDNode> &nd,
   float delta_c; // maximum search distance (critical distance) for local
                  // density calculation
   if (layer <= lastLayerEE)
-    delta_c = vecDeltas[0];
+    delta_c = vecDeltas_[0];
   else if (layer <= lastLayerFH)
-    delta_c = vecDeltas[1];
+    delta_c = vecDeltas_[1];
   else
-    delta_c = vecDeltas[2];
+    delta_c = vecDeltas_[2];
 
   // for each node calculate local density rho and store it
   for (unsigned int i = 0; i < nd.size(); ++i) {
@@ -325,11 +325,11 @@ int HGCalImagingAlgo::findAndAssignClusters(
   unsigned int nClustersOnLayer = 0;
   float delta_c; // critical distance
   if (layer <= lastLayerEE)
-    delta_c = vecDeltas[0];
+    delta_c = vecDeltas_[0];
   else if (layer <= lastLayerFH)
-    delta_c = vecDeltas[1];
+    delta_c = vecDeltas_[1];
   else
-    delta_c = vecDeltas[2];
+    delta_c = vecDeltas_[2];
 
   std::vector<size_t> rs =
       sorted_indices(nd); // indices sorted by decreasing rho
@@ -341,17 +341,17 @@ int HGCalImagingAlgo::findAndAssignClusters(
 
     if (nd[ds[i]].data.delta < delta_c)
       break; // no more cluster centers to be looked at
-    if (dependSensor) {
+    if (dependSensor_) {
 
-      float rho_c = kappa * nd[ds[i]].data.sigmaNoise;
+      float rho_c = kappa_ * nd[ds[i]].data.sigmaNoise;
       if (nd[ds[i]].data.rho < rho_c)
         continue; // set equal to kappa times noise threshold
 
-    } else if (nd[ds[i]].data.rho * kappa < maxdensity)
+    } else if (nd[ds[i]].data.rho * kappa_ < maxdensity)
       continue;
 
     nd[ds[i]].data.clusterIndex = nClustersOnLayer;
-    if (verbosity < pINFO) {
+    if (verbosity_ < pINFO) {
       std::cout << "Adding new cluster with index " << nClustersOnLayer
                 << std::endl;
       std::cout << "Cluster center is hit " << ds[i] << std::endl;
@@ -379,7 +379,7 @@ int HGCalImagingAlgo::findAndAssignClusters(
   // make room in the temporary cluster vector for the additional clusterIndex
   // clusters
   // from this layer
-  if (verbosity < pINFO) {
+  if (verbosity_ < pINFO) {
     std::cout << "resizing cluster vector by " << nClustersOnLayer << std::endl;
   }
   clustersOnLayer.resize(nClustersOnLayer);
@@ -441,7 +441,7 @@ int HGCalImagingAlgo::findAndAssignClusters(
       if (nd[i].data.rho <= rho_b[ci])
         nd[i].data.isHalo = true;
       clustersOnLayer[ci].push_back(nd[i]);
-      if (verbosity < pINFO) {
+      if (verbosity_ < pINFO) {
         std::cout << "Pushing hit " << i << " into cluster with index " << ci
                   << std::endl;
       }
@@ -449,7 +449,7 @@ int HGCalImagingAlgo::findAndAssignClusters(
   }
 
   // prepare the offset for the next layer if there is one
-  if (verbosity < pINFO) {
+  if (verbosity_ < pINFO) {
     std::cout << "moving cluster offset by " << nClustersOnLayer << std::endl;
   }
   return nClustersOnLayer;
@@ -568,7 +568,7 @@ void HGCalImagingAlgo::shareEnergy(
         double d2 = (std::pow(ihit.x - centroids[j].x(), 2.0) +
                      std::pow(ihit.y - centroids[j].y(), 2.0) +
                      std::pow(ihit.z - centroids[j].z(), 2.0)) /
-                    sigma2;
+                    sigma2_;
         dist2[j] = d2;
         // now we set the fractions up based on hit type
         if (i == seeds[j]) { // this cluster's seed
@@ -617,28 +617,28 @@ void HGCalImagingAlgo::computeThreshold() {
   // fourth) will address the Scintillators. This change will support both
   // geometries at the same time.
 
-  if (initialized)
+  if (initialized_)
     return; // only need to calculate thresholds once
 
-  initialized = true;
+  initialized_ = true;
 
   std::vector<double> dummy;
   const unsigned maxNumberOfThickIndices = 3;
   dummy.resize(maxNumberOfThickIndices + 1, 0); // +1 to accomodate for the Scintillators
-  thresholds.resize(maxlayer, dummy);
-  v_sigmaNoise.resize(maxlayer, dummy);
+  thresholds_.resize(maxlayer, dummy);
+  v_sigmaNoise_.resize(maxlayer, dummy);
 
   for (unsigned ilayer = 1; ilayer <= maxlayer; ++ilayer) {
     for (unsigned ithick = 0; ithick < maxNumberOfThickIndices; ++ithick) {
       float sigmaNoise =
-          0.001f * fcPerEle * nonAgedNoises[ithick] * dEdXweights[ilayer] /
-          (fcPerMip[ithick] * thicknessCorrection[ithick]);
-      thresholds[ilayer - 1][ithick] = sigmaNoise * ecut;
-      v_sigmaNoise[ilayer - 1][ithick] = sigmaNoise;
+          0.001f * fcPerEle_ * nonAgedNoises_[ithick] * dEdXweights_[ilayer] /
+          (fcPerMip_[ithick] * thicknessCorrection_[ithick]);
+      thresholds_[ilayer - 1][ithick] = sigmaNoise * ecut_;
+      v_sigmaNoise_[ilayer - 1][ithick] = sigmaNoise;
     }
-    float scintillators_sigmaNoise = 0.001f * noiseMip * dEdXweights[ilayer];
-    thresholds[ilayer - 1][maxNumberOfThickIndices] = ecut * scintillators_sigmaNoise;
-    v_sigmaNoise[ilayer -1][maxNumberOfThickIndices] = scintillators_sigmaNoise;
+    float scintillators_sigmaNoise = 0.001f * noiseMip_ * dEdXweights_[ilayer];
+    thresholds_[ilayer - 1][maxNumberOfThickIndices] = ecut_ * scintillators_sigmaNoise;
+    v_sigmaNoise_[ilayer -1][maxNumberOfThickIndices] = scintillators_sigmaNoise;
   }
 
 }

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -170,8 +170,12 @@ std::float_t RecHitTools::getSiThickness(const DetId& id) const {
     thick    = ddd->cellThickness(hid.layer(),hid.waferU(),hid.waferV());
   } else {
     LogDebug("getSiThickness::InvalidSiliconDetid")
-      << "det id: " << std::hex << id.rawId() << std::dec << ":" 
+      << "det id: " << std::hex << id.rawId() << std::dec << ":"
       << id.det() << " is not HGCal silicon!";
+    // It does not make any sense to return 0.37 as thickness for a detector
+    // that is not Silicon(does it?). Mark it as 0. to be able to distinguish
+    // the case.
+    thick = 0.f;
   }
   return thick;
 }
@@ -207,7 +211,7 @@ std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
     size     = ddd->cellSizeHex(hid.type());
   } else {
     edm::LogError("getRadiusToSide::InvalidSiliconDetid")
-      << "det id: " << std::hex << id.rawId() << std::dec << ":" 
+      << "det id: " << std::hex << id.rawId() << std::dec << ":"
       << id.det() << " is not HGCal silicon!";
   }
   return size;
@@ -310,7 +314,7 @@ unsigned int RecHitTools::getWafer(const DetId& id) const {
   }
   else {
     edm::LogError("getWafer::InvalidSiliconDetid")
-      << "det id: " << std::hex << id.rawId() << std::dec << ":" 
+      << "det id: " << std::hex << id.rawId() << std::dec << ":"
       << id.det() << " is not HGCal silicon!";
   }
   return wafer;
@@ -323,7 +327,7 @@ unsigned int RecHitTools::getCell(const DetId& id) const {
   }
   else {
     edm::LogError("getCell::InvalidSiliconDetid")
-      << "det id: " << std::hex << id.rawId() << std::dec << ":" 
+      << "det id: " << std::hex << id.rawId() << std::dec << ":"
       << id.det() << " is not HGCal silicon!";
   }
   return cell;


### PR DESCRIPTION
In the ImagingAlgo code there were a few references to specific geometry layers that were lost while adopting the post TDR geometry.  This PR will make the code as geometry-independent as possible.

I'd expect no regression on workflows that use the TDR geometry and some regression on workflows that use the post TDR ones.