### PR TITLE
initialize counters and flags in TrackEfficiencyMonitor

### DIFF
--- a/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
@@ -296,7 +296,10 @@ void TrackEfficiencyMonitor::analyze(const edm::Event& iEvent, const edm::EventS
   iSetup.get<NavigationSchoolRecord>().get("CosmicNavigationSchool", nav); 
   iSetup.get<CkfComponentsRecord>().get(measurementTrackerHandle);
  
-  nCompatibleLayers = 0; 
+  //initialize values
+  failedToPropagate = 0;
+  nCompatibleLayers = 0;
+  findDetLayer = 0;
   
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theTTrackBuilder);
   iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny",thePropagator);

--- a/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
@@ -299,7 +299,7 @@ void TrackEfficiencyMonitor::analyze(const edm::Event& iEvent, const edm::EventS
   //initialize values
   failedToPropagate = 0;
   nCompatibleLayers = 0;
-  findDetLayer = 0;
+  findDetLayer = false;
   
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theTTrackBuilder);
   iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny",thePropagator);


### PR DESCRIPTION
Muon /TkTrack plots occasionally show random differences.
It looks like some of the flags are not initialized and can lead to these random diffs.
This PR is an attempt to fix.

The changes are based on just visual code inspection, I did not run valgrind to confirm.

The latest example is in tests of #24620 in https://cmssdt.cern.ch/SDT/jenkins-artifacts/baseLineComparisons/CMSSW_10_3_X_2018-09-21-2300+24620/28551/7.3_CosmicsSPLoose_UP17+CosmicsSPLoose_UP17+DIGICOS_UP17+RECOCOS_UP17+ALCACOS_UP17+HARVESTCOS_UP17/Muons_TKTrack.html

