### PR TITLE
monitor island superclusters and photons for HI

### DIFF
--- a/DQMOffline/EGamma/python/egammaDQMOffline_cff.py
+++ b/DQMOffline/EGamma/python/egammaDQMOffline_cff.py
@@ -50,3 +50,8 @@ phase2_hgcal.toReplaceWith(
   egammaDQMOffline, _egammaDQMOfflineHGCal
 )
 
+from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+for e in [peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017]:
+    e.toModify(stdPhotonAnalysis, phoProducer = cms.InputTag('islandPhotons'))

--- a/Validation/EcalClusters/python/egammaSCAnalyzer_cfi.py
+++ b/Validation/EcalClusters/python/egammaSCAnalyzer_cfi.py
@@ -55,3 +55,11 @@ egammaSuperClusterAnalyzer = DQMEDAnalyzer('EgammaSuperClusters',
 )
 
 
+from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+for e in [peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017]:
+    e.toModify(egammaSuperClusterAnalyzer, barrelCorSuperClusterCollection = cms.InputTag("correctedIslandBarrelSuperClusters"))
+    e.toModify(egammaSuperClusterAnalyzer, barrelRawSuperClusterCollection = cms.InputTag("islandSuperClusters","islandBarrelSuperClusters"))
+    e.toModify(egammaSuperClusterAnalyzer, endcapCorSuperClusterCollection = cms.InputTag("correctedIslandEndcapSuperClusters"))
+    e.toModify(egammaSuperClusterAnalyzer, endcapRawSuperClusterCollection = cms.InputTag("islandSuperClusters","islandEndcapSuperClusters"))


### PR DESCRIPTION
Island SC and island photons were standard objects in the DQM of HI reco. Apparently this was not propagated to the HI-related eras (eg. pp_on_AA). HI DQM histograms are now filled with island SC and photons.

Needed for 2018 pbpb data monitoring. Tests pass workflows 158, 148 and give the expected output.
@mandrenguyen @BetterWang @bi-ran @innakucher
