### PR TITLE
Allow PluginDescription default to work in release build

### DIFF
--- a/FWCore/ParameterSet/interface/PluginDescription.h
+++ b/FWCore/ParameterSet/interface/PluginDescription.h
@@ -145,7 +145,9 @@ protected:
                  int indentation,
                  bool& wroteSomething) const final {
     if(not defaultType_.empty()) {
-      edmplugin::PluginManager::configure(edmplugin::standard::config());
+      auto conf = edmplugin::standard::config();
+      conf.allowNoCache();
+      edmplugin::PluginManager::configure(conf);
 
       loadPlugin(defaultType_);
       

--- a/FWCore/PluginManager/interface/PluginManager.h
+++ b/FWCore/PluginManager/interface/PluginManager.h
@@ -63,8 +63,16 @@ class PluginManager
        const SearchPath& searchPath() const {
          return m_path;
        }
+       void allowNoCache() {
+         m_mustHaveCache = false;
+       }
+       
+       bool mustHaveCache() const {
+         return m_mustHaveCache;
+       }
        private:
        SearchPath m_path;
+       bool m_mustHaveCache = true;
      };
 
       ~PluginManager();

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -109,7 +109,7 @@ PluginManager::PluginManager(const PluginManager::Config& iConfig) :
         readCacheFile(poisonedCacheFile, dir/"poisoned", categoryToInfos_);
       }
     }
-    if(not foundAtLeastOneCacheFile) {
+    if(not foundAtLeastOneCacheFile and iConfig.mustHaveCache()) {
       auto ex = cms::Exception("PluginManagerNoCacheFile")<<"No cache files named '"<<standard::cachefileName()<<"' were found in the directories \n";
       for( auto const& seen : alreadySeen) {
         ex <<" '"<<seen<<"'\n";


### PR DESCRIPTION
The use of a default user plugin type with PluginDescription was failing when doing a full release build because it was requiring the global .edmplugincache file to already exist.
This pull request removes that requirement.