### PR TITLE
Revert "L1T offline emulator DQM config upgrades - 102x"

### DIFF
--- a/DQMOffline/L1Trigger/python/L1EmulatorQualityTestsOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1EmulatorQualityTestsOffline_cff.py
@@ -108,22 +108,7 @@ l1EmulatorObjNoIsoEGQualityTests.qtestOnEndLumi = False
 # Mu quality tests
 l1EmulatorObjMuQualityTests.qtestOnEndLumi = False
 
-# stage 2
-from DQM.L1TMonitorClient.L1TStage2QualityTests_cff import *
-l1TStage2CaloLayer1QualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2BMTFQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2OMTFQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2EMTFQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2uGMTQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2uGTQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2MuonQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2MuonQualityTestsCollisions.qtestOnEndLumi = cms.untracked.bool(False)
 
-from DQM.L1TMonitorClient.L1TStage2EmulatorQualityTests_cff import *
-l1TStage2CaloLayer1DEQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2BMTFDEQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2OMTFDEQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2EMTFDEQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2uGMTDEQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
-l1TStage2uGTDEQualityTests.qtestOnEndLumi = cms.untracked.bool(False)
+
+
 

--- a/DQMOffline/L1Trigger/python/L1TEmulatorMonitorClientOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TEmulatorMonitorClientOffline_cff.py
@@ -27,7 +27,4 @@ l1temuEventInfoClient.runInEndLumi = False
 l1temuEventInfoClient.runInEndRun = True
 l1temuEventInfoClient.runInEndJob = False
     
-# stage 2
-from DQM.L1TMonitorClient.L1TStage2EmulatorMonitorClient_cff import *
-l1tStage2EmulatorMonitorClientOffline = cms.Sequence(l1tStage2EmulatorMonitorClient)
 

--- a/DQMOffline/L1Trigger/python/L1TEmulatorMonitorOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TEmulatorMonitorOffline_cff.py
@@ -5,33 +5,3 @@ import FWCore.ParameterSet.Config as cms
 # DQM online L1 Trigger emulator modules 
 from DQM.L1TMonitor.L1TEmulatorMonitor_cff import *
 
-
-# Stage 2
-
-from DQM.L1TMonitor.L1TStage2Emulator_cff import *
-# add calo layer 2 emulation with inputs from the calo layer 1 emulator since the full unpacked data to emulate layer 2 is only available for validation events
-valCaloStage2Layer2DigisOffline = valCaloStage2Layer2Digis.clone()
-valCaloStage2Layer2DigisOffline.towerToken = cms.InputTag("valCaloStage2Layer1Digis")
-
-Stage2L1HardwareValidationForOfflineCalo = cms.Sequence(valCaloStage2Layer2DigisOffline)
-
-# Calo layer 2 emulator DQM modules for offline
-from DQM.L1TMonitor.L1TdeStage2CaloLayer2_cfi import *
-l1tdeStage2CaloLayer2Offline = l1tdeStage2CaloLayer2.clone()
-l1tdeStage2CaloLayer2Offline.calol2JetCollectionEmul = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tdeStage2CaloLayer2Offline.calol2EGammaCollectionEmul = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tdeStage2CaloLayer2Offline.calol2TauCollectionEmul = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tdeStage2CaloLayer2Offline.calol2EtSumCollectionEmul = cms.InputTag("valCaloStage2Layer2DigisOffline")
-
-from DQM.L1TMonitor.L1TStage2CaloLayer2Emul_cfi import *
-l1tStage2CaloLayer2EmulOffline = l1tStage2CaloLayer2Emul.clone()
-l1tStage2CaloLayer2EmulOffline.stage2CaloLayer2JetSource = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tStage2CaloLayer2EmulOffline.stage2CaloLayer2EGammaSource = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tStage2CaloLayer2EmulOffline.stage2CaloLayer2TauSource = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tStage2CaloLayer2EmulOffline.stage2CaloLayer2EtSumSource = cms.InputTag("valCaloStage2Layer2DigisOffline")
-
-l1tStage2EmulatorOfflineDQMForCalo = cms.Sequence(
-    l1tdeStage2CaloLayer2Offline +
-    l1tStage2CaloLayer2EmulOffline
-)
-

--- a/DQMOffline/L1Trigger/python/L1TMonitorClientOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TMonitorClientOffline_cff.py
@@ -33,19 +33,3 @@ l1tGmtClient.runInEndLumi = False
 
 # GCT client
 l1tGctClient.runInEndLumi = False
-
-# stage 2
-from DQM.L1TMonitorClient.L1TStage2MonitorClient_cff import *
-l1tStage2MonitorClientOffline = cms.Sequence(l1tStage2MonitorClient)
-
-l1tStage1Layer2Client.runInEndLumi = False
-
-from DQM.L1TMonitorClient.L1TStage2EMTFEventInfoClient_cfi import *
-l1tStage2EMTFEventInfoClient.runInEndLumi = False
-
-from DQM.L1TMonitorClient.L1TStage2EventInfoClient_cfi import *
-l1tStage2EventInfoClient.runInEndLumi = False
-
-from DQM.L1TMonitorClient.L1TStage2EmulatorEventInfoClient_cfi import *
-l1tStage2EmulatorEventInfoClient.runInEndLumi = False
-

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMEfficiency_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMEfficiency_cff.py
@@ -46,17 +46,9 @@ l1tMuonDQMEfficiency = DQMEDHarvester("DQMGenericClient",
     verbose = cms.untracked.uint32(0)
 )
 
-# emulator efficiency
-l1tMuonDQMEmuEfficiency = l1tMuonDQMEfficiency.clone(
-    subDirs = cms.untracked.vstring("L1TEMU/L1TObjects/L1TMuon/L1TriggerVsReco/")
-)
-
 # modifications for the pp reference run
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 ppRef_2017.toModify(l1tMuonDQMEfficiency,
-    efficiencyProfile = cms.untracked.vstring(generateEfficiencyStrings(ptQualCuts_HI))
-)
-ppRef_2017.toModify(l1tMuonDQMEmuEfficiency,
     efficiencyProfile = cms.untracked.vstring(generateEfficiencyStrings(ptQualCuts_HI))
 )
 

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
@@ -64,12 +64,6 @@ l1tMuonDQMOffline = DQMEDAnalyzer('L1TMuonDQMOffline',
     verbose   = cms.untracked.bool(False)
 )
 
-# emulator module
-l1tMuonDQMOfflineEmu = l1tMuonDQMOffline.clone(
-    gmtInputTag  = cms.untracked.InputTag("simGmtStage2Digis"),
-    histFolder = cms.untracked.string('L1TEMU/L1TObjects/L1TMuon/L1TriggerVsReco')
-)
-
 # modifications for the pp reference run
 # A list of pt cut + quality cut pairs for which efficiency plots should be made
 ptQualCuts_HI = [[12, 12], [7, 8], [5, 4]]
@@ -85,12 +79,4 @@ ppRef_2017.toModify(l1tMuonDQMOffline,
         "HLT_HIL3Mu12_v*",
     )
 )
-ppRef_2017.toModify(l1tMuonDQMOfflineEmu,
-    tagPtCut = cms.untracked.double(14.),
-    cuts = cms.untracked.VPSet(cutsPSets_HI),
-    triggerNames = cms.untracked.vstring(
-        "HLT_HIL3Mu12_v*",
-    )
-)
-
 

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
@@ -1,8 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMOffline.L1Trigger.L1TMonitorClientOffline_cff import *
-from DQMOffline.L1Trigger.L1TEmulatorMonitorClientOffline_cff import *
-
 from DQMOffline.L1Trigger.L1TEtSumEfficiency_cfi import *
 from DQMOffline.L1Trigger.L1TEtSumDiff_cfi import *
 
@@ -19,14 +16,12 @@ from DQMOffline.L1Trigger.L1TMuonDQMEfficiency_cff import *
 
 # harvesting sequence for all datasets
 DQMHarvestL1TMon = cms.Sequence(
-    l1tStage2MonitorClientOffline
-    * l1tStage2EmulatorMonitorClientOffline
 )
 
 # harvesting sequence for electron dataset
 DQMHarvestL1TEg = cms.Sequence(
     l1tEGammaEfficiency
-    * l1tEGammaEmuEfficiency
+    #* l1tEGammaEmuEfficiency
     #* l1tEGammaEmuDiff
 )
 
@@ -39,14 +34,12 @@ DQMHarvestL1TEg = cms.Sequence(
 DQMHarvestL1TMuon = cms.Sequence(
     l1tEtSumEfficiency
     * l1tJetEfficiency
-    * l1tEtSumEmuEfficiency
-    * l1tJetEmuEfficiency
+    #* l1tEtSumEmuEfficiency
+    #* l1tJetEmuEfficiency
     #* l1tEtSumEmuDiff
     #* l1tJetEmuDiff
     * l1tTauEfficiency
-    * l1tTauEmuEfficiency
     #* l1tTauEmuDiff
     * l1tMuonDQMEfficiency
-    * l1tMuonDQMEmuEfficiency
 )
 

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -281,10 +281,14 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 from L1Trigger.L1TGlobal.GlobalParameters_cff import *
 
 from DQMOffline.L1Trigger.L1TEtSumJetOffline_cfi import *
+l1tEtSumJetOfflineDQMEmu.stage2CaloLayer2JetSource=cms.InputTag("valCaloStage2Layer2Digis")
+l1tEtSumJetOfflineDQMEmu.stage2CaloLayer2EtSumSource=cms.InputTag("valCaloStage2Layer2Digis")
 
 from DQMOffline.L1Trigger.L1TEGammaOffline_cfi import *
+l1tEGammaOfflineDQMEmu.stage2CaloLayer2EGammaSource=cms.InputTag("valCaloStage2Layer2Digis")
 
 from DQMOffline.L1Trigger.L1TTauOffline_cfi import *
+l1tTauOfflineDQMEmu.stage2CaloLayer2TauSource=cms.InputTag("valCaloStage2Layer2Digis")
 
 from DQMOffline.L1Trigger.L1TMuonDQMOffline_cfi import *
 
@@ -294,6 +298,18 @@ from DQMOffline.L1Trigger.L1TriggerDqmOffline_SecondStep_cff import *
 ##Stage 2 Emulator
 
 from DQM.L1TMonitor.L1TStage2Emulator_cff import *
+from DQM.L1TMonitorClient.L1TStage2CaloLayer2DEClient_cfi import *
+from DQM.L1TMonitorClient.L1TStage2MonitorClient_cff import *
+# L1T monitor client sequence (system clients and quality tests)
+l1TStage2EmulatorClients = cms.Sequence(
+                        l1tStage2CaloLayer2DEClient
+                        # l1tStage2EmulatorEventInfoClient
+                        )
+
+l1tStage2EmulatorMonitorClient = cms.Sequence(
+                        # l1TStage2EmulatorQualityTests +
+                        l1TStage2EmulatorClients
+                        )
 
 #
 # define sequences
@@ -341,21 +357,18 @@ l1tStage2EmulatorOnlineDQM.remove(l1tStage2uGtEmul)
 
 # sequence to run for all datasets
 Stage2l1TriggerEmulatorOffline = cms.Sequence(
-                                Stage2l1TriggerEmulatorOnline +
-                                Stage2L1HardwareValidationForOfflineCalo +
-                                l1tStage2EmulatorOfflineDQMForCalo
+                                Stage2l1TriggerEmulatorOnline
                                 )
 
 # sequence to run only for modules requiring an electron dataset
 Stage2l1tEgEmulatorOffline = cms.Sequence(
-                                l1tEGammaOfflineDQMEmu
+                                #l1tEGammaOfflineDQMEmu
                                 )
 
 # sequence to run only for modules requiring a muon dataset
 Stage2l1tMuonEmulatorOffline = cms.Sequence(
-                                l1tEtSumJetOfflineDQMEmuSeq +
-                                l1tTauOfflineDQMEmu +
-                                l1tMuonDQMOfflineEmu
+                                #l1tEtSumJetOfflineDQMEmuSeq +
+                                #l1tTauOfflineDQMEmu
                                 )
 
 ##############################################################################
@@ -384,6 +397,8 @@ Stage2l1tMuonDqmOffline = cms.Sequence(
 
 # DQM Offline sequence
 Stage2l1TriggerDqmOfflineClient = cms.Sequence(
+                                l1tStage2EmulatorMonitorClient *
+                                l1tStage2MonitorClient *
                                 DQMHarvestL1TMon
                                 )
 
@@ -409,5 +424,6 @@ stage2L1Trigger.toReplaceWith(l1TriggerMuonDqmOffline, Stage2l1tMuonDqmOffline)
 stage2L1Trigger.toReplaceWith(l1TriggerDqmOfflineClient, Stage2l1TriggerDqmOfflineClient)
 stage2L1Trigger.toReplaceWith(l1TriggerEgDqmOfflineClient, Stage2l1tEgDqmOfflineClient)
 stage2L1Trigger.toReplaceWith(l1TriggerMuonDqmOfflineClient, Stage2l1tMuonDqmOfflineClient)
+stage2L1Trigger.toReplaceWith(l1EmulatorMonitorClient,l1tStage2EmulatorMonitorClient)
 stage2L1Trigger.toReplaceWith(l1TriggerDqmOfflineCosmics, Stage2l1TriggerDqmOffline)
 stage2L1Trigger.toReplaceWith(l1TriggerDqmOfflineCosmicsClient, Stage2l1TriggerDqmOfflineClient)


### PR DESCRIPTION
Reverts cms-sw/cmssw#24291

This PR assumes the output of the L1 simGmtStage2Digis available on input, but this is not true in the standard repacking. Pending a properly tested solution, this update is temporarily reverted.