### PR TITLE
BMTF-KMTF DQM Algo Selector for the DQM/L1TMonitor Subsystem

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2BMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2BMTF.h
@@ -99,9 +99,10 @@ private:
   MonitorElement* bmtf_hwPt_bx;   
   MonitorElement* bmtf_hwQual_bx; 
 
+  MonitorElement* bmtf_hwDXY;
+  MonitorElement* bmtf_hwPt2;
 
-  MonitorElement* kbmtf_hwDXY;
-  MonitorElement* kbmtf_hwPt2;
+
   /* MonitorElement* bmtf_twinmuxInput_PhiBX; */
   /* MonitorElement* bmtf_twinmuxInput_PhiPhi; */
   /* MonitorElement* bmtf_twinmuxInput_PhiPhiB; */
@@ -110,7 +111,7 @@ private:
   /* MonitorElement* bmtf_twinmuxInput_PhiSector; */
   /* MonitorElement* bmtf_twinmuxInput_PhiWheel; */
   /* MonitorElement* bmtf_twinmuxInput_PhiTrSeg; */
-  /* MonitorElement*  bmtf_twinmuxInput_PhiWheel_PhiSector; */
+  /* MonitorElement* bmtf_twinmuxInput_PhiWheel_PhiSector; */
 
   /* MonitorElement* bmtf_twinmuxInput_TheBX; */
   /* MonitorElement* bmtf_twinmuxInput_ThePhi; */

--- a/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
@@ -43,7 +43,7 @@ class L1TStage2RegionalMuonCandComp : public DQMEDAnalyzer {
   bool ignoreBadTrkAddr;
   std::vector<int> ignoreBin;
   bool verbose;
-  bool kalman;
+  bool isBmtf;
   
   MonitorElement* summary;
   MonitorElement* errorSummaryNum;

--- a/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
+++ b/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
@@ -5,10 +5,8 @@
 
 #include "L1TBMTFAlgoSelector.h"
 
-//The Constructor Initializes 2 RegionalMuonCandBxCollections and defines what to be consumed
-dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::L1TBMTFAlgoSelector(const edm::ParameterSet & ps)//:
-//  bmtfTriggering(new l1t::RegionalMuonCandBxCollection()),
-//  bmtfSecondary(new l1t::RegionalMuonCandBxCollection())
+//The Constructor defines what to be consumed and produced
+dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::L1TBMTFAlgoSelector(const edm::ParameterSet & ps)
 {
   bmtfKalmanToken = consumes<l1t::RegionalMuonCandBxCollection>(ps.getParameter<edm::InputTag>("bmtfKalman"));
   bmtfLegacyToken = consumes<l1t::RegionalMuonCandBxCollection>(ps.getParameter<edm::InputTag>("bmtfLegacy"));
@@ -52,7 +50,7 @@ void dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::produce(edm::Event & eve, const e
                      header.lvl1ID(), header.bxID(), false, false ) ) {
 
     edm::LogError("L1TDQM") << "Could not extract AMC13 Packet.";
-   // return;
+    return;
   }
 
   edm::LogInfo("L1TDQM") << "AMC13-packet-payload size = " << packet.payload().size();
@@ -80,39 +78,12 @@ void dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::produce(edm::Event & eve, const e
   edm::Handle<l1t::RegionalMuonCandBxCollection> bmtfLegacy;
   eve.getByToken(bmtfLegacyToken, bmtfLegacy);
 
-  // auto *bmtfKalman_copy = new l1t::RegionalMuonCandBxCollection(bmtfKalman->size(),
-  // 								bmtfKalman->getFirstBX(),
-  // 								bmtfKalman->getLastBX()
-  // 								);
-  // auto *bmtfLegacy_copy = new l1t::RegionalMuonCandBxCollection(bmtfLegacy->size(),
-  // 								bmtfLegacy->getFirstBX(),
-  // 								bmtfLegacy->getLastBX()
-  // 								);
-
-  // unsigned int idx = 0;
-  // for (auto bx = bmtfKalman_copy->getFirstBX(); bx <= bmtfKalman_copy->getLastBX(); bx++) {
-
-  //   if ( not bmtfKalman->isEmpty(bx) )
-  //     bmtfKalman_copy->set(bx, idx, (*bmtfKalman)[idx]);
-
-  //   idx++;
-  // }
-
-  // idx = 0;
-  // for (auto bx = bmtfLegacy_copy->getFirstBX(); bx <= bmtfLegacy_copy->getLastBX(); bx++) {
-
-  //   if ( not bmtfLegacy->isEmpty(bx) )
-  //     bmtfLegacy_copy->set(bx, idx, (*bmtfLegacy)[idx]);
-
-  //   idx++;
-  // }
-
   auto *bmtfKalman_copy = new l1t::RegionalMuonCandBxCollection(*bmtfKalman);
   auto *bmtfLegacy_copy = new l1t::RegionalMuonCandBxCollection(*bmtfLegacy);
 
-  std::cout << "copy RegionalMuonCandBxCollections created" << std::endl;
-  std::cout << "bmtfKalman_copy address: " << bmtfKalman_copy << std::endl;
-  std::cout << "bmtfLegacy_copy address: " << bmtfLegacy_copy << std::endl;
+  edm::LogInfo("L1TDQM") << "copy RegionalMuonCandBxCollections created";
+  edm::LogInfo("L1TDQM") << "bmtfKalman_copy address: " << bmtfKalman_copy;
+  edm::LogInfo("L1TDQM") << "bmtfLegacy_copy address: " << bmtfLegacy_copy;
 
   std::unique_ptr<l1t::RegionalMuonCandBxCollection> bmtfTriggering, bmtfSecondary;
   if ( algo_ver >= 2499805536) {//95000160(hex)
@@ -126,14 +97,13 @@ void dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::produce(edm::Event & eve, const e
     bmtfSecondary.reset(bmtfKalman_copy);
   }
 
-  std::cout << "Triggering and Secondary pointers filled:" << std::endl;
-  std::cout << "bmtfTriggering address: " << bmtfTriggering.get() << std::endl;
-  std::cout << "bmtfSecondary address: " << bmtfSecondary.get() << std::endl;
+  edm::LogInfo("L1TDQM") << "Triggering and Secondary pointers filled:";
+  edm::LogInfo("L1TDQM") << "bmtfTriggering address: " << bmtfTriggering.get();
+  edm::LogInfo("L1TDQM") << "bmtfSecondary address: " << bmtfSecondary.get();
   
   eve.put(std::move(bmtfTriggering),"BMTF");
   eve.put(std::move(bmtfSecondary),"BMTF2");
 
-  std::cout << "reached return..." << std::endl;
   return;
 }
 

--- a/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
+++ b/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
@@ -1,0 +1,144 @@
+/*
+/P.Katsoulis
+/G.Karathanasis     
+*/
+
+#include "L1TBMTFAlgoSelector.h"
+
+//The Constructor Initializes 2 RegionalMuonCandBxCollections and defines what to be consumed
+dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::L1TBMTFAlgoSelector(const edm::ParameterSet & ps)//:
+//  bmtfTriggering(new l1t::RegionalMuonCandBxCollection()),
+//  bmtfSecondary(new l1t::RegionalMuonCandBxCollection())
+{
+  bmtfKalmanToken = consumes<l1t::RegionalMuonCandBxCollection>(ps.getParameter<edm::InputTag>("bmtfKalman"));
+  bmtfLegacyToken = consumes<l1t::RegionalMuonCandBxCollection>(ps.getParameter<edm::InputTag>("bmtfLegacy"));
+  fedToken = consumes<FEDRawDataCollection>(ps.getParameter<edm::InputTag>("feds"));
+
+  produces<l1t::RegionalMuonCandBxCollection>("BMTF");
+  produces<l1t::RegionalMuonCandBxCollection>("BMTF2");
+}
+
+
+dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::~L1TBMTFAlgoSelector() {
+}
+
+void dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::produce(edm::Event & eve, const edm::EventSetup & eveSetup)
+{
+
+  edm::Handle<FEDRawDataCollection> feds;
+  eve.getByToken(fedToken, feds);
+
+  //Get the fw-ver
+  int nonEmptyFed=0;
+  if (feds->FEDData(1376).size() > 0)
+    nonEmptyFed = 1376;
+  else if (feds->FEDData(1377).size() > 0)
+    nonEmptyFed = 1377;
+  else {
+    edm::LogError("L1TDQM") << "[L1TBMTFAlgoSelector] Both BMTF feds (1376, 1377) seem empty.";
+   // return;
+  }
+  const FEDRawData& l1tRcd = feds->FEDData(nonEmptyFed);;
+  edm::LogInfo("L1TDQM") << "L1T Rcd taken from the FEDData.";
+  edm::LogInfo("L1TDQM") << "l1tRcd.size=" << l1tRcd.size() << "   for fed:" << nonEmptyFed;
+
+  const unsigned char *data = l1tRcd.data();
+  FEDHeader header(data);
+  edm::LogInfo("L1TDQM") << "header and data extracted from the Rcd.";
+
+  amc13::Packet packet;
+  if (!packet.parse( (const uint64_t*) data, (const uint64_t*) (data + 8),
+                     (l1tRcd.size()) / 8,
+                     header.lvl1ID(), header.bxID(), false, false ) ) {
+
+    edm::LogError("L1TDQM") << "Could not extract AMC13 Packet.";
+   // return;
+  }
+
+  edm::LogInfo("L1TDQM") << "AMC13-packet-payload size = " << packet.payload().size();
+  unsigned algo_ver;
+  if (packet.payload().size() > 0) {
+    auto payload64 = ( packet.payload().at(0) ).data();
+    const uint32_t *start = (const uint32_t*) payload64.get();
+    const uint32_t *end = start + (packet.payload().at(0).size() * 2);
+
+    l1t::MP7Payload payload(start, end, false);
+    algo_ver = payload.getAlgorithmFWVersion();
+
+    edm::LogInfo("L1TDQM") << "algo-ver = " << algo_ver << std::endl;
+  }
+  else {
+    edm::LogError("L1TDQM") << "amc13 payload is empty, cannot extract AMC13 Packet...";
+    return;
+  }
+
+  std::cout << "algo-rev obtained: " << algo_ver << std::endl;
+
+  // Make the Decision which Algo Triggers
+  edm::Handle<l1t::RegionalMuonCandBxCollection> bmtfKalman;
+  eve.getByToken(bmtfKalmanToken, bmtfKalman);
+  edm::Handle<l1t::RegionalMuonCandBxCollection> bmtfLegacy;
+  eve.getByToken(bmtfLegacyToken, bmtfLegacy);
+
+  // auto *bmtfKalman_copy = new l1t::RegionalMuonCandBxCollection(bmtfKalman->size(),
+  // 								bmtfKalman->getFirstBX(),
+  // 								bmtfKalman->getLastBX()
+  // 								);
+  // auto *bmtfLegacy_copy = new l1t::RegionalMuonCandBxCollection(bmtfLegacy->size(),
+  // 								bmtfLegacy->getFirstBX(),
+  // 								bmtfLegacy->getLastBX()
+  // 								);
+
+  // unsigned int idx = 0;
+  // for (auto bx = bmtfKalman_copy->getFirstBX(); bx <= bmtfKalman_copy->getLastBX(); bx++) {
+
+  //   if ( not bmtfKalman->isEmpty(bx) )
+  //     bmtfKalman_copy->set(bx, idx, (*bmtfKalman)[idx]);
+
+  //   idx++;
+  // }
+
+  // idx = 0;
+  // for (auto bx = bmtfLegacy_copy->getFirstBX(); bx <= bmtfLegacy_copy->getLastBX(); bx++) {
+
+  //   if ( not bmtfLegacy->isEmpty(bx) )
+  //     bmtfLegacy_copy->set(bx, idx, (*bmtfLegacy)[idx]);
+
+  //   idx++;
+  // }
+
+  auto *bmtfKalman_copy = new l1t::RegionalMuonCandBxCollection(*bmtfKalman);
+  auto *bmtfLegacy_copy = new l1t::RegionalMuonCandBxCollection(*bmtfLegacy);
+
+  std::cout << "copy RegionalMuonCandBxCollections created" << std::endl;
+  std::cout << "bmtfKalman_copy address: " << bmtfKalman_copy << std::endl;
+  std::cout << "bmtfLegacy_copy address: " << bmtfLegacy_copy << std::endl;
+
+  std::unique_ptr<l1t::RegionalMuonCandBxCollection> bmtfTriggering, bmtfSecondary;
+  if ( algo_ver >= 2499805536) {//95000160(hex)
+    // kalman triggers
+    bmtfTriggering.reset(bmtfKalman_copy);
+    bmtfSecondary.reset(bmtfLegacy_copy);
+  }
+  else {
+    // legacy triggers
+    bmtfTriggering.reset(bmtfLegacy_copy);
+    bmtfSecondary.reset(bmtfKalman_copy);
+  }
+
+  std::cout << "Triggering and Secondary pointers filled:" << std::endl;
+  std::cout << "bmtfTriggering address: " << bmtfTriggering.get() << std::endl;
+  std::cout << "bmtfSecondary address: " << bmtfSecondary.get() << std::endl;
+  
+  eve.put(std::move(bmtfTriggering),"BMTF");
+  eve.put(std::move(bmtfSecondary),"BMTF2");
+
+  std::cout << "reached return..." << std::endl;
+  return;
+}
+
+//void L1TBMTFAlgoSelector::beginStream(edm::StreamID) {}
+//void L1TBMTFAlgoSelector::endStream() {}
+
+using namespace dqmBmtfAlgoSelector;
+DEFINE_FWK_MODULE(L1TBMTFAlgoSelector);

--- a/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
+++ b/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
@@ -55,7 +55,7 @@ void dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::produce(edm::Event & eve, const e
 
   edm::LogInfo("L1TDQM") << "AMC13-packet-payload size = " << packet.payload().size();
   unsigned algo_ver;
-  if (packet.payload().size() > 0) {
+  if (!packet.payload().empty()) {
     auto payload64 = ( packet.payload().at(0) ).data();
     const uint32_t *start = (const uint32_t*) payload64.get();
     const uint32_t *end = start + (packet.payload().at(0).size() * 2);

--- a/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
+++ b/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
@@ -107,8 +107,5 @@ void dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::produce(edm::Event & eve, const e
   return;
 }
 
-//void L1TBMTFAlgoSelector::beginStream(edm::StreamID) {}
-//void L1TBMTFAlgoSelector::endStream() {}
-
 using namespace dqmBmtfAlgoSelector;
 DEFINE_FWK_MODULE(L1TBMTFAlgoSelector);

--- a/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.h
+++ b/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.h
@@ -1,7 +1,6 @@
 #ifndef DQM_L1TMonitor_L1TBMTFAlgoSelector_h
 #define DQM_L1TMonitor_L1TBMTFAlgoSelector_h
 
-
 // system requirements
 #include <iosfwd>
 #include <memory>
@@ -30,9 +29,6 @@
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
-#include "DataFormats/L1Trigger/interface/Muon.h"
-#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "EventFilter/L1TRawToDigi/interface/AMC13Spec.h"
 #include "EventFilter/L1TRawToDigi/interface/Block.h"
 
@@ -53,13 +49,8 @@ namespace dqmBmtfAlgoSelector{
     // member functions
   private:
     void produce(edm::Event&, const edm::EventSetup&) override;
-    //void beginStream(edm::StreamID) override;
-    //void endStream() override;
-
 
     // data members  
-    unique_ptr<l1t::RegionalMuonCandBxCollection> bmtfTriggering;
-    unique_ptr<l1t::RegionalMuonCandBxCollection> bmtfSecondary;
     edm::EDGetToken bmtfKalmanToken;
     edm::EDGetToken bmtfLegacyToken;
     edm::EDGetToken fedToken;

--- a/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.h
+++ b/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.h
@@ -44,7 +44,7 @@ namespace dqmBmtfAlgoSelector{
     // class constructor
     explicit L1TBMTFAlgoSelector(const edm::ParameterSet & ps);
     // class destructor
-    ~L1TBMTFAlgoSelector();
+    ~L1TBMTFAlgoSelector() override;
 
     // member functions
   private:

--- a/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.h
+++ b/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.h
@@ -1,0 +1,68 @@
+#ifndef DQM_L1TMonitor_L1TBMTFAlgoSelector_h
+#define DQM_L1TMonitor_L1TBMTFAlgoSelector_h
+
+
+// system requirements
+#include <iosfwd>
+#include <memory>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+// general requirements
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+// stage2 requirements
+#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/FEDRawData/interface/FEDHeader.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+#include "EventFilter/L1TRawToDigi/interface/AMC13Spec.h"
+#include "EventFilter/L1TRawToDigi/interface/Block.h"
+
+
+// class decleration
+
+namespace dqmBmtfAlgoSelector{
+
+  class  L1TBMTFAlgoSelector: public edm::stream::EDProducer<> {
+
+  public:
+
+    // class constructor
+    explicit L1TBMTFAlgoSelector(const edm::ParameterSet & ps);
+    // class destructor
+    ~L1TBMTFAlgoSelector();
+
+    // member functions
+  private:
+    void produce(edm::Event&, const edm::EventSetup&) override;
+    //void beginStream(edm::StreamID) override;
+    //void endStream() override;
+
+
+    // data members  
+    unique_ptr<l1t::RegionalMuonCandBxCollection> bmtfTriggering;
+    unique_ptr<l1t::RegionalMuonCandBxCollection> bmtfSecondary;
+    edm::EDGetToken bmtfKalmanToken;
+    edm::EDGetToken bmtfLegacyToken;
+    edm::EDGetToken fedToken;
+  };
+}
+#endif

--- a/DQM/L1TMonitor/python/L1TBMTFAlgoSelector_cfi.py
+++ b/DQM/L1TMonitor/python/L1TBMTFAlgoSelector_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+l1tBmtfAlgoSelector = cms.EDProducer(
+    'L1TBMTFAlgoSelector',
+    # verbose = cms.untracked.bool(False),
+    bmtfKalman = cms.InputTag("simKBmtfDigis:BMTF"),
+    bmtfLegacy = cms.InputTag("simBmtfDigis:BMTF"),
+    feds = cms.InputTag("rawDataCollector")
+    )
+

--- a/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
@@ -34,18 +34,18 @@ l1tStage2BmtfZeroSuppFatEvts = l1tStage2BmtfZeroSupp.clone()
 l1tStage2BmtfZeroSuppFatEvts.monitorDir = cms.untracked.string("L1T/L1TStage2BMTF/zeroSuppression/FatEvts")
 l1tStage2BmtfZeroSuppFatEvts.maxFEDReadoutSize = cms.untracked.int32(25000)
 
-#New Kalman Plots for BMTF
-l1tStage2KalmanBmtf = l1tStage2Bmtf.clone()
-l1tStage2KalmanBmtf.bmtfSource = cms.InputTag("bmtfDigis","kBMTF")
-l1tStage2KalmanBmtf.monitorDir = cms.untracked.string("L1T/L1TStage2BMTF/L1TStage2KalmanBMTF")
-l1tStage2KalmanBmtf.verbose = cms.untracked.bool(False)
-l1tStage2KalmanBmtf.kalman = cms.untracked.bool(True)
+# Plots for BMTF's Secondary Algo
+l1tStage2BmtfSecond = l1tStage2Bmtf.clone()
+l1tStage2BmtfSecond.bmtfSource = cms.InputTag("bmtfDigis","BMTF2")
+l1tStage2BmtfSecond.monitorDir = cms.untracked.string("L1T/L1TStage2BMTF/L1TStage2BMTF-Secondary")
+l1tStage2BmtfSecond.verbose = cms.untracked.bool(False)
+l1tStage2BmtfSecond.isBmtf = cms.untracked.bool(True)
 
 # sequences
 l1tStage2BmtfOnlineDQMSeq = cms.Sequence(
     l1tStage2Bmtf +
-    l1tStage2BmtfZeroSupp +
-    l1tStage2KalmanBmtf
+    l1tStage2BmtfSecond +
+    l1tStage2BmtfZeroSupp
 
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -18,13 +18,13 @@ from L1Trigger.L1TCalorimeter.simCaloStage2Digis_cfi import simCaloStage2Digis
 valCaloStage2Layer2Digis = simCaloStage2Digis.clone()
 valCaloStage2Layer2Digis.towerToken = cms.InputTag("caloStage2Digis", "CaloTower")
 
-# BMTF
+# BMTF-Legacy
 from L1Trigger.L1TMuonBarrel.simBmtfDigis_cfi import *
 valBmtfDigis = simBmtfDigis.clone()
 valBmtfDigis.DTDigi_Source = cms.InputTag("bmtfDigis")
 valBmtfDigis.DTDigi_Theta_Source = cms.InputTag("bmtfDigis")
 
-# KBMTF
+# BMTF-Kalman
 from L1Trigger.L1TMuonBarrel.simKBmtfDigis_cfi import *
 from L1Trigger.L1TMuonBarrel.simKBmtfStubs_cfi import *
 valKBmtfStubs = simKBmtfStubs.clone()
@@ -32,6 +32,12 @@ valKBmtfStubs.srcPhi = cms.InputTag("bmtfDigis")
 valKBmtfStubs.srcTheta = cms.InputTag("bmtfDigis")
 valKBmtfDigis = simKBmtfDigis.clone()
 valKBmtfDigis.src = cms.InputTag("valKBmtfStubs")
+
+# BMTF-AlgoTriggerSelector
+from DQM.L1TMonitor.L1TBMTFAlgoSelector_cfi import *
+valBmtfAlgoSel = l1tBmtfAlgoSelector.clone()
+valBmtfAlgoSel.bmtfKalman = cms.InputTag("valKBmtfDigis:BMTF")
+valBmtfAlgoSel.bmtfLegacy = cms.InputTag("valBmtfDigis:BMTF")
 
 # OMTF
 from L1Trigger.L1TMuonOverlap.simOmtfDigis_cfi import *
@@ -43,7 +49,7 @@ valOmtfDigis.srcRPC = cms.InputTag('omtfStage2Digis')
 
 # EMTF
 from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *
-valEmtfStage2Digis = simEmtfDigisData.clone()
+valEmtfStage2Digis = simEmtfDigis.clone()
 valEmtfStage2Digis.CSCInput = "emtfStage2Digis"
 valEmtfStage2Digis.RPCInput = "muonRPCDigis"
 
@@ -80,6 +86,7 @@ Stage2L1HardwareValidation = cms.Sequence(
     valBmtfDigis +
     valKBmtfStubs +
     valKBmtfDigis +
+    valBmtfAlgoSel +
     valOmtfDigis +
     valEmtfStage2Digis +
     valGmtCaloSumDigis +
@@ -103,9 +110,7 @@ from DQM.L1TMonitor.L1TStage2CaloLayer2Emul_cfi import *
 
 # BMTF
 from DQM.L1TMonitor.L1TdeStage2BMTF_cfi import *
-
-# kBMTF
-from DQM.L1TMonitor.L1TdeStage2kBMTF_cff import *
+from DQM.L1TMonitor.L1TdeStage2BMTFSecond_cff import *
 
 # OMTF
 from DQM.L1TMonitor.L1TdeStage2OMTF_cfi import *
@@ -126,7 +131,7 @@ from DQM.L1TMonitor.L1TdeStage2uGT_cfi import *
 # sequence to run for every event
 l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2Bmtf +
-    l1tdeStage2KalmanBmtf +
+    l1tdeStage2BmtfSecond +
     l1tdeStage2Omtf +
     l1tdeStage2EmtfOnlineDQMSeq +
     l1tStage2uGMTEmulatorOnlineDQMSeq +
@@ -140,4 +145,3 @@ l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(
     l1tdeStage2CaloLayer2 +
     l1tStage2CaloLayer2Emul
 )
-

--- a/DQM/L1TMonitor/python/L1TdeStage2BMTFSecond_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2BMTFSecond_cff.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+# the Emulator kBMTF DQM module
+from DQM.L1TMonitor.L1TdeStage2BMTF_cfi import *
+
+# compares the unpacked BMTF2 regional muon collection to the emulated BMTF2 regional muon collection (after the TriggerAlgoSelector decide which is BMTF2)
+# Plots for BMTF
+l1tdeStage2BmtfSecond = l1tdeStage2Bmtf.clone()
+l1tdeStage2BmtfSecond.regionalMuonCollection1 = cms.InputTag("bmtfDigis","BMTF2")
+l1tdeStage2BmtfSecond.regionalMuonCollection2 = cms.InputTag("valBmtfAlgoSel", "BMTF2")
+l1tdeStage2BmtfSecond.monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2BMTF/L1TdeStage2BMTF-Secondary")
+l1tdeStage2BmtfSecond.regionalMuonCollection1Title = cms.untracked.string("BMTF2 data")
+l1tdeStage2BmtfSecond.regionalMuonCollection2Title = cms.untracked.string("BMTF2 emulator")
+l1tdeStage2BmtfSecond.summaryTitle = cms.untracked.string("Summary of comparison between BMTF2 muons and BMTF2 emulator muons")
+l1tdeStage2BmtfSecond.ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Bmtf)
+l1tdeStage2BmtfSecond.verbose = cms.untracked.bool(False)
+l1tdeStage2BmtfSecond.isBmtf = cms.untracked.bool(True)
+
+
+
+# sequences

--- a/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
@@ -9,12 +9,14 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tdeStage2Bmtf = DQMEDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("bmtfDigis", "BMTF"),
-    regionalMuonCollection2 = cms.InputTag("valBmtfDigis", "BMTF"),
+    # regionalMuonCollection2 = cms.InputTag("valBmtfDigis", "BMTF"), # didn't remove the default config
+    regionalMuonCollection2 = cms.InputTag("valBmtfAlgoSel", "BMTF"),
     monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2BMTF"),
     regionalMuonCollection1Title = cms.untracked.string("BMTF data"),
     regionalMuonCollection2Title = cms.untracked.string("BMTF emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between BMTF muons and BMTF emulator muons"),
     ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Bmtf),
     verbose = cms.untracked.bool(False),
+    isBmtf = cms.untracked.bool(True)
 )
 

--- a/DQM/L1TMonitor/src/L1TStage2BMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2BMTF.cc
@@ -82,10 +82,10 @@ void L1TStage2BMTF::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run& i
 
   bmtf_hwQual_bx   = ibooker.book2D(histoPrefix+"_hwQual_bx"  , "HW Quality vs BX"      ,  hwQual_bxbins,   -0.5,  hwQual_bxbins-0.5,  5, -2.5, 2.5);
   bmtf_hwQual_bx->setTitle("; HW Quality; BX");
-  if (kalman) {
-    kbmtf_hwDXY = ibooker.book1D(histoPrefix+"_hwDXY", "HW DXY", 4, 0, 4);
-    kbmtf_hwPt2 = ibooker.book1D(histoPrefix+"_hwPt2", "HW p_{T}2", 512, -0.5, 511.5);
-  }
+
+  bmtf_hwDXY = ibooker.book1D(histoPrefix+"_hwDXY", "HW DXY", 4, 0, 4);
+  bmtf_hwPt2 = ibooker.book1D(histoPrefix+"_hwPt2", "HW p_{T}2", 512, -0.5, 511.5);
+
   // bmtf_twinmuxInput_PhiBX = ibooker.book1D(histoPrefix+"_twinmuxInput_PhiBX"  , "TwinMux Input Phi BX"      ,  5, -2.5, 2.5);
   // bmtf_twinmuxInput_PhiPhi = ibooker.book1D(histoPrefix+"_twinmuxInput_PhiPhi"  , "TwinMux Input Phi HW Phi"      , 201, -100.5, 100.5);
   // bmtf_twinmuxInput_PhiPhiB = ibooker.book1D(histoPrefix+"_twinmuxInput_PhiPhiB"  , "TwinMux Input Phi HW PhiB"   , 201, -100.5, 100.5);
@@ -142,10 +142,10 @@ void L1TStage2BMTF::analyze(const edm::Event & eve, const edm::EventSetup & eveS
           bmtf_hwPt->Fill(itMuon->hwPt());
           bmtf_hwQual->Fill(itMuon->hwQual());
           bmtf_proc->Fill(itMuon->processor());
-          if (kalman) {
-            kbmtf_hwDXY->Fill(itMuon->hwDXY());
-            kbmtf_hwPt2->Fill(itMuon->hwPt2());
-          }
+
+	  bmtf_hwDXY->Fill(itMuon->hwDXY());
+	  bmtf_hwPt2->Fill(itMuon->hwPt2());
+
           if (fabs(bmtfMuon->getLastBX()-bmtfMuon->getFirstBX())>3){
             bmtf_wedge_bx->Fill(itMuon->processor(), itBX);  
             bmtf_hwEta_bx->Fill(itMuon->hwEta(), itBX);  

--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
@@ -11,7 +11,7 @@ L1TStage2RegionalMuonCandComp::L1TStage2RegionalMuonCandComp(const edm::Paramete
       ignoreBadTrkAddr(ps.getUntrackedParameter<bool>("ignoreBadTrackAddress")),
       ignoreBin(ps.getUntrackedParameter<std::vector<int>>("ignoreBin")),
       verbose(ps.getUntrackedParameter<bool>("verbose")),
-      kalman(ps.getUntrackedParameter<bool>("kalman"))
+      isBmtf(ps.getUntrackedParameter<bool>("isBmtf"))
 {
   // First include all bins
   for (unsigned int i = 1; i <= RPT2; i++) { 
@@ -39,7 +39,7 @@ void L1TStage2RegionalMuonCandComp::fillDescriptions(edm::ConfigurationDescripti
   desc.addUntracked<bool>("ignoreBadTrackAddress", false)->setComment("Ignore muon track address mismatches.");
   desc.addUntracked<std::vector<int>>("ignoreBin", std::vector<int>())->setComment("List of bins to ignore");
   desc.addUntracked<bool>("verbose", false);
-  desc.addUntracked<bool>("kalman", false);
+  desc.addUntracked<bool>("isBmtf", false);
   descriptions.add("l1tStage2RegionalMuonCandComp", desc);
 }
 
@@ -54,7 +54,7 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker, c
   }
 
   int nbins = 17;
-  if (kalman) {
+  if (isBmtf) {
     nbins += 2;
   }
 
@@ -80,13 +80,13 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker, c
   summary->setBinLabel(PROCBAD, "processor mismatch", 1);
   summary->setBinLabel(TFBAD, "track finder type mismatch", 1);
   summary->setBinLabel(TRACKADDRBAD, "track address mismatch", 1);
-  if (kalman){
+  if (isBmtf){
     summary->setBinLabel(DXYBAD, "DXY mismatch", 1);
     summary->setBinLabel(PT2BAD, "P_{T}2 mismatch", 1);
   }
 
   int nbinsNum = 14;
-  if (kalman) {
+  if (isBmtf) {
     nbinsNum += 2;
   }
 
@@ -105,7 +105,7 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker, c
   errorSummaryNum->setBinLabel(RPROC, "processor mismatch", 1);
   errorSummaryNum->setBinLabel(RTF, "track finder type mismatch", 1);
   errorSummaryNum->setBinLabel(RTRACKADDR, "track address mismatch", 1);
-  if (kalman) {
+  if (isBmtf) {
     errorSummaryNum->setBinLabel(RDXY, "DXY mismatch", 1);
     errorSummaryNum->setBinLabel(RPT2, "P_{T}2 mismatch", 1);
   }
@@ -164,7 +164,7 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker, c
   muColl1TrkAddr = ibooker.book2D("muTrkAddrColl1", (muonColl1Title+" mismatching muon track address"+trkAddrIgnoreText).c_str(), 10, -0.5, 9.5, 16, -0.5, 15.5);
   muColl1TrkAddr->setAxisTitle("key", 1);
   muColl1TrkAddr->setAxisTitle("value", 2);
-  if (kalman) {
+  if (isBmtf) {
     muColl1hwDXY = ibooker.book1D("muhwDXYColl1", (muonColl1Title+" HW DXY"+trkAddrIgnoreText).c_str(), 4, 0, 4);
     muColl1hwDXY->setAxisTitle("Hardware DXY",1);
     muColl1hwPt2 = ibooker.book1D("muhwPt2Coll1", (muonColl1Title+"HW p_{T}2"+trkAddrIgnoreText).c_str(), 512, -0.5, 511.5);
@@ -205,7 +205,7 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker, c
   muColl2TrkAddr = ibooker.book2D("muTrkAddrColl2", (muonColl2Title+" mismatching muon track address"+trkAddrIgnoreText).c_str(), 10, -0.5, 9.5, 16, -0.5, 15.5);
   muColl2TrkAddr->setAxisTitle("key", 1);
   muColl2TrkAddr->setAxisTitle("value", 2);
-  if (kalman) {
+  if (isBmtf) {
     muColl2hwDXY = ibooker.book1D("muhwDXYColl2", (muonColl2Title+" HW DXY"+trkAddrIgnoreText).c_str(), 4, 0, 4);
     muColl2hwDXY->setAxisTitle("Hardware DXY",1);
     muColl2hwPt2 = ibooker.book1D("muhwPt2Coll2", (muonColl2Title+"HW p_{T}2"+trkAddrIgnoreText).c_str(), 512, -0.5, 511.5);
@@ -269,10 +269,10 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
           muColl1trackFinderType->Fill(muonIt1->trackFinderType());
           muColl1hwHF->Fill(muonIt1->hwHF());
           muColl1TrkAddrSize->Fill(muon1TrackAddr.size());
-          if (kalman){
+          if (isBmtf){
             muColl1hwDXY->Fill(muonIt1->hwDXY());
             muColl1hwPt2->Fill(muonIt1->hwPt2());         
-          }
+	  }
           for (std::map<int, int>::const_iterator trIt1 = muon1TrackAddr.begin(); trIt1 != muon1TrackAddr.end(); ++trIt1) {
             muColl1TrkAddr->Fill(trIt1->first, trIt1->second);
           }
@@ -292,10 +292,10 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
           muColl2trackFinderType->Fill(muonIt2->trackFinderType());
           muColl2hwHF->Fill(muonIt2->hwHF());
           muColl2TrkAddrSize->Fill(muon2TrackAddr.size());
-          if (kalman){
+          if (isBmtf){
             muColl2hwDXY->Fill(muonIt2->hwDXY());
             muColl2hwPt2->Fill(muonIt2->hwPt2());
-          }
+	  }
           for (std::map<int, int>::const_iterator trIt2 = muon2TrackAddr.begin(); trIt2 != muon2TrackAddr.end(); ++trIt2) {
             muColl2TrkAddr->Fill(trIt2->first, trIt2->second);
           }
@@ -434,7 +434,7 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
         errorSummaryNum->Fill(RMUON);
       }
 
-      if(kalman) {
+      if(isBmtf) {
         if (muonIt1->hwDXY() != muonIt2->hwDXY()) {
           muonMismatch = true;
           summary->Fill(DXYBAD);
@@ -466,10 +466,10 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
         muColl1trackFinderType->Fill(muonIt1->trackFinderType());
         muColl1hwHF->Fill(muonIt1->hwHF());
         muColl1TrkAddrSize->Fill(muon1TrackAddr.size());
-        if (kalman){
+        if (isBmtf){
           muColl1hwDXY->Fill(muonIt1->hwDXY());
           muColl1hwPt2->Fill(muonIt1->hwPt2());
-        }
+	}
         for (std::map<int, int>::const_iterator trIt1 = muon1TrackAddr.begin(); trIt1 != muon1TrackAddr.end(); ++trIt1) {
           muColl1TrkAddr->Fill(trIt1->first, trIt1->second);
         }
@@ -485,10 +485,10 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
         muColl2trackFinderType->Fill(muonIt2->trackFinderType());
         muColl2hwHF->Fill(muonIt2->hwHF());
         muColl2TrkAddrSize->Fill(muon2TrackAddr.size());
-        if (kalman){
+        if (isBmtf){
           muColl2hwDXY->Fill(muonIt2->hwDXY());
           muColl2hwPt2->Fill(muonIt2->hwPt2());
-        }
+	}
         for (std::map<int, int>::const_iterator trIt2 = muon2TrackAddr.begin(); trIt2 != muon2TrackAddr.end(); ++trIt2) {
           muColl2TrkAddr->Fill(trIt2->first, trIt2->second);
         }

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFSecondEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFSecondEmulatorClient_cff.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.L1TMonitor.L1TdeStage2BMTF_cfi import ignoreBinsDeStage2Bmtf
+
+# RegionalMuonCands
+l1tStage2BMTFEmulatorSecondCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/L1TdeStage2BMTF-Secondary'),
+    inputNum = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/L1TdeStage2BMTF-Secondary/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/L1TdeStage2BMTF-Secondary/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF2 muons and BMTF2 emulator muons'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True),
+    ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Bmtf)
+)
+
+# sequences
+l1tStage2BMTFEmulatorSecondClient = cms.Sequence(
+    l1tStage2BMTFEmulatorSecondCompRatioClient
+)
+

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -25,8 +25,8 @@ from DQM.L1TMonitorClient.L1TStage2uGMTEmulatorClient_cff import *
 # BMTF emulator client
 from DQM.L1TMonitorClient.L1TStage2BMTFEmulatorClient_cff import *
 
-# KBMTF emulator client
-from DQM.L1TMonitorClient.L1TStage2kBMTFEmulatorClient_cff import *
+# Second BMTF Emulator Client
+from DQM.L1TMonitorClient.L1TStage2BMTFSecondEmulatorClient_cff import *
 
 # OMTF emulator client
 from DQM.L1TMonitorClient.L1TStage2OMTFEmulatorClient_cff import *
@@ -49,7 +49,7 @@ l1TStage2EmulatorClients = cms.Sequence(
 		        l1tStage2CaloLayer2DEClientSummary
                       + l1tStage2uGMTEmulatorClient
                       + l1tStage2BMTFEmulatorClient
-                      + l1tStage2kBMTFEmulatorClient
+                      + l1tStage2BMTFEmulatorSecondClient
                       + l1tStage2OMTFEmulatorClient
                       + l1tStage2EMTFEmulatorClient
                       + l1tStage2EmulatorEventInfoClient

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFCollections.cc
@@ -6,12 +6,12 @@ namespace l1t {
    namespace stage2 {
       BMTFCollections::~BMTFCollections()
       {
-				event_.put(std::move(outputMuons_),"BMTF");
-				event_.put(std::move(outputKalmanMuons_),"kBMTF");
-				//event_.put(std::move(inputMuonsPh_),"PhiDigis");
-				//event_.put(std::move(inputMuonsTh_),"TheDigis");
-				event_.put(std::move(inputMuonsPh_));
-                                event_.put(std::move(inputMuonsTh_));
+        event_.put(std::move(outputMuons_),"BMTF");
+        event_.put(std::move(outputMuons2_),"BMTF2");
+        //event_.put(std::move(inputMuonsPh_),"PhiDigis");
+        //event_.put(std::move(inputMuonsTh_),"TheDigis");
+        event_.put(std::move(inputMuonsPh_));
+        event_.put(std::move(inputMuonsTh_));
 
       }
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFCollections.h
@@ -15,7 +15,7 @@ namespace l1t {
             BMTFCollections(edm::Event& e) :
                UnpackerCollections(e),
                outputMuons_ (new RegionalMuonCandBxCollection()),
-	       outputKalmanMuons_ (new RegionalMuonCandBxCollection()),
+	       outputMuons2_ (new RegionalMuonCandBxCollection()),
                inputMuonsPh_ (new L1MuDTChambPhContainer),
                inputMuonsTh_ (new L1MuDTChambThContainer)
             {};
@@ -23,13 +23,13 @@ namespace l1t {
             ~BMTFCollections() override;
 
 	    inline RegionalMuonCandBxCollection* getBMTFMuons() {return outputMuons_.get();};
-	    inline RegionalMuonCandBxCollection* getkBMTFMuons() {return outputKalmanMuons_.get();};
+	    inline RegionalMuonCandBxCollection* getBMTF2Muons() {return outputMuons2_.get();};
 	    inline L1MuDTChambPhContainer* getInMuonsPh() { return inputMuonsPh_.get(); };
 	    inline L1MuDTChambThContainer* getInMuonsTh() { return inputMuonsTh_.get(); };
 
      private:
 	    std::unique_ptr<RegionalMuonCandBxCollection> outputMuons_;
-	    std::unique_ptr<RegionalMuonCandBxCollection> outputKalmanMuons_;
+	    std::unique_ptr<RegionalMuonCandBxCollection> outputMuons2_;
 	    std::unique_ptr<L1MuDTChambPhContainer> inputMuonsPh_;
 	    std::unique_ptr<L1MuDTChambThContainer> inputMuonsTh_;
       };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
@@ -69,8 +69,8 @@ namespace l1t
 	  RegionalMuonCand muCand;
 	  RegionalMuonRawDigiTranslator::fillRegionalMuonCand(muCand, raw_first, raw_secnd, processor, tftype::bmtf);
 
-	  if (muCand.hwQual() == 0 && !isKalman)
-	    continue;//though away muons with Zero-Quality (ONLY BMTF)
+	  if (muCand.hwQual() == 0)
+	    continue;
 
 	  muCand.setLink(48 + processor);	//the link corresponds to the uGMT input
 	  if (isKalman) {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
@@ -23,10 +23,10 @@ namespace l1t
 	bxBlocks = block.getBxBlocks((unsigned int)6, false);//it returnes 6-32bit bxBlocks originated from the amc13 Block
 			
       RegionalMuonCandBxCollection *res;
-      if (isKalman)
-	res = static_cast<BMTFCollections*>(coll)->getkBMTFMuons();
-      else
+      if (isTriggeringAlgo)
 	res = static_cast<BMTFCollections*>(coll)->getBMTFMuons();
+      else
+	res = static_cast<BMTFCollections*>(coll)->getBMTF2Muons();
 
       //BxBlocks changed the format of the blocks
       int firstBX = 0, lastBX = 0;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.h
@@ -9,11 +9,21 @@ namespace l1t{
     class BMTFUnpackerOutput : public Unpacker
     {
     public:
-      BMTFUnpackerOutput(){isKalman = false;}
-      BMTFUnpackerOutput(const bool type){isKalman = type;}
+      //the default constructor assumes
+      //that unpacks BMTF and BMTF is triggering
+      BMTFUnpackerOutput() {
+	isKalman = false;
+	isTriggeringAlgo = true;
+      }
+      BMTFUnpackerOutput(const bool isTriggering_/*, const bool isKalman_*/) {
+	isTriggeringAlgo = isTriggering_;
+	//isKalman = isKalman_;
+      }
       ~BMTFUnpackerOutput() override{};
       bool unpack(const Block& block, UnpackerCollections *coll) override;
+      void setKalmanAlgoTrue() {isKalman = true;}
     private:
+      bool isTriggeringAlgo;
       bool isKalman;
     };
 

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -35,14 +35,11 @@ l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonCand(RegionalMuonCand& mu, u
     int segSel = (rawTrackAddress >> bmtfTrAddrSegSelShift_) & bmtfTrAddrSegSelMask_;
     int detSide = (rawTrackAddress >> bmtfTrAddrDetSideShift_) & 0x1;
     int wheelNum = (rawTrackAddress >> bmtfTrAddrWheelShift_) & bmtfTrAddrWheelMask_;
-    int statAddr1 = ((rawTrackAddress >> bmtfTrAddrStat1Shift_) & bmtfTrAddrStat1Mask_)
-                  | ((segSel & 0x1) << 2);
-    int statAddr2 = ((rawTrackAddress >> bmtfTrAddrStat2Shift_) & bmtfTrAddrStat2Mask_)
-                  | ((segSel & 0x2) << 3);
-    int statAddr3 = ((rawTrackAddress >> bmtfTrAddrStat3Shift_) & bmtfTrAddrStat3Mask_)
-                  | ((segSel & 0x4) << 2);
-    int statAddr4 = ((rawTrackAddress >> bmtfTrAddrStat4Shift_) & bmtfTrAddrStat4Mask_)
-                  | ((segSel & 0x8) << 1);
+    int statAddr1 = ((rawTrackAddress >> bmtfTrAddrStat1Shift_) & bmtfTrAddrStat1Mask_);
+    int statAddr2 = ((rawTrackAddress >> bmtfTrAddrStat2Shift_) & bmtfTrAddrStat2Mask_);
+    int statAddr3 = ((rawTrackAddress >> bmtfTrAddrStat3Shift_) & bmtfTrAddrStat3Mask_);
+    int statAddr4 = ((rawTrackAddress >> bmtfTrAddrStat4Shift_) & bmtfTrAddrStat4Mask_);
+
     mu.setTrackSubAddress(RegionalMuonCand::kWheelSide, detSide);
     mu.setTrackSubAddress(RegionalMuonCand::kWheelNum, wheelNum);
     mu.setTrackSubAddress(RegionalMuonCand::kStat1, statAddr1);


### PR DESCRIPTION
This is the introduction of a new DQM plugin that selects the correct output muons of the BMTF depending on the algorithm that is triggering (Kalman BMTF/ Legacy BMTF).
Also, the PR includes the last BMTF Unpacker which is required by the DQM workflow and by the L1TBMTFAlgoSelector to operate correctly