### PR TITLE
Eliminate an infinite loop from MVAVariableManager<T>::init()

### DIFF
--- a/RecoEgamma/EgammaTools/interface/MVAVariableManager.h
+++ b/RecoEgamma/EgammaTools/interface/MVAVariableManager.h
@@ -45,6 +45,9 @@ class MVAVariableManager {
         std::string name, formula, upper, lower;
         while( true ) {
             file >> name;
+            if(file.eof()) {
+                break;
+            }
             if (name.find("#") != std::string::npos) {
                 file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
                 continue;


### PR DESCRIPTION
While doing something unrelated, git+scram got into a state thinking that the photon ID MVA text files are removed, and thus the `MVAVariableManager<T>::init()` got a file with only content of `#error ...` that lead to an infinite loop. This PR suggests to add a check for the EOF also when reading the `name`, eliminating the infinite loop (and leading to a later exception in my test case).

Tested in CMSSW_10_3_X_2018-09-26-1100, no changes expected.