### PR TITLE
Replaced BOOST_STATIC_ASSERT with static_assert keyword

### DIFF
--- a/CommonTools/UtilAlgos/interface/SelectionAdderTrait.h
+++ b/CommonTools/UtilAlgos/interface/SelectionAdderTrait.h
@@ -11,7 +11,6 @@
 #include "DataFormats/Common/interface/RefToBaseProd.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/Common/interface/AssociationVector.h"
-#include <boost/static_assert.hpp>
 
 namespace helper {
 
@@ -79,7 +78,7 @@ namespace helper {
 
   template<typename InputCollection, typename StoreContainer>
   struct SelectionAdderTrait {
-    BOOST_STATIC_ASSERT(sizeof(InputCollection) == 0); 
+    static_assert(sizeof(InputCollection) == 0); 
   };
 
   template<typename InputCollection, typename T>

--- a/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
+++ b/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
@@ -13,7 +13,6 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include <memory>
-#include "boost/static_assert.hpp"
 #include "boost/type_traits.hpp"
 
 namespace helper {

--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -393,8 +393,8 @@ namespace eos {
 			// after reading the note above you still might decide to 
 			// deactivate this static assert and try if it works out.
 			typename traits::bits bits;
-			BOOST_STATIC_ASSERT(sizeof(bits) == sizeof(T));
-			BOOST_STATIC_ASSERT(std::numeric_limits<T>::is_iec559);
+			static_assert(sizeof(bits) == sizeof(T));
+			static_assert(std::numeric_limits<T>::is_iec559);
 
 			load(bits);
 			traits::set_bits(t, bits);

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -388,8 +388,8 @@ namespace eos {
 			// after reading the note above you still might decide to 
 			// deactivate this static assert and try if it works out.
 			typename traits::bits bits;
-			BOOST_STATIC_ASSERT(sizeof(bits) == sizeof(T));
-			BOOST_STATIC_ASSERT(std::numeric_limits<T>::is_iec559);
+			static_assert(sizeof(bits) == sizeof(T));
+			static_assert(std::numeric_limits<T>::is_iec559);
 
 			// examine value closely
 			switch (fp::fpclassify(t))

--- a/DataFormats/BTauReco/interface/TaggingVariable.h
+++ b/DataFormats/BTauReco/interface/TaggingVariable.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include <string>
 
-#include <boost/static_assert.hpp>
 #include <boost/pointee.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
@@ -209,7 +208,7 @@ namespace reco {
     // [begin, end) must identify a valid range of iterators to TaggingVariableList
     template <typename InputIterator>
     TaggingVariableList( const InputIterator begin, const InputIterator end ) : m_list() {
-      BOOST_STATIC_ASSERT(( boost::is_convertible< const TaggingVariableList, typename boost::pointee<InputIterator>::type >::value ));
+      static_assert(( boost::is_convertible< const TaggingVariableList, typename boost::pointee<InputIterator>::type >::value ));
       for (const InputIterator i = begin; i != end; i++)
         insert(*i);
     }

--- a/PhysicsTools/UtilAlgos/interface/SelectionAdderTrait.h
+++ b/PhysicsTools/UtilAlgos/interface/SelectionAdderTrait.h
@@ -11,7 +11,6 @@
 #include "DataFormats/Common/interface/RefToBaseProd.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/Common/interface/AssociationVector.h"
-#include <boost/static_assert.hpp>
 
 namespace helper {
 
@@ -79,7 +78,7 @@ namespace helper {
 
   template<typename InputCollection, typename StoreContainer>
   struct SelectionAdderTrait {
-    BOOST_STATIC_ASSERT(sizeof(InputCollection) == 0); 
+    static_assert(sizeof(InputCollection) == 0); 
   };
 
   template<typename InputCollection, typename T>

--- a/PhysicsTools/Utilities/interface/Fraction.h
+++ b/PhysicsTools/Utilities/interface/Fraction.h
@@ -10,7 +10,7 @@ namespace funct {
 
   template<int n, int m>
   struct FractionStruct { 
-    BOOST_STATIC_ASSERT(m != 0);
+    static_assert(m != 0);
     static const int numerator = n, denominator = m;
     double operator()() const { return double(n) / double (m); }
     operator double() const { return double(n) / double (m); }

--- a/PhysicsTools/Utilities/interface/RooFitFunction.h
+++ b/PhysicsTools/Utilities/interface/RooFitFunction.h
@@ -5,7 +5,6 @@
 #include "RooRealProxy.h"
 #include "RooAbsReal.h"
 #include <vector>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits.hpp>
 #include <iostream>
 namespace root {

--- a/PhysicsTools/Utilities/interface/Sum.h
+++ b/PhysicsTools/Utilities/interface/Sum.h
@@ -1,7 +1,6 @@
 #ifndef PhysicsTools_Utilities_Sum_h
 #define PhysicsTools_Utilities_Sum_h
 #include "PhysicsTools/Utilities/interface/Numerical.h"
-#include <boost/static_assert.hpp>
 
 namespace funct {
   template<typename A, typename B>

--- a/PhysicsTools/Utilities/test/testSimplifications.cc
+++ b/PhysicsTools/Utilities/test/testSimplifications.cc
@@ -21,54 +21,54 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testSimplifications);
 void testSimplifications::checkAll() {
   using namespace funct;
   using namespace boost;
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Sum<Numerical<2>, Numerical<3> >::type, 
 		       Numerical<5>
 		       >::value));
   
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Difference<Numerical<2>, Numerical<3> >::type, 
 		       Numerical<-1>
 		       >::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Product<Numerical<2>, Numerical<3> >::type, 
 		       Numerical<6>
 		       >::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Minus<Numerical<6> >::type, 
 		       Numerical<-6>
 		       >::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Fraction<2,4>::type,
 		       Fraction<1,2>::type
 		       >::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Fraction<-1,2>::type,
 		       Fraction<1,-2>::type
 		       >::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Fraction<4,2>::type,
 		       Numerical<2>
 		       >::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Fraction<3,4>::type,
 		       Fraction<21,28>::type
 		       >::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Fraction<3,1>::type,
 		       Numerical<3>
 		       >::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((is_same<
 		       Product<Minus<X>::type, Minus<Y>::type>::type,
 		       Product<X, Y>::type
 		       >::value));
-  BOOST_STATIC_ASSERT((!Parametric<Power<X, Y>::type>::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((!Parametric<Power<X, Y>::type>::value));
+  static_assert((is_same<
 		       Product<Power<X, Y>::type, Power<X, Z>::type>::type,
 		       Power<X, Sum<Y, Z>::type>::type
 		       >::value));
-  BOOST_STATIC_ASSERT((!Parametric<Ratio<Sin<X>::type, Cos<X>::type>::type>::value));
-  BOOST_STATIC_ASSERT((is_same<
+  static_assert((!Parametric<Ratio<Sin<X>::type, Cos<X>::type>::type>::value));
+  static_assert((is_same<
 		       Ratio<Sin<X>::type, Cos<X>::type>::type,
 		       Tan<X>::type
 		       >::value));

--- a/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h
@@ -15,7 +15,7 @@ template <typename ConcreteJetTagComputer>
 class JetTagComputerESProducer: public edm::ESProducer {
 private:
   // check that the template parameter inherits from JetTagComputer
-  BOOST_STATIC_ASSERT((boost::is_convertible<ConcreteJetTagComputer*,JetTagComputer*>::value));
+  static_assert((boost::is_convertible<ConcreteJetTagComputer*,JetTagComputer*>::value));
   
 public:
   JetTagComputerESProducer(const edm::ParameterSet & pset) : m_pset(pset) {

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -23,7 +23,6 @@
 #include <boost/mem_fn.hpp>
 
 #include <boost/type_traits/is_base_of.hpp>
-#include <boost/static_assert.hpp>
 
 namespace reco { namespace tau {
 
@@ -75,7 +74,7 @@ RefVectorType castView(const edm::Handle<BaseView>& view) {
   typedef typename RefVectorType::value_type OutputRef;
   // Double check at compile time that the inheritance is okay.  It can still
   // fail at runtime if you pass it the wrong collection.
-  BOOST_STATIC_ASSERT(
+  static_assert(
       (boost::is_base_of<typename BaseView::value_type,
                          typename RefVectorType::member_type>::value));
   RefVectorType output;


### PR DESCRIPTION
Hi, I was playing around a bit with replacing things in the codebase using regular expressions.

As a first try, I replaced all occurrences of the obsolete `BOOST_STATIC_ASSERT` with the `static_assert` keyword which exists since C++11.

I'll come up with more exciting easy replacements that might actually speed the code up in the future.