### PR TITLE
Added unit test to make sure poisoned datafiles are not read from release

### DIFF
--- a/CondTools/Geometry/test/BuildFile.xml
+++ b/CondTools/Geometry/test/BuildFile.xml
@@ -28,3 +28,4 @@
  <flags EDM_PLUGIN="1"/>
 </library> 
 
+<test name="test-data-file-deletion" command="test-data-file-deletion.sh"/>

--- a/CondTools/Geometry/test/test-data-file-deletion.sh
+++ b/CondTools/Geometry/test/test-data-file-deletion.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+cd $CMSSW_BASE
+rm -rf test-data-file-deletion
+mkdir -p test-data-file-deletion/src/Geometry/CMSCommonData/data/dir-for-data-file
+#Create symlink for datafile to point to the directory. cmsRun should fail to open this datafile via FileInPath mechanism
+ln -s dir-for-data-file test-data-file-deletion/src/Geometry/CMSCommonData/data/materials.xml
+ERR=0
+pushd test-data-file-deletion
+  CMSSW_SEARCH_PATH=$(pwd)/src1:${CMSSW_SEARCH_PATH} cmsRun $CMSSW_BASE/src/CondTools/Geometry/test/writehelpers/geometryxmlwriter.py || ERR=$?
+popd
+let FILE_IN_PATH_ERROR=$(grep ' FileInPathError *= *' $CMSSW_RELEASE_BASE/src/FWCore/Utilities/interface/EDMException.h | sed 's|.*= *||;s|,.*$||')%256
+rm -rf test-data-file-deletion
+if [ "$ERR" = "$FILE_IN_PATH_ERROR" ] ; then
+  exit 0
+fi
+
+echo "ERROR: This tests should have failed with FileInPath error."
+exit 1

--- a/CondTools/Geometry/test/test-data-file-deletion.sh
+++ b/CondTools/Geometry/test/test-data-file-deletion.sh
@@ -6,7 +6,7 @@ mkdir -p test-data-file-deletion/src/Geometry/CMSCommonData/data/dir-for-data-fi
 ln -s dir-for-data-file test-data-file-deletion/src/Geometry/CMSCommonData/data/materials.xml
 ERR=0
 pushd test-data-file-deletion
-  CMSSW_SEARCH_PATH=$(pwd)/src1:${CMSSW_SEARCH_PATH} cmsRun $CMSSW_BASE/src/CondTools/Geometry/test/writehelpers/geometryxmlwriter.py || ERR=$?
+  CMSSW_SEARCH_PATH=$(pwd)/src:${CMSSW_SEARCH_PATH} cmsRun $CMSSW_BASE/src/CondTools/Geometry/test/writehelpers/geometryxmlwriter.py || ERR=$?
 popd
 let FILE_IN_PATH_ERROR=$(grep ' FileInPathError *= *' $CMSSW_RELEASE_BASE/src/FWCore/Utilities/interface/EDMException.h | sed 's|.*= *||;s|,.*$||')%256
 rm -rf test-data-file-deletion


### PR DESCRIPTION
New `git-cms-checkdeps` ( https://github.com/cms-sw/cms-git-tools/commit/612fa046f52ef1db7335b8279fc3e987d784e93a ) now poisons deleted datafile by creating a symlink to an emptry directory. This Allow us to make sure that a deleted datafile (from a src directory) is not read from `CMSSW_RELEASE_BASE` 

This unit test simulates the `git-cms-checkdeps` behaviour and poisons Geometry/CMSCommonData/data/materials.xml 