### PR TITLE
RecoTauTag/RecoTau: replace functions and templates removed by stict std=c++17(where possible).

### DIFF
--- a/RecoTauTag/RecoTau/interface/CombinatoricGenerator.h
+++ b/RecoTauTag/RecoTau/interface/CombinatoricGenerator.h
@@ -177,7 +177,7 @@ template <typename T>
       //std::copy(newCombo.begin(), newCombo.end(), std::ostream_iterator<int>(std::cout, " "));
       //std::cout << std::endl;
 
-      //return std::auto_ptr<Combinatoric<T> >(new Combinatoric<T>(begin_, indices_, newCombo));
+      //return std::unique_ptr<Combinatoric<T> >(new Combinatoric<T>(begin_, indices_, newCombo));
       return Combinatoric<T>(begin_, indices_, newCombo, done);
     }
 
@@ -257,7 +257,7 @@ template<typename T>
 
     public:
 
-    typedef std::auto_ptr<CombinatoricIterator<T> > CombIterPtr;
+    typedef std::unique_ptr<CombinatoricIterator<T> > CombIterPtr;
     typedef CombinatoricIterator<T> iterator;
     typedef typename iterator::value_type::ValueIter combo_iterator;
 

--- a/RecoTauTag/RecoTau/interface/RecoTauIsolationMasking.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauIsolationMasking.h
@@ -45,7 +45,7 @@ class RecoTauIsolationMasking {
     double hcalCone_;
     double maxSigmas_;
     double finalHcalCone_;
-    std::auto_ptr<PFEnergyResolution> resolutions_;
+    std::unique_ptr<PFEnergyResolution> resolutions_;
 };
 
 }}

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
@@ -25,8 +25,8 @@ class PFRecoTauDiscriminationByNProngs : public PFTauDiscriminationProducerBase 
 	double discriminate(const reco::PFTauRef&) const override;
 
     private:
-	std::auto_ptr<tau::RecoTauQualityCuts> qcuts_;
-	std::auto_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
+	std::unique_ptr<tau::RecoTauQualityCuts> qcuts_;
+	std::unique_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
 
 	uint32_t minN,maxN;
 	bool booleanOutput;

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -92,8 +92,8 @@ class PFTauPrimaryVertexProducer final : public edm::stream::EDProducer<> {
   bool RemoveMuonTracks_;
   bool RemoveElectronTracks_;
   DiscCutPairVec discriminators_;
-  std::auto_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
-  std::auto_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
+  std::unique_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
 };
 
 PFTauPrimaryVertexProducer::PFTauPrimaryVertexProducer(const edm::ParameterSet& iConfig):

--- a/RecoTauTag/RecoTau/plugins/RecoTauMVATransform.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauMVATransform.cc
@@ -26,13 +26,13 @@
 namespace {
 
 // Build the transformation function from the PSet format
-std::auto_ptr<TGraph> buildTransform(const edm::ParameterSet &pset) {
+std::unique_ptr<TGraph> buildTransform(const edm::ParameterSet &pset) {
   double min = pset.getParameter<double>("min");
   double max = pset.getParameter<double>("max");
   const std::vector<double> &values =
       pset.getParameter<std::vector<double> >("transform");
   double stepSize = (max - min)/(values.size()-1);
-  std::auto_ptr<TGraph> output(new TGraph(values.size()));
+  std::unique_ptr<TGraph> output(new TGraph(values.size()));
   for (size_t step = 0; step < values.size(); ++step) {
     double x = min + step*stepSize;
     output->SetPoint(step, x, values[step]);
@@ -78,7 +78,7 @@ RecoTauMVATransform::RecoTauMVATransform(const edm::ParameterSet& pset)
 
     if (!transforms_.count(decayMode)) {
       // Add it
-      transforms_.insert(decayMode, buildTransform(transformImpl));
+      transforms_.insert(decayMode, buildTransform(transformImpl).get());
     } else {
       edm::LogError("DecayModeNotUnique") << "The tau decay mode with "
         "nCharged/nPiZero = " << nCharged << "/" << nPiZeros <<

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
@@ -29,7 +29,7 @@ class RecoTauPiZeroCombinatoricPlugin : public RecoTauPiZeroBuilderPlugin {
   public:
   explicit RecoTauPiZeroCombinatoricPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC);
     ~RecoTauPiZeroCombinatoricPlugin() override {}
-    // Return type is auto_ptr<PiZeroVector>
+    // Return type is unique_ptr<PiZeroVector>
     return_type operator()(const reco::PFJet& jet) const override;
 
   private:
@@ -79,7 +79,7 @@ RecoTauPiZeroCombinatoricPlugin::operator()(
   for (ComboGenerator::iterator combo = generator.begin();
       combo != generator.end(); ++combo) {
     const Candidate::LorentzVector totalP4;
-    std::auto_ptr<RecoTauPiZero> piZero(
+    std::unique_ptr<RecoTauPiZero> piZero(
         new RecoTauPiZero(0, totalP4, Candidate::Point(0, 0, 0),
                           111, 10001, true, RecoTauPiZero::kCombinatoric));
     // Add our daughters from this combination
@@ -94,7 +94,7 @@ RecoTauPiZeroCombinatoricPlugin::operator()(
 
     if ((maxMass_ < 0 || piZero->mass() < maxMass_) &&
         piZero->mass() > minMass_)
-      output.push_back(piZero);
+      output.push_back(piZero.get());
   }
   return output.release();
 }

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -114,7 +114,7 @@ RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset)
   // Check if we want to apply a final output selection
   if (pset.exists("outputSelection")) {
     std::string selection = pset.getParameter<std::string>("outputSelection");
-    if (selection != "") {
+    if (!selection.empty()) {
       outputSelector_.reset(
           new StringCutObjectSelector<reco::RecoTauPiZero>(selection));
     }
@@ -223,8 +223,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     if (piZeroMass_ >= 0) {
       std::for_each(
           cleanPiZeros.begin(), cleanPiZeros.end(),
-          std::bind2nd(
-              std::mem_fun_ref(&reco::RecoTauPiZero::setMass), piZeroMass_));
+              [&](auto c){c.setMass(this->piZeroMass_);});
     }
     // Add to association
     if ( verbosity_ >= 2 ) {

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -221,9 +221,8 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     }
     // Apply the mass hypothesis if desired
     if (piZeroMass_ >= 0) {
-      std::for_each(
-          cleanPiZeros.begin(), cleanPiZeros.end(),
-              [&](auto c){c.setMass(this->piZeroMass_);});
+      for( auto& cleanPiZero: cleanPiZeros )
+         { cleanPiZero.setMass(this->piZeroMass_);};
     }
     // Add to association
     if ( verbosity_ >= 2 ) {

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -47,7 +47,7 @@ class RecoTauPiZeroStripPlugin : public RecoTauPiZeroBuilderPlugin {
   public:
   explicit RecoTauPiZeroStripPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC);
     ~RecoTauPiZeroStripPlugin() override {}
-    // Return type is auto_ptr<PiZeroVector>
+    // Return type is unique_ptr<PiZeroVector>
     return_type operator()(const reco::PFJet& jet) const override;
     // Hook to update PV information
     void beginEvent() override;
@@ -117,7 +117,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
     cands.pop_front();
 
     // Add a new candidate to our collection using this seed
-    std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(
+    std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(
             *seed, RecoTauPiZero::kStrips));
     strip->addDaughter(seed);
 
@@ -141,7 +141,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
     // Update the vertex
     if (strip->daughterPtr(0).isNonnull())
       strip->setVertex(strip->daughterPtr(0)->vertex());
-    output.push_back(strip);
+    output.push_back(strip.get());
   }
 
   // Check if we want to combine our strips
@@ -167,7 +167,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
         secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
         Candidate::LorentzVector totalP4 = firstP4 + secondP4;
         // Make our new combined strip
-        std::auto_ptr<RecoTauPiZero> combinedStrips(
+        std::unique_ptr<RecoTauPiZero> combinedStrips(
             new RecoTauPiZero(0, totalP4,
               Candidate::Point(0, 0, 0),
               //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
@@ -186,7 +186,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
         if (combinedStrips->daughterPtr(0).isNonnull())
           combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
         // Add to our collection of combined strips
-        stripCombinations.push_back(combinedStrips);
+        stripCombinations.push_back(combinedStrips.get());
       }
     }
     // When done doing all the combinations, add the combined strips to the

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -71,7 +71,7 @@ class RecoTauProducer : public edm::stream::EDProducer<>
   BuilderList builders_;
   ModifierList modifiers_;
   // Optional selection on the output of the taus
-  std::auto_ptr<StringCutObjectSelector<reco::PFTau> > outputSelector_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFTau> > outputSelector_;
   // Whether or not to add build a tau from a jet for which the builders
   // return no taus.  The tau will have no content, only the four vector of
   // the orginal jet.
@@ -118,7 +118,7 @@ RecoTauProducer::RecoTauProducer(const edm::ParameterSet& pset)
   // Check if we want to apply a final output selection
   if ( pset.exists("outputSelection") ) {
     std::string selection = pset.getParameter<std::string>("outputSelection");
-    if ( selection != "" ) {
+    if ( !selection.empty() ) {
       outputSelector_.reset(new StringCutObjectSelector<reco::PFTau>(selection));
     }
   }


### PR DESCRIPTION
replace bind2nd with equivalent lambda function
replace auto_ptr with unique_ptr where possible
Until boost is moved to 1.67 the basis of ptr_vector and ptr_list is std::auto_ptr. The remaining auto_ptr in this package can be changed to unique_ptr then,