### PR TITLE
Bugfix on FPix online clusters position maps (backport of #24770)

### DIFF
--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -388,8 +388,8 @@ void SiPixelPhase1Summary::fillTrendPlots(DQMStore::IBooker & iBooker, DQMStore:
       toReset->Reset();
     }
   }
-  for (auto it : {-3,-2,-1,1,2,3}){ //PXForward
-    histName = "PixelPhase1/Phase1_MechanicalView/PXForward/clusterposition_xy_PXDisk_" + std::to_string(it);
+  for (auto it : {"-3","-2","-1","+1","+2","+3"}){ //PXForward
+    histName = "PixelPhase1/Phase1_MechanicalView/PXForward/clusterposition_xy_PXDisk_" + std::string(it);
     MonitorElement * toReset = iGetter.get(histName);
     if (toReset!=nullptr) {
       toReset->Reset();


### PR DESCRIPTION
Fix to bug which prevent FPix clusters position maps on plus side to be reset every 10LS. Backport of #24770 