### PR TITLE
enable PF HEM mitigation for HI 2018 and add Run2_2018_pp_on_AA_noHCALmitigation era

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pf_badHcalMitigation_cff import pf_badHcalMitigation
 
-Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018, pp_on_AA_2018)
+Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018, pp_on_AA_2018, pf_badHcalMitigation)

--- a/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_noHCALmitigation_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_noHCALmitigation_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
+from Configuration.Eras.Modifier_pf_badHcalMitigation_cff import pf_badHcalMitigation
+
+Run2_2018_pp_on_AA_noHCALmitigation = cms.ModifierChain(Run2_2018_pp_on_AA.copyAndExclude([pf_badHcalMitigation]))

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -28,6 +28,7 @@ class Eras (object):
                  'Run2_2017_ppRef',
                  'Run2_2018',
                  'Run2_2018_pp_on_AA',
+                 'Run2_2018_pp_on_AA_noHCALmitigation',
                  'Run2_2018_highBetaStar',
                  'Run3',
                  'Phase2',


### PR DESCRIPTION
- current default era for 2018 HI processing Run2_2018_pp_on_AA now has the PF bad HCAL mitigation enabled
- to perform tests for comparisons without the mitigation, a new era Run2_2018_pp_on_AA_noHCALmitigation is introduced

@franzoni this is a follow up to your request by email to have two eras for the 2018 HI.

@mandrenguyen 