### PR TITLE
OfflineDQM: Offline L1T muon DQM with coordinates extrapolated to the muon system CMSLITDPG-729

### DIFF
--- a/DQMOffline/L1Trigger/BuildFile.xml
+++ b/DQMOffline/L1Trigger/BuildFile.xml
@@ -23,4 +23,5 @@
 <use name="RecoMuon/TrackingTools"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="DQM/L1TMonitor"/>
+<use name="MuonAnalysis/MuonAssociators"/>
 <flags   EDM_PLUGIN="1"/>

--- a/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
@@ -28,17 +28,16 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/TrackTransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -95,9 +94,7 @@ class L1TMuonDQMOffline : public DQMEDAnalyzer {
 
         HLTConfigProvider m_hltConfig;
 
-        edm::ESHandle<MagneticField> m_BField;
-        edm::ESHandle<Propagator> m_propagatorAlong;
-        edm::ESHandle<Propagator> m_propagatorOpposite;
+        PropagateToMuon m_propagator;
 
         std::vector<float> getHistBinsEff(EffType eff);
         std::tuple<int, double, double> getHistBinsRes(ResType res);
@@ -176,7 +173,7 @@ class L1TMuonDQMOffline : public DQMEDAnalyzer {
 //
 class MuonGmtPair {
     public :
-        MuonGmtPair(const reco::Muon *muon, const l1t::Muon *regMu, bool useAtVtxCoord);
+        MuonGmtPair(const reco::Muon *muon, const l1t::Muon *regMu, const PropagateToMuon& propagator, bool useAtVtxCoord);
         MuonGmtPair(const MuonGmtPair& muonGmtPair);
         ~MuonGmtPair() { };
 
@@ -195,23 +192,9 @@ class MuonGmtPair {
         double getDeltaVar(const L1TMuonDQMOffline::ResType) const;
         double getVar(const L1TMuonDQMOffline::EffType) const;
 
-        void propagate(edm::ESHandle<MagneticField> bField,
-        edm::ESHandle<Propagator> propagatorAlong,
-        edm::ESHandle<Propagator> propagatorOpposite);
-
-    private :
-    // propagation private members
-        TrajectoryStateOnSurface cylExtrapTrkSam(reco::TrackRef track, double rho);
-        TrajectoryStateOnSurface surfExtrapTrkSam(reco::TrackRef track, double z);
-        FreeTrajectoryState freeTrajStateMuon(reco::TrackRef track);
-
     private :
         const reco::Muon *m_muon;
         const l1t::Muon *m_regMu;
-
-        edm::ESHandle<MagneticField> m_BField;
-        edm::ESHandle<Propagator> m_propagatorAlong;
-        edm::ESHandle<Propagator> m_propagatorOpposite;
 
         // L1T muon eta and phi coordinates to be used
         // Can be the coordinates from the 2nd muon station or from the vertex
@@ -219,8 +202,7 @@ class MuonGmtPair {
         double m_gmtPhi;
 
         double m_eta;
-        double m_phi_bar;
-        double m_phi_end;
+        double m_phi;
 };
 
 #endif

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
@@ -61,6 +61,15 @@ l1tMuonDQMOffline = DQMEDAnalyzer('L1TMuonDQMOffline',
     efficiencyVsEtaBins = cms.untracked.vdouble(effVsEtaBins),
     efficiencyVsVtxBins = cms.untracked.vdouble(effVsVtxBins),
 
+    # muon track extrapolation to 2nd station
+    muProp = cms.PSet(
+        useTrack = cms.string("tracker"),  # 'none' to use Candidate P4; or 'tracker', 'muon', 'global'
+        useState = cms.string("atVertex"), # 'innermost' and 'outermost' require the TrackExtra
+        useSimpleGeometry = cms.bool(True),
+        useStation2 = cms.bool(True),
+        fallbackToME1 = cms.bool(False),
+    ),
+
     verbose   = cms.untracked.bool(False)
 )
 

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
@@ -29,7 +29,7 @@ effVsEtaBins = [i*(etaMax-etaMin)/nEtaBins + etaMin for i in range(nEtaBins+1)]
 effVsVtxBins = range(0, 101)
 
 # A list of pt cut + quality cut pairs for which efficiency plots should be made
-ptQualCuts = [[25, 12], [15, 8], [7, 8], [3, 4]]
+ptQualCuts = [[22, 12], [15, 8], [7, 8], [3, 4]]
 cutsPSets = []
 for ptQualCut in ptQualCuts:
     cutsPSets.append(cms.untracked.PSet(ptCut = cms.untracked.int32(ptQualCut[0]),
@@ -38,8 +38,8 @@ for ptQualCut in ptQualCuts:
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tMuonDQMOffline = DQMEDAnalyzer('L1TMuonDQMOffline',
     histFolder = cms.untracked.string('L1T/L1TObjects/L1TMuon/L1TriggerVsReco'),
-    tagPtCut = cms.untracked.double(30.),
-    recoToL1PtCutFactor = cms.untracked.double(1.25),
+    tagPtCut = cms.untracked.double(26.),
+    recoToL1PtCutFactor = cms.untracked.double(1.2),
     cuts = cms.untracked.VPSet(cutsPSets),
     useL1AtVtxCoord = cms.untracked.bool(True),
 

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -9,8 +9,6 @@
 
 #include "DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
-#include "DataFormats/GeometrySurface/interface/Cylinder.h"
-#include "DataFormats/GeometrySurface/interface/Plane.h"
 
 #include <array>
 
@@ -22,8 +20,8 @@ using namespace l1t;
 
 //__________RECO-GMT Muon Pair Helper Class____________________________
 
-MuonGmtPair::MuonGmtPair(const reco::Muon *muon, const l1t::Muon *regMu, bool useAtVtxCoord) :
-        m_muon(muon), m_regMu(regMu), m_eta(999.), m_phi_bar(999.), m_phi_end(999.)
+MuonGmtPair::MuonGmtPair(const reco::Muon *muon, const l1t::Muon *regMu, const PropagateToMuon& propagator, bool useAtVtxCoord) :
+        m_muon(muon), m_regMu(regMu)
 {
     if (m_regMu) {
         if (useAtVtxCoord) {
@@ -37,6 +35,16 @@ MuonGmtPair::MuonGmtPair(const reco::Muon *muon, const l1t::Muon *regMu, bool us
         m_gmtEta = -5.;
         m_gmtPhi = -5.;
     }
+    if (m_muon) {
+        TrajectoryStateOnSurface trajectory = propagator.extrapolate(*m_muon);
+        if (trajectory.isValid()) {
+            m_eta = trajectory.globalPosition().eta();
+            m_phi = trajectory.globalPosition().phi();
+        }
+    } else {
+        m_eta = 999.;
+        m_phi = 999.;
+    }
 };
 
 MuonGmtPair::MuonGmtPair(const MuonGmtPair& muonGmtPair) {
@@ -47,45 +55,19 @@ MuonGmtPair::MuonGmtPair(const MuonGmtPair& muonGmtPair) {
     m_gmtPhi  = muonGmtPair.m_gmtPhi;
 
     m_eta     = muonGmtPair.m_eta;
-    m_phi_bar = muonGmtPair.m_phi_bar;
-    m_phi_end = muonGmtPair.m_phi_end;
+    m_phi     = muonGmtPair.m_phi;
 }
 
 double MuonGmtPair::dR() {
-    float dEta = m_regMu ? (m_gmtEta - eta()) : 999.;
-    float dPhi = m_regMu ? reco::deltaPhi(m_gmtPhi, phi()) : 999.;
+    float dEta = m_regMu ? (m_gmtEta - m_eta) : 999.;
+    float dPhi = m_regMu ? reco::deltaPhi(m_gmtPhi, m_phi) : 999.;
     return sqrt(dEta*dEta + dPhi*dPhi);
 }
 
-void MuonGmtPair::propagate(ESHandle<MagneticField> bField,
-                ESHandle<Propagator> propagatorAlong,
-                ESHandle<Propagator> propagatorOpposite) {
-    m_BField = bField;
-    m_propagatorAlong = propagatorAlong;
-    m_propagatorOpposite = propagatorOpposite;
-    TrackRef standaloneMuon = m_muon->outerTrack();
-    TrajectoryStateOnSurface trajectory;
-    trajectory = cylExtrapTrkSam(standaloneMuon, 500);  // track at MB2 radius - extrapolation
-    if (trajectory.isValid()) {
-        m_eta     = trajectory.globalPosition().eta();
-        m_phi_bar = trajectory.globalPosition().phi();
-    }
-    trajectory = surfExtrapTrkSam(standaloneMuon, 790);   // track at ME2+ plane - extrapolation
-    if (trajectory.isValid()) {
-        m_eta     = trajectory.globalPosition().eta();
-        m_phi_end = trajectory.globalPosition().phi();
-    }
-    trajectory = surfExtrapTrkSam(standaloneMuon, -790); // track at ME2- disk - extrapolation
-    if (trajectory.isValid()) {
-        m_eta     = trajectory.globalPosition().eta();
-        m_phi_end = trajectory.globalPosition().phi();
-    }
-}
-
 L1TMuonDQMOffline::EtaRegion MuonGmtPair::etaRegion() const {
-    if (std::abs(eta()) < 0.83) return L1TMuonDQMOffline::kEtaRegionBmtf;
-    if (std::abs(eta()) < 1.24) return L1TMuonDQMOffline::kEtaRegionOmtf;
-    if (std::abs(eta()) < 2.4)  return L1TMuonDQMOffline::kEtaRegionEmtf;
+    if (std::abs(m_eta) < 0.83) return L1TMuonDQMOffline::kEtaRegionBmtf;
+    if (std::abs(m_eta) < 1.24) return L1TMuonDQMOffline::kEtaRegionOmtf;
+    if (std::abs(m_eta) < 2.4)  return L1TMuonDQMOffline::kEtaRegionEmtf;
     return L1TMuonDQMOffline::kEtaRegionOut;
 }
 
@@ -93,59 +75,22 @@ double MuonGmtPair::getDeltaVar(const L1TMuonDQMOffline::ResType type) const {
     if (type == L1TMuonDQMOffline::kResPt)      return (gmtPt() - pt()) / pt();
     if (type == L1TMuonDQMOffline::kRes1OverPt) return (pt() - gmtPt()) / gmtPt(); // (1/gmtPt - 1/pt) / (1/pt)
     if (type == L1TMuonDQMOffline::kResQOverPt) return (gmtCharge()*charge()*pt() - gmtPt()) / gmtPt(); // (gmtCharge/gmtPt - charge/pt) / (charge/pt) with gmtCharge/charge = gmtCharge*charge
-    if (type == L1TMuonDQMOffline::kResPhi)     return reco::deltaPhi(gmtPhi(), phi());
-    if (type == L1TMuonDQMOffline::kResEta)     return gmtEta() - eta();
+    if (type == L1TMuonDQMOffline::kResPhi)     return reco::deltaPhi(gmtPhi(), m_phi);
+    if (type == L1TMuonDQMOffline::kResEta)     return gmtEta() - m_eta;
     if (type == L1TMuonDQMOffline::kResCh)      return gmtCharge() - charge();
     return -999.;
 }
 
 double MuonGmtPair::getVar(const L1TMuonDQMOffline::EffType type) const {
     if (type == L1TMuonDQMOffline::kEffPt)  return pt();
-    if (type == L1TMuonDQMOffline::kEffPhi) return phi();
-    if (type == L1TMuonDQMOffline::kEffEta) return eta();
+    if (type == L1TMuonDQMOffline::kEffPhi) return m_phi;
+    if (type == L1TMuonDQMOffline::kEffEta) return m_eta;
     return -999.;
-}
-
-TrajectoryStateOnSurface MuonGmtPair::cylExtrapTrkSam(TrackRef track, double rho)
-{
-    Cylinder::PositionType pos(0, 0, 0);
-    Cylinder::RotationType rot;
-    Cylinder::CylinderPointer myCylinder = Cylinder::build(pos, rot, rho);
-
-    FreeTrajectoryState recoStart = freeTrajStateMuon(track);
-    TrajectoryStateOnSurface recoProp;
-    recoProp = m_propagatorAlong->propagate(recoStart, *myCylinder);
-    if (!recoProp.isValid()) {
-      recoProp = m_propagatorOpposite->propagate(recoStart, *myCylinder);
-    }
-    return recoProp;
-}
-
-TrajectoryStateOnSurface MuonGmtPair::surfExtrapTrkSam(TrackRef track, double z)
-{
-    Plane::PositionType pos(0, 0, z);
-    Plane::RotationType rot;
-    Plane::PlanePointer myPlane = Plane::build(pos, rot);
-
-    FreeTrajectoryState recoStart = freeTrajStateMuon(track);
-    TrajectoryStateOnSurface recoProp;
-    recoProp = m_propagatorAlong->propagate(recoStart, *myPlane);
-    if (!recoProp.isValid()) {
-      recoProp = m_propagatorOpposite->propagate(recoStart, *myPlane);
-    }
-    return recoProp;
-}
-
-FreeTrajectoryState MuonGmtPair::freeTrajStateMuon(TrackRef track)
-{
-    GlobalPoint  innerPoint(track->innerPosition().x(), track->innerPosition().y(),  track->innerPosition().z());
-    GlobalVector innerVec  (track->innerMomentum().x(),  track->innerMomentum().y(),  track->innerMomentum().z());
-    FreeTrajectoryState recoStart(innerPoint, innerVec, track->charge(), &*m_BField);
-    return recoStart;
 }
 
 //__________DQM_base_class_______________________________________________
 L1TMuonDQMOffline::L1TMuonDQMOffline(const ParameterSet & ps) :
+    m_propagator(ps.getParameter<edm::ParameterSet>("muProp")),
     m_effTypes({kEffPt, kEffPhi, kEffEta, kEffVtx}),
     m_resTypes({kResPt, kResQOverPt, kResPhi, kResEta}),
     m_etaRegions({kEtaRegionAll, kEtaRegionBmtf, kEtaRegionOmtf, kEtaRegionEmtf}),
@@ -201,6 +146,7 @@ void L1TMuonDQMOffline::dqmBeginRun(const edm::Run& run, const edm::EventSetup& 
     if (m_verbose) cout << "[L1TMuonDQMOffline:] Called beginRun." << endl;
     bool changed = true;
     m_hltConfig.init(run,iSetup,m_trigProcess,changed);
+    m_propagator.init(iSetup);
 }
 
 //_____________________________________________________________________
@@ -254,10 +200,6 @@ void L1TMuonDQMOffline::analyze(const Event & iEvent, const EventSetup & eventSe
     iEvent.getByToken(m_trigProcess_token,trigResults);
     edm::Handle<trigger::TriggerEvent> trigEvent;
     iEvent.getByToken(m_trigInputTag,trigEvent);
-
-    eventSetup.get<IdealMagneticFieldRecord>().get(m_BField);
-    eventSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial",m_propagatorAlong);
-    eventSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterialOpposite",m_propagatorOpposite);
 
     const auto nVtx = getNVertices(vertex);
     const Vertex primaryVertex = getPrimaryVertex(vertex,beamSpot);
@@ -579,17 +521,17 @@ void L1TMuonDQMOffline::getMuonGmtPairs(edm::Handle<l1t::MuonBxCollection> & gmt
     l1t::MuonBxCollection::const_iterator gmtEnd = gmtCands->end(0);
 
     for (; probeMuIt!=probeMuEnd; ++probeMuIt) {
-        m_ControlHistos[kCtrlProbeEta]->Fill((*probeMuIt)->eta());
-        m_ControlHistos[kCtrlProbePhi]->Fill((*probeMuIt)->phi());
-        m_ControlHistos[kCtrlProbePt]->Fill((*probeMuIt)->pt());
+        MuonGmtPair pairBestCand((*probeMuIt), nullptr, m_propagator, m_useAtVtxCoord);
 
-        MuonGmtPair pairBestCand((*probeMuIt), nullptr, m_useAtVtxCoord);
-//      pairBestCand.propagate(m_BField,m_propagatorAlong,m_propagatorOpposite);
+        // Fill the control histograms with the probe muon kinematic variables used
+        m_ControlHistos[kCtrlProbeEta]->Fill(pairBestCand.getVar(L1TMuonDQMOffline::kEffEta));
+        m_ControlHistos[kCtrlProbePhi]->Fill(pairBestCand.getVar(L1TMuonDQMOffline::kEffPhi));
+        m_ControlHistos[kCtrlProbePt]->Fill(pairBestCand.getVar(L1TMuonDQMOffline::kEffPt));
+
         gmtIt = gmtCands->begin(0); // use only on L1T muons from BX 0
 
         for(; gmtIt!=gmtEnd; ++gmtIt) {
-            MuonGmtPair pairTmpCand((*probeMuIt),&(*gmtIt), m_useAtVtxCoord);
-//          pairTmpCand.propagate(m_BField,m_propagatorAlong,m_propagatorOpposite);     
+            MuonGmtPair pairTmpCand((*probeMuIt), &(*gmtIt), m_propagator, m_useAtVtxCoord);
 
             if ( (pairTmpCand.dR() < m_maxGmtMuonDR) && (pairTmpCand.dR() < pairBestCand.dR() ) ) {
                 pairBestCand = pairTmpCand;


### PR DESCRIPTION
Solves https://its.cern.ch/jira/browse/CMSLITDPG-729

Description: The offline muon DQM efficiency and resolution calculations are now done with the reco muon coordinates extrapolated to the 2nd muon station. The legacy code used to perform the extrapolation in Run-1 has been replaced with the current one used in the L1 ntuple generation. In addition, the pT thresholds of the tag and the probe muons have been updated to the 2018 values.