### PR TITLE
Start conversion to using user-defined literals for Geometry

### DIFF
--- a/DetectorDescription/Core/interface/DDTypes.h
+++ b/DetectorDescription/Core/interface/DDTypes.h
@@ -32,7 +32,7 @@ std::ostream & operator<<(std::ostream & os, const DDVectorArguments & t);
 std::ostream & operator<<(std::ostream & os, const DDMapArguments & t);
 std::ostream & operator<<(std::ostream & os, const DDStringVectorArguments & t);
 
-// Formats an angle in radians as a 0-padded string in degrees; e.g. "001.293900" for 1.2939 degrees.
+// Formats an angle in radians as a 0-padded string in degrees; e.g. "0001.293900" for 1.2939 degrees.
 std::string formatAsDegrees(double radianVal);
 
 #endif // DDTYPES

--- a/DetectorDescription/Core/interface/DDTypes.h
+++ b/DetectorDescription/Core/interface/DDTypes.h
@@ -31,4 +31,8 @@ std::ostream & operator<<(std::ostream & os, const DDStringArguments & t);
 std::ostream & operator<<(std::ostream & os, const DDVectorArguments & t);
 std::ostream & operator<<(std::ostream & os, const DDMapArguments & t);
 std::ostream & operator<<(std::ostream & os, const DDStringVectorArguments & t);
+
+// Formats an angle in radians as a 0-padded string in degrees; e.g. "001.293900" for 1.2939 degrees.
+std::string formatAsDegrees(double radianVal);
+
 #endif // DDTYPES

--- a/DetectorDescription/Core/src/DDTypes.cc
+++ b/DetectorDescription/Core/src/DDTypes.cc
@@ -71,13 +71,13 @@ std::ostream & operator<<(std::ostream & os, const DDStringVectorArguments & t)
 }
 
 
-// Formats an angle in radians as a 0-padded string in degrees; e.g. "001.293900" for 1.2939 degrees.
+// Formats an angle in radians as a 0-padded string in degrees; e.g. "-001.293900" for -1.2939 degrees.
 std::string formatAsDegrees(double radianVal)
 {
-	const unsigned short numlen = 11;
+	const unsigned short numlen = 12;
 	char degstr[numlen];
 	int retval = snprintf(degstr, numlen, "%0*Lf", numlen - 1, CONVERT_TO( radianVal, deg ));
 	if (retval == numlen - 1)
 		return degstr;
-	else return "000.000000";
+	else return "0000.000000";
 }

--- a/DetectorDescription/Core/src/DDTypes.cc
+++ b/DetectorDescription/Core/src/DDTypes.cc
@@ -1,7 +1,12 @@
 #include "DetectorDescription/Core/interface/DDTypes.h"
+#include "DetectorDescription/Core/interface/DDUnits.h"
 
 #include <iostream>
 #include <utility>
+
+using namespace dd;
+using namespace dd::operators;
+
 
 ////////// output operator for printing the arguments of an algorithm
 
@@ -65,3 +70,14 @@ std::ostream & operator<<(std::ostream & os, const DDStringVectorArguments & t)
   return os;
 }
 
+
+// Formats an angle in radians as a 0-padded string in degrees; e.g. "001.293900" for 1.2939 degrees.
+std::string formatAsDegrees(double radianVal)
+{
+	const unsigned short numlen = 11;
+	char degstr[numlen];
+	int retval = snprintf(degstr, numlen, "%0*Lf", numlen - 1, CONVERT_TO( radianVal, deg ));
+	if (retval == numlen - 1)
+		return degstr;
+	else return "000.000000";
+}

--- a/Geometry/MuonCommonData/plugins/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/DDGEMAngular.cc
@@ -67,7 +67,12 @@ void DDGEMAngular::execute(DDCompactView& cpv) {
 
   for (int ii=0; ii<n; ii++) {
 
-    double phitmp = phi;
+    double phitmp = CONVERT_TO( phi, deg );
+    int factor = 1;
+    if (phitmp < 0.0) factor = -1;
+    // Round angle to nearest degree
+    phitmp = (double) factor * int(std::abs(phitmp) + 0.1);
+    phitmp *= _pi / 180.0;
     if (phitmp >= 2._pi) phitmp -= 2._pi;
     DDRotation rotation;
     std::string rotstr("RG");

--- a/Geometry/MuonCommonData/plugins/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/DDGEMAngular.cc
@@ -67,12 +67,7 @@ void DDGEMAngular::execute(DDCompactView& cpv) {
 
   for (int ii=0; ii<n; ii++) {
 
-    double phitmp = CONVERT_TO( phi, deg );
-    int factor = 1;
-    if (phitmp < 0.0) factor = -1;
-    // Round angle to nearest degree
-    phitmp = (double) factor * int(std::abs(phitmp) + 0.1);
-    phitmp *= _pi / 180.0;
+    double phitmp = phi;
     if (phitmp >= 2._pi) phitmp -= 2._pi;
     DDRotation rotation;
     std::string rotstr("RG");

--- a/Geometry/MuonCommonData/plugins/DDMuonAngular.cc
+++ b/Geometry/MuonCommonData/plugins/DDMuonAngular.cc
@@ -9,8 +9,11 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
+#include "DetectorDescription/Core/interface/DDUnits.h"
 #include "Geometry/MuonCommonData/plugins/DDMuonAngular.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+using namespace dd;
+using namespace dd::operators;
 
 //#define EDM_ML_DEBUG
 
@@ -36,8 +39,8 @@ void DDMuonAngular::initialize(const DDNumericArguments & nArgs,
   incrCopyNo  = int (nArgs["incrCopyNo"]);
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("MuonGeom") << "DDMuonAngular debug: Parameters for positioning-- "
-			   << n << " copies in steps of " << stepAngle/CLHEP::deg 
-			   << " from " << startAngle/CLHEP::deg << " \tZoffest " 
+			   << n << " copies in steps of " << CONVERT_TO( stepAngle, deg )
+			   << " from " << CONVERT_TO( startAngle, deg ) << " \tZoffest " 
 			   << zoffset << "\tStart and inremental copy nos " 
 			   << startCopyNo << ", " << incrCopyNo;
 #endif
@@ -59,30 +62,22 @@ void DDMuonAngular::execute(DDCompactView& cpv) {
 
   for (int ii=0; ii<n; ii++) {
 
-    double phideg = phi/CLHEP::deg;
-    int    iphi;
-    if (phideg > 0)  iphi = int(phideg+0.1);
-    else             iphi = int(phideg-0.1);
-    if (iphi >= 360) iphi   -= 360;
-    phideg = iphi;
+    double phitmp = phi;
+    if (phitmp >= 2._pi) phitmp -= 2._pi;
     DDRotation rotation;
     std::string rotstr("NULL");
 
-    if (iphi != 0) {
+    if (std::abs(phitmp) >= 1.0_deg) {
       rotstr = "R"; 
-      if (phideg >=0 && phideg < 10) rotstr = "R00"; 
-      else if (phideg < 100)         rotstr = "R0";
-      rotstr = rotstr + std::to_string(phideg);
+      rotstr  += formatAsDegrees(phitmp);
       rotation = DDRotation(DDName(rotstr, rotns)); 
       if (!rotation) {
 #ifdef EDM_ML_DEBUG
         edm::LogInfo("MuonGeom") << "DDMuonAngular test: Creating a new rotation "
 				 << DDName(rotstr, idNameSpace) << "\t90, " 
-				 << phideg << ", 90, " << (phideg+90) << ", 0, 0";
+				 << CONVERT_TO( phitmp, deg ) << ", 90, " << CONVERT_TO(phitmp + 90._deg, deg) << ", 0, 0";
 #endif
-        rotation = DDrot(DDName(rotstr, rotns), 90*CLHEP::deg, 
-			 phideg*CLHEP::deg, 90*CLHEP::deg, 
-			 (90+phideg)*CLHEP::deg, 0*CLHEP::deg,  0*CLHEP::deg);
+        rotation = DDrot(DDName(rotstr, rotns), 90._deg, phitmp, 90._deg, 90._deg + phitmp, 0., 0.);
       } 
     }
     


### PR DESCRIPTION
It is hoped that replacing constants from CLHEP/Units/GlobalSystemOfUnits.h with user-defined literals from DetectorDescription/Core/interface/DDUnits.h will improve performance by eliminating unnecessary floating point operations and conversions. This PR is a preliminary step in a campaign to convert the Geometry code to employ user-defined literals.

The changes in this PR do not appreciably change performance since the affected code is run only once at the start of simulation, but it does show the sort of changes entailed in the conversion to user-defined literals.