### PR TITLE
Hybrid zero suppression fixes

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1549,7 +1549,7 @@ steps['RECOHID10']['--eventcontent']+=',REPACKRAW'
 
 steps['HYBRIDRepackHI2015VR']={'--eventcontent':'RAW',
                                '--datatier':'RAW',
-                               '--conditions':'auto:run2_data',
+                               '--conditions':'auto:run2_hlt_hi',
                                '--step':'RAW2DIGI,REPACK:DigiToHybridRawRepack',
                                '--scenario':'HeavyIons',                     
                                '--data':'',

--- a/RecoLocalTracker/SiStripZeroSuppression/python/customiseHybrid.py
+++ b/RecoLocalTracker/SiStripZeroSuppression/python/customiseHybrid.py
@@ -4,6 +4,7 @@ import FWCore.ParameterSet.Config as cms
 def runOnHybridZS(process):
     process.load("RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_cfi")
     process.load("RecoLocalTracker.SiStripClusterizer.SiStripClusterizer_cfi")
+    process.siStripZeroSuppression.Algorithms.APVInspectMode = "Hybrid"
     zsInputs = process.siStripZeroSuppression.RawDigiProducersList
     clusInputs = process.siStripClusters.DigiProducersList
     unpackedZS = cms.InputTag("siStripDigis", "ZeroSuppressed")

--- a/RecoLocalTracker/SiStripZeroSuppression/python/customiseHybrid.py
+++ b/RecoLocalTracker/SiStripZeroSuppression/python/customiseHybrid.py
@@ -34,7 +34,7 @@ def addHybridEmulationBeforeRepack(process):
     zs.Algorithms.APVInspectMode = "HybridEmulation"
     zs.Algorithms.APVRestoreMode = ""
     zs.Algorithms.CommonModeNoiseSubtractionMode = 'Median'
-    zs.Algorithms.MeanCM = 512
+    zs.Algorithms.MeanCM = 0
     zs.Algorithms.DeltaCMThreshold = 20
     zs.Algorithms.Use10bitsTruncation = True
     zs.RawDigiProducersList = cms.VInputTag(cms.InputTag("siStripDigis", "VirginRaw"))

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
@@ -324,7 +324,7 @@ inline uint16_t SiStripAPVRestorer::hybridEmulationInspect(uint16_t firstAPV, co
         MeanAPVCM = itCMMap->second[iAPV];
 
       const float DeltaCM = median_[iAPV] - (MeanAPVCM+1024)/2;
-      if ( ( DeltaCM < 0 ) && ( std::abs(DeltaCM) > deltaCMThreshold_ ) ) {
+      if ( ( DeltaCM < 0 ) && ( std::abs(DeltaCM) > deltaCMThreshold_/2 ) ) {
         apvFlags_[iAPV] = "HybridEmulation";
         ++nAPVflagged;
       }

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
@@ -46,8 +46,8 @@ SiStripAPVRestorer::SiStripAPVRestorer(const edm::ParameterSet& conf):
   size_window_(conf.getParameter<int>("sizeWindow")),
   width_cluster_(conf.getParameter<int>("widthCluster"))
 {
-  if ( restoreAlgo_ == "BaselineFollower" && inspectAlgo_ != "BaselineFollower" )
-    throw cms::Exception("Incompatible Algorithm") << "The BaselineFollower restore method requires the BaselineFollower inspect method";
+  if ( restoreAlgo_ == "BaselineFollower" && inspectAlgo_ != "BaselineFollower" && inspectAlgo_ != "Hybrid" )
+    throw cms::Exception("Incompatible Algorithm") << "The BaselineFollower restore method requires the BaselineFollower (or Hybrid) inspect method";
 }
 
 

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
@@ -323,7 +323,7 @@ inline uint16_t SiStripAPVRestorer::hybridEmulationInspect(uint16_t firstAPV, co
       if ( useRealMeanCM_ && ( std::end(meanCMmap_) != itCMMap ) )
         MeanAPVCM = itCMMap->second[iAPV];
 
-      const float DeltaCM = median_[iAPV] - MeanAPVCM;
+      const float DeltaCM = median_[iAPV] - (MeanAPVCM+1024)/2;
       if ( ( DeltaCM < 0 ) && ( std::abs(DeltaCM) > deltaCMThreshold_ ) ) {
         apvFlags_[iAPV] = "HybridEmulation";
         ++nAPVflagged;


### PR DESCRIPTION
This PR collects a few fixes related to the hybrid zero-suppression (and emulation):
- a configuration error: the "Hybrid" inspection method of the APV restorer should be used for hybrid data (this needs to be propagated to the HLT menu for HI; there was also a check to enfoce "BaselineFollower" as inspect method when it was used as restore method, that has been relaxed accordingly).
- hybrid emulation needs the complete pedestals, but the global tag used in the relval to test it did not include these, so changed "auto:run2_data" to "auto:run2_hlt_hi" there
- for the hybrid emulation, the "x->(x+1024)/2" transformation is applied to the `MeanCM` parameter (as it is to the VR digis), to align the interpretation with its online equivalent

@icali @CesarBernardes @erikbutz @mmusich 
