### PR TITLE
Move tinyxml->tinixml2 in CalibTracker/StandaloneTrackerTopology pkg

### DIFF
--- a/CalibTracker/StandaloneTrackerTopology/BuildFile.xml
+++ b/CalibTracker/StandaloneTrackerTopology/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/TrackerCommon"/>
-<use   name="tinyxml"/>
+<use   name="tinyxml2"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CalibTracker/StandaloneTrackerTopology/src/StandaloneTrackerTopology.cc
+++ b/CalibTracker/StandaloneTrackerTopology/src/StandaloneTrackerTopology.cc
@@ -22,7 +22,7 @@ namespace {
     public:
     bool VisitEnter(const tinyxml2::XMLElement& elem, const tinyxml2::XMLAttribute*) override
       {
-        if ( elem.Value() == std::string("Vector").c_str() ) {
+        if ( std::strcmp(elem.Value(), "Vector") == 0 ) {
           const std::string att_type{elem.Attribute("type")};
           if ( att_type == "numeric" ) {
             const std::string att_name{elem.Attribute("name")};
@@ -169,7 +169,8 @@ namespace {
 namespace StandaloneTrackerTopology {
 TrackerTopology fromTrackerParametersXMLFile( const std::string& xmlFileName ) {
   tinyxml2::XMLDocument xmlDoc;
-  if ( xmlDoc.LoadFile(xmlFileName.c_str()) ) {
+  xmlDoc.LoadFile(xmlFileName.c_str());
+  if ( ! xmlDoc.Error() ) {
     TrackerTopologyExtractor extr{};
     xmlDoc.Accept(&extr);
     return extr.getTrackerTopology();

--- a/CalibTracker/StandaloneTrackerTopology/src/StandaloneTrackerTopology.cc
+++ b/CalibTracker/StandaloneTrackerTopology/src/StandaloneTrackerTopology.cc
@@ -1,6 +1,6 @@
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 
-#include "tinyxml.h"
+#include "tinyxml2.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 namespace {
@@ -17,12 +17,12 @@ namespace {
     return out;
   }
 
-  class TrackerTopologyExtractor : public TiXmlVisitor
+  class TrackerTopologyExtractor : public tinyxml2::XMLVisitor
   {
     public:
-      bool VisitEnter(const TiXmlElement& elem, const TiXmlAttribute*) override
+    bool VisitEnter(const tinyxml2::XMLElement& elem, const tinyxml2::XMLAttribute*) override
       {
-        if ( elem.ValueStr() == "Vector" ) {
+        if ( elem.Value() == std::string("Vector").c_str() ) {
           const std::string att_type{elem.Attribute("type")};
           if ( att_type == "numeric" ) {
             const std::string att_name{elem.Attribute("name")};
@@ -168,24 +168,24 @@ namespace {
 
 namespace StandaloneTrackerTopology {
 TrackerTopology fromTrackerParametersXMLFile( const std::string& xmlFileName ) {
-  TiXmlDocument xmlDoc;
-  if ( xmlDoc.LoadFile(xmlFileName) ) {
+  tinyxml2::XMLDocument xmlDoc;
+  if ( xmlDoc.LoadFile(xmlFileName.c_str()) ) {
     TrackerTopologyExtractor extr{};
     xmlDoc.Accept(&extr);
     return extr.getTrackerTopology();
   } else {
-    throw cms::Exception("StandaloneTrackerTopology", std::string{"Failed to parse file "}+xmlFileName+": "+xmlDoc.ErrorDesc());
+    throw cms::Exception("StandaloneTrackerTopology", std::string{"Failed to parse file "}+xmlFileName+": "+xmlDoc.ErrorStr());
   }
 }
 TrackerTopology fromTrackerParametersXMLString( const std::string& xmlContent ) {
-  TiXmlDocument xmlDoc;
+  tinyxml2::XMLDocument xmlDoc;
   xmlDoc.Parse(xmlContent.c_str());
   if ( ! xmlDoc.Error() ) {
     TrackerTopologyExtractor extr{};
     xmlDoc.Accept(&extr);
     return extr.getTrackerTopology();
   } else {
-    throw cms::Exception("StandaloneTrackerTopology", std::string{"Error while parsing XML: "}+xmlDoc.ErrorDesc());
+    throw cms::Exception("StandaloneTrackerTopology", std::string{"Error while parsing XML: "}+xmlDoc.ErrorStr());
   }
 }
 }


### PR DESCRIPTION
Recently we added tinyxml2 external and now we are moving pkgs that were using tinyxml to tinyxml2.