### PR TITLE
HCALDQM: Add FCDTask for FCD demonstrator (10_2_X)

### DIFF
--- a/DQM/HcalTasks/interface/FCDTask.h
+++ b/DQM/HcalTasks/interface/FCDTask.h
@@ -1,0 +1,54 @@
+#ifndef FCDTask_h
+#define FCDTask_h
+
+/*
+ *	file:			FCDTask.h
+ *	Author:			Quan Wang
+ *	Description:
+ *		Task for ZDC Read out
+ */
+
+#include "DQM/HcalCommon/interface/ElectronicsMap.h"
+
+class FCDTask : public DQMEDAnalyzer
+{
+	public:
+	struct FCDChannel {
+		int crate;
+		int slot;
+		int fiber;
+		int fiberChannel;
+	};
+
+	public:
+		FCDTask(edm::ParameterSet const&);
+		~FCDTask() override{}
+
+		void bookHistograms(DQMStore::IBooker&,
+		edm::Run const&, edm::EventSetup const&) override;
+
+	protected:
+		void analyze(edm::Event const&, edm::EventSetup const&) override;
+
+		//	tags
+		edm::InputTag	_tagQIE10;
+		edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
+
+		//	hcaldqm::Containers
+		std::map<HcalElectronicsId, MonitorElement*>   _cADC;
+		std::map<HcalElectronicsId, MonitorElement*>   _cADC_vs_TS;
+		std::map<HcalElectronicsId, MonitorElement*>   _cTDC;
+		std::map<HcalElectronicsId, MonitorElement*>   _cTDCTime;
+
+		std::vector<HcalElectronicsId> _fcd_eids;
+		std::vector<FCDChannel> _channels;
+		HcalElectronicsMap const* _emap;
+		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
+
+
+};
+
+#endif
+
+
+

--- a/DQM/HcalTasks/plugins/FCDTask.cc
+++ b/DQM/HcalTasks/plugins/FCDTask.cc
@@ -39,16 +39,12 @@ FCDTask::FCDTask(edm::ParameterSet const& ps)
 	std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
 	for (auto& it_gid : gids) {
 		if (it_gid.genericSubdet() != HcalGenericDetId::HcalGenZDC) {
-			std::cout << "[debug] \tSkipping non-ZDC channel " << it_gid << std::endl;
 			continue;
 		}
 		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(it_gid));
 		for (auto& it_channel : _channels) {
 			if ((eid.crateId() == it_channel.crate) && (eid.slot() == it_channel.slot) && (eid.fiberIndex() == it_channel.fiber) && (eid.fiberChanId() == it_channel.fiberChannel)) {
-				std::cout << "[debug] Using FCD channel " << eid << std::endl;
 				_fcd_eids.push_back(eid);
-			} else {
-				std::cout << "[debug] \tSkipping non-FCD channel " << eid << std::endl;
 			}
 		}
 	}
@@ -72,7 +68,7 @@ FCDTask::FCDTask(edm::ParameterSet const& ps)
 
 		ib.setCurrentFolder("Hcal/FCDTask/TDC");
 		_cTDC[it_eid] = ib.book1D( histoname.c_str(), histoname.c_str(), 64, -0.5, 63.5);
-		_cTDC[it_eid]->setAxisTitle("TDC time [ns]", 1);
+		_cTDC[it_eid]->setAxisTitle("TDC", 1);
 
 	}
 }

--- a/DQM/HcalTasks/plugins/FCDTask.cc
+++ b/DQM/HcalTasks/plugins/FCDTask.cc
@@ -1,0 +1,110 @@
+
+#include "DQM/HcalTasks/interface/FCDTask.h"
+
+bool operator==(const FCDTask::FCDChannel& lhs, const FCDTask::FCDChannel& rhs) {
+    return ((lhs.crate == rhs.crate) && (lhs.slot == rhs.slot) && (lhs.fiber == rhs.fiber) && (lhs.fiberChannel == rhs.fiberChannel));
+}
+
+
+FCDTask::FCDTask(edm::ParameterSet const& ps)
+{
+	//	tags
+	_tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10",
+		edm::InputTag("hcalDigis", "ZDC"));
+	_tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
+
+	// channels
+	edm::ParameterSet channelPSet = ps.getParameter<edm::ParameterSet>("fcdChannels");
+	std::vector<int32_t> crates = channelPSet.getUntrackedParameter<std::vector<int32_t> >("crate");
+	std::vector<int32_t> slots = channelPSet.getUntrackedParameter<std::vector<int32_t> >("slot");
+	std::vector<int32_t> fibers = channelPSet.getUntrackedParameter<std::vector<int32_t> >("fiber");
+	std::vector<int32_t> fiberChannels = channelPSet.getUntrackedParameter<std::vector<int32_t> >("fiber_channel");
+	for (unsigned int i = 0; i < crates.size(); ++i) {
+		_channels.push_back({crates[i], slots[i], fibers[i], fiberChannels[i]});
+	}
+}
+
+/* virtual */ void FCDTask::bookHistograms(DQMStore::IBooker &ib,
+	edm::Run const& r, edm::EventSetup const& es)
+{
+	edm::ESHandle<HcalDbService> dbService;
+	es.get<HcalDbRecord>().get(dbService);
+	_emap = dbService->getHcalMapping();
+	_ehashmap.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap);
+
+	ib.cd();
+
+	//book histos per channel
+	std::string histoname;
+	std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
+	for (auto& it_gid : gids) {
+		if (it_gid.genericSubdet() != HcalGenericDetId::HcalGenZDC) {
+			std::cout << "[debug] \tSkipping non-ZDC channel " << it_gid << std::endl;
+			continue;
+		}
+		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(it_gid));
+		for (auto& it_channel : _channels) {
+			if ((eid.crateId() == it_channel.crate) && (eid.slot() == it_channel.slot) && (eid.fiberIndex() == it_channel.fiber) && (eid.fiberChanId() == it_channel.fiberChannel)) {
+				std::cout << "[debug] Using FCD channel " << eid << std::endl;
+				_fcd_eids.push_back(eid);
+			} else {
+				std::cout << "[debug] \tSkipping non-FCD channel " << eid << std::endl;
+			}
+		}
+	}
+	for (auto& it_eid : _fcd_eids) {
+		// EM Pos
+		histoname = std::to_string(it_eid.crateId()) + "-" + std::to_string(it_eid.slot()) + "-" + std::to_string(it_eid.fiberIndex()) + "-" + std::to_string(it_eid.fiberChanId());
+		ib.setCurrentFolder("Hcal/FCDTask/ADC");
+		_cADC[it_eid] = ib.book1D( histoname.c_str(), histoname.c_str(), 256, 0, 256);
+		_cADC[it_eid]->setAxisTitle("ADC", 1);
+		_cADC[it_eid]->setAxisTitle("N", 2);
+
+		ib.setCurrentFolder("Hcal/FCDTask/ADC_vs_TS"),
+		_cADC_vs_TS[it_eid] = ib.book2D( histoname.c_str(), histoname.c_str(), 10, 0, 10, 64, 0, 256);
+		_cADC_vs_TS[it_eid]->setAxisTitle("TS", 1);
+		_cADC_vs_TS[it_eid]->setAxisTitle("ADC", 2);
+
+		ib.setCurrentFolder("Hcal/FCDTask/TDCTime");
+		_cTDCTime[it_eid] = ib.book1D( histoname.c_str(), histoname.c_str(), 500, 0., 250.);
+		_cTDCTime[it_eid]->setAxisTitle("TDC time [ns]", 1);
+
+
+		ib.setCurrentFolder("Hcal/FCDTask/TDC");
+		_cTDC[it_eid] = ib.book1D( histoname.c_str(), histoname.c_str(), 64, -0.5, 63.5);
+		_cTDC[it_eid]->setAxisTitle("TDC time [ns]", 1);
+
+	}
+}
+
+
+/* virtual */ void FCDTask::analyze(edm::Event const& e, edm::EventSetup const&)
+{
+	edm::Handle<QIE10DigiCollection> digis;
+	if (!e.getByToken(_tokQIE10, digis))
+		edm::LogError("Collection QIE10DigiCollection for ZDC isn't available"
+				+ _tagQIE10.label() + " " + _tagQIE10.instance());
+
+	for ( auto it = digis->begin(); it != digis->end(); it++ ) {
+		const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+		HcalGenericDetId const& gdid = digi.detid();
+		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(gdid));
+		if (std::find(_fcd_eids.begin(), _fcd_eids.end(), eid) == _fcd_eids.end()) {
+			continue;
+		}
+
+		for ( int i = 0; i < digi.samples(); i++ ) {
+			// iter over all samples
+			_cADC[eid]->Fill(digi[i].adc());
+			_cADC_vs_TS[eid]->Fill(i, digi[i].adc());
+			_cTDC[eid]->Fill(digi[i].le_tdc());
+			if (digi[i].le_tdc() <= 50.) {
+				double tdctime = 25. * i + 0.5 * digi[i].le_tdc();
+				_cTDCTime[eid]->Fill(tdctime);
+			}
+		}
+	}
+}
+
+
+DEFINE_FWK_MODULE(FCDTask);

--- a/DQM/HcalTasks/python/FCDTask.py
+++ b/DQM/HcalTasks/python/FCDTask.py
@@ -1,0 +1,77 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+# FCD channel coordinates (ieta, iphi, depth)
+fcd_channels_tuple = [
+	(-1,  5, -98),
+	(-1,  6, -98),
+	(-1,  7, -98),
+	(-1,  8, -98),
+	(-1,  9, -98),
+	(-1, 10, -98),
+	(-1, 11, -98),
+	(-1, 12, -98),
+	(-1, 13, -98),
+	(-1, 14, -98),
+	(-1, 15, -98),
+	(-1, 16, -98),
+	(-1, 17, -98),
+	(-1, 18, -98),
+	(-1, 19, -98),
+	(-1, 20, -98),
+	(-1, 21, -98),
+	(-1, 22, -98),
+	(-1, 23, -98),
+	(-1, 24, -98),
+	(-1, 25, -98),
+	(-1, 26, -98),
+	(-1, 27, -98),
+	(-1, 28, -98),
+]
+
+fcd_channels_tuple = [
+	(38, 11, 0, 0),
+	(38, 11, 0, 1),
+	(38, 11, 0, 2),
+	(38, 11, 0, 3),
+	(38, 11, 1, 0),
+	(38, 11, 1, 1),
+	(38, 11, 1, 2),
+	(38, 11, 1, 3),
+	(38, 11, 2, 0),
+	(38, 11, 2, 1),
+	(38, 11, 2, 2),
+	(38, 11, 2, 3),
+	(38, 11, 3, 0),
+	(38, 11, 3, 1),
+	(38, 11, 3, 2),
+	(38, 11, 3, 3),
+	(38, 11, 4, 0),
+	(38, 11, 4, 1),
+	(38, 11, 4, 2),
+	(38, 11, 4, 3),
+	(38, 11, 5, 0),
+	(38, 11, 5, 1),
+	(38, 11, 5, 2),
+	(38, 11, 5, 3),
+]
+
+# Convert tuple to CMSSW object
+fcd_channels = cms.PSet(
+	crate = cms.untracked.vint32(),
+	slot = cms.untracked.vint32(),
+	fiber = cms.untracked.vint32(),
+	fiber_channel = cms.untracked.vint32()
+)
+for channel in fcd_channels_tuple:
+	fcd_channels.crate.append(channel[0])
+	fcd_channels.slot.append(channel[1])
+	fcd_channels.fiber.append(channel[2])
+	fcd_channels.fiber_channel.append(channel[3])
+
+fcdTask = DQMEDAnalyzer(
+	"FCDTask",
+	tagFCDDigis = cms.untracked.InputTag('hcalDigis', 'ZDC'),
+	fcdChannels = fcd_channels,
+)

--- a/DQM/HcalTasks/python/FCDTask.py
+++ b/DQM/HcalTasks/python/FCDTask.py
@@ -72,6 +72,17 @@ for channel in fcd_channels_tuple:
 
 fcdTask = DQMEDAnalyzer(
 	"FCDTask",
+	#	standard parameters
+	name = cms.untracked.string("FDCTask"),
+	debug = cms.untracked.int32(0),
+	runkeyVal = cms.untracked.int32(0),
+	runkeyName = cms.untracked.string("pp_run"),
+	ptype = cms.untracked.int32(0),
+	mtype = cms.untracked.bool(True),
+	subsystem = cms.untracked.string("Hcal"),
+
+	#	tags
 	tagFCDDigis = cms.untracked.InputTag('hcalDigis', 'ZDC'),
+
 	fcdChannels = fcd_channels,
 )

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -119,6 +119,7 @@ process.load("DQM.HcalTasks.DigiTask")
 process.load('DQM.HcalTasks.TPTask')
 process.load('DQM.HcalTasks.RawTask')
 process.load('DQM.HcalTasks.NoCQTask')
+process.load('DQM.HcalTasks.FCDTask')
 #process.load('DQM.HcalTasks.ZDCTask')
 #process.load('DQM.HcalTasks.QIE11Task') # 2018: integrate QIE11Task into DigiTask
 process.load('DQM.HcalTasks.HcalOnlineHarvesting')
@@ -133,7 +134,7 @@ if useMap:
 		record = cms.string("HcalElectronicsMapRcd"),
         tag = cms.string("HcalElectronicsMap_v7.05_hlt"),
         )
-    )
+    )    
 
 #-------------------------------------
 #	For Debugginb
@@ -160,6 +161,8 @@ process.tpTask.runkeyName = runTypeName
 #process.qie11Task.runkeyVal = runType
 #process.qie11Task.runkeyName = runTypeName
 #process.qie11Task.tagQIE11 = cms.untracked.InputTag("hcalDigis")
+process.fcdTask.runkeyVal = runType
+process.fcdTask.runkeyName = runTypeName
 
 #-------------------------------------
 #	Hcal DQM Tasks/Clients Sequences Definition
@@ -169,6 +172,7 @@ process.tasksPath = cms.Path(
 		+process.digiTask
 		+process.tpTask
 		+process.nocqTask
+		+process.fcdTask
 		#+process.qie11Task
 		#ZDC to be removed for 2017 pp running
 		#+process.zdcTask


### PR DESCRIPTION
Backport to 10_2_X of https://github.com/cms-sw/cmssw/pull/24605.

Adds a new task to the online DQM HCAL application for monitoring the FCD (forward Cherenkov detector) demonstrator.

