### PR TITLE
Pr103x HeavyIon  2018 CaloLayer2, Un/Packer, Emulator,  O2O

### DIFF
--- a/DataFormats/L1Trigger/interface/EtSum.h
+++ b/DataFormats/L1Trigger/interface/EtSum.h
@@ -44,7 +44,12 @@ namespace l1t {
       kTotalHtxHF,
       kTotalHtyHF,
       kMissingHtHF,
-      kTowerCount      
+      kTowerCount,
+      kCentrality,
+      kAsymEt,
+      kAsymHt,
+      kAsymEtHF,
+      kAsymHtHF
     };
 
     EtSum(){}

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSetup.cc
@@ -63,46 +63,53 @@ namespace l1t {
       UnpackerMap
       CaloSetup::getUnpackers(int fed, int board, int amc, unsigned int fw)
       {
-         auto tower_unp = UnpackerFactory::get()->make("stage2::CaloTowerUnpacker");
-         auto egamma_unp = UnpackerFactory::get()->make("stage2::EGammaUnpacker");
-         auto etsum_unp = UnpackerFactory::get()->make("stage2::EtSumUnpacker");
-         auto jet_unp = UnpackerFactory::get()->make("stage2::JetUnpacker");
-         auto tau_unp = UnpackerFactory::get()->make("stage2::TauUnpacker");
 
-         auto mp_unp = UnpackerFactory::get()->make("stage2::MPUnpacker");
-         if (fw >= 0x1001000b) {
+	UnpackerMap res;
+	if (fed == 1366 || (fed == 1360 && board == 0x221B)) {
+
+	  auto egamma_unp = UnpackerFactory::get()->make("stage2::EGammaUnpacker");
+	  auto etsum_unp = UnpackerFactory::get()->make("stage2::EtSumUnpacker");
+	  auto jet_unp = UnpackerFactory::get()->make("stage2::JetUnpacker");
+	  auto tau_unp = UnpackerFactory::get()->make("stage2::TauUnpacker");
+
+	  if (fw >= 0x10010057) {
+	    etsum_unp = UnpackerFactory::get()->make("stage2::EtSumUnpacker_0x10010057");
+	  }
+
+	  res[9]  = egamma_unp;
+	  res[11] = egamma_unp;
+	  res[13] = jet_unp;
+	  res[15] = jet_unp;
+	  res[17] = tau_unp;
+	  res[19] = tau_unp;
+	  res[21] = etsum_unp;
+
+	} else if (fed == 1360 && board != 0x221B) {
+
+	  auto tower_unp = UnpackerFactory::get()->make("stage2::CaloTowerUnpacker");
+	  auto mp_unp = UnpackerFactory::get()->make("stage2::MPUnpacker");
+	  if (fw >= 0x1001000b) {
             mp_unp = UnpackerFactory::get()->make("stage2::MPUnpacker_0x1001000b");
-         }
-         if (fw >= 0x10010010) {
+	  }
+	  if (fw >= 0x10010010) {
             mp_unp = UnpackerFactory::get()->make("stage2::MPUnpacker_0x10010010");
-         }
-         if (fw >= 0x10010033) {
+	  }
+	  if (fw >= 0x10010033) {
             mp_unp = UnpackerFactory::get()->make("stage2::MPUnpacker_0x10010033");
-         }
+	  }
 
+	  res[121] = mp_unp;
+	  res[123] = mp_unp;
+	  res[125] = mp_unp;
+	  res[127] = mp_unp;
+	  res[129] = mp_unp;
+	  res[131] = mp_unp;
 
-         UnpackerMap res;
-         if (fed == 1366 || (fed == 1360 && board == 0x221B)) {
-            res[9]  = egamma_unp;
-            res[11] = egamma_unp;
-            res[13] = jet_unp;
-            res[15] = jet_unp;
-            res[17] = tau_unp;
-            res[19] = tau_unp;
-            res[21] = etsum_unp;
-         } else if (fed == 1360 && board != 0x221B) {
-            res[121] = mp_unp;
-            res[123] = mp_unp;
-            res[125] = mp_unp;
-            res[127] = mp_unp;
-            res[129] = mp_unp;
-            res[131] = mp_unp;
+	  for (int link = 0; link < 144; link += 2)
+	    res[link] = tower_unp;
+	}
 
-            for (int link = 0; link < 144; link += 2)
-               res[link] = tower_unp;
-         }
-
-         return res;
+	return res;
       }
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumPacker.cc
@@ -44,6 +44,15 @@ namespace stage2 {
 	  if (j->getType()==l1t::EtSum::kMissingEtHF)   methf_word |= word;
 	  if (j->getType()==l1t::EtSum::kMissingHtHF)   mhthf_word |= word;
 	  if (j->getType()==l1t::EtSum::kTowerCount)    ht_word |= (word << 12);
+	  if (j->getType()==l1t::EtSum::kAsymEt)        met_word |= (word << 20);
+	  if (j->getType()==l1t::EtSum::kAsymHt)        mht_word |= (word << 20);
+	  if (j->getType()==l1t::EtSum::kAsymEtHF)      methf_word |= (word << 20);
+	  if (j->getType()==l1t::EtSum::kAsymHtHF)      mhthf_word |= (word << 20);
+	  if (j->getType()==l1t::EtSum::kCentrality){
+	    methf_word |= ((word & 0xF) << 28);
+	    mhthf_word |= (((word>>4) & 0xF) << 28);
+	  } 
+	  
 	}
 	
 	load.push_back(et_word);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker_0x10010057.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker_0x10010057.cc
@@ -1,0 +1,250 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
+
+#include "L1Trigger/L1TCalorimeter/interface/CaloTools.h"
+
+#include "L1TObjectCollections.h"
+
+#include "L1TStage2Layer2Constants.h"
+#include "EtSumUnpacker_0x10010057.h"
+
+namespace l1t {
+namespace stage2 {
+  EtSumUnpacker_0x10010057::EtSumUnpacker_0x10010057() : EtSumCopy_(0)
+  {
+  }
+  
+   bool
+   EtSumUnpacker_0x10010057::unpack(const Block& block, UnpackerCollections *coll)
+   {
+
+     using namespace l1t::stage2::layer2;
+
+     LogDebug("L1T") << "Block ID  = " << block.header().getID() << " size = " << block.header().getSize();
+
+     int nBX = int(ceil(block.header().getSize() / demux::nOutputFramePerBX)); // Since there 6 frames per demux output event
+     // expect the first four frames to be the first 4 EtSum objects reported per event (see CMS IN-2013/005)
+
+     // Find the central, first and last BXs
+     int firstBX = -(ceil((double)nBX/2.)-1);
+     int lastBX;
+     if (nBX % 2 == 0) {
+       lastBX = ceil((double)nBX/2.);
+     } else {
+       lastBX = ceil((double)nBX/2.)-1;
+     }
+
+     auto res_ = static_cast<L1TObjectCollections*>(coll)->getEtSums(EtSumCopy_);
+     res_->setBXRange(firstBX, lastBX);
+
+     LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;
+
+     // Loop over multiple BX and fill EtSums collection
+     for (int bx=firstBX; bx<=lastBX; bx++){
+
+
+       // ET
+       int iFrame = (bx-firstBX)*demux::nOutputFramePerBX;
+
+       uint32_t raw_data = block.payload().at(iFrame);
+
+       l1t::EtSum et = l1t::EtSum();
+    
+       et.setHwPt(raw_data & 0xFFF);
+       et.setType(l1t::EtSum::kTotalEt);       
+       et.setP4( l1t::CaloTools::p4Demux(&et) );
+
+       LogDebug("L1T") << "ET: pT " << et.hwPt() << " bx " << bx;
+
+       res_->push_back(bx,et);
+
+
+       // ET EM
+
+       l1t::EtSum etem = l1t::EtSum();
+    
+       etem.setHwPt( (raw_data >> 12) & 0xFFF);
+       etem.setType(l1t::EtSum::kTotalEtEm);       
+       etem.setP4( l1t::CaloTools::p4Demux(&etem) );
+
+       LogDebug("L1T") << "ETEM: pT " << etem.hwPt() << " bx " << bx;
+
+       res_->push_back(bx,etem);
+
+
+       // MBHFPT0
+
+       l1t::EtSum mbp0 = l1t::EtSum();
+       mbp0.setHwPt( (raw_data>>28) & 0xf );
+       mbp0.setType( l1t::EtSum::kMinBiasHFP0 );
+
+       res_->push_back(bx, mbp0);
+
+
+       // HT
+
+       raw_data = block.payload()[iFrame+1];
+
+       l1t::EtSum ht = l1t::EtSum();
+
+       ht.setHwPt(raw_data & 0xFFF);
+       ht.setType(l1t::EtSum::kTotalHt);       
+       ht.setP4( l1t::CaloTools::p4Demux(&ht) );
+
+       LogDebug("L1T") << "HT: pT " << ht.hwPt();
+
+       res_->push_back(bx,ht);
+
+       //MBHFMT0
+
+       l1t::EtSum mbm0 = l1t::EtSum();
+       mbm0.setHwPt( (raw_data>>28) & 0xf );
+       mbm0.setType( l1t::EtSum::kMinBiasHFM0 );
+
+       res_->push_back(bx, mbm0);
+
+
+       //  MET (no HF)
+
+       raw_data = block.payload()[iFrame+2];
+
+       l1t::EtSum met = l1t::EtSum();
+    
+       met.setHwPt(raw_data & 0xFFF);
+       met.setHwPhi((raw_data >> 12) & 0xFF);
+       met.setType(l1t::EtSum::kMissingEt);       
+       met.setP4( l1t::CaloTools::p4Demux(&met) );
+
+       LogDebug("L1T") << "MET: phi " << met.hwPhi() << " pT " << met.hwPt() << " bx " << bx;
+
+       res_->push_back(bx,met);
+
+       // MBHFPT1
+
+       l1t::EtSum mbp1 = l1t::EtSum();
+       mbp1.setHwPt( (raw_data>>28) & 0xf );
+       mbp1.setType( l1t::EtSum::kMinBiasHFP1 );
+
+       res_->push_back(bx, mbp1);
+
+       // ET ASYMM
+
+       l1t::EtSum etAsym = l1t::EtSum();
+       etAsym.setHwPt( (raw_data>>20) & 0xFF );
+       etAsym.setType( l1t::EtSum::kAsymEt );
+
+       res_->push_back(bx, etAsym);
+
+       // MHT 
+
+       raw_data = block.payload()[iFrame+3];
+
+       l1t::EtSum mht = l1t::EtSum();
+    
+       mht.setHwPt(raw_data & 0xFFF);
+       mht.setHwPhi((raw_data >> 12) & 0xFF);
+       mht.setType(l1t::EtSum::kMissingHt);       
+       mht.setP4( l1t::CaloTools::p4Demux(&mht) );
+
+       LogDebug("L1T") << "MHT: phi " << mht.hwPhi() << " pT " << mht.hwPt() << " bx " << bx;
+
+       res_->push_back(bx,mht);
+
+       // MBHFMT1
+
+       l1t::EtSum mbm1 = l1t::EtSum();
+       mbm1.setHwPt( (raw_data>>28) & 0xf );
+       mbm1.setType( l1t::EtSum::kMinBiasHFM1 );
+
+       res_->push_back(bx, mbm1);
+
+       // HT ASYMM
+
+       l1t::EtSum htAsym = l1t::EtSum();
+       htAsym.setHwPt( (raw_data>>20) & 0xFF );
+       htAsym.setType( l1t::EtSum::kAsymHt );
+
+       res_->push_back(bx, htAsym);
+
+       
+       //  MET (with HF)
+
+       raw_data = block.payload()[iFrame+4];
+
+       l1t::EtSum methf = l1t::EtSum();
+    
+       methf.setHwPt(raw_data & 0xFFF);
+       methf.setHwPhi((raw_data >> 12) & 0xFF);
+       methf.setType(l1t::EtSum::kMissingEtHF);       
+       methf.setP4( l1t::CaloTools::p4Demux(&methf) );
+
+       LogDebug("L1T") << "METHF: phi " << methf.hwPhi() << " pT " << methf.hwPt() << " bx " << bx;
+
+       res_->push_back(bx,methf);
+
+       // ETHF ASYMM
+
+       l1t::EtSum etHFAsym = l1t::EtSum();
+       etHFAsym.setHwPt( (raw_data>>20) & 0xFF );
+       etHFAsym.setType( l1t::EtSum::kAsymEtHF );
+
+       res_->push_back(bx, etHFAsym);
+
+       // CENTRALITY LOWER NIB
+
+       uint32_t centLN = ((raw_data >> 28) & 0xF);
+
+       // MHT with HF
+
+       raw_data = block.payload()[iFrame+5];
+
+       l1t::EtSum mhthf = l1t::EtSum();
+    
+       mhthf.setHwPt(raw_data & 0xFFF);
+       mhthf.setHwPhi((raw_data >> 12) & 0xFF);
+       mhthf.setType(l1t::EtSum::kMissingHtHF);       
+       mhthf.setP4( l1t::CaloTools::p4Demux(&mhthf) );
+
+       LogDebug("L1T") << "MHThf: phi " << mhthf.hwPhi() << " pT " << mhthf.hwPt() << " bx " << bx;
+
+       res_->push_back(bx,mhthf);
+
+       // HTHF ASYMM
+       
+       l1t::EtSum htHFAsym = l1t::EtSum();
+       htHFAsym.setHwPt( (raw_data>>20) & 0xFF );
+       htHFAsym.setType( l1t::EtSum::kAsymHtHF );
+
+       res_->push_back(bx, htHFAsym);
+
+
+       // CENTRALITY UPPER NIB
+
+       uint32_t centUN = ((raw_data >> 28) & 0xF);
+
+       l1t::EtSum cent = l1t::EtSum();
+       cent.setHwPt(centUN & centLN); 
+       cent.setType( l1t::EtSum::kCentrality );
+       
+       res_->push_back(bx, cent);
+
+       //HI-SUM
+       
+       raw_data = block.payload()[iFrame+1];
+
+       l1t::EtSum towCount = l1t::EtSum();
+       towCount.setHwPt( (raw_data>>12) & 0x1FFF );
+       towCount.setType( (l1t::EtSum::kTowerCount) );
+       towCount.setP4( l1t::CaloTools::p4Demux(&towCount) );
+
+       res_->push_back(bx, towCount);
+    
+   
+     }
+
+     return true;
+   }
+}
+}
+
+DEFINE_L1T_UNPACKER(l1t::stage2::EtSumUnpacker_0x10010057);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker_0x10010057.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker_0x10010057.cc
@@ -223,7 +223,7 @@ namespace stage2 {
        uint32_t centUN = ((raw_data >> 28) & 0xF);
 
        l1t::EtSum cent = l1t::EtSum();
-       cent.setHwPt(centUN & centLN); 
+       cent.setHwPt( (centUN << 4) | centLN); 
        cent.setType( l1t::EtSum::kCentrality );
        
        res_->push_back(bx, cent);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker_0x10010057.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker_0x10010057.h
@@ -1,0 +1,23 @@
+#ifndef L1T_PACKER_STAGE2_ETSUMUNPACKER_0X10010057_H
+#define L1T_PACKER_STAGE2_ETSUMUNPACKER_0X10010057_H
+
+#include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
+
+namespace l1t {
+   namespace stage2 {
+      class EtSumUnpacker_0x10010057 : public Unpacker {
+         public:
+            EtSumUnpacker_0x10010057();
+            ~EtSumUnpacker_0x10010057() override {};
+
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
+
+            inline void setEtSumCopy(const unsigned int copy) { EtSumCopy_ = copy; };
+
+         private:
+            unsigned int EtSumCopy_;
+      };
+   }
+}
+
+#endif

--- a/EventFilter/L1TRawToDigi/utils/unpackBuffers-CaloStage2.py
+++ b/EventFilter/L1TRawToDigi/utils/unpackBuffers-CaloStage2.py
@@ -20,6 +20,11 @@ options.register('fwVersion',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "Firmware version for unpacker configuration")
+options.register('demuxFWVersion',
+                 268501079,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Firmware version for demux unpacker configuration")
 options.register('mpFramesPerEvent',
                  40,
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -286,6 +291,7 @@ process.stage2DemuxRaw.nFramesOffset    = cms.untracked.vuint32(dmOffset)
 process.stage2DemuxRaw.nFramesLatency   = cms.untracked.vuint32(options.dmLatency)
 process.stage2DemuxRaw.rxFile = cms.untracked.string("demux_rx_summary.txt")
 process.stage2DemuxRaw.txFile = cms.untracked.string("demux_tx_summary.txt")
+process.stage2DemuxRaw.fwVersion = cms.untracked.int32(options.demuxFWVersion)
 
 # GT config
 if (options.doGT):
@@ -316,6 +322,7 @@ process.load('EventFilter.L1TRawToDigi.caloStage2Digis_cfi')
 process.caloStage2Digis.InputLabel = cms.InputTag('rawDataCollector')
 process.caloStage2Digis.debug      = cms.untracked.bool(options.debug)
 process.caloStage2Digis.FWId  = cms.uint32(options.fwVersion)
+process.caloStage2Digis.DmxFWId = cms.uint32(options.demuxFWVersion)
 process.caloStage2Digis.FWOverride = cms.bool(True)
 process.caloStage2Digis.TMTCheck   = cms.bool(False)
 

--- a/L1Trigger/Configuration/python/customiseSettings.py
+++ b/L1Trigger/Configuration/python/customiseSettings.py
@@ -2,6 +2,10 @@ from __future__ import print_function
 import os.path
 import FWCore.ParameterSet.Config as cms
 
+def L1TSettingsToCaloParams_2018_v1_4(process):
+    process.load("L1Trigger.L1TCalorimeter.caloParams_2018_v1_4_cfi")
+    return process
+
 def L1TSettingsToCaloParams_2018_v1_2(process):
     process.load("L1Trigger.L1TCalorimeter.caloParams_2018_v1_2_cfi")
     return process

--- a/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
@@ -56,7 +56,8 @@ namespace l1t {
 	   egBypassHoEFlag=44,
 	   etSumCentralityLower=45,
 	   etSumCentralityUpper=46,
-	   NUM_CALOPARAMNODES=47
+           jetPUSUseChunkySandwichFlag=47,
+	   NUM_CALOPARAMNODES=48
     };
 
     CaloParamsHelper() { pnode_.resize(NUM_CALOPARAMNODES); }
@@ -335,6 +336,7 @@ namespace l1t {
     }
 
     unsigned jetBypassPUS() const { return pnode_[jetBypassPUSFlag].uparams_[0]; }
+    unsigned jetPUSUseChunkySandwich() const { return pnode_[jetPUSUseChunkySandwichFlag].uparams_[0]; }
 
     std::string jetPUSType() const { return pnode_[jetPUS].type_; }
     std::vector<double> const& jetPUSParams() const { return pnode_[jetPUS].dparams_; }
@@ -365,6 +367,10 @@ namespace l1t {
     void setJetBypassPUS(unsigned flag) { 
       pnode_[jetBypassPUSFlag].uparams_.resize(1);
       pnode_[jetBypassPUSFlag].uparams_[0] = flag; 
+    }
+    void setJetPUSUseChunkySandwich(unsigned flag) { 
+      pnode_[jetPUSUseChunkySandwichFlag].uparams_.resize(1);
+      pnode_[jetPUSUseChunkySandwichFlag].uparams_[0] = flag; 
     }
     
     // sums

--- a/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
@@ -54,7 +54,9 @@ namespace l1t {
 	   egBypassShapeFlag=42,
 	   egBypassECALFGFlag=43,
 	   egBypassHoEFlag=44,
-	   NUM_CALOPARAMNODES=45
+	   etSumCentralityLower=45,
+	   etSumCentralityUpper=46,
+	   NUM_CALOPARAMNODES=47
     };
 
     CaloParamsHelper() { pnode_.resize(NUM_CALOPARAMNODES); }
@@ -470,7 +472,27 @@ namespace l1t {
     void setQ2LUT(const l1t::LUT & lut) { pnode_[hiQ2].LUT_ = lut; }
 
     // HI parameters
-
+    double etSumCentLower(unsigned centClass) const {
+      if (pnode_[etSumCentralityLower].dparams_.size()>centClass)
+	return pnode_[etSumCentralityLower].dparams_.at(centClass);
+      else return 0.;
+    }
+    double etSumCentUpper(unsigned centClass) const { 
+      if (pnode_[etSumCentralityUpper].dparams_.size()>centClass)
+	return pnode_[etSumCentralityUpper].dparams_.at(centClass);
+      else return 0.;
+    }
+    void setEtSumCentLower(unsigned centClass, double loBound){
+      if (pnode_[etSumCentralityLower].dparams_.size()<=centClass) 
+	pnode_[etSumCentralityLower].dparams_.resize(centClass+1);
+      pnode_[etSumCentralityLower].dparams_.at(centClass) = loBound;
+    }
+    void setEtSumCentUpper(unsigned centClass, double upBound) {
+      if (pnode_[etSumCentralityUpper].dparams_.size()<=centClass) 
+	pnode_[etSumCentralityUpper].dparams_.resize(centClass+1);
+      pnode_[etSumCentralityUpper].dparams_.at(centClass) = upBound;
+    }
+    
     // Layer 1 LUT specification
     std::vector<double> const& layer1ECalScaleFactors() const { return pnode_[layer1ECal].dparams_; }
     std::vector<double> const& layer1HCalScaleFactors() const { return pnode_[layer1HCal].dparams_; }

--- a/L1Trigger/L1TCalorimeter/interface/CaloTools.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloTools.h
@@ -102,7 +102,7 @@ namespace l1t {
     static int gtPhi(int ieta, int iphi);      // GT phi scale
 
     // integer divide for HI asymmetry 
-    static double intDivide(int x, unsigned nHigh = 9, unsigned nLow = 9);
+    static unsigned int gloriousDivision(uint32_t aNumerator, uint32_t aDenominator);
 
     // conversion methods
     static math::PtEtaPhiMLorentzVector p4Demux(l1t::L1Candidate*);

--- a/L1Trigger/L1TCalorimeter/interface/CaloTools.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloTools.h
@@ -101,6 +101,9 @@ namespace l1t {
     static int gtEta(int ieta);      // GT eta scale
     static int gtPhi(int ieta, int iphi);      // GT phi scale
 
+    // integer divide for HI asymmetry 
+    static double intDivide(int x, unsigned nHigh = 9, unsigned nLow = 9);
+
     // conversion methods
     static math::PtEtaPhiMLorentzVector p4Demux(l1t::L1Candidate*);
     static l1t::EGamma egP4Demux(l1t::EGamma&);

--- a/L1Trigger/L1TCalorimeter/interface/Stage2Layer2DemuxSumsAlgoFirmware.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage2Layer2DemuxSumsAlgoFirmware.h
@@ -28,6 +28,7 @@ namespace l1t {
 			      std::vector<l1t::EtSum> & outputSums) override;
   private:
 
+    CaloParamsHelper* params_;
     Cordic cordic_;
 
   };

--- a/L1Trigger/L1TCalorimeter/interface/Stage2Layer2DemuxSumsAlgoFirmware.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage2Layer2DemuxSumsAlgoFirmware.h
@@ -28,7 +28,7 @@ namespace l1t {
 			      std::vector<l1t::EtSum> & outputSums) override;
   private:
 
-    CaloParamsHelper* params_;
+    CaloParamsHelper const* params_;
     Cordic cordic_;
 
   };

--- a/L1Trigger/L1TCalorimeter/interface/Stage2Layer2JetAlgorithmFirmware.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage2Layer2JetAlgorithmFirmware.h
@@ -39,8 +39,17 @@ namespace l1t {
     int donutPUEstimate(int jetEta, int jetPhi, int size,
                         const std::vector<l1t::CaloTower> & towers);
 
+    std::vector<int> getChunkyRing(Jet & jet, int pos,
+				   const std::vector<l1t::CaloTower> & towers,
+				   const std::string chunkyString);
+
     int chunkyDonutPUEstimate(Jet & jet, int pos,
                               const std::vector<l1t::CaloTower> & towers);
+
+    //Adding chunky sandwich, chunkydonut variant using only phiflaps. Useful for simple handiling of calorimeter hardware ieta strips, and in high pu environment like PbPb
+    int chunkySandwichPUEstimate(Jet & jet, int pos,
+				 const std::vector<l1t::CaloTower> & towers,
+				 const std::string chunkySandwichStr);
 
   private:
 

--- a/L1Trigger/L1TCalorimeter/macros/compHwEmu.C
+++ b/L1Trigger/L1TCalorimeter/macros/compHwEmu.C
@@ -369,6 +369,27 @@ void compHwEmu (
    // HI Tower count
   TH1D* hwHITowerCount = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sumhitowercount/et");
   TH1D* emHITowerCount = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/sumhitowercount/et");
+  
+  // HI centrality
+  TH1D* hwHICentrality = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sumcentrality/et");
+  TH1D* emHICentrality = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/sumcentrality/et");
+
+  // ET Asym
+  TH1D* hwEtAsymSum = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sumasymet/et");
+  TH1D* emEtAsymSum = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/sumasymet/et");
+
+  // HT Asym
+  TH1D* hwHtAsymSum = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sumasymht/et");
+  TH1D* emHtAsymSum = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/sumasymht/et");
+
+  // ET HF Asym
+  TH1D* hwEtAsymSumHF = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sumasymethf/et");
+  TH1D* emEtAsymSumHF = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/sumasymethf/et");
+
+  // HT HF Asym
+  TH1D* hwHtAsymSumHF = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sumasymhthf/et");
+  TH1D* emHtAsymSumHF = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/sumasymhthf/et");
+
 
   // Sorts
   TH1D* hwSortMP = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/sortMP");
@@ -987,6 +1008,46 @@ void compHwEmu (
       emMhtHFPhi,
       runNo, dataset, "MHT i#phi", "DemuxSums/DemMhtHFPhi.pdf", 1, 13, 0, 143
       );
+
+    // plot demux sum Centrality
+    create_plot(
+      hwHICentrality,
+      emHICentrality,
+      runNo, dataset, "Centrality", "DemuxSums/DemSumCentrality.pdf", 1, 13, 0, 300
+      );
+
+    // plot demux sum Et Asym
+    create_plot(
+      hwEtAsymSum,
+      emEtAsymSum,
+      runNo, dataset, "iE_{T} Asym", "DemuxSums/DemSumEtAsym.pdf", 1, 13, 0, 300
+      );
+
+    // plot demux sum Ht Asym
+    create_plot(
+      hwHtAsymSum,
+      emHtAsymSum,
+      runNo, dataset, "iH_{T} Asym", "DemuxSums/DemSumHtAsym.pdf", 1, 13, 0, 300
+      );
+
+    // plot demux sum Et Asym HF
+    create_plot(
+      hwEtAsymSumHF,
+      emEtAsymSumHF,
+      runNo, dataset, "iE_{T} Asym", "DemuxSums/DemSumEtAsymHF.pdf", 1, 13, 0, 300
+      );
+
+    // plot demux sum Ht Asym HF
+    create_plot(
+      hwHtAsymSumHF,
+      emHtAsymSumHF,
+      runNo, dataset, "iH_{T} Asym", "DemuxSums/DemSumHtAsymHF.pdf", 1, 13, 0, 300
+      );
+
+    
+
+
+
   }
 // ========================= demux sums end ========================
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
@@ -229,6 +229,7 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setJetRegionMask(conf.getParameter<int>("jetRegionMask"));
   m_params_helper.setJetPUSType(conf.getParameter<std::string>("jetPUSType"));
   m_params_helper.setJetBypassPUS(conf.getParameter<unsigned>("jetBypassPUS"));
+  m_params_helper.setJetPUSUseChunkySandwich(conf.getParameter<unsigned>("jetPUSUseChunkySandwich"));
   m_params_helper.setJetCalibrationType(conf.getParameter<std::string>("jetCalibrationType"));
   m_params_helper.setJetCalibrationParams(conf.getParameter<std::vector<double> >("jetCalibrationParams"));
   edm::FileInPath jetCalibrationLUTFile = conf.getParameter<edm::FileInPath>("jetCalibrationLUTFile");

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
@@ -308,6 +308,18 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setEtSumEcalSumCalibrationLUT(*etSumEcalSumCalibrationLUT);
 
   // HI centrality trigger
+  std::vector<double> etSumCentLower = conf.getParameter<std::vector<double>>("etSumCentralityLower");
+  std::vector<double> etSumCentUpper = conf.getParameter<std::vector<double>>("etSumCentralityUpper");
+  if (etSumCentLower.size() == etSumCentUpper.size()){
+    for (unsigned i=0; i<etSumCentLower.size(); ++i) {
+      m_params_helper.setEtSumCentLower(i, etSumCentLower.at(i));
+      m_params_helper.setEtSumCentUpper(i, etSumCentUpper.at(i));
+    }
+  }
+  else {
+    edm::LogError("l1t|calo") << "Inconsistent number of Centrality boundaries" << std::endl;
+  }
+
   edm::FileInPath centralityLUTFile = conf.getParameter<edm::FileInPath>("centralityLUTFile");
   std::ifstream centralityLUTStream(centralityLUTFile.fullPath());
   auto centralityLUT = std::make_shared<LUT>(centralityLUTStream);

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
@@ -315,6 +315,19 @@ L1TCaloStage2ParamsESProducer::L1TCaloStage2ParamsESProducer(const edm::Paramete
   m_params_helper.setEtSumEcalSumCalibrationLUT(*etSumEcalSumCalibrationLUT);
 
   // HI centrality trigger
+  std::vector<double> etSumCentLower = conf.getParameter<std::vector<double>>("etSumCentralityLower");
+  std::vector<double> etSumCentUpper = conf.getParameter<std::vector<double>>("etSumCentralityUpper");
+  if (etSumCentLower.size() == etSumCentUpper.size()){
+    for (unsigned i=0; i<etSumCentLower.size(); ++i) {
+      m_params_helper.setEtSumCentLower(i, etSumCentLower.at(i));
+      m_params_helper.setEtSumCentUpper(i, etSumCentUpper.at(i));
+    }
+  }
+  else {
+    edm::LogError("l1t|calo") << "Inconsistent number of Centrality boundaries" << std::endl;
+  }
+
+  // HI centrality trigger
   edm::FileInPath centralityLUTFile = conf.getParameter<edm::FileInPath>("centralityLUTFile");
   std::ifstream centralityLUTStream(centralityLUTFile.fullPath());
   std::shared_ptr<LUT> centralityLUT( new LUT(centralityLUTStream) );

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
@@ -234,6 +234,7 @@ L1TCaloStage2ParamsESProducer::L1TCaloStage2ParamsESProducer(const edm::Paramete
   m_params_helper.setJetRegionMask(conf.getParameter<int>("jetRegionMask"));
   m_params_helper.setJetPUSType(conf.getParameter<std::string>("jetPUSType"));
   m_params_helper.setJetBypassPUS(conf.getParameter<unsigned>("jetBypassPUS"));
+  m_params_helper.setJetPUSUseChunkySandwich(conf.getParameter<unsigned>("jetPUSUseChunkySandwich"));
   m_params_helper.setJetCalibrationType(conf.getParameter<std::string>("jetCalibrationType"));
   m_params_helper.setJetCalibrationParams(conf.getParameter<std::vector<double> >("jetCalibrationParams"));
   edm::FileInPath jetCalibrationLUTFile = conf.getParameter<edm::FileInPath>("jetCalibrationLUTFile");

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
@@ -651,8 +651,10 @@ namespace l1t {
 
           switch(itr->getType()){
           case l1t::EtSum::EtSumType::kTotalEt:     het_.at(SumET)       ->Fill( itr->hwPt() ); break;
+          case l1t::EtSum::EtSumType::kTotalEtHF:   break;
           case l1t::EtSum::EtSumType::kTotalEtEm:   het_.at(SumETEm)     ->Fill( itr->hwPt() ); break;
           case l1t::EtSum::EtSumType::kTotalHt:     het_.at(SumHT)       ->Fill( itr->hwPt() ); break;
+          case l1t::EtSum::EtSumType::kTotalHtHF:   break;
           case l1t::EtSum::EtSumType::kMissingEt:   het_.at(SumMET)      ->Fill( itr->hwPt() ); hphi_.at(SumMET)  ->Fill( itr->hwPhi() ); break;
           case l1t::EtSum::EtSumType::kMissingEtHF:  het_.at(SumMETHF)     ->Fill( itr->hwPt() ); hphi_.at(SumMETHF) ->Fill( itr->hwPhi() ); break;
           case l1t::EtSum::EtSumType::kMissingHt:   het_.at(SumMHT)      ->Fill( itr->hwPt() ); hphi_.at(SumMHT)  ->Fill( itr->hwPhi() ); break;
@@ -662,13 +664,13 @@ namespace l1t {
           case l1t::EtSum::EtSumType::kMinBiasHFP1: het_.at(MinBiasHFP1) ->Fill( itr->hwPt() ); break;
           case l1t::EtSum::EtSumType::kMinBiasHFM1: het_.at(MinBiasHFM1) ->Fill( itr->hwPt() ); break;
 	  case l1t::EtSum::EtSumType::kTowerCount:  het_.at(SumHITowCount) ->Fill( itr->hwPt() ); break;
-	  case l1t::EtSum::EtSumType::kCentrality:  het_.at(SumCentrality) ->Fill( itr->hwPt() ); break;  
+	  case l1t::EtSum::EtSumType::kCentrality:  het_.at(SumCentrality) ->Fill( itr->hwPt() ); std::cout << "Cent = " << itr->hwPt() << std::endl; break;  
 	  case l1t::EtSum::EtSumType::kAsymEt:      het_.at(SumAsymEt)     ->Fill( itr->hwPt() ); break;
 	  case l1t::EtSum::EtSumType::kAsymHt:      het_.at(SumAsymHt)     ->Fill( itr->hwPt() ); break;
-	  case l1t::EtSum::EtSumType::kAsymEtHF:    het_.at(SumAsymEtHF)   ->Fill( itr->hwPt() ); break;
+	  case l1t::EtSum::EtSumType::kAsymEtHF:    het_.at(SumAsymEtHF)   ->Fill( itr->hwPt() ); std::cout << "Asym = " << itr->hwPt() << std::endl; break;
 	  case l1t::EtSum::EtSumType::kAsymHtHF:    het_.at(SumAsymHtHF)   ->Fill( itr->hwPt() ); break;
 
-          default: std::cout<<"wrong type of demux sum"<<std::endl;
+          default: std::cout<<"wrong type of demux sum: "<< itr->getType() << std::endl;
           }
 
           text << "Sum : " << " type=" << itr->getType() << " BX=" << ibx << " ipt=" << itr->hwPt() << " ieta=" << itr->hwEta() << " iphi=" << itr->hwPhi() << std::endl;

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
@@ -109,7 +109,12 @@ namespace l1t {
       MinBiasHFM0=36,
       MPSumETEm = 37,
       MPSumHITowCount = 38,
-      SumHITowCount = 39
+      SumHITowCount = 39,
+      SumCentrality = 40,
+      SumAsymEt = 41,
+      SumAsymEtHF = 42,
+      SumAsymHt = 43,
+      SumAsymHtHF = 44
     };
     
     std::vector< ObjectType > types_;
@@ -242,6 +247,11 @@ namespace l1t {
     types_.push_back( MinBiasHFM1 );
     types_.push_back( MPSumHITowCount );
     types_.push_back( SumHITowCount );
+    types_.push_back( SumCentrality );
+    types_.push_back( SumAsymEt );
+    types_.push_back( SumAsymEtHF );
+    types_.push_back( SumAsymHt );
+    types_.push_back( SumAsymHtHF );
 
     typeStr_.push_back( "tower" );
     typeStr_.push_back( "cluster" );
@@ -281,6 +291,11 @@ namespace l1t {
     typeStr_.push_back( "minbiashfm1" );
     typeStr_.push_back( "mpsumhitowercount");
     typeStr_.push_back( "sumhitowercount");
+    typeStr_.push_back( "sumcentrality" );
+    typeStr_.push_back( "sumasymet" );
+    typeStr_.push_back( "sumasymethf" );
+    typeStr_.push_back( "sumasymht" );
+    typeStr_.push_back( "sumasymhthf" );
   }
 
 
@@ -647,6 +662,11 @@ namespace l1t {
           case l1t::EtSum::EtSumType::kMinBiasHFP1: het_.at(MinBiasHFP1) ->Fill( itr->hwPt() ); break;
           case l1t::EtSum::EtSumType::kMinBiasHFM1: het_.at(MinBiasHFM1) ->Fill( itr->hwPt() ); break;
 	  case l1t::EtSum::EtSumType::kTowerCount:  het_.at(SumHITowCount) ->Fill( itr->hwPt() ); break;
+	  case l1t::EtSum::EtSumType::kCentrality:  het_.at(SumCentrality) ->Fill( itr->hwPt() ); break;  
+	  case l1t::EtSum::EtSumType::kAsymEt:      het_.at(SumAsymEt)     ->Fill( itr->hwPt() ); break;
+	  case l1t::EtSum::EtSumType::kAsymHt:      het_.at(SumAsymHt)     ->Fill( itr->hwPt() ); break;
+	  case l1t::EtSum::EtSumType::kAsymEtHF:    het_.at(SumAsymEtHF)   ->Fill( itr->hwPt() ); break;
+	  case l1t::EtSum::EtSumType::kAsymHtHF:    het_.at(SumAsymHtHF)   ->Fill( itr->hwPt() ); break;
 
           default: std::cout<<"wrong type of demux sum"<<std::endl;
           }

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
@@ -664,10 +664,10 @@ namespace l1t {
           case l1t::EtSum::EtSumType::kMinBiasHFP1: het_.at(MinBiasHFP1) ->Fill( itr->hwPt() ); break;
           case l1t::EtSum::EtSumType::kMinBiasHFM1: het_.at(MinBiasHFM1) ->Fill( itr->hwPt() ); break;
 	  case l1t::EtSum::EtSumType::kTowerCount:  het_.at(SumHITowCount) ->Fill( itr->hwPt() ); break;
-	  case l1t::EtSum::EtSumType::kCentrality:  het_.at(SumCentrality) ->Fill( itr->hwPt() ); std::cout << "Cent = " << itr->hwPt() << std::endl; break;  
+	  case l1t::EtSum::EtSumType::kCentrality:  het_.at(SumCentrality) ->Fill( itr->hwPt() ); break;  
 	  case l1t::EtSum::EtSumType::kAsymEt:      het_.at(SumAsymEt)     ->Fill( itr->hwPt() ); break;
 	  case l1t::EtSum::EtSumType::kAsymHt:      het_.at(SumAsymHt)     ->Fill( itr->hwPt() ); break;
-	  case l1t::EtSum::EtSumType::kAsymEtHF:    het_.at(SumAsymEtHF)   ->Fill( itr->hwPt() ); std::cout << "Asym = " << itr->hwPt() << std::endl; break;
+	  case l1t::EtSum::EtSumType::kAsymEtHF:    het_.at(SumAsymEtHF)   ->Fill( itr->hwPt() ); break;
 	  case l1t::EtSum::EtSumType::kAsymHtHF:    het_.at(SumAsymHtHF)   ->Fill( itr->hwPt() ); break;
 
           default: std::cout<<"wrong type of demux sum: "<< itr->getType() << std::endl;

--- a/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_cfi.py
@@ -1,0 +1,179 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TCalorimeter.caloParams_cfi import caloParamsSource
+import L1Trigger.L1TCalorimeter.caloParams_cfi
+caloStage2Params = L1Trigger.L1TCalorimeter.caloParams_cfi.caloParams.clone()
+
+# towers
+caloStage2Params.towerLsbH        = cms.double(0.5)
+caloStage2Params.towerLsbE        = cms.double(0.5)
+caloStage2Params.towerLsbSum      = cms.double(0.5)
+caloStage2Params.towerNBitsH      = cms.int32(8)
+caloStage2Params.towerNBitsE      = cms.int32(8)
+caloStage2Params.towerNBitsSum    = cms.int32(9)
+caloStage2Params.towerNBitsRatio  = cms.int32(3)
+caloStage2Params.towerEncoding    = cms.bool(True)
+
+# regions
+caloStage2Params.regionLsb        = cms.double(0.5)
+caloStage2Params.regionPUSType    = cms.string("None")
+caloStage2Params.regionPUSParams  = cms.vdouble()
+
+# EG
+caloStage2Params.egLsb                      = cms.double(0.5)
+caloStage2Params.egEtaCut                   = cms.int32(28)
+caloStage2Params.egSeedThreshold            = cms.double(2.)
+caloStage2Params.egNeighbourThreshold       = cms.double(1.)
+caloStage2Params.egHcalThreshold            = cms.double(0.)
+caloStage2Params.egTrimmingLUTFile          = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egTrimmingLUT_10_v16.01.19.txt")
+caloStage2Params.egMaxHcalEt                = cms.double(0.)
+caloStage2Params.egMaxPtHOverE          = cms.double(128.)
+caloStage2Params.egMaxHOverELUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/HoverEIdentification_0.995_v15.12.23.txt")
+caloStage2Params.egHOverEcutBarrel          = cms.int32(1)
+caloStage2Params.egHOverEcutEndcap          = cms.int32(1)
+caloStage2Params.egBypassExtHOverE          = cms.uint32(1)
+caloStage2Params.egBypassShape              = cms.uint32(1)
+caloStage2Params.egBypassECALFG             = cms.uint32(1)
+
+caloStage2Params.egCompressShapesLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egCompressLUT_v4.txt")
+caloStage2Params.egShapeIdType              = cms.string("compressed")
+caloStage2Params.egShapeIdVersion           = cms.uint32(0)
+caloStage2Params.egShapeIdLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08.txt")#Not used any more in the current emulator version, merged with calibration LUT
+
+caloStage2Params.egPUSType                  = cms.string("None")
+caloStage2Params.egIsolationType            = cms.string("compressed")
+caloStage2Params.egIsoLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/EG_Iso_LUT_04_04_2017.2.txt")
+caloStage2Params.egIsoLUTFile2               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/EG_LoosestIso_2018.2.txt")
+caloStage2Params.egIsoAreaNrTowersEta       = cms.uint32(2)
+caloStage2Params.egIsoAreaNrTowersPhi       = cms.uint32(4)
+caloStage2Params.egIsoVetoNrTowersPhi       = cms.uint32(2)
+#caloStage2Params.egIsoPUEstTowerGranularity = cms.uint32(1)
+#caloStage2Params.egIsoMaxEtaAbsForTowerSum  = cms.uint32(4)
+#caloStage2Params.egIsoMaxEtaAbsForIsoSum    = cms.uint32(27)
+caloStage2Params.egPUSParams                = cms.vdouble(1,4,32) #Isolation window in firmware goes up to abs(ieta)=32 for now
+caloStage2Params.egCalibrationType          = cms.string("compressed")
+caloStage2Params.egCalibrationVersion       = cms.uint32(0)
+#caloStage2Params.egCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/EG_Calibration_LUT_FW_v17.04.04_shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08_correct.txt")
+caloStage2Params.egCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/corrections_Trimming10_compressedieta_compressedE_compressedshape_PANTELIS_v2_NEW_CALIBRATIONS_withShape_v17.04.04.txt")
+
+# Tau
+caloStage2Params.tauLsb                        = cms.double(0.5)
+caloStage2Params.isoTauEtaMax                  = cms.int32(25)
+caloStage2Params.tauSeedThreshold              = cms.double(0.)
+caloStage2Params.tauNeighbourThreshold         = cms.double(0.)
+caloStage2Params.tauIsoAreaNrTowersEta         = cms.uint32(2)
+caloStage2Params.tauIsoAreaNrTowersPhi         = cms.uint32(4)
+caloStage2Params.tauIsoVetoNrTowersPhi         = cms.uint32(2)
+caloStage2Params.tauPUSType                    = cms.string("None")
+caloStage2Params.tauIsoLUTFile                 = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_22_2017_FW_v9.0.0.txt")
+caloStage2Params.tauIsoLUTFile2                = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_22_2017_FW_v9.0.0.txt")
+#caloStage2Params.tauCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Calibration_LUT_2017_Layer1Calibration_FW_v12.0.0.txt")
+caloStage2Params.tauCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Calibration_LUT_2018_Layer1CalibrationNewHCAL_FW_v13.0.0.txt")
+caloStage2Params.tauCompressLUTFile            = cms.FileInPath("L1Trigger/L1TCalorimeter/data/tauCompressAllLUT_12bit_v3.txt")
+caloStage2Params.tauPUSParams                  = cms.vdouble(1,4,32)
+
+# jets
+caloStage2Params.jetLsb                = cms.double(0.5)
+caloStage2Params.jetSeedThreshold      = cms.double(4.0)
+caloStage2Params.jetNeighbourThreshold = cms.double(0.)
+caloStage2Params.jetPUSType            = cms.string("ChunkySandwich")
+caloStage2Params.jetPUSUseChunkySandwich = cms.uint32(True)
+caloStage2Params.jetBypassPUS          = cms.uint32(0)
+
+# Calibration options
+caloStage2Params.jetCalibrationType = cms.string("LUT")
+
+caloStage2Params.jetCompressPtLUTFile     = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_pt_compress_2017v1.txt")
+caloStage2Params.jetCompressEtaLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_eta_compress_2017v1.txt")
+caloStage2Params.jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_calib_2018v1_ECALZS_noHFJEC.txt")
+
+
+# sums: 0=ET, 1=HT, 2=MET, 3=MHT
+caloStage2Params.etSumLsb                = cms.double(0.5)
+caloStage2Params.etSumEtaMin             = cms.vint32(1, 1, 1, 1, 1)
+caloStage2Params.etSumEtaMax             = cms.vint32(28,  26, 28,  26, 28)
+caloStage2Params.etSumEtThreshold        = cms.vdouble(0.,  30.,  0.,  30., 0.) # only 2nd (HT) and 4th (MHT) values applied
+caloStage2Params.etSumMetPUSType         = cms.string("LUT") # et threshold from this LUT supercedes et threshold in line above
+caloStage2Params.etSumEttPUSType         = cms.string("None")
+caloStage2Params.etSumEcalSumPUSType     = cms.string("None")
+caloStage2Params.etSumBypassMetPUS       = cms.uint32(0)
+caloStage2Params.etSumBypassEttPUS       = cms.uint32(1)
+caloStage2Params.etSumBypassEcalSumPUS    = cms.uint32(1)
+caloStage2Params.etSumXCalibrationType    = cms.string("None")
+caloStage2Params.etSumYCalibrationType    = cms.string("None")
+caloStage2Params.etSumEttCalibrationType  = cms.string("None")
+caloStage2Params.etSumEcalSumCalibrationType = cms.string("None")
+
+caloStage2Params.etSumCentralityLower =   cms.vdouble(16.5,183.5,1460.0,3143.5,5837.0,1.0,1.0,1.0)
+caloStage2Params.etSumCentralityUpper = cms.vdouble(  25.5,230.5,1612.5,3316.0,5965.0,0.0,0.0,0.0)
+
+caloStage2Params.etSumMetPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_2017v7.txt")
+caloStage2Params.etSumEttPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt")
+caloStage2Params.etSumEcalSumPUSLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt")
+caloStage2Params.etSumXCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.etSumYCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.etSumEttCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.etSumEcalSumCalibrationLUTFile   = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+
+
+# Layer 1 SF
+caloStage2Params.layer1ECalScaleETBins = cms.vint32([3, 6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256])
+caloStage2Params.layer1ECalScaleFactors = cms.vdouble([
+        1.128436, 1.102229, 1.128385, 1.127897, 1.142444, 1.115476, 1.104283, 1.124583, 1.115929, 1.115196, 1.130342, 1.127173, 1.130640, 1.125474, 1.126652, 1.143535, 1.148905, 1.309035, 1.156021, 1.292685, 1.314302, 1.327634, 1.341229, 1.364885, 1.411117, 0.000000, 0.000000, 0.000000, 
+        1.128436, 1.102229, 1.128385, 1.127897, 1.142444, 1.115476, 1.104283, 1.124583, 1.115929, 1.115196, 1.130342, 1.127173, 1.130640, 1.125474, 1.126652, 1.143535, 1.148905, 1.309035, 1.156021, 1.292685, 1.314302, 1.327634, 1.341229, 1.364885, 1.411117, 1.432419, 0.000000, 0.000000, 
+        1.078545, 1.072734, 1.075464, 1.081920, 1.078434, 1.072281, 1.079780, 1.082043, 1.094741, 1.074544, 1.082784, 1.084089, 1.086375, 1.099718, 1.092858, 1.092855, 1.105166, 1.256155, 1.126301, 1.215671, 1.226302, 1.268900, 1.281721, 1.310629, 1.356976, 1.386428, 1.220159, 0.000000,  
+        1.052366, 1.053986, 1.055250, 1.051033, 1.055017, 1.062249, 1.059624, 1.065355, 1.062623, 1.054089, 1.060477, 1.074504, 1.075570, 1.078549, 1.071588, 1.080279, 1.078463, 1.211087, 1.103915, 1.186517, 1.194161, 1.234868, 1.250080, 1.274639, 1.327394, 1.362218, 1.161404, 1.062366, 
+        1.044640, 1.043507, 1.046185, 1.042067, 1.042425, 1.044121, 1.050677, 1.051604, 1.046070, 1.040140, 1.052732, 1.055652, 1.057201, 1.062982, 1.059512, 1.054542, 1.063873, 1.189094, 1.091948, 1.165298, 1.177338, 1.213632, 1.223587, 1.259376, 1.312025, 1.330172, 1.160220, 1.059058, 
+        1.032947, 1.033877, 1.036016, 1.036056, 1.037819, 1.036489, 1.040341, 1.035373, 1.042736, 1.030510, 1.039291, 1.043943, 1.051946, 1.049653, 1.045154, 1.048874, 1.043392, 1.146608, 1.083743, 1.161479, 1.164940, 1.197187, 1.229915, 1.238886, 1.289410, 1.344620, 1.078591, 1.051894, 
+        1.025813, 1.028301, 1.026054, 1.032050, 1.029899, 1.032383, 1.033763, 1.034211, 1.033892, 1.023902, 1.034960, 1.039866, 1.039984, 1.042478, 1.041047, 1.044143, 1.038748, 1.146814, 1.069148, 1.134356, 1.147952, 1.175102, 1.202532, 1.234549, 1.285897, 1.280056, 1.055845, 1.050155, 
+        1.025370, 1.024465, 1.023378, 1.024989, 1.026322, 1.025140, 1.026122, 1.028451, 1.029161, 1.020083, 1.031555, 1.032971, 1.036222, 1.042410, 1.038053, 1.036796, 1.037195, 1.123576, 1.071556, 1.129229, 1.129561, 1.170449, 1.190240, 1.218357, 1.270482, 1.302586, 1.047321, 1.049100, 
+        1.018591, 1.019825, 1.020823, 1.019265, 1.021761, 1.021521, 1.024053, 1.024121, 1.024979, 1.015315, 1.026035, 1.028734, 1.030409, 1.031414, 1.030694, 1.033450, 1.035642, 1.103688, 1.066969, 1.117955, 1.135950, 1.163170, 1.180714, 1.228736, 1.254963, 1.307361, 1.047123, 1.047264, 
+        1.017483, 1.016714, 1.018925, 1.017087, 1.020438, 1.018852, 1.020796, 1.022534, 1.023495, 1.013378, 1.024097, 1.026067, 1.029037, 1.030731, 1.028759, 1.032480, 1.034680, 1.101491, 1.069770, 1.110644, 1.129222, 1.147881, 1.176695, 1.219110, 1.253033, 1.308691, 1.040706, 1.046607, 
+        1.015432, 1.014445, 1.016057, 1.014908, 1.019115, 1.016567, 1.020411, 1.019852, 1.020255, 1.010779, 1.023433, 1.023674, 1.027479, 1.027385, 1.027332, 1.027537, 1.029061, 1.091079, 1.063278, 1.108876, 1.122727, 1.171282, 1.172058, 1.211259, 1.245839, 1.303968, 1.033863, 1.047743, 
+        1.014370, 1.013304, 1.013397, 1.014261, 1.013673, 1.013183, 1.018534, 1.016581, 1.017015, 1.008220, 1.019515, 1.021560, 1.024502, 1.025611, 1.025905, 1.025863, 1.027252, 1.085230, 1.063040, 1.112256, 1.116617, 1.140393, 1.159214, 1.191434, 1.240601, 1.268525, 1.033247, 1.042853, 
+        1.010174, 1.009843, 1.011520, 1.011041, 1.012957, 1.009075, 1.013178, 1.013301, 1.015033, 1.005133, 1.017533, 1.018564, 1.020319, 1.022634, 1.022429, 1.022338, 1.025613, 1.077639, 1.057895, 1.107098, 1.111157, 1.136106, 1.161737, 1.179259, 1.232736, 1.290141, 1.018941, 1.014733, 
+        1.000302, 1.007651, 1.000751, 1.007791, 1.008949, 1.005394, 1.009599, 1.010180, 1.010865, 1.001827, 1.012447, 1.015231, 1.019545, 1.020611, 1.022404, 1.019032, 1.023113, 1.065127, 1.054688, 1.102754, 1.106151, 1.125574, 1.134480, 1.180965, 1.231939, 1.277289, 1.018941, 1.014733
+    ])
+
+caloStage2Params.layer1HCalScaleETBins = cms.vint32([6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256])
+caloStage2Params.layer1HCalScaleFactors = cms.vdouble([
+        1.691347, 1.704095, 1.729441, 1.735242, 1.726367, 1.780424, 1.794996, 1.815904, 1.817388, 1.894632, 1.932656, 1.957527, 1.970890, 2.005818, 2.041546, 2.042775, 1.989288, 1.594904, 
+        1.659821, 1.676038, 1.495936, 1.505035, 1.512590, 1.511470, 1.494893, 1.378435, 1.430994, 1.500227, 1.531796, 1.547539, 1.559295, 1.561478, 1.568922, 1.601485, 1.616591, 1.620739, 
+        1.642884, 1.678420, 1.692987, 1.728681, 1.728957, 1.766650, 1.782739, 1.782875, 1.751371, 1.431918, 1.487225, 1.483881, 1.336485, 1.349895, 1.363924, 1.375728, 1.377818, 1.310078, 
+        1.334588, 1.399686, 1.465418, 1.462800, 1.475840, 1.474735, 1.474407, 1.506928, 1.526279, 1.524000, 1.532718, 1.583398, 1.608380, 1.623528, 1.619634, 1.646501, 1.667856, 1.674628, 
+        1.635381, 1.350235, 1.394938, 1.383940, 1.244552, 1.256971, 1.261180, 1.282746, 1.279512, 1.221092, 1.241831, 1.351526, 1.390201, 1.404198, 1.416259, 1.404045, 1.418265, 1.437914, 
+        1.450857, 1.463511, 1.462653, 1.501891, 1.518896, 1.548252, 1.545831, 1.565901, 1.574314, 1.575115, 1.557629, 1.301893, 1.326949, 1.312526, 1.197573, 1.210304, 1.222283, 1.239081, 
+        1.240673, 1.185591, 1.207651, 1.275166, 1.314260, 1.335228, 1.340603, 1.323027, 1.324793, 1.347954, 1.349916, 1.363145, 1.359628, 1.402624, 1.416518, 1.457202, 1.461053, 1.484090, 
+        1.500787, 1.498450, 1.471731, 1.215732, 1.253565, 1.243598, 1.157168, 1.164428, 1.175435, 1.189310, 1.192682, 1.142038, 1.162810, 1.230426, 1.262901, 1.265380, 1.274364, 1.276111, 
+        1.282349, 1.291748, 1.305521, 1.301818, 1.305124, 1.336506, 1.345742, 1.357458, 1.370139, 1.381995, 1.394554, 1.388952, 1.363805, 1.166810, 1.204780, 1.193913, 1.118331, 1.124657, 
+        1.136138, 1.148564, 1.147392, 1.085564, 1.109949, 1.184837, 1.221607, 1.219692, 1.235950, 1.230444, 1.234908, 1.245100, 1.256813, 1.252608, 1.263569, 1.284188, 1.300083, 1.309901, 
+        1.312849, 1.335500, 1.339967, 1.328269, 1.309282, 1.128239, 1.173002, 1.163030, 1.077388, 1.087037, 1.085620, 1.099773, 1.097418, 1.047416, 1.080447, 1.135984, 1.186335, 1.189457, 
+        1.186903, 1.191054, 1.192951, 1.218812, 1.222226, 1.220196, 1.221331, 1.264243, 1.284869, 1.277098, 1.263366, 1.276293, 1.291829, 1.275918, 1.248086, 1.095700, 1.143874, 1.132783, 
+        1.054939, 1.055922, 1.055405, 1.058330, 1.062463, 1.012972, 1.028538, 1.089975, 1.155949, 1.153120, 1.157186, 1.163320, 1.157607, 1.174722, 1.181157, 1.179473, 1.186948, 1.192614, 
+        1.207973, 1.215075, 1.252322, 1.231549, 1.241483, 1.224214, 1.207592, 1.069829, 1.112551, 1.107158, 1.025349, 1.026181, 1.028466, 1.035129, 1.030918, 0.977843, 1.004295, 1.075236, 
+        1.122942, 1.124839, 1.130900, 1.139241, 1.134602, 1.141732, 1.154381, 1.154366, 1.162207, 1.167863, 1.182334, 1.189497, 1.179567, 1.185553, 1.205978, 1.188532, 1.154839, 1.058371, 
+        1.096597, 1.086545, 0.997724, 1.000690, 1.005683, 1.009107, 1.006028, 0.962736, 0.974019, 1.035748, 1.094997, 1.098600, 1.101567, 1.102895, 1.106445, 1.113255, 1.114956, 1.118930, 
+        1.128154, 1.135288, 1.145308, 1.151612, 1.142554, 1.153640, 1.154025, 1.138100, 1.127446, 1.034945, 1.069153, 1.062188, 0.977909, 0.972598, 0.972539, 0.978454, 0.975065, 0.941113, 
+        0.948722, 1.004971, 1.055020, 1.054883, 1.059317, 1.061911, 1.062005, 1.066707, 1.074156, 1.064278, 1.072810, 1.076579, 1.084072, 1.091055, 1.090640, 1.086634, 1.095179, 1.075771, 
+        1.051884, 1.005930, 1.033331, 1.024734, 0.943637, 0.941986, 0.937779, 0.943865, 0.928477, 0.902234, 0.908232, 0.960607, 1.005841, 1.011405, 1.012527, 1.015557, 1.014508, 1.020877, 
+        1.019076, 1.015173, 1.015651, 1.019594, 1.026845, 1.024959, 1.025915, 1.029455, 1.017985, 1.016933, 0.989723, 0.977768, 0.993744, 0.985200, 0.907247, 0.903328, 0.912164, 0.898908, 
+        0.886431, 0.851162, 0.863541, 0.890523
+    ])
+
+caloStage2Params.layer1HFScaleETBins = cms.vint32([6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256])
+
+caloStage2Params.layer1HFScaleFactors = cms.vdouble([
+    1.401648, 1.138462, 1.188641, 1.173580, 1.218745, 1.238716, 1.279351, 1.306353, 1.352201, 1.425513, 1.766435, 1.913788, 
+    1.284459, 1.081785, 1.142576, 1.136715, 1.118770, 1.156336, 1.173606, 1.201886, 1.276473, 1.291960, 1.663819, 1.755983, 
+    1.204911, 1.055869, 1.092000, 1.100584, 1.049183, 1.082497, 1.082629, 1.113835, 1.167107, 1.195128, 1.573579, 1.696511, 
+    1.148313, 1.036986, 1.094283, 1.054889, 1.001794, 1.023684, 1.032747, 1.048416, 1.096110, 1.146655, 1.541076, 1.641335, 
+    1.100579, 1.014459, 1.045712, 1.024446, 0.964075, 0.978100, 0.990507, 1.007612, 1.048333, 1.095952, 1.501771, 1.598874, 
+    1.062801, 0.988340, 1.024694, 0.983528, 0.925067, 0.939920, 0.957879, 0.972375, 1.007824, 1.060773, 1.440472, 1.545380, 
+    1.022108, 0.970880, 1.008919, 0.956236, 0.907449, 0.922011, 0.938728, 0.950612, 0.987919, 1.036760, 1.395258, 1.500256, 
+    0.997997, 0.952793, 0.987330, 0.928038, 0.891417, 0.906300, 0.921343, 0.936786, 0.970373, 1.014640, 1.342585, 1.464742, 
+    0.980560, 0.939970, 0.976677, 0.911275, 0.883970, 0.896411, 0.909605, 0.928250, 0.960889, 1.000147, 1.299124, 1.444636, 
+    0.960950, 0.924990, 0.949128, 0.902849, 0.880957, 0.892083, 0.904219, 0.920509, 0.950512, 0.989206, 1.253466, 1.428955, 
+    0.947099, 0.903350, 0.941550, 0.892063, 0.873377, 0.886352, 0.900072, 0.915840, 0.944985, 0.981827, 1.199814, 1.410339, 
+    0.915085, 0.901126, 0.930501, 0.883655, 0.869623, 0.883995, 0.896408, 0.913637, 0.946368, 0.979263, 1.145768, 1.360238, 
+    0.886918, 0.895145, 0.914478, 0.882066, 0.871161, 0.886831, 0.900315, 0.917568, 0.952193, 0.984897, 1.097738, 1.285041
+    ])

--- a/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
@@ -133,6 +133,8 @@ caloParams = cms.ESProducer(
 
 
     # HI
+    etSumCentralityLower =   cms.vdouble(0,200,400,600,800, 1000,1200,1400),
+    etSumCentralityUpper = cms.vdouble(200,400,600,800,1000,1200,1400,1600),
     centralityNodeVersion = cms.int32(1),
     centralityRegionMask = cms.int32(0),
     minimumBiasThresholds = cms.vint32(0, 0, 0, 0),

--- a/L1Trigger/L1TCalorimeter/python/convertParamsToOnlineFormat.py
+++ b/L1Trigger/L1TCalorimeter/python/convertParamsToOnlineFormat.py
@@ -128,7 +128,8 @@ def getFullListOfParameters(aModule):
       (('mp_jet', 'HT_jetThreshold'),    '8_HtThreshold.mif',           int(aModule.etSumEtThreshold[1] / aModule.etSumLsb.value())),
       (('mp_jet', 'MHT_jetThreshold'),   '9_MHtThreshold.mif',          int(aModule.etSumEtThreshold[3] / aModule.etSumLsb.value())),
       (('mp_jet', 'jetBypassPileUpSub'), 'BypassJetPUS.mif',            bool(aModule.jetBypassPUS.value())),
-      (('mp_jet', 'jetEnergyCalibLUT'),  'L_JetCalibration_11to18.mif', parseOfflineLUTfile(aModule.jetCalibrationLUTFile.value(), 2048))
+      (('mp_jet', 'jetEnergyCalibLUT'),  'L_JetCalibration_11to18.mif', parseOfflineLUTfile(aModule.jetCalibrationLUTFile.value(), 2048)),
+      (('mp_jet', 'jetPUSUseChunkySandwich'), 'SandwichPUS.mif',        bool(aModule.jetPUSUseChunkySandwich.value())),
     ]
 
     result += [

--- a/L1Trigger/L1TCalorimeter/python/convertParamsToOnlineFormat.py
+++ b/L1Trigger/L1TCalorimeter/python/convertParamsToOnlineFormat.py
@@ -104,6 +104,8 @@ def getFullListOfParameters(aModule):
       (('mp_egamma', 'egammaRelaxationThreshold'),  '10_EgRelaxThr.mif',              divideByEgLsb(aModule.egMaxPtHOverE)),
       (('mp_egamma', 'egammaMaxEta'),               'egammaMaxEta.mif',          aModule.egEtaCut.value()),
       (('mp_egamma', 'egammaBypassCuts'),           'BypassEgVeto.mif',               bool(aModule.egBypassEGVetos.value())),
+      (('mp_egamma', 'egammaBypassShape'),          'BypassEgShape.mif',              bool(aModule.egBypassShape.value())),
+      (('mp_egamma', 'egammaBypassEcalFG'),         'BypassEcalFG.mif',               bool(aModule.egBypassECALFG.value())),
       (('mp_egamma', 'egammaHOverECut_iEtaLT15'),   '_RatioCutLt15.mif',              aModule.egHOverEcutBarrel.value()),
       (('mp_egamma', 'egammaHOverECut_iEtaGTEq15'), '_RatioCutGe15.mif',              aModule.egHOverEcutEndcap.value()),
       (('mp_egamma', 'egammaBypassExtendedHOverE'), '_BypassExtHE.mif',               bool(aModule.egBypassExtHOverE)),
@@ -140,7 +142,9 @@ def getFullListOfParameters(aModule):
 
     result += [
       (('demux', 'sdfile'),  None, ''),
-      (('demux', 'algoRev'), None, 0xcafe)
+      (('demux', 'algoRev'), None, 0xcafe),
+      (('demux', 'ET_centralityLowerThresholds'), 'CentralityLowerThrs.mif', [ int(round(loBound / aModule.etSumLsb.value())) for loBound in aModule.etSumCentralityLower.value()]),
+      (('demux', 'ET_centralityUpperThresholds'), 'CentralityUpperThrs.mif', [ int(round(upBound / aModule.etSumLsb.value())) for upBound in aModule.etSumCentralityUpper.value()])
     ]
 
     result = [(a, b, parseOfflineLUTfile(c.value()) if isinstance(c, cms.FileInPath) else c) for a, b, c in result]
@@ -242,8 +246,8 @@ if __name__ == '__main__':
     os.mkdir(args.output_dir)
 
     if args.mif:
-        for fileName, value in getMifParameterMap(six.iteritems(caloParams)):
+        for fileName, value in six.iteritems(getMifParameterMap(caloParams)):
             createMIF(args.output_dir + '/' + fileName, value) 
     else:
-        for fileTag, paramList in getXmlParameterMap(six.iteritems(caloParams)):
+        for fileTag, paramList in six.iteritems(getXmlParameterMap(caloParams)):
             createXML(paramList, 'MainProcessor' if fileTag.startswith('mp') else 'Demux', args.output_dir + '/algo_' + fileTag + '.xml')

--- a/L1Trigger/L1TCalorimeter/python/customiseReEmulateCaloLayer2.py
+++ b/L1Trigger/L1TCalorimeter/python/customiseReEmulateCaloLayer2.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-static_config = 'L1Trigger.L1TCalorimeter.caloParams_2018_v1_3_cfi'
+static_config = 'L1Trigger.L1TCalorimeter.caloParams_2018_v1_4_cfi'
 
 def hwEmulCompHistos(process):
     

--- a/L1Trigger/L1TCalorimeter/python/l1tStage2InputPatternWriter_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/l1tStage2InputPatternWriter_cfi.py
@@ -7,6 +7,6 @@ l1tStage2InputPatternWriter = cms.EDAnalyzer('L1TStage2InputPatternWriter',
     nChanPerQuad   = cms.untracked.uint32(4),
     nQuads         = cms.untracked.uint32(18),
     nHeaderFrames  = cms.untracked.uint32(1),
-    nPayloadFrames = cms.untracked.uint32(39),
-    nClearFrames   = cms.untracked.uint32(6)
+    nPayloadFrames = cms.untracked.uint32(40),
+    nClearFrames   = cms.untracked.uint32(13)
 )

--- a/L1Trigger/L1TCalorimeter/src/CaloTools.cc
+++ b/L1Trigger/L1TCalorimeter/src/CaloTools.cc
@@ -459,9 +459,79 @@ l1t::EtSum l1t::CaloTools::etSumP4MP(l1t::EtSum& etsum) {
 		     etsum.hwQual() );
   
 }
+unsigned int l1t::CaloTools::gloriousDivision( uint32_t aNumerator , uint32_t aDenominator)
+{ 
 
-double l1t::CaloTools::intDivide(int x, unsigned nHigh, unsigned nLow) {
- 
-  return 1.0;
+  static const uint64_t lLut[] = { 0, 
+           16777215, 4194304, 1864135, 1048576, 671089, 466034, 342392, 262144, 207126, 167772, 138655, 116508,  99273,  85598,  74565,
+	 65536,  58053,  51782,  46474,  41943,  38044,  34664,  31715,  29127,  26844,  24818,  23014,  21400,  19949,  18641,  17458,
+	 16384,  15406,  14513,  13696,  12945,  12255,  11619,  11030,  10486,   9980,   9511,   9074,   8666,   8285,   7929,   7595,
+	  7282,   6988,   6711,   6450,   6205,   5973,   5754,   5546,   5350,   5164,   4987,   4820,   4660,   4509,   4365,   4227,
+	  4096,   3971,   3852,   3737,   3628,   3524,   3424,   3328,   3236,   3148,   3064,   2983,   2905,   2830,   2758,   2688,
+	  2621,   2557,   2495,   2435,   2378,   2322,   2268,   2217,   2166,   2118,   2071,   2026,   1982,   1940,   1899,   1859,
+	  1820,   1783,   1747,   1712,   1678,   1645,   1613,   1581,   1551,   1522,   1493,   1465,   1438,   1412,   1387,   1362,
+	  1337,   1314,   1291,   1269,   1247,   1226,   1205,   1185,   1165,   1146,   1127,   1109,   1091,   1074,   1057,   1040,
+	  1024,   1008,    993,    978,    963,    948,    934,    921,    907,    894,    881,    868,    856,    844,    832,    820,
+	   809,    798,    787,    776,    766,    756,    746,    736,    726,    717,    707,    698,    689,    681,    672,    664,
+	   655,    647,    639,    631,    624,    616,    609,    602,    594,    587,    581,    574,    567,    561,    554,    548,
+	   542,    536,    530,    524,    518,    512,    506,    501,    496,    490,    485,    480,    475,    470,    465,    460,
+	   455,    450,    446,    441,    437,    432,    428,    424,    419,    415,    411,    407,    403,    399,    395,    392,
+	   388,    384,    380,    377,    373,    370,    366,    363,    360,    356,    353,    350,    347,    344,    340,    337,
+	   334,    331,    328,    326,    323,    320,    317,    314,    312,    309,    306,    304,    301,    299,    296,    294,
+	   291,    289,    286,    284,    282,    280,    277,    275,    273,    271,    268,    266,    264,    262,    260,    258,
+	   256,    254,    252,    250,    248,    246,    244,    243,    241,    239,    237,    235,    234,    232,    230,    228,
+	   227,    225,    223,    222,    220,    219,    217,    216,    214,    212,    211,    209,    208,    207,    205,    204,
+	   202,    201,    199,    198,    197,    195,    194,    193,    191,    190,    189,    188,    186,    185,    184,    183,
+	   182,    180,    179,    178,    177,    176,    175,    173,    172,    171,    170,    169,    168,    167,    166,    165,
+	   164,    163,    162,    161,    160,    159,    158,    157,    156,    155,    154,    153,    152,    151,    150,    149,
+	   149,    148,    147,    146,    145,    144,    143,    143,    142,    141,    140,    139,    139,    138,    137,    136,
+	   135,    135,    134,    133,    132,    132,    131,    130,    129,    129,    128,    127,    127,    126,    125,    125,
+	   124,    123,    123,    122,    121,    121,    120,    119,    119,    118,    117,    117,    116,    116,    115,    114,
+	   114,    113,    113,    112,    111,    111,    110,    110,    109,    109,    108,    108,    107,    106,    106,    105,
+	   105,    104,    104,    103,    103,    102,    102,    101,    101,    100,    100,     99,     99,     98,     98,     97,
+	    97,     96,     96,     96,     95,     95,     94,     94,     93,     93,     92,     92,     92,     91,     91,     90,
+	    90,     89,     89,     89,     88,     88,     87,     87,     87,     86,     86,     85,     85,     85,     84,     84,
+	    84,     83,     83,     82,     82,     82,     81,     81,     81,     80,     80,     80,     79,     79,     79,     78,
+	    78,     78,     77,     77,     77,     76,     76,     76,     75,     75,     75,     74,     74,     74,     73,     73,
+	    73,     73,     72,     72,     72,     71,     71,     71,     70,     70,     70,     70,     69,     69,     69,     68,
+	    68,     68,     68,     67,     67,     67,     67,     66,     66,     66,     66,     65,     65,     65,     65,     64 };
 
+// Firmware uses 18bit integers - make sure we are in the same range
+  aNumerator &= 0x3FFFF;
+  aDenominator &= 0x3FFFF;  
+  
+// Shift the denominator to optimise the polynomial expansion
+// I limit the shift to half the denominator size in the firmware to save on resources
+  uint32_t lBitShift(0);
+  for( ;lBitShift!=9 ; ++lBitShift )
+  {
+    if ( aDenominator & 0x20000 ) break; // There is a 1 in the MSB
+    aDenominator <<= 1;
+  }
+
+// The magical polynomial expansion Voodoo
+  uint64_t lInverseDenominator( ( ( aDenominator & 0x3FE00 ) - ( aDenominator & 0x001FF ) ) * ( lLut[ aDenominator >> 9 ] ) );
+
+// Save on DSPs by throwing away a bunch of LSBs
+  lInverseDenominator >>= 17;
+
+// Multiply the numerator by the inverse denominator
+  uint64_t lResult( aNumerator * lInverseDenominator );
+
+// Add two bits to the result, to make the Voodoo below work (saves us having an if-else on the shift direction)
+  lResult <<= 2;
+
+// Restore the scale by taking into account the bitshift applied above.
+// We are now 18 bit left-shifted, so the 18 LSBs are effectively the fractional part...
+  
+  uint32_t aFractional = ( lResult >>= ( 9 - lBitShift) ) & 0x3FFFF; 
+// ...and the top 18 bits are the integer part
+  
+  // uint32_t aInteger    = ( lResult >>= 18 ) & 0x3FFFF; 
+
+  unsigned int result = aFractional >> 10;
+
+  return result;
+
+// Simples!      
 }

--- a/L1Trigger/L1TCalorimeter/src/CaloTools.cc
+++ b/L1Trigger/L1TCalorimeter/src/CaloTools.cc
@@ -459,3 +459,9 @@ l1t::EtSum l1t::CaloTools::etSumP4MP(l1t::EtSum& etsum) {
 		     etsum.hwQual() );
   
 }
+
+double l1t::CaloTools::intDivide(int x, unsigned nHigh, unsigned nLow) {
+ 
+  return 1.0;
+
+}

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
@@ -24,7 +24,9 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
                                                               std::vector<l1t::EtSum> & outputSums) {
 
   int et(0), etHF(0), etHFOnly(0), etem(0), metx(0), mety(0), metxHF(0), metyHF(0), ht(0), htHF(0), mhtx(0), mhty(0), mhtxHF(0), mhtyHF(0), metPhi(0), metPhiHF(0), mhtPhi(0), mhtPhiHF(0);
-  int etPos(0), etNeg(0), etHFPos(0), etHFNeg(0), htPos(0), htNeg(0), htHFPos(0), htHFNeg(0), asymEt(0), asymEtHF(0), asymHt(0), asymHtHF(0), cent(0);
+  double etPos(0), etNeg(0), etHFPos(0), etHFNeg(0), htPos(0), htNeg(0), htHFPos(0), htHFNeg(0);
+  int cent(0);
+  unsigned int asymEt(0), asymEtHF(0), asymHt(0), asymHtHF(0);
   bool posEt(0), posEtHF(0), posHt(0), posHtHF(0);
   unsigned int met(0), metHF(0), mht(0), mhtHF(0);
   unsigned int mbp0(0), mbm0(0), mbp1(0), mbm1(0);
@@ -144,21 +146,19 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
 
   // calculate centrality
   etHFOnly = abs(etHF - et);
-  std::cout << "et HF = " << etHFOnly << std::endl;
   for(uint i=0; i<8; ++i){
     if(etHFOnly >= (params_->etSumCentLower(i)/params_->towerLsbSum())
        && etHFOnly <= (params_->etSumCentUpper(i)/params_->towerLsbSum())){
       cent |= 1 << i;
-      std::cout << "cent = " << cent << std::endl;
     }
   }
   
   // calculate HI imbalance
-  asymEt   = abs(etPos   - etNeg  ) ; //* l1t::CaloTools::intDivide(et);
-  asymEtHF = abs(etHFPos - etHFNeg) ; //* l1t::CaloTools::intDivide(etHF);
-  asymHt   = abs(htPos   - htNeg  ) ; //* l1t::CaloTools::intDivide(ht);
-  asymHtHF = abs(htHFPos - htHFNeg) ; //* l1t::CaloTools::intDivide(htHF);
-  
+  asymEt   = l1t::CaloTools::gloriousDivision(abs(etPos-etNeg), et);
+  asymEtHF = l1t::CaloTools::gloriousDivision(abs(etHFPos-etHFNeg), etHF);
+  asymHt   = l1t::CaloTools::gloriousDivision(abs(htPos-htNeg), ht);
+  asymHtHF = l1t::CaloTools::gloriousDivision(abs(htHFPos-htHFNeg), htHF);
+
   if (et>0xFFF)   et   = 0xFFF;
   if (etHF>0xFFF) etHF = 0xFFF;
   if (etem>0xFFF) etem = 0xFFF;
@@ -226,9 +226,6 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
   l1t::EtSum htAsym(p4,l1t::EtSum::EtSumType::kAsymHt,asymHt,0,0,0);
   l1t::EtSum htHFAsym(p4,l1t::EtSum::EtSumType::kAsymHtHF,asymHtHF,0,0,0);
   l1t::EtSum centrality(p4,l1t::EtSum::EtSumType::kCentrality,cent,0,0,0);
-
-  std::cout << "Emu cent = " << cent << std::endl;
-  std::cout << "Emu etAsymHF = " << asymEtHF << std::endl;
 
   outputSums.push_back(etSumTotalEt);
   outputSums.push_back(etSumTotalEtHF);

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
@@ -7,7 +7,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "L1Trigger/L1TCalorimeter/interface/Stage2Layer2DemuxSumsAlgoFirmware.h"
-
+#include "L1Trigger/L1TCalorimeter/interface/CaloTools.h"
 #include "L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h"
 
 #include <vector>
@@ -23,7 +23,9 @@ l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::Stage2Layer2DemuxSumsAlgoFirmwareImp
 void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<l1t::EtSum> & inputSums,
                                                               std::vector<l1t::EtSum> & outputSums) {
 
-  int et(0), etem(0), metx(0), mety(0), metxHF(0), metyHF(0), ht(0), mhtx(0), mhty(0), mhtxHF(0), mhtyHF(0), metPhi(0), metPhiHF(0), mhtPhi(0), mhtPhiHF(0);
+  int et(0), etHF(0), etHFOnly(0), etem(0), metx(0), mety(0), metxHF(0), metyHF(0), ht(0), htHF(0), mhtx(0), mhty(0), mhtxHF(0), mhtyHF(0), metPhi(0), metPhiHF(0), mhtPhi(0), mhtPhiHF(0);
+  int etPos(0), etNeg(0), etHFPos(0), etHFNeg(0), htPos(0), htNeg(0), htHFPos(0), htHFNeg(0), asymEt(0), asymEtHF(0), asymHt(0), asymHtHF(0), cent(0);
+  bool posEt(0), posEtHF(0), posHt(0), posHtHF(0);
   unsigned int met(0), metHF(0), mht(0), mhtHF(0);
   unsigned int mbp0(0), mbm0(0), mbp1(0), mbm1(0);
   unsigned int ntow(0);
@@ -36,7 +38,21 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
       switch (eSum.getType()) {
 
       case l1t::EtSum::EtSumType::kTotalEt:
-        et += eSum.hwPt();
+	et += eSum.hwPt();
+	if(posEt) etPos = eSum.hwPt();
+	else {
+	  etNeg = eSum.hwPt();
+	  posEt = true;
+	}
+        break;
+
+      case l1t::EtSum::EtSumType::kTotalEtHF:
+        etHF += eSum.hwPt();
+	if(posEtHF) etHFPos = eSum.hwPt();
+	else {
+	  etHFNeg = eSum.hwPt();
+	  posEtHF = true;
+	}
         break;
 
       case l1t::EtSum::EtSumType::kTotalEtEm:
@@ -55,6 +71,20 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
 
       case l1t::EtSum::EtSumType::kTotalHt:
         ht += eSum.hwPt();
+	if(posHt) htPos = eSum.hwPt();
+	else {
+	  htNeg = eSum.hwPt();
+	  posHt = true;
+	}
+        break;
+
+      case l1t::EtSum::EtSumType::kTotalHtHF:
+        htHF += eSum.hwPt();
+	if(posHtHF) htHFPos = eSum.hwPt();
+	else {
+	  htHFNeg = eSum.hwPt();
+	  posHtHF = true;
+	}
         break;
 
       case l1t::EtSum::EtSumType::kTotalHtx:
@@ -110,13 +140,37 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
       default:
         continue; // Should throw an exception or something?
       }
-    }
+  }
 
+  // calculate centrality
+  etHFOnly = abs(etHF - et);
+  std::cout << "et HF = " << etHFOnly << std::endl;
+  for(uint i=0; i<8; ++i){
+    if(etHFOnly >= (params_->etSumCentLower(i)/params_->towerLsbSum())
+       && etHFOnly <= (params_->etSumCentUpper(i)/params_->towerLsbSum())){
+      cent |= 1 << i;
+      std::cout << "cent = " << cent << std::endl;
+    }
+  }
+  
+  // calculate HI imbalance
+  asymEt   = abs(etPos   - etNeg  ) ; //* l1t::CaloTools::intDivide(et);
+  asymEtHF = abs(etHFPos - etHFNeg) ; //* l1t::CaloTools::intDivide(etHF);
+  asymHt   = abs(htPos   - htNeg  ) ; //* l1t::CaloTools::intDivide(ht);
+  asymHtHF = abs(htHFPos - htHFNeg) ; //* l1t::CaloTools::intDivide(htHF);
   
   if (et>0xFFF)   et   = 0xFFF;
+  if (etHF>0xFFF) etHF = 0xFFF;
   if (etem>0xFFF) etem = 0xFFF;
   if (ht>0xFFF)   ht   = 0xFFF;
-  
+  if (htHF>0xFFF) htHF = 0xFFF;
+
+  if(asymEt   > 0xFF) asymEt   = 0xFF;
+  if(asymEtHF > 0xFF) asymEtHF = 0xFF;
+  if(asymHt   > 0xFF) asymHt   = 0xFF;
+  if(asymHtHF > 0xFF) asymHtHF = 0xFF;
+
+
   //if (mhtx>0xFFF) mhtx = 0xFFF;
   //if (mhty>0xFFF) mhty = 0xFFF;
 
@@ -154,10 +208,12 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
   math::XYZTLorentzVector p4;
 
   l1t::EtSum etSumTotalEt(p4,l1t::EtSum::EtSumType::kTotalEt,et,0,0,0);
+  l1t::EtSum etSumTotalEtHF(p4,l1t::EtSum::EtSumType::kTotalEtHF,etHF,0,0,0);
   l1t::EtSum etSumTotalEtEm(p4,l1t::EtSum::EtSumType::kTotalEtEm,etem,0,0,0);
   l1t::EtSum etSumMissingEt(p4,l1t::EtSum::EtSumType::kMissingEt,met,0,metPhi>>4,0);
   l1t::EtSum etSumMissingEtHF(p4,l1t::EtSum::EtSumType::kMissingEtHF,metHF,0,metPhiHF>>4,0);
   l1t::EtSum htSumht(p4,l1t::EtSum::EtSumType::kTotalHt,ht,0,0,0);
+  l1t::EtSum htSumhtHF(p4,l1t::EtSum::EtSumType::kTotalHtHF,htHF,0,0,0);
   l1t::EtSum htSumMissingHt(p4,l1t::EtSum::EtSumType::kMissingHt,mht,0,mhtPhi>>4,0);
   l1t::EtSum htSumMissingHtHF(p4,l1t::EtSum::EtSumType::kMissingHtHF,mhtHF,0,mhtPhiHF>>4,0);
   l1t::EtSum etSumMinBiasHFP0(p4,l1t::EtSum::EtSumType::kMinBiasHFP0,mbp0,0,0,0);
@@ -165,11 +221,21 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
   l1t::EtSum etSumMinBiasHFP1(p4,l1t::EtSum::EtSumType::kMinBiasHFP1,mbp1,0,0,0);
   l1t::EtSum etSumMinBiasHFM1(p4,l1t::EtSum::EtSumType::kMinBiasHFM1,mbm1,0,0,0);
   l1t::EtSum etSumTowCount(p4,l1t::EtSum::EtSumType::kTowerCount,ntow,0,0,0);
+  l1t::EtSum etAsym(p4,l1t::EtSum::EtSumType::kAsymEt,asymEt,0,0,0);
+  l1t::EtSum etHFAsym(p4,l1t::EtSum::EtSumType::kAsymEtHF,asymEtHF,0,0,0);
+  l1t::EtSum htAsym(p4,l1t::EtSum::EtSumType::kAsymHt,asymHt,0,0,0);
+  l1t::EtSum htHFAsym(p4,l1t::EtSum::EtSumType::kAsymHtHF,asymHtHF,0,0,0);
+  l1t::EtSum centrality(p4,l1t::EtSum::EtSumType::kCentrality,cent,0,0,0);
+
+  std::cout << "Emu cent = " << cent << std::endl;
+  std::cout << "Emu etAsymHF = " << asymEtHF << std::endl;
 
   outputSums.push_back(etSumTotalEt);
+  outputSums.push_back(etSumTotalEtHF);
   outputSums.push_back(etSumTotalEtEm);
   outputSums.push_back(etSumMinBiasHFP0);
   outputSums.push_back(htSumht);
+  outputSums.push_back(htSumhtHF);
   outputSums.push_back(etSumMinBiasHFM0);
   outputSums.push_back(etSumMissingEt);
   outputSums.push_back(etSumMinBiasHFP1);
@@ -178,5 +244,10 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
   outputSums.push_back(etSumMissingEtHF);
   outputSums.push_back(htSumMissingHtHF);
   outputSums.push_back(etSumTowCount);
+  outputSums.push_back(etAsym);
+  outputSums.push_back(etHFAsym);
+  outputSums.push_back(htAsym);
+  outputSums.push_back(htHFAsym);
+  outputSums.push_back(centrality);
 
 }

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
@@ -27,7 +27,7 @@ void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<
   double etPos(0), etNeg(0), etHFPos(0), etHFNeg(0), htPos(0), htNeg(0), htHFPos(0), htHFNeg(0);
   int cent(0);
   unsigned int asymEt(0), asymEtHF(0), asymHt(0), asymHtHF(0);
-  bool posEt(0), posEtHF(0), posHt(0), posHtHF(0);
+  bool posEt(false), posEtHF(false), posHt(false), posHtHF(false);
   unsigned int met(0), metHF(0), mht(0), mhtHF(0);
   unsigned int mbp0(0), mbm0(0), mbp1(0), mbm1(0);
   unsigned int ntow(0);

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
@@ -14,8 +14,8 @@
 #include <algorithm>
 
 
-l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::Stage2Layer2DemuxSumsAlgoFirmwareImp1(CaloParamsHelper const* ) :
-  cordic_(Cordic(144*16,17,8))  // These are the settings in the hardware - should probably make this configurable
+l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::Stage2Layer2DemuxSumsAlgoFirmwareImp1(CaloParamsHelper const* params) :
+  params_(params), cordic_(Cordic(144*16,17,8))  // These are the settings in the hardware - should probably make this configurable
 {
 }
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
@@ -150,7 +150,11 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
 	    CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(CaloTools::kHFEnd) &&
 	    (tower.hwQual() & 0x4) > 0) 
 	  ringMB0 += 1;
-	  
+	if (CaloTools::mpEta(abs(tower.hwEta()))>=CaloTools::mpEta(CaloTools::kHFBegin) &&
+	    CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(CaloTools::kHFEnd) &&
+	    (tower.hwQual() & 0x8) > 0) 
+	  ringMB1 += 1;
+	
         // tower counting 
 	if (tower.hwPt()>nTowThresholdHw_ && CaloTools::mpEta(abs(tower.hwEta()))<=nTowEtaMax_) 
 	  ringNtowers += 1;

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -166,6 +166,11 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::create(const std::vector<l1t::Ca
 		puEt = chunkyDonutPUEstimate(jet, 5, towers);
 		iEt -= puEt;
 	      }
+
+	      if(PUSubMethod.find("ChunkySandwich") != std::string::npos){
+		puEt = chunkySandwichPUEstimate(jet, 5, towers, PUSubMethod);
+		iEt -= puEt;
+	      }
 	    }
 	    
 	    if (iEt<=0) continue;
@@ -337,15 +342,19 @@ int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::donutPUEstimate(int jetEta,
   return 4*( ring[1]+ring[2] ); // This should really be multiplied by 4.5 not 4.
 }
 
-int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & jet, int size, 
-								     const std::vector<l1t::CaloTower> & towers){
- 
+
+std::vector<int> l1t::Stage2Layer2JetAlgorithmFirmwareImp1::getChunkyRing(l1t::Jet & jet, int size, 
+									  const std::vector<l1t::CaloTower> & towers,
+									  const std::string chunkyString)
+{
   int jetPhi = jet.hwPhi();
   int jetEta = CaloTools::mpEta(jet.hwEta());
 
-   // ring is a vector with 4 ring strips, one for each side of the ring
-  // order is PhiUp, PhiDown, EtaUp, EtaDown
-  std::vector<int> ring(4,0);
+  // ring is a vector with 4 or 8 eta or strips, one for each side of the ring in ChunkyDonut, else pure phi
+  int ringSize = 4;
+  if(chunkyString == "ChunkySandwich8") ringSize = 8;
+
+  std::vector<int> ring(ringSize,0);
   
   // number of strips in donut - should make this configurable
   int nStrips = 3;
@@ -358,11 +367,7 @@ int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & 
     while ( iphiUp > CaloTools::kHBHENrPhi )   iphiUp   -= CaloTools::kHBHENrPhi;
     while ( iphiDown < 1 ) iphiDown += CaloTools::kHBHENrPhi;
 
-    int ietaUp   = jetEta + size + stripIt;
-    int ietaDown = jetEta - size - stripIt;
-    if ( jetEta<0 && ietaUp>=0 )   ietaUp   += 1;
-    if ( jetEta>0 && ietaDown<=0 ) ietaDown -= 1;
-    
+    // we will always do phiUp and PhiDown
     // do PhiUp and PhiDown
     for (int ieta=jetEta-size+1; ieta<jetEta+size; ++ieta) {
       
@@ -381,53 +386,103 @@ int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & 
       ring[1] += towEt;
 
     } 
-    
-    // do EtaUp
-    for (int iphi=jetPhi-size+1; iphi<jetPhi+size; ++iphi) {
+
+    //Only consider eta for chunkydonut
+    if(chunkyString == "ChunkyDonut"){
+      int ietaUp   = jetEta + size + stripIt;
+      int ietaDown = jetEta - size - stripIt;
+      if ( jetEta<0 && ietaUp>=0 )   ietaUp   += 1;
+      if ( jetEta>0 && ietaDown<=0 ) ietaDown -= 1;
       
-      if (abs(ietaUp) <= CaloTools::mpEta(CaloTools::kHFEnd)) {    
-        int towPhi = iphi;
-        while ( towPhi > CaloTools::kHBHENrPhi ) towPhi -= CaloTools::kHBHENrPhi;
-        while ( towPhi < 1 ) towPhi += CaloTools::kHBHENrPhi;
-
-        const CaloTower& towEtaUp = CaloTools::getTower(towers, CaloTools::caloEta(ietaUp), towPhi);
-        int towEt = towEtaUp.hwPt();
-        ring[2] += towEt;
-      }
-
-    }
-
-    // do EtaDown
-    for (int iphi=jetPhi-size+1; iphi<jetPhi+size; ++iphi) {
-      
-      if (abs(ietaDown) <= CaloTools::mpEta(CaloTools::kHFEnd)) {
-        int towPhi = iphi;
-        while ( towPhi > CaloTools::kHBHENrPhi ) towPhi -= CaloTools::kHBHENrPhi;
-        while ( towPhi < 1 ) towPhi += CaloTools::kHBHENrPhi;
+      // do EtaUp
+      for (int iphi=jetPhi-size+1; iphi<jetPhi+size; ++iphi) {
 	
-        const CaloTower& towEtaDown = CaloTools::getTower(towers, CaloTools::caloEta(ietaDown), towPhi);
-        int towEt = towEtaDown.hwPt();
-        ring[3] += towEt;
+	if (abs(ietaUp) <= CaloTools::mpEta(CaloTools::kHFEnd)) {    
+	  int towPhi = iphi;
+	  while ( towPhi > CaloTools::kHBHENrPhi ) towPhi -= CaloTools::kHBHENrPhi;
+	  while ( towPhi < 1 ) towPhi += CaloTools::kHBHENrPhi;
+	  
+	  const CaloTower& towEtaUp = CaloTools::getTower(towers, CaloTools::caloEta(ietaUp), towPhi);
+	  int towEt = towEtaUp.hwPt();
+	  ring[2] += towEt;
+	}
       }
-     
-    }     
-    
-    
-  }
-    
-  // for donut subtraction we only use the middle 2 (in energy) ring strips
-  // std::sort(ring.begin(), ring.end(), std::greater<int>());
-  // return ( ring[1]+ring[2] ); 
 
-  // use lowest 3 strips as PU estimate
+      // do EtaDown
+      for (int iphi=jetPhi-size+1; iphi<jetPhi+size; ++iphi) {
+	
+	if (abs(ietaDown) <= CaloTools::mpEta(CaloTools::kHFEnd)) {
+	  int towPhi = iphi;
+	  while ( towPhi > CaloTools::kHBHENrPhi ) towPhi -= CaloTools::kHBHENrPhi;
+	  while ( towPhi < 1 ) towPhi += CaloTools::kHBHENrPhi;
+	  
+	  const CaloTower& towEtaDown = CaloTools::getTower(towers, CaloTools::caloEta(ietaDown), towPhi);
+	  int towEt = towEtaDown.hwPt();
+	  ring[3] += towEt;
+	}	
+      }     
+    }
+    else if(chunkyString == "ChunkySandwich2"){//simplest of the sandwiches - we will just reuse phi flaps
+      for(int i = 0; i < 2; ++i){ring[i+2] = ring[i];}
+    }
+    else if(chunkyString == "ChunkySandwich2Ave" || chunkyString == "ChunkySandwich"){//simplest of the sandwiches - we will just reuse phi flaps
+      ring[2] = ((ring[0] + ring[1]) >> 1); //bitwise, effective div by 2
+      ring[3] = (ring[0] + ring[1]); // just make sure it is >= max val
+    }
+    else if(chunkyString == "ChunkySandwich4" || chunkyString == "ChunkySandwich8"){//Need to calculate two or siz additional phiflaps. Note that ChunkySandwich defaults to ChunkySandwich4 variant
+
+      for(int rI = 0; rI < (ringSize-2)/2; ++rI){
+	int iphiUp2   = jetPhi + size + (stripIt + nStrips*(rI+1));
+	int iphiDown2 = jetPhi - size - (stripIt + nStrips*(rI+1));
+	while ( iphiUp2 > CaloTools::kHBHENrPhi )   iphiUp2   -= CaloTools::kHBHENrPhi;
+	while ( iphiDown2 < 1 ) iphiDown2 += CaloTools::kHBHENrPhi;
+	
+	for (int ieta=jetEta-size+1; ieta<jetEta+size; ++ieta) {	
+	  if (abs(ieta) > CaloTools::mpEta(CaloTools::kHFEnd)) continue;
+	  
+	  int towEta = ieta;
+	  if (jetEta>0 && towEta<=0) towEta-=1;
+	  if (jetEta<0 && towEta>=0) towEta+=1;
+	  
+	  const CaloTower& towPhiUp = CaloTools::getTower(towers, CaloTools::caloEta(towEta), iphiUp2);
+	  int towEt = towPhiUp.hwPt();
+	  ring[2 + rI*2] += towEt;
+	  
+	  const CaloTower& towPhiDown = CaloTools::getTower(towers, CaloTools::caloEta(towEta), iphiDown2);
+	  towEt = towPhiDown.hwPt();
+	  ring[3 + rI*2] += towEt;	
+	}
+      }
+    }    
+  }
+
+  //sort our final ring and return;
   std::sort( ring.begin(), ring.end() );
   
-  for(unsigned int i=0; i<4; ++i) jet.setPUDonutEt(i, (short int) ring[i]);
-
-  return ( ring[0] + ring[1] + ring[2] );
-  
+  return ring;  
 }
 
+
+int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & jet, int size, 
+								     const std::vector<l1t::CaloTower> & towers){
+ 
+   // ring is a vector with 4 ring strips, one for each side of the ring
+  // PhiUp, PhiDown, EtaUp, EtaDown, sorted w/ call to chunkyring
+  std::vector<int> ring = getChunkyRing(jet, size, towers, "ChunkyDonut");
+  for(unsigned int i=0; i<4; ++i) jet.setPUDonutEt(i, (short int) ring[i]);
+  return ( ring[0] + ring[1] + ring[2] );  
+}
+
+//Following example of chunky donut, but considering only phi flaps
+//Useful for simple handling of zeroed ieta strips and for high PU environments like PbPb
+int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkySandwichPUEstimate(l1t::Jet & jet, int size, 
+									const std::vector<l1t::CaloTower> & towers,
+									const std::string chunkySandwichStr){
+  //ring will be handled identically by all variants for now - could consider a different picking w/ ChunkySandwich8, say to exclude a downward fluctuation w/ 1,2,3 from ring, etc.
+  std::vector<int> ring = getChunkyRing(jet, size, towers, chunkySandwichStr);
+  for(unsigned int i=0; i<4; ++i) jet.setPUDonutEt(i, (short int)ring[i]);
+  return (ring[0] + ring[1] + ring[2]);  
+}
 
 
 void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::calibrate(std::vector<l1t::Jet> & jets, int calibThreshold, bool isAllJets) {

--- a/L1Trigger/L1TCalorimeter/test/runCaloLayer2MPFWValidation.py
+++ b/L1Trigger/L1TCalorimeter/test/runCaloLayer2MPFWValidation.py
@@ -115,7 +115,7 @@ process.simCaloStage2Digis.useStaticConfig = True
 process.simCaloStage2Digis.towerToken = cms.InputTag("caloStage2Digis","CaloTower")
 
 # emulator ES
-process.load('L1Trigger.L1TCalorimeter.caloParams_2018_v1_3_cfi')
+process.load('L1Trigger.L1TCalorimeter.caloParams_2018_v1_4_cfi')
 
 # histograms
 process.load('L1Trigger.L1TCalorimeter.l1tStage2CaloAnalyzer_cfi')

--- a/L1Trigger/L1TCalorimeter/test/runEmulator-CaloStage2.py
+++ b/L1Trigger/L1TCalorimeter/test/runEmulator-CaloStage2.py
@@ -122,7 +122,7 @@ process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("ecalDigis:EcalTrigger
 process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag("hcalDigis")
 
 # emulator ES
-process.load('L1Trigger.L1TCalorimeter.caloParams_2018_v1_3_cfi')
+process.load('L1Trigger.L1TCalorimeter.caloParams_2018_v1_4_cfi')
 
 # histograms
 process.load('L1Trigger.L1TCalorimeter.l1tStage2CaloAnalyzer_cfi')

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -37,7 +37,12 @@ namespace L1Analysis
       kTotalHtxHF,
       kTotalHtyHF,
       kMissingHtHF,
-      kTowerCount      
+      kTowerCount,
+      kCentrality,
+      kAsymEt,
+      kAsymHt,
+      kAsymEtHF,
+      kAsymHtHF    
   };
   
   struct L1AnalysisL1UpgradeDataFormat

--- a/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
+++ b/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
@@ -46,7 +46,12 @@ namespace l1t {
 	   layer1HOverE=39,
 	   PUTowerThreshold=40,
 	   tauTrimmingShapeVeto=41,
-	   NUM_CALOPARAMNODES=42
+	   egBypassShapeFlag=42,
+	   egBypassECALFGFlag=43,
+	   egBypassHoEFlag=44,
+	   etSumCentralityLower=45,
+	   etSumCentralityUpper=46,
+	   NUM_CALOPARAMNODES=47
     };
 
     CaloParamsHelperO2O() { pnode_.resize(NUM_CALOPARAMNODES); }
@@ -394,7 +399,30 @@ namespace l1t {
     void setEtSumEttCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumEttCalibration].LUT_ = lut; }
     void setEtSumEcalSumCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumEcalSumCalibration].LUT_ = lut; }
 
-
+    double etSumCentLower(unsigned centClass) const {
+      if (pnode_[etSumCentralityLower].dparams_.size()>centClass)
+	return pnode_[etSumCentralityLower].dparams_.at(centClass);
+      else return 0.;
+    }
+    
+    double etSumCentUpper(unsigned centClass) const {
+      if (pnode_[etSumCentralityUpper].dparams_.size()>centClass)
+	return pnode_[etSumCentralityUpper].dparams_.at(centClass);
+      else return 0.;
+    }
+    
+    void setEtSumCentLower(unsigned centClass, double loBound) {
+      if (pnode_[etSumCentralityLower].dparams_.size()<=centClass) 
+	pnode_[etSumCentralityLower].dparams_.resize(centClass+1);
+      pnode_[etSumCentralityLower].dparams_.at(centClass) = loBound;
+    }
+    
+    void setEtSumCentUpper(unsigned centClass, double upBound) {
+      if (pnode_[etSumCentralityUpper].dparams_.size()<=centClass) 
+	pnode_[etSumCentralityUpper].dparams_.resize(centClass+1);
+      pnode_[etSumCentralityUpper].dparams_.at(centClass) = upBound;
+    }
+    
     // HI centrality
     int centralityRegionMask() const {
       if(pnode_[hiCentrality].version_ == 1)

--- a/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
+++ b/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
@@ -64,7 +64,7 @@ namespace l1t {
     };
     ~CaloParamsHelperO2O() {}
 
-    bool isValidForStage1() {return 1; } 
+    bool isValidForStage1() {return true; } 
     bool isValidForStage2() {return (version_ >= 2); }
 
     L1CaloEtScale emScale() { return emScale_; }

--- a/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
+++ b/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
@@ -51,7 +51,8 @@ namespace l1t {
 	   egBypassHoEFlag=44,
 	   etSumCentralityLower=45,
 	   etSumCentralityUpper=46,
-	   NUM_CALOPARAMNODES=47
+	   jetPUSUseChunkySandwichFlag=47,
+	   NUM_CALOPARAMNODES=48
     };
 
     CaloParamsHelperO2O() { pnode_.resize(NUM_CALOPARAMNODES); }
@@ -294,6 +295,7 @@ namespace l1t {
     }
 
     unsigned jetBypassPUS() const { return pnode_[jetBypassPUSFlag].uparams_[0]; }
+    unsigned jetPUSUseChunkySandwich() const { return pnode_[jetPUSUseChunkySandwichFlag].uparams_[0]; }
 
     std::string jetPUSType() const { return pnode_[jetPUS].type_; }
     std::vector<double> jetPUSParams() { return pnode_[jetPUS].dparams_; }
@@ -322,7 +324,10 @@ namespace l1t {
       pnode_[jetBypassPUSFlag].uparams_.resize(1);
       pnode_[jetBypassPUSFlag].uparams_[0] = flag; 
     }
-    
+    void setJetPUSUseChunkySandwich(unsigned flag) {
+      pnode_[jetPUSUseChunkySandwichFlag].uparams_.resize(1);
+      pnode_[jetPUSUseChunkySandwichFlag].uparams_[0] = flag; 
+    }
     // sums
 
     double etSumLsb() const { return etSumLsb_; }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -126,6 +126,7 @@ std::map<std::string, l1t::Mask>& ) {
   paramsHelper.setTauNeighbourThreshold((conf["leptonTowerThreshold"].getValue<int>())/2);
   paramsHelper.setJetSeedThreshold((conf["jetSeedThreshold"].getValue<int>())/2);
   paramsHelper.setJetBypassPUS(conf["jetBypassPileUpSub"].getValue<bool>());
+  paramsHelper.setJetPUSUseChunkySandwich(conf["jetPUSUseChunkySandwich"].getValue<bool>());
   paramsHelper.setEgBypassEGVetos(conf["egammaBypassCuts"].getValue<bool>());
   paramsHelper.setEgHOverEcutBarrel(conf["egammaHOverECut_iEtaLT15"].getValue<int>());
   paramsHelper.setEgHOverEcutEndcap(conf["egammaHOverECut_iEtaGTEq15"].getValue<int>());


### PR DESCRIPTION
PR 10_3_X

EtSum type algorithms designed for HeavyIon 2018 data taking.
 *  kTowerCount,
 * kCentrality,
 *  kAsymEt,
 *  kAsymHt,
 *  kAsymEtHF,
 *  kAsymHtHF
are implemented in CaloLayer2 subsystem of the L1 trigger.  

Changes are made in the CaloLayer 
 - Unpacker, 
 - Packer, 
 - Emulator, 
 - O2O online producer

This PR does not depend on the updated UTM library, and can be merged independently.

However, this PR is needed merged for a PR on GlobalTrigger (#24570) to be tested, which in turn
also depends on the new UTM library v 0.7.1 (https://github.com/cms-sw/cmsdist/pull/4338).

