### PR TITLE
Remove uGT in DQM L1TMonitor and L1TMonitorClient.

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -83,8 +83,8 @@ Stage2L1HardwareValidation = cms.Sequence(
     valOmtfDigis +
     valEmtfStage2Digis +
     valGmtCaloSumDigis +
-    valGmtStage2Digis +
-    valGtStage2Digis
+    valGmtStage2Digis #+
+    #valGtStage2Digis
 )
 
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
@@ -136,8 +136,8 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
 
 # sequence to run only for validation events
 l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(
-    l1tdeStage2CaloLayer1 +
-    l1tdeStage2CaloLayer2 +
-    l1tStage2CaloLayer2Emul
+    l1tdeStage2CaloLayer1 #+
+    #l1tdeStage2CaloLayer2 +
+    #l1tStage2CaloLayer2Emul
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -129,15 +129,15 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2KalmanBmtf +
     l1tdeStage2Omtf +
     l1tdeStage2EmtfOnlineDQMSeq +
-    l1tStage2uGMTEmulatorOnlineDQMSeq +
-    l1tdeStage2uGT +
-    l1tStage2uGtEmul
+    l1tStage2uGMTEmulatorOnlineDQMSeq #+
+    #l1tdeStage2uGT +
+    #l1tStage2uGtEmul
 )
 
 # sequence to run only for validation events
 l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(
-    l1tdeStage2CaloLayer1 #+
-    #l1tdeStage2CaloLayer2 +
-    #l1tStage2CaloLayer2Emul
+    l1tdeStage2CaloLayer1 +
+    l1tdeStage2CaloLayer2 +
+    l1tStage2CaloLayer2Emul
 )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -53,11 +53,11 @@ l1TStage2EmulatorClients = cms.Sequence(
                       + l1tStage2OMTFEmulatorClient
                       + l1tStage2EMTFEmulatorClient
                       + l1tStage2EmulatorEventInfoClient
-                      + l1tStage2uGTEmulatorClient
+                      #+ l1tStage2uGTEmulatorClient
                         )
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(
-                        l1TStage2EmulatorQualityTests +
-                        l1TStage2EmulatorClients
+                        l1TStage2EmulatorQualityTests #+
+                      #  l1TStage2EmulatorClients
                         )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -57,7 +57,7 @@ l1TStage2EmulatorClients = cms.Sequence(
                         )
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(
-                        l1TStage2EmulatorQualityTests #+
-                      #  l1TStage2EmulatorClients
+                        l1TStage2EmulatorQualityTests +
+                        l1TStage2EmulatorClients
                         )
 


### PR DESCRIPTION
Intended for Online DQM, if used during HI test and no uGT support for HI algos in CMSSW.