### PR TITLE
Improved SIM debug printout

### DIFF
--- a/SimG4CMS/Calo/interface/HFFibreFiducial.h
+++ b/SimG4CMS/Calo/interface/HFFibreFiducial.h
@@ -10,8 +10,6 @@
 class HFFibreFiducial {
 
 public:
-  HFFibreFiducial() {}
-  virtual ~HFFibreFiducial() {}
   static int PMTNumber(const G4ThreeVector& pe_effect); // M.K. HF acceptance
 };
 

--- a/SimG4CMS/Calo/interface/HFFibreFiducial.h
+++ b/SimG4CMS/Calo/interface/HFFibreFiducial.h
@@ -7,10 +7,8 @@
 
 #include "G4ThreeVector.hh"
 
-class HFFibreFiducial {
-
-public:
-  static int PMTNumber(const G4ThreeVector& pe_effect); // M.K. HF acceptance
+namespace HFFibreFiducial {
+  int PMTNumber(const G4ThreeVector& pe_effect); // M.K. HF acceptance
 };
 
 #endif

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -81,7 +81,7 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
   primAncestor = cleanIndex = totalHits = primIDSaved = 0;
   forceSave = false;
   
-  edm::LogInfo("CaloSim") << "CaloSD: Minimum energy of track for saving it " 
+  edm::LogVerbatim("CaloSim") << "CaloSD: Minimum energy of track for saving it " 
                           << energyCut/GeV  << " GeV" << "\n"
                           << "        Use of HitID Map " << useMap << "\n"
                           << "        Check last " << nCheckedHits 
@@ -143,7 +143,7 @@ G4bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   } else { 
     if(aStep->GetTotalEnergyDeposit() > 0.0) { 
       const G4TouchableHistory* touch = static_cast<const G4TouchableHistory*>(theTrack->GetTouchable());
-      edm::LogInfo("CaloSim") << "CaloSD::ProcessHits: unitID= " << unitID
+      edm::LogVerbatim("CaloSim") << "CaloSD::ProcessHits: unitID= " << unitID
 			      << " currUnit=   " << currentID.unitID()
 			      << " Detector: " << GetName()
 			      << " trackID= " << theTrack->GetTrackID() << " "

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -89,7 +89,7 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
   std::vector<double>      tempD = getDDDArray("EnergyWeight",sv);
   if (!tempD.empty()) { if (tempD[0] < 0.1) useWeight = false; }
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("EcalSim") << "ECalSD:: useWeight " << tempD.size() << ":" 
+  edm::LogVerbatim("EcalSim") << "ECalSD:: useWeight " << tempD.size() << ":" 
                           << useWeight << std::endl;
 #endif
   std::vector<std::string> tempS = getStringArray("Depth1Name",sv);
@@ -99,7 +99,7 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
   if (!tempS.empty()) depth2Name = tempS[0];
   else                  depth2Name = " ";
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("EcalSim") << "Names (Depth 1):" << depth1Name << " (Depth 2):" 
+  edm::LogVerbatim("EcalSim") << "Names (Depth 1):" << depth1Name << " (Depth 2):" 
                           << depth2Name << std::endl;
 #endif
   EcalNumberingScheme* scheme=nullptr;
@@ -121,10 +121,10 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
 
   if (scheme)  setNumberingScheme(scheme);
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("EcalSim") << "Constructing a ECalSD  with name " << GetName();
+  edm::LogVerbatim("EcalSim") << "Constructing a ECalSD  with name " << GetName();
 #endif
   if (useWeight) {
-    edm::LogInfo("EcalSim")  << "ECalSD:: Use of Birks law is set to      " 
+    edm::LogVerbatim("EcalSim")  << "ECalSD:: Use of Birks law is set to      " 
                              << useBirk << "        with three constants kB = "
                              << birk1 << ", C1 = " << birk2 << ", C2 = " 
                              << birk3 <<"\n         Use of L3 parametrization "
@@ -133,11 +133,11 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
                              << "         Slope for Light yield is set to "
                              << slopeLY;
   } else {
-    edm::LogInfo("EcalSim")  << "ECalSD:: energy deposit is not corrected "
+    edm::LogVerbatim("EcalSim")  << "ECalSD:: energy deposit is not corrected "
                              << " by Birk or light yield curve";
   }
 
-  edm::LogInfo("EcalSim") << "ECalSD:: Suppression Flag " << suppressHeavy
+  edm::LogVerbatim("EcalSim") << "ECalSD:: Suppression Flag " << suppressHeavy
                           << "\tprotons below " << kmaxProton << " MeV,"
                           << "\tneutrons below " << kmaxNeutron << " MeV"
                           << "\tions below " << kmaxIon << " MeV"
@@ -208,7 +208,7 @@ double ECalSD::getEnergyDeposit(const G4Step * aStep) {
   double wt2 = theTrack->GetWeight();
   if(wt2 > 0.0) { edep *= wt2; }
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("EcalSim") << lv->GetName()
+  edm::LogVerbatim("EcalSim") << lv->GetName()
                           << " Light Collection Efficiency " << weight << ":"
                           << wt1 << " wt2= " << wt2
                           << " Weighted Energy Deposit " << edep/MeV << " MeV";
@@ -305,7 +305,7 @@ uint32_t ECalSD::setDetUnitId(const G4Step * aStep) {
 
 void ECalSD::setNumberingScheme(EcalNumberingScheme* scheme) {
   if (scheme != nullptr) {
-    edm::LogInfo("EcalSim") << "EcalSD: updates numbering scheme for " 
+    edm::LogVerbatim("EcalSim") << "EcalSD: updates numbering scheme for " 
                             << GetName();
     if (numberingScheme) delete numberingScheme;
     numberingScheme = scheme;
@@ -338,7 +338,7 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
         if (!any(useDepth1, lv)) {
            useDepth1.push_back(lv);
 #ifdef EDM_ML_DEBUG
-          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+          edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " 
                                   << lvname <<" in Depth 1 volume list";
 #endif
         }
@@ -346,7 +346,7 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
         if (lvr != nullptr && !any(useDepth1, lvr)) {
           useDepth1.push_back(lvr);
 #ifdef EDM_ML_DEBUG
-          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+          edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " 
                                   << lvname << "_refl"
                                   <<" in Depth 1 volume list";
 #endif
@@ -358,7 +358,7 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
         if (!any(useDepth2, lv)) {
           useDepth2.push_back(lv);
 #ifdef EDM_ML_DEBUG
-          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+          edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " 
                                   << lvname <<" in Depth 2 volume list";
 #endif
         }
@@ -366,7 +366,7 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
         if (lvr != nullptr && !any(useDepth2,lvr)) {
           useDepth2.push_back(lvr);
 #ifdef EDM_ML_DEBUG
-          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+          edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " 
                                   << lvname << "_refl"
                                   <<" in Depth 2 volume list";
 #endif
@@ -380,7 +380,7 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
           const DDSolid & sol  = fv.logicalPart().solid();
           const std::vector<double> & paras = sol.parameters();
 #ifdef EDM_ML_DEBUG
-          edm::LogInfo("EcalSim") << "ECalSD::initMap (for " << sd 
+          edm::LogVerbatim("EcalSim") << "ECalSD::initMap (for " << sd 
                                   << "): Solid " << lvname << " Shape " 
                                   << sol.shape() << " Parameter 0 = "
                                   << paras[0] << " Logical Volume " << lv;
@@ -398,7 +398,7 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
         if (!any(noWeight,lv)) {
           noWeight.push_back(lv);
 #ifdef EDM_ML_DEBUG
-          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume "
+          edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume "
                                   << lvname << " Material " << matname 
                                   << " in noWeight list";
 #endif
@@ -407,7 +407,7 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
         if (lv != nullptr && !any(noWeight,lv)) {
           noWeight.push_back(lv);
 #ifdef EDM_ML_DEBUG
-          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+          edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " 
                                   << lvname << " Material " << matname 
                                   << " in noWeight list";
 #endif
@@ -417,13 +417,13 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
     dodet = fv.next();
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("EcalSim") << "ECalSD: Length Table for " << attribute << " = " 
+  edm::LogVerbatim("EcalSim") << "ECalSD: Length Table for " << attribute << " = " 
                           << sd << ":";   
   int i=0;
   for (auto ite : xtalLMap) {
     G4String name("Unknown");
     if (ite.first != 0) name = (ite.first)->GetName();
-    edm::LogInfo("EcalSim") << " " << i << " " << ite.first << " " << name 
+    edm::LogVerbatim("EcalSim") << " " << i << " " << ite.first << " " << name 
                             << " L = " << ite.second;
     ++i;
   }
@@ -465,7 +465,7 @@ void ECalSD::getBaseNumber(const G4Step* aStep) {
     for (int ii = 0; ii < theSize ; ii++) {
       theBaseNumber.addLevel(touch->GetVolume(ii)->GetName(),touch->GetReplicaNumber(ii));
 #ifdef EDM_ML_DEBUG
-      edm::LogInfo("EcalSim") << "ECalSD::getBaseNumber(): Adding level " << ii
+      edm::LogVerbatim("EcalSim") << "ECalSD::getBaseNumber(): Adding level " << ii
                               << ": " << touch->GetVolume(ii)->GetName() << "["
                               << touch->GetReplicaNumber(ii) << "]";
 #endif
@@ -490,7 +490,7 @@ double ECalSD::getBirkL3(const G4Step* aStep) {
       else if (weight > 1.) weight = 1.;
     }
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << "ECalSD::getBirkL3 in " << mat->GetName()
+    edm::LogVerbatim("EcalSim") << "ECalSD::getBirkL3 in " << mat->GetName()
                             << " Charge " << charge << " dE/dx " << dedx
                             << " Birk Const " << rkb << " Weight = " << weight 
                             << " dE " << aStep->GetTotalEnergyDeposit();
@@ -503,12 +503,12 @@ std::vector<double> ECalSD::getDDDArray(const std::string & str,
                                         const DDsvalues_type & sv) {
 
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("EcalSim") << "ECalSD:getDDDArray called for " << str;
+  edm::LogVerbatim("EcalSim") << "ECalSD:getDDDArray called for " << str;
 #endif
   DDValue value(str);
   if (DDfetch(&sv,value)) {
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << value;
+    edm::LogVerbatim("EcalSim") << value;
 #endif
     const std::vector<double> & fvec = value.doubles();
     return fvec;
@@ -522,12 +522,12 @@ std::vector<std::string> ECalSD::getStringArray(const std::string & str,
                                                 const DDsvalues_type & sv) {
 
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("EcalSim") << "ECalSD:getStringArray called for " << str;
+  edm::LogVerbatim("EcalSim") << "ECalSD:getStringArray called for " << str;
 #endif
   DDValue value(str);
   if (DDfetch(&sv,value)) {
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << value;
+    edm::LogVerbatim("EcalSim") << value;
 #endif
     const std::vector<std::string> & fvec = value.strings();
     return fvec;

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -104,7 +104,7 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
 			      << "\n"
 			      << "***************************************************";
 #endif
-  edm::LogInfo("HcalSim") << "HCalSD:: Use of HF code is set to " << useHF
+  edm::LogVerbatim("HcalSim") << "HCalSD:: Use of HF code is set to " << useHF
                           << "\nUse of shower parametrization set to "
                           << useParam << "\nUse of shower library is set to " 
                           << useShowerLibrary << "\nUse PMT Hit is set to "
@@ -113,7 +113,7 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
                           << "\n         Use of Birks law is set to      " 
                           << useBirk << "  with three constants kB = "
                           << birk1 << ", C1 = " << birk2 << ", C2 = " << birk3;
-  edm::LogInfo("HcalSim") << "HCalSD:: Suppression Flag " << suppressHeavy
+  edm::LogVerbatim("HcalSim") << "HCalSD:: Suppression Flag " << suppressHeavy
                           << " protons below " << kmaxProton << " MeV,"
                           << " neutrons below " << kmaxNeutron << " MeV and"
                           << " ions below " << kmaxIon << " MeV\n"
@@ -181,7 +181,7 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
       ss << "\n        HF[" << i << "] = " << namv
          << " LV " << hfLV[i] << " at level " << hfLevels[i];
     }
-    edm::LogInfo("HcalSim") << ss.str();
+    edm::LogVerbatim("HcalSim") << ss.str();
   
     // HF Fibre volume names
     fillLogVolumeVector(attribute, "HFFibre", cpv, fibreLV, fibreNames);
@@ -232,7 +232,7 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     if(i/10*10 == i) { sss << "\n"; }
     sss << "  "  << matNames[i];
   }
-  edm::LogInfo("HcalSim") << "HCalSD: Material names for " << attribute 
+  edm::LogVerbatim("HcalSim") << "HCalSD: Material names for " << attribute 
                           << " = " << name << ":" << sss.str();
 
   if (useLayerWt) { readWeightFromFile(file); }
@@ -310,7 +310,7 @@ void HCalSD::fillLogVolumeVector(const std::string& attribute, const std::string
     if(i/10*10 == i) { ss << "\n"; }
     ss << "  " << namv;
   }
-  edm::LogInfo("HcalSim") << ss.str();
+  edm::LogVerbatim("HcalSim") << ss.str();
 }
 
 bool HCalSD::getFromLibrary(const G4Step * aStep) {
@@ -337,7 +337,7 @@ bool HCalSD::getFromLibrary(const G4Step * aStep) {
         }
       }
 #ifdef EDM_ML_DEBUG
-      edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary: HFLumiDarkening at "
+      edm::LogVerbatim("HcalSim") << "HCalSD::getFromLibrary: HFLumiDarkening at "
 			      << "r= " << r << ", z= " << z << " Dose= "
 			      << dose_acquired << " weight= " << weight_;
 #endif
@@ -360,7 +360,7 @@ bool HCalSD::getFromLibrary(const G4Step * aStep) {
 #ifdef EDM_ML_DEBUG
 	auto nameVolume = 
 	  aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetName();
-	edm::LogInfo("HcalSim") << "HCalSD: Starts shower library from " 
+	edm::LogVerbatim("HcalSim") << "HCalSD: Starts shower library from " 
 				<< nameVolume << " for Track " 
 				<< track->GetTrackID() << " ("
 				<< track->GetDefinition()->GetParticleName()
@@ -372,7 +372,7 @@ bool HCalSD::getFromLibrary(const G4Step * aStep) {
     }
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary ID= " 
+  edm::LogVerbatim("HcalSim") << "HCalSD::getFromLibrary ID= " 
                           << track->GetTrackID() << " ("
                           << track->GetDefinition()->GetParticleName() 
                           << ") kill= " << kill << " weight= " << weight_ 
@@ -389,7 +389,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
   if(isHF) {
     if (useShowerLibrary && G4TrackToParticleID::isMuon(theTrack) && isItFibre(lv)) {
 #ifdef EDM_ML_DEBUG
-      edm::LogInfo("HcalSim") << "HCalSD: Hit at Fibre in LV " << lv->GetName()
+      edm::LogVerbatim("HcalSim") << "HCalSD: Hit at Fibre in LV " << lv->GetName()
                               << " for track " 
 			      << aStep->GetTrack()->GetTrackID() <<" ("
                               << aStep->GetTrack()->GetDefinition()->GetParticleName()
@@ -403,7 +403,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
   if (isItPMT(lv)) {
     if(usePMTHit && showerPMT) { getHitPMT(aStep); }
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD: Hit from PMT parametrization in LV " 
+    edm::LogVerbatim("HcalSim") << "HCalSD: Hit from PMT parametrization in LV " 
                             <<  lv->GetName() << " for Track " 
                             << aStep->GetTrack()->GetTrackID() << " ("
                             << aStep->GetTrack()->GetDefinition()->GetParticleName()
@@ -414,7 +414,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
   } else if (isItStraightBundle(lv)) {
     if(useFibreBundle && showerBundle) { getHitFibreBundle(aStep, false); }
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD: Hit from straight FibreBundle in LV: "
+    edm::LogVerbatim("HcalSim") << "HCalSD: Hit from straight FibreBundle in LV: "
 			    << lv->GetName() << " for track " 
 			    << aStep->GetTrack()->GetTrackID() << " ("
 			    << aStep->GetTrack()->GetDefinition()->GetParticleName()
@@ -425,7 +425,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
   } else if(isItConicalBundle(lv)) {
     if(useFibreBundle && showerBundle) { getHitFibreBundle(aStep, true); }
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD: Hit from conical FibreBundle PV: "
+    edm::LogVerbatim("HcalSim") << "HCalSD: Hit from conical FibreBundle PV: "
 			    << lv->GetName() << " for track " 
 			    << aStep->GetTrack()->GetTrackID() << " ("
 			    << aStep->GetTrack()->GetDefinition()->GetParticleName()
@@ -452,7 +452,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
   }
   lay   = (touch->GetReplicaNumber(0)/10)%100 + 1;
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalSim") << "HCalSD: det: " << det << " ieta: "<< ieta 
+  edm::LogVerbatim("HcalSim") << "HCalSD: det: " << det << " ieta: "<< ieta 
                           << " iphi: " << phi << " zside " << z << "  lay: " 
                           << lay-2;
 #endif 
@@ -467,7 +467,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
     double dweight = m_HBDarkening->degradation(deliveredLumi,ieta,lay);
     weight_ *= dweight;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
+    edm::LogVerbatim("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
                             << " coefficient = " << dweight << " Weight= "
 			    << weight_;
 #endif  
@@ -477,7 +477,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
     double dweight = m_HEDarkening->degradation(deliveredLumi,ieta,lay);
     weight_ *= dweight;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
+    edm::LogVerbatim("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
                             << " coefficient = " << dweight << " Weight= "
 			    << weight_;
 #endif  
@@ -505,7 +505,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
   double edep = weight_*wt1*destep;
   if (wt2 > 0.0) { edep *= wt2; }
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalSim") 
+  edm::LogVerbatim("HcalSim") 
     << "HCalSD: edep= " << edep << " Det: " << det+2 << " depth= " << depth_
     << " weight= " << weight_ << " wt1= " << wt1 << " wt2= " << wt2; 
 #endif
@@ -527,7 +527,7 @@ uint32_t HCalSD::setDetUnitId(const G4Step * aStep) {
 
 void HCalSD::setNumberingScheme(HcalNumberingScheme * scheme) {
   if (scheme != nullptr) {
-    edm::LogInfo("HcalSim") << "HCalSD: updates numbering scheme for "
+    edm::LogVerbatim("HcalSim") << "HCalSD: updates numbering scheme for "
 			    << GetName();
     numberingScheme.reset(scheme);
   }
@@ -553,7 +553,7 @@ void HCalSD::update(const BeginOfJob * job) {
   for (unsigned int ig=0; ig<gpar.size(); ig++) {
     sss << "\n         gpar[" << ig << "] = " << gpar[ig]/cm << " cm";
   }
-  edm::LogInfo("HcalSim") << "Maximum depth for HF " 
+  edm::LogVerbatim("HcalSim") << "Maximum depth for HF " 
 			  << hcalConstants->getMaxDepth(2)
                           << gpar.size()<< " gpar (cm)" << sss.str();
   //Test Hcal Numbering Scheme
@@ -720,13 +720,13 @@ bool HCalSD::isItinFidVolume (const G4ThreeVector& hitPoint) {
   if (applyFidCut) {
     int npmt = HFFibreFiducial::PMTNumber(hitPoint);
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD::isItinFidVolume:#PMT= " << npmt 
+    edm::LogVerbatim("HcalSim") << "HCalSD::isItinFidVolume:#PMT= " << npmt 
                             << " for hit point " << hitPoint;
 #endif
     if (npmt <= 0) flag = false;
   }
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD::isItinFidVolume: point " << hitPoint
+    edm::LogVerbatim("HcalSim") << "HCalSD::isItinFidVolume: point " << hitPoint
                             << " return flag " << flag;
 #endif
   return flag;
@@ -753,7 +753,7 @@ void HCalSD::getFromHFLibrary (const G4Step* aStep, bool& isKilled) {
     edepositHAD = 1.*GeV;
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary " <<hits.size() 
+  edm::LogVerbatim("HcalSim") << "HCalSD::getFromLibrary " <<hits.size() 
                           << " hits for " << GetName() << " of " << primaryID 
                           << " with " << theTrack->GetDefinition()->GetParticleName() 
                           << " of " << aStep->GetPreStepPoint()->GetKineticEnergy()/GeV << " GeV";
@@ -793,7 +793,7 @@ void HCalSD::hitForFibre (const G4Step* aStep) { // if not ParamShower
   }
  
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalSim") << "HCalSD::hitForFibre " << hits.size() 
+  edm::LogVerbatim("HcalSim") << "HCalSD::hitForFibre " << hits.size() 
                           << " hits for " << GetName() << " of " << primaryID 
                           << " with " << theTrack->GetDefinition()->GetParticleName() 
                           << " of " << preStepPoint->GetKineticEnergy()/GeV 
@@ -826,7 +826,7 @@ void HCalSD::getFromParam (const G4Step* aStep, bool& isKilled) {
   int det   = 5;
 
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalSim") << "HCalSD::getFromParam " << hits.size() << " hits for " 
+  edm::LogVerbatim("HcalSim") << "HCalSD::getFromParam " << hits.size() << " hits for " 
                             << GetName() << " of " << primaryID << " with " 
                             <<  aStep->GetTrack()->GetDefinition()->GetParticleName()
                             << " of " << preStepPoint->GetKineticEnergy()/GeV 
@@ -878,7 +878,7 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
     }
     if (hitPoint.z() < 0) etaR =-etaR;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD::Hit for Detector " << det << " etaR "
+    edm::LogVerbatim("HcalSim") << "HCalSD::Hit for Detector " << det << " etaR "
                             << etaR << " phi " << phi/deg << " depth " <<depth;
 #endif
     double time = (aStep->GetPostStepPoint()->GetGlobalTime());
@@ -982,7 +982,7 @@ void HCalSD::readWeightFromFile(const std::string& fName) {
       layerWeights.insert(std::pair<uint32_t,double>(id,wt));
       ++entry;
 #ifdef EDM_ML_DEBUG
-      edm::LogInfo("HcalSim") << "HCalSD::readWeightFromFile:Entry " << entry
+      edm::LogVerbatim("HcalSim") << "HCalSD::readWeightFromFile:Entry " << entry
                               << " ID " << std::hex << id << std::dec << " ("
                               << det << "/" << zside << "/1/" << etaR << "/"
                               << phi << "/" << lay << ") Weight " << wt;
@@ -990,7 +990,7 @@ void HCalSD::readWeightFromFile(const std::string& fName) {
     }
     infile.close();
   }
-  edm::LogInfo("HcalSim") << "HCalSD::readWeightFromFile: reads " << entry
+  edm::LogVerbatim("HcalSim") << "HCalSD::readWeightFromFile: reads " << entry
                           << " weights from " << fName;
   if (entry <= 0) useLayerWt = false;
 }
@@ -1008,7 +1008,7 @@ double HCalSD::layerWeight(int det, const G4ThreeVector& pos, int depth, int lay
     std::map<uint32_t,double>::const_iterator ite = layerWeights.find(id);
     if (ite != layerWeights.end()) wt = ite->second;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD::layerWeight: ID " << std::hex << id 
+    edm::LogVerbatim("HcalSim") << "HCalSD::layerWeight: ID " << std::hex << id 
                             << std::dec << " (" << tmp.subdet << "/"  
                             << tmp.zside << "/1/" << tmp.etaR << "/" 
                             << tmp.phis << "/"  << tmp.lay << ") Weight " <<wt;

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -23,7 +23,7 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
   edm::ParameterSet m_HF = p.getParameter<edm::ParameterSet>("HFShower");
   cFibre           = c_light*(m_HF.getParameter<double>("CFibre"));
   
-  edm::LogInfo("HFShower") << "HFFibre:: Speed of light in fibre " << cFibre
+  edm::LogVerbatim("HFShower") << "HFFibre:: Speed of light in fibre " << cFibre
                            << " m/ns";
 
   std::string attribute = "Volume"; 
@@ -43,14 +43,14 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
       if(it/10*10 == it) { ss1 << "\n"; }
       ss1 << "  " << attL[it]*cm;
     }
-    edm::LogInfo("HFShower") << "HFFibre: " << nBinAtt << " attL(1/cm): " << ss1.str();
+    edm::LogVerbatim("HFShower") << "HFFibre: " << nBinAtt << " attL(1/cm): " << ss1.str();
 
     // Limits on Lambda
     int nb   = 2;
     std::vector<double>  nvec = getDDDArray("lambLim",sv,nb);
     lambLim[0] = static_cast<int>(nvec[0]);
     lambLim[1] = static_cast<int>(nvec[1]);
-    edm::LogInfo("HFShower") << "HFFibre: Limits on lambda " << lambLim[0]
+    edm::LogVerbatim("HFShower") << "HFFibre: Limits on lambda " << lambLim[0]
                              << " and " << lambLim[1];
 
     // Fibre Lengths
@@ -61,7 +61,7 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
       if(it/10*10 == it) { ss2 << "\n"; }
       ss2 << "  " << longFL[it]/cm;
     }
-    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Long Fibre Length(cm):" << ss2.str();
+    edm::LogVerbatim("HFShower") << "HFFibre: " << nb << " Long Fibre Length(cm):" << ss2.str();
     nb = 0;
     shortFL   = getDDDArray("ShortFL",sv,nb);
     std::stringstream ss3;
@@ -69,7 +69,7 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
       if(it/10*10 == it) { ss3 << "\n"; }
       ss3 << "  " << shortFL[it]/cm;
     } 
-    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Short Fibre Length(cm):" << ss3.str();
+    edm::LogVerbatim("HFShower") << "HFFibre: " << nb << " Short Fibre Length(cm):" << ss3.str();
   } else {
     edm::LogError("HFShower") << "HFFibre: cannot get filtered "
                               << " view for " << attribute << " matching "
@@ -91,7 +91,7 @@ void HFFibre::initRun(const HcalDDDSimConstants* hcons) {
     if(i/10*10 == i) { sss << "\n"; }
     sss << "  " << radius[i]/cm;
   }
-  edm::LogInfo("HFShower") << "HFFibre: " << radius.size() <<" rTable(cm):" << sss.str();
+  edm::LogVerbatim("HFShower") << "HFFibre: " << radius.size() <<" rTable(cm):" << sss.str();
 }
 
 double HFFibre::attLength(double lambda) {
@@ -105,7 +105,7 @@ double HFFibre::attLength(double lambda) {
     j = 0;
   double att = attL[j];
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFFibre::attLength for Lambda " << lambda
+  edm::LogVerbatim("HFShower") << "HFFibre::attLength for Lambda " << lambda
                            << " index " << i  << " " << j << " Att. Length " 
                            << att;
 #endif
@@ -117,7 +117,7 @@ double HFFibre::tShift(const G4ThreeVector& point, int depth, int fromEndAbs) {
   double zFibre = zShift(point, depth, fromEndAbs);
   double time   = zFibre/cFibre;
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFFibre::tShift for point " << point
+  edm::LogVerbatim("HFShower") << "HFFibre::tShift for point " << point
                            << " ( depth = " << depth <<", traversed length = " 
                            << zFibre/cm  << " cm) = " << time/ns << " ns";
 #endif
@@ -152,7 +152,7 @@ double HFFibre::zShift(const G4ThreeVector& point, int depth, int fromEndAbs) { 
   }
 
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFFibre::zShift for point " << point
+  edm::LogVerbatim("HFShower") << "HFFibre::zShift for point " << point
                            << " (R = " << hR/cm << " cm, Index = " << ieta 
                            << ", depth = " << depth << ", Fibre Length = " 
                            << length/cm       << " cm = " << zFibre/cm  

--- a/SimG4CMS/Calo/src/HFFibreFiducial.cc
+++ b/SimG4CMS/Calo/src/HFFibreFiducial.cc
@@ -4,8 +4,6 @@
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-#include<iostream>
-
 int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
 {
   double xv  = pe_effect.x();          // X in global system
@@ -15,8 +13,8 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   double dph = CLHEP::pi/18;           // 10 deg = a half sector width
   double sph = dph+dph;                // 20 deg = a sector width
   int   nphi = phi/dph;                // 10 deg sector #
-  edm::LogVerbatim("HFShower") <<"HFFibreFiducial:***> P = " << pe_effect 
-			       << ", phi = " << phi/CLHEP::deg;
+  LogDebug("HFShower") <<"HFFibreFiducial:***> P = " << pe_effect 
+		       << ", phi = " << phi/CLHEP::deg;
   if (nphi > 35) nphi=35;              // Just for security
   double xl=0.;                        // local sector coordinates (left/right)
   double yl=0.;                        // local sector coordinates (down/up)
@@ -45,14 +43,14 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
     double sinr= sin(phir);
     yl= xv*cosr+yv*sinr;
     xl= yv*cosr-xv*sinr;
-    edm::LogVerbatim("HFShower") << "HFFibreFiducial: nr " << nr << " phi " 
-				 << phir/CLHEP::deg;
+    LogDebug("HFShower") << "HFFibreFiducial: nr " << nr << " phi " 
+			 << phir/CLHEP::deg;
   }
   if (yl < 0) yl =-yl;
-  edm::LogVerbatim("HFShower") << "HFFibreFiducial: Global Point " << pe_effect
-			       << " nphi " << nphi 
-			       << " Local Sector Coordinates (" 
-			       << xl << ", " << yl << "), widget # " << nwid;
+  LogDebug("HFShower") << "HFFibreFiducial: Global Point " << pe_effect
+		       << " nphi " << nphi 
+		       << " Local Sector Coordinates (" 
+		       << xl << ", " << yl << "), widget # " << nwid;
   // Provides a PMT # for the (x,y) hit in the widget # nwid (M. Kosov, 11.2010)
   // Send comments/questions to Mikhail.Kossov@cern.ch
   // nwid = 1-18 for Forward HF, 19-36 for Backward HF (all equal now)
@@ -60,14 +58,14 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
 
   static const int nWidM=36;
   if (nwid > nWidM || nwid <= 0)   {
-    edm::LogVerbatim("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: "
+    LogDebug("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: "
 				 << nwid << " == wrong widget number";
     return 0;
   }
   static const double yMin= 13.1*CLHEP::cm; // start of the active area (Conv to mm?)
   static const double yMax=129.6*CLHEP::cm; // finish of the active area (Conv to mm?)
   if( yl < yMin || yl >= yMax ) {
-    edm::LogVerbatim("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: "
+    LogDebug("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: "
 				 << "Point with y = " << yl 
 				 << " outside acceptance [" << yMin << ":" 
 				 << yMax << "],  X = " << xv << ", Y = " 
@@ -85,7 +83,7 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   }
   static const double tg10=.17632698070847; // phi-angular acceptance of the widget
   if (r > tg10) {
-    edm::LogVerbatim("HFShower") <<"-Warning-HFFibreFiducial::PMTNumber: (x = "
+    LogDebug("HFShower") <<"-Warning-HFFibreFiducial::PMTNumber: (x = "
 				 << xl << ", y = " << yl << ", tg = " << r 
 				 << ") out of the widget acceptance tg(10) "
 				 << tg10;
@@ -1511,13 +1509,13 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   double     fx=xl/cellSize;
   int ny=static_cast<int>((yl-yMin)/cellSize);   // Layer number (starting from 0)
   if (ny < 0 || ny >= nLay) {// Sould never happen as was checked beforehand
-    edm::LogVerbatim("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: "
+    LogDebug("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: "
 				 << "check limits y = " << yl << ", nL=" 
 				 << nLay;
     return 0;
   }
   int nx=static_cast<int>(fx);           // Cell number (starting from 0)
-  edm::LogVerbatim("HFShower") << "HFFibreFiducial::PMTNumber:X = " << xv 
+  LogDebug("HFShower") << "HFFibreFiducial::PMTNumber:X = " << xv 
 			       << ", Y = " << yv << ", Z = " << pe_effect.z()
 			       << ", fX = " << fx << "-> nX = " << nx 
 			       << ", nY = " << ny << ", mX = " << nSL[ny]
@@ -1527,7 +1525,7 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
 			       << atan2(xl, yl)/CLHEP::deg
 			       << ", phir = " << phir/CLHEP::deg;
   if (nx >= nSL[ny]) {
-    edm::LogVerbatim("HFShower") << "HFFibreFiducial::nx/ny (" << nx 
+    LogDebug("HFShower") << "HFFibreFiducial::nx/ny (" << nx 
 				 << "," << ny <<") " << " above limit " 
 				 << nSL[ny];
     return 0;                           // ===> out of the acceptance
@@ -1538,7 +1536,7 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   int flag= code%10;
   int npmt= code/10;
   bool src= false;                       // by default: not a source-tube
-  edm::LogVerbatim("HFShower") << "HFFibreFiducial::nx/ny (" << nx << ","
+  LogDebug("HFShower") << "HFFibreFiducial::nx/ny (" << nx << ","
 			       << ny << ") code/flag/npmt " <<  code << "/" 
 			       << flag << "/" << npmt;
 
@@ -1547,7 +1545,7 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   else if (flag==3 || flag==4) {
     src=true;
   }
-  edm::LogVerbatim("HFShower") << "HFFibreFiducial::PMTNumber: src = " << src 
+  LogDebug("HFShower") << "HFFibreFiducial::PMTNumber: src = " << src 
 			       << ", npmt =" << npmt;
   if (src) return -npmt;   // return the negative number for the source
   return npmt;

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -32,7 +32,7 @@ HFShower::HFShower(const std::string & name, const DDCompactView & cpv,
   applyFidCut            = m_HF.getParameter<bool>("ApplyFiducialCut");
   probMax                = m_HF.getParameter<double>("ProbMax");
 
-  edm::LogInfo("HFShower") << "HFShower:: Maximum probability cut off " 
+  edm::LogVerbatim("HFShower") << "HFShower:: Maximum probability cut off " 
                            << probMax << " Check flag " << chkFibre;
 
   cherenkov = new HFCherenkov(m_HF);
@@ -51,7 +51,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
 
   double edep    = weight*(aStep->GetTotalEnergyDeposit());
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFShower::getHits: energy " << aStep->GetTotalEnergyDeposit() << " weight " << weight << " edep " << edep;
+  edm::LogVerbatim("HFShower") << "HFShower::getHits: energy " << aStep->GetTotalEnergyDeposit() << " weight " << weight << " edep " << edep;
 #endif
   double stepl   = 0.;
 
@@ -59,7 +59,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
     stepl = aStep->GetStepLength();
   if ((edep == 0.) || (stepl == 0.)) {
 #ifdef DebugLog
-    edm::LogInfo("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
+    edm::LogVerbatim("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
 #endif
     return hits;
   }
@@ -103,7 +103,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
       }
     }
 #ifdef DebugLog
-    edm::LogInfo("HFShower") << "HFShower: npmt " << npmt 
+    edm::LogVerbatim("HFShower") << "HFShower: npmt " << npmt 
                              << " zv " << std::abs(globalPos.z()) 
                              << ":" << gpar[4] << ":" << zv << ":" 
                              << gpar[0] << " ok " << ok << " depth " << depth;
@@ -123,7 +123,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
   double time     = fibre->tShift(localPos, depth, chkFibre);
 
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFShower::getHits: in " << name << " Z " 
+  edm::LogVerbatim("HFShower") << "HFShower::getHits: in " << name << " Z " 
                            << zCoor << "(" << globalPos.z() << ") " << zFibre 
                            << " Trans " << translation << " Time " << tSlice  
                            << " " << time << "\n                  Direction " 
@@ -145,7 +145,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
       double r1  = G4UniformRand();
       double r2  = G4UniformRand();
 #ifdef DebugLog
-      edm::LogInfo("HFShower") << "HFShower::getHits: " << i << " attenuation "
+      edm::LogVerbatim("HFShower") << "HFShower::getHits: " << i << " attenuation "
                                << r1 <<":" << exp(-p*zFibre) << " r2 " << r2 
                                << ":" << probMax << " Survive: " 
                                << (r1 <= exp(-p*zFibre) && r2 <= probMax);
@@ -168,9 +168,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
   }
 
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
+  edm::LogVerbatim("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
   for (int i=0; i<nHit; ++i)
-    edm::LogInfo("HFShower") << "HFShower::Hit " << i << " WaveLength " 
+    edm::LogVerbatim("HFShower") << "HFShower::Hit " << i << " WaveLength " 
                              << hits[i].wavelength << " Time " << hits[i].time
                              << " Momentum " << hits[i].momentum <<" Position "
                              << hits[i].position;
@@ -193,7 +193,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
     stepl = aStep->GetStepLength();
   if ((edep == 0.) || (stepl == 0.)) {
 #ifdef DebugLog
-    edm::LogInfo("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
+    edm::LogVerbatim("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
 #endif
     return hits;
   }
@@ -238,7 +238,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
       }
     }
 #ifdef DebugLog
-    edm::LogInfo("HFShower") << "HFShower: npmt " << npmt 
+    edm::LogVerbatim("HFShower") << "HFShower: npmt " << npmt 
                              << " zv " << std::abs(globalPos.z()) 
                              << ":" << gpar[4] << ":" << zv << ":" 
                              << gpar[0] << " ok " << ok << " depth " << depth;
@@ -258,7 +258,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
   double time     = fibre->tShift(localPos, depth, chkFibre);
 
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFShower::getHits: in " << name << " Z " <<zCoor
+  edm::LogVerbatim("HFShower") << "HFShower::getHits: in " << name << " Z " <<zCoor
                            << "(" << globalPos.z() <<") " << zFibre <<" Trans "
                            << translation << " Time " << tSlice  << " " << time
                            << "\n                  Direction " << momentumDir 
@@ -280,7 +280,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
       double r1  = G4UniformRand();
       double r2  = G4UniformRand();
 #ifdef DebugLog
-      edm::LogInfo("HFShower") << "HFShower::getHits: " << i << " attenuation "
+      edm::LogVerbatim("HFShower") << "HFShower::getHits: " << i << " attenuation "
                                << r1 << ":" << exp(-p*zFibre) << " r2 " << r2 
                                << ":" << probMax << " Survive: " 
                                << (r1 <= exp(-p*zFibre) && r2 <= probMax);
@@ -303,9 +303,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
   }
 
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
+  edm::LogVerbatim("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
   for (int i=0; i<nHit; ++i)
-    edm::LogInfo("HFShower") << "HFShower::Hit " << i << " WaveLength " 
+    edm::LogVerbatim("HFShower") << "HFShower::Hit " << i << " WaveLength " 
                              << hits[i].wavelength << " Time " << hits[i].time
                              << " Momentum " << hits[i].momentum <<" Position "
                              << hits[i].position;
@@ -325,7 +325,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibra
     stepl = aStep->GetStepLength();
   if ((edep == 0.) || (stepl == 0.)) {
 #ifdef DebugLog
-    edm::LogInfo("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
+    edm::LogVerbatim("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
 #endif
     return hits;
   }
@@ -369,7 +369,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibra
       }
     }
 #ifdef DebugLog
-    edm::LogInfo("HFShower") << "HFShower:getHits(SL): npmt " << npmt 
+    edm::LogVerbatim("HFShower") << "HFShower:getHits(SL): npmt " << npmt 
                              << " zv " << std::abs(globalPos.z()) 
                              << ":" << gpar[4] << ":" << zv << ":" 
                              << gpar[0] << " ok " << ok << " depth " << depth;
@@ -389,7 +389,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibra
   double time     = fibre->tShift(localPos, depth, chkFibre);
 
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFShower::getHits(SL): in " << name << " Z " 
+  edm::LogVerbatim("HFShower") << "HFShower::getHits(SL): in " << name << " Z " 
                            << zCoor << "(" << globalPos.z() << ") " << zFibre 
                            << " Trans " << translation << " Time " << tSlice  
                            << " " << time << "\n                  Direction " 

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -55,7 +55,7 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
     throw cms::Exception("Unknown", "HFShowerLibrary") 
       << "Opening of " << pTreeName << " fails\n";
   } else {
-    edm::LogInfo("HFShower") << "HFShowerLibrary: opening " << nTree 
+    edm::LogVerbatim("HFShower") << "HFShowerLibrary: opening " << nTree 
                              << " successfully"; 
   }
 
@@ -92,7 +92,7 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
     if(i/10*10 == i && i > 0) { ss << "\n"; }
     ss << "  " << pmom[i]/CLHEP::GeV;
   }
-  edm::LogInfo("HFShower") << ss.str();
+  edm::LogVerbatim("HFShower") << ss.str();
 
   std::string nameBr = branchPre + emName + branchPost;
   emBranch         = event->GetBranch(nameBr.c_str());
@@ -106,7 +106,7 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
     v3version=true;
   }
   
-  edm::LogInfo("HFShower") << " HFShowerLibrary:Branch " << emName 
+  edm::LogVerbatim("HFShower") << " HFShowerLibrary:Branch " << emName 
                            << " has " << emBranch->GetEntries() 
                            << " entries and Branch " << hadName 
                            << " has " << hadBranch->GetEntries() 
@@ -139,7 +139,7 @@ void HFShowerLibrary::initRun(G4ParticleTable*, const HcalDDDSimConstants* hcons
   //Delta phi
   std::vector<double> phibin   = hcons->getPhiTableHF();
   dphi       = phibin[0];
-  edm::LogInfo("HFShower") << "HFShowerLibrary: rMIN " << rMin/cm 
+  edm::LogVerbatim("HFShower") << "HFShowerLibrary: rMIN " << rMin/cm 
                            << " cm and rMax " << rMax/cm
                            << " (Half) Phi Width of wedge " 
                            << dphi/deg;
@@ -172,7 +172,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(const G4Step * aStep,
     preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
   double zoff   = localPos.z() + 0.5*gpar[1];
 
-  edm::LogInfo("HFShower") << "HFShowerLibrary::getHits " << partType
+  edm::LogVerbatim("HFShower") << "HFShowerLibrary::getHits " << partType
                            << " of energy " << pin/GeV << " GeV"
                            << " weight= " << weight << " onlyLong: " << onlyLong
                            << "  dir.orts " << momDir.x() << ", " <<momDir.y()
@@ -241,7 +241,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
   for (int i = 0; i < npe; ++i) {
     double zv = std::abs(pe[i].z()); // abs local z  
 #ifdef DebugLog
-    edm::LogInfo("HFShower") << "HFShowerLibrary: Hit " << i << " " << pe[i] << " zv " << zv;
+    edm::LogVerbatim("HFShower") << "HFShowerLibrary: Hit " << i << " " << pe[i] << " zv " << zv;
 #endif
     if (zv <= gpar[1] && pe[i].lambda() > 0 && 
         (pe[i].z() >= 0 || (zv > gpar[0] && (!onlyLong)))) {
@@ -280,7 +280,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
       if (dfi < 0) dfi = -dfi;
       double dfir  = r * sin(dfi);
 #ifdef DebugLog
-      edm::LogInfo("HFShower") << "HFShowerLibrary: Position shift " << xx 
+      edm::LogVerbatim("HFShower") << "HFShowerLibrary: Position shift " << xx 
                                << ", " << yy << ", "  << zz << ": " << pos 
                                << " R " << r << " Phi " << fi << " Section " 
                                << isect << " R*Dfi " << dfir << " Dist " << zv;
@@ -292,7 +292,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
       if (!applyFidCut) dfir += gpar[5];
 
 #ifdef DebugLog
-      edm::LogInfo("HFShower") << "HFShowerLibrary: rLimits " << rInside(r)
+      edm::LogVerbatim("HFShower") << "HFShowerLibrary: rLimits " << rInside(r)
                                << " attenuation " << r1 <<":" << exp(-p*zv) 
                                << " r2 " << r2 << " r3 " << r3 << " rDfi "  
                                << gpar[5] << " zz " 
@@ -315,7 +315,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
         oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,depth,1)));
         hit.push_back(oneHit);
 #ifdef DebugLog
-        edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
+        edm::LogVerbatim("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
                                  <<" position " << (hit[nHit].position) 
                                  << " Depth " << (hit[nHit].depth) <<" Time " 
                                  << tSlice << ":" << pe[i].t() << ":" 
@@ -336,7 +336,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
           oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,2,1)));
           hit.push_back(oneHit);
 #ifdef DebugLog
-          edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
+          edm::LogVerbatim("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
                                    << " position " << (hit[nHit].position) 
                                    << " Depth " << (hit[nHit].depth) <<" Time "
                                    << tSlice << ":" << pe[i].t() << ":" 
@@ -350,7 +350,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
   }
 
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFShowerLibrary: Total Hits " << nHit
+  edm::LogVerbatim("HFShower") << "HFShowerLibrary: Total Hits " << nHit
                            << " out of " << npe << " PE";
 #endif
   if (nHit > npe && !onlyLong) {
@@ -430,7 +430,7 @@ void HFShowerLibrary::loadEventInfo(TBranch* branch) {
     std::vector<HFShowerLibraryEventInfo> eventInfoCollection;
     branch->SetAddress(&eventInfoCollection);
     branch->GetEntry(0);
-    edm::LogInfo("HFShower") << "HFShowerLibrary::loadEventInfo loads "
+    edm::LogVerbatim("HFShower") << "HFShowerLibrary::loadEventInfo loads "
                              << " EventInfo Collection of size "
                              << eventInfoCollection.size() << " records";
     totEvents   = eventInfoCollection[0].totalEvents();
@@ -440,7 +440,7 @@ void HFShowerLibrary::loadEventInfo(TBranch* branch) {
     listVersion = eventInfoCollection[0].physListVersion();
     pmom        = eventInfoCollection[0].energyBins();
   } else {
-    edm::LogInfo("HFShower") << "HFShowerLibrary::loadEventInfo loads "
+    edm::LogVerbatim("HFShower") << "HFShowerLibrary::loadEventInfo loads "
                              << " EventInfo from hardwired numbers";
     nMomBin     = 16;
     evtPerBin   = 5000;

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -55,10 +55,10 @@ HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
       pmtFib2.push_back(ifib);
     }
 #ifdef DebugLog
-    edm::LogInfo("HFShower") << "HFShowerPMT: gets the Index matches for "
+    edm::LogVerbatim("HFShower") << "HFShowerPMT: gets the Index matches for "
                              << neta.size() << " PMTs";
     for (unsigned int ii=0; ii<neta.size(); ii++) {
-      edm::LogInfo("HFShower") << "HFShowerPMT: rIndexR[" << ii << "] = "
+      edm::LogVerbatim("HFShower") << "HFShowerPMT: rIndexR[" << ii << "] = "
                                << pmtR1[ii] << " fibreR[" << ii << "] = "
                                << pmtFib1[ii] << " rIndexL[" << ii << "] = "
                                << pmtR2[ii] << " fibreL[" << ii << "] = "
@@ -87,7 +87,7 @@ void HFShowerPMT::initRun(const HcalDDDSimConstants* hcons) {
     if(ig/10*10 == ig) { sss << "\n"; }
     sss << "  " << rTable[ig]/cm;
   }
-  edm::LogInfo("HFShowerPMT") << "HFShowerPMT: " << rTable.size() 
+  edm::LogVerbatim("HFShowerPMT") << "HFShowerPMT: " << rTable.size() 
                               << " rTable(cm):" << sss.str();
 }
 

--- a/SimG4CMS/Calo/src/HFShowerParam.cc
+++ b/SimG4CMS/Calo/src/HFShowerParam.cc
@@ -44,7 +44,7 @@ HFShowerParam::HFShowerParam(const std::string & name, const DDCompactView & cpv
   aperture                = cos(asin(m_HF.getParameter<double>("Aperture")));
   applyFidCut             = m_HF.getParameter<bool>("ApplyFiducialCut");
   parametrizeLast         = m_HF.getUntrackedParameter<bool>("ParametrizeLast",false);
-  edm::LogInfo("HFShower") << "HFShowerParam::Use of shower library is set to "
+  edm::LogVerbatim("HFShower") << "HFShowerParam::Use of shower library is set to "
                            << useShowerLibrary << " Use of Gflash is set to "
                            << useGflash << " P.E. per GeV " << pePerGeV
                            << ", ref. index of fibre " << ref_index 
@@ -76,7 +76,7 @@ HFShowerParam::HFShowerParam(const std::string & name, const DDCompactView & cpv
     em_long_sl      = showerDir.make<TH1F>("em_long_sl","Longitudinal Profile From Shower Library;cm;Number of Spots",800,800.0,1600.0);
   } else {
     fillHisto = false;
-    edm::LogInfo("HFShower") << "HFShowerParam::No file is available for "
+    edm::LogVerbatim("HFShower") << "HFShowerParam::No file is available for "
                              << "saving histos so the flag is set to false";
   }
 #endif
@@ -85,7 +85,7 @@ HFShowerParam::HFShowerParam(const std::string & name, const DDCompactView & cpv
   if (useGflash)        gflash        = new HFGflash(p);
   fibre = new HFFibre(name, cpv, p);
   attLMeanInv = fibre->attLength(lambdaMean);
-  edm::LogInfo("HFShower") << "att. length used for (lambda=" << lambdaMean
+  edm::LogVerbatim("HFShower") << "att. length used for (lambda=" << lambdaMean
                            << ") = " << 1/(attLMeanInv*cm) << " cm";
 }
 
@@ -115,7 +115,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
   double zz     = std::abs(zint) - gpar[4];
 
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFShowerParam: getHits " 
+  edm::LogVerbatim("HFShower") << "HFShowerParam: getHits " 
                            << track->GetDefinition()->GetParticleName()
                            << " of energy " << pin << " GeV" 
                            << " Pos x,y,z = " << hitPoint.x() << "," 
@@ -134,7 +134,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
   double dirz  = (track->GetDynamicParticle()->GetMomentumDirection()).z();
   if (hitPoint.z() < 0) dirz *= -1.;
 #ifdef DebugLog
-  edm::LogInfo("HFShower") << "HFShowerParam: getHits Momentum " 
+  edm::LogVerbatim("HFShower") << "HFShowerParam: getHits Momentum " 
                            <<track->GetDynamicParticle()->GetMomentumDirection()
                            << " HitPoint " << hitPoint << " dirz " << dirz;
 #endif  
@@ -154,7 +154,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
     }
     std::string path = "ShowerLibrary";
 #ifdef DebugLog
-    edm::LogInfo("HFShower") << "HFShowerParam: getHits edep = " << edep
+    edm::LogVerbatim("HFShower") << "HFShowerParam: getHits edep = " << edep
                              << " weight " << weight << " final " <<edep*weight
                              << ", Kill = " << kill << ", pin = " << pin 
                              << ", edMin = " << edMin << " Other " << other;
@@ -167,7 +167,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
           for (unsigned int i=0; i<hitSL.size(); i++) {
             bool ok = true;
 #ifdef DebugLog
-            edm::LogInfo("HFShower") << "HFShowerParam: getHits applyFidCut = " << applyFidCut;
+            edm::LogVerbatim("HFShower") << "HFShowerParam: getHits applyFidCut = " << applyFidCut;
 #endif
             if (applyFidCut) { // @@ For showerlibrary no z-cut for Short (no z)
               int npmt = HFFibreFiducial:: PMTNumber(hitSL[i].position);
@@ -198,7 +198,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
               }
 #endif
 #ifdef DebugLog
-              edm::LogInfo("HFShower") << "HFShowerParam: Hit at depth " 
+              edm::LogVerbatim("HFShower") << "HFShowerParam: Hit at depth " 
                                        << hit.depth << " with edep " << hit.edep
                                        << " Time " << hit.time;
 #endif
@@ -223,12 +223,12 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
             if (ok && applyFidCut) {
               npmt = HFFibreFiducial:: PMTNumber(pe_effect);
 #ifdef DebugLog
-              edm::LogInfo("HFShower") << "HFShowerParam::getHits:#PMT= "
+              edm::LogVerbatim("HFShower") << "HFShowerParam::getHits:#PMT= "
                                        << npmt << ",z = " << zv;
 #endif
               if (npmt <= 0) {
 #ifdef DebugLog
-                edm::LogInfo("HFShower") << "-#PMT=0 cut-HFShowerParam::"
+                edm::LogVerbatim("HFShower") << "-#PMT=0 cut-HFShowerParam::"
                                          << "getHits: npmt = " << npmt;
 #endif
                 ok = false;
@@ -237,14 +237,14 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
                   depth = 2; 
                 } else {
 #ifdef DebugLog
-                  edm::LogInfo("HFShower") << "-SHORT cut-HFShowerParam::"
+                  edm::LogVerbatim("HFShower") << "-SHORT cut-HFShowerParam::"
                                            << "getHits:zMin=" << gpar[0];
 #endif
                   ok = false;
                 }
               }
 #ifdef DebugLog
-              edm::LogInfo("HFShower") << "HFShowerParam: npmt " << npmt 
+              edm::LogVerbatim("HFShower") << "HFShowerParam: npmt " << npmt 
                                        << " zv " << std::abs(pe_effect.z()) 
                                        << ":" << gpar[4] << ":" << zv << ":" 
                                        << gpar[0] << " ok " << ok << " depth "
@@ -258,7 +258,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
             double dist = fibre->zShift(localPoint,depth,0); // distance to PMT
             double r1   = G4UniformRand();
 #ifdef DebugLog
-            edm::LogInfo("HFShower") << "HFShowerParam:Distance to PMT (" <<npmt
+            edm::LogVerbatim("HFShower") << "HFShowerParam:Distance to PMT (" <<npmt
                                      << ") " << dist << ", exclusion flag " 
                                      << (r1 > exp(-attLMeanInv*zv));
 #endif
@@ -266,7 +266,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
             if (ok) {
               double r2   = G4UniformRand();
 #ifdef DebugLog
-              edm::LogInfo("HFShower") << "HFShowerParam:Extra exclusion "
+              edm::LogVerbatim("HFShower") << "HFShowerParam:Extra exclusion "
                                        << r2 << ">" << weight << " "
                                        << (r2 > weight);
 #endif
@@ -296,7 +296,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
                 }
 #endif
 #ifdef DebugLog
-                edm::LogInfo("HFShower") << "HFShowerParam: Hit at depth " 
+                edm::LogVerbatim("HFShower") << "HFShowerParam: Hit at depth " 
                                          << hit.depth << " with edep " 
                                          << hit.edep << " Time "  << hit.time;
 #endif
@@ -315,7 +315,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
           if (npmt <= 0) ok = false;
         } 
 #ifdef DebugLog
-        edm::LogInfo("HFShower") << "HFShowerParam: getHits hitPoint " << hitPoint << " flag " << ok;
+        edm::LogVerbatim("HFShower") << "HFShowerParam: getHits hitPoint " << hitPoint << " flag " << ok;
 #endif
         if (ok) {
           hit.depth     = 1;
@@ -323,7 +323,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
           hit.edep      = edep;
           hits.push_back(hit);
 #ifdef DebugLog
-          edm::LogInfo("HFShower") << "HFShowerParam: Hit at depth 1 with edep "
+          edm::LogVerbatim("HFShower") << "HFShowerParam: Hit at depth 1 with edep "
                                    << edep << " Time " << tSlice << ":" << time
                                    << ":" << hit.time;
 #endif
@@ -339,7 +339,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
             hit.time  = tSlice+time;
             hits.push_back(hit);
 #ifdef DebugLog
-            edm::LogInfo("HFShower") <<"HFShowerParam: Hit at depth 2 with edep "
+            edm::LogVerbatim("HFShower") <<"HFShowerParam: Hit at depth 2 with edep "
                                      << edep << " Time " << tSlice << ":" << time
                                      << hit.time;
 #endif
@@ -354,7 +354,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
 #ifdef DebugLog
       for (unsigned int ii=0; ii<hits.size(); ++ii) {
         double zv = std::abs(hits[ii].position.z());
-        if (zv > 12790) edm::LogInfo("HFShower")<< "HFShowerParam: Abnormal hit along " 
+        if (zv > 12790) edm::LogVerbatim("HFShower")<< "HFShowerParam: Abnormal hit along " 
                                                 << path << " in " 
                                                 << preStepPoint->GetPhysicalVolume()->GetLogicalVolume()->GetName()
                                                 << " at " << hits[ii].position << " zz " 
@@ -362,7 +362,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
                                                 <<track->GetDefinition()->GetParticleName()
                                                 << " time " << hit.time;
       }
-      edm::LogInfo("HFShower") << "HFShowerParam: getHits kill (" << kill
+      edm::LogVerbatim("HFShower") << "HFShowerParam: getHits kill (" << kill
                                << ") track " << track->GetTrackID() 
                                << " at " << hitPoint
                                << " and deposit " << edep << " " << hits.size()

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -72,7 +72,7 @@ Generator::Generator(const ParameterSet & p) :
       for ( unsigned int ii = 0; ii < pdgFilter.size(); ++ii) {
 	ss << pdgFilter[ii] << "  ";
       }
-      edm::LogInfo("SimG4CoreGenerator") << ss.str();
+      edm::LogVerbatim("SimG4CoreGenerator") << ss.str();
     }
   }
 
@@ -84,7 +84,7 @@ Generator::Generator(const ParameterSet & p) :
   Z_hector = theRDecLenCut*((1 - exp(-2*theEtaCutForHector)) 
 			    / ( 2*exp(-theEtaCutForHector) ) );
 
-  edm::LogInfo("SimG4CoreGenerator") 
+  edm::LogVerbatim("SimG4CoreGenerator") 
     << " Rdecaycut= " << theRDecLenCut/cm 
     << " cm;  Zdecaycut= " << theDecLenCut/cm 
     << "Z_min= " << Z_lmin/cm << " cm; Z_max= " << Z_lmax 
@@ -131,7 +131,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
                                      (*(evt->vertices_begin()))->position().t());
 
   if(verbose > 0) {
-    edm::LogInfo("SimG4CoreGenerator") << &evt;
+    edm::LogVerbatim("SimG4CoreGenerator") << &evt;
     LogDebug("SimG4CoreGenerator") << "Primary Vertex = (" 
 				   << vtx_->x() << "," 
 				   << vtx_->y() << ","
@@ -230,7 +230,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
       if (fPDGFilter) { 
 	bool isInTheList = IsInTheFilterList(pdg);
 	if((!pdgFilterSel && isInTheList) || (pdgFilterSel && !isInTheList)) { 
-	  edm::LogInfo("SimG4CoreGenerator") 
+	  edm::LogVerbatim("SimG4CoreGenerator") 
 	    << " Skiped GenParticle barcode= " << (*pitr)->barcode() 
 	    << " PDGid= " << pdg
 	    << " status= " << status 
@@ -242,7 +242,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent * evt_orig, G4Event * g4evt)
         }
       }
 
-      edm::LogInfo("SimG4CoreGenerator") 
+      edm::LogVerbatim("SimG4CoreGenerator") 
 	<< " pdg= " << pdg
 	<< " status= " << status 
 	<< " hasPreDefinedDecay: " << hasDecayVertex


### PR DESCRIPTION
In several classes LogInfo is substituted by LogVerbatim. In SIM step LogInfo is good to use by the main producer and LogVerbatim is more adequate to user action classes, primary particles handling or sensitive detector classes. SHould have no effect on production. Reduced size of Debug printouts.