### PR TITLE
Bug fix: truncate when copying digis in hybrid zero-suppression

### DIFF
--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
@@ -79,7 +79,7 @@ uint16_t SiStripRawProcessingAlgorithms::suppressHybridData(uint32_t id, uint16_
     } else {
       for ( uint16_t i = 0; i < 128; ++i ) {
         const int16_t digi = procRawDigisPedSubtracted[128*(iAPV-firstAPV)+i];
-        if ( digi > 0 ) { suppressedDigis.push_back(SiStripDigi(iAPV*128+i, digi)); }
+        if ( digi > 0 ) { suppressedDigis.push_back(SiStripDigi(iAPV*128+i, suppressor->truncate(digi))); }
       }
     }
   }


### PR DESCRIPTION
This change should fix most of the differences observed between standard zero-suppression and the hybrid mode in https://github.com/cms-sw/cmssw/pull/24597 (e.g. in the cluster charge distribution). I'm sorry for figuring it out just after the other PR got merged.
In the currently planned scenario (10bit hybridZS data taking, 8bit repacking in the HLT), the following happens: for the "non-flagged" APVs (without modified baseline), baseline subtraction and zero-suppression are performed, and digis saved with 10bit precision (in the emulation as well as in the FED firmware). When running the remaining zero-suppression in software afterwards, the "flagged" APVs are zero-suppressed and their digis brought in the range 0-255 ([255,1022]-> 254, 1023->255), and repacked in the 8bit ZS raw format.
The problem is that for the non-flagged APVs the 10bit digis were simply [copied](https://github.com/cms-sw/cmssw/blob/998183e58ab4280b63f4cee3059eaae407d89147/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc#L82), but the packer [assumes](https://github.com/cms-sw/cmssw/blob/998183e58ab4280b63f4cee3059eaae407d89147/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc#L112) they are also already 8bit-truncated and simply discards the two most significant bits (so `adc % 256` instead of 254 (or 255)). Therefore, clusters with adc>255 strips got a lower total charge or were split.

The following plots show the number of digis and clusters, and cluster charge and width, in the hybrid zero-suppressed scenario (red) compared to standard zero-suppression with `process.siStripZeroSuppression.Algorithms.CommonModeNoiseSubtractionMode = "Median"` (black) to maximally align the zero-suppression settings, to be compared with those in https://github.com/cms-sw/cmssw/pull/24597#issuecomment-423974148 .
![plotdigistatdiff_ndigis](https://user-images.githubusercontent.com/8883677/46012895-e011f480-c0ca-11e8-80cf-c968aed4035a.png)
![plotclusterstatdiff_nclus](https://user-images.githubusercontent.com/8883677/46012920-ee601080-c0ca-11e8-9931-7c042383e6c4.png)
![plotclusterstatdiff_cluswidth](https://user-images.githubusercontent.com/8883677/46012927-f4ee8800-c0ca-11e8-81b9-6741b1d4bcd8.png)
![plotclusterstatdiff_cluscharge](https://user-images.githubusercontent.com/8883677/46012930-f6b84b80-c0ca-11e8-947a-d5ddd434e8b7.png)

CC: @icali @CesarBernardes @erikbutz @mmusich @echabert 