### PR TITLE
L1T offline DQM - Run L1T emulator sequences before the DQM modules

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -280,6 +280,16 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #from L1Trigger.L1TCalorimeter.hackConditions_cff import *
 from L1Trigger.L1TGlobal.GlobalParameters_cff import *
 
+# L1T emulator sequences
+from L1Trigger.Configuration.SimL1Emulator_cff import *
+simTwinMuxDigis.RPC_Source = cms.InputTag("muonRPCDigis")
+simOmtfDigis.srcRPC = cms.InputTag("muonRPCDigis")
+simEmtfDigis.CSCInput = cms.InputTag("emtfStage2Digis")
+simEmtfDigis.RPCInput = cms.InputTag("muonRPCDigis")
+# use unpacker calo TPs
+simCaloStage2Layer1Digis.ecalToken = cms.InputTag("ecalDigis","EcalTriggerPrimitives")
+simCaloStage2Layer1Digis.hcalToken = cms.InputTag("hcalDigis")
+
 from DQMOffline.L1Trigger.L1TEtSumJetOffline_cfi import *
 
 from DQMOffline.L1Trigger.L1TEGammaOffline_cfi import *
@@ -348,11 +358,14 @@ Stage2l1TriggerEmulatorOffline = cms.Sequence(
 
 # sequence to run only for modules requiring an electron dataset
 Stage2l1tEgEmulatorOffline = cms.Sequence(
+                                SimL1TCalorimeter +
                                 l1tEGammaOfflineDQMEmu
                                 )
 
 # sequence to run only for modules requiring a muon dataset
 Stage2l1tMuonEmulatorOffline = cms.Sequence(
+                                SimL1TCalorimeter +
+                                SimL1TMuon +
                                 l1tEtSumJetOfflineDQMEmuSeq +
                                 l1tTauOfflineDQMEmu +
                                 l1tMuonDQMOfflineEmu

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -283,6 +283,9 @@ from L1Trigger.L1TGlobal.GlobalParameters_cff import *
 # L1T emulator sequences
 from L1Trigger.Configuration.SimL1Emulator_cff import *
 from L1Trigger.L1TTwinMux.simTwinMuxDigis_cfi import *
+stage2L1Trigger.toModify(simCscTriggerPrimitiveDigis, CSCComparatorDigiProducer = cms.InputTag("muonCSCDigis","MuonCSCComparatorDigi"))
+stage2L1Trigger.toModify(simCscTriggerPrimitiveDigis, CSCWireDigiProducer = cms.InputTag("muonCSCDigis","MuonCSCWireDigi"))
+stage2L1Trigger.toModify(simDtTriggerPrimitiveDigis, digiTag = cms.InputTag("muonDTDigis"))
 simTwinMuxDigis.RPC_Source = cms.InputTag("muonRPCDigis")
 simOmtfDigis.srcRPC = cms.InputTag("muonRPCDigis")
 simEmtfDigis.CSCInput = cms.InputTag("emtfStage2Digis")

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -282,6 +282,7 @@ from L1Trigger.L1TGlobal.GlobalParameters_cff import *
 
 # L1T emulator sequences
 from L1Trigger.Configuration.SimL1Emulator_cff import *
+from L1Trigger.L1TTwinMux.simTwinMuxDigis_cfi import *
 simTwinMuxDigis.RPC_Source = cms.InputTag("muonRPCDigis")
 simOmtfDigis.srcRPC = cms.InputTag("muonRPCDigis")
 simEmtfDigis.CSCInput = cms.InputTag("emtfStage2Digis")


### PR DESCRIPTION
The L1T emulators should run before the offline L1T DQM modules that use them.
This PR places the required sequences in front of the modules.