### PR TITLE
Clean-up Geant4 interface

### DIFF
--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -39,7 +39,6 @@ class G4Event;
 class G4Field;
 class G4StateManager;
 class G4GeometryManager;
-class G4Field;
 class RunAction;
 
 class SimRunInterface;

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -37,6 +37,9 @@ class G4MTRunManagerKernel;
 class G4Run;
 class G4Event;
 class G4Field;
+class G4StateManager;
+class G4GeometryManager;
+class G4Field;
 class RunAction;
 
 class SimRunInterface;
@@ -104,6 +107,9 @@ private:
   bool m_pUseMagneticField;
   RunAction* m_userRunAction;
   G4Run* m_currentRun;
+  G4StateManager* m_stateManager;
+  G4GeometryManager* m_geometryManager;
+
   std::unique_ptr<SimRunInterface> m_runInterface;
 
   const std::string m_PhysicsTablesDir;

--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -190,7 +190,7 @@ void OscarMTMasterThread::stopThread() {
   m_masterThreadState = ThreadState::Destruct;
   m_masterCanProceed = true;
   edm::LogVerbatim("SimG4CoreApplication") 
-    << "OscarMTMasterThread::stopTread: stop main thread";
+    << "OscarMTMasterThread::stopTread: notify";
   m_notifyMasterCv.notify_one();
   lk2.unlock();
 

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -89,7 +89,9 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
   m_currentRun = nullptr;
 
   m_kernel = new G4MTRunManagerKernel();
-  G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
+  m_stateManager = G4StateManager::GetStateManager();
+  m_stateManager->SetExceptionHandler(new ExceptionHandler());
+  m_geometryManager->G4GeometryManager::GetInstance();
 
   m_check = p.getUntrackedParameter<bool>("CheckOverlap",false);
   m_WriteFile = p.getUntrackedParameter<std::string>("FileNameGDML","");
@@ -100,8 +102,8 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
 RunManagerMT::~RunManagerMT() 
 {
   if(!m_runTerminated) { terminateRun(); }
-  G4StateManager::GetStateManager()->SetNewState(G4State_Quit);
-  G4GeometryManager::GetInstance()->OpenGeometry();
+  m_stateManager->SetNewState(G4State_Quit);
+  m_geometryManager->OpenGeometry();
 }
 
 void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF, 
@@ -194,7 +196,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
     }
   }
 
-  G4StateManager::GetStateManager()->SetNewState(G4State_Init);
+  m_stateManager->SetNewState(G4State_Init);
   m_kernel->InitializePhysics();
   m_kernel->SetUpDecayChannels();
 
@@ -246,7 +248,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   //
   //G4ParticleTable::GetParticleTable()->DumpTable("ALL");
   //
-  G4StateManager::GetStateManager()->SetNewState(G4State_GeomClosed);
+  m_stateManager->SetNewState(G4State_GeomClosed);
   m_currentRun = new G4Run(); 
   m_userRunAction->BeginOfRunAction(m_currentRun); 
 }
@@ -265,7 +267,7 @@ void  RunManagerMT::Connect(RunAction* runAction)
 
 void RunManagerMT::stopG4()
 {
-  G4StateManager::GetStateManager()->SetNewState(G4State_Quit);
+  m_stateManager->SetNewState(G4State_Quit);
   if(!m_runTerminated) { terminateRun(); }
 }
 

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -184,6 +184,17 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   }
   
   m_kernel->SetPhysics(phys);
+
+  // Geant4 UI commands before initialisation of physics
+  if(!m_G4Commands.empty()) {
+    G4cout << "RunManagerMT: Requested UI commands: " << G4endl;
+    for (const std::string& command : m_G4Commands) {
+      G4cout << "    " << command << G4endl;
+      G4UImanager::GetUIpointer()->ApplyCommand(command);
+    }
+  }
+
+  G4StateManager::GetStateManager()->SetNewState(G4State_Init);
   m_kernel->InitializePhysics();
   m_kernel->SetUpDecayChannels();
 
@@ -211,14 +222,6 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   }
 
   initializeUserActions();
-
-  if(!m_G4Commands.empty()) {
-    G4cout << "RunManagerMT: Requested UI commands: " << G4endl;
-    for (unsigned it=0; it<m_G4Commands.size(); ++it) {
-      G4cout << "    " << m_G4Commands[it] << G4endl;
-      G4UImanager::GetUIpointer()->ApplyCommand(m_G4Commands[it]);
-    }
-  }
 
   if(verb > 1) { m_physicsList->DumpCutValuesTable(); }
 

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -101,9 +101,7 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
 
 RunManagerMT::~RunManagerMT() 
 {
-  if(!m_runTerminated) { terminateRun(); }
-  m_stateManager->SetNewState(G4State_Quit);
-  m_geometryManager->OpenGeometry();
+  stopG4();
 }
 
 void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF, 
@@ -267,6 +265,7 @@ void  RunManagerMT::Connect(RunAction* runAction)
 
 void RunManagerMT::stopG4()
 {
+  m_geometryManager->OpenGeometry();
   m_stateManager->SetNewState(G4State_Quit);
   if(!m_runTerminated) { terminateRun(); }
 }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -73,7 +73,7 @@ namespace {
   int getThreadIndex() { return s_thread_index; }
 
   void createWatchers(const edm::ParameterSet& iP,
-                      SimActivityRegistry* iReg,
+                      SimActivityRegistry& iReg,
                       std::vector<std::shared_ptr<SimWatcher> >& oWatchers,
                       std::vector<std::shared_ptr<SimProducer> >& oProds,
                       int thisThreadID
@@ -88,14 +88,14 @@ namespace {
       std::unique_ptr<SimWatcherMakerBase> maker(
         SimWatcherFactory::get()->create(watcher.getParameter<std::string>("type"))
       );
-      if(maker==nullptr) {
+      if(maker.get()==nullptr) {
         throw edm::Exception(edm::errors::Configuration)
 	  << "Unable to find the requested Watcher <"
 	  << watcher.getParameter<std::string>("type");
       }
       std::shared_ptr<SimWatcher> watcherTemp;
       std::shared_ptr<SimProducer> producerTemp;
-      maker->make(watcher,*(iReg),watcherTemp,producerTemp);
+      maker->make(watcher,iReg,watcherTemp,producerTemp);
       oWatchers.push_back(watcherTemp);
       if(producerTemp) {
         oProds.push_back(producerTemp);
@@ -108,7 +108,7 @@ struct RunManagerMTWorker::TLSData {
   std::unique_ptr<CustomUIsession> UIsession;
   std::unique_ptr<RunAction> userRunAction;
   std::unique_ptr<SimRunInterface> runInterface;
-  std::unique_ptr<SimActivityRegistry> registry;
+  SimActivityRegistry registry;
   std::unique_ptr<SimTrackManager> trackManager;
   std::vector<SensitiveTkDetector*> sensTkDets;
   std::vector<SensitiveCaloDetector*> sensCaloDets;
@@ -116,8 +116,8 @@ struct RunManagerMTWorker::TLSData {
   std::vector<std::shared_ptr<SimProducer> > producers;
   std::unique_ptr<G4Run> currentRun;
   std::unique_ptr<G4Event> currentEvent;
-  std::unique_ptr<G4RunManagerKernel> kernel;
   edm::RunNumber_t currentRunNumber = 0;
+  G4RunManagerKernel* kernel = nullptr;
   bool threadInitialized = false;
   bool runTerminated = false;
 };
@@ -159,20 +159,19 @@ void RunManagerMTWorker::endRun() {
 void RunManagerMTWorker::initializeTLS() {
   if(m_tls) { return; }
   m_tls = new TLSData;
-  m_tls->registry.reset(new SimActivityRegistry());
 
   edm::Service<SimActivityRegistry> otherRegistry;
   //Look for an outside SimActivityRegistry
   // this is used by the visualization code
   int thisID = getThreadIndex();
   if(otherRegistry){
-    m_tls->registry->connect(*otherRegistry);
+    m_tls->registry.connect(*otherRegistry);
     if(thisID > 0) {
       throw edm::Exception(edm::errors::Configuration) << "SimActivityRegistry service (i.e. visualization) is not supported for more than 1 thread. If this use case is needed, RunManagerMTWorker has to be updated.";
     }
   }
   if(m_hasWatchers) {
-    createWatchers(m_p, m_tls->registry.get(), m_tls->watchers, m_tls->producers, thisID);
+    createWatchers(m_p, m_tls->registry, m_tls->watchers, m_tls->producers, thisID);
   }
 }
 
@@ -208,8 +207,8 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
   G4WorkerThread::BuildGeometryAndPhysicsVector();
 
   // Create worker run manager
-  m_tls->kernel.reset(G4WorkerRunManagerKernel::GetRunManagerKernel());
-  if(!m_tls->kernel) { m_tls->kernel.reset(new G4WorkerRunManagerKernel()); }
+  m_tls->kernel = G4WorkerRunManagerKernel::GetRunManagerKernel();
+  if(!m_tls->kernel) { m_tls->kernel = new G4WorkerRunManagerKernel(); }
 
   // Define G4 exception handler
   G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
@@ -250,7 +249,7 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
                   runManagerMaster.catalog(),
                   m_p,
                   m_tls->trackManager.get(),
-                  *(m_tls->registry.get()));
+                  m_tls->registry);
 
   m_tls->sensTkDets.swap(sensDets.first);
   m_tls->sensCaloDets.swap(sensDets.second);
@@ -266,6 +265,16 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
   edm::LogVerbatim("SimG4CoreApplication") 
     << "RunManagerMTWorker: start initialisation of PhysicsList for the thread";
 
+  // Geant4 UI commands in PreInit state
+  if(!runManagerMaster.G4Commands().empty()) {
+    G4cout << "RunManagerMTWorker: Requested UI commands: " << G4endl;
+    for(const std::string& command: runManagerMaster.G4Commands()) {
+      G4cout << "          " << command << G4endl;
+      G4UImanager::GetUIpointer()->ApplyCommand(command);
+    }
+  }
+  G4StateManager::GetStateManager()->SetNewState(G4State_Init);
+
   physicsList->InitializeWorker();
   m_tls->kernel->SetPhysics(physicsList);
   m_tls->kernel->InitializePhysics();
@@ -275,9 +284,10 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
     throw edm::Exception(edm::errors::Configuration)
       << "RunManagerMTWorker: Geant4 kernel initialization failed";
   }
+
   //tell all interesting parties that we are beginning the job
   BeginOfJob aBeginOfJob(&es);
-  m_tls->registry->beginOfJobSignal_(&aBeginOfJob);
+  m_tls->registry.beginOfJobSignal_(&aBeginOfJob);
 
   G4int sv = m_p.getParameter<int>("SteppingVerbosity");
   G4double elim = m_p.getParameter<double>("StepVerboseThreshold")*CLHEP::GeV;
@@ -293,11 +303,7 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
   edm::LogVerbatim("SimG4CoreApplication")
     << "RunManagerMTWorker::initializeThread done for the thread " << thisID;
 
-  for(const std::string& command: runManagerMaster.G4Commands()) {
-    edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker:: Requests UI: "
-                                         << command;
-    G4UImanager::GetUIpointer()->ApplyCommand(command);
-  }
+  G4StateManager::GetStateManager()->SetNewState(G4State_Idle);
 }
 
 void RunManagerMTWorker::initializeUserActions() {
@@ -333,25 +339,25 @@ void RunManagerMTWorker::initializeUserActions() {
 
 void  RunManagerMTWorker::Connect(RunAction* runAction)
 {
-  runAction->m_beginOfRunSignal.connect(m_tls->registry->beginOfRunSignal_);
-  runAction->m_endOfRunSignal.connect(m_tls->registry->endOfRunSignal_);
+  runAction->m_beginOfRunSignal.connect(m_tls->registry.beginOfRunSignal_);
+  runAction->m_endOfRunSignal.connect(m_tls->registry.endOfRunSignal_);
 }
 
 void  RunManagerMTWorker::Connect(EventAction* eventAction)
 {
-  eventAction->m_beginOfEventSignal.connect(m_tls->registry->beginOfEventSignal_);
-  eventAction->m_endOfEventSignal.connect(m_tls->registry->endOfEventSignal_);
+  eventAction->m_beginOfEventSignal.connect(m_tls->registry.beginOfEventSignal_);
+  eventAction->m_endOfEventSignal.connect(m_tls->registry.endOfEventSignal_);
 }
 
 void  RunManagerMTWorker::Connect(TrackingAction* trackingAction)
 {
-  trackingAction->m_beginOfTrackSignal.connect(m_tls->registry->beginOfTrackSignal_);
-  trackingAction->m_endOfTrackSignal.connect(m_tls->registry->endOfTrackSignal_);
+  trackingAction->m_beginOfTrackSignal.connect(m_tls->registry.beginOfTrackSignal_);
+  trackingAction->m_endOfTrackSignal.connect(m_tls->registry.endOfTrackSignal_);
 }
 
 void  RunManagerMTWorker::Connect(SteppingAction* steppingAction)
 {
-  steppingAction->m_g4StepSignal.connect(m_tls->registry->g4StepSignal_);
+  steppingAction->m_g4StepSignal.connect(m_tls->registry.g4StepSignal_);
 }
 
 SimTrackManager* RunManagerMTWorker::GetSimTrackManager() {

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -73,7 +73,7 @@ namespace {
   int getThreadIndex() { return s_thread_index; }
 
   void createWatchers(const edm::ParameterSet& iP,
-                      SimActivityRegistry& iReg,
+                      SimActivityRegistry* iReg,
                       std::vector<std::shared_ptr<SimWatcher> >& oWatchers,
                       std::vector<std::shared_ptr<SimProducer> >& oProds,
                       int thisThreadID
@@ -88,14 +88,14 @@ namespace {
       std::unique_ptr<SimWatcherMakerBase> maker(
         SimWatcherFactory::get()->create(watcher.getParameter<std::string>("type"))
       );
-      if(maker.get()==nullptr) {
+      if(maker==nullptr) {
         throw edm::Exception(edm::errors::Configuration)
 	  << "Unable to find the requested Watcher <"
 	  << watcher.getParameter<std::string>("type");
       }
       std::shared_ptr<SimWatcher> watcherTemp;
       std::shared_ptr<SimProducer> producerTemp;
-      maker->make(watcher,iReg,watcherTemp,producerTemp);
+      maker->make(watcher,*(iReg),watcherTemp,producerTemp);
       oWatchers.push_back(watcherTemp);
       if(producerTemp) {
         oProds.push_back(producerTemp);
@@ -108,7 +108,7 @@ struct RunManagerMTWorker::TLSData {
   std::unique_ptr<CustomUIsession> UIsession;
   std::unique_ptr<RunAction> userRunAction;
   std::unique_ptr<SimRunInterface> runInterface;
-  SimActivityRegistry registry;
+  std::unique_ptr<SimActivityRegistry> registry;
   std::unique_ptr<SimTrackManager> trackManager;
   std::vector<SensitiveTkDetector*> sensTkDets;
   std::vector<SensitiveCaloDetector*> sensCaloDets;
@@ -116,8 +116,8 @@ struct RunManagerMTWorker::TLSData {
   std::vector<std::shared_ptr<SimProducer> > producers;
   std::unique_ptr<G4Run> currentRun;
   std::unique_ptr<G4Event> currentEvent;
+  std::unique_ptr<G4RunManagerKernel> kernel;
   edm::RunNumber_t currentRunNumber = 0;
-  G4RunManagerKernel* kernel = nullptr;
   bool threadInitialized = false;
   bool runTerminated = false;
 };
@@ -159,19 +159,20 @@ void RunManagerMTWorker::endRun() {
 void RunManagerMTWorker::initializeTLS() {
   if(m_tls) { return; }
   m_tls = new TLSData;
+  m_tls->registry.reset(new SimActivityRegistry());
 
   edm::Service<SimActivityRegistry> otherRegistry;
   //Look for an outside SimActivityRegistry
   // this is used by the visualization code
   int thisID = getThreadIndex();
   if(otherRegistry){
-    m_tls->registry.connect(*otherRegistry);
+    m_tls->registry->connect(*otherRegistry);
     if(thisID > 0) {
       throw edm::Exception(edm::errors::Configuration) << "SimActivityRegistry service (i.e. visualization) is not supported for more than 1 thread. If this use case is needed, RunManagerMTWorker has to be updated.";
     }
   }
   if(m_hasWatchers) {
-    createWatchers(m_p, m_tls->registry, m_tls->watchers, m_tls->producers, thisID);
+    createWatchers(m_p, m_tls->registry.get(), m_tls->watchers, m_tls->producers, thisID);
   }
 }
 
@@ -207,8 +208,8 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
   G4WorkerThread::BuildGeometryAndPhysicsVector();
 
   // Create worker run manager
-  m_tls->kernel = G4WorkerRunManagerKernel::GetRunManagerKernel();
-  if(!m_tls->kernel) { m_tls->kernel = new G4WorkerRunManagerKernel(); }
+  m_tls->kernel.reset(G4WorkerRunManagerKernel::GetRunManagerKernel());
+  if(!m_tls->kernel) { m_tls->kernel.reset(new G4WorkerRunManagerKernel()); }
 
   // Define G4 exception handler
   G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
@@ -249,7 +250,7 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
                   runManagerMaster.catalog(),
                   m_p,
                   m_tls->trackManager.get(),
-                  m_tls->registry);
+                  *(m_tls->registry.get()));
 
   m_tls->sensTkDets.swap(sensDets.first);
   m_tls->sensCaloDets.swap(sensDets.second);
@@ -284,10 +285,9 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
     throw edm::Exception(edm::errors::Configuration)
       << "RunManagerMTWorker: Geant4 kernel initialization failed";
   }
-
   //tell all interesting parties that we are beginning the job
   BeginOfJob aBeginOfJob(&es);
-  m_tls->registry.beginOfJobSignal_(&aBeginOfJob);
+  m_tls->registry->beginOfJobSignal_(&aBeginOfJob);
 
   G4int sv = m_p.getParameter<int>("SteppingVerbosity");
   G4double elim = m_p.getParameter<double>("StepVerboseThreshold")*CLHEP::GeV;
@@ -339,25 +339,25 @@ void RunManagerMTWorker::initializeUserActions() {
 
 void  RunManagerMTWorker::Connect(RunAction* runAction)
 {
-  runAction->m_beginOfRunSignal.connect(m_tls->registry.beginOfRunSignal_);
-  runAction->m_endOfRunSignal.connect(m_tls->registry.endOfRunSignal_);
+  runAction->m_beginOfRunSignal.connect(m_tls->registry->beginOfRunSignal_);
+  runAction->m_endOfRunSignal.connect(m_tls->registry->endOfRunSignal_);
 }
 
 void  RunManagerMTWorker::Connect(EventAction* eventAction)
 {
-  eventAction->m_beginOfEventSignal.connect(m_tls->registry.beginOfEventSignal_);
-  eventAction->m_endOfEventSignal.connect(m_tls->registry.endOfEventSignal_);
+  eventAction->m_beginOfEventSignal.connect(m_tls->registry->beginOfEventSignal_);
+  eventAction->m_endOfEventSignal.connect(m_tls->registry->endOfEventSignal_);
 }
 
 void  RunManagerMTWorker::Connect(TrackingAction* trackingAction)
 {
-  trackingAction->m_beginOfTrackSignal.connect(m_tls->registry.beginOfTrackSignal_);
-  trackingAction->m_endOfTrackSignal.connect(m_tls->registry.endOfTrackSignal_);
+  trackingAction->m_beginOfTrackSignal.connect(m_tls->registry->beginOfTrackSignal_);
+  trackingAction->m_endOfTrackSignal.connect(m_tls->registry->endOfTrackSignal_);
 }
 
 void  RunManagerMTWorker::Connect(SteppingAction* steppingAction)
 {
-  steppingAction->m_g4StepSignal.connect(m_tls->registry.g4StepSignal_);
+  steppingAction->m_g4StepSignal.connect(m_tls->registry->g4StepSignal_);
 }
 
 SimTrackManager* RunManagerMTWorker::GetSimTrackManager() {


### PR DESCRIPTION
In verbose mode at initialisation of Geant4, a warning appears in each thread once. This PR includes the fix of the warning by defining correctly Geant4 state per thread. 

Geant4 UI commands (optional Geant4 feature) were issued after initialisation of Geant4 physics, now they issued before.

Also minor clean-up for end of run.

These fixes should not affect CMS production WFs. 