### PR TITLE
skip getting event auxiliary if duplicate checker is disabled

### DIFF
--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1689,7 +1689,7 @@ namespace edm {
   RootFile::initializeDuplicateChecker(
     std::vector<std::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
     std::vector<std::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile) {
-    if(duplicateChecker_) {
+    if(duplicateChecker_ && !duplicateChecker_->checkDisabled()) {
       if(eventTree_.next()) {
         fillThisEventAuxiliary();
         duplicateChecker_->inputFileOpened(eventAux().isRealData(),


### PR DESCRIPTION
RootFile::initializeDuplicateChecker() calls fillThisEventAuxiliary() even if checking for duplicates is disabled.  We've observed that this can lead to the EventTree TTreeCache prefetching the entire EventAuxiliary branch, reading records scattered throughout the entire file.  This PR skips all duplicate checker initialization if checking is disabled.  DuplicateChecker::inputFileOpened() is a no-op if duplicate checking is disabled, so this change should be safe.  Partially addresses issue #24780