### PR TITLE
some quick damage control to uninitialized arrays and global statics in CastorDigiMonitor

### DIFF
--- a/DQM/CastorMonitor/src/CastorDigiMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorDigiMonitor.cc
@@ -207,7 +207,7 @@ void CastorDigiMonitor::processEvent(edm::Event const& event,
     return;
   }
 
-  float Ecell[14][16];
+  float Ecell[14][16] {};
   for (CastorDigiCollection::const_iterator j = castorDigis.begin();
        j != castorDigis.end(); j++) {
     const CastorDataFrame digi = (const CastorDataFrame)(*j);

--- a/DQM/CastorMonitor/src/CastorDigiMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorDigiMonitor.cc
@@ -24,12 +24,14 @@
 using namespace std;
 using namespace edm;
 
+namespace {
 vector<std::string> HltPaths_;
 int StatusBadChannel = 1;
-int ChannelStatus[14][16];
+int ChannelStatus[14][16] {};
 int N_GoodChannels = 224;
 int EtowerLastModule = 5;
 int TrigIndexMax = 0;
+}
 
 CastorDigiMonitor::CastorDigiMonitor(const edm::ParameterSet& ps) {
   fVerbosity = ps.getUntrackedParameter<int>("debug", 0);


### PR DESCRIPTION
I came across this when checking for random differences that recently appeared in CASTOR monitoring plots.

There should be a proper fix to the non-const statics. I have only made them local with a quick fix.