### PR TITLE
Fireworks packages: changes required to compile with Apple Clang 9.1 

### DIFF
--- a/Fireworks/Core/BuildFile.xml
+++ b/Fireworks/Core/BuildFile.xml
@@ -30,10 +30,10 @@
 <lib name="Geom"/>
 <lib name="GeomPainter"/>
 <lib name="GuiHtml"/>
-<architecture name="!amd64_clang8">
+<architecture name="!osx10">
 <lib name="GX11"/>
 </architecture>
-<architecture name="amd64_clang8">
+<architecture name="osx10">
 <lib name="GCocoa"/>
 </architecture>
 <lib name="RGL"/>

--- a/Fireworks/Core/bin/cmsShow.cc
+++ b/Fireworks/Core/bin/cmsShow.cc
@@ -91,7 +91,7 @@ void run_app(TApplication &app, int argc, char **argv)
    edm::MessageLoggerQ::setMLscribe_ptr(std::shared_ptr<edm::service::AbstractMLscribe>(std::make_shared<SilentMLscribe>()));
    edm::MessageDrop::instance()->messageLoggerScribeIsRunning = edm::MLSCRIBE_RUNNING_INDICATOR;
    //---------------------
-   std::auto_ptr<CmsShowMain> pMain( new CmsShowMain(argc,argv) );
+   std::unique_ptr<CmsShowMain> pMain( new CmsShowMain(argc,argv) );
 
    // Avoid haing root handling various associated to an error and install 
    // back the default ones.

--- a/Fireworks/Core/interface/CmsShowMainBase.h
+++ b/Fireworks/Core/interface/CmsShowMainBase.h
@@ -149,18 +149,18 @@ protected:
 private:
    // The base class is responsible for the destruction of fwlite / FF
    // agnostic managers.
-   std::auto_ptr<FWModelChangeManager>   m_changeManager;
-   std::auto_ptr<FWColorManager>         m_colorManager;
-   std::auto_ptr<FWConfigurationManager> m_configurationManager;
-   std::auto_ptr<FWEventItemsManager>    m_eiManager;
-   std::auto_ptr<FWGUIManager>           m_guiManager;
-   std::auto_ptr<FWSelectionManager>     m_selectionManager;
-   std::auto_ptr<CmsShowTaskExecutor>    m_startupTasks;
-   std::auto_ptr<FWViewManagerManager>   m_viewManager;
+   std::unique_ptr<FWModelChangeManager>   m_changeManager;
+   std::unique_ptr<FWColorManager>         m_colorManager;
+   std::unique_ptr<FWConfigurationManager> m_configurationManager;
+   std::unique_ptr<FWEventItemsManager>    m_eiManager;
+   std::unique_ptr<FWGUIManager>           m_guiManager;
+   std::unique_ptr<FWSelectionManager>     m_selectionManager;
+   std::unique_ptr<CmsShowTaskExecutor>    m_startupTasks;
+   std::unique_ptr<FWViewManagerManager>   m_viewManager;
 
   
 
-   std::auto_ptr<SignalTimer>                 m_autoLoadTimer;
+   std::unique_ptr<SignalTimer>                 m_autoLoadTimer;
    
    // These are actually set by the concrete implementation via the setup 
    // method.

--- a/Fireworks/Core/interface/FWEveView.h
+++ b/Fireworks/Core/interface/FWEveView.h
@@ -147,8 +147,8 @@ private:
    FWBoolParameter   m_useGlobalEnergyScale;
 
    std::shared_ptr<FWViewContextMenuHandlerGL>   m_viewContextMenu;
-   std::auto_ptr<FWViewContext> m_viewContext;
-   std::auto_ptr<FWViewEnergyScale> m_localEnergyScale;
+   std::unique_ptr<FWViewContext> m_viewContext;
+   std::unique_ptr<FWViewEnergyScale> m_localEnergyScale;
 
    mutable FWViewEnergyScaleEditor* m_viewEnergyScaleEditor;
 };

--- a/Fireworks/Core/interface/FWGUIManager.h
+++ b/Fireworks/Core/interface/FWGUIManager.h
@@ -281,7 +281,7 @@ private:
 
    sigc::connection   m_modelChangeConn;
 
-   std::auto_ptr<CmsShowTaskExecutor> m_tasks;
+   std::unique_ptr<CmsShowTaskExecutor> m_tasks;
     std::vector<FWViewBase*> m_regionViews;
    int m_WMOffsetX, m_WMOffsetY, m_WMDecorH;
 };

--- a/Fireworks/Core/interface/FWXMLConfigParser.h
+++ b/Fireworks/Core/interface/FWXMLConfigParser.h
@@ -186,7 +186,7 @@ debug_config_state_machine(const char *where, const std::string &tag, int state)
 private:
    std::vector<std::pair<std::string, FWConfiguration *> > m_configs;
    enum STATES                                             m_state;
-   std::auto_ptr<FWConfiguration>                          m_first;
+   std::unique_ptr<FWConfiguration>                          m_first;
    //   unsigned int                                            m_currentConfigVersion;
    std::string                                             m_currentConfigName;
 };

--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -592,7 +592,7 @@ void
 CmsShowMain::openDataViaURL()
 {
    if (m_searchFiles.get() == nullptr) {
-      m_searchFiles = std::auto_ptr<CmsShowSearchFiles>(new CmsShowSearchFiles("",
+      m_searchFiles = std::unique_ptr<CmsShowSearchFiles>(new CmsShowSearchFiles("",
                                                                                "Open Remote Data Files",
                                                                                guiManager()->getMainFrame(),
                                                                                500, 400));
@@ -771,7 +771,7 @@ CmsShowMain::setLoadedAnyInputFileAfterStartup()
 void
 CmsShowMain::setupSocket(unsigned int iSocket)
 {
-   m_monitor = std::auto_ptr<TMonitor>(new TMonitor);
+   m_monitor = std::unique_ptr<TMonitor>(new TMonitor);
    TServerSocket* server = new TServerSocket(iSocket,kTRUE);
    if (server->GetErrorCode())
    {

--- a/Fireworks/Core/src/CmsShowMain.h
+++ b/Fireworks/Core/src/CmsShowMain.h
@@ -112,25 +112,25 @@ private:
    void checkLiveMode();
 
    // ---------- member data --------------------------------
-   std::auto_ptr<CmsShowNavigator>           m_navigator;
-   std::auto_ptr<FWLiteJobMetadataManager>   m_metadataManager;
-   std::auto_ptr<fireworks::Context>         m_context;
+   std::unique_ptr<CmsShowNavigator>           m_navigator;
+   std::unique_ptr<FWLiteJobMetadataManager>   m_metadataManager;
+   std::unique_ptr<fireworks::Context>         m_context;
 
    std::vector<std::string> m_inputFiles;
    bool                     m_loadedAnyInputFile;
    const TFile             *m_openFile;
 
-   std::auto_ptr<CmsShowSearchFiles>  m_searchFiles;
+   std::unique_ptr<CmsShowSearchFiles>  m_searchFiles;
 
    // live options
    bool                         m_live;
-   std::auto_ptr<SignalTimer>   m_liveTimer;
+   std::unique_ptr<SignalTimer>   m_liveTimer;
    int                          m_liveTimeout;
    UInt_t                       m_lastXEventSerial;
 
    bool                         m_noVersionCheck;
 
-   std::auto_ptr<TMonitor> m_monitor;
+   std::unique_ptr<TMonitor> m_monitor;
 };
 
 #endif

--- a/Fireworks/Core/src/FWConfigurationManager.cc
+++ b/Fireworks/Core/src/FWConfigurationManager.cc
@@ -159,7 +159,7 @@ FWConfigurationManager::readFromOldFile(const std::string& iName) const
       message += iName;
       throw std::runtime_error(message.c_str());
    }
-   std::auto_ptr<FWConfiguration> config( reinterpret_cast<FWConfiguration*>(lConfig) );
+   std::unique_ptr<FWConfiguration> config( reinterpret_cast<FWConfiguration*>(lConfig) );
 
    setFrom( *config);
 }

--- a/Fireworks/Core/src/FWFileEntry.cc
+++ b/Fireworks/Core/src/FWFileEntry.cc
@@ -354,7 +354,7 @@ void FWFileEntry::runFilter(Filter* filter, const FWEventItemsManager* eiMng)
 
    {
       TObjArray* branches = m_eventTree->GetListOfBranches();
-      std::auto_ptr<TIterator> pIt( branches->MakeIterator());
+      std::unique_ptr<TIterator> pIt( branches->MakeIterator());
       while (TObject* branchObj = pIt->Next())
       {
          TBranch* b = dynamic_cast<TBranch*> (branchObj);

--- a/Fireworks/Core/src/FWGUIValidatingTextEntry.cc
+++ b/Fireworks/Core/src/FWGUIValidatingTextEntry.cc
@@ -195,7 +195,7 @@ FWGUIValidatingTextEntry::showOptions() {
                                       0, GetHeight(), ax, ay, wdummy);
 
       //Wait to change focus for when the popup has already openned
-      std::auto_ptr<TTimer> timer( new ChangeFocusTimer(m_list->GetContainer()) );
+      std::unique_ptr<TTimer> timer( new ChangeFocusTimer(m_list->GetContainer()) );
       timer->TurnOn();
       //NOTE: this call has its own internal GUI event loop and will not return
       // until the popup has been shut down

--- a/Fireworks/Core/src/FWJobMetadataManager.cc
+++ b/Fireworks/Core/src/FWJobMetadataManager.cc
@@ -22,7 +22,7 @@ FWJobMetadataManager::~FWJobMetadataManager()
 void
 FWJobMetadataManager::update(FWJobMetadataUpdateRequest *request)
 {
-   std::auto_ptr<FWJobMetadataUpdateRequest> ptr(request);
+   std::unique_ptr<FWJobMetadataUpdateRequest> ptr(request);
    if (doUpdate(request))
       metadataChanged_();
 }

--- a/Fireworks/Core/test/unittest_fwconfiguration.cc
+++ b/Fireworks/Core/test/unittest_fwconfiguration.cc
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE( fwconfiguration )
    FWConfiguration::streamTo(std::cout, topConfig, "top");
 
    //Test manager
-   std::auto_ptr<Conf> pConf(new Conf() );
+   std::unique_ptr<Conf> pConf(new Conf() );
    
    FWConfigurationManager confMgr;
    confMgr.add("first", pConf.get() );

--- a/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
@@ -175,8 +175,9 @@ FWConvTrackHitsDetailView::build (const FWModelId &id, const reco::Conversion* c
    for( TEveElement::List_i i = m_modules->BeginChildren(), end = m_modules->EndChildren(); i != end; ++i )
    {
       TEveGeoShape* gs = dynamic_cast<TEveGeoShape*>(*i);
+      const auto & rhs  = *(*(i));
       if (gs == nullptr && (*i != nullptr)) {
-         std::cerr << "Got a " << typeid(**i).name() << ", expecting TEveGeoShape. ignoring (it must be the clusters)." << std::endl;
+         std::cerr << "Got a " << typeid( rhs ).name() << ", expecting TEveGeoShape. ignoring (it must be the clusters)." << std::endl;
          continue;
       }
      // gs->SetMainTransparency(75);

--- a/Fireworks/Macros/FileUrlService.C
+++ b/Fireworks/Macros/FileUrlService.C
@@ -192,7 +192,7 @@ void FileUrlBase::SendString(TSocket& socket, TString& str, const TString& eh)
 
 void FileUrlBase::ReceiveString(TSocket& socket, TString& str, const TString& eh)
 {
-   std::auto_ptr<TMessage> msg(ReceiveMessage(socket, gkStringMT, eh));
+   std::unique_ptr<TMessage> msg(ReceiveMessage(socket, gkStringMT, eh));
    str.Streamer(*msg);
 }
 
@@ -207,7 +207,7 @@ void FileUrlBase::SendRequest(TSocket& socket, FileUrlRequest& request, const TS
 
 void FileUrlBase::ReceiveRequest(TSocket& socket, FileUrlRequest& request, const TString& eh)
 {
-   std::auto_ptr<TMessage> msg(ReceiveMessage(socket, gkUrlRequestMT, eh));
+   std::unique_ptr<TMessage> msg(ReceiveMessage(socket, gkUrlRequestMT, eh));
    request.Streamer(*msg);
 }
 
@@ -347,7 +347,7 @@ FileUrlServer::~FileUrlServer()
    delete fServerThread;
 
    {
-      std::auto_ptr<TList> socks(fMonitor->GetListOfActives());
+      std::unique_ptr<TList> socks(fMonitor->GetListOfActives());
       while ( ! socks->IsEmpty())
       {
          TObject *obj = socks->First();
@@ -661,7 +661,7 @@ public:
 
 TSocket* FileUrlClient::OpenSocket(const TString& eh)
 {
-   std::auto_ptr<TSocket> s(new TSocket(fHost, fPort));
+   std::unique_ptr<TSocket> s(new TSocket(fHost, fPort));
 
    if (!s->IsValid())
    {
@@ -690,7 +690,7 @@ void FileUrlClient::GetNextFile(Bool_t loop)
       return;
    }
 
-   std::auto_ptr<TSocket> s(OpenSocket(_eh));
+   std::unique_ptr<TSocket> s(OpenSocket(_eh));
 
    fRequest.fMode = FileUrlRequest::kPullNext;
 
@@ -721,7 +721,7 @@ void FileUrlClient::GetLastFile()
       return;
    }
 
-   std::auto_ptr<TSocket> s(OpenSocket(_eh));
+   std::unique_ptr<TSocket> s(OpenSocket(_eh));
 
    fRequest.fMode = FileUrlRequest::kPullLast;
 
@@ -748,7 +748,7 @@ void FileUrlClient::BeginServerPushMode()
 
    try
    {
-      std::auto_ptr<TSocket> s(OpenSocket(_eh));
+      std::unique_ptr<TSocket> s(OpenSocket(_eh));
       fRequest.fMode = FileUrlRequest::kServerPush;
       SendRequest(*s, fRequest, _eh);
       fSocket = s.release();

--- a/Fireworks/Macros/eve_macros.cc
+++ b/Fireworks/Macros/eve_macros.cc
@@ -136,7 +136,7 @@ TEveGeoShape * clone( const TEveElement * element, TEveElement * parent /* = 0 *
 {
   TEveGeoShape* shape = new TEveGeoShape( get_name(element), get_title(element) );
 
-  std::auto_ptr<TGeoMatrix> matrix( get_transform(element) );
+  std::unique_ptr<TGeoMatrix> matrix( get_transform(element) );
   shape->SetTransMatrix( matrix.get() );
   delete matrix;
 

--- a/Fireworks/Muons/plugins/FWCSCStripDigiProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWCSCStripDigiProxyBuilder.cc
@@ -90,7 +90,7 @@ FWCSCStripDigiProxyBuilder::build(const FWEventItem* iItem, TEveElementList* pro
          TEveStraightLineSet* stripDigiSet = new TEveStraightLineSet();
          setupAddElement(stripDigiSet, product);
              
-         if( std::find_if( adcCounts.begin(), adcCounts.end(), bind2nd( std::greater<int>(), signalThreshold )) != adcCounts.end()) 
+         if( std::find_if( adcCounts.begin(), adcCounts.end(), [&](auto c) { return c >signalThreshold; }) != adcCounts.end()) 
          {
             stripDigiSet->SetLineWidth(3);
             int stripId = (*dit).getStrip();  

--- a/Fireworks/Muons/src/FWMuonBuilder.cc
+++ b/Fireworks/Muons/src/FWMuonBuilder.cc
@@ -73,7 +73,7 @@ void addMatchInformation( const reco::Muon* muon,
   const std::vector<reco::MuonChamberMatch>& matches = muon->matches();
    
   //need to use auto_ptr since the segmentSet may not be passed to muonList
-  std::auto_ptr<TEveStraightLineSet> segmentSet( new TEveStraightLineSet );
+  std::unique_ptr<TEveStraightLineSet> segmentSet( new TEveStraightLineSet );
   // FIXME: This should be set elsewhere.
   segmentSet->SetLineWidth( 4 );
 

--- a/Fireworks/Tracks/plugins/FWTrackHitsDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackHitsDetailView.cc
@@ -102,8 +102,9 @@ FWTrackHitsDetailView::build (const FWModelId &id, const reco::Track* track)
    for( TEveElement::List_i i = m_modules->BeginChildren(), end = m_modules->EndChildren(); i != end; ++i )
    {
       TEveGeoShape* gs = dynamic_cast<TEveGeoShape*>(*i);
+       const auto & rhs = *(*(i));
       if (gs == nullptr && (*i != nullptr)) {
-        std::cerr << "Got a " << typeid(**i).name() << ", expecting TEveGeoShape. ignoring (it must be the clusters)." << std::endl;
+        std::cerr << "Got a " << typeid(rhs).name() << ", expecting TEveGeoShape. ignoring (it must be the clusters)." << std::endl;
         continue;
       }
       gs->SetMainTransparency(75);

--- a/Fireworks/Tracks/src/TrackUtils.cc
+++ b/Fireworks/Tracks/src/TrackUtils.cc
@@ -359,7 +359,8 @@ addSiStripClusters( const FWEventItem* iItem, const reco::Track &t, class TEveEl
    {
       for( trackingRecHit_iterator it = t.recHitsBegin(), itEnd = t.recHitsEnd(); it != itEnd; ++it )
       {
-         if( typeid( **it ) == typeid( SiStripRecHit2D ))
+          const auto & rhs = *(*(it));
+         if(  typeid( rhs ) == typeid( SiStripRecHit2D ))
          {
             const SiStripRecHit2D &hit = static_cast<const SiStripRecHit2D &>( **it );
             if( hit.cluster().isNonnull() && hit.cluster().isAvailable())
@@ -370,7 +371,7 @@ addSiStripClusters( const FWEventItem* iItem, const reco::Track &t, class TEveEl
                break;
             }
          }
-         else if( typeid( **it ) == typeid( SiStripRecHit1D ))
+         else if( typeid( rhs ) == typeid( SiStripRecHit1D ))
          {
             const SiStripRecHit1D &hit = static_cast<const SiStripRecHit1D &>( **it );
             if( hit.cluster().isNonnull() && hit.cluster().isAvailable())
@@ -520,7 +521,8 @@ pushNearbyPixelHits( std::vector<TVector3> &pixelPoints, const FWEventItem &iIte
    const edmNew::DetSetVector<SiPixelCluster> * allClusters = nullptr;
    for( trackingRecHit_iterator it = t.recHitsBegin(), itEnd = t.recHitsEnd(); it != itEnd; ++it)
    {
-      if( typeid(**it) == typeid( SiPixelRecHit ))
+       const auto & rhs  = *(*(it));
+      if( typeid( rhs ) == typeid( SiPixelRecHit ))
       {
          const SiPixelRecHit &hit = static_cast<const SiPixelRecHit &>(**it);
          if( hit.cluster().isNonnull() && hit.cluster().isAvailable())


### PR DESCRIPTION
Fireworks packages: changes required to compile with Clang 9.1  strict enforcement of c++17 std deprecated function removal.