### PR TITLE
Fix seg fault occurring after EventSetup exception

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -209,10 +209,13 @@ namespace edm {
 
     void doErrorStuff();
 
-    void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalBeginSucceeded);
+    void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalBeginSucceeded,
+                  bool& eventSetupForInstanceSucceeded);
     void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalBeginSucceeded, bool cleaningUpAfterException);
-    void endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalBeginSucceeded, bool cleaningUpAfterException);
-    
+    void endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run,
+                          bool globalBeginSucceeded, bool cleaningUpAfterException,
+                          bool eventSetupForInstanceSucceeded);
+
     InputSource::ItemType processLumis(std::shared_ptr<void> const& iRunResource);
     void endUnfinishedLumi();
     

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -43,7 +43,8 @@ struct RunResources {
   ~RunResources() noexcept {
     try {
       //If we skip empty runs, this would be called conditionally
-      ep_.endUnfinishedRun(processHistoryID(), run(), globalTransitionSucceeded_, cleaningUpAfterException_);
+      ep_.endUnfinishedRun(processHistoryID(), run(), globalTransitionSucceeded_,
+                           cleaningUpAfterException_, eventSetupForInstanceSucceeded_);
     }
     catch(...) {
       if(cleaningUpAfterException_ or not ep_.setDeferredException(std::current_exception())) {
@@ -76,6 +77,7 @@ struct RunResources {
   bool cleaningUpAfterException_ = true;
   bool success_ = false;
   bool globalTransitionSucceeded_ = false;
+  bool eventSetupForInstanceSucceeded_ = false;
 };
 
 class LumisInRunProcessor {
@@ -162,7 +164,9 @@ private:
       }
       currentRun_ = std::make_shared<RunResources>(iEP,runID.first,runID.second);
       iEP.readRun();
-      iEP.beginRun(runID.first,runID.second, currentRun_->globalTransitionSucceeded_);
+      iEP.beginRun(runID.first,runID.second,
+                   currentRun_->globalTransitionSucceeded_,
+                   currentRun_->eventSetupForInstanceSucceeded_);
       //only if we succeed at beginRun should we run writeRun
       currentRun_->succeeded();
     } else {

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -236,8 +236,10 @@ namespace edm {
     output_ << "\tdoErrorStuff\n";
   }
 
-  void MockEventProcessor::beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalTransitionSucceeded) {
+  void MockEventProcessor::beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalTransitionSucceeded,
+                                    bool& eventSetupForInstanceSucceeded) {
     output_ << "\tbeginRun " << run << "\n";
+    eventSetupForInstanceSucceeded = true;
     throwIfNeeded();
     globalTransitionSucceeded = true;
   }
@@ -247,10 +249,14 @@ namespace edm {
     output_ << "\tendRun " << run << postfix;
   }
 
-  void MockEventProcessor::endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTransitionSucceeded, bool cleaningUpAfterException ) {
-    endRun(phid,run,globalTransitionSucceeded,cleaningUpAfterException);
-    if(globalTransitionSucceeded) {
-      writeRun(phid,run);
+  void MockEventProcessor::endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run,
+                                            bool globalTransitionSucceeded, bool cleaningUpAfterException,
+                                            bool eventSetupForInstanceSucceeded ) {
+    if (eventSetupForInstanceSucceeded) {
+      endRun(phid,run,globalTransitionSucceeded,cleaningUpAfterException);
+      if(globalTransitionSucceeded) {
+        writeRun(phid,run);
+      }
     }
     deleteRunFromCache(phid,run);
   }

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -54,8 +54,11 @@ namespace edm {
 
     void doErrorStuff();
 
-    void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalTransitionSucceeded);
-    void endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTranstitionSucceeded, bool cleaningUpAfterException);
+    void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalTransitionSucceeded,
+                  bool& eventSetupForInstanceSucceeded);
+    void endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run,
+                          bool globalTranstitionSucceeded, bool cleaningUpAfterException,
+                          bool eventSetupForInstanceSucceeded);
 
     void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTranstitionSucceeded, bool cleaningUpAfterException);
 


### PR DESCRIPTION
There was a bug occurring after an EventSetup exception
during beginRun eventSetupForInstance. Instead of printing
the exception message, it was seg faulting. This happened
because at endRun eventSetupForInstance was called again
before the original exception had been caught and when the
same exception was thrown again the problem occurred.