### PR TITLE
Prepare ecal ESProducers for concurrent IOVs

### DIFF
--- a/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
+++ b/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
@@ -20,6 +20,11 @@ class EcalCondObjectContainer {
                 EcalCondObjectContainer() {};
                 ~EcalCondObjectContainer() {};
 
+                void clear() {
+                  eb_.clear();
+                  ee_.clear();
+                }
+
                 inline const Items & barrelItems() const { return eb_.items(); };
 
                 inline const Items & endcapItems() const { return ee_.items(); };

--- a/DataFormats/EcalDetId/interface/EcalContainer.h
+++ b/DataFormats/EcalDetId/interface/EcalContainer.h
@@ -29,6 +29,11 @@ class EcalContainer {
                    
                 EcalContainer() {checkAndResize();}
 
+                void clear() {
+                        m_items.clear();
+                        checkAndResize();
+                }
+
                 void insert(std::pair<uint32_t, Item> const &a) {
                         (*this)[a.first] = a.second;
                 }

--- a/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
+++ b/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
@@ -1,8 +1,10 @@
 #include <memory>
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProductHost.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
@@ -24,42 +26,49 @@ public:
   typedef std::shared_ptr<EcalSeverityLevelAlgo> ReturnType;
   
   ReturnType produce(const EcalSeverityLevelAlgoRcd& iRecord);
-  
-
 
 private:
 
-  void chstatusCallback(const EcalChannelStatusRcd& chs);
-  
-  ReturnType algo_;
+  void setupChannelStatus(const EcalChannelStatusRcd&,
+                          EcalSeverityLevelAlgo*);
+
+  using HostType = edm::ESProductHost<EcalSeverityLevelAlgo,
+                                      EcalChannelStatusRcd>;
+
+  edm::ReusableObjectHolder<HostType> holder_;
+  edm::ParameterSet pset_;
 };
 
-EcalSeverityLevelESProducer::EcalSeverityLevelESProducer(const edm::ParameterSet& iConfig){
+EcalSeverityLevelESProducer::EcalSeverityLevelESProducer(const edm::ParameterSet& iConfig) :
+  pset_(iConfig) {
+
   //the following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced(this, 
-		  dependsOn (&EcalSeverityLevelESProducer::chstatusCallback));
-
-  algo_ = std::make_shared<EcalSeverityLevelAlgo>(iConfig);
+  setWhatProduced(this);
 }
-
-
 
 EcalSeverityLevelESProducer::ReturnType
 EcalSeverityLevelESProducer::produce(const EcalSeverityLevelAlgoRcd& iRecord){
-  
-  return algo_ ;
+
+  auto host = holder_.makeOrGet([this]() {
+    return new HostType(pset_);
+  });
+
+  host->ifRecordChanges<EcalChannelStatusRcd>(iRecord,
+                                              [this,h=host.get()](auto const& rec) {
+    setupChannelStatus(rec, h);
+  });
+
+  return host;
 }
 
-
 void 
-EcalSeverityLevelESProducer::chstatusCallback(const EcalChannelStatusRcd& chs){
+EcalSeverityLevelESProducer::setupChannelStatus(const EcalChannelStatusRcd& chs,
+                                                EcalSeverityLevelAlgo* algo){
   edm::ESHandle <EcalChannelStatus> h;
   chs.get (h);
-  algo_->setChannelStatus(*h.product());
+  algo->setChannelStatus(*h.product());
 }
 
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(EcalSeverityLevelESProducer);
-
-


### PR DESCRIPTION
Currently the Framework only allows one EventSetup IOV (Interval of Validity) to be processed at a time, but we are preparing to change this in the future and allow multiple concurrent IOVs. This PR modifies two ESProducers related to ECAL preparation for this change.

Prior to this, these ESProducers held a pointer to a single produced object. After this PR it will use the ReusableObjectHolder class to manage multiple objects, one for each concurrent IOV. The objects need to hold different content for different IOVs and the ESProducers need to modify them during their produce call in a thread safe manner.

The dependsOn feature of the EventSetup has difficulty communicating with these different objects in the callbacks and produce function calls. The usage of the dependsOn feature is replaced by usage of the new ESProductHost class. It has a similar purpose, but works better when there are multiple IOVs because its interface allows direct communication via arguments between the produce methods and the lambda function that gets called when the dependent record changes.

Tested using runTheMatrix test 25.0 step 3 by printing out the contents of the produced products and comparing before and after the change. I also stepped through the changes in a debugger.
