### PR TITLE
Prepare some Geometry ESProducers for concurrent IOVs

### DIFF
--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.cc
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.cc
@@ -1,5 +1,3 @@
-
-// user include files
 #include "EcalElectronicsMappingBuilder.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalElectronicsId.h"
@@ -9,9 +7,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/DataRecord/interface/EcalMappingElectronicsRcd.h"
 
-//
-// constructors and destructor
-//
 EcalElectronicsMappingBuilder::EcalElectronicsMappingBuilder(const edm::ParameterSet&)
 {
   //the following line is needed to tell the framework what
@@ -19,18 +14,8 @@ EcalElectronicsMappingBuilder::EcalElectronicsMappingBuilder(const edm::Paramete
   setWhatProduced(this);
 }
 
-
-EcalElectronicsMappingBuilder::~EcalElectronicsMappingBuilder()
-{ 
-}
-
-//
-// member functions
-//
-
 // ------------ method called to produce the data  ------------
 EcalElectronicsMappingBuilder::ReturnType
-// EcalElectronicsMappingBuilder::produce(const IdealGeometryRecord& iRecord)
 EcalElectronicsMappingBuilder::produce(const EcalMappingRcd& iRecord)
 {
    auto prod = std::make_unique<EcalElectronicsMapping>();
@@ -47,7 +32,6 @@ EcalElectronicsMappingBuilder::produce(const EcalMappingRcd& iRecord)
 void EcalElectronicsMappingBuilder::FillFromDatabase(const std::vector<EcalMappingElement>& ee,
 						     EcalElectronicsMapping& theMap)   
 {
-  //  std::cout << " --- Reading the EE mapping from Database --- " << std::endl;
   for (unsigned int i=0; i < ee.size(); i++) 
     {
       if (ee[i].electronicsid == 0)

--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.cc
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.cc
@@ -5,33 +5,18 @@
 #include "DataFormats/EcalDetId/interface/EcalElectronicsId.h"
 #include "DataFormats/EcalDetId/interface/EcalTriggerElectronicsId.h"
 
-#include <iostream>
-#include <fstream>
-
-
-#include <vector>
-
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "CondFormats/EcalObjects/interface/EcalMappingElectronics.h"
 #include "CondFormats/DataRecord/interface/EcalMappingElectronicsRcd.h"
-
-
-
-using namespace edm;
-
 
 //
 // constructors and destructor
 //
-EcalElectronicsMappingBuilder::EcalElectronicsMappingBuilder(const edm::ParameterSet& iConfig) :
-  Mapping_ ( nullptr )
+EcalElectronicsMappingBuilder::EcalElectronicsMappingBuilder(const edm::ParameterSet&)
 {
   //the following line is needed to tell the framework what
   // data is being produced
-  // setWhatProduced(this);
-  setWhatProduced(this, (dependsOn (&EcalElectronicsMappingBuilder::DBCallback)) );
-  //now do what ever other initialization is needed
+  setWhatProduced(this);
 }
 
 
@@ -43,26 +28,20 @@ EcalElectronicsMappingBuilder::~EcalElectronicsMappingBuilder()
 // member functions
 //
 
-void EcalElectronicsMappingBuilder::DBCallback (const EcalMappingElectronicsRcd& fRecord)
-{
-
-  edm::ESHandle <EcalMappingElectronics> item;
-  fRecord.get (item);
-  Mapping_ = item.product () ;
-}
-
-
 // ------------ method called to produce the data  ------------
 EcalElectronicsMappingBuilder::ReturnType
 // EcalElectronicsMappingBuilder::produce(const IdealGeometryRecord& iRecord)
 EcalElectronicsMappingBuilder::produce(const EcalMappingRcd& iRecord)
 {
-   using namespace edm::es;
    auto prod = std::make_unique<EcalElectronicsMapping>();
-   const std::vector<EcalMappingElement>& ee = Mapping_ -> endcapItems();
+
+   const EcalMappingElectronicsRcd& fRecord = iRecord.getRecord<EcalMappingElectronicsRcd>();
+   edm::ESHandle <EcalMappingElectronics> item;
+   fRecord.get(item);
+
+   const std::vector<EcalMappingElement>& ee = item->endcapItems();
    FillFromDatabase(ee,*prod);
    return prod;
-
 }
 
 void EcalElectronicsMappingBuilder::FillFromDatabase(const std::vector<EcalMappingElement>& ee,
@@ -79,8 +58,3 @@ void EcalElectronicsMappingBuilder::FillFromDatabase(const std::vector<EcalMappi
     }
   return;
 }
-
-
-
-
-

--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
@@ -1,48 +1,31 @@
-
 #ifndef Geometry_EcalMapping_EcalElectronicsMappingBuilder
 #define Geometry_EcalMapping_EcalElectronicsMappingBuilder
 
-// system include files
 #include <memory>
+#include <vector>
 
-// user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-// #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-// #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
 #include "CondFormats/EcalObjects/interface/EcalMappingElectronics.h"
-
-#include <vector>
 
 namespace edm {
   class ParameterSet;
 }
 
-//
-// class decleration
-//
-
-// class EcalElectronicsMappingBuilder : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
-class EcalElectronicsMappingBuilder : public edm::ESProducer 
+class EcalElectronicsMappingBuilder : public edm::ESProducer
 {
  public:
   EcalElectronicsMappingBuilder(const edm::ParameterSet&);
-  ~EcalElectronicsMappingBuilder() override;
-  
-  typedef std::unique_ptr<EcalElectronicsMapping> ReturnType;
-  
-  // ReturnType produce(const IdealGeometryRecord&);
+
+  using ReturnType = std::unique_ptr<EcalElectronicsMapping>;
+
   ReturnType produce(const EcalMappingRcd&);
-  
+
  private:
   void FillFromDatabase(const std::vector<EcalMappingElement>& ee,
                         EcalElectronicsMapping& theMap);
-  
-  // void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
-  // ----------member data ---------------------------
 };
-
 #endif

--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
@@ -9,21 +9,17 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-
-// class EcalMappingRcd;
-
-
 // #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 // #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 #include "Geometry/EcalMapping/interface/EcalElectronicsMapping.h"
-#include "CondFormats/DataRecord/interface/EcalMappingElectronicsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalMappingElectronics.h"
 
 #include <vector>
+
+namespace edm {
+  class ParameterSet;
+}
 
 //
 // class decleration
@@ -41,14 +37,10 @@ class EcalElectronicsMappingBuilder : public edm::ESProducer
   // ReturnType produce(const IdealGeometryRecord&);
   ReturnType produce(const EcalMappingRcd&);
   
-  void DBCallback (const EcalMappingElectronicsRcd& fRecord);
-  
  private:
   void FillFromDatabase(const std::vector<EcalMappingElement>& ee,
                         EcalElectronicsMapping& theMap);
   
-  
-  const EcalMappingElectronics* Mapping_ ;
   // void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
   // ----------member data ---------------------------
 };

--- a/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HcalDDDSimConstantsESModule
 // Class:      HcalDDDSimConstantsESModule
-// 
+//
 /**\class HcalDDDSimConstantsESModule Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
 
  Description: <one line class summary>
@@ -16,10 +16,8 @@
 //
 //
 
-// system include files
 #include <memory>
 
-// user include files
 #include <FWCore/Framework/interface/ModuleFactory.h>
 #include <FWCore/Framework/interface/ESProducer.h>
 #include <FWCore/Framework/interface/ESHandle.h>
@@ -31,9 +29,8 @@ class HcalDDDSimConstantsESModule : public edm::ESProducer {
 
 public:
   HcalDDDSimConstantsESModule(const edm::ParameterSet&);
-  ~HcalDDDSimConstantsESModule() override;
 
-  typedef std::unique_ptr<HcalDDDSimConstants> ReturnType;
+  using ReturnType = std::unique_ptr<HcalDDDSimConstants>;
 
   static void fillDescriptions( edm::ConfigurationDescriptions & );
 
@@ -43,8 +40,6 @@ public:
 HcalDDDSimConstantsESModule::HcalDDDSimConstantsESModule(const edm::ParameterSet&) {
   setWhatProduced(this);
 }
-
-HcalDDDSimConstantsESModule::~HcalDDDSimConstantsESModule() {}
 
 void HcalDDDSimConstantsESModule::fillDescriptions( edm::ConfigurationDescriptions & descriptions ) {
   edm::ParameterSetDescription desc;

--- a/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
@@ -23,12 +23,9 @@
 #include <FWCore/Framework/interface/ModuleFactory.h>
 #include <FWCore/Framework/interface/ESProducer.h>
 #include <FWCore/Framework/interface/ESHandle.h>
-#include <FWCore/MessageLogger/interface/MessageLogger.h>
 
 #include <Geometry/HcalCommonData/interface/HcalDDDSimConstants.h>
 #include <Geometry/Records/interface/HcalSimNumberingRecord.h>
-
-//#define EDM_ML_DEBUG
 
 class HcalDDDSimConstantsESModule : public edm::ESProducer {
 
@@ -36,23 +33,15 @@ public:
   HcalDDDSimConstantsESModule(const edm::ParameterSet&);
   ~HcalDDDSimConstantsESModule() override;
 
-  typedef std::shared_ptr<HcalDDDSimConstants> ReturnType;
+  typedef std::unique_ptr<HcalDDDSimConstants> ReturnType;
 
   static void fillDescriptions( edm::ConfigurationDescriptions & );
 
   ReturnType produce(const HcalSimNumberingRecord&);
-
-  void initializeHcalDDDSimConstants( const HcalParametersRcd& igr);
-
-private:
-  HcalDDDSimConstants* hcalDDDConst_;
 };
 
-HcalDDDSimConstantsESModule::HcalDDDSimConstantsESModule(const edm::ParameterSet& iConfig) : hcalDDDConst_(nullptr) {
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") <<"constructing HcalDDDSimConstantsESModule";
-#endif
-  setWhatProduced(this, dependsOn(&HcalDDDSimConstantsESModule::initializeHcalDDDSimConstants));
+HcalDDDSimConstantsESModule::HcalDDDSimConstantsESModule(const edm::ParameterSet&) {
+  setWhatProduced(this);
 }
 
 HcalDDDSimConstantsESModule::~HcalDDDSimConstantsESModule() {}
@@ -65,30 +54,12 @@ void HcalDDDSimConstantsESModule::fillDescriptions( edm::ConfigurationDescriptio
 // ------------ method called to produce the data  ------------
 HcalDDDSimConstantsESModule::ReturnType
 HcalDDDSimConstantsESModule::produce(const HcalSimNumberingRecord& iRecord) {
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "in HcalDDDSimConstantsESModule::produce";
-#endif
-  if (hcalDDDConst_ == nullptr) {
-    edm::LogError("HCalGeom") << "HcalDDDSimConstantsESModule::produceHcalDDDSimConstants has NOT been initialized!";
-    throw cms::Exception("DDException") << "HcalDDDSimConstantsESModule::Cannot produce HcalDDDSimConstnats";
-  }
-  return HcalDDDSimConstantsESModule::ReturnType(hcalDDDConst_) ;
-}
 
-void HcalDDDSimConstantsESModule::initializeHcalDDDSimConstants(const HcalParametersRcd& igr) {
-
-  std::string                   label_;
+  const HcalParametersRcd& parRecord = iRecord.getRecord<HcalParametersRcd>();
   edm::ESHandle<HcalParameters> parHandle;
-  igr.get(label_, parHandle);
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "in HcalDDDSimConstantsESModule::initializeHcalDDDSimConstants";
-#endif
-  const HcalParameters* hpar = &(*parHandle);
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "about to make my new hcalDDDConst_ with " 
-			       << hpar;
-#endif
-  hcalDDDConst_ = new HcalDDDSimConstants(hpar);
+  parRecord.get(parHandle);
+
+  return std::make_unique<HcalDDDSimConstants>(parHandle.product());
 }
 
 //define this as a plug-in

--- a/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
@@ -1,11 +1,8 @@
 #ifndef Geometry_HcalEventSetup_HcalDDDGeometryEP_H
 #define Geometry_HcalEventSetup_HcalDDDGeometryEP_H 1
 
-
-// system include files
 #include <memory>
 
-// user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
@@ -16,27 +13,19 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalDDDGeometryLoader.h"
 
-//
-// class decleration
-//
-
 class HcalDDDGeometryEP : public edm::ESProducer {
 
 public:
 
   HcalDDDGeometryEP(const edm::ParameterSet&);
-  ~HcalDDDGeometryEP() override;
 
-  typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
- 
+  using ReturnType = std::unique_ptr<CaloSubdetectorGeometry>;
+
   ReturnType produceIdeal(const HcalRecNumberingRecord&);
   ReturnType produceAligned(const HcalGeometryRecord&);
 
 private:
 
-  // ----------member data ---------------------------
-
   bool m_applyAlignment ;
 };
 #endif
-

--- a/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
@@ -27,10 +27,8 @@ public:
   HcalDDDGeometryEP(const edm::ParameterSet&);
   ~HcalDDDGeometryEP() override;
 
-  typedef std::shared_ptr<CaloSubdetectorGeometry> ReturnType;
+  typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
  
-  void idealRecordCallBack(const HcalRecNumberingRecord&) {}
-
   ReturnType produceIdeal(const HcalRecNumberingRecord&);
   ReturnType produceAligned(const HcalGeometryRecord&);
 
@@ -38,7 +36,6 @@ private:
 
   // ----------member data ---------------------------
 
-  HcalDDDGeometryLoader* m_loader ;
   bool m_applyAlignment ;
 };
 #endif

--- a/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
@@ -19,12 +19,10 @@ public:
   HcalHardcodeGeometryEP(const edm::ParameterSet&);
   ~HcalHardcodeGeometryEP() override;
 
-  typedef std::shared_ptr<CaloSubdetectorGeometry> ReturnType;
+  typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
 
   ReturnType produceIdeal(const HcalRecNumberingRecord&);
   ReturnType produceAligned(const HcalGeometryRecord& );
-
-  void       idealRecordCallBack(const HcalRecNumberingRecord&) {}
 
 private:
   edm::ParameterSet ps0;

--- a/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
@@ -1,14 +1,11 @@
 #ifndef Geometry_HcalEventSetup_HcalHardcodeGeometryEP_H
 #define Geometry_HcalEventSetup_HcalHardcodeGeometryEP_H 1
 
-// system include files
 #include <memory>
 
-// user include files
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-// class declarations
 class CaloSubdetectorGeometry;
 class HcalRecNumberingRecord;
 class HcalGeometryRecord;
@@ -17,15 +14,14 @@ class HcalHardcodeGeometryEP : public edm::ESProducer {
 
 public:
   HcalHardcodeGeometryEP(const edm::ParameterSet&);
-  ~HcalHardcodeGeometryEP() override;
 
-  typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
+  using ReturnType = std::unique_ptr<CaloSubdetectorGeometry>;
 
   ReturnType produceIdeal(const HcalRecNumberingRecord&);
   ReturnType produceAligned(const HcalGeometryRecord& );
 
 private:
-  edm::ParameterSet ps0;
+
   bool              useOld_;
 };
 #endif

--- a/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
@@ -1,11 +1,8 @@
 #ifndef GEOMETRY_HCALEVENTSETUP_HCALTOPOLOGYIDEALEP_H
 #define GEOMETRY_HCALEVENTSETUP_HCALTOPOLOGYIDEALEP_H 1
 
-
-// system include files
 #include <memory>
 
-// user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
@@ -18,20 +15,15 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-//
-// class decleration
-//
-
 class HcalTopologyIdealEP : public edm::ESProducer {
 
 public:
   HcalTopologyIdealEP(const edm::ParameterSet&);
-  ~HcalTopologyIdealEP() override;
 
-  typedef std::unique_ptr<HcalTopology> ReturnType;
+  using ReturnType = std::unique_ptr<HcalTopology>;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    
+
   ReturnType produce(const HcalRecNumberingRecord&);
 
 private:

--- a/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
@@ -28,18 +28,15 @@ public:
   HcalTopologyIdealEP(const edm::ParameterSet&);
   ~HcalTopologyIdealEP() override;
 
-  typedef std::shared_ptr<HcalTopology> ReturnType;
+  typedef std::unique_ptr<HcalTopology> ReturnType;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     
   ReturnType produce(const HcalRecNumberingRecord&);
 
-  void       hcalRecordCallBack( const IdealGeometryRecord& ) {}
-
 private:
   // ----------member data ---------------------------
   std::string m_restrictions;
   bool        m_mergePosition;
-  const edm::ParameterSet m_pSet;
 };
 #endif

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CaloTowerHardcodeGeometryEP
 // Class:      CaloTowerHardcodeGeometryEP
-// 
+//
 /**\class CaloTowerHardcodeGeometryEP CaloTowerHardcodeGeometryEP.h tmp/CaloTowerHardcodeGeometryEP/interface/CaloTowerHardcodeGeometryEP.h
 
  Description: <one line class summary>
@@ -22,17 +22,6 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 CaloTowerHardcodeGeometryEP::CaloTowerHardcodeGeometryEP(const edm::ParameterSet& iConfig)
 {
    //the following line is needed to tell the framework what
@@ -41,19 +30,12 @@ CaloTowerHardcodeGeometryEP::CaloTowerHardcodeGeometryEP(const edm::ParameterSet
                    &CaloTowerHardcodeGeometryEP::produce,
 		   edm::es::Label("TOWER"));
 
-  //now do what ever other initialization is needed
   loader_=new CaloTowerHardcodeGeometryLoader(); /// TODO : allow override of Topology.
 }
 
-
-CaloTowerHardcodeGeometryEP::~CaloTowerHardcodeGeometryEP() { 
+CaloTowerHardcodeGeometryEP::~CaloTowerHardcodeGeometryEP() {
   delete loader_;
 }
-
-
-//
-// member functions
-//
 
 // ------------ method called to produce the data  ------------
 CaloTowerHardcodeGeometryEP::ReturnType
@@ -64,9 +46,6 @@ CaloTowerHardcodeGeometryEP::produce(const CaloTowerGeometryRecord& iRecord) {
   iRecord.getRecord<HcalRecNumberingRecord>().get( hcaltopo );
   edm::ESHandle<HcalDDDRecConstants> pHRNDC;
   iRecord.getRecord<HcalRecNumberingRecord>().get( pHRNDC );
-  
+
   return std::unique_ptr<CaloSubdetectorGeometry>( loader_->load( &*cttopo, &*hcaltopo, &*pHRNDC ));
-
 }
-
-

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
@@ -39,8 +39,7 @@ CaloTowerHardcodeGeometryEP::CaloTowerHardcodeGeometryEP(const edm::ParameterSet
    // data is being produced
    setWhatProduced(this,
                    &CaloTowerHardcodeGeometryEP::produce,
-                   dependsOn( &CaloTowerHardcodeGeometryEP::idealRecordCallBack ),
-		   "TOWER");
+		   edm::es::Label("TOWER"));
 
   //now do what ever other initialization is needed
   loader_=new CaloTowerHardcodeGeometryLoader(); /// TODO : allow override of Topology.

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
@@ -29,8 +29,6 @@ public:
 
   ReturnType produce(const CaloTowerGeometryRecord&);
 
-  void       idealRecordCallBack( const HcalRecNumberingRecord& ) {}
-
 private:
       // ----------member data ---------------------------
   CaloTowerHardcodeGeometryLoader* loader_;

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
@@ -1,10 +1,8 @@
 #ifndef GEOMETRY_HCALEVENTSETUP_CALOTOWERHARDCODEGEOMETRYEP_H
 #define GEOMETRY_HCALEVENTSETUP_CALOTOWERHARDCODEGEOMETRYEP_H 1
 
-// system include files
 #include <memory>
 
-// user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
@@ -13,9 +11,6 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/CaloTowerHardcodeGeometryLoader.h"
 
-//
-// class decleration
-//
 class HcalRecNumberingRecord;
 class IdealGeometryRecord;
 
@@ -25,14 +20,13 @@ public:
   CaloTowerHardcodeGeometryEP(const edm::ParameterSet&);
   ~CaloTowerHardcodeGeometryEP() override;
 
-  typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
+  using ReturnType = std::unique_ptr<CaloSubdetectorGeometry>;
 
   ReturnType produce(const CaloTowerGeometryRecord&);
 
 private:
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
   CaloTowerHardcodeGeometryLoader* loader_;
 };
-
 
 #endif

--- a/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HcalDDDGeometryEP
 // Class:      HcalDDDGeometryEP
-// 
+//
 /**\class HcalDDDGeometryEP HcalDDDGeometryEP.h tmp/HcalDDDGeometryEP/interface/HcalDDDGeometryEP.h
 
  Description: <one line class summary>
@@ -19,18 +19,6 @@
 #include "Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-//#define DebugLog
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 
 HcalDDDGeometryEP::HcalDDDGeometryEP(const edm::ParameterSet& ps ) :
   m_applyAlignment(ps.getUntrackedParameter<bool>("applyAlignment", false) ) {
@@ -41,13 +29,6 @@ HcalDDDGeometryEP::HcalDDDGeometryEP(const edm::ParameterSet& ps ) :
 		   &HcalDDDGeometryEP::produceAligned,
 		   edm::es::Label("HCAL"));
 }
-
-HcalDDDGeometryEP::~HcalDDDGeometryEP() { 
-}
-
-//
-// member functions
-//
 
 // ------------ method called to produce the data  ------------
 HcalDDDGeometryEP::ReturnType

--- a/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
@@ -33,21 +33,17 @@
 //
 
 HcalDDDGeometryEP::HcalDDDGeometryEP(const edm::ParameterSet& ps ) :
-  m_loader ( nullptr ) ,
   m_applyAlignment(ps.getUntrackedParameter<bool>("applyAlignment", false) ) {
 
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced( this,
 		   &HcalDDDGeometryEP::produceAligned,
-		   dependsOn( &HcalDDDGeometryEP::idealRecordCallBack ),
-		   "HCAL");
+		   edm::es::Label("HCAL"));
 }
 
 HcalDDDGeometryEP::~HcalDDDGeometryEP() { 
-  if (m_loader) delete m_loader ;
 }
-
 
 //
 // member functions
@@ -64,14 +60,9 @@ HcalDDDGeometryEP::produceIdeal(const HcalRecNumberingRecord& iRecord) {
   edm::ESHandle<HcalTopology> topology ;
   iRecord.get( topology ) ;
 
-  assert( nullptr == m_loader ) ;
-  m_loader = new HcalDDDGeometryLoader(&(*hcons)); 
-#ifdef DebugLog
-  LogDebug("HCalGeom")<<"HcalDDDGeometryEP:Initialize HcalDDDGeometryLoader";
-#endif
-  ReturnType pC ( m_loader->load(*topology) ) ;
+  HcalDDDGeometryLoader loader(&(*hcons));
 
-  return pC;
+  return ReturnType(loader.load(*topology));
 }
 
 HcalDDDGeometryEP::ReturnType

--- a/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
@@ -48,8 +48,7 @@ HcalHardcodeGeometryEP::HcalHardcodeGeometryEP( const edm::ParameterSet& ps ) : 
   // data is being produced
   setWhatProduced( this,
 		   &HcalHardcodeGeometryEP::produceAligned,
-		   dependsOn( &HcalHardcodeGeometryEP::idealRecordCallBack ),
-		   HcalGeometry::producerTag() );
+		   edm::es::Label(HcalGeometry::producerTag()));
 
 // disable
 //   setWhatProduced( this,

--- a/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HcalHardcodeGeometryEP
 // Class:      HcalHardcodeGeometryEP
-// 
+//
 /**\class HcalHardcodeGeometryEP HcalHardcodeGeometryEP.h tmp/HcalHardcodeGeometryEP/interface/HcalHardcodeGeometryEP.h
 
  Description: <one line class summary>
@@ -30,40 +30,14 @@
 
 class HcalTopology;
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-
-HcalHardcodeGeometryEP::HcalHardcodeGeometryEP( const edm::ParameterSet& ps ) : ps0(ps) {
+HcalHardcodeGeometryEP::HcalHardcodeGeometryEP( const edm::ParameterSet& ps ) {
   useOld_ = ps.getParameter<bool>("UseOldLoader");
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced( this,
 		   &HcalHardcodeGeometryEP::produceAligned,
 		   edm::es::Label(HcalGeometry::producerTag()));
-
-// disable
-//   setWhatProduced( this,
-//		    &HcalHardcodeGeometryEP::produceIdeal,
-//		    edm::es::Label( "HCAL" ) );
 }
-
-
-HcalHardcodeGeometryEP::~HcalHardcodeGeometryEP() { }
-
-
-//
-// member functions
-//
-
 
 HcalHardcodeGeometryEP::ReturnType
 HcalHardcodeGeometryEP::produceIdeal( const HcalRecNumberingRecord& iRecord ) {
@@ -74,10 +48,10 @@ HcalHardcodeGeometryEP::produceIdeal( const HcalRecNumberingRecord& iRecord ) {
    edm::ESHandle<HcalTopology> topology ;
    iRecord.get( topology ) ;
    if (useOld_) {
-     HcalHardcodeGeometryLoader loader(ps0);
+     HcalHardcodeGeometryLoader loader;
      return ReturnType (loader.load (*topology));
    } else {
-      HcalFlexiHardcodeGeometryLoader loader(ps0);
+      HcalFlexiHardcodeGeometryLoader loader;
      return ReturnType (loader.load (*topology, *hcons));
    }
 }
@@ -87,4 +61,3 @@ HcalHardcodeGeometryEP::produceAligned( const HcalGeometryRecord& iRecord ) {
   const HcalRecNumberingRecord& idealRecord = iRecord.getRecord<HcalRecNumberingRecord>();
   return produceIdeal (idealRecord);
 }
-

--- a/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
@@ -39,8 +39,7 @@
 //
 HcalTopologyIdealEP::HcalTopologyIdealEP(const edm::ParameterSet& conf)
   : m_restrictions(conf.getUntrackedParameter<std::string>("Exclude")),
-    m_mergePosition(conf.getUntrackedParameter<bool>("MergePosition")),
-    m_pSet(conf) {
+    m_mergePosition(conf.getUntrackedParameter<bool>("MergePosition")) {
 #ifdef DebugLog
   std::cout << "HcalTopologyIdealEP::HcalTopologyIdealEP with Exclude: " 
 	    << m_restrictions << " MergePosition: " << m_mergePosition
@@ -48,8 +47,7 @@ HcalTopologyIdealEP::HcalTopologyIdealEP(const edm::ParameterSet& conf)
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::HcalTopologyIdealEP";
 #endif
   setWhatProduced(this,
-                  &HcalTopologyIdealEP::produce,
-                  dependsOn( &HcalTopologyIdealEP::hcalRecordCallBack ));
+                  &HcalTopologyIdealEP::produce);
 }
 
 

--- a/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HcalTopologyIdealEP
 // Class:      HcalTopologyIdealEP
-// 
+//
 /**\class HcalTopologyIdealEP HcalTopologyIdealEP.h tmp/HcalTopologyIdealEP/interface/HcalTopologyIdealEP.h
 
  Description: <one line class summary>
@@ -26,22 +26,11 @@
 
 //#define DebugLog
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 HcalTopologyIdealEP::HcalTopologyIdealEP(const edm::ParameterSet& conf)
   : m_restrictions(conf.getUntrackedParameter<std::string>("Exclude")),
     m_mergePosition(conf.getUntrackedParameter<bool>("MergePosition")) {
 #ifdef DebugLog
-  std::cout << "HcalTopologyIdealEP::HcalTopologyIdealEP with Exclude: " 
+  std::cout << "HcalTopologyIdealEP::HcalTopologyIdealEP with Exclude: "
 	    << m_restrictions << " MergePosition: " << m_mergePosition
 	    << std::endl;
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::HcalTopologyIdealEP";
@@ -49,9 +38,6 @@ HcalTopologyIdealEP::HcalTopologyIdealEP(const edm::ParameterSet& conf)
   setWhatProduced(this,
                   &HcalTopologyIdealEP::produce);
 }
-
-
-HcalTopologyIdealEP::~HcalTopologyIdealEP() { }
 
 void HcalTopologyIdealEP::fillDescriptions( edm::ConfigurationDescriptions & descriptions ) {
 
@@ -61,28 +47,24 @@ void HcalTopologyIdealEP::fillDescriptions( edm::ConfigurationDescriptions & des
   descriptions.add( "hcalTopologyIdealBase", desc );
 }
 
-//
-// member functions
-//
-
 // ------------ method called to produce the data  ------------
 HcalTopologyIdealEP::ReturnType
 HcalTopologyIdealEP::produce(const HcalRecNumberingRecord& iRecord) {
 #ifdef DebugLog
   std::cout << "HcalTopologyIdealEP::produce(const IdealGeometryRecord& iRecord)" << std::endl;
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::produce(const HcalGeometryRecord& iRecord)";
-#endif  
+#endif
   edm::ESHandle<HcalDDDRecConstants> pHRNDC;
   iRecord.get( pHRNDC );
   const HcalDDDRecConstants* hdc = &(*pHRNDC);
 
 #ifdef DebugLog
-  std::cout << "mode = " << hdc->getTopoMode() << ", maxDepthHB = " 
+  std::cout << "mode = " << hdc->getTopoMode() << ", maxDepthHB = "
 	    << hdc->getMaxDepth(0) << ", maxDepthHE = " << hdc->getMaxDepth(1)
 	    << ", maxDepthHF = " << hdc->getMaxDepth(2) << std::endl;
   edm::LogInfo("HCAL") << "mode = " << hdc->getTopoMode() << ", maxDepthHB = "
-		       << hdc->getMaxDepth(0) << ", maxDepthHE = " 
-		       << hdc->getMaxDepth(1) << ", maxDepthHF = " 
+		       << hdc->getMaxDepth(0) << ", maxDepthHE = "
+		       << hdc->getMaxDepth(1) << ", maxDepthHF = "
 		       << hdc->getMaxDepth(2);
 #endif
   ReturnType myTopo(new HcalTopology(hdc,m_mergePosition));
@@ -96,5 +78,3 @@ HcalTopologyIdealEP::produce(const HcalRecNumberingRecord& iRecord) {
   }
   return myTopo ;
 }
-
-

--- a/Geometry/HcalEventSetup/src/SealModule.cc
+++ b/Geometry/HcalEventSetup/src/SealModule.cc
@@ -3,7 +3,6 @@
 #include "Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h"
 #include "Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h"
 #include "Geometry/HcalEventSetup/interface/CaloTowerTopologyEP.h"
-#include "Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h"
 #include "Geometry/HcalEventSetup/interface/HcalAlignmentEP.h"
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(HcalHardcodeGeometryEP);
@@ -11,5 +10,4 @@ DEFINE_FWK_EVENTSETUP_MODULE(HcalDDDGeometryEP);
 DEFINE_FWK_EVENTSETUP_MODULE(CaloTowerHardcodeGeometryEP);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalTopologyIdealEP);
 DEFINE_FWK_EVENTSETUP_MODULE(CaloTowerTopologyEP);
-DEFINE_FWK_EVENTSETUP_MODULE(HcalDDDGeometryEP);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalAlignmentEP);

--- a/Geometry/HcalTowerAlgo/interface/HcalDDDGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalDDDGeometryLoader.h
@@ -44,7 +44,6 @@ public:
   
   const HcalDDDRecConstants* hcalConstants_;
 
-  HcalTopology* dummyTopology_;
   bool          isBH_;
 };
 

--- a/Geometry/HcalTowerAlgo/interface/HcalFlexiHardcodeGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalFlexiHardcodeGeometryLoader.h
@@ -18,8 +18,8 @@ class HcalGeometry;
 class HcalFlexiHardcodeGeometryLoader {
 
 public:
-  HcalFlexiHardcodeGeometryLoader(const edm::ParameterSet&);
-  
+  HcalFlexiHardcodeGeometryLoader();
+
   CaloSubdetectorGeometry* load(const HcalTopology& fTopology, const HcalDDDRecConstants& hcons);
 
 private:
@@ -28,7 +28,7 @@ private:
     HBHOCellParameters (int f_eta, int f_depth, int f_phi, double f_phi0, double f_dPhi, double f_rMin, double f_rMax, double f_etaMin, double f_etaMax)
     : ieta(f_eta), depth(f_depth), iphi(f_phi), phi(f_phi0), dphi(f_dPhi), rMin(f_rMin), rMax(f_rMax), etaMin(f_etaMin), etaMax(f_etaMax)
     {}
- 
+
     int ieta;
     int depth;
     int iphi;
@@ -44,7 +44,7 @@ private:
     HECellParameters (int f_eta, int f_depth, int f_phi, double f_phi0, double f_dPhi, double f_zMin, double f_zMax, double f_etaMin, double f_etaMax)
     : ieta(f_eta), depth(f_depth), iphi(f_phi), phi(f_phi0), dphi(f_dPhi), zMin(f_zMin), zMax(f_zMax), etaMin(f_etaMin), etaMax(f_etaMax)
     {}
- 
+
     int ieta;
     int depth;
     int iphi;
@@ -60,7 +60,7 @@ private:
     HFCellParameters (int f_eta, int f_depth, int f_phiFirst, int f_phiStep, int f_nPhi, int f_dPhi, float f_zMin, float f_zMax, float f_rMin, float f_rMax)
     : eta(f_eta), depth(f_depth), phiFirst(f_phiFirst), phiStep(f_phiStep), nPhi(f_nPhi), dphi(f_dPhi), zMin(f_zMin), zMax(f_zMax), rMin(f_rMin), rMax(f_rMax)
     {}
- 
+
     int eta;
     int depth;
     int phiFirst;

--- a/Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h
@@ -17,8 +17,8 @@ class HcalGeometry;
 class HcalHardcodeGeometryLoader {
 
 public:
-  HcalHardcodeGeometryLoader(const edm::ParameterSet&);
-  
+  HcalHardcodeGeometryLoader();
+
   CaloSubdetectorGeometry* load(const HcalTopology& fTopology);
 
 private:
@@ -27,7 +27,7 @@ private:
     HBHOCellParameters (int f_eta, int f_depth, int f_phiFirst, int f_phiStep, int f_dPhi, float f_rMin, float f_rMax, float f_etaMin, float f_etaMax)
       : eta(f_eta), depth(f_depth), phiFirst(f_phiFirst), phiStep(f_phiStep), dphi(f_dPhi), rMin(f_rMin), rMax(f_rMax), etaMin(f_etaMin), etaMax(f_etaMax)
     {}
- 
+
     int eta;
     int depth;
     int phiFirst;
@@ -43,7 +43,7 @@ private:
     HECellParameters (int f_eta, int f_depth, int f_phiFirst, int f_phiStep, int f_dPhi, float f_zMin, float f_zMax, float f_etaMin, float f_etaMax)
       : eta(f_eta), depth(f_depth), phiFirst(f_phiFirst), phiStep(f_phiStep), dphi(f_dPhi), zMin(f_zMin), zMax(f_zMax), etaMin(f_etaMin), etaMax(f_etaMax)
     {}
- 
+
     int eta;
     int depth;
     int phiFirst;
@@ -59,7 +59,7 @@ private:
     HFCellParameters (int f_eta, int f_depth, int f_phiFirst, int f_phiStep, int f_dPhi, float f_zMin, float f_zMax, float f_rMin, float f_rMax)
       : eta(f_eta), depth(f_depth), phiFirst(f_phiFirst), phiStep(f_phiStep), dphi(f_dPhi), zMin(f_zMin), zMax(f_zMax), rMin(f_rMin), rMax(f_rMax)
     {}
- 
+
     int eta;
     int depth;
     int phiFirst;
@@ -85,7 +85,7 @@ private:
   double DEGREE2RAD;
 
   std::vector<std::vector<int> > m_segmentation;
-  
+
 };
 
 #endif

--- a/Geometry/HcalTowerAlgo/src/HcalFlexiHardcodeGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalFlexiHardcodeGeometryLoader.cc
@@ -10,13 +10,13 @@
 #include <vector>
 #include <algorithm>
 
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
+using CCGFloat = CaloCellGeometry::CCGFloat;
 
 //#define EDM_ML_DEBUG
 
 // ==============> Loader Itself <==========================
 
-HcalFlexiHardcodeGeometryLoader::HcalFlexiHardcodeGeometryLoader(const edm::ParameterSet&) {
+HcalFlexiHardcodeGeometryLoader::HcalFlexiHardcodeGeometryLoader() {
 
   MAX_HCAL_PHI = 72;
   DEGREE2RAD = M_PI / 180.;
@@ -29,10 +29,10 @@ CaloSubdetectorGeometry* HcalFlexiHardcodeGeometryLoader::load(const HcalTopolog
 							       HcalGeometry::k_NumberOfParametersPerShape ) ;
   isBH_ = hcons.isBH();
 #ifdef EDM_ML_DEBUG
-  std::cout << "FlexiGeometryLoader initialize with ncells " 
-	    << fTopology.ncells() << " and shapes " 
+  std::cout << "FlexiGeometryLoader initialize with ncells "
+	    << fTopology.ncells() << " and shapes "
 	    << hcalGeometry->numberOfShapes() << ":"
-	    << HcalGeometry::k_NumberOfParametersPerShape 
+	    << HcalGeometry::k_NumberOfParametersPerShape
 	    << " with BH Flag " << isBH_ << std::endl;
 #endif
   if (fTopology.mode() == HcalTopologyMode::H2) {  // TB geometry
@@ -59,7 +59,7 @@ std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> HcalFlexiHardco
   std::vector<HcalDDDRecConstants::HcalEtaBin> etabins = hcons.getEtaBins(0);
 
 #ifdef EDM_ML_DEBUG
-  std::cout << "FlexiGeometryLoader called for " << etabins.size() 
+  std::cout << "FlexiGeometryLoader called for " << etabins.size()
 	    << " Eta Bins" << std::endl;
   for (unsigned int k=0; k<gconsHB.size(); ++k) {
     std::cout << "gconsHB[" << k << "] = " << gconsHB[k].first << " +- "
@@ -69,8 +69,8 @@ std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> HcalFlexiHardco
   for (auto & etabin : etabins) {
     int iring = (etabin.zside >= 0) ? etabin.ieta : -etabin.ieta;
     int depth = etabin.depthStart;
-    double dphi = (etabin.phis.size() > 1) ? 
-      (etabin.phis[1].second-etabin.phis[0].second) : 
+    double dphi = (etabin.phis.size() > 1) ?
+      (etabin.phis[1].second-etabin.phis[0].second) :
       ((2.0*M_PI)/MAX_HCAL_PHI);
     for (unsigned int k=0; k<etabin.layer.size(); ++k) {
       int layf = etabin.layer[k].first-1;
@@ -81,8 +81,8 @@ std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> HcalFlexiHardco
 #ifdef EDM_ML_DEBUG
 	std::cout << "HBRing " << iring << " eta " << etabin.etaMin << ":"
 		  << etabin.etaMax << " depth " << depth << " R " << rmin
-		  << ":" << rmax << " Phi " << etabin.phis[j].first << ":" 
-		  << etabin.phis[j].second << ":" << dphi << " layer[" << k 
+		  << ":" << rmax << " Phi " << etabin.phis[j].first << ":"
+		  << etabin.phis[j].second << ":" << dphi << " layer[" << k
 		  << "]: " << etabin.layer[k].first-1 << ":"
 		  << etabin.layer[k].second << std::endl;
 #endif
@@ -148,15 +148,15 @@ void HcalFlexiHardcodeGeometryLoader::fillHBHO (HcalGeometry* fGeometry, const s
     cellParams.emplace_back ( fabs( refPoint.eta() ) ) ;
     cellParams.emplace_back ( fabs( refPoint.z() ) ) ;
 #ifdef EDM_ML_DEBUG
-    std::cout << "HcalFlexiHardcodeGeometryLoader::fillHBHO-> " << hid 
-	      << " " << hid.rawId() << " " << std::hex << hid.rawId() 
-	      << std::dec << " " << hid << " " << refPoint << '/' 
-	      << cellParams [0] << '/' << cellParams [1] << '/' 
+    std::cout << "HcalFlexiHardcodeGeometryLoader::fillHBHO-> " << hid
+	      << " " << hid.rawId() << " " << std::hex << hid.rawId()
+	      << std::dec << " " << hid << " " << refPoint << '/'
+	      << cellParams [0] << '/' << cellParams [1] << '/'
 	      << cellParams [2] << std::endl;
 #endif
-    fGeometry->newCellFast(refPoint,  refPoint,  refPoint, 
-		       CaloCellGeometry::getParmPtr(cellParams, 
-						    fGeometry->parMgr(), 
+    fGeometry->newCellFast(refPoint,  refPoint,  refPoint,
+		       CaloCellGeometry::getParmPtr(cellParams,
+						    fGeometry->parMgr(),
 						    fGeometry->parVecVec()),
 		       hid ) ;
   }
@@ -176,26 +176,26 @@ std::vector<HcalFlexiHardcodeGeometryLoader::HECellParameters> HcalFlexiHardcode
     std::vector<HcalDDDRecConstants::HcalEtaBin> etabins = hcons.getEtaBins(1);
 
 #ifdef EDM_ML_DEBUG
-    std::cout << "FlexiGeometryLoader called for HE with " << etabins.size() 
-	      << " Eta Bins and " << gconsHE.size() << " depths" 
+    std::cout << "FlexiGeometryLoader called for HE with " << etabins.size()
+	      << " Eta Bins and " << gconsHE.size() << " depths"
 	      << std::endl;
     for (unsigned int i=0; i<gconsHE.size(); ++i)
-      std::cout << " Depth[" << i << "] = " << gconsHE[i].first << " +- " 
+      std::cout << " Depth[" << i << "] = " << gconsHE[i].first << " +- "
 		<< gconsHE[i].second;
     std::cout << std::endl;
 #endif
     for (auto & etabin : etabins) {
       int    iring = (etabin.zside >= 0) ? etabin.ieta : -etabin.ieta;
       int    depth = etabin.depthStart;
-      double dphi = (etabin.phis.size() > 1) ? 
-	(etabin.phis[1].second-etabin.phis[0].second) : 
+      double dphi = (etabin.phis.size() > 1) ?
+	(etabin.phis[1].second-etabin.phis[0].second) :
 	((2.0*M_PI)/MAX_HCAL_PHI);
 #ifdef EDM_ML_DEBUG
-      std::cout << "FlexiGeometryLoader::Ring " << iring << " nphi " 
-		<< etabin.phis.size() << " dstart " << depth << " dphi " 
+      std::cout << "FlexiGeometryLoader::Ring " << iring << " nphi "
+		<< etabin.phis.size() << " dstart " << depth << " dphi "
 		<< dphi << " layers "<< etabin.layer.size() << std::endl;
-      for (unsigned int j=0; j<etabin.phis.size(); ++j) 
-	std::cout << " [" << j << "] " << etabin.phis[j].first << ":" 
+      for (unsigned int j=0; j<etabin.phis.size(); ++j)
+	std::cout << " [" << j << "] " << etabin.phis[j].first << ":"
 		  << etabin.phis[j].second;
       std::cout << std::endl;
 #endif
@@ -217,9 +217,9 @@ std::vector<HcalFlexiHardcodeGeometryLoader::HECellParameters> HcalFlexiHardcode
 #ifdef EDM_ML_DEBUG
 	  std::cout << "HERing " << iring << " eta " << etabin.etaMin << ":"
 		    << etabin.etaMax << " depth " << depth << " Z " << zmin
-		    << ":" << zmax << " Phi :" << etabin.phis[j].first 
-		    << ":" << etabin.phis[j].second << ":" << dphi 
-		    << " layer[" << k << "]: " << etabin.layer[k].first-1 
+		    << ":" << zmax << " Phi :" << etabin.phis[j].first
+		    << ":" << etabin.phis[j].second << ":" << dphi
+		    << " layer[" << k << "]: " << etabin.layer[k].first-1
 		    << ":" << etabin.layer[k].second-1 << std::endl;
 #endif
 	  result.emplace_back(HcalFlexiHardcodeGeometryLoader::HECellParameters(iring, depth, etabin.phis[j].first, etabin.phis[j].second, dphi, zmin, zmax, etabin.etaMin, etabin.etaMax));
@@ -290,7 +290,7 @@ std::vector <HcalFlexiHardcodeGeometryLoader::HFCellParameters> HcalFlexiHardcod
   }
   return result;
 }
-  
+
 void HcalFlexiHardcodeGeometryLoader::fillHE (HcalGeometry* fGeometry, const std::vector <HcalFlexiHardcodeGeometryLoader::HECellParameters>& fCells) {
 
   fGeometry->increaseReserve(fCells.size());
@@ -315,12 +315,12 @@ void HcalFlexiHardcodeGeometryLoader::fillHE (HcalGeometry* fGeometry, const std
 #ifdef EDM_ML_DEBUG
     std::cout << "HcalFlexiHardcodeGeometryLoader::fillHE-> " << hid << " "
 	      << hid.rawId() << " " << std::hex << hid.rawId() << std::dec
-	      << " " << hid << refPoint << '/' << cellParams [0] << '/' 
+	      << " " << hid << refPoint << '/' << cellParams [0] << '/'
 	      << cellParams [1] << '/' << cellParams [2] << std::endl;
 #endif
-    fGeometry->newCellFast(refPoint,  refPoint,  refPoint, 
-		       CaloCellGeometry::getParmPtr(cellParams, 
-						    fGeometry->parMgr(), 
+    fGeometry->newCellFast(refPoint,  refPoint,  refPoint,
+		       CaloCellGeometry::getParmPtr(cellParams,
+						    fGeometry->parMgr(),
 						    fGeometry->parVecVec()),
 		       hid ) ;
   }
@@ -340,7 +340,7 @@ void HcalFlexiHardcodeGeometryLoader::fillHF (HcalGeometry* fGeometry, const std
       float iEta = inner.eta();
       float oEta = outer.eta();
       float etaCenter = 0.5 * ( iEta + oEta );
-	
+
       float perp = param.zMin / sinh (etaCenter);
       float x = perp * cos (phiCenter);
       float y = perp * sin (phiCenter);
@@ -355,14 +355,14 @@ void HcalFlexiHardcodeGeometryLoader::fillHF (HcalGeometry* fGeometry, const std
       cellParams.emplace_back ( fabs( refPoint.eta()));
       cellParams.emplace_back ( fabs( refPoint.z() ) ) ;
 #ifdef EDM_ML_DEBUG
-      std::cout << "HcalFlexiHardcodeGeometryLoader::fillHF-> " << hid << " " 
-		<< hid.rawId() << " " << std::hex << hid.rawId() << std::dec 
-		<< " " << hid << " " << refPoint << '/' << cellParams [0] 
+      std::cout << "HcalFlexiHardcodeGeometryLoader::fillHF-> " << hid << " "
+		<< hid.rawId() << " " << std::hex << hid.rawId() << std::dec
+		<< " " << hid << " " << refPoint << '/' << cellParams [0]
 		<< '/' << cellParams [1] << '/' << cellParams [2] << std::endl;
-#endif	
-      fGeometry->newCellFast(refPoint,  refPoint,  refPoint, 
-			 CaloCellGeometry::getParmPtr(cellParams, 
-						      fGeometry->parMgr(), 
+#endif
+      fGeometry->newCellFast(refPoint,  refPoint,  refPoint,
+			 CaloCellGeometry::getParmPtr(cellParams,
+						      fGeometry->parMgr(),
 						      fGeometry->parVecVec()),
 			 hid ) ;
     }

--- a/Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryLoader.cc
@@ -8,11 +8,11 @@
 #include <vector>
 #include <algorithm>
 
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
+using CCGFloat = CaloCellGeometry::CCGFloat;
 //#define DebugLog
 // ==============> Loader Itself <==========================
 
-HcalHardcodeGeometryLoader::HcalHardcodeGeometryLoader(const edm::ParameterSet& ) {
+HcalHardcodeGeometryLoader::HcalHardcodeGeometryLoader() {
 
   MAX_HCAL_PHI = 72;
   DEGREE2RAD = M_PI / 180.;

--- a/Geometry/HcalTowerAlgo/test/HcalCellSizeCheck.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalCellSizeCheck.cc
@@ -19,19 +19,15 @@ class HcalCellSizeCheck : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalCellSizeCheck(const edm::ParameterSet& );
   ~HcalCellSizeCheck( void ) override {}
-    
+
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endJob() override {}
-
-private:
-  edm::ParameterSet ps0_;
 };
 
-HcalCellSizeCheck::HcalCellSizeCheck( const edm::ParameterSet& iConfig ) :
-  ps0_(iConfig) { }
+HcalCellSizeCheck::HcalCellSizeCheck( const edm::ParameterSet& iConfig ) { }
 
-void HcalCellSizeCheck::analyze(const edm::Event& /*iEvent*/, 
+void HcalCellSizeCheck::analyze(const edm::Event& /*iEvent*/,
 				 const edm::EventSetup& iSetup) {
 
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
@@ -42,7 +38,7 @@ void HcalCellSizeCheck::analyze(const edm::Event& /*iEvent*/,
   iSetup.get<HcalRecNumberingRecord>().get(topologyHandle);
   const HcalTopology topology = (*topologyHandle);
 
-  HcalFlexiHardcodeGeometryLoader m_loader(ps0_);
+  HcalFlexiHardcodeGeometryLoader m_loader;
   CaloSubdetectorGeometry*  geom = m_loader.load(topology, hcons);
 
   const std::vector<DetId>& idsb=geom->getValidDetIds(DetId::Hcal,HcalBarrel);
@@ -51,7 +47,7 @@ void HcalCellSizeCheck::analyze(const edm::Event& /*iEvent*/,
     std::pair<double,double> rz = hcons.getRZ(hid);
     std::cout << hid << " Front " << rz.first << " Back " << rz.second << "\n";
   }
-  
+
   const std::vector<DetId>& idse=geom->getValidDetIds(DetId::Hcal,HcalEndcap);
   for (auto id : idse) {
     HcalDetId hid(id.rawId());

--- a/Geometry/HcalTowerAlgo/test/HcalDetIdTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalDetIdTester.cc
@@ -15,24 +15,23 @@ class HcalDetIdTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalDetIdTester( const edm::ParameterSet& );
   ~HcalDetIdTester( void ) override;
-    
+
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  edm::ParameterSet ps0_;
   bool              geomDB_;
 };
 
-HcalDetIdTester::HcalDetIdTester( const edm::ParameterSet& iConfig ) : ps0_(iConfig) {
+HcalDetIdTester::HcalDetIdTester( const edm::ParameterSet& iConfig ) {
   geomDB_ = iConfig.getParameter<bool>("GeometryFromDB");
 }
 
 HcalDetIdTester::~HcalDetIdTester( void ) {}
 
 void
-HcalDetIdTester::analyze(const edm::Event& /*iEvent*/, 
+HcalDetIdTester::analyze(const edm::Event& /*iEvent*/,
 			 const edm::EventSetup& iSetup ) {
 
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
@@ -49,7 +48,7 @@ HcalDetIdTester::analyze(const edm::Event& /*iEvent*/,
     const CaloGeometry* geo = pG.product();
     caloGeom = (CaloSubdetectorGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
   } else {
-    HcalFlexiHardcodeGeometryLoader m_loader(ps0_);
+    HcalFlexiHardcodeGeometryLoader m_loader;
     caloGeom = m_loader.load(topology, hcons);
   }
 
@@ -58,7 +57,7 @@ HcalDetIdTester::analyze(const edm::Event& /*iEvent*/,
 
   int nfail0(0);
   for (int det = 1; det <= HcalForward; det++) {
-    for (int eta = -HcalDetId::kHcalEtaMask2; 
+    for (int eta = -HcalDetId::kHcalEtaMask2;
 	 eta <= HcalDetId::kHcalEtaMask2; eta++) {
       for (int depth = 1; depth <= maxDepth; depth++) {
 	for (int phi = 0; phi <= HcalDetId::kHcalPhiMask2; phi++) {
@@ -86,7 +85,7 @@ HcalDetIdTester::analyze(const edm::Event& /*iEvent*/,
     }
   }
 
-  std::cout << "\nNumber of failures:\nTopology certifies but geometry fails " 
+  std::cout << "\nNumber of failures:\nTopology certifies but geometry fails "
 	    << nfail0 << "\nGeometry certifies but Topology fails " << nfail1
 	    << std::endl << std::endl;
 }

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryAnalyzer.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryAnalyzer.cc
@@ -22,12 +22,12 @@ public:
   void endJob() override {}
 
 private:
-  edm::ParameterSet ps0_;
+
   bool              useOld_;
   bool              geomDB_;
 };
 
-HcalGeometryAnalyzer::HcalGeometryAnalyzer( const edm::ParameterSet& iConfig ) : ps0_(iConfig) {
+HcalGeometryAnalyzer::HcalGeometryAnalyzer( const edm::ParameterSet& iConfig ) {
   useOld_ = iConfig.getParameter<bool>("UseOldLoader");
   geomDB_ = iConfig.getParameter<bool>("GeometryFromDB");
 }
@@ -51,10 +51,10 @@ HcalGeometryAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::EventSet
     const CaloGeometry* geo = pG.product();
     caloGeom = (CaloSubdetectorGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
   } else if (useOld_) {
-    HcalHardcodeGeometryLoader m_loader(ps0_);
+    HcalHardcodeGeometryLoader m_loader;
     caloGeom = m_loader.load(topology);
   } else {
-    HcalFlexiHardcodeGeometryLoader m_loader(ps0_);
+    HcalFlexiHardcodeGeometryLoader m_loader;
     caloGeom = m_loader.load(topology, hcons);
   }
   const std::vector<DetId>& ids = caloGeom->getValidDetIds();

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdAnalyzer.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdAnalyzer.cc
@@ -14,17 +14,17 @@ class HcalGeometryDetIdAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalGeometryDetIdAnalyzer( const edm::ParameterSet& );
   ~HcalGeometryDetIdAnalyzer( void ) override;
-    
+
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  edm::ParameterSet ps0_;
+
   bool              useOld_;
 };
 
-HcalGeometryDetIdAnalyzer::HcalGeometryDetIdAnalyzer(const edm::ParameterSet& iConfig ) : ps0_(iConfig) {
+HcalGeometryDetIdAnalyzer::HcalGeometryDetIdAnalyzer(const edm::ParameterSet& iConfig ) {
   useOld_ = iConfig.getParameter<bool>("UseOldLoader");
 }
 
@@ -41,10 +41,10 @@ HcalGeometryDetIdAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::Eve
 
   CaloSubdetectorGeometry* caloGeom(nullptr);
   if (useOld_) {
-    HcalHardcodeGeometryLoader m_loader(ps0_);
+    HcalHardcodeGeometryLoader m_loader;
     caloGeom = m_loader.load(topology);
   } else {
-    HcalFlexiHardcodeGeometryLoader m_loader(ps0_);
+    HcalFlexiHardcodeGeometryLoader m_loader;
     caloGeom = m_loader.load(topology, hcons);
   }
   const std::vector<DetId>& ids = caloGeom->getValidDetIds();
@@ -55,8 +55,8 @@ HcalGeometryDetIdAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::Eve
     HcalDetId hid = (*i);
     unsigned int did = topology.detId2denseId(*i);
     HcalDetId rhid = topology.denseId2detId(did);
-	
-    std::cout << counter << ": din " << std::hex << did << std::dec << ": " 
+
+    std::cout << counter << ": din " << std::hex << did << std::dec << ": "
 	      << hid << " == " << rhid << std::endl;
     assert(hid == rhid);
   }

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryDump.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryDump.cc
@@ -15,24 +15,23 @@ class HcalGeometryDump : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalGeometryDump( const edm::ParameterSet& );
   ~HcalGeometryDump( void ) override;
-    
+
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  edm::ParameterSet ps0_;
   bool              geomDB_;
 };
 
-HcalGeometryDump::HcalGeometryDump( const edm::ParameterSet& iConfig ) : ps0_(iConfig) {
+HcalGeometryDump::HcalGeometryDump( const edm::ParameterSet& iConfig ) {
   geomDB_ = iConfig.getParameter<bool>("GeometryFromDB");
 }
 
 HcalGeometryDump::~HcalGeometryDump( void ) {}
 
 void
-HcalGeometryDump::analyze(const edm::Event& /*iEvent*/, 
+HcalGeometryDump::analyze(const edm::Event& /*iEvent*/,
 			  const edm::EventSetup& iSetup ) {
 
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
@@ -49,7 +48,7 @@ HcalGeometryDump::analyze(const edm::Event& /*iEvent*/,
     const CaloGeometry* geo = pG.product();
     caloGeom = (HcalGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
   } else {
-    HcalFlexiHardcodeGeometryLoader m_loader(ps0_);
+    HcalFlexiHardcodeGeometryLoader m_loader;
     caloGeom = (HcalGeometry*)(m_loader.load(topology, hcons));
   }
 
@@ -67,12 +66,12 @@ HcalGeometryDump::analyze(const edm::Event& /*iEvent*/,
 	      << std::endl;
     std::sort(detIds.begin(), detIds.end());
     int counter = 0;
-    for (std::vector<unsigned int>::const_iterator i = detIds.begin();  
+    for (std::vector<unsigned int>::const_iterator i = detIds.begin();
 	 i != detIds.end(); ++i, ++counter)  {
       HcalDetId hid = HcalDetId(*i);
       auto cell = caloGeom->getGeometry(*i);
-      std::cout << hid << "\tCaloCellGeometry " << cell->getPosition() 
-		<< "\tHcalGeometry " << caloGeom->getPosition(hid) 
+      std::cout << hid << "\tCaloCellGeometry " << cell->getPosition()
+		<< "\tHcalGeometry " << caloGeom->getPosition(hid)
 		<< std::endl;
     }
   }

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryPlan1Tester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryPlan1Tester.cc
@@ -17,22 +17,20 @@ class HcalGeometryPlan1Tester : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalGeometryPlan1Tester( const edm::ParameterSet& );
   ~HcalGeometryPlan1Tester( void ) override {}
-    
+
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  edm::ParameterSet ps0_;
   bool              geomES_;
 };
 
-HcalGeometryPlan1Tester::HcalGeometryPlan1Tester( const edm::ParameterSet& iConfig ) :
-  ps0_(iConfig) {
+HcalGeometryPlan1Tester::HcalGeometryPlan1Tester( const edm::ParameterSet& iConfig ) {
   geomES_ = iConfig.getParameter<bool>("GeometryFromES");
 }
 
-void HcalGeometryPlan1Tester::analyze(const edm::Event& /*iEvent*/, 
+void HcalGeometryPlan1Tester::analyze(const edm::Event& /*iEvent*/,
 				      const edm::EventSetup& iSetup) {
 
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
@@ -49,7 +47,7 @@ void HcalGeometryPlan1Tester::analyze(const edm::Event& /*iEvent*/,
     const CaloGeometry* geo = pG.product();
     geom = (geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
   } else {
-    HcalFlexiHardcodeGeometryLoader m_loader(ps0_);
+    HcalFlexiHardcodeGeometryLoader m_loader;
     geom = (m_loader.load(topology, hcons));
   }
   //  geom  = (HcalGeometry*)(geom0);
@@ -76,10 +74,10 @@ void HcalGeometryPlan1Tester::analyze(const edm::Event& /*iEvent*/,
       dphi = std::abs(pt0.phi() - pt2.phi());
       if (dphi > M_PI) dphi -= (2*M_PI);
       if ((deta>0.00001) || (dphi>0.00001)) ok = false;
-      std::cout << "Unmerged ID " << (*itr) << " (" << pt1.eta() << ", " 
+      std::cout << "Unmerged ID " << (*itr) << " (" << pt1.eta() << ", "
 		<< pt1.phi() << ", " << pt1.z() << ") Merged ID " << idnew
 		<< " (" << pt2.eta() << ", " << pt2.phi() << ", " << pt2.z()
-		<< ") or (" << pt0.eta() << ", " << pt0.phi() << ", " 
+		<< ") or (" << pt0.eta() << ", " << pt0.phi() << ", "
 		<< pt0.z() << ")";
       if (ok) ++ngood;
       else    std::cout << " ***** ERROR *****";

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
@@ -36,12 +36,10 @@ private:
 			    std::vector<int> &dins);
   void testFlexiGeomHF(CaloSubdetectorGeometry* geom);
 
-  edm::ParameterSet ps0_;
   bool              useOld_;
 };
 
-HcalGeometryTester::HcalGeometryTester( const edm::ParameterSet& iConfig ) :
-  ps0_(iConfig) {
+HcalGeometryTester::HcalGeometryTester( const edm::ParameterSet& iConfig ) {
   useOld_ = iConfig.getParameter<bool>( "UseOldLoader" );
 }
 
@@ -56,10 +54,10 @@ void HcalGeometryTester::analyze(const edm::Event& /*iEvent*/,
   const HcalTopology topology = (*topologyHandle);
   CaloSubdetectorGeometry* geom(nullptr);
   if (useOld_) {
-    HcalHardcodeGeometryLoader m_loader(ps0_);
+    HcalHardcodeGeometryLoader m_loader;
     geom = m_loader.load(topology);
   } else {
-    HcalFlexiHardcodeGeometryLoader m_loader(ps0_);
+    HcalFlexiHardcodeGeometryLoader m_loader;
     geom = m_loader.load(topology, hcons);
   }
 
@@ -168,7 +166,7 @@ void HcalGeometryTester::testTriggerGeometry(const HcalTopology& topology) {
   HcalDetId forwardDet2(HcalForward, 29, 71, 2);
   HcalDetId forwardDet3(HcalForward, 40, 71, 1);
 
-  typedef std::vector<HcalTrigTowerDetId> TowerDets;
+  using TowerDets = std::vector<HcalTrigTowerDetId>;
   if (topology.valid(barrelDet)) {
     TowerDets barrelTowers = trigTowers.towerIds(barrelDet);
     std::cout << "Trigger Tower Size: Barrel " << barrelTowers.size()

--- a/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
+++ b/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
@@ -30,9 +30,8 @@ class MuonNumberingInitialization : public edm::ESProducer
 public:
   
   MuonNumberingInitialization( const edm::ParameterSet& );
-  ~MuonNumberingInitialization() override;
 
-  typedef std::unique_ptr<MuonDDDConstants> ReturnType;
+  using ReturnType = std::unique_ptr<MuonDDDConstants>;
 
   ReturnType produce( const MuonNumberingRecord& );
 };
@@ -41,9 +40,6 @@ MuonNumberingInitialization::MuonNumberingInitialization( const edm::ParameterSe
 {
   setWhatProduced(this);
 }
-
-MuonNumberingInitialization::~MuonNumberingInitialization()
-{}
 
 MuonNumberingInitialization::ReturnType
 MuonNumberingInitialization::produce(const MuonNumberingRecord& iRecord)

--- a/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
+++ b/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
@@ -21,11 +21,7 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "DetectorDescription/Core/interface/DDFilter.h"
-#include "DetectorDescription/Core/interface/DDFilteredView.h"
-#include "DetectorDescription/Core/interface/DDsvalues.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 #include "Geometry/Records/interface/MuonNumberingRecord.h"
 
@@ -39,19 +35,11 @@ public:
   typedef std::unique_ptr<MuonDDDConstants> ReturnType;
 
   ReturnType produce( const MuonNumberingRecord& );
-
-  void initializeMuonDDDConstants( const IdealGeometryRecord& igr );
-
-private:
-  
-  std::string label_;
-  MuonDDDConstants* muonDDDConst_;
 };
 
-MuonNumberingInitialization::MuonNumberingInitialization( const edm::ParameterSet& iConfig )
-  : muonDDDConst_( nullptr )
+MuonNumberingInitialization::MuonNumberingInitialization( const edm::ParameterSet& )
 {
-  setWhatProduced( this, dependsOn( &MuonNumberingInitialization::initializeMuonDDDConstants ));
+  setWhatProduced(this);
 }
 
 MuonNumberingInitialization::~MuonNumberingInitialization()
@@ -60,25 +48,11 @@ MuonNumberingInitialization::~MuonNumberingInitialization()
 MuonNumberingInitialization::ReturnType
 MuonNumberingInitialization::produce(const MuonNumberingRecord& iRecord)
 {
-  if ( muonDDDConst_ == nullptr )
-  {
-    edm::LogError( "MuonNumberingInitialization" ) << "MuonNumberingInitialization::produceMuonDDDConstants has NOT been initialized!";
-    throw;
-  }
-  return std::unique_ptr<MuonDDDConstants> ( muonDDDConst_ ) ;
-}
-
-void
-MuonNumberingInitialization::initializeMuonDDDConstants( const IdealGeometryRecord& igr )
-{
+  const IdealGeometryRecord& idealGeometryRecord = iRecord.getRecord<IdealGeometryRecord>();
   edm::ESTransientHandle<DDCompactView> pDD;
-  igr.get( label_, pDD );
+  idealGeometryRecord.get(pDD);
 
-  if( muonDDDConst_ != nullptr ) {
-    delete muonDDDConst_;
-  }
-
-  muonDDDConst_ = new MuonDDDConstants( *pDD );
+  return std::make_unique<MuonDDDConstants>(*pDD);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(MuonNumberingInitialization);


### PR DESCRIPTION
The following types of changes are included:
    - changing return type of produce to unique_ptr
    - removing unnecessary "dependsOn" callbacks
    - some callback content moved to produce
    - 4 callbacks were simply empty (did nothing)
    - some objects do not need to be cached create on stack
    - removing unneeded data members, includes, declarations
    - fix potential assert failure if produce called more than once
    - fix potential double delete if produce called more than once
    - 2 memory leaks
    - some general cleanup deleting unnecessary things