### PR TITLE
fix the output name repetition issue and adjust the job splitting

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -246,7 +246,9 @@ class MatrixInjector(object):
             wmsplit['RECOUP17_PU25']=1
             wmsplit['DIGICOS_UP17']=1
             wmsplit['RECOCOS_UP17']=1
-
+            wmsplit['HYBRIDRepackHI2015VR']=1
+            wmsplit['HYBRIDZSHI2015']=1
+            wmsplit['RECOHID15']=1
                                     
             #import pprint
             #pprint.pprint(wmsplit)            
@@ -485,6 +487,8 @@ class MatrixInjector(object):
                     t['KeepOutput']=True
                 elif t['TaskName'] in self.keep:
                     t['KeepOutput']=True
+                if t['TaskName'].startswith('HYBRIDRepackHI2015VR'):
+                    t['KeepOutput']=False
                 t.pop('nowmIO')
                 itask+=1
                 chainDict['Task%d'%(itask)]=t


### PR DESCRIPTION
To fix the dataset name issue in the new HI workflow 144.55 introduced in PR #24484 