### PR TITLE
Fix HiFJRhoProducer.cc for ConfDB (103X)

### DIFF
--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
@@ -231,7 +231,7 @@ void HiFJRhoProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<int>("nExcl2", 2);
   desc.add<double>("etaMaxExcl2",2.);
   desc.add<double>("ptMinExcl2",20.);
-  desc.add<std::vector<double> >("etaRanges");
+  desc.add<std::vector<double> >("etaRanges",{});
   descriptions.add("hiFJRhoProducer",desc);
 }
 


### PR DESCRIPTION
Fix HiFJRhoProducer.cc for ConfDB parsing (103X)
Needed for HIon data taking.
Based on CMSSW_10_0_0 (to allow possible backport from same branch if needed)