### PR TITLE
Disable IMT for merging of NanoAOD (master branch)

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -66,6 +66,7 @@ def mergeProcess(*inputFiles, **options):
     elif mergeNANO:
         import Configuration.EventContent.EventContent_cff
         outMod = OutputModule("NanoAODOutputModule",Configuration.EventContent.EventContent_cff.NANOAODEventContent.clone())
+        process.add_(Service("InitRootHandlers", EnableIMT = CfgTypes.untracked.bool(False)))
     else:
         outMod = OutputModule("PoolOutputModule")
 


### PR DESCRIPTION
As documented in CMSCOMPPR-3348, IMT triggers a crash in ROOT due to the fact that NanoAOD adds branches to the trxee.  This patch is a simple workaround - we disable IMT for the merge jobs (which are single core anyway) - until the ROOT issue is resolved.

This is the master version of #24508.  @arizzi 