### PR TITLE
DataFormats/TrackingRecHit: replace auto_ptr removed in strict std=c++17

### DIFF
--- a/DataFormats/TrackingRecHit/src/classes.h
+++ b/DataFormats/TrackingRecHit/src/classes.h
@@ -22,7 +22,7 @@ namespace DataFormats_TrackingRecHit {
                              edm::ClonePolicy<TrackingRecHit> >::const_iterator,
               edm::OwnVector<TrackingRecHit,
                              edm::ClonePolicy<TrackingRecHit> >::const_iterator> pr1;    
-    std::auto_ptr<TrackingRecHitRef> ap1;
+    std::unique_ptr<TrackingRecHitRef> ap1;
     edm::Wrapper<TrackingRecHitCollection> w1;
   };
 }

--- a/DataFormats/TrackingRecHit/src/classes_def.xml
+++ b/DataFormats/TrackingRecHit/src/classes_def.xml
@@ -33,7 +33,6 @@
   <class name="edm::RefVectorIterator<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit> >"/>
   <!-- Warning: Unused class rule: std::iterator<*edm::Ref*> -->
   <!-- <class pattern="std::iterator<*edm::Ref*>"/> -->
-  <class name="std::auto_ptr<edm::Ref<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit> > >"/>
   <class name="std::pair<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >::const_iterator,edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >::const_iterator>"/>
   <class name="edm::RefProd<edm::OwnVector<TrackingRecHit, edm::ClonePolicy<TrackingRecHit> > >"/>
   <class name="edm::RefVector<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit> >"/>


### PR DESCRIPTION
Note the change to classes_def.xml requires a patch for root 6.12.x so that unique_ptr is added to dictionary generation.
see https://sft.its.cern.ch/jira/browse/ROOT-9698 for the patch needed