### PR TITLE
add gen fragment for DarkSUSY MC relval production

### DIFF
--- a/Configuration/Generator/python/DarkSUSY_mH_125_mN1_60_mGammaD_10_cT_10_Madgraph_LHE_13TeV_cfi.py
+++ b/Configuration/Generator/python/DarkSUSY_mH_125_mN1_60_mGammaD_10_cT_10_Madgraph_LHE_13TeV_cfi.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+                            
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/madgraph/V5_2.4.2/MSSMD_Mneu1_60_MAD_10_cT_10/v3/MSSMD_Mneu1_60_MAD_10_cT_10_slc6_amd64_gcc481_CMSSW_7_1_30_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+    )
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MSSMD
+
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    crossSection = cms.untracked.double(0.0),
+    comEnergy = cms.double(13000.0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+        )
+    )
+)


### PR DESCRIPTION
as discussed with PdmV and SUSY HLT
we would need a new MC relval in the standard relval matrix
which produces events of the DarkSUSY process 
DarkSUSY_mH_125_mN1_60_mGammaD_10_cT_10

this is the GEN fragment needed for the LHE,GEN,SIM step


the SUSY HLT team might provide some extra filters 
in order to make the relval sample more pure wrt offline selection
in that case, we will either update this config or add a new fragment

@prebello @zhenbin.wu@cern.ch hope it is fine
do we need a backport to 102X ? in case, let me know, because we need a rebase of this
