### PR TITLE
[10.3.X] customize Tracker Alignment X->mumu ALCARECOs for pp_on_AA eras

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_cff.py
@@ -50,3 +50,10 @@ ALCARECOTkAlJpsiMuMu.TwoBodyDecaySelector.acoplanarDistance = 1 ##radian
 ALCARECOTkAlJpsiMuMu.TwoBodyDecaySelector.numberOfCandidates = 1 	 
 
 seqALCARECOTkAlJpsiMuMu = cms.Sequence(ALCARECOTkAlJpsiMuMuHLT+ALCARECOTkAlJpsiMuMuDCSFilter+ALCARECOTkAlJpsiMuMuGoodMuons+ALCARECOTkAlJpsiMuMu)
+
+## customizations for the pp_on_AA eras
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(ALCARECOTkAlJpsiMuMuHLT,
+                                           eventSetupPathsKey='TkAlJpsiMuMuHI'
+                                           )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_cff.py
@@ -48,3 +48,15 @@ ALCARECOTkAlMuonIsolated.TwoBodyDecaySelector.applyChargeFilter = False
 ALCARECOTkAlMuonIsolated.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 
 seqALCARECOTkAlMuonIsolated = cms.Sequence(ALCARECOTkAlMuonIsolatedHLT+ALCARECOTkAlMuonIsolatedDCSFilter+ALCARECOTkAlMuonIsolatedGoodMuons+ALCARECOTkAlMuonIsolatedRelCombIsoMuons+ALCARECOTkAlMuonIsolated)
+
+
+## customizations for the pp_on_AA eras
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(ALCARECOTkAlMuonIsolatedHLT,
+                                           eventSetupPathsKey='TkAlMuonIsolatedHI'
+                                           )
+
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(ALCARECOTkAlMuonIsolated.GlobalSelector,
+                                           minJetDeltaR=0.0
+                                           )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
@@ -55,3 +55,10 @@ ALCARECOTkAlUpsilonMuMu.TwoBodyDecaySelector.acoplanarDistance = 1 ##radian
 ALCARECOTkAlUpsilonMuMu.TwoBodyDecaySelector.numberOfCandidates = 1	 
 
 seqALCARECOTkAlUpsilonMuMu = cms.Sequence(ALCARECOTkAlUpsilonMuMuHLT+ALCARECOTkAlUpsilonMuMuDCSFilter+ALCARECOTkAlUpsilonMuMuGoodMuons+ALCARECOTkAlUpsilonMuMuRelCombIsoMuons+ALCARECOTkAlUpsilonMuMu)
+
+## customizations for the pp_on_AA eras
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(ALCARECOTkAlUpsilonMuMuHLT,
+                                           eventSetupPathsKey='TkAlUpsilonMuMuHI'
+                                           )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
@@ -52,3 +52,10 @@ ALCARECOTkAlZMuMu.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 ALCARECOTkAlZMuMu.TwoBodyDecaySelector.numberOfCandidates = 1
 
 seqALCARECOTkAlZMuMu = cms.Sequence(ALCARECOTkAlZMuMuHLT+ALCARECOTkAlZMuMuDCSFilter+ALCARECOTkAlZMuMuGoodMuons+ALCARECOTkAlZMuMuRelCombIsoMuons+ALCARECOTkAlZMuMu)
+
+## customizations for the pp_on_AA eras
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(ALCARECOTkAlZMuMuHLT,
+                                           eventSetupPathsKey='TkAlZMuMuHI'
+                                           )


### PR DESCRIPTION
Follow-up PR of #24596, this time for the muon Tracker Alignment ALCARECO producers configurations.
In this PR, era modifiers are used to change parameters for the `pp_on_AA_2018` and `pp_on_XeXe_2017` eras such that the pp-flavored ALCARECO producer is configured as if it was the corresponding HI one.
The main change involves `ALCARECOTkAlMuonIsolated` for which the isolation parameter `ALCARECOTkAlMuonIsolated.GlobalSelector.minJetDeltaR` is set to zero.
I also profited to change the `eventSetupPathKey` to point to the HI-flavored one as we don't want to pollute the regular pp keys with HI trigger paths.
@connorpa @hroskes 
