### PR TITLE
Prepare for concurrent IOVs, MisalignedMuonESProducer

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
@@ -158,9 +158,9 @@ AlignmentMonitorAsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
       DTGeometryBuilderFromDDD DTGeometryBuilder;
       CSCGeometryBuilderFromDDD CSCGeometryBuilder;
       auto theMuonDT = std::make_shared<DTGeometry>();
-      DTGeometryBuilder.build(theMuonDT, &(*cpv), *mdc);
+      DTGeometryBuilder.build(*theMuonDT, &(*cpv), *mdc);
       auto theMuonCSC = std::make_shared<CSCGeometry>();
-      CSCGeometryBuilder.build(theMuonCSC, &(*cpv), *mdc);
+      CSCGeometryBuilder.build(*theMuonCSC, &(*cpv), *mdc);
       
       edm::ESHandle<Alignments> globalPositionRcd;
       iSetup.get<GlobalPositionRcd>().get(globalPositionRcd);

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -538,9 +538,9 @@ AlignmentProducerBase::createGeometries(const edm::EventSetup& iSetup,
     DTGeometryBuilderFromDDD DTGeometryBuilder;
     CSCGeometryBuilderFromDDD CSCGeometryBuilder;
     muonDTGeometry_ = std::make_shared<DTGeometry>();
-    DTGeometryBuilder.build(muonDTGeometry_, &(*cpv), *mdc);
+    DTGeometryBuilder.build(*muonDTGeometry_, &(*cpv), *mdc);
     muonCSCGeometry_ = std::make_shared<CSCGeometry>();
-    CSCGeometryBuilder.build(muonCSCGeometry_, &(*cpv), *mdc );
+    CSCGeometryBuilder.build(*muonCSCGeometry_, &(*cpv), *mdc );
   }
 }
 

--- a/Alignment/MuonAlignment/plugins/MisalignedMuonESProducer.cc
+++ b/Alignment/MuonAlignment/plugins/MisalignedMuonESProducer.cc
@@ -49,8 +49,8 @@ public:
   ~MisalignedMuonESProducer() override; 
   
   /// Produce the misaligned Muon geometry and store it
-  edm::ESProducts< std::shared_ptr<DTGeometry>,
- 				   std::shared_ptr<CSCGeometry> > produce( const MuonGeometryRecord&  );
+  edm::ESProducts< std::unique_ptr<DTGeometry>,
+                   std::unique_ptr<CSCGeometry> > produce( const MuonGeometryRecord&  );
 
   /// Save alignemnts and error to database
   void saveToDB();
@@ -61,9 +61,6 @@ private:
 
   std::string theDTAlignRecordName, theDTErrorRecordName;
   std::string theCSCAlignRecordName, theCSCErrorRecordName;
-  
-  std::shared_ptr<DTGeometry> theDTGeometry;
-  std::shared_ptr<CSCGeometry> theCSCGeometry;
 
   Alignments*      dt_Alignments;
   AlignmentErrorsExtended* dt_AlignmentErrorsExtended;
@@ -97,7 +94,7 @@ MisalignedMuonESProducer::~MisalignedMuonESProducer() {}
 
 
 //__________________________________________________________________________________________________
-edm::ESProducts< std::shared_ptr<DTGeometry>, std::shared_ptr<CSCGeometry> >
+edm::ESProducts< std::unique_ptr<DTGeometry>, std::unique_ptr<CSCGeometry> >
 MisalignedMuonESProducer::produce( const MuonGeometryRecord& iRecord )
 { 
 
@@ -114,11 +111,10 @@ MisalignedMuonESProducer::produce( const MuonGeometryRecord& iRecord )
   DTGeometryBuilderFromDDD  DTGeometryBuilder;
   CSCGeometryBuilderFromDDD CSCGeometryBuilder;
 
-  theDTGeometry = std::make_shared<DTGeometry>();
-  DTGeometryBuilder.build(theDTGeometry,  &(*cpv), *mdc );
-  theCSCGeometry  = std::make_shared<CSCGeometry>();
-  CSCGeometryBuilder.build( theCSCGeometry,  &(*cpv), *mdc );
-
+  auto theDTGeometry = std::make_unique<DTGeometry>();
+  DTGeometryBuilder.build(*theDTGeometry,  &(*cpv), *mdc);
+  auto theCSCGeometry  = std::make_unique<CSCGeometry>();
+  CSCGeometryBuilder.build(*theCSCGeometry,  &(*cpv), *mdc);
 
   // Create the alignable hierarchy
   AlignableMuon* theAlignableMuon = new AlignableMuon( &(*theDTGeometry) , &(*theCSCGeometry) );
@@ -151,8 +147,7 @@ MisalignedMuonESProducer::produce( const MuonGeometryRecord& iRecord )
 
   edm::LogInfo("MisalignedMuon") << "Producer done";
 
-  return edm::es::products( theDTGeometry, theCSCGeometry ); 
-  
+  return edm::es::products( std::move(theDTGeometry), std::move(theCSCGeometry) );
 }
 
 

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputMethod.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputMethod.cc
@@ -75,7 +75,7 @@ std::shared_ptr<DTGeometry> MuonAlignmentInputMethod::idealDTGeometry(const edm:
    DTGeometryBuilderFromDDD DTGeometryBuilder;
 
    auto boost_dtGeometry = std::make_shared<DTGeometry>();
-   DTGeometryBuilder.build(boost_dtGeometry, &(*cpv), *mdc);
+   DTGeometryBuilder.build(*boost_dtGeometry, &(*cpv), *mdc);
 
    return boost_dtGeometry;
 }
@@ -89,7 +89,7 @@ std::shared_ptr<CSCGeometry> MuonAlignmentInputMethod::idealCSCGeometry(const ed
    CSCGeometryBuilderFromDDD CSCGeometryBuilder;
 
    auto boost_cscGeometry = std::make_shared<CSCGeometry>();
-   CSCGeometryBuilder.build(boost_cscGeometry, &(*cpv), *mdc);
+   CSCGeometryBuilder.build(*boost_cscGeometry, &(*cpv), *mdc);
 
    return boost_cscGeometry;
 }

--- a/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
@@ -131,10 +131,10 @@ void MuonAlignmentOutputXML::write(AlignableMuon *alignableMuon, const edm::Even
       CSCGeometryBuilderFromDDD CSCGeometryBuilder;
  
       auto dtGeometry = std::make_shared<DTGeometry>();
-      DTGeometryBuilder.build(dtGeometry, &(*cpv), *mdc);
+      DTGeometryBuilder.build(*dtGeometry, &(*cpv), *mdc);
 
       auto boost_cscGeometry = std::make_shared<CSCGeometry>();
-      CSCGeometryBuilder.build(boost_cscGeometry, &(*cpv), *mdc);
+      CSCGeometryBuilder.build(*boost_cscGeometry, &(*cpv), *mdc);
 
       AlignableMuon ideal_alignableMuon(&(*dtGeometry), &(*boost_cscGeometry));
 

--- a/Alignment/MuonAlignment/test/TestReader.cpp
+++ b/Alignment/MuonAlignment/test/TestReader.cpp
@@ -123,9 +123,9 @@ TestMuonReader::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup
   CSCGeometryBuilderFromDDD CSCGeometryBuilder;
 
   auto dtGeometry = std::make_shared<DTGeometry>();
-  DTGeometryBuilder.build(dtGeometry, &(*cpv), *mdc);
+  DTGeometryBuilder.build(*dtGeometry, &(*cpv), *mdc);
   auto cscGeometry = std::make_shared<CSCGeometry>();
-  CSCGeometryBuilder.build(cscGeometry, &(*cpv), *mdc);
+  CSCGeometryBuilder.build(*cscGeometry, &(*cpv), *mdc);
 
   AlignableMuon ideal_alignableMuon(&(*dtGeometry), &(*cscGeometry));
 

--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
@@ -131,7 +131,7 @@ void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record, st
       record.getRecord<IdealGeometryRecord>().get(cpv);
       rec.get(mdc);
       CSCGeometryBuilderFromDDD builder;
-      builder.build(host, &(*cpv), *mdc);
+      builder.build(*host, &(*cpv), *mdc);
     });
   } else {
     bool recreateGeometry = false;
@@ -153,7 +153,7 @@ void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record, st
       record.getRecord<CSCRecoGeometryRcd>().get(rig);
       record.getRecord<CSCRecoDigiParametersRcd>().get(rdp);
       CSCGeometryBuilder cscgb;
-      cscgb.build(host, *rig, *rdp);
+      cscgb.build(*host, *rig, *rdp);
     }
   }
 }

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.cc
@@ -16,7 +16,7 @@ CSCGeometryBuilder::CSCGeometryBuilder() : myName("CSCGeometryBuilder"){}
 CSCGeometryBuilder::~CSCGeometryBuilder(){}
 
 
-void CSCGeometryBuilder::build( const std::shared_ptr<CSCGeometry>& theGeometry
+void CSCGeometryBuilder::build( CSCGeometry& theGeometry
 				, const RecoIdealGeometry& rig
 				, const CSCRecoDigiParameters& cscpars ) {
 
@@ -109,7 +109,7 @@ void CSCGeometryBuilder::build( const std::shared_ptr<CSCGeometry>& theGeometry
     LogTrace(myName) << myName << ": end of wire group info. " ;
       
     // Are we going to apply centre-to-intersection offsets, even if values exist in the specs file?
-    if ( !theGeometry->centreTIOffsets() ) fupar[30] = 0.;  // reset to zero if flagged 'off'
+    if ( !theGeometry.centreTIOffsets() ) fupar[30] = 0.;  // reset to zero if flagged 'off'
       
     buildChamber (theGeometry, detid, fpar, fupar, gtran, grmat, wg ); //, cscpars.pWGPs[cs] );
     fupar.clear();
@@ -117,7 +117,7 @@ void CSCGeometryBuilder::build( const std::shared_ptr<CSCGeometry>& theGeometry
 }
 
 void CSCGeometryBuilder::buildChamber (  
-				       const std::shared_ptr<CSCGeometry>& theGeometry // the geometry container
+				       CSCGeometry& theGeometry // the geometry container
 				       , CSCDetId chamberId                         // the DetId for this chamber
 				       , const std::vector<float>& fpar           // volume parameters hB, hT. hD, hH	
 				       , const std::vector<float>& fupar          // user parameters 
@@ -153,17 +153,17 @@ void CSCGeometryBuilder::buildChamber (
 		   << " upar[" << fupar.size()-1 << "]=" << fupar[fupar.size()-1];
 
 
-  const CSCChamber* chamber = theGeometry->chamber( chamberId );
+  const CSCChamber* chamber = theGeometry.chamber( chamberId );
   if ( chamber ){
   }
   else { // this chamber not yet built/stored
   
     LogTrace(myName) << myName <<": CSCChamberSpecs::build requested for ME" << jstat << jring ;
      int chamberType = CSCChamberSpecs::whatChamberType( jstat, jring );
-     const CSCChamberSpecs* aSpecs = theGeometry->findSpecs( chamberType );
+     const CSCChamberSpecs* aSpecs = theGeometry.findSpecs( chamberType );
     if ( !fupar.empty() && aSpecs == nullptr ) {
       // make new one:
-      aSpecs = theGeometry->buildSpecs (chamberType, fpar, fupar, wg);
+      aSpecs = theGeometry.buildSpecs (chamberType, fpar, fupar, wg);
     } else if ( fupar.empty() && aSpecs == nullptr ) {
       edm::LogError(myName) << "SHOULD BE THROW? Error, wg and/or fupar size are 0 BUT this Chamber Spec has not been built!";
     }
@@ -238,7 +238,7 @@ void CSCGeometryBuilder::buildChamber (
     Plane::PlanePointer plane = Plane::build(aVec, aRot, bounds); 
 
     CSCChamber* chamber = new CSCChamber( plane, chamberId, aSpecs );
-    theGeometry->addChamber( chamber ); 
+    theGeometry.addChamber( chamber ); 
 
     LogTrace(myName) << myName << ": Create chamber E" << jend << " S" << jstat 
  	             << " R" << jring << " C" << jch 
@@ -267,7 +267,7 @@ void CSCGeometryBuilder::buildChamber (
       CSCDetId layerId = CSCDetId( jend, jstat, jring, jch, j );
 
       // extra-careful check that we haven't already built this layer
-      const CSCLayer* cLayer = dynamic_cast<const CSCLayer*> (theGeometry->idToDet( layerId ) );
+      const CSCLayer* cLayer = dynamic_cast<const CSCLayer*> (theGeometry.idToDet( layerId ) );
 
       if ( cLayer == nullptr ) {
 
@@ -298,7 +298,7 @@ void CSCGeometryBuilder::buildChamber (
 		    << " adr=" << layer << " layerGeom adr=" << geom ;
 
         chamber->addComponent(j, layer); 
-        theGeometry->addLayer( layer );
+        theGeometry.addLayer( layer );
       }
       else {
         edm::LogError(myName) << ": ERROR, layer " << j <<

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.h
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilder.h
@@ -15,8 +15,6 @@
 
 #include <string>
 
-#include <memory>
-
 class CSCGeometry;
 
 class CSCGeometryBuilder {
@@ -28,16 +26,14 @@ public:
   virtual ~CSCGeometryBuilder();
 
   /// Build the geometry
-  void build( const std::shared_ptr<CSCGeometry>& theGeometry
-		      , const RecoIdealGeometry& rig
-		      , const CSCRecoDigiParameters& cscpars ) ;
-
-protected:
+  void build( CSCGeometry& theGeometry
+              , const RecoIdealGeometry& rig
+              , const CSCRecoDigiParameters& cscpars ) ;
 
 private:
   /// Build one CSC chamber, and its component layers, and add them to the geometry
   void buildChamber (  
-		     const std::shared_ptr<CSCGeometry>& theGeometry        // the geometry container
+		     CSCGeometry& theGeometry        // the geometry container
 		     , CSCDetId chamberId              // the DetId of this chamber
 		     , const std::vector<float>& fpar  // volume parameters
 		     , const std::vector<float>& fupar // user parameters

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilderFromDDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilderFromDDD.cc
@@ -16,7 +16,7 @@ CSCGeometryBuilderFromDDD::CSCGeometryBuilderFromDDD() : myName("CSCGeometryBuil
 CSCGeometryBuilderFromDDD::~CSCGeometryBuilderFromDDD(){}
 
 
-void CSCGeometryBuilderFromDDD::build(std::shared_ptr<CSCGeometry> geom, const DDCompactView* cview, const MuonDDDConstants& muonConstants){
+void CSCGeometryBuilderFromDDD::build(CSCGeometry& geom, const DDCompactView* cview, const MuonDDDConstants& muonConstants){
 
   RecoIdealGeometry rig;
   CSCRecoDigiParameters rdp;
@@ -28,7 +28,5 @@ void CSCGeometryBuilderFromDDD::build(std::shared_ptr<CSCGeometry> geom, const D
     throw cms::Exception("CSCGeometryBuilderFromDDD", "Failed to build the necessary objects from the DDD");
   }
   CSCGeometryBuilder realbuilder;
-  realbuilder.build(std::move(geom), rig, rdp);
-  //  return realbuilder.build(rig, rdp); 
-
+  realbuilder.build(geom, rig, rdp);
 }

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilderFromDDD.h
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryBuilderFromDDD.h
@@ -9,7 +9,7 @@
  */
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
-#include <memory>
+
 #include <string>
 
 class DDCompactView;
@@ -25,7 +25,7 @@ public:
   virtual ~CSCGeometryBuilderFromDDD();
 
   /// Build the geometry
-  void build(std::shared_ptr<CSCGeometry> geom, const DDCompactView* fv, const MuonDDDConstants& muonConstants);
+  void build(CSCGeometry& geom, const DDCompactView* fv, const MuonDDDConstants& muonConstants);
 
 protected:
 

--- a/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.cc
+++ b/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.cc
@@ -112,7 +112,7 @@ void DTGeometryESModule::setupGeometry( const MuonNumberingRecord& record,
   record.getRecord<IdealGeometryRecord>().get(cpv);
 
   DTGeometryBuilderFromDDD builder;
-  builder.build(host, &(*cpv), *mdc);
+  builder.build(*host, &(*cpv), *mdc);
 }
 
 void DTGeometryESModule::setupDBGeometry( const DTRecoGeometryRcd& record,

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
@@ -34,7 +34,7 @@ DTGeometryBuilderFromDDD::DTGeometryBuilderFromDDD() {}
 DTGeometryBuilderFromDDD::~DTGeometryBuilderFromDDD(){}
 
 
-void DTGeometryBuilderFromDDD::build(std::shared_ptr<DTGeometry> theGeometry,
+void DTGeometryBuilderFromDDD::build(DTGeometry& theGeometry,
                                      const DDCompactView* cview,
                                      const MuonDDDConstants& muonConstants){
   //  cout << "DTGeometryBuilderFromDDD::build" << endl;
@@ -48,17 +48,13 @@ void DTGeometryBuilderFromDDD::build(std::shared_ptr<DTGeometry> theGeometry,
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
 
   DDFilteredView fview(*cview,filter);
-  buildGeometry(std::move(theGeometry), fview, muonConstants);
+  buildGeometry(theGeometry, fview, muonConstants);
 }
 
 
-void DTGeometryBuilderFromDDD::buildGeometry(const std::shared_ptr<DTGeometry>& theGeometry,
+void DTGeometryBuilderFromDDD::buildGeometry(DTGeometry& theGeometry,
                                              DDFilteredView& fv,
                                              const MuonDDDConstants& muonConstants) const {
-  // static const string t0 = "DTGeometryBuilderFromDDD::buildGeometry";
-  // TimeMe timer(t0,true);
-
-  //DTGeometry* theGeometry = new DTGeometry;
 
   bool doChamber = fv.firstChild();
 
@@ -82,7 +78,7 @@ void DTGeometryBuilderFromDDD::buildGeometry(const std::shared_ptr<DTGeometry>& 
     while (doSL) {
       SLCounter++;
       DTSuperLayer* sl = buildSuperLayer(fv, chamber, type, muonConstants);
-      theGeometry->add(sl);
+      theGeometry.add(sl);
 
       bool doL = fv.firstChild();
       int LCounter=0;
@@ -90,7 +86,7 @@ void DTGeometryBuilderFromDDD::buildGeometry(const std::shared_ptr<DTGeometry>& 
       while (doL) {
         LCounter++;
         DTLayer* layer = buildLayer(fv, sl, type, muonConstants);
-        theGeometry->add(layer);
+        theGeometry.add(layer);
 
         fv.parent();
         doL = fv.nextSibling(); // go to next layer
@@ -99,7 +95,7 @@ void DTGeometryBuilderFromDDD::buildGeometry(const std::shared_ptr<DTGeometry>& 
       fv.parent();
       doSL = fv.nextSibling(); // go to next SL
     } // sls
-    theGeometry->add(chamber);
+    theGeometry.add(chamber);
 
     fv.parent();
     doChamber = fv.nextSibling(); // go to next chamber

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.h
@@ -10,7 +10,7 @@
  */
 
 #include "DataFormats/GeometrySurface/interface/Plane.h"
-#include <memory>
+
 #include <vector>
 
 class DTGeometry;
@@ -31,7 +31,7 @@ class DTGeometryBuilderFromDDD {
     virtual ~DTGeometryBuilderFromDDD();
 
     // Operations
-    void build(std::shared_ptr<DTGeometry> theGeometry,
+    void build(DTGeometry& theGeometry,
                const DDCompactView* cview, 
                const MuonDDDConstants& muonConstants);
 
@@ -61,7 +61,7 @@ class DTGeometryBuilderFromDDD {
     RCPPlane plane(const DDFilteredView& fv, 
                    Bounds * bounds) const ;
 
-    void buildGeometry(const std::shared_ptr<DTGeometry>& theGeometry,
+    void buildGeometry(DTGeometry& theGeometry,
                        DDFilteredView& fv,
                        const MuonDDDConstants& muonConstants) const;
 


### PR DESCRIPTION
Change produced type from shared_ptr to unique_ptr.

Note this required changing the arguments to the
GeometryBuilders build functions to just be simple
references which is better anyway because the old
interface restricted the caller to using shared_ptr
for no reason.