### PR TITLE
[10.3.X] CalibrationTrackSelectorFromDetIdList: clone hits only when building track

### DIFF
--- a/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorFromDetIdList.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorFromDetIdList.cc
@@ -46,7 +46,7 @@ private:
   void beginRun(edm::Run const& run, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
   edm::EDGetTokenT<reco::TrackCollection> m_label;
-  TrackCandidate makeCandidate(const reco::Track &tk, std::vector<std::unique_ptr<TrackingRecHit> >::iterator hitsBegin, std::vector<std::unique_ptr<TrackingRecHit> >::iterator hitsEnd);
+  TrackCandidate makeCandidate(const reco::Track &tk, std::vector<const TrackingRecHit*>::iterator hitsBegin, std::vector<const TrackingRecHit*>::iterator hitsEnd);
 
   std::vector<DetIdSelector> detidsels_;
   bool m_verbose;
@@ -82,19 +82,20 @@ void CalibrationTrackSelectorFromDetIdList::produce(edm::Event& iEvent, const ed
   using namespace edm;
   using namespace std;
 
-  edm::Handle<std::vector<reco::Track> > tracks;
-  iEvent.getByToken(m_label, tracks);
+  edm::Handle<std::vector<reco::Track> > trackCollectionHandle;
+  iEvent.getByToken(m_label, trackCollectionHandle);
+  auto const & tracks = *trackCollectionHandle;
+
   auto output = std::make_unique<TrackCandidateCollection>();
   
   // loop on tracks
-  for (std::vector<reco::Track>::const_iterator ittrk = tracks->begin(), edtrk = tracks->end(); ittrk != edtrk; ++ittrk) {
-    const reco::Track *trk = &(*ittrk);
+  for(auto &trk : tracks){
 
-    std::vector<std::unique_ptr<TrackingRecHit> > hits; 
+    std::vector<const TrackingRecHit*>  hits; 
    
     bool saveTrack(false);
 
-    for (trackingRecHit_iterator ith = trk->recHitsBegin(), edh = trk->recHitsEnd(); ith != edh; ++ith) {
+    for (trackingRecHit_iterator ith = trk.recHitsBegin(), edh = trk.recHitsEnd(); ith != edh; ++ith) {
       const TrackingRecHit * hit = (*ith); // ith is an iterator on edm::Ref to rechit
       DetId detid = hit->geographicalId();
       
@@ -107,12 +108,12 @@ void CalibrationTrackSelectorFromDetIdList::produce(edm::Event& iEvent, const ed
       }
 
       // here there will be the selection
-      hits.emplace_back(hit->clone());
+      hits.emplace_back(hit);
 
     }
 
     if(saveTrack){
-      output->push_back( makeCandidate ( *ittrk, hits.begin(), hits.end() ) );
+      output->push_back( makeCandidate (trk, hits.begin(), hits.end() ) );
     }
 
   }
@@ -120,7 +121,7 @@ void CalibrationTrackSelectorFromDetIdList::produce(edm::Event& iEvent, const ed
 }
 
 TrackCandidate
-CalibrationTrackSelectorFromDetIdList::makeCandidate(const reco::Track &tk, std::vector<std::unique_ptr<TrackingRecHit> >::iterator hitsBegin, std::vector<std::unique_ptr<TrackingRecHit> >::iterator hitsEnd) {
+CalibrationTrackSelectorFromDetIdList::makeCandidate(const reco::Track &tk, std::vector<const TrackingRecHit*>::iterator hitsBegin, std::vector<const TrackingRecHit*>::iterator hitsEnd) {
   
   PropagationDirection   pdir = tk.seedDirection();
   PTrajectoryStateOnDet state;
@@ -139,7 +140,7 @@ CalibrationTrackSelectorFromDetIdList::makeCandidate(const reco::Track &tk, std:
   TrackCandidate::RecHitContainer ownHits;
   ownHits.reserve(hitsEnd - hitsBegin);
   for ( ; hitsBegin != hitsEnd; ++hitsBegin) {
-    ownHits.push_back( hitsBegin->release() );
+    ownHits.push_back( (*hitsBegin)->clone() );
   }
 
   TrackCandidate cand(ownHits, seed, state, tk.seedRef());


### PR DESCRIPTION
Greetings,
in the review of #24626, it has been hinted in https://github.com/cms-sw/cmssw/pull/24626#discussion_r219674569 that in `CalibrationTrackSelectorFromDetIdList` it might be more efficient not to clone all hits for all the tracks and then let the unused hits to be deleted (by going out of scope), but instead to store them in a `std::vector<const TrackingRecHit*>`  and clone them later in
`CalibrationTrackSelectorFromDetIdList::makeCandidate` only when a track candidate is built.
This is what is proposed here. 
I checked that there is no memory penalty by re-ALCARECOeing 1000  `ExpressStream` 
events as I don't observe substantial deviations from the baseline. 

![memory2](https://user-images.githubusercontent.com/5082376/46221728-8883bb00-c34e-11e8-9340-c50425a4afc5.png)

