### PR TITLE
Add protection for disabled FEDs in the SiStrip packer

### DIFF
--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -13,7 +13,7 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
-#include <vector>
+#include <boost/format.hpp>
 
 namespace sistrip {
 
@@ -25,7 +25,8 @@ namespace sistrip {
     mode_(mode),
     packetCode_(packetCode),
     useFedKey_(useFedKey),
-    bufferGenerator_()
+    bufferGenerator_(),
+    warnings_("DigiToRaw", "[sistrip::DigiToRaw::createFedBuffers_]", edm::isDebugEnabled())
   {
     if ( edm::isDebugEnabled() ) {
       LogDebug("DigiToRaw")
@@ -145,176 +146,178 @@ namespace sistrip {
 	  
 	  //need to construct full object to copy full header
 	  std::unique_ptr<const sistrip::FEDBuffer> fedbuffer;
-	  //std::unique_ptr<const sistrip::FEDBufferBase> bufferBase;
-	  try {
-	    fedbuffer.reset(new sistrip::FEDBuffer(rawfedData.data(),rawfedData.size(),true));
-	    //bufferBase.reset(new sistrip::FEDBufferBase(rawfedData.data(),rawfedData.size()));
-	  } catch (const cms::Exception& e) {
-	    edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
-		      << " Invalid raw data, cannot get buffer..."
-		      << std::endl;
-	  }
-	  
-	  if ( edm::isDebugEnabled() ) {
-	    edm::LogWarning("DigiToRaw")
-	      << "[sistrip::DigiToRaw::createFedBuffers_]"
-	      << " Original header type: " << fedbuffer->headerType();
-	  }
-
-	  bufferGenerator_.setHeaderType(FEDHeaderType::HEADER_TYPE_FULL_DEBUG);
-	  //fedbuffer->headerType());
-	  bufferGenerator_.daqHeader() = fedbuffer->daqHeader();
-	  bufferGenerator_.daqTrailer() = fedbuffer->daqTrailer();
-	  
-	  bufferGenerator_.trackerSpecialHeader() = fedbuffer->trackerSpecialHeader();
-	  bufferGenerator_.setReadoutMode(mode_);
-
-	  if ( edm::isDebugEnabled() ) {
-	    std::ostringstream debugStream;
-	    if(ifed==fed_ids.begin()){  bufferGenerator_.trackerSpecialHeader().print(std::cout); std::cout << std::endl;}
-	    bufferGenerator_.trackerSpecialHeader().print(debugStream);
-	    edm::LogWarning("DigiToRaw")
-	      << "[sistrip::DigiToRaw::createFedBuffers_]"
-	      << " Tracker special header apveAddress: " << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apveAddress())
-	      << " - event type = " << bufferGenerator_.getDAQEventType()
-	      << " - buffer format = " << bufferGenerator_.getBufferFormat() << "\n"
-	      << " - SpecialHeader bufferformat " << bufferGenerator_.trackerSpecialHeader().bufferFormat()
-	      << " - headertype " << bufferGenerator_.trackerSpecialHeader().headerType()
-	      << " - readoutmode " << bufferGenerator_.trackerSpecialHeader().readoutMode()
-	      << " - apvaddrregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apvAddressErrorRegister())
-	      << " - feenabledregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feEnableRegister())
-	      << " - feoverflowregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feOverflowRegister())
-	      << " - statusregister " << bufferGenerator_.trackerSpecialHeader().fedStatusRegister() << "\n"
-	      << " SpecialHeader: " << debugStream.str();
-	  }
-
-	  std::unique_ptr<FEDFEHeader> tempFEHeader(fedbuffer->feHeader()->clone());
-	  FEDFullDebugHeader* fedFeHeader = dynamic_cast<FEDFullDebugHeader*>(tempFEHeader.get());
-	  if ( edm::isDebugEnabled() ) {
-	    std::ostringstream debugStream;
-	    if(ifed==fed_ids.begin()){  std::cout << "FEHeader before transfer: " << std::endl;fedFeHeader->print(std::cout);std::cout  <<std::endl;}
-	    fedFeHeader->print(debugStream);
-	    edm::LogWarning("DigiToRaw")
-	      << "[sistrip::DigiToRaw::createFedBuffers_]"
-	      << " length of original feHeader: " << fedFeHeader->lengthInBytes() << "\n"
-	      << debugStream.str();
-	  }
-          //status registers
-          (bufferGenerator_.feHeader()).setBEStatusRegister(fedFeHeader->beStatusRegister());
-          (bufferGenerator_.feHeader()).setDAQRegister2(fedFeHeader->daqRegister2());
-          (bufferGenerator_.feHeader()).setDAQRegister(fedFeHeader->daqRegister());
-          for(uint8_t iFE=1; iFE<6; iFE++) {
-            (bufferGenerator_.feHeader()).set32BitReservedRegister(iFE,fedFeHeader->get32BitWordFrom(fedFeHeader->feWord(iFE)+10));
-          }
-
-          std::vector<bool> feEnabledVec;
-	  feEnabledVec.resize(FEUNITS_PER_FED,true);
-	  for (uint8_t iFE = 0; iFE < FEUNITS_PER_FED; iFE++) {
-            feEnabledVec[iFE]=fedbuffer->trackerSpecialHeader().feEnabled(iFE);  
-            (bufferGenerator_.feHeader()).setFEUnitMajorityAddress(iFE,fedFeHeader->feUnitMajorityAddress(iFE));
-	    for (uint8_t iFEUnitChannel = 0; iFEUnitChannel < FEDCH_PER_FEUNIT; iFEUnitChannel++) {
-	      (bufferGenerator_.feHeader()).setChannelStatus(iFE,iFEUnitChannel,fedFeHeader->getChannelStatus(iFE,iFEUnitChannel));
-	    }//loop on channels
-	  }//loop on fe units
-          bufferGenerator_.setFEUnitEnables(feEnabledVec);
-
-	  if ( edm::isDebugEnabled() ) {
-	    std::ostringstream debugStream;
-	    if(ifed==fed_ids.begin()){  std::cout << "\nFEHeader after transfer: " << std::endl;bufferGenerator_.feHeader().print(std::cout); std::cout << std::endl;}
-	    bufferGenerator_.feHeader().print(debugStream);
-	    edm::LogWarning("DigiToRaw")
-	      << "[sistrip::DigiToRaw::createFedBuffers_]"
-	      << " length of feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
-	      << debugStream.str();
-	  }
-          auto conns = cabling->fedConnections(*ifed);
-          
-          FEDStripData fedData(dataIsAlready8BitTruncated);
-          
-          
-          for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {
-            
-            // Determine FED key from cabling
-            uint32_t fed_key = ( ( iconn->fedId() & sistrip::invalid_ ) << 16 ) | ( iconn->fedCh() & sistrip::invalid_ );
-            
-            // Determine whether DetId or FED key should be used to index digi containers
-            uint32_t key = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? fed_key : iconn->detId();
-            
-            // Check key is non-zero and valid
-            if ( !key || ( key == sistrip::invalid32_ ) ) { continue; }
-            
-            // Determine APV pair number (needed only when using DetId)
-            uint16_t ipair = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? 0 : iconn->apvPairNumber();
-            
-            FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
-
-            // Find digis for DetID in collection
-            if (!collection.isValid()){
-              if ( edm::isDebugEnabled() ) {
-                edm::LogWarning("DigiToRaw") 
-          	<< "[DigiToRaw::createFedBuffers] " 
-          	<< "digis collection is not valid...";
-              }
-              break;
+          if ( rawfedData.size() == 0 ) {
+            warnings_.add("Invalid raw data for FED, skipping", (boost::format("id %1%") % *ifed).str());
+          } else {
+            try {
+              fedbuffer.reset(new sistrip::FEDBuffer(rawfedData.data(),rawfedData.size(),true));
+            } catch (const cms::Exception& e) {
+              edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
+                        << " Could not construct FEDBuffer for FED " << *ifed
+                        << std::endl;
             }
-            typename std::vector< edm::DetSet<Digi_t> >::const_iterator digis = collection->find( key );
-            if (digis == collection->end()) { continue; } 
+            
+            if ( edm::isDebugEnabled() ) {
+              edm::LogWarning("DigiToRaw")
+                << "[sistrip::DigiToRaw::createFedBuffers_]"
+                << " Original header type: " << fedbuffer->headerType();
+            }
 
-            typename edm::DetSet<Digi_t>::const_iterator idigi, digis_begin(digis->data.begin());
-            for ( idigi = digis_begin; idigi != digis->data.end(); idigi++ ) {
+            bufferGenerator_.setHeaderType(FEDHeaderType::HEADER_TYPE_FULL_DEBUG);
+            //fedbuffer->headerType());
+            bufferGenerator_.daqHeader() = fedbuffer->daqHeader();
+            bufferGenerator_.daqTrailer() = fedbuffer->daqTrailer();
+            
+            bufferGenerator_.trackerSpecialHeader() = fedbuffer->trackerSpecialHeader();
+            bufferGenerator_.setReadoutMode(mode_);
+
+            if ( edm::isDebugEnabled() ) {
+              std::ostringstream debugStream;
+              if(ifed==fed_ids.begin()){  bufferGenerator_.trackerSpecialHeader().print(std::cout); std::cout << std::endl;}
+              bufferGenerator_.trackerSpecialHeader().print(debugStream);
+              edm::LogWarning("DigiToRaw")
+                << "[sistrip::DigiToRaw::createFedBuffers_]"
+                << " Tracker special header apveAddress: " << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apveAddress())
+                << " - event type = " << bufferGenerator_.getDAQEventType()
+                << " - buffer format = " << bufferGenerator_.getBufferFormat() << "\n"
+                << " - SpecialHeader bufferformat " << bufferGenerator_.trackerSpecialHeader().bufferFormat()
+                << " - headertype " << bufferGenerator_.trackerSpecialHeader().headerType()
+                << " - readoutmode " << bufferGenerator_.trackerSpecialHeader().readoutMode()
+                << " - apvaddrregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apvAddressErrorRegister())
+                << " - feenabledregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feEnableRegister())
+                << " - feoverflowregister " << std::hex << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feOverflowRegister())
+                << " - statusregister " << bufferGenerator_.trackerSpecialHeader().fedStatusRegister() << "\n"
+                << " SpecialHeader: " << debugStream.str();
+            }
+
+            std::unique_ptr<FEDFEHeader> tempFEHeader(fedbuffer->feHeader()->clone());
+            FEDFullDebugHeader* fedFeHeader = dynamic_cast<FEDFullDebugHeader*>(tempFEHeader.get());
+            if ( edm::isDebugEnabled() ) {
+              std::ostringstream debugStream;
+              if(ifed==fed_ids.begin()){  std::cout << "FEHeader before transfer: " << std::endl;fedFeHeader->print(std::cout);std::cout  <<std::endl;}
+              fedFeHeader->print(debugStream);
+              edm::LogWarning("DigiToRaw")
+                << "[sistrip::DigiToRaw::createFedBuffers_]"
+                << " length of original feHeader: " << fedFeHeader->lengthInBytes() << "\n"
+                << debugStream.str();
+            }
+            //status registers
+            (bufferGenerator_.feHeader()).setBEStatusRegister(fedFeHeader->beStatusRegister());
+            (bufferGenerator_.feHeader()).setDAQRegister2(fedFeHeader->daqRegister2());
+            (bufferGenerator_.feHeader()).setDAQRegister(fedFeHeader->daqRegister());
+            for(uint8_t iFE=1; iFE<6; iFE++) {
+              (bufferGenerator_.feHeader()).set32BitReservedRegister(iFE,fedFeHeader->get32BitWordFrom(fedFeHeader->feWord(iFE)+10));
+            }
+
+            std::vector<bool> feEnabledVec;
+            feEnabledVec.resize(FEUNITS_PER_FED,true);
+            for (uint8_t iFE = 0; iFE < FEUNITS_PER_FED; iFE++) {
+              feEnabledVec[iFE]=fedbuffer->trackerSpecialHeader().feEnabled(iFE);  
+              (bufferGenerator_.feHeader()).setFEUnitMajorityAddress(iFE,fedFeHeader->feUnitMajorityAddress(iFE));
+              for (uint8_t iFEUnitChannel = 0; iFEUnitChannel < FEDCH_PER_FEUNIT; iFEUnitChannel++) {
+                (bufferGenerator_.feHeader()).setChannelStatus(iFE,iFEUnitChannel,fedFeHeader->getChannelStatus(iFE,iFEUnitChannel));
+              }//loop on channels
+            }//loop on fe units
+            bufferGenerator_.setFEUnitEnables(feEnabledVec);
+
+            if ( edm::isDebugEnabled() ) {
+              std::ostringstream debugStream;
+              if(ifed==fed_ids.begin()){  std::cout << "\nFEHeader after transfer: " << std::endl;bufferGenerator_.feHeader().print(std::cout); std::cout << std::endl;}
+              bufferGenerator_.feHeader().print(debugStream);
+              edm::LogWarning("DigiToRaw")
+                << "[sistrip::DigiToRaw::createFedBuffers_]"
+                << " length of feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
+                << debugStream.str();
+            }
+            auto conns = cabling->fedConnections(*ifed);
+            
+            FEDStripData fedData(dataIsAlready8BitTruncated);
+            
+            
+            for (auto iconn = conns.begin() ; iconn != conns.end(); iconn++ ) {
               
-              if ( STRIP(idigi, digis_begin) < ipair*256 ||
-          	 STRIP(idigi, digis_begin) > ipair*256+255 ) { continue; }
-              const unsigned short strip = STRIP(idigi, digis_begin) % 256;
+              // Determine FED key from cabling
+              uint32_t fed_key = ( ( iconn->fedId() & sistrip::invalid_ ) << 16 ) | ( iconn->fedCh() & sistrip::invalid_ );
               
-              if ( strip >= STRIPS_PER_FEDCH ) {
+              // Determine whether DetId or FED key should be used to index digi containers
+              uint32_t key = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? fed_key : iconn->detId();
+              
+              // Check key is non-zero and valid
+              if ( !key || ( key == sistrip::invalid32_ ) ) { continue; }
+              
+              // Determine APV pair number (needed only when using DetId)
+              uint16_t ipair = ( useFedKey_ || mode_ == READOUT_MODE_SCOPE ) ? 0 : iconn->apvPairNumber();
+              
+              FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
+
+              // Find digis for DetID in collection
+              if (!collection.isValid()){
                 if ( edm::isDebugEnabled() ) {
-          	std::stringstream ss;
-          	ss << "[sistrip::DigiToRaw::createFedBuffers]"
-          	   << " strip >= strips_per_fedCh";
-          	edm::LogWarning("DigiToRaw") << ss.str();
+                  edm::LogWarning("DigiToRaw") 
+                  << "[DigiToRaw::createFedBuffers] " 
+                  << "digis collection is not valid...";
                 }
-                continue;
+                break;
               }
-              
-              // check if value already exists
-              if ( edm::isDebugEnabled() ) {
-                const uint16_t value = 0;//chanData[strip];
-                if ( value && value != (*idigi).adc() ) {
-          	std::stringstream ss; 
-          	ss << "[sistrip::DigiToRaw::createFedBuffers]" 
-          	   << " Incompatible ADC values in buffer!"
-          	   << "  FedId/FedCh: " << *ifed << "/" << iconn->fedCh()
-          	   << "  DetStrip: " << STRIP(idigi, digis_begin)
-          	   << "  FedChStrip: " << strip
-          	   << "  AdcValue: " << (*idigi).adc()
-          	   << "  RawData[" << strip << "]: " << value;
-          	edm::LogWarning("DigiToRaw") << ss.str();
-                }
-              }
-              
-              // Add digi to buffer
-              chanData[strip] = (*idigi).adc();
-            }
-          }
-          // if ((*idigi).strip() >= (ipair+1)*256) break;
-          
-          if ( edm::isDebugEnabled() ) {
-            edm::LogWarning("DigiToRaw") 
-              << "DigiToRaw::createFedBuffers] " 
-              << "Almost at the end...";
-          }
-          //create the buffer
-          FEDRawData& fedrawdata = buffers->FEDData( *ifed );
-          bufferGenerator_.generateBuffer(&fedrawdata, fedData, *ifed, packetCode_);
+              typename std::vector< edm::DetSet<Digi_t> >::const_iterator digis = collection->find( key );
+              if (digis == collection->end()) { continue; } 
 
-          if ( edm::isDebugEnabled() ) {
-            std::ostringstream debugStream;
-            bufferGenerator_.feHeader().print(debugStream);
-            edm::LogWarning("DigiToRaw")
-              << "[sistrip::DigiToRaw::createFedBuffers_]"
-              << " length of final feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
-              << debugStream.str();
+              typename edm::DetSet<Digi_t>::const_iterator idigi, digis_begin(digis->data.begin());
+              for ( idigi = digis_begin; idigi != digis->data.end(); idigi++ ) {
+                
+                if ( STRIP(idigi, digis_begin) < ipair*256 ||
+                   STRIP(idigi, digis_begin) > ipair*256+255 ) { continue; }
+                const unsigned short strip = STRIP(idigi, digis_begin) % 256;
+                
+                if ( strip >= STRIPS_PER_FEDCH ) {
+                  if ( edm::isDebugEnabled() ) {
+                  std::stringstream ss;
+                  ss << "[sistrip::DigiToRaw::createFedBuffers]"
+                     << " strip >= strips_per_fedCh";
+                  edm::LogWarning("DigiToRaw") << ss.str();
+                  }
+                  continue;
+                }
+                
+                // check if value already exists
+                if ( edm::isDebugEnabled() ) {
+                  const uint16_t value = 0;//chanData[strip];
+                  if ( value && value != (*idigi).adc() ) {
+                  std::stringstream ss; 
+                  ss << "[sistrip::DigiToRaw::createFedBuffers]" 
+                     << " Incompatible ADC values in buffer!"
+                     << "  FedId/FedCh: " << *ifed << "/" << iconn->fedCh()
+                     << "  DetStrip: " << STRIP(idigi, digis_begin)
+                     << "  FedChStrip: " << strip
+                     << "  AdcValue: " << (*idigi).adc()
+                     << "  RawData[" << strip << "]: " << value;
+                  edm::LogWarning("DigiToRaw") << ss.str();
+                  }
+                }
+                
+                // Add digi to buffer
+                chanData[strip] = (*idigi).adc();
+              }
+            }
+            // if ((*idigi).strip() >= (ipair+1)*256) break;
+            
+            if ( edm::isDebugEnabled() ) {
+              edm::LogWarning("DigiToRaw") 
+                << "DigiToRaw::createFedBuffers] " 
+                << "Almost at the end...";
+            }
+            //create the buffer
+            FEDRawData& fedrawdata = buffers->FEDData( *ifed );
+            bufferGenerator_.generateBuffer(&fedrawdata, fedData, *ifed, packetCode_);
+
+            if ( edm::isDebugEnabled() ) {
+              std::ostringstream debugStream;
+              bufferGenerator_.feHeader().print(debugStream);
+              edm::LogWarning("DigiToRaw")
+                << "[sistrip::DigiToRaw::createFedBuffers_]"
+                << " length of final feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
+                << debugStream.str();
+            }
           }
 	}//loop on fedids
 	if ( edm::isDebugEnabled() ) {

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -21,7 +21,7 @@ namespace sistrip {
   /** */
   DigiToRaw::DigiToRaw( FEDReadoutMode mode,
                         uint8_t packetCode,
-			bool useFedKey ) :
+                        bool useFedKey ) :
     mode_(mode),
     packetCode_(packetCode),
     useFedKey_(useFedKey),
@@ -30,8 +30,8 @@ namespace sistrip {
   {
     if ( edm::isDebugEnabled() ) {
       LogDebug("DigiToRaw")
-	<< "[sistrip::DigiToRaw::DigiToRaw]"
-	<< " Constructing object...";
+        << "[sistrip::DigiToRaw::DigiToRaw]"
+        << " Constructing object...";
     }
     bufferGenerator_.setReadoutMode(mode_);
   }
@@ -41,8 +41,8 @@ namespace sistrip {
   DigiToRaw::~DigiToRaw() {
     if ( edm::isDebugEnabled() ) {
       LogDebug("DigiToRaw")
-	<< "[sistrip::DigiToRaw::~DigiToRaw]"
-	<< " Destructing object...";
+        << "[sistrip::DigiToRaw::~DigiToRaw]"
+        << " Destructing object...";
     }
   }
 
@@ -56,33 +56,33 @@ namespace sistrip {
       buffer to stdout, retrieves data from various header fields
   */
   void DigiToRaw::createFedBuffers( edm::Event& event,
-				    edm::ESHandle<SiStripFedCabling>& cabling,
-				    edm::Handle< edm::DetSetVector<SiStripDigi> >& collection,
-				    std::unique_ptr<FEDRawDataCollection>& buffers ) { 
+                                    edm::ESHandle<SiStripFedCabling>& cabling,
+                                    edm::Handle< edm::DetSetVector<SiStripDigi> >& collection,
+                                    std::unique_ptr<FEDRawDataCollection>& buffers ) {
     createFedBuffers_(event, cabling, collection, buffers, true);
   }
   
   void DigiToRaw::createFedBuffers( edm::Event& event,
-				    edm::ESHandle<SiStripFedCabling>& cabling,
-				    edm::Handle< edm::DetSetVector<SiStripRawDigi> >& collection,
-				    std::unique_ptr<FEDRawDataCollection>& buffers ) { 
+                                    edm::ESHandle<SiStripFedCabling>& cabling,
+                                    edm::Handle< edm::DetSetVector<SiStripRawDigi> >& collection,
+                                    std::unique_ptr<FEDRawDataCollection>& buffers ) {
     createFedBuffers_(event, cabling, collection, buffers, false);
   }
 
   //with copy of headers from initial raw data collection (raw->digi->raw)
   void DigiToRaw::createFedBuffers( edm::Event& event,
-				    edm::ESHandle<SiStripFedCabling>& cabling,
-				    edm::Handle<FEDRawDataCollection> & rawbuffers,
-				    edm::Handle< edm::DetSetVector<SiStripDigi> >& collection,
-				    std::unique_ptr<FEDRawDataCollection>& buffers ) { 
+                                    edm::ESHandle<SiStripFedCabling>& cabling,
+                                    edm::Handle<FEDRawDataCollection> & rawbuffers,
+                                    edm::Handle< edm::DetSetVector<SiStripDigi> >& collection,
+                                    std::unique_ptr<FEDRawDataCollection>& buffers ) {
     createFedBuffers_(event, cabling, rawbuffers, collection, buffers, true);
   }
   
   void DigiToRaw::createFedBuffers( edm::Event& event,
-				    edm::ESHandle<SiStripFedCabling>& cabling,
-				    edm::Handle<FEDRawDataCollection> & rawbuffers,
-				    edm::Handle< edm::DetSetVector<SiStripRawDigi> >& collection,
-				    std::unique_ptr<FEDRawDataCollection>& buffers ) { 
+                                    edm::ESHandle<SiStripFedCabling>& cabling,
+                                    edm::Handle<FEDRawDataCollection> & rawbuffers,
+                                    edm::Handle< edm::DetSetVector<SiStripRawDigi> >& collection,
+                                    std::unique_ptr<FEDRawDataCollection>& buffers ) {
     createFedBuffers_(event, cabling, rawbuffers, collection, buffers, false);
   }
 
@@ -91,10 +91,10 @@ namespace sistrip {
 
   template<class Digi_t>
   void DigiToRaw::createFedBuffers_( edm::Event& event,
-				     edm::ESHandle<SiStripFedCabling>& cabling,
-				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
-				     std::unique_ptr<FEDRawDataCollection>& buffers,
-				     bool zeroSuppressed) {
+                                     edm::ESHandle<SiStripFedCabling>& cabling,
+                                     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
+                                     std::unique_ptr<FEDRawDataCollection>& buffers,
+                                     bool zeroSuppressed) {
 
     edm::Handle<FEDRawDataCollection> rawbuffers;
     //CAMM initialise to some dummy empty buffers??? Or OK like this ?
@@ -104,11 +104,11 @@ namespace sistrip {
 
   template<class Digi_t>
   void DigiToRaw::createFedBuffers_( edm::Event& event,
-				     edm::ESHandle<SiStripFedCabling>& cabling,
-				     edm::Handle<FEDRawDataCollection> & rawbuffers,
-				     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
-				     std::unique_ptr<FEDRawDataCollection>& buffers,
-				     bool zeroSuppressed) {
+                                     edm::ESHandle<SiStripFedCabling>& cabling,
+                                     edm::Handle<FEDRawDataCollection> & rawbuffers,
+                                     edm::Handle< edm::DetSetVector<Digi_t> >& collection,
+                                     std::unique_ptr<FEDRawDataCollection>& buffers,
+                                     bool zeroSuppressed) {
     const bool dataIsAlready8BitTruncated = zeroSuppressed && ( ! (
           //for special mode premix raw, data is zero-suppressed but not converted to 8 bit
              ( mode_ == READOUT_MODE_PREMIX_RAW )
@@ -125,27 +125,27 @@ namespace sistrip {
 
       //copy header if valid rawbuffers handle
       if (rawbuffers.isValid()){
-	if ( edm::isDebugEnabled() ) {
-	  edm::LogWarning("DigiToRaw")
-	    << "[sistrip::DigiToRaw::createFedBuffers_]"
-	    << " Valid raw buffers, getting headers from them..."
-	    << " Number of feds: " << fed_ids.size() << " between "
-	    << *(fed_ids.begin()) << " and " << *(fed_ids.end());
-	}
-	
-	const FEDRawDataCollection& rawDataCollection = *rawbuffers;
+        if ( edm::isDebugEnabled() ) {
+          edm::LogWarning("DigiToRaw")
+            << "[sistrip::DigiToRaw::createFedBuffers_]"
+            << " Valid raw buffers, getting headers from them..."
+            << " Number of feds: " << fed_ids.size() << " between "
+            << *(fed_ids.begin()) << " and " << *(fed_ids.end());
+        }
 
-	for ( auto ifed = fed_ids.begin(); ifed != fed_ids.end(); ++ifed ) {
-	  const FEDRawData& rawfedData = rawDataCollection.FEDData(*ifed);
+        const FEDRawDataCollection& rawDataCollection = *rawbuffers;
 
-	  if ( edm::isDebugEnabled() ) {
-	    edm::LogWarning("DigiToRaw")
-	      << "[sistrip::DigiToRaw::createFedBuffers_]"
-	      << "Fed " << *ifed << " : size of buffer = " << rawfedData.size();
-	  }
-	  
-	  //need to construct full object to copy full header
-	  std::unique_ptr<const sistrip::FEDBuffer> fedbuffer;
+        for ( auto ifed = fed_ids.begin(); ifed != fed_ids.end(); ++ifed ) {
+          const FEDRawData& rawfedData = rawDataCollection.FEDData(*ifed);
+
+          if ( edm::isDebugEnabled() ) {
+            edm::LogWarning("DigiToRaw")
+              << "[sistrip::DigiToRaw::createFedBuffers_]"
+              << "Fed " << *ifed << " : size of buffer = " << rawfedData.size();
+          }
+
+          //need to construct full object to copy full header
+          std::unique_ptr<const sistrip::FEDBuffer> fedbuffer;
           if ( rawfedData.size() == 0 ) {
             warnings_.add("Invalid raw data for FED, skipping", (boost::format("id %1%") % *ifed).str());
           } else {
@@ -156,7 +156,7 @@ namespace sistrip {
                         << " Could not construct FEDBuffer for FED " << *ifed
                         << std::endl;
             }
-            
+
             if ( edm::isDebugEnabled() ) {
               edm::LogWarning("DigiToRaw")
                 << "[sistrip::DigiToRaw::createFedBuffers_]"
@@ -167,7 +167,7 @@ namespace sistrip {
             //fedbuffer->headerType());
             bufferGenerator_.daqHeader() = fedbuffer->daqHeader();
             bufferGenerator_.daqTrailer() = fedbuffer->daqTrailer();
-            
+
             bufferGenerator_.trackerSpecialHeader() = fedbuffer->trackerSpecialHeader();
             bufferGenerator_.setReadoutMode(mode_);
 
@@ -319,12 +319,12 @@ namespace sistrip {
                 << debugStream.str();
             }
           }
-	}//loop on fedids
-	if ( edm::isDebugEnabled() ) {
-	  edm::LogWarning("DigiToRaw")
-	    << "[sistrip::DigiToRaw::createFedBuffers_]"
-	    << "end of first loop on feds";
-	}
+        }//loop on fedids
+        if ( edm::isDebugEnabled() ) {
+          edm::LogWarning("DigiToRaw")
+            << "[sistrip::DigiToRaw::createFedBuffers_]"
+            << "end of first loop on feds";
+        }
 
       }//end of workflow for copying header, below is workflow without copying header
       else{     
@@ -363,8 +363,8 @@ namespace sistrip {
             if (!collection.isValid()){
               if ( edm::isDebugEnabled() ) {
                 edm::LogWarning("DigiToRaw") 
-          	<< "[DigiToRaw::createFedBuffers] " 
-          	<< "digis collection is not valid...";
+                  << "[DigiToRaw::createFedBuffers] "
+                  << "digis collection is not valid...";
               }
               break;
             }
@@ -375,15 +375,15 @@ namespace sistrip {
             for ( idigi = digis_begin; idigi != digis->data.end(); idigi++ ) {
               
               if ( STRIP(idigi, digis_begin) < ipair*256 ||
-          	 STRIP(idigi, digis_begin) > ipair*256+255 ) { continue; }
+                   STRIP(idigi, digis_begin) > ipair*256+255 ) { continue; }
               const unsigned short strip = STRIP(idigi, digis_begin) % 256;
               
               if ( strip >= STRIPS_PER_FEDCH ) {
                 if ( edm::isDebugEnabled() ) {
-          	std::stringstream ss;
-          	ss << "[sistrip::DigiToRaw::createFedBuffers]"
-          	   << " strip >= strips_per_fedCh";
-          	edm::LogWarning("DigiToRaw") << ss.str();
+                  std::stringstream ss;
+                  ss << "[sistrip::DigiToRaw::createFedBuffers]"
+                     << " strip >= strips_per_fedCh";
+                  edm::LogWarning("DigiToRaw") << ss.str();
                 }
                 continue;
               }
@@ -392,15 +392,15 @@ namespace sistrip {
               if ( edm::isDebugEnabled() ) {
                 const uint16_t value = 0;//chanData[strip];
                 if ( value && value != (*idigi).adc() ) {
-          	std::stringstream ss; 
-          	ss << "[sistrip::DigiToRaw::createFedBuffers]" 
-          	   << " Incompatible ADC values in buffer!"
-          	   << "  FedId/FedCh: " << *ifed << "/" << iconn->fedCh()
-          	   << "  DetStrip: " << STRIP(idigi, digis_begin)
-          	   << "  FedChStrip: " << strip
-          	   << "  AdcValue: " << (*idigi).adc()
-          	   << "  RawData[" << strip << "]: " << value;
-          	edm::LogWarning("DigiToRaw") << ss.str();
+                  std::stringstream ss;
+                  ss << "[sistrip::DigiToRaw::createFedBuffers]"
+                     << " Incompatible ADC values in buffer!"
+                     << "  FedId/FedCh: " << *ifed << "/" << iconn->fedCh()
+                     << "  DetStrip: " << STRIP(idigi, digis_begin)
+                     << "  FedChStrip: " << strip
+                     << "  AdcValue: " << (*idigi).adc()
+                     << "  RawData[" << strip << "]: " << value;
+                  edm::LogWarning("DigiToRaw") << ss.str();
                 }
               }
               
@@ -411,8 +411,8 @@ namespace sistrip {
           // if ((*idigi).strip() >= (ipair+1)*256) break;
           
           if ( edm::isDebugEnabled() ) {
-            edm::LogWarning("DigiToRaw") 
-              << "DigiToRaw::createFedBuffers] " 
+            edm::LogWarning("DigiToRaw")
+              << "DigiToRaw::createFedBuffers] "
               << "Almost at the end...";
           }
           //create the buffer
@@ -432,9 +432,9 @@ namespace sistrip {
     }//try
     catch (const std::exception& e) {
       if ( edm::isDebugEnabled() ) {
-	edm::LogWarning("DigiToRaw") 
-	  << "DigiToRaw::createFedBuffers] " 
-	  << "Exception caught : " << e.what();
+        edm::LogWarning("DigiToRaw")
+          << "DigiToRaw::createFedBuffers] "
+          << "Exception caught : " << e.what();
       }
     }
   

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h"
+#include "WarningSummary.h"
 
 class SiStripFedCabling;
 class FEDRawDataCollection;
@@ -56,6 +57,8 @@ namespace sistrip {
     
     inline void fedReadoutMode( FEDReadoutMode mode ) { mode_ = mode; }
 
+    void printWarningSummary() const { warnings_.printSummary(); }
+
   private: // ----- private data members -----
     
     template<class Digi_t>
@@ -82,7 +85,8 @@ namespace sistrip {
     uint8_t packetCode_;
     bool useFedKey_;
     FEDBufferGenerator bufferGenerator_;
-    
+
+    WarningSummary warnings_;
   };
   
 }

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -174,5 +174,9 @@ namespace sistrip {
   
   }
 
+  void DigiToRawModule::endStream()
+  {
+    digiToRaw_->printWarningSummary();
+  }
 }
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -37,6 +37,7 @@ namespace sistrip {
   
     void produce( edm::Event&, const edm::EventSetup& ) override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    void endStream() override;
   
   private:
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -66,33 +66,6 @@ namespace sistrip {
 
   }
 
-  void RawToDigiUnpacker::WarningSummary::add(const std::string& message, const std::string& details)
-  {
-    const auto wIt = std::find_if(std::begin(m_warnings), std::end(m_warnings),
-        [&message] ( const std::pair<std::string,std::size_t>& item ) { return item.first == message; } );
-    if ( std::end(m_warnings) == wIt ) {
-      m_warnings.emplace_back(message, 1);
-      edm::LogWarning(m_category) << message << ": " << details << (m_debug?"":"\nNote: further warnings of this type will be suppressed (this can be changed by enabling debugging printout)");
-    } else {
-      ++(wIt->second);
-      if ( m_debug ) {
-        edm::LogWarning(m_category) << message << ": " << details;
-      }
-    }
-  }
-
-  void RawToDigiUnpacker::WarningSummary::printSummary() const
-  {
-    if ( ! m_warnings.empty() ) {
-      std::stringstream message;
-      message << m_name << " warnings:";
-      for ( const auto& warnAndCount : m_warnings ) {
-        message << std::endl << warnAndCount.first << " (" << warnAndCount.second << ")";
-      }
-      edm::LogWarning(m_category) << message.str();
-    }
-  }
-
   void RawToDigiUnpacker::createDigis( const SiStripFedCabling& cabling, const FEDRawDataCollection& buffers, SiStripEventSummary& summary, RawDigis& scope_mode, RawDigis& virgin_raw, RawDigis& proc_raw, Digis& zero_suppr, DetIdCollection& detids, RawDigis& cm_values ) {
 
     // Clear done at the end

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
@@ -7,10 +7,7 @@
 #include "DataFormats/DetId/interface/DetIdCollection.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h"
-#include "boost/cstdint.hpp"
-#include <iostream>
-#include <string>
-#include <vector>
+#include "WarningSummary.h"
  
 /// sistrip classes
 namespace sistrip { class RawToClustersLazyUnpacker; }
@@ -149,23 +146,6 @@ namespace sistrip {
     std::vector<SiStripRawDigi> proc_work_digis_;
     std::vector<SiStripRawDigi> cm_work_digis_;
 
-    class WarningSummary {
-    public:
-      WarningSummary(const std::string& category, const std::string& name, bool debug=false)
-        : m_debug(debug)
-        , m_category(category)
-        , m_name(name)
-      {}
-
-      void add(const std::string& message, const std::string& details="");
-      void printSummary() const;
-
-    private:
-      bool m_debug;
-      std::string m_category;
-      std::string m_name;
-      std::vector<std::pair<std::string,std::size_t>> m_warnings;
-    };
     WarningSummary warnings_;
   };
 }

--- a/EventFilter/SiStripRawToDigi/plugins/WarningSummary.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/WarningSummary.cc
@@ -3,13 +3,14 @@
 
 #include <algorithm>
 
-void WarningSummary::add(const std::string& message, const std::string& details)
+void sistrip::WarningSummary::add(const std::string& message, const std::string& details)
 {
   const auto wIt = std::find_if(std::begin(m_warnings), std::end(m_warnings),
       [&message] ( const std::pair<std::string,std::size_t>& item ) { return item.first == message; } );
   if ( std::end(m_warnings) == wIt ) {
-    m_warnings.emplace_back(message, 1);
-    edm::LogWarning(m_category) << message << ": " << details << (m_debug?"":"\nNote: further warnings of this type will be suppressed (this can be changed by enabling debugging printout)");
+    m_warnings.emplace(message, 1);
+    edm::LogWarning(m_category) << message << ": " << details << (m_debug?"":
+        "\nNote: further warnings of this type will be suppressed (this can be changed by enabling debugging printout)");
   } else {
     ++(wIt->second);
     if ( m_debug ) {
@@ -18,7 +19,7 @@ void WarningSummary::add(const std::string& message, const std::string& details)
   }
 }
 
-void WarningSummary::printSummary() const
+void sistrip::WarningSummary::printSummary() const
 {
   if ( ! m_warnings.empty() ) {
     std::stringstream message;

--- a/EventFilter/SiStripRawToDigi/plugins/WarningSummary.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/WarningSummary.cc
@@ -1,0 +1,31 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "EventFilter/SiStripRawToDigi/plugins/WarningSummary.h"
+
+#include <algorithm>
+
+void WarningSummary::add(const std::string& message, const std::string& details)
+{
+  const auto wIt = std::find_if(std::begin(m_warnings), std::end(m_warnings),
+      [&message] ( const std::pair<std::string,std::size_t>& item ) { return item.first == message; } );
+  if ( std::end(m_warnings) == wIt ) {
+    m_warnings.emplace_back(message, 1);
+    edm::LogWarning(m_category) << message << ": " << details << (m_debug?"":"\nNote: further warnings of this type will be suppressed (this can be changed by enabling debugging printout)");
+  } else {
+    ++(wIt->second);
+    if ( m_debug ) {
+      edm::LogWarning(m_category) << message << ": " << details;
+    }
+  }
+}
+
+void WarningSummary::printSummary() const
+{
+  if ( ! m_warnings.empty() ) {
+    std::stringstream message;
+    message << m_name << " warnings:";
+    for ( const auto& warnAndCount : m_warnings ) {
+      message << std::endl << warnAndCount.first << " (" << warnAndCount.second << ")";
+    }
+    edm::LogWarning(m_category) << message.str();
+  }
+}

--- a/EventFilter/SiStripRawToDigi/plugins/WarningSummary.h
+++ b/EventFilter/SiStripRawToDigi/plugins/WarningSummary.h
@@ -2,8 +2,9 @@
 #define EventFilter_SiStripRawToDigi_WarningSummary 1
 
 #include <string>
-#include <vector>
+#include <map>
 
+namespace sistrip {
 class WarningSummary {
 public:
   WarningSummary(const std::string& category, const std::string& name, bool debug=false)
@@ -19,6 +20,7 @@ private:
   bool m_debug;
   std::string m_category;
   std::string m_name;
-  std::vector<std::pair<std::string,std::size_t>> m_warnings;
+  std::map<std::string,std::size_t> m_warnings;
 };
+}
 #endif // EventFilter_SiStripRawToDigi_WarningSummary

--- a/EventFilter/SiStripRawToDigi/plugins/WarningSummary.h
+++ b/EventFilter/SiStripRawToDigi/plugins/WarningSummary.h
@@ -1,0 +1,24 @@
+#ifndef EventFilter_SiStripRawToDigi_WarningSummary
+#define EventFilter_SiStripRawToDigi_WarningSummary 1
+
+#include <string>
+#include <vector>
+
+class WarningSummary {
+public:
+  WarningSummary(const std::string& category, const std::string& name, bool debug=false)
+    : m_debug(debug)
+    , m_category(category)
+    , m_name(name)
+  {}
+
+  void add(const std::string& message, const std::string& details="");
+  void printSummary() const;
+
+private:
+  bool m_debug;
+  std::string m_category;
+  std::string m_name;
+  std::vector<std::pair<std::string,std::size_t>> m_warnings;
+};
+#endif // EventFilter_SiStripRawToDigi_WarningSummary


### PR DESCRIPTION
This PR fixes a problem found during the HI rehearsal (the packer tries to copy the FED header without checking that it sent any data, which leads to a segmentation fault at the repacking stage when there are disabled FEDs).
Most of the diff is due to whitespace changes (indentation) and moving the `WarningSummary` helper class (which prints only the first warning and keeps a count afterwards, unless debugging is enabled) from inside `SiStripRawToDigiUnpacker` to `EventFilter/SiStripRawToDigi/plugins`.

CC: @icali @erikbutz @mmusich