### PR TITLE
HCALDQM: bad capid/LED misfire sound alarms only for last 60 LSes (master/10_4_X)

### DIFF
--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -11,6 +11,9 @@
   <LINK name="*Hcal/DigiTask/LED_CUCountvsLS/Subdet/*">
     <TestName activate="true">LEDMisfireThreshold</TestName>
   </LINK>
+  <LINK name="*Hcal/DigiTask/LED_CUCountvsLSmod60/Subdet/*">
+    <TestName activate="true">LEDMisfireThreshold</TestName>
+  </LINK>
 
   <QTEST name="BadCapIDThreshold">
     <TYPE>ContentsWithinExpected</TYPE>

--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -24,7 +24,7 @@
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
-  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLSmod50*">
+  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLS*">
     <TestName activate="true">BadCapIDThreshold</TestName>
   </LINK>
 </TESTSCONFIGURATION>

--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -24,7 +24,7 @@
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
-  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLS*">
+  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLSmod50*">
     <TestName activate="true">BadCapIDThreshold</TestName>
   </LINK>
 </TESTSCONFIGURATION>

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -204,6 +204,7 @@ class DigiTask : public hcaldqm::DQTask
 		std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
 
 		hcaldqm::Container1D _LED_CUCountvsLS_Subdet; // Misfire count vs LS
+		hcaldqm::Container1D _LED_CUCountvsLSmod60_Subdet; // Misfire count vs LS
 		hcaldqm::Container2D _LED_ADCvsBX_Subdet; // Pin diode amplitude vs BX	
 };
 

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -185,6 +185,7 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotuTCA[4]; // CrateSlot 2D histograms for each (capid-BX)%4
 		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotVME[4]; // CrateSlot 2D histograms for each (capid-BX)%4
 		hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLS;
+		hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLSmod60; // Same as _cCapid_BadvsFEDvsLS, but only for last 50 LSes (for sound alarm turning off when problem goes away)
 
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -555,7 +555,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
 	if (_ptype == fOnline) {
 		_cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
-		_cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod50");
+		_cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod60");
 	}
 	for (int i = 0; i < 4; ++i) {
 		char aux[10];

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -487,6 +487,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			hcaldqm::hashfunctions::fSubdet,
 			new hcaldqm::quantity::LumiSection(_maxLS),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+		if (_ptype == fOnline) {
+			_LED_CUCountvsLSmod60_Subdet.initialize(_name, "LED_CUCountvsLSmod60",
+				hcaldqm::hashfunctions::fSubdet,
+				new hcaldqm::quantity::LumiSection(60),
+				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+		}
 	}
 
 	//	BOOK HISTOGRAMS
@@ -563,6 +569,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	if (_ptype != fLocal) {
 		_LED_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
 		_LED_CUCountvsLS_Subdet.book(ib, _emap, _subsystem);
+		if (_ptype == fOnline) {
+			_LED_CUCountvsLSmod60_Subdet.book(ib, _emap, _subsystem);
+		}
 	}
 
 	//	BOOK HISTOGRAMS that are only for Online
@@ -875,6 +884,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 							}
 							if (channelLEDSignalPresent) {
 								_LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS);
+								if (_ptype == fOnline) {
+									_LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
+								}
 							}
 						}
 					}
@@ -1251,6 +1263,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 								}
 								if (channelLEDSignalPresent) {
 									_LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS);
+									if (_ptype == fOnline) { 
+										_LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS % 60);
+									}
 								}
 							}
 						}

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -341,7 +341,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				new hcaldqm::quantity::FEDQuantity(vFEDs),		
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 
-			_cCapid_BadvsFEDvsLSmod50.initialize(_name, "CapID", 
+			_cCapid_BadvsFEDvsLSmod60.initialize(_name, "CapID", 
 				new hcaldqm::quantity::LumiSection(60),
 				new hcaldqm::quantity::FEDQuantity(vFEDs),		
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
@@ -549,7 +549,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
 	if (_ptype == fOnline) {
 		_cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
-		_cCapid_BadvsFEDvsLSmod50.book(ib, _subsystem, "BadvsLSmod50");
+		_cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod50");
 	}
 	for (int i = 0; i < 4; ++i) {
 		char aux[10];
@@ -745,7 +745,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (!good_capidmbx) {
 				_xBadCapid.get(eid)++;
 				_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-				_cCapid_BadvsFEDvsLSmod50.fill(eid, _currentLS % 60);
+				_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
 			}
 			if (eid.isVMEid()) {
 				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -925,7 +925,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (!good_capidmbx) {
 				_xBadCapid.get(eid)++;
 				_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-				_cCapid_BadvsFEDvsLSmod50.fill(eid, _currentLS % 60);
+				_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
 			}
 			if (eid.isVMEid()) {
 				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -1108,7 +1108,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (!good_capidmbx) {
 				_xBadCapid.get(eid)++;
 				_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-				_cCapid_BadvsFEDvsLSmod50.fill(eid, _currentLS % 60);
+				_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
 			}
 			if (eid.isVMEid()) {
 				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -1297,7 +1297,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				if (!good_capidmbx) {
 					_xBadCapid.get(eid)++;
 					_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-					_cCapid_BadvsFEDvsLSmod50.fill(eid, _currentLS % 60);
+					_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
 				}
 				if (eid.isVMEid()) {
 					_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -1451,11 +1451,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 {
 	DQTask::beginLuminosityBlock(lb, es);
 	if (_ptype == fOnline) {
-		// Reset the bin for _cCapid_BadvsFEDvsLSmod50
+		// Reset the bin for _cCapid_BadvsFEDvsLSmod60
 		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
 				it!=_vhashFEDs.end(); ++it) {
 			HcalElectronicsId eid = HcalElectronicsId(*it);
-			_cCapid_BadvsFEDvsLSmod50.setBinContent(eid, _currentLS % 50, 0);
+			_cCapid_BadvsFEDvsLSmod60.setBinContent(eid, _currentLS % 50, 0);
 		}	
 	}
 }


### PR DESCRIPTION
Adds "LSmod60" versions of the bad capid and LED misfire vs LS plots, which only record the last 60 LSes. This is so that the error condition goes away after ~25 minutes, so the sound alarms don't keep triggering.