### PR TITLE
Fix premixing for HGCal v9 geometry

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -277,7 +277,7 @@ void HGCDigitizer::finalizeEvent(edm::Event& e, edm::EventSetup const& es, CLHEP
   if(premixStage1_) {
     std::unique_ptr<PHGCSimAccumulator> simResult;
     if(!simHitAccumulator_->empty()) {
-      simResult = std::make_unique<PHGCSimAccumulator>(simHitAccumulator_->begin()->first);
+      simResult = std::make_unique<PHGCSimAccumulator>();
       saveSimHitAccumulator(*simResult, *simHitAccumulator_, validIds_, premixStage1MinCharge_, premixStage1MaxCharge_);
     }
     e.put(std::move(simResult), digiCollection());


### PR DESCRIPTION
This PR fixes the premixing for HGCal v9 geometry by increasing the size of a bitfield containing the subdet-specific data from 27 bits to 32 bits in `PHGCSimAccumulator` (this leads to the size of an internal struct to increase from 32 bits to 64 bits) as outlined in #23624.

I measured the file size with D17 100 ttbar+PU200 events (BX -3...3), and the increase of the three HGCal products is rather small, between 1 and 2.5 %, total HGCal being 1.3 % (you can compare with my slide 16 of
https://indico.cern.ch/event/711343/contributions/2964389/attachments/1631761/2601778/slides_premix_20180412.pdf
). The total event size increases only a few per mille. I think these are small enough to declare #23624 solved, because it is better to focus work elsewhere for much larger size reductions.

Tested in 10_3_0_pre3, no changes expected (except for a hypothetical premixing workflow with D28 geometry to work). Fixes #23624.

@kpedro88 @mdhildreth 