### PR TITLE
Prepare RPCInverse ESProducers for concurrent IOVs

### DIFF
--- a/CondTools/RPC/plugins/RPCInverseCPPFLinkMapESProducer.h
+++ b/CondTools/RPC/plugins/RPCInverseCPPFLinkMapESProducer.h
@@ -4,6 +4,8 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include "CondFormats/RPCObjects/interface/RPCInverseAMCLinkMap.h"
 
@@ -23,12 +25,17 @@ public:
 
     static void fillDescriptions(edm::ConfigurationDescriptions & _descs);
 
-    void RPCCPPFLinkMapCallback(RPCCPPFLinkMapRcd const & _rcd);
-
     std::shared_ptr<RPCInverseAMCLinkMap> produce(RPCInverseCPPFLinkMapRcd const & _rcd);
 
-protected:
-    std::shared_ptr<RPCInverseAMCLinkMap> inverse_linkmap_;
+private:
+
+    using HostType = edm::ESProductHost<RPCInverseAMCLinkMap,
+                                        RPCCPPFLinkMapRcd>;
+
+    void setupRPCCPPFLinkMap(RPCCPPFLinkMapRcd const&,
+                             RPCInverseAMCLinkMap*);
+
+    edm::ReusableObjectHolder<HostType> holder_;
 };
 
 #endif // CondTools_RPC_RPCInverseCPPFLinkMapESProducer_h

--- a/CondTools/RPC/plugins/RPCInverseLBLinkMapESProducer.h
+++ b/CondTools/RPC/plugins/RPCInverseLBLinkMapESProducer.h
@@ -4,6 +4,8 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include "CondFormats/RPCObjects/interface/RPCInverseLBLinkMap.h"
 
@@ -23,12 +25,17 @@ public:
 
     static void fillDescriptions(edm::ConfigurationDescriptions & _descs);
 
-    void RPCLBLinkMapCallback(RPCLBLinkMapRcd const & _rcd);
-
     std::shared_ptr<RPCInverseLBLinkMap> produce(RPCInverseLBLinkMapRcd const & _rcd);
 
-protected:
-    std::shared_ptr<RPCInverseLBLinkMap> inverse_linkmap_;
+private:
+
+    using HostType = edm::ESProductHost<RPCInverseLBLinkMap,
+                                        RPCLBLinkMapRcd>;
+
+    void setupRPCLBLinkMap(RPCLBLinkMapRcd const&,
+                           RPCInverseLBLinkMap*);
+
+    edm::ReusableObjectHolder<HostType> holder_;
 };
 
 #endif // CondTools_RPC_RPCInverseLBLinkMapESProducer_h

--- a/CondTools/RPC/plugins/RPCInverseOMTFLinkMapESProducer.h
+++ b/CondTools/RPC/plugins/RPCInverseOMTFLinkMapESProducer.h
@@ -4,6 +4,8 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include "CondFormats/RPCObjects/interface/RPCInverseAMCLinkMap.h"
 
@@ -23,12 +25,17 @@ public:
 
     static void fillDescriptions(edm::ConfigurationDescriptions & _descs);
 
-    void RPCOMTFLinkMapCallback(RPCOMTFLinkMapRcd const & _rcd);
-
     std::shared_ptr<RPCInverseAMCLinkMap> produce(RPCInverseOMTFLinkMapRcd const & _rcd);
 
-protected:
-    std::shared_ptr<RPCInverseAMCLinkMap> inverse_linkmap_;
+private:
+
+    using HostType = edm::ESProductHost<RPCInverseAMCLinkMap,
+                                        RPCOMTFLinkMapRcd>;
+
+    void setupRPCOMTFLinkMap(RPCOMTFLinkMapRcd const&,
+                             RPCInverseAMCLinkMap*);
+
+    edm::ReusableObjectHolder<HostType> holder_;
 };
 
 #endif // CondTools_RPC_RPCInverseOMTFLinkMapESProducer_h

--- a/CondTools/RPC/plugins/RPCInverseTwinMuxLinkMapESProducer.h
+++ b/CondTools/RPC/plugins/RPCInverseTwinMuxLinkMapESProducer.h
@@ -4,6 +4,8 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include "CondFormats/RPCObjects/interface/RPCInverseAMCLinkMap.h"
 
@@ -23,12 +25,17 @@ public:
 
     static void fillDescriptions(edm::ConfigurationDescriptions & _descs);
 
-    void RPCTwinMuxLinkMapCallback(RPCTwinMuxLinkMapRcd const & _rcd);
-
     std::shared_ptr<RPCInverseAMCLinkMap> produce(RPCInverseTwinMuxLinkMapRcd const & _rcd);
 
-protected:
-    std::shared_ptr<RPCInverseAMCLinkMap> inverse_linkmap_;
+private:
+
+    using HostType = edm::ESProductHost<RPCInverseAMCLinkMap,
+                                        RPCTwinMuxLinkMapRcd>;
+
+    void setupRPCTwinMuxLinkMap(RPCTwinMuxLinkMapRcd const&,
+                                RPCInverseAMCLinkMap*);
+
+    edm::ReusableObjectHolder<HostType> holder_;
 };
 
 #endif // CondTools_RPC_RPCInverseTwinMuxLinkMapESProducer_h


### PR DESCRIPTION
Currently the Framework only allows one EventSetup IOV (Interval of Validity) to be processed at a time, but we are preparing to change this in the future and allow multiple concurrent IOVs. This PR modifies the ESProducers related to RPCs in preparation for this change.

Prior to this, the ESProducer held a pointer to a single produced object. After this PR it will use the ReusableObjectHolder class to manage multiple objects, one for each concurrent IOV. The objects needs to hold different content for different IOVs and the ESProducer needs to modify them during its produce call in a thread safe manner.

The dependsOn feature of the EventSetup has difficulty communicating with these different objects in the callbacks and produce function calls. The usage of the dependsOn feature is replaced by usage of the new ESProductHost class. It has a similar purpose, but works better when there are multiple IOVs because its interface allows direct communication via arguments between the produce methods and the lambda function that gets called when the dependent record changes.

Note, I could not find anything in CMSSW that actually uses these modules. (It is possible they are not needed at all.) The standard tests I tried do not run them, so to test I manually created a test configuration that runs them and stepped through in the debugger to see they were performing as I expected.