### PR TITLE
HCALDQM: Fix sources for heavy ion runs (10_3_X)

### DIFF
--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -106,6 +106,20 @@ process.emulTPDigisNoTDCCut.parameters = cms.untracked.PSet(
 
 # For sent-received comparison
 process.load("L1Trigger.Configuration.L1TRawToDigi_cff")
+# For heavy ion runs, need to reconfigure sources for L1TRawToDigi
+if isHeavyIon:
+	process.csctfDigis.producer = cms.InputTag("rawDataRepacker")
+	process.dttfDigis.DTTF_FED_Source = cms.InputTag("rawDataRepacker")
+	process.RPCTwinMuxRawToDigi.inputTag = cms.InputTag("rawDataRepacker")
+	process.twinMuxStage2Digis.DTTM7_FED_Source = cms.InputTag("rawDataRepacker")
+	process.omtfStage2Digis.inputLabel = cms.InputTag("rawDataRepacker")
+	process.caloStage1Digis.InputLabel = cms.InputTag("rawDataRepacker") #new
+	process.bmtfDigis.InputLabel = cms.InputTag("rawDataRepacker")
+	process.emtfStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
+	process.caloLayer1Digis.InputLabel = cms.InputTag("rawDataRepacker") #not sure
+	process.caloStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
+	process.gmtStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
+	process.gtStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
 
 # Exclude the laser FEDs. They contaminate the QIE10/11 digi collections. 
 #from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017


### PR DESCRIPTION
@threus pointed out that the HCAL DQM client is crashing on heavy ion runs, due to misnamed sources for L1TRawToDigi. This PR fixes that problem..