### PR TITLE
FWCore/Framework: changes needed for Clang 9.1 on macOS wrapped in ifdef statements.

### DIFF
--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -117,12 +117,7 @@ EventSetupRecordProvider::setDependentProviders(const std::vector< std::shared_p
 
    std::shared_ptr<EventSetupRecordIntervalFinder> old = swapFinder(newFinder);
 
-#ifdef __APPLE
-// Apple Clang strictly enforces c++17 std removal of deprecated function mem_fun
    for(auto const& p: iProviders) { newFinder->addProviderWeAreDependentOn(p); };
-#else
-   for_all(iProviders, std::bind(std::mem_fun(&DependentRecordIntervalFinder::addProviderWeAreDependentOn), &(*newFinder), _1));
-#endif
    //if a finder was already set, add it as a depedency.  This is done to ensure that the IOVs properly change even if the
    // old finder does not update each time a dependent record does change
    if(old.get() != nullptr) {

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "make_shared_noexcept_false.h"
 
 
 
@@ -108,12 +109,7 @@ void
 EventSetupRecordProvider::setDependentProviders(const std::vector< std::shared_ptr<EventSetupRecordProvider> >& iProviders)
 {
    using std::placeholders::_1;
-#ifdef __APPLE__
-// libc++ for Apple Clang does not allow make_shared for a class with a non standard destructor
-   std::shared_ptr<DependentRecordIntervalFinder> newFinder = std::shared_ptr<DependentRecordIntervalFinder>(new DependentRecordIntervalFinder(key()));
-#else
-   std::shared_ptr<DependentRecordIntervalFinder> newFinder = std::make_shared<DependentRecordIntervalFinder>(key());
-#endif
+   std::shared_ptr<DependentRecordIntervalFinder> newFinder = make_shared_noexcept_false<DependentRecordIntervalFinder>(key());
 
    std::shared_ptr<EventSetupRecordIntervalFinder> old = swapFinder(newFinder);
 
@@ -130,12 +126,7 @@ EventSetupRecordProvider::usePreferred(const DataToPreferredProviderMap& iMap)
   using std::placeholders::_1;
   for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper,this,_1,iMap));
   if (1 < multipleFinders_->size()) {
-#ifdef __APPLE__
-// libc++ for Apple Clang does not allow make_shared for a class with a non standard destructor
-     std::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder = std::shared_ptr<IntersectingIOVRecordIntervalFinder>(new IntersectingIOVRecordIntervalFinder(key_));
-#else
-     std::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder = std::make_shared<IntersectingIOVRecordIntervalFinder>(key_);
-#endif
+     std::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder = make_shared_noexcept_false<IntersectingIOVRecordIntervalFinder>(key_);
      intFinder->swapFinders(*multipleFinders_);
      finder_ = intFinder;
   }

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -34,6 +34,7 @@
 #include "FWCore/Utilities/interface/TypeID.h"
 
 
+
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
@@ -44,6 +45,9 @@
 #include <set>
 #include <exception>
 #include <sstream>
+
+#include "make_shared_noexcept_false.h"
+
 
 namespace edm {
 
@@ -81,12 +85,7 @@ namespace edm {
       bool postCalled = false;
       std::shared_ptr<TriggerResultInserter> returnValue;
       try {
-#ifdef __APPLE__
-// libc++ for Apple Clang does not allow make_shared for a class with a non standard destructor
-        maker::ModuleHolderT<TriggerResultInserter> holder(std::shared_ptr<TriggerResultInserter>(new TriggerResultInserter(*trig_pset, iPrealloc.numberOfStreams())),static_cast<Maker const*>(nullptr));
-#else
-        maker::ModuleHolderT<TriggerResultInserter> holder(std::make_shared<TriggerResultInserter>(*trig_pset, iPrealloc.numberOfStreams()),static_cast<Maker const*>(nullptr));
-#endif
+        maker::ModuleHolderT<TriggerResultInserter> holder(make_shared_noexcept_false<TriggerResultInserter>(*trig_pset, iPrealloc.numberOfStreams()),static_cast<Maker const*>(nullptr));
         holder.setModuleDescription(md);
         holder.registerProductsAndCallbacks(&preg);
         returnValue =holder.module();
@@ -137,14 +136,8 @@ namespace edm {
         bool postCalled = false;
 
         try {
-#ifdef __APPLE__
-// libc++ for Apple Clang does not allow make_shared for a class with a non standard destructor
-          maker::ModuleHolderT<T> holder(std::shared_ptr<T>(new T(iPrealloc.numberOfStreams())),
+          maker::ModuleHolderT<T> holder(make_shared_noexcept_false<T>(iPrealloc.numberOfStreams()),
                                          static_cast<Maker const*>(nullptr));
-#else
-          maker::ModuleHolderT<T> holder(std::make_shared<T>(iPrealloc.numberOfStreams()),
-                                         static_cast<Maker const*>(nullptr));
-#endif
           holder.setModuleDescription(md);
           holder.registerProductsAndCallbacks(&preg);
           pathStatusInserters.emplace_back(holder.module());
@@ -484,21 +477,7 @@ namespace edm {
     assert(0<prealloc.numberOfStreams());
     streamSchedules_.reserve(prealloc.numberOfStreams());
     for(unsigned int i=0; i<prealloc.numberOfStreams();++i) {
-#ifdef __APPLE__
-// libc++ for Apple Clang does not allow make_shared for a class with a non standard destructor
-      streamSchedules_.emplace_back(std::shared_ptr<StreamSchedule>( new StreamSchedule(
-        resultsInserter(),
-        pathStatusInserters_,
-        endPathStatusInserters_,
-        moduleRegistry(),
-        proc_pset,tns,prealloc,preg,
-        branchIDListHelper,actions,
-        areg,processConfiguration,
-        !hasSubprocesses,
-        StreamID{i},
-        processContext)));
-#else
-      streamSchedules_.emplace_back(std::make_shared<StreamSchedule>(
+      streamSchedules_.emplace_back(make_shared_noexcept_false<StreamSchedule>(
         resultsInserter(),
         pathStatusInserters_,
         endPathStatusInserters_,
@@ -509,7 +488,6 @@ namespace edm {
         !hasSubprocesses,
         StreamID{i},
         processContext));
-#endif
     }
 
     //TriggerResults are injected automatically by StreamSchedules and are

--- a/FWCore/Framework/src/make_shared_noexcept_false.h
+++ b/FWCore/Framework/src/make_shared_noexcept_false.h
@@ -1,0 +1,16 @@
+#ifndef FWCore_Framework_make_shared_noexcept_false_h
+#define FWCore_Framework_make_shared_noexcept_false_h
+#include <memory>
+namespace edm {
+template<typename T, typename ... Args>
+std::shared_ptr<T> make_shared_noexcept_false(Args&& ... args) {
+#if defined(__APPLE)
+// libc++ from Apple Clang does not allow non-default destructors 
+// in some cases the destructor uses noexcept(false).
+return std::shared_ptr<T>( new T(std::forward<Args>(args)... );
+#else
+return std::make_shared<T>(std::forward<Args>(args)... );
+#endif
+} 
+}
+#endif


### PR DESCRIPTION
On macOS using Clang 9.1 and libc++ the std::make_shared template does not allow a type with a non-default destructor.