### PR TITLE
Migrate from boost::optional to std::optional in EventSetup system

### DIFF
--- a/CondTools/SiStrip/plugins/SiStripFedCablingReader.cc
+++ b/CondTools/SiStrip/plugins/SiStripFedCablingReader.cc
@@ -13,7 +13,7 @@
 #include <sstream>
 
 // -----------------------------------------------------------------------------
-// 
+//
 SiStripFedCablingReader::SiStripFedCablingReader( const edm::ParameterSet& pset ) :
   printFecCabling_( pset.getUntrackedParameter<bool>("PrintFecCabling",false) ),
   printDetCabling_( pset.getUntrackedParameter<bool>("PrintDetCabling",false) ),
@@ -21,54 +21,49 @@ SiStripFedCablingReader::SiStripFedCablingReader( const edm::ParameterSet& pset 
 {;}
 
 // -----------------------------------------------------------------------------
-// 
-void SiStripFedCablingReader::beginRun( const edm::Run& run, 
-					const edm::EventSetup& setup ) {
+//
+void SiStripFedCablingReader::beginRun( const edm::Run& run,
+                                        const edm::EventSetup& setup ) {
 
-  edm::eventsetup::EventSetupRecordKey FedRecordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiStripFedCablingRcd"));
-  edm::eventsetup::EventSetupRecordKey FecRecordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiStripFecCablingRcd"));
-  edm::eventsetup::EventSetupRecordKey DetRecordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiStripDetCablingRcd"));
-  edm::eventsetup::EventSetupRecordKey RegRecordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiStripRegionCablingRcd"));
-
-  bool FedRcdfound=setup.find(FedRecordKey) != nullptr?true:false;  
-  bool FecRcdfound=setup.find(FecRecordKey) != nullptr?true:false;  
-  bool DetRcdfound=setup.find(DetRecordKey) != nullptr?true:false;  
-  bool RegRcdfound=setup.find(RegRecordKey) != nullptr?true:false;  
+  auto const fedRec = setup.tryToGet<SiStripFedCablingRcd>();
+  auto const fecRec = setup.tryToGet<SiStripFecCablingRcd>();
+  auto const detRec = setup.tryToGet<SiStripDetCablingRcd>();
+  auto const regRec = setup.tryToGet<SiStripRegionCablingRcd>();
 
   edm::ESHandle<SiStripFedCabling> fed;
-  if(FedRcdfound){
-    edm::LogVerbatim("SiStripFedCablingReader") 
+  if(fedRec){
+    edm::LogVerbatim("SiStripFedCablingReader")
       << "[SiStripFedCablingReader::" << __func__ << "]"
       << " Retrieving FED cabling...";
-    setup.get<SiStripFedCablingRcd>().get( fed ); 
+    fedRec->get( fed );
   }
 
   edm::ESHandle<SiStripFecCabling> fec;
-  if(FecRcdfound){
-    edm::LogVerbatim("SiStripFedCablingReader") 
+  if(fecRec){
+    edm::LogVerbatim("SiStripFedCablingReader")
       << "[SiStripFedCablingReader::" << __func__ << "]"
       << " Retrieving FEC cabling...";
-      setup.get<SiStripFecCablingRcd>().get( fec ); 
+    fecRec->get( fec );
   }
 
   edm::ESHandle<SiStripDetCabling> det;
-  if(DetRcdfound){
-    edm::LogVerbatim("SiStripFedCablingReader") 
+  if(detRec){
+    edm::LogVerbatim("SiStripFedCablingReader")
       << "[SiStripFedCablingReader::" << __func__ << "]"
       << " Retrieving DET cabling...";
-    setup.get<SiStripDetCablingRcd>().get( det ); 
+    detRec->get( det );
   }
 
   edm::ESHandle<SiStripRegionCabling> region;
-  if(RegRcdfound){
-    edm::LogVerbatim("SiStripFedCablingReader") 
+  if(regRec){
+    edm::LogVerbatim("SiStripFedCablingReader")
       << "[SiStripFedCablingReader::" << __func__ << "]"
       << " Retrieving REGION cabling...";
-    setup.get<SiStripRegionCablingRcd>().get( region ); 
+    regRec->get( region );
   }
 
   if ( !fed.isValid() ) {
-    edm::LogError("SiStripFedCablingReader") 
+    edm::LogError("SiStripFedCablingReader")
       << " Invalid handle to FED cabling object: ";
     return;
   }
@@ -77,22 +72,22 @@ void SiStripFedCablingReader::beginRun( const edm::Run& run,
     std::stringstream ss;
     ss << "[SiStripFedCablingReader::" << __func__ << "]"
        << " VERBOSE DEBUG" << std::endl;
-    if(FedRcdfound) {
+    if(fedRec) {
       edm::ESHandle<TrackerTopology> tTopo;
       setup.get<TrackerTopologyRcd>().get(tTopo);
       fed->print(ss, tTopo.product());
     }
     ss << std::endl;
-    if ( FecRcdfound && printFecCabling_ && fec.isValid() ) { fec->print( ss ); }
+    if ( fecRec && printFecCabling_ && fec.isValid() ) { fec->print( ss ); }
     ss << std::endl;
-    if ( DetRcdfound && printDetCabling_ && det.isValid() ) { det->print( ss ); }
+    if ( detRec && printDetCabling_ && det.isValid() ) { det->print( ss ); }
     ss << std::endl;
-    if ( RegRcdfound && printRegionCabling_ && region.isValid() ) { region->print( ss ); }
+    if ( regRec && printRegionCabling_ && region.isValid() ) { region->print( ss ); }
     ss << std::endl;
     edm::LogVerbatim("SiStripFedCablingReader") << ss.str();
   }
-  
-  if(FedRcdfound){
+
+  if(fedRec){
     std::stringstream ss;
     ss << "[SiStripFedCablingReader::" << __func__ << "]"
        << " TERSE DEBUG" << std::endl;
@@ -100,8 +95,8 @@ void SiStripFedCablingReader::beginRun( const edm::Run& run,
     ss << std::endl;
     edm::LogVerbatim("SiStripFedCablingReader") << ss.str();
   }
-  
-  if(FedRcdfound){
+
+  if(fedRec){
     std::stringstream ss;
     ss << "[SiStripFedCablingReader::" << __func__ << "]"
        << " SUMMARY DEBUG" << std::endl;
@@ -111,5 +106,5 @@ void SiStripFedCablingReader::beginRun( const edm::Run& run,
     ss << std::endl;
     edm::LogVerbatim("SiStripFedCablingReader") << ss.str();
   }
-  
+
 }

--- a/DQM/DTMonitorClient/src/DTDAQInfo.cc
+++ b/DQM/DTMonitorClient/src/DTDAQInfo.cc
@@ -1,4 +1,3 @@
-
 /*
  *  See header file for a description of this class.
  *
@@ -77,10 +76,7 @@ DTDAQInfo::~DTDAQInfo() {}
   bookingdone = true; 
   }  //booking done
 
-  // create a record key for RunInfoRcd
-  eventsetup::EventSetupRecordKey recordKey(eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-
-  if(setup.find(recordKey) != nullptr) { 
+  if(auto runInfoRec = setup.tryToGet<RunInfoRcd>()) {
     // reset to 0
     totalDAQFraction->Fill(0.);
     daqFractions[-2]->Fill(0.);
@@ -93,7 +89,7 @@ DTDAQInfo::~DTDAQInfo() {}
     daqMap->Reset();
     //get fed summary information
     ESHandle<RunInfo> sumFED;
-    setup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
     vector<int> fedInIDs = sumFED->m_fed_in;   
 
     // the range of DT feds
@@ -136,7 +132,3 @@ DTDAQInfo::~DTDAQInfo() {}
 }
 
 void DTDAQInfo::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter) {}
-
-
-
-

--- a/DQM/EcalPreshowerMonitorModule/src/ESDaqInfoTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESDaqInfoTask.cc
@@ -130,12 +130,10 @@ void ESDaqInfoTask::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, 
      if ( meESDaqError_ ) meESDaqError_->setBinContent(i, 0.0);
    }
    
-   edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-
-   if( iSetup.find( recordKey ) ) {
+   if(auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
 
       edm::ESHandle<RunInfo> sumFED;
-      iSetup.get<RunInfoRcd>().get(sumFED);    
+      runInfoRec->get(sumFED);
 
       std::vector<int> FedsInIds= sumFED->m_fed_in;   
 

--- a/DQM/HcalCommon/src/DQClient.cc
+++ b/DQM/HcalCommon/src/DQClient.cc
@@ -55,13 +55,10 @@ namespace hcaldqm
 			}
 
 			//	get FEDs registered @cDAQ
-			edm::eventsetup::EventSetupRecordKey recordKey(
-				edm::eventsetup::EventSetupRecordKey::TypeTag::findType(
-					"RunInfoRcd"));
-			if (es.find(recordKey))
+                        if (auto runInfoRec = es.tryToGet<RunInfoRcd>())
 			{
 				edm::ESHandle<RunInfo> ri;
-				es.get<RunInfoRcd>().get(ri);
+                                runInfoRec->get(ri);
 				std::vector<int> vfeds=ri->m_fed_in;
 				for (std::vector<int>::const_iterator it=vfeds.begin();
 					it!=vfeds.end(); ++it)

--- a/DQM/HcalCommon/src/DQHarvester.cc
+++ b/DQM/HcalCommon/src/DQHarvester.cc
@@ -59,13 +59,10 @@ namespace hcaldqm
 			}
 
 			//	get the FEDs registered at cDAQ
-			edm::eventsetup::EventSetupRecordKey recordKey(
-				edm::eventsetup::EventSetupRecordKey::TypeTag::findType(
-				"RunInfoRcd"));
-			if (es.find(recordKey))
+                        if (auto runInfoRec = es.tryToGet<RunInfoRcd>())
 			{
 				edm::ESHandle<RunInfo> ri;
-				es.get<RunInfoRcd>().get(ri);
+                                runInfoRec->get(ri);
 				std::vector<int> vfeds= ri->m_fed_in;
 				for (std::vector<int>::const_iterator it=vfeds.begin();
 					it!=vfeds.end(); ++it)

--- a/DQM/HcalCommon/src/DQTask.cc
+++ b/DQM/HcalCommon/src/DQTask.cc
@@ -1,4 +1,3 @@
-
 #include "DQM/HcalCommon/interface/DQTask.h"
 
 namespace hcaldqm
@@ -46,13 +45,10 @@ namespace hcaldqm
 		//	get the run info FEDs - FEDs registered at cDAQ
 		//	and determine if there are any HCAL FEDs in.
 		//	push them as ElectronicsIds into the vector
-		edm::eventsetup::EventSetupRecordKey recordKey(
-			edm::eventsetup::EventSetupRecordKey::TypeTag::findType(
-			"RunInfoRcd"));
-		if (es.find(recordKey))
+                if (auto runInfoRec = es.tryToGet<RunInfoRcd>())
 		{
 			edm::ESHandle<RunInfo> ri;
-			es.get<RunInfoRcd>().get(ri); 
+                        runInfoRec->get(ri);
 			std::vector<int> vfeds= ri->m_fed_in;
 			for (std::vector<int>::const_iterator it=vfeds.begin();
 				it!=vfeds.end(); ++it)
@@ -225,9 +221,3 @@ namespace hcaldqm
 		return calibType;
 	}
 }
-
-
-
-
-
-

--- a/DQM/RPCMonitorClient/src/RPCDCSSummary.cc
+++ b/DQM/RPCMonitorClient/src/RPCDCSSummary.cc
@@ -49,15 +49,13 @@ void  RPCDCSSummary::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter & 
 
 void  RPCDCSSummary::checkDCSbit( edm::EventSetup const& setup ){
 
- edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-
  defaultValue_ = 1.; 
  
- if(nullptr != setup.find( recordKey ) ) {
+ if(auto runInfoRec = setup.tryToGet<RunInfoRcd>()) {
    defaultValue_ = -1.;
    //get fed summary information
    edm::ESHandle<RunInfo> sumFED;
-   setup.get<RunInfoRcd>().get(sumFED);    
+   runInfoRec->get(sumFED);
    std::vector<int> FedsInIds= sumFED->m_fed_in;   
    unsigned int f = 0;
    bool flag = false;
@@ -149,8 +147,3 @@ void  RPCDCSSummary::myBooker(DQMStore::IBooker & ibooker ){
     dcsDiskFractions[i+2]->Fill(defaultValue_);
   }
 }
-
-
-
-
-

--- a/DQM/RPCMonitorClient/src/RPCDaqInfo.cc
+++ b/DQM/RPCMonitorClient/src/RPCDaqInfo.cc
@@ -24,15 +24,13 @@ RPCDaqInfo::~RPCDaqInfo(){}
 void RPCDaqInfo::beginJob(){}
 void RPCDaqInfo::dqmEndLuminosityBlock(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter, edm::LuminosityBlock const & LB, edm::EventSetup const& iSetup){
   
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-  
   if(!init_){this->myBooker(ibooker);}
 
-  if(nullptr != iSetup.find( recordKey ) ) {
+  if(auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
     
     //get fed summary information
     edm::ESHandle<RunInfo> sumFED;
-    iSetup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
     std::vector<int> FedsInIds= sumFED->m_fed_in;   
 
     int FedCount=0;
@@ -119,7 +117,3 @@ void RPCDaqInfo::myBooker(DQMStore::IBooker & ibooker){
   init_=true;
 
 }
-
-
-
-

--- a/DQM/RPCMonitorClient/src/RPCDataCertification.cc
+++ b/DQM/RPCMonitorClient/src/RPCDataCertification.cc
@@ -47,15 +47,13 @@ void RPCDataCertification::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGet
 
 
 void RPCDataCertification::checkFED(edm::EventSetup const& setup){
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-    
   double defaultValue = 1.;
   
-  if(nullptr != setup.find( recordKey ) ) {
+  if(auto runInfoRec = setup.tryToGet<RunInfoRcd>()) {
       defaultValue = -1;
       //get fed summary information
       edm::ESHandle<RunInfo> sumFED;
-      setup.get<RunInfoRcd>().get(sumFED);    
+      runInfoRec->get(sumFED);
       std::vector<int> FedsInIds= sumFED->m_fed_in;   
       unsigned int f = 0;
       bool flag = false;
@@ -151,18 +149,3 @@ void RPCDataCertification::myBooker(DQMStore::IBooker & ibooker){
       certDiskFractions[i+2]->Fill(defaultValue_);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/DQM/RPCMonitorClient/src/RPCEventSummary.cc
+++ b/DQM/RPCMonitorClient/src/RPCEventSummary.cc
@@ -64,11 +64,11 @@ void RPCEventSummary::dqmEndLuminosityBlock(DQMStore::IBooker & ibooker, DQMStor
     int defaultValue = 1;
     isIn_ = true;
 
-    if(nullptr != setup.find( recordKey ) ) {
+    if(auto runInfoRec = setup.tryToGet<RunInfoRcd>()) {
       defaultValue = -1;
       //get fed summary information
       edm::ESHandle<RunInfo> sumFED;
-      setup.get<RunInfoRcd>().get(sumFED);    
+      runInfoRec->get(sumFED);
       std::vector<int> FedsInIds= sumFED->m_fed_in;   
       unsigned int f = 0;
       isIn_ = false;

--- a/DQM/SiPixelMonitorClient/src/SiPixelDaqInfo.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelDaqInfo.cc
@@ -40,11 +40,10 @@ void SiPixelDaqInfo::dqmEndLuminosityBlock(DQMStore::IBooker & iBooker, DQMStore
     firstLumi = false;
   }
 
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-  if(nullptr != iSetup.find( recordKey ) ) {
+  if(auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
     //get fed summary information
     ESHandle<RunInfo> sumFED;
-    iSetup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
     vector<int> FedsInIds= sumFED->m_fed_in;   
 
     int FedCount=0;

--- a/DQM/SiPixelMonitorClient/src/SiPixelDcsInfo.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelDcsInfo.cc
@@ -23,8 +23,7 @@ void SiPixelDcsInfo::dqmEndLuminosityBlock(DQMStore::IBooker & iBooker, DQMStore
     FractionEndcap_= iBooker.bookFloat("PixelEndcapFraction");  
   }
 
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-  if(nullptr != iSetup.find( recordKey ) ) {
+  if(iSetup.tryToGet<RunInfoRcd>()) {
       //all Pixel:
       Fraction_->Fill(1.);
       //Barrel:

--- a/DQM/SiStripMonitorClient/plugins/SiStripCertificationInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripCertificationInfo.cc
@@ -64,11 +64,10 @@ void SiStripCertificationInfo::beginRun(edm::Run const& run, edm::EventSetup con
   const int siStripFedIdMin = FEDNumbering::MINSiStripFEDID;
   const int siStripFedIdMax = FEDNumbering::MAXSiStripFEDID; 
 
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-  if( eSetup.find( recordKey ) != nullptr) {
+  if(auto runInfoRec = eSetup.tryToGet<RunInfoRcd>()) {
 
     edm::ESHandle<RunInfo> sumFED;
-    eSetup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
     
     if ( sumFED.isValid() ) {
       std::vector<int> FedsInIds= sumFED->m_fed_in;   

--- a/DQM/SiStripMonitorClient/plugins/SiStripDaqInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripDaqInfo.cc
@@ -133,11 +133,10 @@ void SiStripDaqInfo::beginRun(edm::Run const& run, edm::EventSetup const& eSetup
   const int siStripFedIdMin = FEDNumbering::MINSiStripFEDID;
   const int siStripFedIdMax = FEDNumbering::MAXSiStripFEDID; 
 
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-  if( eSetup.find( recordKey ) != nullptr) {
+  if(auto runInfoRec = eSetup.tryToGet<RunInfoRcd>()) {
 
     edm::ESHandle<RunInfo> sumFED;
-    eSetup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
     
     if ( sumFED.isValid() ) {
       std::vector<int> FedsInIds= sumFED->m_fed_in;   

--- a/DQM/SiStripMonitorClient/plugins/SiStripDcsInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripDcsInfo.cc
@@ -107,11 +107,10 @@ void SiStripDcsInfo::beginRun(edm::Run const& run, edm::EventSetup const& eSetup
   const int siStripFedIdMax = FEDNumbering::MAXSiStripFEDID; 
 
   // Count Tracker FEDs from RunInfo
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-  if( eSetup.find( recordKey ) != nullptr) {
+  if(auto runInfoRec = eSetup.tryToGet<RunInfoRcd>()) {
     
     edm::ESHandle<RunInfo> sumFED;
-    eSetup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
     
     if ( sumFED.isValid() ) {
       std::vector<int> FedsInIds= sumFED->m_fed_in;   

--- a/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
@@ -126,11 +126,10 @@ void SiStripOfflineDQM::beginRun(edm::Run const& run, edm::EventSetup const& eSe
   edm::LogInfo ("BeginRun") <<"SiStripOfflineDQM:: Begining of Run";
 
   int nFEDs = 0;
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-  if( eSetup.find( recordKey ) != nullptr) {
+  if(auto runInfoRec = eSetup.tryToGet<RunInfoRcd>()) {
 
     edm::ESHandle<RunInfo> sumFED;
-    eSetup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
     if ( sumFED.isValid() ) {
 
       const int siStripFedIdMin = FEDNumbering::MINSiStripFEDID;

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -243,11 +243,10 @@ void SiStripMonitorDigi::dqmBeginRun(const edm::Run& run, const edm::EventSetup&
     //const int siStripFedIdMin = FEDNumbering::MINSiStripFEDID;
     //const int siStripFedIdMax = FEDNumbering::MAXSiStripFEDID;
 
-    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-    if( es.find( recordKey ) != nullptr) {
+    if(auto runInfoRec = es.tryToGet<RunInfoRcd>()) {
 
       edm::ESHandle<RunInfo> sumFED;
-      es.get<RunInfoRcd>().get(sumFED);
+      runInfoRec->get(sumFED);
 
       if ( sumFED.isValid() ) {
 	std::vector<int> FedsInIds= sumFED->m_fed_in;

--- a/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.cc
+++ b/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.cc
@@ -101,11 +101,12 @@ void TrackingOfflineDQM::beginRun(edm::Run const& run, edm::EventSetup const& eS
 
   int nFEDs = 0;
   int nPixelFEDs = 0;
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-  if( eSetup.find( recordKey ) != nullptr) {
+
+  if(auto runInfoRec = eSetup.tryToGet<RunInfoRcd>()) {
 
     edm::ESHandle<RunInfo> sumFED;
-    eSetup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
+
     if ( sumFED.isValid() ) {
 
       const int siStripFedIdMin = FEDNumbering::MINSiStripFEDID;

--- a/DQM/TrackingMonitorClient/src/TrackingCertificationInfo.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingCertificationInfo.cc
@@ -114,11 +114,10 @@ void TrackingCertificationInfo::beginRun(edm::Run const& run, edm::EventSetup co
   const int siPixelFedIdMax = FEDNumbering::MAXSiPixelFEDID;
   const int siPixelFeds = (siPixelFedIdMax-siPixelFedIdMin+1);
 
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
-  if( eSetup.find( recordKey ) != nullptr) {
+  if(auto runInfoRec = eSetup.tryToGet<RunInfoRcd>()) {
 
     edm::ESHandle<RunInfo> sumFED;
-    eSetup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
     
     if ( sumFED.isValid() ) {
 

--- a/DQMServices/Components/src/DQMDaqInfo.cc
+++ b/DQMServices/Components/src/DQMDaqInfo.cc
@@ -11,10 +11,10 @@ void DQMDaqInfo::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, con
   
   edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
   
-  if( std::nullopt != iSetup.find( recordKey ) ) {
+  if(auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
     
     edm::ESHandle<RunInfo> sumFED;
-    iSetup.get<RunInfoRcd>().get(sumFED);    
+    runInfoRec->get(sumFED);
    
     //const RunInfo* summaryFED=sumFED.product();
   

--- a/DQMServices/Components/src/DQMDaqInfo.cc
+++ b/DQMServices/Components/src/DQMDaqInfo.cc
@@ -11,7 +11,7 @@ void DQMDaqInfo::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, con
   
   edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("RunInfoRcd"));
   
-  if( nullptr != iSetup.find( recordKey ) ) {
+  if( std::nullopt != iSetup.find( recordKey ) ) {
     
     edm::ESHandle<RunInfo> sumFED;
     iSetup.get<RunInfoRcd>().get(sumFED);    
@@ -155,4 +155,3 @@ DQMDaqInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
  
 
 }
-

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESProducer
-// 
+//
 /**\class ESProducer ESProducer.h FWCore/Framework/interface/ESProducer.h
 
  Description: An EventSetup algorithmic Provider that encapsulates the algorithm as a member method
@@ -19,7 +19,7 @@
       1) add a method name 'produce' to the class.  The 'produce' takes as its argument a const reference
          to the record that is to hold the data item being produced.  If only one data item is being produced,
          the 'produce' method must return either an 'std::unique_ptr' or 'std::shared_ptr' to the object being
-         produced.  (The choice depends on if the EventSetup or the ESProducer is managing the lifetime of 
+         produced.  (The choice depends on if the EventSetup or the ESProducer is managing the lifetime of
          the object).  If multiple items are being Produced they the 'produce' method must return an
          ESProducts<> object which holds all of the items.
       2) add 'setWhatProduced(this);' to their classes constructor
@@ -38,7 +38,7 @@ Example: one algorithm creating only one object
 Example: one algorithm creating two objects
 \code
    class FoosProd : public edm::ESProducer {
-      edm::ESProducts<std::unique_ptr<Foo1>, std::unique_ptr<Foo2> > produce(const FooRecord&);
+      edm::ESProducts<std::unique_ptr<Foo1>, std::unique_ptr<Foo2>> produce(const FooRecord&);
       ...
    };
 \endcode
@@ -84,151 +84,126 @@ Example: two algorithms each creating only one objects
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {      
-      
-      //used by ESProducer to create the proper Decorator based on the
-      //  argument type passed.  The default it to just 'pass through'
-      //  the argument as the decorator itself
-      template< typename T, typename TRecord, typename TDecorator >
-      inline const TDecorator& createDecoratorFrom(T*, const TRecord*, const TDecorator& iDec) {
-         return iDec;
+  namespace eventsetup {
+
+    //used by ESProducer to create the proper Decorator based on the
+    //  argument type passed.  The default it to just 'pass through'
+    //  the argument as the decorator itself
+    template< typename T, typename TRecord, typename TDecorator >
+    inline const TDecorator& createDecoratorFrom(T*, const TRecord*, const TDecorator& iDec) {
+      return iDec;
+    }
+  }
+  class ESProducer : public ESProxyFactoryProducer
+  {
+
+  public:
+    ESProducer();
+    ~ESProducer() noexcept(false) override;
+
+    // ---------- const member functions ---------------------
+
+    // ---------- static member functions --------------------
+
+    // ---------- member functions ---------------------------
+  protected:
+    /** \param iThis the 'this' pointer to an inheriting class instance
+        The method determines the Record argument and return value of the 'produce'
+        method in order to do the registration with the EventSetup
+    */
+    template<typename T>
+    void setWhatProduced(T* iThis, const es::Label& iLabel = es::Label()) {
+      setWhatProduced(iThis , &T::produce, iLabel);
+    }
+
+    template<typename T>
+    void setWhatProduced(T* iThis, const char* iLabel) {
+      setWhatProduced(iThis , es::Label(iLabel));
+    }
+    template<typename T>
+    void setWhatProduced(T* iThis, const std::string& iLabel) {
+      setWhatProduced(iThis , es::Label(iLabel));
+    }
+
+    template<typename T, typename TDecorator >
+    void setWhatProduced(T* iThis, const TDecorator& iDec, const es::Label& iLabel = es::Label()) {
+      setWhatProduced(iThis , &T::produce, iDec, iLabel);
+    }
+    /** \param iThis the 'this' pointer to an inheriting class instance
+        \param iMethod a member method of then inheriting class
+        The method determines the Record argument and return value of the iMethod argument
+        method in order to do the registration with the EventSetup
+    */
+    template<typename T, typename TReturn, typename TRecord>
+    void setWhatProduced(T* iThis,
+                         TReturn (T ::* iMethod)(const TRecord&),
+                         const es::Label& iLabel = es::Label()) {
+      setWhatProduced(iThis, iMethod, eventsetup::CallbackSimpleDecorator<TRecord>(),iLabel);
+    }
+    /** \param iThis the 'this' pointer to an inheriting class instance
+        \param iMethod a member method of then inheriting class
+        \param iDecorator a class with 'pre'&'post' methods which are placed around the method call
+        The method determines the Record argument and return value of the iMethod argument
+        method in order to do the registration with the EventSetup
+    */
+    template<typename T, typename TReturn, typename TRecord, typename TArg>
+    void setWhatProduced(T* iThis,
+                         TReturn (T ::* iMethod)(const TRecord&),
+                         const TArg& iDec,
+                         const es::Label& iLabel = es::Label()) {
+      auto callback = std::make_shared<eventsetup::Callback<T,
+                                                            TReturn,
+                                                            TRecord,
+                                                            typename eventsetup::DecoratorFromArg<T,TRecord,TArg>::Decorator_t>>(iThis,
+                                                                                                                                 iMethod,
+                                                                                                                                 createDecoratorFrom(iThis,
+                                                                                                                                                     static_cast<const TRecord*>(nullptr),
+                                                                                                                                                     iDec));
+      registerProducts(callback,
+                       static_cast<const typename eventsetup::produce::product_traits<TReturn>::type *>(nullptr),
+                       static_cast<const TRecord*>(nullptr),
+                       iLabel);
+      //static_assert((std::is_base_of<ED, T>::type));
+    }
+
+    ESProducer(const ESProducer&) = delete; // stop default
+    ESProducer const& operator=(const ESProducer&) = delete; // stop default
+
+  private:
+
+    template<typename CallbackT, typename TList, typename TRecord>
+    void registerProducts(std::shared_ptr<CallbackT> iCallback, const TList*, const TRecord* iRecord,
+                          const es::Label& iLabel) {
+      registerProduct(iCallback, static_cast<const typename TList::tail_type*>(nullptr), iRecord, iLabel);
+      registerProducts(iCallback, static_cast<const typename TList::head_type*>(nullptr), iRecord, iLabel);
+    }
+    template<typename T, typename TRecord>
+    void registerProducts(std::shared_ptr<T>, const eventsetup::produce::Null*, const TRecord*,const es::Label&) {
+      //do nothing
+    }
+
+
+    template<typename T, typename TProduct, typename TRecord>
+    void registerProduct(std::shared_ptr<T> iCallback, const TProduct*, const TRecord*,const es::Label& iLabel) {
+      typedef eventsetup::CallbackProxy<T, TRecord, TProduct> ProxyType;
+      typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T>> FactoryType;
+      registerFactory(std::make_unique<FactoryType>(iCallback), iLabel.default_);
+    }
+
+    template<typename T, typename TProduct, typename TRecord, int IIndex>
+    void registerProduct(std::shared_ptr<T> iCallback, const es::L<TProduct,IIndex>*, const TRecord*,const es::Label& iLabel) {
+      if(iLabel.labels_.size() <= IIndex ||
+         iLabel.labels_[IIndex] == es::Label::def()) {
+        Exception::throwThis(errors::Configuration,
+                             "Unnamed Label\nthe index ",
+                             IIndex,
+                             " was never assigned a name in the 'setWhatProduced' method");
       }
-   }
-class ESProducer : public ESProxyFactoryProducer
-{
+      typedef eventsetup::CallbackProxy<T, TRecord, es::L<TProduct, IIndex>> ProxyType;
+      typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T>> FactoryType;
+      registerFactory(std::make_unique<FactoryType>(iCallback), iLabel.labels_[IIndex]);
+    }
 
-   public:
-      ESProducer();
-      ~ESProducer() noexcept(false) override;
-
-      // ---------- const member functions ---------------------
-
-      // ---------- static member functions --------------------
-
-      // ---------- member functions ---------------------------
-   protected:
-      /** \param iThis the 'this' pointer to an inheriting class instance
-         The method determines the Record argument and return value of the 'produce'
-         method in order to do the registration with the EventSetup
-         */
-      template<typename T>
-         void setWhatProduced(T* iThis, const es::Label& iLabel = es::Label()) {
-            //static_assert((typename std::is_base_of<ED, T>::type));
-            setWhatProduced(iThis , &T::produce, iLabel);
-         }
-
-      template<typename T>
-         void setWhatProduced(T* iThis, const char* iLabel) {
-            //static_assert((typename std::is_base_of<ED, T>::type));
-            setWhatProduced(iThis , es::Label(iLabel));
-         }
-      template<typename T>
-         void setWhatProduced(T* iThis, const std::string& iLabel) {
-            //static_assert((typename std::is_base_of<ED, T>::type));
-            setWhatProduced(iThis , es::Label(iLabel));
-         }
-      
-      template<typename T, typename TDecorator >
-         void setWhatProduced(T* iThis, const TDecorator& iDec, const es::Label& iLabel = es::Label()) {
-            //static_assert((typename std::is_base_of<ED, T>::type));
-            setWhatProduced(iThis , &T::produce, iDec, iLabel);
-         }
-      /** \param iThis the 'this' pointer to an inheriting class instance
-         \param iMethod a member method of then inheriting class
-         The method determines the Record argument and return value of the iMethod argument
-         method in order to do the registration with the EventSetup
-         */
-      template<typename T, typename TReturn, typename TRecord>
-         void setWhatProduced(T* iThis, 
-                              TReturn (T ::* iMethod)(const TRecord&),
-                              const es::Label& iLabel = es::Label()) {
-            setWhatProduced(iThis, iMethod, eventsetup::CallbackSimpleDecorator<TRecord>(),iLabel);
-         }
-      /** \param iThis the 'this' pointer to an inheriting class instance
-         \param iMethod a member method of then inheriting class
-         \param iDecorator a class with 'pre'&'post' methods which are placed around the method call
-         The method determines the Record argument and return value of the iMethod argument
-         method in order to do the registration with the EventSetup
-         */
-      template<typename T, typename TReturn, typename TRecord, typename TArg>
-         void setWhatProduced(T* iThis, 
-                              TReturn (T ::* iMethod)(const TRecord&),
-                              const TArg& iDec,
-                              const es::Label& iLabel = es::Label()) {
-            auto callback = std::make_shared<eventsetup::Callback<T,
-                                          TReturn,
-                                          TRecord, 
-                                          typename eventsetup::DecoratorFromArg<T,TRecord,TArg>::Decorator_t>>(
-                                                               iThis, 
-                                                               iMethod, 
-                                                               createDecoratorFrom(iThis, 
-                                                                                    static_cast<const TRecord*>(nullptr),
-                                                                                    iDec));
-            registerProducts(callback,
-                             static_cast<const typename eventsetup::produce::product_traits<TReturn>::type *>(nullptr),
-                             static_cast<const TRecord*>(nullptr),
-                             iLabel);
-            //static_assert((std::is_base_of<ED, T>::type));
-         }
-
-      /*
-      template<typename T, typename TReturn, typename TArg>
-         void setWhatProduced(T* iThis, TReturn (T ::* iMethod)(const TArg&)) {
-            registerProducts(iThis, static_cast<const typename produce::product_traits<TReturn>::type *>(nullptr));
-            registerGet(iThis, static_cast<const TArg*>(nullptr));
-            //static_assert((std::is_base_of<ED, T>::type));
-         }
-      */
-   private:
-      ESProducer(const ESProducer&) = delete; // stop default
-
-      ESProducer const& operator=(const ESProducer&) = delete; // stop default
-
-      /*
-      template<typename T, typename TProduct>
-         void registerGet(T* i, const TProduct* iProd) {
-            std::cout <<"registered 'get' for product type "
-            << test::name(iProd) <<
-            std::endl;
-         };
-      */
-      template<typename CallbackT, typename TList, typename TRecord>
-         void registerProducts(std::shared_ptr<CallbackT> iCallback, const TList*, const TRecord* iRecord,
-                               const es::Label& iLabel) {
-            registerProduct(iCallback, static_cast<const typename TList::tail_type*>(nullptr), iRecord, iLabel);
-            registerProducts(iCallback, static_cast<const typename TList::head_type*>(nullptr), iRecord, iLabel);
-         }
-      template<typename T, typename TRecord>
-         void registerProducts(std::shared_ptr<T>, const eventsetup::produce::Null*, const TRecord*,const es::Label&) {
-            //do nothing
-         }
-      
-      
-      template<typename T, typename TProduct, typename TRecord>
-         void registerProduct(std::shared_ptr<T> iCallback, const TProduct*, const TRecord*,const es::Label& iLabel) {
-	    typedef eventsetup::CallbackProxy<T, TRecord, TProduct> ProxyType;
-	    typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T> > FactoryType;
-            registerFactory(std::make_unique<FactoryType>(iCallback), iLabel.default_);
-         }
-      
-      template<typename T, typename TProduct, typename TRecord, int IIndex>
-         void registerProduct(std::shared_ptr<T> iCallback, const es::L<TProduct,IIndex>*, const TRecord*,const es::Label& iLabel) {
-            if(iLabel.labels_.size() <= IIndex ||
-               iLabel.labels_[IIndex] == es::Label::def()) {
-               Exception::throwThis(errors::Configuration,
-                 "Unnamed Label\nthe index ",
-                 IIndex,
-                 " was never assigned a name in the 'setWhatProduced' method");
-            }
-	    typedef eventsetup::CallbackProxy<T, TRecord, es::L<TProduct, IIndex> > ProxyType;
-	    typedef eventsetup::ProxyArgumentFactoryTemplate<ProxyType, std::shared_ptr<T> > FactoryType;
-            registerFactory(std::make_unique<FactoryType>(iCallback), iLabel.labels_[IIndex]);
-         }
-      
-      // ---------- member data --------------------------------
-      // NOTE: the factories share ownership of the callback
-      //std::vector<std::shared_ptr<CallbackBase> > callbacks_;
-      
-};
+  };
 }
 #endif

--- a/FWCore/Framework/interface/ESProducts.h
+++ b/FWCore/Framework/interface/ESProducts.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESProducts
-// 
+//
 /**\class ESProducts ESProducts.h FWCore/Framework/interface/ESProducts.h
 
  Description: Container for multiple products created by an ESProducer
@@ -28,114 +28,113 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {      
-      namespace produce {
-         template<typename T1, typename... TArgs>
-            struct ProductHolder : public ProductHolder<TArgs...> {
-              using parent_type = ProductHolder<TArgs...>;
-              
-              ProductHolder() : value() {}
-              ProductHolder(ProductHolder<T1,TArgs...>&&) = default;
-              ProductHolder(ProductHolder<T1,TArgs...> const&) = default;
-              ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...>&&) = default;
-              ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...> const&) = default;
+  namespace eventsetup::produce {
 
-               template<typename T>
-                  void setAllValues(T& iValuesFrom) {
-                     iValuesFrom.setFromRecursive(*this);
-                  }
-               using parent_type::moveTo;
-               void moveTo(T1& oValue) { oValue = std::move(value); }
+    template<typename T1, typename... TArgs>
+    struct ProductHolder : public ProductHolder<TArgs...> {
+      using parent_type = ProductHolder<TArgs...>;
 
-               using parent_type::setFrom;
-               void setFrom(T1& iValue) { value = iValue ; }
-               void setFrom(T1&& iValue) { value = std::move(iValue) ; }
+      ProductHolder() : value() {}
+      ProductHolder(ProductHolder<T1,TArgs...>&&) = default;
+      ProductHolder(ProductHolder<T1,TArgs...> const&) = default;
+      ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...>&&) = default;
+      ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...> const&) = default;
 
-               template<typename T>
-                  void setFromRecursive(T& iValuesTo) {
-                     iValuesTo.setFrom(value);
-                     parent_type::setFromRecursive(iValuesTo);
-                  }
-
-               template<typename T>
-                  void moveToRecursive(T& iValuesTo) {
-                     iValuesTo.moveTo(value);
-                     parent_type::moveToRecursive(iValuesTo);
-                  }
-               T1 value;
-               
-               using tail_type = T1;
-               using head_type = parent_type;
-            };
-         
-         template<typename T1>
-            struct ProductHolder<T1> {
-               
-              ProductHolder() : value() {}
-              ProductHolder(ProductHolder<T1>&&) = default;
-              ProductHolder(ProductHolder<T1> const&) = default;
-              ProductHolder<T1>& operator=(ProductHolder<T1>&&) = default;
-              ProductHolder<T1>& operator=(ProductHolder<T1> const&) = default;
-
-              template<typename T>
-               void setAllValues(T& iValuesFrom) {
-                  iValuesFrom.moveToRecursive(*this);
-               }
-               void moveTo(T1& oValue) { oValue = std::move(value); }
-               void setFrom(T1& iValue) { value = iValue ; }
-               void setFrom(T1&& iValue) { value = std::move(iValue) ; }
-               template<typename T>
-               void moveToRecursive(T& iValuesTo) {
-                  iValuesTo.moveTo(value);
-               }
-               template<typename T>
-               void setFromRecursive(T& iValuesTo) {
-                  iValuesTo.setFrom(value);
-               }
-               T1 value;
-               
-               using tail_type = T1;
-               using head_type = Null;
-            };
-         
+      template<typename T>
+      void setAllValues(T& iValuesFrom) {
+        iValuesFrom.setFromRecursive(*this);
       }
-   }
-   struct ESFillDirectly {};
+      using parent_type::moveTo;
+      void moveTo(T1& oValue) { oValue = std::move(value); }
 
-   template<typename ...TArgs>
-   struct ESProducts : public eventsetup::produce::ProductHolder<TArgs...> {
-      typedef eventsetup::produce::ProductHolder<TArgs...> parent_type;
-      template<typename... S>
-      ESProducts(ESProducts<S...>&& iProducts) {
-         parent_type::setAllValues(iProducts);
+      using parent_type::setFrom;
+      void setFrom(T1& iValue) { value = iValue; }
+      void setFrom(T1&& iValue) { value = std::move(iValue); }
+
+      template<typename T>
+      void setFromRecursive(T& iValuesTo) {
+        iValuesTo.setFrom(value);
+        parent_type::setFromRecursive(iValuesTo);
+      }
+
+      template<typename T>
+      void moveToRecursive(T& iValuesTo) {
+        iValuesTo.moveTo(value);
+        parent_type::moveToRecursive(iValuesTo);
+      }
+      T1 value;
+
+      using tail_type = T1;
+      using head_type = parent_type;
+    };
+
+    template<typename T1>
+    struct ProductHolder<T1> {
+
+      ProductHolder() : value() {}
+      ProductHolder(ProductHolder<T1>&&) = default;
+      ProductHolder(ProductHolder<T1> const&) = default;
+      ProductHolder<T1>& operator=(ProductHolder<T1>&&) = default;
+      ProductHolder<T1>& operator=(ProductHolder<T1> const&) = default;
+
+      template<typename T>
+      void setAllValues(T& iValuesFrom) {
+        iValuesFrom.moveToRecursive(*this);
+      }
+      void moveTo(T1& oValue) { oValue = std::move(value); }
+      void setFrom(T1& iValue) { value = iValue; }
+      void setFrom(T1&& iValue) { value = std::move(iValue); }
+      template<typename T>
+      void moveToRecursive(T& iValuesTo) {
+        iValuesTo.moveTo(value);
       }
       template<typename T>
-      /*explicit*/ ESProducts(T&& iValues) {
-         parent_type::setAllValues(iValues);
+      void setFromRecursive(T& iValuesTo) {
+        iValuesTo.setFrom(value);
       }
-      template<typename ...Vars>
-      ESProducts(ESFillDirectly, Vars&&... vars) {
-         (this->setFrom(std::forward<Vars>(vars)), ...);
-      }
+      T1 value;
 
-      ESProducts(ESProducts<TArgs...> const&) = default;
-      ESProducts(ESProducts<TArgs...>&&) = default;
-      ESProducts<TArgs...>& operator=(ESProducts<TArgs...> const&) = default;
-      ESProducts<TArgs...>& operator=(ESProducts<TArgs...>&&) = default;
-   };
+      using tail_type = T1;
+      using head_type = Null;
+    };
 
-   namespace es {
-      template<typename ...TArgs>
-      ESProducts<std::remove_reference_t<TArgs>...> products(TArgs&&... args) {
-         return ESProducts<std::remove_reference_t<TArgs>...>(edm::ESFillDirectly{}, std::forward<TArgs>(args)...);
-      }
-   }
+  }
+  struct ESFillDirectly {};
 
-   template<typename ...TArgs, typename ToT>
-     void moveFromTo(ESProducts<TArgs...>& iFrom,
-                     ToT& iTo) {
-       iFrom.moveTo(iTo);
-     }
+  template<typename ...TArgs>
+  struct ESProducts : public eventsetup::produce::ProductHolder<TArgs...> {
+    typedef eventsetup::produce::ProductHolder<TArgs...> parent_type;
+    template<typename... S>
+    ESProducts(ESProducts<S...>&& iProducts) {
+      parent_type::setAllValues(iProducts);
+    }
+    template<typename T>
+    /*explicit*/ ESProducts(T&& iValues) {
+      parent_type::setAllValues(iValues);
+    }
+    template<typename ...Vars>
+    ESProducts(ESFillDirectly, Vars&&... vars) {
+      (this->setFrom(std::forward<Vars>(vars)), ...);
+    }
+
+    ESProducts(ESProducts<TArgs...> const&) = default;
+    ESProducts(ESProducts<TArgs...>&&) = default;
+    ESProducts<TArgs...>& operator=(ESProducts<TArgs...> const&) = default;
+    ESProducts<TArgs...>& operator=(ESProducts<TArgs...>&&) = default;
+  };
+
+  namespace es {
+    template<typename ...TArgs>
+    ESProducts<std::remove_reference_t<TArgs>...> products(TArgs&&... args) {
+      return ESProducts<std::remove_reference_t<TArgs>...>(edm::ESFillDirectly{}, std::forward<TArgs>(args)...);
+    }
+  }
+
+  template<typename ...TArgs, typename ToT>
+  void moveFromTo(ESProducts<TArgs...>& iFrom,
+                  ToT& iTo) {
+    iFrom.moveTo(iTo);
+  }
 }
 
 

--- a/FWCore/Framework/interface/ESProducts.h
+++ b/FWCore/Framework/interface/ESProducts.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESProducts
-//
+// 
 /**\class ESProducts ESProducts.h FWCore/Framework/interface/ESProducts.h
 
  Description: Container for multiple products created by an ESProducer
@@ -28,113 +28,114 @@
 
 // forward declarations
 namespace edm {
-  namespace eventsetup::produce {
+   namespace eventsetup {      
+      namespace produce {
+         template<typename T1, typename... TArgs>
+            struct ProductHolder : public ProductHolder<TArgs...> {
+              using parent_type = ProductHolder<TArgs...>;
+              
+              ProductHolder() : value() {}
+              ProductHolder(ProductHolder<T1,TArgs...>&&) = default;
+              ProductHolder(ProductHolder<T1,TArgs...> const&) = default;
+              ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...>&&) = default;
+              ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...> const&) = default;
 
-    template<typename T1, typename... TArgs>
-    struct ProductHolder : public ProductHolder<TArgs...> {
-      using parent_type = ProductHolder<TArgs...>;
+               template<typename T>
+                  void setAllValues(T& iValuesFrom) {
+                     iValuesFrom.setFromRecursive(*this);
+                  }
+               using parent_type::moveTo;
+               void moveTo(T1& oValue) { oValue = std::move(value); }
 
-      ProductHolder() : value() {}
-      ProductHolder(ProductHolder<T1,TArgs...>&&) = default;
-      ProductHolder(ProductHolder<T1,TArgs...> const&) = default;
-      ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...>&&) = default;
-      ProductHolder<T1, TArgs...>& operator=(ProductHolder<T1,TArgs...> const&) = default;
+               using parent_type::setFrom;
+               void setFrom(T1& iValue) { value = iValue ; }
+               void setFrom(T1&& iValue) { value = std::move(iValue) ; }
 
-      template<typename T>
-      void setAllValues(T& iValuesFrom) {
-        iValuesFrom.setFromRecursive(*this);
+               template<typename T>
+                  void setFromRecursive(T& iValuesTo) {
+                     iValuesTo.setFrom(value);
+                     parent_type::setFromRecursive(iValuesTo);
+                  }
+
+               template<typename T>
+                  void moveToRecursive(T& iValuesTo) {
+                     iValuesTo.moveTo(value);
+                     parent_type::moveToRecursive(iValuesTo);
+                  }
+               T1 value;
+               
+               using tail_type = T1;
+               using head_type = parent_type;
+            };
+         
+         template<typename T1>
+            struct ProductHolder<T1> {
+               
+              ProductHolder() : value() {}
+              ProductHolder(ProductHolder<T1>&&) = default;
+              ProductHolder(ProductHolder<T1> const&) = default;
+              ProductHolder<T1>& operator=(ProductHolder<T1>&&) = default;
+              ProductHolder<T1>& operator=(ProductHolder<T1> const&) = default;
+
+              template<typename T>
+               void setAllValues(T& iValuesFrom) {
+                  iValuesFrom.moveToRecursive(*this);
+               }
+               void moveTo(T1& oValue) { oValue = std::move(value); }
+               void setFrom(T1& iValue) { value = iValue ; }
+               void setFrom(T1&& iValue) { value = std::move(iValue) ; }
+               template<typename T>
+               void moveToRecursive(T& iValuesTo) {
+                  iValuesTo.moveTo(value);
+               }
+               template<typename T>
+               void setFromRecursive(T& iValuesTo) {
+                  iValuesTo.setFrom(value);
+               }
+               T1 value;
+               
+               using tail_type = T1;
+               using head_type = Null;
+            };
+         
       }
-      using parent_type::moveTo;
-      void moveTo(T1& oValue) { oValue = std::move(value); }
+   }
+   struct ESFillDirectly {};
 
-      using parent_type::setFrom;
-      void setFrom(T1& iValue) { value = iValue; }
-      void setFrom(T1&& iValue) { value = std::move(iValue); }
-
-      template<typename T>
-      void setFromRecursive(T& iValuesTo) {
-        iValuesTo.setFrom(value);
-        parent_type::setFromRecursive(iValuesTo);
-      }
-
-      template<typename T>
-      void moveToRecursive(T& iValuesTo) {
-        iValuesTo.moveTo(value);
-        parent_type::moveToRecursive(iValuesTo);
-      }
-      T1 value;
-
-      using tail_type = T1;
-      using head_type = parent_type;
-    };
-
-    template<typename T1>
-    struct ProductHolder<T1> {
-
-      ProductHolder() : value() {}
-      ProductHolder(ProductHolder<T1>&&) = default;
-      ProductHolder(ProductHolder<T1> const&) = default;
-      ProductHolder<T1>& operator=(ProductHolder<T1>&&) = default;
-      ProductHolder<T1>& operator=(ProductHolder<T1> const&) = default;
-
-      template<typename T>
-      void setAllValues(T& iValuesFrom) {
-        iValuesFrom.moveToRecursive(*this);
-      }
-      void moveTo(T1& oValue) { oValue = std::move(value); }
-      void setFrom(T1& iValue) { value = iValue; }
-      void setFrom(T1&& iValue) { value = std::move(iValue); }
-      template<typename T>
-      void moveToRecursive(T& iValuesTo) {
-        iValuesTo.moveTo(value);
+   template<typename ...TArgs>
+   struct ESProducts : public eventsetup::produce::ProductHolder<TArgs...> {
+      typedef eventsetup::produce::ProductHolder<TArgs...> parent_type;
+      template<typename... S>
+      ESProducts(ESProducts<S...>&& iProducts) {
+         parent_type::setAllValues(iProducts);
       }
       template<typename T>
-      void setFromRecursive(T& iValuesTo) {
-        iValuesTo.setFrom(value);
+      /*explicit*/ ESProducts(T&& iValues) {
+         parent_type::setAllValues(iValues);
       }
-      T1 value;
+      template<typename ...Vars>
+      ESProducts(ESFillDirectly, Vars&&... vars) {
+         (this->setFrom(std::forward<Vars>(vars)), ...);
+      }
 
-      using tail_type = T1;
-      using head_type = Null;
-    };
+      ESProducts(ESProducts<TArgs...> const&) = default;
+      ESProducts(ESProducts<TArgs...>&&) = default;
+      ESProducts<TArgs...>& operator=(ESProducts<TArgs...> const&) = default;
+      ESProducts<TArgs...>& operator=(ESProducts<TArgs...>&&) = default;
+   };
 
-  }
-  struct ESFillDirectly {};
+   namespace es {
+      template<typename ...TArgs>
+      ESProducts<std::remove_reference_t<TArgs>...> products(TArgs&&... args) {
+         return ESProducts<std::remove_reference_t<TArgs>...>(edm::ESFillDirectly{}, std::forward<TArgs>(args)...);
+      }
+   }
 
-  template<typename ...TArgs>
-  struct ESProducts : public eventsetup::produce::ProductHolder<TArgs...> {
-    typedef eventsetup::produce::ProductHolder<TArgs...> parent_type;
-    template<typename... S>
-    ESProducts(ESProducts<S...>&& iProducts) {
-      parent_type::setAllValues(iProducts);
-    }
-    template<typename T>
-    /*explicit*/ ESProducts(T&& iValues) {
-      parent_type::setAllValues(iValues);
-    }
-    template<typename ...Vars>
-    ESProducts(ESFillDirectly, Vars&&... vars) {
-      (this->setFrom(std::forward<Vars>(vars)), ...);
-    }
-
-    ESProducts(ESProducts<TArgs...> const&) = default;
-    ESProducts(ESProducts<TArgs...>&&) = default;
-    ESProducts<TArgs...>& operator=(ESProducts<TArgs...> const&) = default;
-    ESProducts<TArgs...>& operator=(ESProducts<TArgs...>&&) = default;
-  };
-
-  namespace es {
-    template<typename ...TArgs>
-    ESProducts<std::remove_reference_t<TArgs>...> products(TArgs&&... args) {
-      return ESProducts<std::remove_reference_t<TArgs>...>(edm::ESFillDirectly{}, std::forward<TArgs>(args)...);
-    }
-  }
-
-  template<typename ...TArgs, typename ToT>
-  void moveFromTo(ESProducts<TArgs...>& iFrom,
-                  ToT& iTo) {
-    iFrom.moveTo(iTo);
-  }
+   template<typename ...TArgs, typename ToT>
+     void moveFromTo(ESProducts<TArgs...>& iFrom,
+                     ToT& iTo) {
+       iFrom.moveTo(iTo);
+     }
 }
 
 

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -21,11 +21,10 @@
 // system include files
 #include <cassert>
 #include <map>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -78,7 +77,7 @@ namespace edm {
       /** returns the Record of type T.  If no such record available
        a null pointer is returned */
       template< typename T>
-        boost::optional<T> tryToGet() const {
+        std::optional<T> tryToGet() const {
            using namespace eventsetup;
            using namespace eventsetup::heterocontainer;
 
@@ -90,7 +89,7 @@ namespace edm {
               rec.setImpl(temp);
               return rec;
            }
-           return boost::none;
+           return std::nullopt;
         }
 
       /** can directly access data if data_default_record_trait<> is defined for this data type **/
@@ -116,8 +115,8 @@ namespace edm {
            const RecordT& rec = this->get<RecordT>();
            rec.get(iTag,iHolder);
         }
-   
-      boost::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
+
+      std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
 
       ///clears the oToFill vector and then fills it with the keys for all available records
       void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class:      EventSetup
-// 
+//
 /**\class EventSetup EventSetup.h FWCore/Framework/interface/EventSetup.h
 
  Description: Container for all Records dealing with non-RunState info
@@ -39,7 +39,7 @@
 namespace edm {
    class ActivityRegistry;
    class ESInputTag;
-   
+
    namespace eventsetup {
       class EventSetupProvider;
       class EventSetupRecord;
@@ -120,7 +120,7 @@ namespace edm {
 
       ///clears the oToFill vector and then fills it with the keys for all available records
       void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
-  
+
       ///returns true if the Record is provided by a Source or a Producer
       /// a value of true does not mean this EventSetup object holds such a record
       bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
@@ -142,25 +142,25 @@ namespace edm {
       }
 
       void add(const eventsetup::EventSetupRecordImpl& iRecord);
-      
+
       void clear();
-      
+
     private:
       EventSetup(ActivityRegistry*);
-      
+
       EventSetup(EventSetup const&) = delete; // stop default
 
       EventSetup const& operator=(EventSetup const&) = delete; // stop default
 
       ActivityRegistry* activityRegistry() const { return activityRegistry_; }
       eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
-     
+
 
       void insert(const eventsetup::EventSetupRecordKey&,
                   const eventsetup::EventSetupRecordImpl*);
 
       // ---------- member data --------------------------------
-    
+
       //NOTE: the records are not owned
       std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const *> recordMap_;
       eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;

--- a/FWCore/Framework/interface/es_Label.h
+++ b/FWCore/Framework/interface/es_Label.h
@@ -53,8 +53,9 @@ namespace edm::es {
 
   struct Label {
     Label() = default;
-    Label(std::string_view const iString) : default_{iString} {}
-    Label(std::string_view const iString, unsigned int const iIndex) :
+    Label(const char* iLabel) : default_{iLabel} {}
+    Label(const std::string& iString) : default_{iString} {}
+    Label(const std::string& iString, unsigned int const iIndex) :
       labels_(iIndex+1, def())
     {
       labels_[iIndex] = iString;

--- a/FWCore/Framework/interface/es_Label.h
+++ b/FWCore/Framework/interface/es_Label.h
@@ -4,13 +4,13 @@
 //
 // Package:     Framework
 // Class  :     es_Label
-// 
+//
 /**\class es_Label es_Label.h FWCore/Framework/interface/es_Label.h
 
- Description: Used to assign labels to data items produced by an ESProducer
+   Description: Used to assign labels to data items produced by an ESProducer
 
- Usage:
-    See the header file for ESProducer for detail examples
+   Usage:
+   See the header file for ESProducer for detail examples
 
 */
 //
@@ -21,6 +21,7 @@
 // system include files
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 // user include files
@@ -29,71 +30,75 @@
 
 // forward declarations
 
-namespace edm {
-   namespace es{
-      template<typename T, int ILabel>
-      struct L {
-         typedef T element_type;
-         
-         L() : product_() {}
-         explicit L(std::shared_ptr<T> iP) : product_(std::move(iP)) {}
-         explicit L(std::unique_ptr<T> iP) : product_(std::move(iP)) {}
-         explicit L(T* iP) : product_(iP) {}
-         
-         T& operator*() { return *product_;}
-         T* operator->() { return product_.get(); }
-         mutable std::shared_ptr<T> product_;
-      };
-      template<int ILabel,typename T>
-         L<T,ILabel> l(std::shared_ptr<T>& iP) { 
-            L<T,ILabel> temp(iP);
-            return temp;
-         }
-      struct Label {
-         Label() : labels_(), default_() {}
-         Label(const char* iLabel) : labels_(), default_(iLabel) {}
-         Label(const std::string& iString) : labels_(), default_(iString) {}
-         Label(const std::string& iString, unsigned int iIndex) : 
-           labels_(iIndex+1,def()), default_() {labels_[iIndex] = iString;}
-         
-         Label& operator()(const std::string& iString, unsigned int iIndex) {
-            if(iIndex==labels_.size()){
-               labels_.push_back(iString);
-            } else if(iIndex > labels_.size()) {
-               std::vector<std::string> temp(iIndex+1,def());
-               copy_all(labels_, temp.begin());
-               labels_.swap(temp);
-            } else {
-               if( labels_[iIndex] != def() ) {
-                  Exception e(errors::Configuration,"Duplicate Label");
-                  e <<"The index "<<iIndex<<" was previously assigned the label \""
-                    <<labels_[iIndex]<<"\" and then was later assigned \""
-                    <<iString<<"\"";
-                  e.raise();
-               }
-               labels_[iIndex] = iString;
-            }
-            return *this;
-         }
-         Label& operator()(int iIndex, const std::string& iString) {
-            return (*this)(iString, iIndex);
-         }
-         
-         static const std::string& def() {
-            static const std::string s_def("\n\t");
-            return s_def;
-         }
-         std::vector<std::string> labels_;
-         std::string default_;
-      };
-      
-      inline Label label(const std::string& iString, int iIndex) {
-         return Label(iString, iIndex);
+namespace edm::es {
+
+  template<typename T, int ILabel>
+  struct L {
+    using element_type = T;
+
+    L() = default;
+    explicit L(std::shared_ptr<T> iP) : product_{std::move(iP)} {}
+    explicit L(std::unique_ptr<T> iP) : product_{std::move(iP)} {}
+    explicit L(T* iP) : product_(iP) {}
+
+    T& operator*() { return *product_;}
+    T* operator->() { return product_.get(); }
+    mutable std::shared_ptr<T> product_{nullptr};
+  };
+
+  template<int ILabel, typename T>
+  L<T,ILabel> l(std::shared_ptr<T>& iP) {
+    return L<T,ILabel>{iP};
+  }
+
+  struct Label {
+    Label() = default;
+    Label(std::string_view const iString) : default_{iString} {}
+    Label(std::string_view const iString, unsigned int const iIndex) :
+      labels_(iIndex+1, def())
+    {
+      labels_[iIndex] = iString;
+    }
+
+    Label& operator()(const std::string& iString, unsigned int const iIndex)
+    {
+      if (iIndex == labels_.size()) {
+        labels_.push_back(iString);
+      } else if(iIndex > labels_.size()) {
+        std::vector<std::string> temp(iIndex+1,def());
+        copy_all(labels_, temp.begin());
+        labels_.swap(temp);
+      } else {
+        if( labels_[iIndex] != def() ) {
+          Exception e(errors::Configuration,"Duplicate Label");
+          e <<"The index "<<iIndex<<" was previously assigned the label \""
+            <<labels_[iIndex]<<"\" and then was later assigned \""
+            <<iString<<"\"";
+          e.raise();
+        }
+        labels_[iIndex] = iString;
       }
-      inline Label label(int iIndex, const std::string& iString) {
-         return Label(iString, iIndex);
-      }
-   }
-}   
+      return *this;
+    }
+    Label& operator()(int iIndex, const std::string& iString) {
+      return (*this)(iString, iIndex);
+    }
+
+    static const std::string& def() {
+      static const std::string s_def("\n\t");
+      return s_def;
+    }
+
+    std::vector<std::string> labels_{};
+    std::string default_{};
+  };
+
+  inline Label label(const std::string& iString, int iIndex) {
+    return Label(iString, iIndex);
+  }
+  inline Label label(int iIndex, const std::string& iString) {
+    return Label(iString, iIndex);
+  }
+}
 
 #endif

--- a/FWCore/Framework/interface/produce_helpers.h
+++ b/FWCore/Framework/interface/produce_helpers.h
@@ -4,13 +4,13 @@
 //
 // Package:     Framework
 // Class  :     produce_helpers
-// 
+//
 /**\class produce_helpers produce_helpers.h FWCore/Framework/interface/produce_helpers.h
 
- Description: <one line class summary>
+   Description: <one line class summary>
 
- Usage:
-    <usage>
+   Usage:
+   <usage>
 
 */
 //
@@ -23,88 +23,85 @@
 #include <optional>
 // user include files
 
-// forward declarations
-namespace edm {
-   namespace eventsetup {
-      
-      namespace produce { struct Null;}
-      
-     template<typename FromT, typename ToT> void moveFromTo(FromT& iFrom,
-                                                            ToT & iTo) {
-       iTo = std::move(iFrom);
-     }
+namespace edm::eventsetup {
 
-     template<typename FromT, typename ToT> void moveFromTo(std::unique_ptr<FromT>& iFrom, ToT & iTo) {
-       iTo = std::move(iFrom);
-     }
-     template<typename FromT, typename ToT> void moveFromTo(std::optional<FromT>& iFrom, ToT & iTo) {
-       iTo = std::move(iFrom.value());
-     }
+  namespace produce { struct Null;}
 
-     namespace produce { 
-         struct Null {};
-         template <typename T> struct EndList {
-           static_assert( (not std::is_pointer_v<T>) ,"use std::shared_ptr or std::unique_ptr to hold EventSetup data products, do not use bare pointers");
-            using tail_type = T;
-            using head_type = Null;
-         };
-         template <typename T> struct product_traits {
-            using type = T;
-         };
-         template< typename T> struct product_traits<T*> {
-            using type = EndList<T*>;
-         };
-         template< typename T> struct product_traits<std::unique_ptr<T> > {
-            using type= EndList<std::unique_ptr<T>>;
-         };
-         template< typename T> struct product_traits<std::shared_ptr<T> > {
-            using type = EndList<std::shared_ptr<T>>;
-         };
-         template< typename T> struct product_traits<std::optional<T> > {
-            using type=EndList<std::optional<T>>;
-         };
-         
-         template<typename T> struct size {
-            using type = typename product_traits<T>::type;
-            constexpr static int value = size< typename type::head_type >::value + 1;
-         };
-         template<> struct size<Null> {
-            constexpr static int value = 0;
-         };
-         
-         template<typename T> struct smart_pointer_traits {
-            using type = typename T::element_type;
-           static auto getPointer(T& iPtr)-> decltype(&*iPtr) { return &*iPtr;}
-         };
-       
-         template<typename T> struct smart_pointer_traits<std::optional<T>> {
-           using type = T;
-           static T* getPointer(std::optional<T>& iPtr) {
-             if(iPtr.has_value()) { return &*iPtr;}
-             return nullptr;
-           }
-         };
+  template<typename FromT, typename ToT> void moveFromTo(FromT& iFrom,
+                                                         ToT& iTo) {
+    iTo = std::move(iFrom);
+  }
 
-         template<typename T, typename FindT> struct find_index {
-            using container_type = typename product_traits<T>::type;
-            template<typename HeadT, typename TailT>
-            constexpr static int findIndexOf() {
-              if constexpr(not std::is_same_v<TailT,FindT>) {
-                using container_type= typename product_traits<HeadT>::type;
-                return findIndexOf<typename container_type::head_type,
-                typename container_type::tail_type>()+1;
-              } else {
-                return 0;
-              }
-            }
-            constexpr static int value = findIndexOf<typename container_type::head_type, typename container_type::tail_type>();
-         };
-         namespace test {
-            template<typename T> const char* name(const T*);
-         }
-         
+  template<typename FromT, typename ToT> void moveFromTo(std::unique_ptr<FromT>& iFrom, ToT& iTo) {
+    iTo = std::move(iFrom);
+  }
+  template<typename FromT, typename ToT> void moveFromTo(std::optional<FromT>& iFrom, ToT& iTo) {
+    iTo = std::move(iFrom.value());
+  }
+
+  namespace produce {
+    struct Null {};
+    template <typename T> struct EndList {
+      static_assert((not std::is_pointer_v<T>), "use std::shared_ptr or std::unique_ptr to hold EventSetup data products, do not use bare pointers");
+      using tail_type = T;
+      using head_type = Null;
+    };
+    template <typename T> struct product_traits {
+      using type = T;
+    };
+    template< typename T> struct product_traits<T*> {
+      using type = EndList<T*>;
+    };
+    template< typename T> struct product_traits<std::unique_ptr<T>> {
+      using type = EndList<std::unique_ptr<T>>;
+    };
+    template< typename T> struct product_traits<std::shared_ptr<T>> {
+      using type = EndList<std::shared_ptr<T>>;
+    };
+    template< typename T> struct product_traits<std::optional<T>> {
+      using type = EndList<std::optional<T>>;
+    };
+
+    template<typename T> struct size {
+      using type = typename product_traits<T>::type;
+      constexpr static int value = size< typename type::head_type >::value + 1;
+    };
+    template<> struct size<Null> {
+      constexpr static int value = 0;
+    };
+
+    template<typename T> struct smart_pointer_traits {
+      using type = typename T::element_type;
+      static auto getPointer(T& iPtr)-> decltype(&*iPtr) { return &*iPtr;}
+    };
+
+    template<typename T> struct smart_pointer_traits<std::optional<T>> {
+      using type = T;
+      static T* getPointer(std::optional<T>& iPtr) {
+        if(iPtr.has_value()) { return &*iPtr;}
+        return nullptr;
       }
-   }
+    };
+
+    template<typename T, typename FindT> struct find_index {
+      using container_type = typename product_traits<T>::type;
+      template<typename HeadT, typename TailT>
+      constexpr static int findIndexOf() {
+        if constexpr(not std::is_same_v<TailT,FindT>) {
+            using container_type= typename product_traits<HeadT>::type;
+            return findIndexOf<typename container_type::head_type,
+                               typename container_type::tail_type>()+1;
+          } else {
+          return 0;
+        }
+      }
+      constexpr static int value = findIndexOf<typename container_type::head_type, typename container_type::tail_type>();
+    };
+    namespace test {
+      template<typename T> const char* name(const T*);
+    }
+
+  }
 }
 
 #endif

--- a/FWCore/Framework/src/ESProducer.cc
+++ b/FWCore/Framework/src/ESProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ESProducer
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -20,47 +20,47 @@
 // constants, enums and typedefs
 //
 namespace edm {
-//
-// static data member definitions
-//
+  //
+  // static data member definitions
+  //
 
-//
-// constructors and destructor
-//
-ESProducer::ESProducer()
-{
-}
+  //
+  // constructors and destructor
+  //
+  ESProducer::ESProducer()
+  {
+  }
 
-// ESProducer::ESProducer(const ESProducer& rhs)
-// {
-//    // do actual copying here;
-// }
+  // ESProducer::ESProducer(const ESProducer& rhs)
+  // {
+  //    // do actual copying here;
+  // }
 
-ESProducer::~ESProducer() noexcept(false)
-{
-}
+  ESProducer::~ESProducer() noexcept(false)
+  {
+  }
 
-//
-// assignment operators
-//
-// const ESProducer& ESProducer::operator=(const ESProducer& rhs)
-// {
-//   //An exception safe implementation is
-//   ESProducer temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+  //
+  // assignment operators
+  //
+  // const ESProducer& ESProducer::operator=(const ESProducer& rhs)
+  // {
+  //   //An exception safe implementation is
+  //   ESProducer temp(rhs);
+  //   swap(rhs);
+  //
+  //   return *this;
+  // }
 
-//
-// member functions
-//
+  //
+  // member functions
+  //
 
-//
-// const member functions
-//
+  //
+  // const member functions
+  //
 
-//
-// static member functions
-//
+  //
+  // static member functions
+  //
 }

--- a/FWCore/Framework/src/ESProducer.cc
+++ b/FWCore/Framework/src/ESProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     ESProducer
-//
+// 
 // Implementation:
 //     <Notes on implementation>
 //
@@ -20,47 +20,47 @@
 // constants, enums and typedefs
 //
 namespace edm {
-  //
-  // static data member definitions
-  //
+//
+// static data member definitions
+//
 
-  //
-  // constructors and destructor
-  //
-  ESProducer::ESProducer()
-  {
-  }
+//
+// constructors and destructor
+//
+ESProducer::ESProducer()
+{
+}
 
-  // ESProducer::ESProducer(const ESProducer& rhs)
-  // {
-  //    // do actual copying here;
-  // }
+// ESProducer::ESProducer(const ESProducer& rhs)
+// {
+//    // do actual copying here;
+// }
 
-  ESProducer::~ESProducer() noexcept(false)
-  {
-  }
+ESProducer::~ESProducer() noexcept(false)
+{
+}
 
-  //
-  // assignment operators
-  //
-  // const ESProducer& ESProducer::operator=(const ESProducer& rhs)
-  // {
-  //   //An exception safe implementation is
-  //   ESProducer temp(rhs);
-  //   swap(rhs);
-  //
-  //   return *this;
-  // }
+//
+// assignment operators
+//
+// const ESProducer& ESProducer::operator=(const ESProducer& rhs)
+// {
+//   //An exception safe implementation is
+//   ESProducer temp(rhs);
+//   swap(rhs);
+//
+//   return *this;
+// }
 
-  //
-  // member functions
-  //
+//
+// member functions
+//
 
-  //
-  // const member functions
-  //
+//
+// const member functions
+//
 
-  //
-  // static member functions
-  //
+//
+// static member functions
+//
 }

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -84,12 +84,12 @@ EventSetup::add(const eventsetup::EventSetupRecordImpl& iRecord)
 //
 // const member functions
 //
-boost::optional<eventsetup::EventSetupRecordGeneric>
+std::optional<eventsetup::EventSetupRecordGeneric>
 EventSetup::find(const eventsetup::EventSetupRecordKey& iKey) const
 {
    auto itFind = recordMap_.find(iKey);
    if(itFind == recordMap_.end()) {
-      return boost::none;
+     return std::nullopt;
    }
   return eventsetup::EventSetupRecordGeneric(itFind->second);
 }

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Module:      EventSetup
-// 
+//
 // Description: <one line class summary>
 //
 // Implementation:
@@ -74,13 +74,13 @@ EventSetup::clear()
 {
    recordMap_.clear();
 }
-   
-void 
+
+void
 EventSetup::add(const eventsetup::EventSetupRecordImpl& iRecord)
 {
    insert(iRecord.key(), &iRecord);
 }
-   
+
 //
 // const member functions
 //
@@ -93,7 +93,7 @@ EventSetup::find(const eventsetup::EventSetupRecordKey& iKey) const
    }
   return eventsetup::EventSetupRecordGeneric(itFind->second);
 }
-  
+
 eventsetup::EventSetupRecordImpl const*
 EventSetup::findImpl(const eventsetup::EventSetupRecordKey& iKey) const
 {
@@ -104,12 +104,12 @@ EventSetup::findImpl(const eventsetup::EventSetupRecordKey& iKey) const
   return itFind->second;
 }
 
-void 
+void
 EventSetup::fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const
 {
   oToFill.clear();
   oToFill.reserve(recordMap_.size());
-  
+
   for(auto it = recordMap_.begin(), itEnd=recordMap_.end();
       it != itEnd;
       ++it) {

--- a/FWCore/Framework/test/DummyData.h
+++ b/FWCore/Framework/test/DummyData.h
@@ -11,15 +11,11 @@
 //used to set the default record
 #include "FWCore/Framework/test/DummyRecord.h"
 
-namespace edm {
-   namespace eventsetup {
-      namespace test {
-         struct DummyData { int value_;
-            DummyData(int iValue=0) : value_(iValue) {}
-            void dummy() {} // Just to suppress compilation warning message
-         };
-      }
-   }
+namespace edm::eventsetup::test {
+  struct DummyData { int value_;
+    DummyData(int iValue=0) : value_(iValue) {}
+    void dummy() {} // Just to suppress compilation warning message
+  };
 }
 
 #include "FWCore/Framework/interface/data_default_record_trait.h"

--- a/FWCore/Framework/test/DummyProxyProvider.h
+++ b/FWCore/Framework/test/DummyProxyProvider.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DummyProvider
-// 
+//
 /**\class DummyProvider DummyProvider.h FWCore/Framework/interface/DummyProvider.h
 
  Description: <one line class summary>
@@ -29,48 +29,41 @@
 #include "FWCore/Framework/interface/DataProxyProvider.h"
 
 // forward declarations
-namespace edm {
-   namespace eventsetup {
-      namespace test {
-class WorkingDummyProxy : public edm::eventsetup::DataProxyTemplate<DummyRecord, DummyData> {
-public:
-   WorkingDummyProxy(const DummyData* iDummy) : data_(iDummy) {}
-   
-protected:
-   
-   const value_type* make(const record_type&, const DataKey&) {
+namespace edm::eventsetup::test {
+  class WorkingDummyProxy : public edm::eventsetup::DataProxyTemplate<DummyRecord, DummyData> {
+  public:
+    WorkingDummyProxy(const DummyData* iDummy) : data_(iDummy) {}
+
+  protected:
+    const value_type* make(const record_type&, const DataKey&) {
       return data_ ;
-   }
-   void invalidateCache() {
-   }   
-private:
-   const DummyData* data_;
-};
+    }
+    void invalidateCache() {
+    }
+
+  private:
+    const DummyData* data_;
+  };
 
 
-class DummyProxyProvider : public edm::eventsetup::DataProxyProvider {
-public:
-   DummyProxyProvider(const DummyData& iData=DummyData()): dummy_(iData) {
-      //std::cout <<"constructed provider"<<std::endl;
+  class DummyProxyProvider : public edm::eventsetup::DataProxyProvider {
+  public:
+    DummyProxyProvider(const DummyData& iData=DummyData()): dummy_(iData) {
       usingRecord<DummyRecord>();
-   }
-   void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/,
+    }
+    void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/,
                      const ValidityInterval& /*iInterval*/) {
       //do nothing
-   }
-protected:
-   void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& iProxies) {
-      //std::cout <<"registered proxy"<<std::endl;
-      
+    }
+  protected:
+    void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& iProxies) {
       std::shared_ptr<WorkingDummyProxy> pProxy = std::make_shared<WorkingDummyProxy>(&dummy_);
       insertProxy(iProxies, pProxy);
-   }
-   
-private:
-   DummyData dummy_;
-};
+    }
 
-      }
-   }
+  private:
+    DummyData dummy_;
+  };
+
 }
 #endif

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -717,8 +717,7 @@ void testEventsetup::introspectionTest()
     eventSetup.fillAvailableRecordKeys(recordKeys);
     CPPUNIT_ASSERT(1==recordKeys.size());
     auto record = eventSetup.find(recordKeys[0]);
-    CPPUNIT_ASSERT(0!=record);
-    
+    CPPUNIT_ASSERT(record.has_value());
   } catch (const cms::Exception& iException) {
     std::cout <<"caught "<<iException.explainSelf()<<std::endl;
     throw;

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -24,10 +24,7 @@
 #include "FWCore/Framework/test/DummyRecord.h"
 #include "FWCore/Framework/test/DummyProxyProvider.h"
 
-//class DummyRecord : public edm::eventsetup::EventSetupRecordImplementation<DummyRecord> {};
-
 #include "FWCore/Framework/interface/HCMethods.h"
-
 
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/Framework/interface/DataProxyProvider.h"
@@ -38,37 +35,37 @@
 using namespace edm;
 namespace {
   bool non_null(const void* iPtr) {
-    return iPtr != 0;
+    return iPtr != nullptr;
   }
 }
 
 class testEventsetup: public CppUnit::TestFixture
 {
-CPPUNIT_TEST_SUITE(testEventsetup);
+  CPPUNIT_TEST_SUITE(testEventsetup);
 
-CPPUNIT_TEST(constructTest);
-CPPUNIT_TEST(getTest);
-CPPUNIT_TEST(tryToGetTest);
-CPPUNIT_TEST_EXCEPTION(getExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
-CPPUNIT_TEST(recordProviderTest);
-CPPUNIT_TEST(provenanceTest);
-CPPUNIT_TEST(getDataWithLabelTest);
-CPPUNIT_TEST(getDataWithESInputTagTest);
-CPPUNIT_TEST_EXCEPTION(recordValidityTest,edm::eventsetup::NoRecordException<DummyRecord>); 
-CPPUNIT_TEST_EXCEPTION(recordValidityExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
-CPPUNIT_TEST(proxyProviderTest);
+  CPPUNIT_TEST(constructTest);
+  CPPUNIT_TEST(getTest);
+  CPPUNIT_TEST(tryToGetTest);
+  CPPUNIT_TEST_EXCEPTION(getExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
+  CPPUNIT_TEST(recordProviderTest);
+  CPPUNIT_TEST(provenanceTest);
+  CPPUNIT_TEST(getDataWithLabelTest);
+  CPPUNIT_TEST(getDataWithESInputTagTest);
+  CPPUNIT_TEST_EXCEPTION(recordValidityTest,edm::eventsetup::NoRecordException<DummyRecord>);
+  CPPUNIT_TEST_EXCEPTION(recordValidityExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
+  CPPUNIT_TEST(proxyProviderTest);
 
-CPPUNIT_TEST_EXCEPTION(producerConflictTest,cms::Exception);
-CPPUNIT_TEST_EXCEPTION(sourceConflictTest,cms::Exception);
-CPPUNIT_TEST(twoSourceTest);
-CPPUNIT_TEST(sourceProducerResolutionTest);
-CPPUNIT_TEST(preferTest);
+  CPPUNIT_TEST_EXCEPTION(producerConflictTest,cms::Exception);
+  CPPUNIT_TEST_EXCEPTION(sourceConflictTest,cms::Exception);
+  CPPUNIT_TEST(twoSourceTest);
+  CPPUNIT_TEST(sourceProducerResolutionTest);
+  CPPUNIT_TEST(preferTest);
 
-CPPUNIT_TEST(introspectionTest);
+  CPPUNIT_TEST(introspectionTest);
 
-CPPUNIT_TEST(iovExtentionTest);
+  CPPUNIT_TEST(iovExtentionTest);
 
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST_SUITE_END();
 public:
   void setUp(){}
   void tearDown(){}
@@ -84,17 +81,17 @@ public:
   void provenanceTest();
   void getDataWithLabelTest();
   void getDataWithESInputTagTest();
-   
+
   void producerConflictTest();
   void sourceConflictTest();
   void twoSourceTest();
   void sourceProducerResolutionTest();
   void preferTest();
-  
+
   void introspectionTest();
-  
+
   void iovExtentionTest();
-  
+
 };
 
 ///registration of the test so that the runner can find it
@@ -106,26 +103,24 @@ namespace {
 
 void testEventsetup::constructTest()
 {
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   const Timestamp time(1);
-   const IOVSyncValue timestamp(time);
-   EventSetup const& eventSetup = provider.eventSetupForInstance(timestamp);
-   CPPUNIT_ASSERT(non_null(&eventSetup));
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  const Timestamp time(1);
+  const IOVSyncValue timestamp(time);
+  EventSetup const& eventSetup = provider.eventSetupForInstance(timestamp);
+  CPPUNIT_ASSERT(non_null(&eventSetup));
 }
 
 void testEventsetup::getTest()
 {
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-   CPPUNIT_ASSERT(non_null(&eventSetup));
-   //eventSetup.get<DummyRecord>();
-   //CPPUNIT_ASSERT_THROW(eventSetup.get<DummyRecord>(), edm::eventsetup::NoRecordException<DummyRecord>);
-   
-   eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
-   provider.addRecordToEventSetup(dummyRecord);
-   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
-   CPPUNIT_ASSERT(non_null(&gottenRecord));
-   CPPUNIT_ASSERT(&dummyRecord == gottenRecord.impl_);
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  CPPUNIT_ASSERT(non_null(&eventSetup));
+
+  eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
+  provider.addRecordToEventSetup(dummyRecord);
+  const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
+  CPPUNIT_ASSERT(non_null(&gottenRecord));
+  CPPUNIT_ASSERT(&dummyRecord == gottenRecord.impl_);
 }
 
 void testEventsetup::tryToGetTest()
@@ -133,9 +128,7 @@ void testEventsetup::tryToGetTest()
   eventsetup::EventSetupProvider provider(&activityRegistry);
   EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   CPPUNIT_ASSERT(non_null(&eventSetup));
-  //eventSetup.get<DummyRecord>();
-  //CPPUNIT_ASSERT_THROW(eventSetup.get<DummyRecord>(), edm::eventsetup::NoRecordException<DummyRecord>);
-  
+
   eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
   provider.addRecordToEventSetup(dummyRecord);
   auto gottenRecord = eventSetup.tryToGet<DummyRecord>();
@@ -145,136 +138,131 @@ void testEventsetup::tryToGetTest()
 
 void testEventsetup::getExcTest()
 {
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-   CPPUNIT_ASSERT(non_null(&eventSetup));
-   eventSetup.get<DummyRecord>();
-   //CPPUNIT_ASSERT_THROW(eventSetup.get<DummyRecord>(), edm::eventsetup::NoRecordException<DummyRecord>);
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  CPPUNIT_ASSERT(non_null(&eventSetup));
+  eventSetup.get<DummyRecord>();
 }
 
 
 class DummyEventSetupProvider : public edm::eventsetup::EventSetupProvider {
 public:
 
-   DummyEventSetupProvider(ActivityRegistry* activityRegistry) : EventSetupProvider(activityRegistry) { }
+  DummyEventSetupProvider(ActivityRegistry* activityRegistry) : EventSetupProvider(activityRegistry) { }
 
-   template<class T>
-   void insert(std::unique_ptr<T> iRecord) {
-      edm::eventsetup::EventSetupProvider::insert(std::move(iRecord));
-   }
+  template<class T>
+  void insert(std::unique_ptr<T> iRecord) {
+    edm::eventsetup::EventSetupProvider::insert(std::move(iRecord));
+  }
 };
 
 void testEventsetup::recordProviderTest()
 {
-   DummyEventSetupProvider provider(&activityRegistry);
-   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
-   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
-   
-   provider.insert(std::move(dummyRecordProvider));
-   
-   //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-   //       for a Record is presently an 'invalid' timestamp on both ends.
-   //       Since the EventSetup::get<> will only retrieve a Record if its
-   //       interval of validity is 'valid' for the present 'instance'
-   //       this is a 'hack' to have the 'get' succeed
-   EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
-   CPPUNIT_ASSERT(non_null(&gottenRecord));
+  DummyEventSetupProvider provider(&activityRegistry);
+  typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
+  auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
+
+  provider.insert(std::move(dummyRecordProvider));
+
+  //NOTE: use 'invalid' timestamp since the default 'interval of validity'
+  //       for a Record is presently an 'invalid' timestamp on both ends.
+  //       Since the EventSetup::get<> will only retrieve a Record if its
+  //       interval of validity is 'valid' for the present 'instance'
+  //       this is a 'hack' to have the 'get' succeed
+  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
+  CPPUNIT_ASSERT(non_null(&gottenRecord));
 }
 
 
 class DummyFinder : public EventSetupRecordIntervalFinder {
 public:
-   DummyFinder() : EventSetupRecordIntervalFinder(), interval_()  {
-      this->findingRecord<DummyRecord>();
-   }
+  DummyFinder() : EventSetupRecordIntervalFinder(), interval_()  {
+    this->findingRecord<DummyRecord>();
+  }
 
-   void setInterval(const ValidityInterval& iInterval) {
-      interval_ = iInterval;
-   }
+  void setInterval(const ValidityInterval& iInterval) {
+    interval_ = iInterval;
+  }
 protected:
-   virtual void setIntervalFor(const eventsetup::EventSetupRecordKey&,
-                                const IOVSyncValue& iTime, 
-                                ValidityInterval& iInterval) {
-      if(interval_.validFor(iTime)) {
-         iInterval = interval_;
-      } else {
-         iInterval = ValidityInterval();
-      }
-   }
+  virtual void setIntervalFor(const eventsetup::EventSetupRecordKey&,
+                              const IOVSyncValue& iTime,
+                              ValidityInterval& iInterval) {
+    if(interval_.validFor(iTime)) {
+      iInterval = interval_;
+    } else {
+      iInterval = ValidityInterval();
+    }
+  }
 private:
-   ValidityInterval interval_;   
+  ValidityInterval interval_;
 };
 
 
 void testEventsetup::recordValidityTest()
 {
-   DummyEventSetupProvider provider(&activityRegistry);
-   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
-   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
+  DummyEventSetupProvider provider(&activityRegistry);
+  typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
+  auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
 
-   std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
-   dummyRecordProvider->addFinder(finder);
-   
-   provider.insert(std::move(dummyRecordProvider));
-   
-   {
-      Timestamp time_1(1);
-      /*EventSetup const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue(time_1));
-   // CPPUNIT_ASSERT_THROW(eventSetup.get<DummyRecord>(), edm::eventsetup::NoRecordException<DummyRecord>);
-   //eventSetup.get<DummyRecord>();
-   }
+  std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
+  dummyRecordProvider->addFinder(finder);
 
-   const Timestamp time_2(2);
-   finder->setInterval(ValidityInterval(IOVSyncValue(time_2), IOVSyncValue(Timestamp(3))));
-   {
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(time_2));
-      eventSetup.get<DummyRecord>();
-   }
-   {
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
-      eventSetup.get<DummyRecord>();
-   }
-   {
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
-   //   CPPUNIT_ASSERT_THROW(eventSetup.get<DummyRecord>(), edm::eventsetup::NoRecordException<DummyRecord>);
-   eventSetup.get<DummyRecord>();
-   }
-   
-   
+  provider.insert(std::move(dummyRecordProvider));
+
+  {
+    Timestamp time_1(1);
+    provider.eventSetupForInstance(IOVSyncValue(time_1));
+  }
+
+  const Timestamp time_2(2);
+  finder->setInterval(ValidityInterval(IOVSyncValue(time_2), IOVSyncValue(Timestamp(3))));
+  {
+    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(time_2));
+    eventSetup.get<DummyRecord>();
+  }
+  {
+    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
+    eventSetup.get<DummyRecord>();
+  }
+  {
+    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
+    eventSetup.get<DummyRecord>();
+  }
+
+
 }
 
 void testEventsetup::recordValidityExcTest()
 {
-   DummyEventSetupProvider provider(&activityRegistry);
-   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
-   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
+  DummyEventSetupProvider provider(&activityRegistry);
+  typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
+  auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
 
-   std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
-   dummyRecordProvider->addFinder(finder);
-   
-   provider.insert(std::move(dummyRecordProvider));
-   
-   {
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(1)));
-   // CPPUNIT_ASSERT_THROW(eventSetup.get<DummyRecord>(), edm::eventsetup::NoRecordException<DummyRecord>);
-   eventSetup.get<DummyRecord>();
-   }
+  std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
+  dummyRecordProvider->addFinder(finder);
+
+  provider.insert(std::move(dummyRecordProvider));
+
+  {
+    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(1)));
+    eventSetup.get<DummyRecord>();
+  }
 
 }
 
 class DummyProxyProvider : public eventsetup::DataProxyProvider {
 public:
-   DummyProxyProvider() {
-      usingRecord<DummyRecord>();
-   }
-   void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/,
-                     const ValidityInterval& /*iInterval*/) {
-      //do nothing
-   }
+  DummyProxyProvider() {
+    usingRecord<DummyRecord>();
+  }
+  void newInterval(const eventsetup::EventSetupRecordKey& /*iRecordType*/,
+                   const ValidityInterval& /*iInterval*/) {
+    //do nothing
+  }
 protected:
-   void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {
-   }
+  void registerProxies(const eventsetup::EventSetupRecordKey&, KeyedProxies& /*iHolder*/) {
+  }
 
 };
 
@@ -283,52 +271,52 @@ static eventsetup::RecordDependencyRegister<DummyRecord> s_factory;
 
 void testEventsetup::proxyProviderTest()
 {
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-   provider.add(dummyProv);
-   
-   EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
-   CPPUNIT_ASSERT(non_null(&gottenRecord));
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+  provider.add(dummyProv);
+
+  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
+  CPPUNIT_ASSERT(non_null(&gottenRecord));
 }
 
 void testEventsetup::producerConflictTest()
 {
-   edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-   using edm::eventsetup::test::DummyProxyProvider;
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   {
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-      dummyProv->setDescription(description);
-      provider.add(dummyProv);
-   }
-   {
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-      dummyProv->setDescription(description);
-      provider.add(dummyProv);
-   }
-   //checking for conflicts is now delayed until first time EventSetup is requested
-   /*EventSetup const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+  using edm::eventsetup::test::DummyProxyProvider;
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  {
+    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    dummyProv->setDescription(description);
+    provider.add(dummyProv);
+  }
+  {
+    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    dummyProv->setDescription(description);
+    provider.add(dummyProv);
+  }
+  //checking for conflicts is now delayed until first time EventSetup is requested
+  /*EventSetup const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
 
 }
 void testEventsetup::sourceConflictTest()
 {
-   edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-   using edm::eventsetup::test::DummyProxyProvider;
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   {
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-      dummyProv->setDescription(description);
-      provider.add(dummyProv);
-   }
-   {
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-      dummyProv->setDescription(description);
-      provider.add(dummyProv);
-   }
-   //checking for conflicts is now delayed until first time EventSetup is requested
-   /*EventSetup const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-   
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+  using edm::eventsetup::test::DummyProxyProvider;
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  {
+    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    dummyProv->setDescription(description);
+    provider.add(dummyProv);
+  }
+  {
+    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    dummyProv->setDescription(description);
+    provider.add(dummyProv);
+  }
+  //checking for conflicts is now delayed until first time EventSetup is requested
+  /*EventSetup const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+
 }
 //#define TEST_EXCLUDE_DEF
 
@@ -353,333 +341,333 @@ void testEventsetup::twoSourceTest()
   }
   //checking for conflicts is now delayed until first time EventSetup is requested
   /*EventSetup const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-  
+
 }
 void testEventsetup::provenanceTest()
 {
-   using edm::eventsetup::test::DummyProxyProvider;
-   using edm::eventsetup::test::DummyData;
-   DummyData kGood; kGood.value_ = 1;
-   DummyData kBad; kBad.value_=0;
+  using edm::eventsetup::test::DummyProxyProvider;
+  using edm::eventsetup::test::DummyData;
+  DummyData kGood; kGood.value_ = 1;
+  DummyData kBad; kBad.value_=0;
 
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   try {
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-	 edm::ParameterSet ps;
-	 ps.addParameter<std::string>("name", "test11");
-	 ps.registerIt();
-         description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
-         dummyProv->setDescription(description);
-         provider.add(dummyProv);
-      }
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","testLabel",false);
-	 edm::ParameterSet ps;
-	 ps.addParameter<std::string>("name", "test22");
-	 ps.registerIt();
-         description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
-         dummyProv->setDescription(description);
-         provider.add(dummyProv);
-      }
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-      edm::ESHandle<DummyData> data;
-      eventSetup.getData(data);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
-      const edm::eventsetup::ComponentDescription* desc = data.description();
-      CPPUNIT_ASSERT( desc->label_ == "testLabel");
-   } catch (const cms::Exception& iException) {
-       std::cout <<"caught "<<iException.explainSelf()<<std::endl;
-      throw;
-   }
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  try {
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      edm::ParameterSet ps;
+      ps.addParameter<std::string>("name", "test11");
+      ps.registerIt();
+      description.pid_ = ps.id();
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      dummyProv->setDescription(description);
+      provider.add(dummyProv);
+    }
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testLabel",false);
+      edm::ParameterSet ps;
+      ps.addParameter<std::string>("name", "test22");
+      ps.registerIt();
+      description.pid_ = ps.id();
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      dummyProv->setDescription(description);
+      provider.add(dummyProv);
+    }
+    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    edm::ESHandle<DummyData> data;
+    eventSetup.getData(data);
+    CPPUNIT_ASSERT(kGood.value_==data->value_);
+    const edm::eventsetup::ComponentDescription* desc = data.description();
+    CPPUNIT_ASSERT( desc->label_ == "testLabel");
+  } catch (const cms::Exception& iException) {
+    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    throw;
+  }
 }
 
 void testEventsetup::getDataWithLabelTest()
 {
-   using edm::eventsetup::test::DummyProxyProvider;
-   using edm::eventsetup::test::DummyData;
-   DummyData kGood; kGood.value_ = 1;
-   DummyData kBad; kBad.value_=0;
-   
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   try {
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-	 edm::ParameterSet ps;
-	 ps.addParameter<std::string>("name", "test11");
-	 ps.registerIt();
-         description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
-         dummyProv->setDescription(description);
-         provider.add(dummyProv);
-      }
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","testLabel",false);
-	 edm::ParameterSet ps;
-	 ps.addParameter<std::string>("name", "test22");
-         ps.addParameter<std::string>("appendToDataLabel","blah");
-	 ps.registerIt();
-         description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
-         dummyProv->setDescription(description);
-         dummyProv->setAppendToDataLabel(ps);
-         provider.add(dummyProv);
-      }
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-      edm::ESHandle<DummyData> data;
-      eventSetup.getData("blah",data);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
-      const edm::eventsetup::ComponentDescription* desc = data.description();
-      CPPUNIT_ASSERT( desc->label_ == "testLabel");
-   } catch (const cms::Exception& iException) {
-      std::cout <<"caught "<<iException.explainSelf()<<std::endl;
-      throw;
-   }
+  using edm::eventsetup::test::DummyProxyProvider;
+  using edm::eventsetup::test::DummyData;
+  DummyData kGood; kGood.value_ = 1;
+  DummyData kBad; kBad.value_=0;
+
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  try {
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      edm::ParameterSet ps;
+      ps.addParameter<std::string>("name", "test11");
+      ps.registerIt();
+      description.pid_ = ps.id();
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      dummyProv->setDescription(description);
+      provider.add(dummyProv);
+    }
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testLabel",false);
+      edm::ParameterSet ps;
+      ps.addParameter<std::string>("name", "test22");
+      ps.addParameter<std::string>("appendToDataLabel","blah");
+      ps.registerIt();
+      description.pid_ = ps.id();
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      dummyProv->setDescription(description);
+      dummyProv->setAppendToDataLabel(ps);
+      provider.add(dummyProv);
+    }
+    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    edm::ESHandle<DummyData> data;
+    eventSetup.getData("blah",data);
+    CPPUNIT_ASSERT(kGood.value_==data->value_);
+    const edm::eventsetup::ComponentDescription* desc = data.description();
+    CPPUNIT_ASSERT( desc->label_ == "testLabel");
+  } catch (const cms::Exception& iException) {
+    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    throw;
+  }
 }
 
 void testEventsetup::getDataWithESInputTagTest()
 {
-   using edm::eventsetup::test::DummyProxyProvider;
-   using edm::eventsetup::test::DummyData;
-   DummyData kGood; kGood.value_ = 1;
-   DummyData kBad; kBad.value_=0;
-   
-   eventsetup::EventSetupProvider provider(&activityRegistry);
-   try {
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
-	 edm::ParameterSet ps;
-	 ps.addParameter<std::string>("name", "test11");
-	 ps.registerIt();
-         description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
-         dummyProv->setDescription(description);
-         provider.add(dummyProv);
-      }
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","testTwo",false);
-	 edm::ParameterSet ps;
-	 ps.addParameter<std::string>("name", "test22");
-         ps.addParameter<std::string>("appendToDataLabel","blah");
-	 ps.registerIt();
-         description.pid_ = ps.id();
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
-         dummyProv->setDescription(description);
-         dummyProv->setAppendToDataLabel(ps);
-         provider.add(dummyProv);
-      }
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-      {
-         edm::ESHandle<DummyData> data;
-         edm::ESInputTag blahTag("","blah");
-         eventSetup.getData(blahTag,data);
-         CPPUNIT_ASSERT(kGood.value_==data->value_);
-         const edm::eventsetup::ComponentDescription* desc = data.description();
-         CPPUNIT_ASSERT( desc->label_ == "testTwo");
-      }
+  using edm::eventsetup::test::DummyProxyProvider;
+  using edm::eventsetup::test::DummyData;
+  DummyData kGood; kGood.value_ = 1;
+  DummyData kBad; kBad.value_=0;
 
-      {
-         edm::ESHandle<DummyData> data;
-         edm::ESInputTag nullTag("","");
-         eventSetup.getData(nullTag,data);
-         CPPUNIT_ASSERT(kBad.value_==data->value_);
-         const edm::eventsetup::ComponentDescription* desc = data.description();
-         CPPUNIT_ASSERT( desc->label_ == "testOne");
-      }
-      
-      {
-         edm::ESHandle<DummyData> data;
-         edm::ESInputTag blahTag("testTwo","blah");
-         eventSetup.getData(blahTag,data);
-         CPPUNIT_ASSERT(kGood.value_==data->value_);
-         const edm::eventsetup::ComponentDescription* desc = data.description();
-         CPPUNIT_ASSERT( desc->label_ == "testTwo");
-      }
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  try {
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
+      edm::ParameterSet ps;
+      ps.addParameter<std::string>("name", "test11");
+      ps.registerIt();
+      description.pid_ = ps.id();
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      dummyProv->setDescription(description);
+      provider.add(dummyProv);
+    }
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","testTwo",false);
+      edm::ParameterSet ps;
+      ps.addParameter<std::string>("name", "test22");
+      ps.addParameter<std::string>("appendToDataLabel","blah");
+      ps.registerIt();
+      description.pid_ = ps.id();
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      dummyProv->setDescription(description);
+      dummyProv->setAppendToDataLabel(ps);
+      provider.add(dummyProv);
+    }
+    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    {
+      edm::ESHandle<DummyData> data;
+      edm::ESInputTag blahTag("","blah");
+      eventSetup.getData(blahTag,data);
+      CPPUNIT_ASSERT(kGood.value_==data->value_);
+      const edm::eventsetup::ComponentDescription* desc = data.description();
+      CPPUNIT_ASSERT( desc->label_ == "testTwo");
+    }
 
-      {
-         edm::ESHandle<DummyData> data;
-         edm::ESInputTag badTag("DoesNotExist","blah");
-         CPPUNIT_ASSERT_THROW(eventSetup.getData(badTag,data), cms::Exception);
-      }
+    {
+      edm::ESHandle<DummyData> data;
+      edm::ESInputTag nullTag("","");
+      eventSetup.getData(nullTag,data);
+      CPPUNIT_ASSERT(kBad.value_==data->value_);
+      const edm::eventsetup::ComponentDescription* desc = data.description();
+      CPPUNIT_ASSERT( desc->label_ == "testOne");
+    }
 
-      
-   } catch (const cms::Exception& iException) {
-      std::cout <<"caught "<<iException.explainSelf()<<std::endl;
-      throw;
-   }
+    {
+      edm::ESHandle<DummyData> data;
+      edm::ESInputTag blahTag("testTwo","blah");
+      eventSetup.getData(blahTag,data);
+      CPPUNIT_ASSERT(kGood.value_==data->value_);
+      const edm::eventsetup::ComponentDescription* desc = data.description();
+      CPPUNIT_ASSERT( desc->label_ == "testTwo");
+    }
+
+    {
+      edm::ESHandle<DummyData> data;
+      edm::ESInputTag badTag("DoesNotExist","blah");
+      CPPUNIT_ASSERT_THROW(eventSetup.getData(badTag,data), cms::Exception);
+    }
+
+
+  } catch (const cms::Exception& iException) {
+    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    throw;
+  }
 }
 
 
 
 void testEventsetup::sourceProducerResolutionTest()
 {
-   using edm::eventsetup::test::DummyProxyProvider;
-   using edm::eventsetup::test::DummyData;
-   DummyData kGood; kGood.value_ = 1;
-   DummyData kBad; kBad.value_=0;
+  using edm::eventsetup::test::DummyProxyProvider;
+  using edm::eventsetup::test::DummyData;
+  DummyData kGood; kGood.value_ = 1;
+  DummyData kBad; kBad.value_=0;
 
-   {
-      eventsetup::EventSetupProvider provider(&activityRegistry);
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
-         dummyProv->setDescription(description);
-         provider.add(dummyProv);
-      }
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
-         dummyProv->setDescription(description);
-         provider.add(dummyProv);
-      }
-      //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-      //       for a Record is presently an 'invalid' timestamp on both ends.
-      //       Since the EventSetup::get<> will only retrieve a Record if its
-      //       interval of validity is 'valid' for the present 'instance'
-      //       this is a 'hack' to have the 'get' succeed
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-      edm::ESHandle<DummyData> data;
-      eventSetup.getData(data);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
-   }
+  {
+    eventsetup::EventSetupProvider provider(&activityRegistry);
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      dummyProv->setDescription(description);
+      provider.add(dummyProv);
+    }
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      dummyProv->setDescription(description);
+      provider.add(dummyProv);
+    }
+    //NOTE: use 'invalid' timestamp since the default 'interval of validity'
+    //       for a Record is presently an 'invalid' timestamp on both ends.
+    //       Since the EventSetup::get<> will only retrieve a Record if its
+    //       interval of validity is 'valid' for the present 'instance'
+    //       this is a 'hack' to have the 'get' succeed
+    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    edm::ESHandle<DummyData> data;
+    eventSetup.getData(data);
+    CPPUNIT_ASSERT(kGood.value_==data->value_);
+  }
 
-   //reverse order
-   {
-      eventsetup::EventSetupProvider provider(&activityRegistry);
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
-         dummyProv->setDescription(description);
-         provider.add(dummyProv);
-      }
-      {
-         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-         std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
-         dummyProv->setDescription(description);
-         provider.add(dummyProv);
-      }
-      //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-      //       for a Record is presently an 'invalid' timestamp on both ends.
-      //       Since the EventSetup::get<> will only retrieve a Record if its
-      //       interval of validity is 'valid' for the present 'instance'
-      //       this is a 'hack' to have the 'get' succeed
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-      edm::ESHandle<DummyData> data;
-      eventSetup.getData(data);
-      CPPUNIT_ASSERT(kGood.value_==data->value_);
-   }
-   
+  //reverse order
+  {
+    eventsetup::EventSetupProvider provider(&activityRegistry);
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      dummyProv->setDescription(description);
+      provider.add(dummyProv);
+    }
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      dummyProv->setDescription(description);
+      provider.add(dummyProv);
+    }
+    //NOTE: use 'invalid' timestamp since the default 'interval of validity'
+    //       for a Record is presently an 'invalid' timestamp on both ends.
+    //       Since the EventSetup::get<> will only retrieve a Record if its
+    //       interval of validity is 'valid' for the present 'instance'
+    //       this is a 'hack' to have the 'get' succeed
+    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    edm::ESHandle<DummyData> data;
+    eventSetup.getData(data);
+    CPPUNIT_ASSERT(kGood.value_==data->value_);
+  }
+
 }
 
 
 void testEventsetup::preferTest()
 {
-   try {
-      using edm::eventsetup::test::DummyProxyProvider;
-      using edm::eventsetup::test::DummyData;
-      DummyData kGood; kGood.value_ = 1;
-      DummyData kBad; kBad.value_=0;
-      
-      {
-         using namespace edm::eventsetup;
-         EventSetupProvider::PreferredProviderInfo preferInfo;
-         EventSetupProvider::RecordToDataMap recordToData;
-         //default means use all proxies
-         preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
-         
-         eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
-         {
-            edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",false);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
-            dummyProv->setDescription(description);
-            provider.add(dummyProv);
-         }
-         {
-            edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
-            dummyProv->setDescription(description);
-            provider.add(dummyProv);
-         }
-         //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-         //       for a Record is presently an 'invalid' timestamp on both ends.
-         //       Since the EventSetup::get<> will only retrieve a Record if its
-         //       interval of validity is 'valid' for the present 'instance'
-         //       this is a 'hack' to have the 'get' succeed
-         EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-         edm::ESHandle<DummyData> data;
-         eventSetup.getData(data);
-         CPPUNIT_ASSERT(kGood.value_==data->value_);
-      }
-      
-      //sources
-      {
-         using namespace edm::eventsetup;
-         EventSetupProvider::PreferredProviderInfo preferInfo;
-         EventSetupProvider::RecordToDataMap recordToData;
-         //default means use all proxies
-         preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
-         eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
-         {
-            edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
-            dummyProv->setDescription(description);
-            provider.add(dummyProv);
-         }
-         {
-            edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
-            dummyProv->setDescription(description);
-            provider.add(dummyProv);
-         }
-         //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-         //       for a Record is presently an 'invalid' timestamp on both ends.
-         //       Since the EventSetup::get<> will only retrieve a Record if its
-         //       interval of validity is 'valid' for the present 'instance'
-         //       this is a 'hack' to have the 'get' succeed
-         EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-         edm::ESHandle<DummyData> data;
-         eventSetup.getData(data);
-         CPPUNIT_ASSERT(kGood.value_==data->value_);
-      }
+  try {
+    using edm::eventsetup::test::DummyProxyProvider;
+    using edm::eventsetup::test::DummyData;
+    DummyData kGood; kGood.value_ = 1;
+    DummyData kBad; kBad.value_=0;
 
-      //specific name
+    {
+      using namespace edm::eventsetup;
+      EventSetupProvider::PreferredProviderInfo preferInfo;
+      EventSetupProvider::RecordToDataMap recordToData;
+      //default means use all proxies
+      preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
+
+      eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
       {
-         using namespace edm::eventsetup;
-         EventSetupProvider::PreferredProviderInfo preferInfo;
-         EventSetupProvider::RecordToDataMap recordToData;
-         recordToData.insert(std::make_pair(std::string("DummyRecord"),
-                                            std::make_pair(std::string("DummyData"),std::string())));
-         preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
-         eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
-         {
-            edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
-            dummyProv->setDescription(description);
-            provider.add(dummyProv);
-         }
-         {
-            edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
-            std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
-            dummyProv->setDescription(description);
-            provider.add(dummyProv);
-         }
-         //NOTE: use 'invalid' timestamp since the default 'interval of validity'
-         //       for a Record is presently an 'invalid' timestamp on both ends.
-         //       Since the EventSetup::get<> will only retrieve a Record if its
-         //       interval of validity is 'valid' for the present 'instance'
-         //       this is a 'hack' to have the 'get' succeed
-         EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-         edm::ESHandle<DummyData> data;
-         eventSetup.getData(data);
-         CPPUNIT_ASSERT(kGood.value_==data->value_);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",false);
+        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+        dummyProv->setDescription(description);
+        provider.add(dummyProv);
       }
-      
-   }catch(const cms::Exception& iException) {
-      std::cout <<"caught "<<iException.explainSelf()<<std::endl;
-      throw;
-   }
+      {
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
+        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+        dummyProv->setDescription(description);
+        provider.add(dummyProv);
+      }
+      //NOTE: use 'invalid' timestamp since the default 'interval of validity'
+      //       for a Record is presently an 'invalid' timestamp on both ends.
+      //       Since the EventSetup::get<> will only retrieve a Record if its
+      //       interval of validity is 'valid' for the present 'instance'
+      //       this is a 'hack' to have the 'get' succeed
+      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+      edm::ESHandle<DummyData> data;
+      eventSetup.getData(data);
+      CPPUNIT_ASSERT(kGood.value_==data->value_);
+    }
+
+    //sources
+    {
+      using namespace edm::eventsetup;
+      EventSetupProvider::PreferredProviderInfo preferInfo;
+      EventSetupProvider::RecordToDataMap recordToData;
+      //default means use all proxies
+      preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
+      eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
+      {
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+        dummyProv->setDescription(description);
+        provider.add(dummyProv);
+      }
+      {
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
+        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+        dummyProv->setDescription(description);
+        provider.add(dummyProv);
+      }
+      //NOTE: use 'invalid' timestamp since the default 'interval of validity'
+      //       for a Record is presently an 'invalid' timestamp on both ends.
+      //       Since the EventSetup::get<> will only retrieve a Record if its
+      //       interval of validity is 'valid' for the present 'instance'
+      //       this is a 'hack' to have the 'get' succeed
+      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+      edm::ESHandle<DummyData> data;
+      eventSetup.getData(data);
+      CPPUNIT_ASSERT(kGood.value_==data->value_);
+    }
+
+    //specific name
+    {
+      using namespace edm::eventsetup;
+      EventSetupProvider::PreferredProviderInfo preferInfo;
+      EventSetupProvider::RecordToDataMap recordToData;
+      recordToData.insert(std::make_pair(std::string("DummyRecord"),
+                                         std::make_pair(std::string("DummyData"),std::string())));
+      preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
+      eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
+      {
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+        dummyProv->setDescription(description);
+        provider.add(dummyProv);
+      }
+      {
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
+        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+        dummyProv->setDescription(description);
+        provider.add(dummyProv);
+      }
+      //NOTE: use 'invalid' timestamp since the default 'interval of validity'
+      //       for a Record is presently an 'invalid' timestamp on both ends.
+      //       Since the EventSetup::get<> will only retrieve a Record if its
+      //       interval of validity is 'valid' for the present 'instance'
+      //       this is a 'hack' to have the 'get' succeed
+      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+      edm::ESHandle<DummyData> data;
+      eventSetup.getData(data);
+      CPPUNIT_ASSERT(kGood.value_==data->value_);
+    }
+
+  }catch(const cms::Exception& iException) {
+    std::cout <<"caught "<<iException.explainSelf()<<std::endl;
+    throw;
+  }
 }
 
 void testEventsetup::introspectionTest()
@@ -688,19 +676,19 @@ void testEventsetup::introspectionTest()
   using edm::eventsetup::test::DummyData;
   DummyData kGood; kGood.value_ = 1;
   DummyData kBad; kBad.value_=0;
-  
+
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
-  {
-    edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-    edm::ParameterSet ps;
-    ps.addParameter<std::string>("name", "test11");
-    ps.registerIt();
-    description.pid_ = ps.id();
-    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
-    dummyProv->setDescription(description);
-    provider.add(dummyProv);
-  }
+    {
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
+      edm::ParameterSet ps;
+      ps.addParameter<std::string>("name", "test11");
+      ps.registerIt();
+      description.pid_ = ps.id();
+      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      dummyProv->setDescription(description);
+      provider.add(dummyProv);
+    }
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
       edm::ParameterSet ps;
@@ -729,12 +717,12 @@ void testEventsetup::iovExtentionTest()
   DummyEventSetupProvider provider(&activityRegistry);
   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
-  
-  std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
+
+  auto finder = std::make_shared<DummyFinder>();
   dummyRecordProvider->addFinder(finder);
-  
+
   provider.insert(std::move(dummyRecordProvider));
-  
+
   const Timestamp time_2(2);
   finder->setInterval(ValidityInterval(IOVSyncValue{time_2}, IOVSyncValue{Timestamp{3}}));
   {
@@ -761,4 +749,3 @@ void testEventsetup::iovExtentionTest()
   }
 
 }
-

--- a/FWCore/Modules/src/EventSetupRecordDataGetter.cc
+++ b/FWCore/Modules/src/EventSetupRecordDataGetter.cc
@@ -197,7 +197,7 @@ private:
          if(not pRecord) {
            edm::LogWarning("RecordNotInIOV") <<"The EventSetup Record '"<<itRecord->first.name()<<"' is not available for this IOV.";
          }
-         if(nullptr != pRecord && pRecord->cacheIdentifier() != recordToCacheIdentifier_[itRecord->first]) {
+         if(pRecord.has_value() && pRecord->cacheIdentifier() != recordToCacheIdentifier_[itRecord->first]) {
             recordToCacheIdentifier_[itRecord->first] = pRecord->cacheIdentifier();
             typedef std::vector<DataKey> Keys;
             Keys const& keys = itRecord->second;

--- a/FWCore/Modules/src/EventSetupRecordDataGetter.cc
+++ b/FWCore/Modules/src/EventSetupRecordDataGetter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EventSetupRecordDataGetter
 // Class:      EventSetupRecordDataGetter
-// 
+//
 /**\class EventSetupRecordDataGetter EventSetupRecordDataGetter.cc src/EventSetupRecordDataGetter/src/EventSetupRecordDataGetter.cc
 
  Description: Can be configured to 'get' any Data in any EventSetup Record.  Primarily used for testing.
@@ -42,8 +42,8 @@ namespace edm {
 public:
      explicit EventSetupRecordDataGetter(ParameterSet const&);
      ~EventSetupRecordDataGetter() override;
-      
-      
+
+
      void analyze(Event const&, EventSetup const&) override;
      void beginRun(Run const&, EventSetup const&) override;
      void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
@@ -54,7 +54,7 @@ private:
      void doGet(EventSetup const&);
         // ----------member data ---------------------------
      const ParameterSet pSet_;
-      
+
      typedef std::map<eventsetup::EventSetupRecordKey, std::vector<eventsetup::DataKey> > RecordToDataKeys;
      RecordToDataKeys recordToDataKeys_;
      std::map<eventsetup::EventSetupRecordKey, unsigned long long> recordToCacheIdentifier_;
@@ -86,19 +86,19 @@ private:
 // ------------ method called to produce the data  ------------
    void EventSetupRecordDataGetter::fillDescriptions(ConfigurationDescriptions& descriptions) {
       descriptions.setComment("Retrieves specified data from the EventSetup sytem whenever that data changes.");
-      
+
       ParameterSetDescription desc;
       desc.addUntracked<bool>("verbose", false)->setComment("Print a message to the logger each time a data item is gotten.");
 
       ParameterSetDescription toGet;
       toGet.add<std::string>("record")->setComment("The name of an EventSetup record holding the data you want obtained.");
-      toGet.add<std::vector<std::string> >("data")->setComment("The identifier for the data you wish to retrieve. " 
+      toGet.add<std::vector<std::string> >("data")->setComment("The identifier for the data you wish to retrieve. "
                                                                "The identifier is in two parts separated by a backslash '/'. "
                                                                "The first part is the C++ class name of the data and the "
                                                                "second part is the label used when getting the data (blank is acceptable). "
                                                                "If there is no label, the backslash may be omitted."
       );
-      
+
       std::vector<edm::ParameterSet> emptyVect;
       desc.addVPSet("toGet", toGet,emptyVect)->setComment("The contained PSets must have the following structure.\n"
                                                 "A 'string' named 'record' that holds the name of an EventSetup record holding the data you want to obtain.\n"
@@ -112,35 +112,35 @@ private:
       descriptions.add("getEventSetupData", desc);
    }
 
-   void 
+   void
    EventSetupRecordDataGetter::beginRun(Run const&, EventSetup const& iSetup) {
       doGet(iSetup);
    }
 
-   void 
+   void
    EventSetupRecordDataGetter::beginLuminosityBlock(LuminosityBlock const&, EventSetup const& iSetup) {
       doGet(iSetup);
    }
-   
+
    void
    EventSetupRecordDataGetter::analyze(edm::Event const& /*iEvent*/, edm::EventSetup const& iSetup) {
       doGet(iSetup);
    }
-   
+
    void
-   EventSetupRecordDataGetter::doGet(EventSetup const& iSetup) {  
+   EventSetupRecordDataGetter::doGet(EventSetup const& iSetup) {
       if(recordToDataKeys_.empty()) {
          typedef std::vector<ParameterSet> Parameters;
          Parameters const& toGet = pSet_.getParameterSetVector("toGet");
-         
+
          for(Parameters::const_iterator itToGet = toGet.begin(), itToGetEnd = toGet.end(); itToGet != itToGetEnd; ++itToGet) {
             std::string recordName = itToGet->getParameter<std::string>("record");
-            
+
             eventsetup::EventSetupRecordKey recordKey(eventsetup::EventSetupRecordKey::TypeTag::findType(recordName));
             if(recordKey.type() == eventsetup::EventSetupRecordKey::TypeTag()) {
               //record not found
               edm::LogWarning("DataGetter") <<"Record \""<< recordName <<"\" does not exist "<<std::endl;
-               
+
                continue;
             }
             typedef std::vector<std::string> Strings;
@@ -158,11 +158,11 @@ private:
                  //not found
                  edm::LogWarning("DataGetter") <<"data item of type \""<< datumName <<"\" does not exist"<<std::endl;
 
-                
+
                   continue;
                }
                eventsetup::DataKey datumKey(datumType, labelName.c_str());
-               dataKeys.push_back(datumKey); 
+               dataKeys.push_back(datumKey);
             }
             recordToDataKeys_.insert(std::make_pair(recordKey, dataKeys));
             recordToCacheIdentifier_.insert(std::make_pair(recordKey, 0));
@@ -175,21 +175,21 @@ private:
 
             for(std::vector<eventsetup::EventSetupRecordKey>::iterator itRKey = recordKeys.begin(), itRKeyEnd = recordKeys.end();
                 itRKey != itRKeyEnd;
-                ++itRKey) {               
+                ++itRKey) {
                auto record = iSetup.find(*itRKey);
                assert(record );
                dataKeys.clear();
                record->fillRegisteredDataKeys(dataKeys);
                recordToDataKeys_.insert(std::make_pair(*itRKey, dataKeys));
-               recordToCacheIdentifier_.insert(std::make_pair(*itRKey, 0));               
+               recordToCacheIdentifier_.insert(std::make_pair(*itRKey, 0));
             }
          }
       }
-      
+
       using namespace edm::eventsetup;
 
       //For each requested Record get the requested data only if the Record is in a new IOV
-      
+
       for(RecordToDataKeys::iterator itRecord = recordToDataKeys_.begin(), itRecordEnd = recordToDataKeys_.end();
            itRecord != itRecordEnd;
            ++itRecord) {

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
@@ -2,7 +2,7 @@
 //
 // Package:    RCTConfigTester
 // Class:      RCTConfigTester
-// 
+//
 /**\class RCTConfigTester RCTConfigTester.h L1TriggerConfig/RCTConfigTester/src/RCTConfigTester.cc
 
  Description: <one line class summary>
@@ -58,25 +58,16 @@ void L1RCTChannelMaskTester::analyze(const edm::Event& iEvent,
 
     rctChanMask->print(std::cout);
 
-    //
-    edm::eventsetup::EventSetupRecordKey recordKey(
-            edm::eventsetup::EventSetupRecordKey::TypeTag::findType(
-                    "L1RCTNoisyChannelMaskRcd"));
-
-    if (evSetup.find(recordKey) == std::nullopt) {
-        //record not found
-        std::cout << "\nRecord \"" << "L1RCTNoisyChannelMaskRcd"
-                << "\" does not exist.\n" << std::endl;
-    } else {
-
+    if (auto maskRecord = evSetup.tryToGet<L1RCTNoisyChannelMaskRcd>()) {
         edm::ESHandle<L1RCTNoisyChannelMask> rctNoisyChanMask;
-        evSetup.get<L1RCTNoisyChannelMaskRcd>().get(rctNoisyChanMask);
+        maskRecord->get(rctNoisyChanMask);
 
         rctNoisyChanMask->print(std::cout);
-
+    } else {
+        std::cout << "\nRecord \"" << "L1RCTNoisyChannelMaskRcd"
+                  << "\" does not exist.\n" << std::endl;
     }
 
 }
 
 DEFINE_FWK_MODULE( L1RCTChannelMaskTester);
-

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
@@ -63,7 +63,7 @@ void L1RCTChannelMaskTester::analyze(const edm::Event& iEvent,
             edm::eventsetup::EventSetupRecordKey::TypeTag::findType(
                     "L1RCTNoisyChannelMaskRcd"));
 
-    if (evSetup.find(recordKey) == nullptr) {
+    if (evSetup.find(recordKey) == std::nullopt) {
         //record not found
         std::cout << "\nRecord \"" << "L1RCTNoisyChannelMaskRcd"
                 << "\" does not exist.\n" << std::endl;

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -139,7 +139,7 @@ namespace  {
       }
    private:
       edm::eventsetup::EventSetupRecordKey m_key;
-     boost::optional<edm::eventsetup::EventSetupRecordGeneric> m_record;
+     std::optional<edm::eventsetup::EventSetupRecordGeneric> m_record;
       fwlite::RecordWriter m_writer;
       unsigned long long m_cacheID;
       std::vector<DataInfo> m_dataInfos;


### PR DESCRIPTION
This PR *does* include some whitespace changes which are due to using C++17's nested namespace declarations.