### PR TITLE
Return 0 after exception to make static analyzer happy

### DIFF
--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -251,9 +251,9 @@ namespace edm {
   {
     if ( holder_ == nullptr )
     {
-	Exception::throwThis(errors::InvalidReference,
-	  "attempting get key from  null RefToBase;\n"
-	  "You should check for nullity before calling key().");
+        Exception::throwThis(errors::InvalidReference,
+          "attempting get key from  null RefToBase;\n"
+          "You should check for nullity before calling key().");
         return 0;
     }
     return  holder_->key();

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -250,9 +250,12 @@ namespace edm {
   RefToBase<T>::key() const
   {
     if ( holder_ == nullptr )
+    {
 	Exception::throwThis(errors::InvalidReference,
 	  "attempting get key from  null RefToBase;\n"
 	  "You should check for nullity before calling key().");
+        return 0;
+    }
     return  holder_->key();
   }
 


### PR DESCRIPTION
Just a little change we discussed here:
https://github.com/cms-sw/cmssw/pull/24432#discussion_r220844186

The static analyzer doesn't seem to get that an exception is thrown, thus it claims about 10 (non-)bugs about accessing a `nullptr`. This should make him happy.

Example:
https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_10_3_X_2018-09-26-1100/slc6_amd64_gcc700/llvm-analysis/report-daae7d.html#EndPath