### PR TITLE
PhysicsTool/Utilities : Changes required to compile with Apple Clang 9.1 

### DIFF
--- a/PhysicsTools/Utilities/interface/Expression.h
+++ b/PhysicsTools/Utilities/interface/Expression.h
@@ -33,7 +33,7 @@ namespace funct {
    inline double operator()() const { return (*_f)(); }
    inline std::ostream& print(std::ostream& cout) const { return _f->print(cout); }
  private:
-   std::auto_ptr<AbsExpression> _f;
+   std::unique_ptr<AbsExpression> _f;
  };
 
  inline std::ostream& operator<<(std::ostream& cout, const Expression& e) { 
@@ -64,7 +64,7 @@ namespace funct {
    inline FunctExpression& operator=(const FunctExpression& e) { _f.reset(e._f->clone()); return *this; }
    inline double operator()(double x) const { return (*_f)(x); }
  private:
-   std::auto_ptr<AbsFunctExpression> _f;
+   std::unique_ptr<AbsFunctExpression> _f;
  };
 
 }

--- a/PhysicsTools/Utilities/interface/NumericalIntegration.h
+++ b/PhysicsTools/Utilities/interface/NumericalIntegration.h
@@ -146,7 +146,7 @@ namespace funct {
     ROOT::Math::IntegrationOneDim::Type type_;
     double absTol_, relTol_;
     unsigned int size_, rule_;
-    mutable std::auto_ptr<ROOT::Math::Integrator> integrator_;
+    mutable std::unique_ptr<ROOT::Math::Integrator> integrator_;
   };    
 }
 

--- a/PhysicsTools/Utilities/interface/RootMinuit.h
+++ b/PhysicsTools/Utilities/interface/RootMinuit.h
@@ -181,7 +181,7 @@ namespace fit {
     std::map<std::string, size_t> parIndices_;
     bool initialized_;
     double minValue_;
-    std::auto_ptr<TMinuit> minuit_;
+    std::unique_ptr<TMinuit> minuit_;
     std::vector<boost::shared_ptr<double> > pars_;
     static std::vector<boost::shared_ptr<double> > *fPars_;
     bool verbose_;


### PR DESCRIPTION
Changes required to compile with Apple Clang 9.1 strict enforcement of c++17 std deprecated function removal.