### PR TITLE
PPS: input flags for lite track producer

### DIFF
--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -35,8 +35,13 @@ public:
   static void fillDescriptions( edm::ConfigurationDescriptions& );
 
 private:
+  bool includeStrips_;
   edm::EDGetTokenT< edm::DetSetVector<TotemRPLocalTrack> > siStripTrackToken_;
+
+  bool includeDiamonds_;
   edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondLocalTrack> > diamondTrackToken_;
+
+  bool includePixels_;
   edm::EDGetTokenT< edm::DetSetVector<CTPPSPixelLocalTrack> > pixelTrackToken_;
 
   std::vector<double> pixelTrackTxRange_;
@@ -53,8 +58,13 @@ CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer( const edm::ParameterSe
 {
   if ( doNothing_ ) return;
 
+  includeStrips_ = iConfig.getParameter<bool>("includeStrips");
   siStripTrackToken_ = consumes< edm::DetSetVector<TotemRPLocalTrack> >     ( iConfig.getParameter<edm::InputTag>("tagSiStripTrack") );
+
+  includeDiamonds_ = iConfig.getParameter<bool>("includeDiamonds");
   diamondTrackToken_ = consumes< edm::DetSetVector<CTPPSDiamondLocalTrack> >( iConfig.getParameter<edm::InputTag>("tagDiamondTrack") );
+
+  includePixels_ = iConfig.getParameter<bool>("includePixels");
   auto tagPixelTrack = iConfig.getParameter<edm::InputTag>("tagPixelTrack"); 
   if (not tagPixelTrack.label().empty()){
     pixelTrackToken_   = consumes< edm::DetSetVector<CTPPSPixelLocalTrack> >  (tagPixelTrack);
@@ -73,61 +83,71 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
   if ( doNothing_ )
     return;
 
-// prepare output
+  // prepare output
   std::unique_ptr< std::vector<CTPPSLocalTrackLite> > pOut( new std::vector<CTPPSLocalTrackLite>() );
   
-//----- TOTEM strips
+  //----- TOTEM strips
 
-// get input from Si strips
-  edm::Handle< edm::DetSetVector<TotemRPLocalTrack> > inputSiStripTracks;
-  iEvent.getByToken( siStripTrackToken_, inputSiStripTracks );
+  // get input from Si strips
+  if (includeStrips_)
+  {
+    edm::Handle< edm::DetSetVector<TotemRPLocalTrack> > inputSiStripTracks;
+    iEvent.getByToken( siStripTrackToken_, inputSiStripTracks );
 
-// process tracks from Si strips
-  for ( const auto& rpv : *inputSiStripTracks ) {
-    const uint32_t rpId = rpv.detId();
-    for ( const auto& trk : rpv ) {
-      if ( !trk.isValid() ) continue;
-      pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma() );
-    }
-  }
-
-//----- diamond detectors
-
-// get input from diamond detectors
-  edm::Handle< edm::DetSetVector<CTPPSDiamondLocalTrack> > inputDiamondTracks;
-  iEvent.getByToken( diamondTrackToken_, inputDiamondTracks );
-
-// process tracks from diamond detectors
-  for ( const auto& rpv : *inputDiamondTracks ) {
-    const unsigned int rpId = rpv.detId();
-    for ( const auto& trk : rpv ) {
-      if ( !trk.isValid() ) continue;
-      pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getT() );
-    }
-  }
-
-
-//----- pixel detectors
-
-// get input from pixel detectors
-  if(pixelTrackTxRange_.size() != 2 || pixelTrackTyRange_.size() != 2) throw cms::Exception("CTPPSLocalTrackLiteProducer") 
-							   << "Wrong number of parameters in pixel track Tx/Ty range";
-  edm::Handle< edm::DetSetVector<CTPPSPixelLocalTrack> > inputPixelTracks;
-  if (not pixelTrackToken_.isUninitialized()){
-    iEvent.getByToken( pixelTrackToken_, inputPixelTracks );
-
-  // process tracks from pixels
-    for ( const auto& rpv : *inputPixelTracks ) {
+    // process tracks from Si strips
+    for ( const auto& rpv : *inputSiStripTracks ) {
       const uint32_t rpId = rpv.detId();
       for ( const auto& trk : rpv ) {
-	if ( !trk.isValid() ) continue;
-	if(trk.getTx()>pixelTrackTxRange_.at(0) && trk.getTx()<pixelTrackTxRange_.at(1)
-	   && trk.getTy()>pixelTrackTyRange_.at(0) && trk.getTy()<pixelTrackTyRange_.at(1) )
-	  pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma() );
+        if ( !trk.isValid() ) continue;
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma() );
       }
     }
   }
-// save output to event
+
+  //----- diamond detectors
+
+  if (includeDiamonds_)
+  {
+    // get input from diamond detectors
+    edm::Handle< edm::DetSetVector<CTPPSDiamondLocalTrack> > inputDiamondTracks;
+    iEvent.getByToken( diamondTrackToken_, inputDiamondTracks );
+
+    // process tracks from diamond detectors
+    for ( const auto& rpv : *inputDiamondTracks ) {
+      const unsigned int rpId = rpv.detId();
+      for ( const auto& trk : rpv ) {
+        if ( !trk.isValid() ) continue;
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getT() );
+      }
+    }
+  }
+
+
+  //----- pixel detectors
+
+  if (includePixels_)
+  {
+    // get input from pixel detectors
+    if(pixelTrackTxRange_.size() != 2 || pixelTrackTyRange_.size() != 2) throw cms::Exception("CTPPSLocalTrackLiteProducer") 
+                                 << "Wrong number of parameters in pixel track Tx/Ty range";
+    edm::Handle< edm::DetSetVector<CTPPSPixelLocalTrack> > inputPixelTracks;
+    if (not pixelTrackToken_.isUninitialized()){
+      iEvent.getByToken( pixelTrackToken_, inputPixelTracks );
+
+    // process tracks from pixels
+      for ( const auto& rpv : *inputPixelTracks ) {
+        const uint32_t rpId = rpv.detId();
+        for ( const auto& trk : rpv ) {
+      if ( !trk.isValid() ) continue;
+      if(trk.getTx()>pixelTrackTxRange_.at(0) && trk.getTx()<pixelTrackTxRange_.at(1)
+         && trk.getTy()>pixelTrackTyRange_.at(0) && trk.getTy()<pixelTrackTyRange_.at(1) )
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma() );
+        }
+      }
+    }
+  }
+
+  // save output to event
   iEvent.put( std::move( pOut ) );
 }
 
@@ -138,10 +158,15 @@ CTPPSLocalTrackLiteProducer::fillDescriptions( edm::ConfigurationDescriptions& d
 {
   edm::ParameterSetDescription desc;
 
+  desc.add<bool>("includeStrips", true)->setComment("whether tracks from Si strips should be included");
   desc.add<edm::InputTag>( "tagSiStripTrack", edm::InputTag( "totemRPLocalTrackFitter" ) )
     ->setComment( "input TOTEM strips' local tracks collection to retrieve" );
+
+  desc.add<bool>("includeDiamonds", true)->setComment("whether tracks from diamonds strips should be included");
   desc.add<edm::InputTag>( "tagDiamondTrack", edm::InputTag( "ctppsDiamondLocalTracks" ) )
     ->setComment( "input diamond detectors' local tracks collection to retrieve" );
+
+  desc.add<bool>("includePixels", true)->setComment("whether tracks from pixels should be included");
   desc.add<edm::InputTag>( "tagPixelTrack"  , edm::InputTag( "ctppsPixelLocalTracks"   ) )
     ->setComment( "input pixel detectors' local tracks collection to retrieve" );
   desc.add<bool>( "doNothing", true ) // disable the module by default


### PR DESCRIPTION
This PR enables to use lite tracks also in workflows which don't include all sub-detectors (strips, pixels and diamonds). It is fully backward compatible due to the default configuration.

I tested the update by running the lite-track producer with default configuration on file
/store/data/Run2017B/DoubleEG/AOD/17Nov2017-v1/50002/C0BB2003-DBDC-E711-90B7-
002590747DA2.root
I attach the distribution of RP ids: blue dashed (new) and red (old) - the histograms are identical.

![validation](https://user-images.githubusercontent.com/17830858/45613845-d7d10e00-ba67-11e8-9fe5-c282baea6145.png)