### PR TITLE
Small bugfix in HCAL peds+ped.widths DB objects names (HcalTextCalibrations input) 

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -226,14 +226,14 @@ std::unique_ptr<HcalPedestals> HcalTextCalibrations::produceEffectivePedestals (
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  return get_impl_topo<HcalPedestals> (mInputs ["PedestalsEffective"],topo);
+  return get_impl_topo<HcalPedestals> (mInputs ["EffectivePedestals"],topo);
 }
 
 std::unique_ptr<HcalPedestalWidths> HcalTextCalibrations::produceEffectivePedestalWidths (const HcalPedestalWidthsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return get_impl_topo<HcalPedestalWidths> (mInputs ["PedestalWidthsEffective"],topo);
+  return get_impl_topo<HcalPedestalWidths> (mInputs ["EffectivePedestalWidths"],topo);
 }
 
 std::unique_ptr<HcalGains> HcalTextCalibrations::produceGains (const HcalGainsRcd& rcd) {


### PR DESCRIPTION
Discrepancy in DB object names of "effective" (i) pedestals and (ii) ped.widths  
didn't allow for reading these conditions from txt files. Now fixed.  