### PR TITLE
HCALDQM: bad capid/LED misfire sound alarms only for last 60 LSes (10_2_X)

### DIFF
--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -67,6 +67,8 @@ namespace hcaldqm
 			ffC_1000000 = 52,
 			fTime_ns_250_coarse = 53,
 			fCapidMinusBXmod4 = 54,
+			fBX_36 = 55,
+			fADC_256_4 = 56, // ADC from 0-255, with 4 ADC granularity
 		};
 		const std::map<ValueQuantityType, std::string> name_value = {
 			{fN,"N"},
@@ -124,6 +126,8 @@ namespace hcaldqm
 			{ffC_1000000, "fC"},
 			{fTime_ns_250_coarse, "Time (ns)"},
 			{fCapidMinusBXmod4, "(CapId - BX) % 4"},
+			{fBX_36, "BX"},
+			{fADC_256_4, "ADC"},
 		};
 		const std::map<ValueQuantityType, double> min_value = {
 			{fN,-0.05},
@@ -180,7 +184,9 @@ namespace hcaldqm
 			{fTimingDiff_ns, -125.},
 			{ffC_1000000,0.},
 			{fTime_ns_250_coarse, -0.5},
-			{fCapidMinusBXmod4, -0.5},			
+			{fCapidMinusBXmod4, -0.5},	
+			{fBX_36, -0.5},
+			{fADC_256_4, -0.5},
 		};
 		const std::map<ValueQuantityType, double> max_value = {
 			{fN,1000},
@@ -238,6 +244,8 @@ namespace hcaldqm
 			{ffC_1000000,1.e6},
 			{fTime_ns_250_coarse, 249.5},
 			{fCapidMinusBXmod4, 3.5},
+			{fBX_36, 3564.-0.5},
+			{fADC_256_4, 255},
 		};
 		const std::map<ValueQuantityType, int> nbins_value = {
 			{fN,200},
@@ -293,7 +301,9 @@ namespace hcaldqm
 			{fTimingDiff_ns, 40},
 			{ffC_1000000,1000},
 			{fTime_ns_250_coarse, 100},
-			{fCapidMinusBXmod4, 4}
+			{fCapidMinusBXmod4, 4},
+			{fBX_36, 99},
+			{fADC_256_4, 64},
 		};
 		class ValueQuantity : public Quantity
 		{

--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -11,6 +11,9 @@
   <LINK name="*Hcal/DigiTask/LED_CUCountvsLS/Subdet/*">
     <TestName activate="true">LEDMisfireThreshold</TestName>
   </LINK>
+  <LINK name="*Hcal/DigiTask/LED_CUCountvsLSmod60/Subdet/*">
+    <TestName activate="true">LEDMisfireThreshold</TestName>
+  </LINK>
 
   <QTEST name="BadCapIDThreshold">
     <TYPE>ContentsWithinExpected</TYPE>

--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -24,7 +24,7 @@
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
-  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLSmod50*">
+  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLS*">
     <TestName activate="true">BadCapIDThreshold</TestName>
   </LINK>
 </TESTSCONFIGURATION>

--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -24,7 +24,7 @@
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
-  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLS*">
+  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLSmod50*">
     <TestName activate="true">BadCapIDThreshold</TestName>
   </LINK>
 </TESTSCONFIGURATION>

--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -8,7 +8,7 @@
       <PARAM name="ymax">0.0</PARAM>
       <PARAM name="useEmptyBins">0</PARAM>
   </QTEST>
-  <LINK name="*Hcal/DigiTask/LED/LEDEventCount*">
+  <LINK name="*Hcal/DigiTask/LED_CUCountvsLS/Subdet/*">
       <TestName activate="true">LEDMisfireThreshold</TestName>
   </LINK>
 

--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -1,15 +1,30 @@
 <TESTSCONFIGURATION>
 
   <QTEST name="LEDMisfireThreshold">
-      <TYPE>ContentsYRange</TYPE>
-      <PARAM name="warning">0.</PARAM>
-      <PARAM name="error">1.</PARAM>
-      <PARAM name="ymin">0.0</PARAM>
-      <PARAM name="ymax">0.0</PARAM>
-      <PARAM name="useEmptyBins">0</PARAM>
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="warning">0.</PARAM>
+    <PARAM name="error">1.</PARAM>
+    <PARAM name="ymin">0.0</PARAM>
+    <PARAM name="ymax">0.0</PARAM>
+    <PARAM name="useEmptyBins">0</PARAM>
   </QTEST>
   <LINK name="*Hcal/DigiTask/LED_CUCountvsLS/Subdet/*">
-      <TestName activate="true">LEDMisfireThreshold</TestName>
+    <TestName activate="true">LEDMisfireThreshold</TestName>
   </LINK>
 
+  <QTEST name="BadCapIDThreshold">
+    <TYPE>ContentsWithinExpected</TYPE>
+      <PARAM name="error">1.0</PARAM>
+      <PARAM name="warning">1.0</PARAM>
+      <PARAM name="minMean">-1.0</PARAM>
+      <PARAM name="maxMean">0.0</PARAM>
+      <PARAM name="minRMS">0.0</PARAM>
+      <PARAM name="maxRMS">0.0</PARAM>
+      <PARAM name="toleranceMean">-1.0</PARAM>
+      <PARAM name="minEntries">0</PARAM>
+      <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLS*">
+    <TestName activate="true">BadCapIDThreshold</TestName>
+  </LINK>
 </TESTSCONFIGURATION>

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -184,7 +184,7 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::Container1D _cCapidMinusBXmod4_SubdetPM;
 		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotuTCA[4]; // CrateSlot 2D histograms for each (capid-BX)%4
 		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotVME[4]; // CrateSlot 2D histograms for each (capid-BX)%4
-
+		hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLS;
 
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -204,6 +204,7 @@ class DigiTask : public hcaldqm::DQTask
 		std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
 
 		hcaldqm::Container1D _LED_CUCountvsLS_Subdet; // Misfire count vs LS
+		hcaldqm::Container1D _LED_CUCountvsLSmod60_Subdet; // Misfire count vs LS
 		hcaldqm::Container2D _LED_ADCvsBX_Subdet; // Pin diode amplitude vs BX	
 };
 

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -185,16 +185,11 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotuTCA[4]; // CrateSlot 2D histograms for each (capid-BX)%4
 		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotVME[4]; // CrateSlot 2D histograms for each (capid-BX)%4
 
-		// For monitoring LED misfires: ADC vs BX
-		MonitorElement* _meLEDMon;
 
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting
 		MonitorElement *meUnknownIds1LS;
 		bool _unknownIdsPresent;
-		MonitorElement *_meLEDEventCount; // Count events with LED pin diode signal > threshold
-		double _thresh_led;
-		bool _ledSignalPresent;
 
 		hcaldqm::Container2D _cSummaryvsLS_FED; // online only
 		hcaldqm::ContainerSingle2D _cSummaryvsLS; // online only
@@ -202,6 +197,13 @@ class DigiTask : public hcaldqm::DQTask
 		bool _qie10InConditions; // Flag to protect against QIE10 digis not in conditions in 2016.
 
 		std::map<HcalSubdetector, short> _capidmbx; // Expected (capid - BX) % 4 for each subdet
+
+		// LED monitoring stuff
+		double _thresh_led;
+		std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
+
+		hcaldqm::Container1D _LED_CUCountvsLS_Subdet; // Misfire count vs LS
+		hcaldqm::Container2D _LED_ADCvsBX_Subdet; // Pin diode amplitude vs BX	
 };
 
 #endif

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -185,6 +185,7 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotuTCA[4]; // CrateSlot 2D histograms for each (capid-BX)%4
 		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotVME[4]; // CrateSlot 2D histograms for each (capid-BX)%4
 		hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLS;
+		hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLSmod60; // Same as _cCapid_BadvsFEDvsLS, but only for last 50 LSes (for sound alarm turning off when problem goes away)
 
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -113,7 +113,9 @@ class LEDTask : public hcaldqm::DQTask
 		hcaldqm::ContainerSingle2D _cLowSignal_CrateSlot;
 
 		// For monitoring LED firing: ADC vs BX
-		MonitorElement* _meLEDMon;
+		std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
+		hcaldqm::Container2D _LED_ADCvsBX_Subdet; // Pin diode amplitude vs BX	(online DQM)
+		hcaldqm::Container2D _LED_ADCvsEvn_Subdet; // Pin diode amplitude vs BX	 (local DQM)
 		
 };
 

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -114,8 +114,8 @@ class LEDTask : public hcaldqm::DQTask
 
 		// For monitoring LED firing: ADC vs BX
 		std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
-		hcaldqm::Container2D _LED_ADCvsBX_Subdet; // Pin diode amplitude vs BX	(online DQM)
-		hcaldqm::Container2D _LED_ADCvsEvn_Subdet; // Pin diode amplitude vs BX	 (local DQM)
+		hcaldqm::Container2D _LED_ADCvsBX_Subdet; // Pin diode amplitude vs BX for online DQM
+		hcaldqm::Container2D _LED_ADCvsEvn_Subdet; // Pin diode amplitude vs Evn for local DQM
 		
 };
 

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -555,7 +555,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
 	if (_ptype == fOnline) {
 		_cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
-		_cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod50");
+		_cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod60");
 	}
 	for (int i = 0; i < 4; ++i) {
 		char aux[10];

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -334,6 +334,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
 		std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
 		std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
+
+		_cCapid_BadvsFEDvsLS.initialize(_name, "CapID", 
+			new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+			new hcaldqm::quantity::FEDQuantity(vFEDs),		
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	
 		std::vector<uint32_t> vFEDHF;
 		vFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN,
@@ -535,6 +540,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cBadTDCCount_depth.book(ib, _emap, _subsystem);
 
 	_cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
+	if (_ptype != fOffline) {
+		_cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
+	}
 	for (int i = 0; i < 4; ++i) {
 		char aux[10];
 		sprintf(aux, "%d_uTCA", i);
@@ -728,6 +736,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
 			if (!good_capidmbx) {
 				_xBadCapid.get(eid)++;
+				if (_ptype != fOffline) {
+					_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
+				}
 			}
 			if (eid.isVMEid()) {
 				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -906,6 +917,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
 			if (!good_capidmbx) {
 				_xBadCapid.get(eid)++;
+				if (_ptype != fOffline) {
+					_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
+				}
 			}
 			if (eid.isVMEid()) {
 				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -1087,6 +1101,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
 			if (!good_capidmbx) {
 				_xBadCapid.get(eid)++;
+				if (_ptype != fOffline) {
+					_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
+				}
 			}
 			if (eid.isVMEid()) {
 				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -1274,6 +1291,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
 				if (!good_capidmbx) {
 					_xBadCapid.get(eid)++;
+					if (_ptype != fOffline) {
+						_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
+					}
 				}
 				if (eid.isVMEid()) {
 					_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -487,6 +487,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			hcaldqm::hashfunctions::fSubdet,
 			new hcaldqm::quantity::LumiSection(_maxLS),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+		if (_ptype == fOnline) {
+			_LED_CUCountvsLSmod60_Subdet.initialize(_name, "LED_CUCountvsLSmod60",
+				hcaldqm::hashfunctions::fSubdet,
+				new hcaldqm::quantity::LumiSection(60),
+				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+		}
 	}
 
 	//	BOOK HISTOGRAMS
@@ -563,6 +569,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	if (_ptype != fLocal) {
 		_LED_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
 		_LED_CUCountvsLS_Subdet.book(ib, _emap, _subsystem);
+		if (_ptype == fOnline) {
+			_LED_CUCountvsLSmod60_Subdet.book(ib, _emap, _subsystem);
+		}
 	}
 
 	//	BOOK HISTOGRAMS that are only for Online
@@ -875,6 +884,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 							}
 							if (channelLEDSignalPresent) {
 								_LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS);
+								if (_ptype == fOnline) {
+									_LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
+								}
 							}
 						}
 					}
@@ -1251,6 +1263,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 								}
 								if (channelLEDSignalPresent) {
 									_LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS);
+									if (_ptype == fOnline) { 
+										_LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS % 60);
+									}
 								}
 							}
 						}

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -852,7 +852,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 								_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), bx, digi[i].adc());
 
 								if (digi[i].adc() > _thresh_led) {
-									//std::cout << "[debug] Found LED misfire! did = " << did << " / " << did.ieta() << " / " << did.iphi() << " / " << did.depth() << " / ADC = " << digi[i].adc() << std::endl;
 									channelLEDSignalPresent = true;
 								}
 							}
@@ -1220,13 +1219,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 						if (hodid.subdet() == HcalCalibration) {
 							// New method: use configurable list of channels
 							if (std::find(_ledCalibrationChannels[HcalForward].begin(), _ledCalibrationChannels[HcalForward].end(), did) != _ledCalibrationChannels[HcalForward].end()) {
-								//std::cout << "[debug] Found HF calibration did with new method: " << did << " / depth = " << did.depth() << " / ieta = " << did.ieta() << " / iphi = " << did.iphi() << std::endl;
 								bool channelLEDSignalPresent = false;
 								for (int i=0; i<digi.samples(); i++) {
 									_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), bx, digi[i].adc());
 
 									if (digi[i].adc() > _thresh_led) {
-										//std::cout << "[debug] Found LED signal in did " << did << std::endl;
 										channelLEDSignalPresent = true;
 									}
 								}

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -341,7 +341,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				new hcaldqm::quantity::FEDQuantity(vFEDs),		
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 
-			_cCapid_BadvsFEDvsLSmod50.initialize(_name, "CapID", 
+			_cCapid_BadvsFEDvsLSmod60.initialize(_name, "CapID", 
 				new hcaldqm::quantity::LumiSection(60),
 				new hcaldqm::quantity::FEDQuantity(vFEDs),		
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
@@ -549,7 +549,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
 	if (_ptype == fOnline) {
 		_cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
-		_cCapid_BadvsFEDvsLSmod50.book(ib, _subsystem, "BadvsLSmod50");
+		_cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod50");
 	}
 	for (int i = 0; i < 4; ++i) {
 		char aux[10];
@@ -745,7 +745,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (!good_capidmbx) {
 				_xBadCapid.get(eid)++;
 				_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-				_cCapid_BadvsFEDvsLSmod50.fill(eid, _currentLS % 60);
+				_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
 			}
 			if (eid.isVMEid()) {
 				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -925,7 +925,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (!good_capidmbx) {
 				_xBadCapid.get(eid)++;
 				_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-				_cCapid_BadvsFEDvsLSmod50.fill(eid, _currentLS % 60);
+				_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
 			}
 			if (eid.isVMEid()) {
 				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -1108,7 +1108,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (!good_capidmbx) {
 				_xBadCapid.get(eid)++;
 				_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-				_cCapid_BadvsFEDvsLSmod50.fill(eid, _currentLS % 60);
+				_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
 			}
 			if (eid.isVMEid()) {
 				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -1297,7 +1297,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				if (!good_capidmbx) {
 					_xBadCapid.get(eid)++;
 					_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-					_cCapid_BadvsFEDvsLSmod50.fill(eid, _currentLS % 60);
+					_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
 				}
 				if (eid.isVMEid()) {
 					_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
@@ -1451,11 +1451,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 {
 	DQTask::beginLuminosityBlock(lb, es);
 	if (_ptype == fOnline) {
-		// Reset the bin for _cCapid_BadvsFEDvsLSmod50
+		// Reset the bin for _cCapid_BadvsFEDvsLSmod60
 		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
 				it!=_vhashFEDs.end(); ++it) {
 			HcalElectronicsId eid = HcalElectronicsId(*it);
-			_cCapid_BadvsFEDvsLSmod50.setBinContent(eid, _currentLS % 50, 0);
+			_cCapid_BadvsFEDvsLSmod60.setBinContent(eid, _currentLS % 50, 0);
 		}	
 	}
 }

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -50,6 +50,35 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_capidmbx[HcalEndcap] = 1;
 	_capidmbx[HcalOuter] = 1;
 	_capidmbx[HcalForward] = 1;
+
+	// LED calibration channels
+	std::vector<edm::ParameterSet> vLedCalibChannels = ps.getParameter<std::vector<edm::ParameterSet>>("ledCalibrationChannels");
+	for (int i = 0; i <= 3; ++i) {
+		HcalSubdetector this_subdet = HcalEmpty;
+		switch (i) {
+			case 0:
+				this_subdet = HcalBarrel;
+				break;
+			case 1:
+				this_subdet = HcalEndcap;
+				break;
+			case 2:
+				this_subdet = HcalOuter;
+				break;
+			case 3:
+				this_subdet = HcalForward;
+				break;
+			default:
+				this_subdet = HcalEmpty;
+				break;
+		}
+		std::vector<int32_t> subdet_calib_ietas = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("ieta");
+		std::vector<int32_t> subdet_calib_iphis = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("iphi");
+		std::vector<int32_t> subdet_calib_depths = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("depth");
+		for (unsigned int ichannel = 0; ichannel < subdet_calib_ietas.size(); ++ichannel) {
+			_ledCalibrationChannels[this_subdet].push_back(HcalDetId(HcalOther, subdet_calib_ietas[ichannel], subdet_calib_iphis[ichannel], subdet_calib_depths[ichannel]));
+		}
+	}
 }
 
 /* virtual */ void DigiTask::bookHistograms(DQMStore::IBooker& ib,
@@ -435,6 +464,18 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			_xBadCapid.initialize(hcaldqm::hashfunctions::fFED);
 		}
 	}
+	if (_ptype != fLocal) {
+		_LED_ADCvsBX_Subdet.initialize(_name, "LED_ADCvsBX", 
+			hcaldqm::hashfunctions::fSubdet, 
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX_36),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+
+		_LED_CUCountvsLS_Subdet.initialize(_name, "LED_CUCountvsLS",
+			hcaldqm::hashfunctions::fSubdet,
+			new hcaldqm::quantity::LumiSection(_maxLS),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+	}
 
 	//	BOOK HISTOGRAMS
 	char cutstr[200];
@@ -503,6 +544,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		_cCapidMinusBXmod4_CrateSlotVME[i].book(ib, _subsystem, aux);
 	}
 
+	if (_ptype != fLocal) {
+		_LED_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
+		_LED_CUCountvsLS_Subdet.book(ib, _emap, _subsystem);
+	}
+
 	//	BOOK HISTOGRAMS that are only for Online
 	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
 	_dhashmap.initialize(_emap, electronicsmap::fE2DHashMap);
@@ -537,12 +583,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		_xUni.book(_emap);
 		_xDigiSize.book(_emap);
 		_xBadCapid.book(_emap);
-
-		// Manually book LED monitoring histogram, to get custom axis
-		ib.setCurrentFolder(_subsystem+"/"+_name+"/LED");
-		_meLEDMon = ib.book2D("LED_ADCvsBX", "Pin diode ADC vs BX", 99, -0.5, 3564-0.5, 64, -0.5, 255.5);
-		_meLEDMon->setAxisTitle("BX", 1);
-		_meLEDMon->setAxisTitle("ADC", 2);
 
 		// just PER HF FED RECORD THE #CHANNELS
 		// ONLY WAY TO DO THAT AUTOMATICALLY AND W/O HARDCODING 1728
@@ -589,10 +629,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_unknownIdsPresent = false;
 	meUnknownIds1LS->setLumiFlag();
 
-	_ledSignalPresent = false;
-	ib.setCurrentFolder(_subsystem+"/"+_name+"/LED");
-	_meLEDEventCount = ib.book1D("LEDEventCount", "LEDEventCount", 1, 0, 2);
-	_meLEDEventCount->setLumiFlag();
 }
 
 /* virtual */ void DigiTask::_resetMonitors(hcaldqm::UpdateFreq uf)
@@ -805,28 +841,31 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		HcalDetId const& did = digi.detid();
 		if (did.subdet() != HcalEndcap) {
 			// LED monitoring from calibration channels
-			if (did.subdet() == HcalOther) {
-				HcalOtherDetId hodid(digi.detid());
-				if (hodid.subdet() == HcalCalibration) {
-					if (did.depth() == 10) {
-						_ledSignalPresent = false;
-						for (int i=0; i<digi.samples(); i++) {
-							if (_ptype == fOnline) {
-								_meLEDMon->Fill(bx, digi[i].adc());
+			if (_ptype != fLocal) {
+				if (did.subdet() == HcalOther) {
+					HcalOtherDetId hodid(digi.detid());
+					if (hodid.subdet() == HcalCalibration) {
+						// New method: use configurable list of channels
+						if (std::find(_ledCalibrationChannels[HcalEndcap].begin(), _ledCalibrationChannels[HcalEndcap].end(), did) != _ledCalibrationChannels[HcalEndcap].end()) {
+							bool channelLEDSignalPresent = false;
+							for (int i=0; i<digi.samples(); i++) {
+								_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), bx, digi[i].adc());
+
+								if (digi[i].adc() > _thresh_led) {
+									//std::cout << "[debug] Found LED misfire! did = " << did << " / " << did.ieta() << " / " << did.iphi() << " / " << did.depth() << " / ADC = " << digi[i].adc() << std::endl;
+									channelLEDSignalPresent = true;
+								}
 							}
-							if (digi[i].adc() > _thresh_led) {
-								_ledSignalPresent = true;
+							if (channelLEDSignalPresent) {
+								_LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS);
 							}
-						}
-						if (_ledSignalPresent) {
-							_meLEDEventCount->Fill(1);
 						}
 					}
 				}
 			}
-
 			continue;
 		}
+
 		uint32_t rawid = _ehashmap.lookup(did);
 		if (rawid == 0) {
 			meUnknownIds1LS->Fill(1);
@@ -1174,6 +1213,30 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			//	Explicit check on the DetIds present in the Collection
 			HcalDetId const& did = digi.detid();
 			if (did.subdet() != HcalForward) {
+				// LED monitoring from calibration channels
+				if (_ptype != fLocal) {
+					if (did.subdet() == HcalOther) {
+						HcalOtherDetId hodid(digi.detid());
+						if (hodid.subdet() == HcalCalibration) {
+							// New method: use configurable list of channels
+							if (std::find(_ledCalibrationChannels[HcalForward].begin(), _ledCalibrationChannels[HcalForward].end(), did) != _ledCalibrationChannels[HcalForward].end()) {
+								//std::cout << "[debug] Found HF calibration did with new method: " << did << " / depth = " << did.depth() << " / ieta = " << did.ieta() << " / iphi = " << did.iphi() << std::endl;
+								bool channelLEDSignalPresent = false;
+								for (int i=0; i<digi.samples(); i++) {
+									_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), bx, digi[i].adc());
+
+									if (digi[i].adc() > _thresh_led) {
+										//std::cout << "[debug] Found LED signal in did " << did << std::endl;
+										channelLEDSignalPresent = true;
+									}
+								}
+								if (channelLEDSignalPresent) {
+									_LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS);
+								}
+							}
+						}
+					}
+				}
 				continue;
 			}
 
@@ -1453,10 +1516,33 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			else
 				_vflags[fUnknownIds]._state = hcaldqm::flag::fGOOD;
 
-			if (_ledSignalPresent)
-				_vflags[fLED]._state = hcaldqm::flag::fBAD;
-			else
-				_vflags[fLED]._state = hcaldqm::flag::fGOOD;
+			// LED misfires
+			if (_ptype != fLocal) {
+				if (hcaldqm::utilities::isFEDHBHE(eid)) {
+					HcalDetId did_hb(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalBarrel, 1, 1, 1)));
+					HcalDetId did_he(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalEndcap, 16, 1, 1)));
+
+					if (_LED_CUCountvsLS_Subdet.getBinContent(did_hb, _currentLS) > 0 || _LED_CUCountvsLS_Subdet.getBinContent(did_he, _currentLS) > 0) {
+						_vflags[fLED]._state = hcaldqm::flag::fBAD;
+					} else {
+						_vflags[fLED]._state = hcaldqm::flag::fGOOD;
+					}
+				} else if (hcaldqm::utilities::isFEDHF(eid)) {
+					HcalDetId did_hf(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalForward, 29, 1, 1)));
+					if (_LED_CUCountvsLS_Subdet.getBinContent(did_hf, _currentLS) > 0) {
+						_vflags[fLED]._state = hcaldqm::flag::fBAD;
+					} else {
+						_vflags[fLED]._state = hcaldqm::flag::fGOOD;
+					}
+				} else if (hcaldqm::utilities::isFEDHO(eid)) {
+					HcalDetId did_ho(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalOuter, 1, 1, 1)));
+					if (_LED_CUCountvsLS_Subdet.getBinContent(did_ho, _currentLS) > 0) {
+						_vflags[fLED]._state = hcaldqm::flag::fBAD;
+					} else {
+						_vflags[fLED]._state = hcaldqm::flag::fGOOD;
+					}
+				}
+			}
 
 			int iflag=0;
 			for (std::vector<hcaldqm::flag::Flag>::iterator ft=_vflags.begin();

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -37,6 +37,36 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		20);
 	_lowHF = ps.getUntrackedParameter<double>("lowHF",
 		20);
+
+	// LED calibration channels
+	std::vector<edm::ParameterSet> vLedCalibChannels = ps.getParameter<std::vector<edm::ParameterSet>>("ledCalibrationChannels");
+	for (int i = 0; i <= 3; ++i) {
+		HcalSubdetector this_subdet = HcalEmpty;
+		switch (i) {
+			case 0:
+				this_subdet = HcalBarrel;
+				break;
+			case 1:
+				this_subdet = HcalEndcap;
+				break;
+			case 2:
+				this_subdet = HcalOuter;
+				break;
+			case 3:
+				this_subdet = HcalForward;
+				break;
+			default:
+				this_subdet = HcalEmpty;
+				break;
+		}
+		std::vector<int32_t> subdet_calib_ietas = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("ieta");
+		std::vector<int32_t> subdet_calib_iphis = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("iphi");
+		std::vector<int32_t> subdet_calib_depths = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("depth");
+		for (unsigned int ichannel = 0; ichannel < subdet_calib_ietas.size(); ++ichannel) {
+			_ledCalibrationChannels[this_subdet].push_back(HcalDetId(HcalOther, subdet_calib_ietas[ichannel], subdet_calib_iphis[ichannel], subdet_calib_depths[ichannel]));
+		}
+	}
+
 }
 	
 /* virtual */ void LEDTask::bookHistograms(DQMStore::IBooker &ib,
@@ -193,17 +223,17 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
 			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),			
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),0);
-		// Manually book LED monitoring histogram, to get custom axis
-		ib.setCurrentFolder(_subsystem+"/"+_name);
-		_meLEDMon = ib.book2D("LED_ADCvsBX", "Pin diode ADC vs BX", 99, -0.5, 3564-0.5, 64, -0.5, 255.5);
-		_meLEDMon->setAxisTitle("BX", 1);
-		_meLEDMon->setAxisTitle("ADC", 2);
+		_LED_ADCvsBX_Subdet.initialize(_name, "LED_ADCvsBX", 
+			hcaldqm::hashfunctions::fSubdet, 
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX_36),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);		
 	} else if (_ptype == fLocal) {
-		// Manually book LED monitoring histogram, to get custom axis
-		ib.setCurrentFolder(_subsystem+"/"+_name);
-		_meLEDMon = ib.book2D("LED_ADCvsEvN", "Pin diode ADC vs EvN", _nevents, -0.5, _nevents-0.5, 64, -0.5, 255.5);
-		_meLEDMon->setAxisTitle("Event Number", 1);
-		_meLEDMon->setAxisTitle("ADC", 2);
+		_LED_ADCvsEvn_Subdet.initialize(_name, "LED_ADCvsEvn", 
+			hcaldqm::hashfunctions::fSubdet, 
+			new hcaldqm::quantity::EventNumber(_nevents),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
 	}
 	
 	//	initialize compact containers
@@ -244,6 +274,12 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		_cSumQ_SubdetPM.book(ib, _emap, _subsystem);
 		_cTDCTime_SubdetPM.book(ib, _emap, _subsystem);
 		_cTDCTime_depth.book(ib, _emap, _subsystem);
+	}
+
+	if (_ptype == fOnline) {
+		_LED_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
+	} else if (_ptype == fLocal) {
+		_LED_ADCvsEvn_Subdet.book(ib, _emap, _subsystem);
 	}
 
 	_xSignalSum.book(_emap);
@@ -405,12 +441,12 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 			if (did.subdet() == HcalOther) {
 				HcalOtherDetId hodid(digi.detid());
 				if (hodid.subdet() == HcalCalibration) {
-					if (did.depth() == 10) {
+					if (std::find(_ledCalibrationChannels[HcalEndcap].begin(), _ledCalibrationChannels[HcalEndcap].end(), did) != _ledCalibrationChannels[HcalEndcap].end()) {
 						for (int i=0; i<digi.samples(); i++) {
 							if (_ptype == fOnline) {
-								_meLEDMon->Fill(e.bunchCrossing(), digi[i].adc());
+								_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), e.bunchCrossing(), digi[i].adc());
 							} else if (_ptype == fLocal) {
-								_meLEDMon->Fill(e.eventAuxiliary().id().event(), digi[i].adc());
+								_LED_ADCvsEvn_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
 							}
 						}
 					}
@@ -513,6 +549,21 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
 		HcalDetId did = digi.detid();
 		if (did.subdet() != HcalForward) {
+			// LED monitoring from calibration channels
+			if (did.subdet() == HcalOther) {
+				HcalOtherDetId hodid(digi.detid());
+				if (hodid.subdet() == HcalCalibration) {
+					if (std::find(_ledCalibrationChannels[HcalForward].begin(), _ledCalibrationChannels[HcalForward].end(), did) != _ledCalibrationChannels[HcalForward].end()) {
+						for (int i=0; i<digi.samples(); i++) {
+							if (_ptype == fOnline) {
+								_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), e.bunchCrossing(), digi[i].adc());
+							} else if (_ptype == fLocal) {
+								_LED_ADCvsEvn_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
+							}
+						}
+					}
+				}
+			}
 			continue;
 		}
 		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -101,7 +101,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	_cSignalRMS_Subdet.initialize(_name, "SignalRMS",
 		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	_cTimingMean_Subdet.initialize(_name, "TimingMean",
 		hcaldqm::hashfunctions::fSubdet, 

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -1,9 +1,13 @@
 import FWCore.ParameterSet.Config as cms
-
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+from DQM.HcalTasks.LEDCalibrationChannels import ledCalibrationChannels
+
 digiTask = DQMEDAnalyzer(
 	"DigiTask",
-	
+
+	# Externals
+	ledCalibrationChannels = ledCalibrationChannels,
+
 	#	standard parameters
 	name = cms.untracked.string("DigiTask"),
 	debug = cms.untracked.int32(0),
@@ -31,6 +35,7 @@ digiTask = DQMEDAnalyzer(
 
 	# Reference digi sizes
 	refDigiSize = cms.untracked.vuint32(10, 10, 10, 4), # HB, HE, HO, HF
+
 )
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017

--- a/DQM/HcalTasks/python/LEDCalibrationChannels.py
+++ b/DQM/HcalTasks/python/LEDCalibrationChannels.py
@@ -1,0 +1,71 @@
+# Specify detector coordinates of LED calibration channels
+import FWCore.ParameterSet.Config as cms
+
+# Coordinates as python tuples, (ieta, iphi, depth)
+led_calibration_channels_tuple = {
+	"HB":{},
+	"HE":{
+		(-16, 48, 10),
+		(-16, 112, 10),
+		(-17, 48, 10),
+		(-17, 112, 10),
+		(-18, 48, 10),
+		(-18, 112, 10),
+		(-19, 48, 10),
+		(-19, 112, 10),
+		(-20, 48, 10),
+		(-20, 112, 10),
+		(-21, 48, 10),
+		(-21, 112, 10),
+		(-22, 48, 10),
+		(-22, 112, 10),
+		(-23, 48, 10),
+		(-23, 112, 10),
+		(-24, 48, 10),
+		(-24, 112, 10),
+		(-48, 48, 10),
+		(-48, 112, 10),
+		(-49, 48, 10),
+		(-49, 112, 10),
+		(-50, 48, 10),
+		(-50, 112, 10),
+		(-51, 48, 10),
+		(-51, 112, 10),
+		(-52, 48, 10),
+		(-52, 112, 10),
+		(-53, 48, 10),
+		(-53, 112, 10),
+		(-54, 48, 10),
+		(-54, 112, 10),
+		(-55, 48, 10),
+		(-55, 112, 10),
+		(-56, 48, 10),
+		(-56, 112, 10),
+	}, 
+
+	"HO":{},
+	"HF":{
+		(-16, 16, 12),
+		(-18, 48, 12),
+		(-20, 80, 12),
+		(-22, 112, 12),
+		(-50, 48, 12),
+		(-52, 80, 12),
+		(-54, 112, 12),
+		(-54, 120, 12),
+	},
+}
+
+# Convert tuples to CMSSW objects
+ledCalibrationChannels = cms.VPSet()
+for subdet in ["HB", "HE", "HO", "HF"]:
+	subdet_channels = cms.untracked.PSet(
+		ieta = cms.untracked.vint32(),
+		iphi = cms.untracked.vint32(),
+		depth = cms.untracked.vint32()
+	)
+	for channel in led_calibration_channels_tuple[subdet]:
+		subdet_channels.ieta.append(channel[0])
+		subdet_channels.iphi.append(channel[1])
+		subdet_channels.depth.append(channel[2])
+	ledCalibrationChannels.append(subdet_channels)

--- a/DQM/HcalTasks/python/LEDTask.py
+++ b/DQM/HcalTasks/python/LEDTask.py
@@ -1,8 +1,12 @@
 import FWCore.ParameterSet.Config as cms
-
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+from DQM.HcalTasks.LEDCalibrationChannels import ledCalibrationChannels
+
 ledTask = DQMEDAnalyzer(
 	"LEDTask",
+
+	# Externals
+	ledCalibrationChannels = ledCalibrationChannels,
 	
 	#	standard parameters
 	name = cms.untracked.string("LEDTask"),
@@ -17,7 +21,8 @@ ledTask = DQMEDAnalyzer(
 	tagHBHE = cms.untracked.InputTag("hcalDigis"),
 	tagHO = cms.untracked.InputTag("hcalDigis"),
 	tagHF = cms.untracked.InputTag("hcalDigis"),
-	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw')
+	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw'),
+
 )
 
 

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -118,8 +118,6 @@ namespace hcaldqm
 		int numEvents = meNumEvents->getBinContent(1);
 		bool unknownIdsPresent = ig.get(_subsystem+"/"
 			+_taskname+"/UnknownIds")->getBinContent(1)>0;
-		bool ledSignalPresent = ig.get(_subsystem+"/"
-			+_taskname+"/LED/LEDEventCount")->getBinContent(1)>0;
 
 		//	book the Numer of Events - set axis extendable
 		if (!_booked)
@@ -193,6 +191,18 @@ namespace hcaldqm
 				vtmpflags[fUnknownIds]._state = flag::fBAD;
 			else
 				vtmpflags[fUnknownIds]._state = flag::fGOOD;
+
+			std::string ledHistName = _subsystem + "/" + _taskname + "/LED_CUCountvsLS/Subdet/";
+			if (did.subdet() == HcalBarrel) {
+				ledHistName += "HB";
+			} else if (did.subdet() == HcalEndcap) {
+				ledHistName += "HE";
+			} else if (did.subdet() == HcalOuter) {
+				ledHistName += "HO";
+			} else if (did.subdet() == HcalForward) {
+				ledHistName += "HF";
+			}
+			bool ledSignalPresent = (ig.get(ledHistName)->getEntries() > 0);
 
 			if (ledSignalPresent)
 				vtmpflags[fLED]._state = flag::fBAD;

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -203,15 +203,19 @@ namespace hcaldqm
 				} else if (did.subdet() == HcalForward) {
 					ledHistName += "HF";
 				}
-				std::cout << "[debug] ledHistName = " << ledHistName << std::endl;
-				bool ledSignalPresent = (ig.get(ledHistName)->getEntries() > 0);
+				MonitorElement* ledHist = ig.get(ledHistName);
+				if (ledHist) {
+					bool ledSignalPresent = (ig.get(ledHistName)->getEntries() > 0);
 
-				if (ledSignalPresent)
-					vtmpflags[fLED]._state = flag::fBAD;
-				else
-					vtmpflags[fLED]._state = flag::fGOOD;
-			} else {
+					if (ledSignalPresent)
+						vtmpflags[fLED]._state = flag::fBAD;
+					else
+						vtmpflags[fLED]._state = flag::fGOOD;
+				} else {
 					vtmpflags[fLED]._state = flag::fNA;
+				}
+			} else {
+				vtmpflags[fLED]._state = flag::fNA;
 			}
 
 

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -192,22 +192,28 @@ namespace hcaldqm
 			else
 				vtmpflags[fUnknownIds]._state = flag::fGOOD;
 
-			std::string ledHistName = _subsystem + "/" + _taskname + "/LED_CUCountvsLS/Subdet/";
-			if (did.subdet() == HcalBarrel) {
-				ledHistName += "HB";
-			} else if (did.subdet() == HcalEndcap) {
-				ledHistName += "HE";
-			} else if (did.subdet() == HcalOuter) {
-				ledHistName += "HO";
-			} else if (did.subdet() == HcalForward) {
-				ledHistName += "HF";
-			}
-			bool ledSignalPresent = (ig.get(ledHistName)->getEntries() > 0);
+			if ((did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel)) {
+				std::string ledHistName = _subsystem + "/" + _taskname + "/LED_CUCountvsLS/Subdet/";
+				if (did.subdet() == HcalBarrel) {
+					ledHistName += "HB";
+				} else if (did.subdet() == HcalEndcap) {
+					ledHistName += "HE";
+				} else if (did.subdet() == HcalOuter) {
+					ledHistName += "HO";
+				} else if (did.subdet() == HcalForward) {
+					ledHistName += "HF";
+				}
+				std::cout << "[debug] ledHistName = " << ledHistName << std::endl;
+				bool ledSignalPresent = (ig.get(ledHistName)->getEntries() > 0);
 
-			if (ledSignalPresent)
-				vtmpflags[fLED]._state = flag::fBAD;
-			else
-				vtmpflags[fLED]._state = flag::fGOOD;
+				if (ledSignalPresent)
+					vtmpflags[fLED]._state = flag::fBAD;
+				else
+					vtmpflags[fLED]._state = flag::fGOOD;
+			} else {
+					vtmpflags[fLED]._state = flag::fNA;
+			}
+
 
 			// push all the flags for this crate
 			lssum._vflags.push_back(vtmpflags);

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -205,8 +205,7 @@ namespace hcaldqm
 				}
 				MonitorElement* ledHist = ig.get(ledHistName);
 				if (ledHist) {
-					bool ledSignalPresent = (ig.get(ledHistName)->getEntries() > 0);
-
+					bool ledSignalPresent = (ledHist->getEntries() > 0);
 					if (ledSignalPresent)
 						vtmpflags[fLED]._state = flag::fBAD;
 					else


### PR DESCRIPTION
10_2_X backport of https://github.com/cms-sw/cmssw/pull/24757.

Adds "LSmod60" versions of the bad capid and LED misfire vs LS plots, which only record the last 60 LSes. This is so that the error condition goes away after ~25 minutes, so the sound alarms don't keep triggering.