### PR TITLE
Fix for LLVM 7.0.0: Explicitly pass the gcc-toolchain to clang

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -382,8 +382,8 @@ def get_diagnostics(translation_unit):
     }, translation_unit.diagnostics)
 
 
-def get_default_gcc_search_paths(gcc = 'g++', language = 'c++'):
-    command = 'echo "" | %s -x%s -v -E - 2>&1' % (gcc, language)
+def get_default_gcc_search_paths(gcc = 'g++', language = 'c++', gcc_toolchain=""):
+    command = 'echo "" | %s -x%s %s -v -E - 2>&1' % (gcc, language, gcc_toolchain)
     logging.debug('Running: %s', command)
 
     paths = []
@@ -457,7 +457,9 @@ class SerializationCodeGenerator(object):
             cxx_flags = []
 
         # We are using libClang, thus we have to follow Clang include paths
-        std_flags = get_default_gcc_search_paths(gcc='clang++')
+        toolchain=""
+        if 'COMPILER_RUNTIME_OBJECTS' in os.environ: toolchain='--gcc-toolchain=%s' % os.environ['COMPILER_RUNTIME_OBJECTS']
+        std_flags = get_default_gcc_search_paths(gcc='clang++',gcc_toolchain=toolchain)
         log_flags('cpp_flags', cpp_flags)
         log_flags('cxx_flags', cxx_flags)
         log_flags('std_flags', std_flags)


### PR DESCRIPTION
We have updated LLVM to version 7.0 for DEVEL IBs. The command `echo "" | clang++ -xc++  -v -E -` now returns system gcc include paths
```
clang version 7.0.0 
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /build/muz/llvm/install-llvm/slc6_amd64_gcc700/external/llvm/7.0.0-cms/bin
Found CUDA installation: /cvmfs/cms-ib.cern.ch/nweek-02542/slc6_amd64_gcc700/external/cuda/9.2.148, version 9.2
 "/build/muz/llvm/install-llvm/slc6_amd64_gcc700/external/llvm/7.0.0-cms/bin/clang-7" -cc1 -triple x86_64-unknown-linux-gnu -E -disable-free -disable-llvm-verifier -discard-value-names -main-file-name - -mrelocation-model static -mthread-model posix -mdisable-fp-elim -fmath-errno -masm-verbose -mconstructor-aliases -munwind-tables -fuse-init-array -target-cpu x86-64 -dwarf-column-info -debugger-tuning=gdb -v -resource-dir /build/muz/llvm/install-llvm/slc6_amd64_gcc700/external/llvm/7.0.0-cms/lib64/clang/7.0.0 -internal-isystem /usr/local/include -internal-isystem /build/muz/llvm/install-llvm/slc6_amd64_gcc700/external/llvm/7.0.0-cms/lib64/clang/7.0.0/include -internal-externc-isystem /include -internal-externc-isystem /usr/include -fdeprecated-macro -fdebug-compilation-dir /build/muz/llvm/CMSSW_10_3_X_2018-09-20-2300/src -ferror-limit 19 -fmessage-length 363 -fobjc-runtime=gcc -fcxx-exceptions -fexceptions -fdiagnostics-show-option -fcolor-diagnostics -o - -x c++ - -faddrsig
clang -cc1 version 7.0.0 based upon LLVM 7.0.0 default target x86_64-unknown-linux-gnu
ignoring nonexistent directory "/include"
#include "..." search starts here:
#include <...> search starts here:
 /usr/local/include
 /build/muz/llvm/install-llvm/slc6_amd64_gcc700/external/llvm/7.0.0-cms/lib64/clang/7.0.0/include
 /usr/include
End of search list.
# 1 "<stdin>"
# 1 "<built-in>" 1
# 1 "<built-in>" 3
# 389 "<built-in>" 3
# 1 "<command line>" 1
# 1 "<built-in>" 2
# 1 "<stdin>" 2
```

while with LLVM 6.0 it was returnings cms external GCC path. This PR should explicitly pass --gcc-toolchain to force clang++ to look in to cms external gcc.