### PR TITLE
Replaced BOOST_FOREACH in RecoTauTag_RecoTau

### DIFF
--- a/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
@@ -1,15 +1,13 @@
 #ifndef RecoTauTag_RecoTau_RecoTauCrossCleaning_h
 #define RecoTauTag_RecoTau_RecoTauCrossCleaning_h
 
-#include <boost/foreach.hpp>
-
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 #include "CommonTools/CandUtils/interface/AddFourMomenta.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
 #include "DataFormats/Candidate/interface/CompositePtrCandidate.h"
 
-namespace reco { namespace tau { namespace xclean {
+namespace reco::tau::xclean {
 
 /// Transform a pizero to remove given candidates
 template<typename PtrIter>
@@ -37,7 +35,7 @@ class CrossCleanPiZeros
   {
     PiZeroList output;
     output.reserve(input.size());
-    BOOST_FOREACH( const RecoTauPiZero& piZero, input ) {
+    for(auto const& piZero : input ) {
       const RecoTauPiZero::daughters& daughters = piZero.daughterPtrVector();
       std::set<reco::CandidatePtr> toCheck(daughters.begin(), daughters.end());
       std::vector<reco::CandidatePtr> cleanDaughters;
@@ -50,7 +48,7 @@ class CrossCleanPiZeros
 	RecoTauPiZero newPiZero = piZero;
 	newPiZero.clearDaughters();
 	// Add our cleaned daughters.
-	BOOST_FOREACH( const reco::CandidatePtr& ptr, cleanDaughters ) {
+	for(auto const& ptr : cleanDaughters ) {
 	  newPiZero.addDaughter(ptr);
 	}
 	// Check if the pizero is not empty.  If empty, forget it.
@@ -134,6 +132,6 @@ PredicateAND<P1, P2> makePredicateAND(const P1& p1, const P2& p2) {
   return PredicateAND<P1, P2>(p1, p2);
 }
 
-}}}
+}
 
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
@@ -19,9 +19,6 @@
  *
  */
 
-#include <boost/function.hpp>
-#include <boost/foreach.hpp>
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
@@ -29,15 +26,17 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+#include <functional>
+
 namespace reco { namespace tau {
 
 class RecoTauQualityCuts 
 {
  public:
   // Quality cut types
-  typedef boost::function<bool (const TrackBaseRef&)> TrackQCutFunc;  
+  typedef std::function<bool (const TrackBaseRef&)> TrackQCutFunc;  
   typedef std::vector<TrackQCutFunc> TrackQCutFuncCollection;
-  typedef boost::function<bool (const PFCandidate&)> CandQCutFunc;  
+  typedef std::function<bool (const PFCandidate&)> CandQCutFunc;  
   typedef std::vector<CandQCutFunc> CandQCutFuncCollection;
   typedef std::map<PFCandidate::ParticleType, CandQCutFuncCollection> CandQCutFuncMap;
   
@@ -63,7 +62,7 @@ class RecoTauQualityCuts
   Coll filterTracks(const Coll& coll, bool invert = false) const 
   {
     Coll output;
-    BOOST_FOREACH( const typename Coll::value_type track, coll ) {
+    for(auto const& track : coll ) {
       if ( filterTrack(track)^invert ) output.push_back(track);
     }
     return output;
@@ -81,7 +80,7 @@ class RecoTauQualityCuts
   Coll filterCandRefs(const Coll& refcoll, bool invert = false) const 
   {
     Coll output;
-    BOOST_FOREACH( const typename Coll::value_type cand, refcoll ) {
+    for(auto const& cand : refcoll ) {
       if ( filterCandRef(cand)^invert ) output.push_back(cand);
     }
     return output;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -125,7 +125,7 @@ PFRecoTauChargedHadronProducer::PFRecoTauChargedHadronProducer(const edm::Parame
   // check if we want to apply a final output selection
   if ( cfg.exists("outputSelection") ) {
     std::string selection = cfg.getParameter<std::string>("outputSelection");
-    if ( selection != "" ) {
+    if ( !selection.empty() ) {
       outputSelector_.reset(new StringCutObjectSelector<reco::PFRecoTauChargedHadron>(selection));
     }
   }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -39,7 +39,6 @@
 
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/ptr_container/ptr_list.hpp>
-#include <boost/foreach.hpp>
 
 #include <string>
 #include <vector>
@@ -142,7 +141,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
   }
 
   // give each of our plugins a chance at doing something with the edm::Event
-  BOOST_FOREACH( Builder& builder, builders_ ) {
+  for(auto& builder : builders_ ) {
     builder.setup(evt, es);
   }
   
@@ -166,7 +165,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
   }
 
   // loop over our jets
-  BOOST_FOREACH( const reco::PFJetRef& pfJet, pfJets ) {
+  for(auto const& pfJet : pfJets ) {
     
     if(pfJet->pt() - minJetPt_ < 1e-5) continue;
     if(std::abs(pfJet->eta()) - maxJetAbsEta_ > -1e-5) continue;
@@ -175,7 +174,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
     ChargedHadronList uncleanedChargedHadrons;
 
     // merge candidates reconstructed by all desired algorithm plugins
-    BOOST_FOREACH( const Builder& builder, builders_ ) {
+    for(auto const& builder : builders_ ) {
       try {
         ChargedHadronVector result(builder(*pfJet));
 	if ( verbosity_ ) {
@@ -273,7 +272,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
 	cleanedChargedHadrons.push_back(*nextChargedHadron);
       } else { // remove overlapping neutral PFCandidates, reevaluate ranking criterion and process ChargedHadron candidate again
 	nextChargedHadron->neutralPFCandidates_.clear();
-	BOOST_FOREACH( const reco::PFCandidatePtr& neutralPFCand, uniqueNeutralPFCands ) {
+    for(auto const& neutralPFCand : uniqueNeutralPFCands ) {
           nextChargedHadron->neutralPFCandidates_.push_back(neutralPFCand);
         }
 	// update ChargedHadron four-momentum

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
@@ -1,5 +1,3 @@
-#include <boost/foreach.hpp>
-
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -70,7 +68,7 @@ PFRecoTauDiscriminationByHPSSelection::PFRecoTauDiscriminationByHPSSelection(con
   // Get the mass cuts for each decay mode
   typedef std::vector<edm::ParameterSet> VPSet;
   const VPSet& decayModes = pset.getParameter<VPSet>("decayModes");
-  BOOST_FOREACH( const edm::ParameterSet &decayMode, decayModes ) {
+  for(auto const& decayMode : decayModes ) {
     // The mass window(s)
     DecayModeCuts cuts;
     if ( decayMode.exists("nTracksMin") ) {
@@ -200,16 +198,14 @@ PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef& tau) c
   }
   // Find the total pizero p4
   reco::Candidate::LorentzVector stripsP4;
-  BOOST_FOREACH(const reco::RecoTauPiZero& cand, 
-      tau->signalPiZeroCandidates()){
+  for(auto const& cand : tau->signalPiZeroCandidates()){
     const math::XYZTLorentzVector& candP4 = cand.p4();
     stripsP4 += candP4;
   }
 
   // Apply strip mass assumption corrections
   if (massWindow.assumeStripMass_ >= 0) {
-    BOOST_FOREACH(const reco::RecoTauPiZero& cand, 
-        tau->signalPiZeroCandidates()){
+    for(auto const& cand : tau->signalPiZeroCandidates()){
       const math::XYZTLorentzVector& uncorrected = cand.p4();
       math::XYZTLorentzVector corrected = 
         applyMassConstraint(uncorrected, massWindow.assumeStripMass_);
@@ -297,7 +293,7 @@ PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef& tau) c
   }
 
   if ( requireTauChargedHadronsToBeChargedPFCands_ ) {
-    BOOST_FOREACH(const reco::PFRecoTauChargedHadron& cand, tau->signalTauChargedHadronCandidates()) {
+    for(auto const& cand : tau->signalTauChargedHadronCandidates()) {
       if ( verbosity_ ) {
 	std::string algo_string;
 	if      ( cand.algo() == reco::PFRecoTauChargedHadron::kChargedPFCandidate ) algo_string = "ChargedPFCandidate";

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByInvMass.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByInvMass.cc
@@ -1,5 +1,3 @@
-#include <boost/foreach.hpp>
-
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -25,7 +23,7 @@ class PFRecoTauDiscriminationByInvMass: public PFTauDiscriminationProducerBase {
         // Get decay mode specific cuts
         std::vector<std::string> decayModeCutNames =
             select.getParameterNamesForType<edm::ParameterSet>();
-        BOOST_FOREACH(const std::string& dmName, decayModeCutNames) {
+        for(auto const& dmName : decayModeCutNames) {
           const edm::ParameterSet &dmPSet =
               select.getParameter<edm::ParameterSet>(dmName);
           unsigned int nCharged = dmPSet.getParameter<unsigned int>("charged");

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
@@ -2,7 +2,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h"
-#include <boost/foreach.hpp>
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 /* class PFRecoTauDiscriminationByNProngs
@@ -59,7 +58,7 @@ double PFRecoTauDiscriminationByNProngs::discriminate(const PFTauRef& tau) const
 	    qcuts_->setPV(pv);
 	    qcuts_->setLeadTrack(tau->leadPFChargedHadrCand());
 
-	    BOOST_FOREACH( const reco::PFCandidatePtr& cand, tau->signalPFChargedHadrCands() ) {
+	    for(auto const& cand : tau->signalPFChargedHadrCands() ) {
 	        if ( qcuts_->filterCandRef(cand) ) np++;
  	    }
 	}

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -47,7 +47,6 @@
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include <memory>
-#include <boost/foreach.hpp>
 #include <TFormula.h>
 
 #include <memory>
@@ -117,7 +116,7 @@ PFTauPrimaryVertexProducer::PFTauPrimaryVertexProducer(const edm::ParameterSet& 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   std::vector<edm::ParameterSet> discriminators =iConfig.getParameter<std::vector<edm::ParameterSet> >("discriminators");
   // Build each of our cuts
-  BOOST_FOREACH(const edm::ParameterSet &pset, discriminators) {
+  for(auto const& pset : discriminators) {
     DiscCutPair* newCut = new DiscCutPair();
     newCut->inputToken_ =consumes<reco::PFTauDiscriminator>(pset.getParameter<edm::InputTag>("discriminator"));
 
@@ -162,7 +161,7 @@ void PFTauPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetu
   reco::VertexRefProd VertexRefProd_out = iEvent.getRefBeforePut<reco::VertexCollection>("PFTauPrimaryVertices");
 
   // Load each discriminator
-  BOOST_FOREACH(DiscCutPair *disc, discriminators_) {
+  for(auto& disc : discriminators_) {
     edm::Handle<reco::PFTauDiscriminator> discr;
     iEvent.getByToken(disc->inputToken_, discr);
     disc->discr_ = &(*discr);
@@ -186,7 +185,7 @@ void PFTauPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetu
       ///////////////////////
       // Check if it passed all the discrimiantors
       bool passed(true); 
-      BOOST_FOREACH(const DiscCutPair* disc, discriminators_) {
+      for(auto const& disc : discriminators_) {
         // Check this discriminator passes
 	bool passedDisc = true;
 	if ( disc->cutFormula_ )passedDisc = (disc->cutFormula_->Eval((*disc->discr_)[tau]) > 0.5);

--- a/RecoTauTag/RecoTau/plugins/PFTauViewRefMerger.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauViewRefMerger.cc
@@ -7,7 +7,6 @@
  * Author: Evan K. Friis
  *
  */
-#include <boost/foreach.hpp>
 
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
@@ -28,13 +27,13 @@ class PFTauViewRefMerger : public edm::EDProducer {
   private:
     void produce(edm::Event & evt, const edm::EventSetup &) override {
       auto out = std::make_unique<reco::PFTauRefVector>();
-      BOOST_FOREACH(const edm::InputTag& inputSrc, src_) {
+      for(auto const& inputSrc : src_) {
         edm::Handle<reco::CandidateView> src;
         evt.getByLabel(inputSrc, src);
         reco::PFTauRefVector inputRefs =
             reco::tau::castView<reco::PFTauRefVector>(src);
         // Merge all the collections
-        BOOST_FOREACH(const reco::PFTauRef tau, inputRefs) {
+        for(auto const& tau : inputRefs) {
           out->push_back(tau);
         }
       }

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -113,7 +113,7 @@ namespace xclean
   template<>
   inline void CrossCleanPtrs<PiZeroList::const_iterator>::initialize(const PiZeroList::const_iterator& piZerosBegin, const PiZeroList::const_iterator& piZerosEnd) 
   {
-    BOOST_FOREACH( const PFCandidatePtr &ptr, flattenPiZeros(piZerosBegin, piZerosEnd) ) {
+    for(auto const& ptr : flattenPiZeros(piZerosBegin, piZerosEnd) ) {
       toRemove_.insert(CandidatePtr(ptr));
     }
   }
@@ -297,7 +297,7 @@ RecoTauBuilderCombinatoricPlugin::operator()(
 	  toRemove.insert(signalPiZero->daughterPtrVector().begin(), signalPiZero->daughterPtrVector().end());
 	}
 	PiZeroList cleanIsolationPiZeros;
-	BOOST_FOREACH( const RecoTauPiZero& precleanedPiZero, precleanedIsolationPiZeros ) {	  
+	for(auto const& precleanedPiZero : precleanedIsolationPiZeros ) {
 	  std::set<reco::CandidatePtr> toCheck(precleanedPiZero.daughterPtrVector().begin(), precleanedPiZero.daughterPtrVector().end());
 	  std::vector<reco::CandidatePtr> cleanDaughters;
 	  std::set_difference(toCheck.begin(), toCheck.end(), toRemove.begin(), toRemove.end(), std::back_inserter(cleanDaughters));

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -118,7 +118,7 @@ namespace xclean
   template<>
   inline void CrossCleanPtrs<PiZeroList::const_iterator>::initialize(const PiZeroList::const_iterator& piZerosBegin, const PiZeroList::const_iterator& piZerosEnd) 
   {
-    BOOST_FOREACH( const PFCandidatePtr &ptr, flattenPiZeros(piZerosBegin, piZerosEnd) ) {
+    for(auto const& ptr : flattenPiZeros(piZerosBegin, piZerosEnd) ) {
       toRemove_.insert(CandidatePtr(ptr));
     }
   }

--- a/RecoTauTag/RecoTau/plugins/RecoTauDecayModeCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDecayModeCutMultiplexer.cc
@@ -1,4 +1,3 @@
-#include <boost/foreach.hpp>
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -27,7 +26,7 @@ RecoTauDecayModeCutMultiplexer::RecoTauDecayModeCutMultiplexer(
   typedef std::vector<edm::ParameterSet> VPSet;
   const VPSet& decayModes = pset.getParameter<VPSet>("decayModes");
   // Setup our cut map
-  BOOST_FOREACH(const edm::ParameterSet &dm, decayModes) {
+  for(auto const& dm : decayModes) {
     // Get the mass window for each decay mode
     decayModeCuts_.insert(std::make_pair(
             // The decay mode as a key

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantFromDiscriminator.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantFromDiscriminator.cc
@@ -8,13 +8,12 @@
  *
  */
 
-#include <boost/foreach.hpp>
 #include <sstream>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauDiscriminantPlugins.h"
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
 
-namespace reco { namespace tau {
+namespace reco::tau {
 
 class RecoTauDiscriminantFromDiscriminator : public RecoTauDiscriminantPlugin{
   public:
@@ -48,7 +47,7 @@ RecoTauDiscriminantFromDiscriminator::RecoTauDiscriminantFromDiscriminator(
     // class might be dealing with multiple tau collections (training)
     std::vector<edm::InputTag> discriminators =
       pset.getParameter<std::vector<edm::InputTag> >("discSrc");
-    BOOST_FOREACH(const edm::InputTag& tag, discriminators) {
+    for(auto const& tag : discriminators) {
       discriminators_.push_back(std::make_pair(
             tag, edm::Handle<reco::PFTauDiscriminator>()));
     }
@@ -57,7 +56,7 @@ RecoTauDiscriminantFromDiscriminator::RecoTauDiscriminantFromDiscriminator(
 
 // Called by base class at the beginning of every event
 void RecoTauDiscriminantFromDiscriminator::beginEvent() {
-  BOOST_FOREACH(DiscInfo& discInfo, discriminators_) {
+  for(auto& discInfo : discriminators_) {
     evt()->getByLabel(discInfo.first, discInfo.second);
   }
 }
@@ -100,7 +99,7 @@ std::vector<double> RecoTauDiscriminantFromDiscriminator::operator()(
   return std::vector<double>(1, result);
 }
 
-}} // end namespace reco::tau
+} // end namespace reco::tau
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauDiscriminantPluginFactory,

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantInvariantWidth.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantInvariantWidth.cc
@@ -8,15 +8,15 @@
  *
  */
 
-#include <boost/foreach.hpp>
 #include "RecoTauTag/RecoTau/interface/RecoTauDiscriminantPlugins.h"
 #include "RecoTauTag/RecoTau/interface/PFTauDecayModeTools.h"
 #include "DataFormats/Math/interface/deltaR.h"
-#include <TFormula.h>
 #include "RecoTauTag/RecoTau/interface/RecoTauDiscriminantFunctions.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-namespace reco { namespace tau {
+#include <TFormula.h>
+
+namespace reco::tau {
 
 class RecoTauDiscriminantInvariantWidth : public RecoTauDiscriminantPlugin {
   public:
@@ -36,8 +36,7 @@ RecoTauDiscriminantInvariantWidth::RecoTauDiscriminantInvariantWidth(
     const edm::ParameterSet& pset):RecoTauDiscriminantPlugin(pset) {
   typedef std::vector<edm::ParameterSet> VPSet;
   // Add each of the transformations
-  BOOST_FOREACH(const edm::ParameterSet& dm,
-      pset.getParameter<VPSet>("decayModes")) {
+  for(auto const& dm : pset.getParameter<VPSet>("decayModes")) {
     uint32_t nCharged = dm.getParameter<uint32_t>("nCharged");
     uint32_t nPiZeros = dm.getParameter<uint32_t>("nPiZeros");
     MeanAndWidthFuncs functions;
@@ -74,7 +73,7 @@ std::vector<double> RecoTauDiscriminantInvariantWidth::operator()(
   return std::vector<double>(1, result);
 }
 
-}} // end namespace reco::tau
+} // end namespace reco::tau
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauDiscriminantPluginFactory,

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminationByFlight.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminationByFlight.cc
@@ -1,4 +1,3 @@
-#include <boost/foreach.hpp>
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -58,7 +57,7 @@ double PFRecoTauDiscriminationByFlight::discriminate(
     tau->signalPFChargedHadrCands();
   std::vector<reco::TransientTrack> signalTransTracks;
   std::vector<reco::TrackRef> signalTrackPtrs;
-  BOOST_FOREACH(const reco::PFCandidatePtr& pftrack, signalTracks) {
+  for(auto const& pftrack : signalTracks) {
     if (pftrack->trackRef().isNonnull()) {
       signalTransTracks.push_back(
           builder_->build(pftrack->trackRef()));
@@ -86,7 +85,7 @@ double PFRecoTauDiscriminationByFlight::discriminate(
     if (uniquePVTracks.size() != pvTrackRefs.size()) {
       std::vector<reco::TransientTrack> pvTransTracks;
       // Build all our unique transient tracks in the PV
-      BOOST_FOREACH(const reco::TrackRef& track, pvTrackRefs) {
+      for(auto const& track : pvTrackRefs) {
         pvTransTracks.push_back(builder_->build(track));
       }
       // Refit our PV

--- a/RecoTauTag/RecoTau/plugins/RecoTauIsolationDiscriminantPlugins.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauIsolationDiscriminantPlugins.cc
@@ -1,8 +1,7 @@
-#include <boost/foreach.hpp>
 #include "RecoTauTag/RecoTau/interface/RecoTauBinnedIsolationPlugin.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauIsolationMasking.h"
 
-namespace reco { namespace tau {
+namespace reco::tau {
 
 template<class Extractor>
 class RecoTauDiscriminationBinnedIsolationImpl
@@ -18,7 +17,7 @@ class RecoTauDiscriminationBinnedIsolationImpl
     Extractor extractor_;
 };
 
-}} // end namespace reco::tau
+} // end namespace reco::tau
 
 
 // Methods to get the right kind of canddiates
@@ -49,7 +48,7 @@ class MaskedECALExtractor {
       reco::tau::RecoTauIsolationMasking::IsoMaskResult
         result = mask_.mask(*tau);
       output.reserve(result.gammas.size());
-      BOOST_FOREACH(const reco::PFCandidatePtr gamma, result.gammas) {
+      for(auto const& gamma : result.gammas) {
         output.push_back(gamma);
       }
       return output;
@@ -75,7 +74,7 @@ class MaskedHCALExtractor {
       reco::tau::RecoTauIsolationMasking::IsoMaskResult
         result = mask_.mask(*tau);
       output.reserve(result.h0s.size());
-      BOOST_FOREACH(const reco::PFCandidatePtr h0, result.h0s) {
+      for(auto const& h0 : result.h0s) {
         output.push_back(h0);
       }
       return output;

--- a/RecoTauTag/RecoTau/plugins/RecoTauMVATransform.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauMVATransform.cc
@@ -8,7 +8,6 @@
  * ============================================================================
  */
 
-#include <boost/foreach.hpp>
 #include <boost/ptr_container/ptr_map.hpp>
 #include <memory>
 
@@ -66,7 +65,7 @@ RecoTauMVATransform::RecoTauMVATransform(const edm::ParameterSet& pset)
   typedef std::vector<edm::ParameterSet> VPSet;
   const VPSet& transforms = pset.getParameter<VPSet>("transforms");
   prediscriminantFailValue_ = -2.0;
-  BOOST_FOREACH(const edm::ParameterSet &transform, transforms) {
+  for(auto const& transform : transforms) {
     unsigned int nCharged = transform.getParameter<unsigned int>("nCharged");
     unsigned int nPiZeros = transform.getParameter<unsigned int>("nPiZeros");
     // Get the transform

--- a/RecoTauTag/RecoTau/plugins/RecoTauPhotonFilter.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPhotonFilter.cc
@@ -10,11 +10,10 @@
  * ===========================================================================
  */
 
-#include <boost/foreach.hpp>
 #include "RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
 
-namespace reco { namespace tau {
+namespace reco::tau {
 
 // Filter photons
 class RecoTauPhotonFilter : public RecoTauModifierPlugin {
@@ -56,7 +55,7 @@ bool RecoTauPhotonFilter::filter( const RecoTauPiZero* piZero,
 
 void RecoTauPhotonFilter::operator()(PFTau& tau) const {
   std::vector<const RecoTauPiZero*> signalPiZeros;
-  BOOST_FOREACH(const RecoTauPiZero& piZero, tau.signalPiZeroCandidates()) {
+  for(auto const& piZero : tau.signalPiZeroCandidates()) {
     signalPiZeros.push_back(&piZero);
   }
   std::sort(signalPiZeros.begin(), signalPiZeros.end(), PiZeroPtSorter());
@@ -107,7 +106,7 @@ void RecoTauPhotonFilter::operator()(PFTau& tau) const {
 
     // Copy the keys to move
     std::set<size_t> keysToMove;
-    BOOST_FOREACH(const PFCandidatePtr& ptr, pfcandsToMove) {
+    for(auto const& ptr : pfcandsToMove) {
       keysToMove.insert(ptr.key());
     }
 
@@ -117,14 +116,14 @@ void RecoTauPhotonFilter::operator()(PFTau& tau) const {
     std::vector<PFCandidatePtr> newIsolationPFCands = tau.isolationPFCands();
 
     // Move the necessary signal pizeros - what a mess!
-    BOOST_FOREACH(const PFCandidatePtr& ptr, tau.signalPFCands()) {
+    for(auto const& ptr : tau.signalPFCands()) {
       if (keysToMove.count(ptr.key()))
         newIsolationPFCands.push_back(ptr);
       else
         newSignalPFCands.push_back(ptr);
     }
 
-    BOOST_FOREACH(const PFCandidatePtr& ptr, tau.signalPFGammaCands()) {
+    for(auto const& ptr : tau.signalPFGammaCands()) {
       if (keysToMove.count(ptr.key()))
         newIsolationPFGammas.push_back(ptr);
       else
@@ -137,7 +136,7 @@ void RecoTauPhotonFilter::operator()(PFTau& tau) const {
     tau.setisolationPFCands(newIsolationPFCands);
   }
 }
-}}  // end namespace reco::tau
+}  // end namespace reco::tau
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory,
     reco::tau::RecoTauPhotonFilter,

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -13,7 +13,6 @@
 
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/ptr_container/ptr_list.hpp>
-#include <boost/foreach.hpp>
 #include <algorithm>
 #include <functional>
 
@@ -133,7 +132,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   evt.getByToken(cand_token, jetView);
 
   // Give each of our plugins a chance at doing something with the edm::Event
-  BOOST_FOREACH(Builder& builder, builders_) {
+  for(auto& builder : builders_) {
     builder.setup(evt, es);
   }
 
@@ -152,7 +151,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   }
 
   // Loop over our jets
-  BOOST_FOREACH(const reco::PFJetRef& jet, jetRefs) {
+  for(auto const& jet : jetRefs) {
 
     if(jet->pt() - minJetPt_ < 1e-5) continue;
     if(std::abs(jet->eta()) - maxJetAbsEta_ > -1e-5) continue;
@@ -160,7 +159,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     PiZeroList dirtyPiZeros;
 
     // Compute the pi zeros from this jet for all the desired algorithms
-    BOOST_FOREACH(const Builder& builder, builders_) {
+    for(auto const& builder : builders_) {
       try {
         PiZeroVector result(builder(*jet));
         dirtyPiZeros.transfer(dirtyPiZeros.end(), result);
@@ -207,7 +206,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
         // add it back into the sorted list of dirty PiZeros
         toAdd->clearDaughters();
         // Add each of the unique daughters back to the pizero
-        BOOST_FOREACH(const reco::CandidatePtr& gamma, uniqueGammas) {
+        for(auto const& gamma : uniqueGammas) {
           toAdd->addDaughter(gamma);
         }
         // Update the four vector
@@ -237,7 +236,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 void RecoTauPiZeroProducer::print(
     const std::vector<reco::RecoTauPiZero>& piZeros, std::ostream& out) {
   const unsigned int width = 25;
-  BOOST_FOREACH(const reco::RecoTauPiZero& piZero, piZeros) {
+  for(auto const& piZero : piZeros) {
     out << piZero;
     out << "* Rankers:" << std::endl;
     for (rankerList::const_iterator ranker = rankers_.begin();

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -174,12 +174,10 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
               111, 10001, true, RecoTauPiZero::kUndefined));
 
         // Now loop over the strip members
-        BOOST_FOREACH(const RecoTauPiZero::daughters::value_type& gamma,
-            first->daughterPtrVector()) {
+        for(auto const& gamma : first->daughterPtrVector()) {
           combinedStrips->addDaughter(gamma);
         }
-        BOOST_FOREACH(const RecoTauPiZero::daughters::value_type& gamma,
-            second->daughterPtrVector()) {
+        for(auto const& gamma : second->daughterPtrVector()) {
           combinedStrips->addDaughter(gamma);
         }
         // Update the vertex

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -319,12 +319,10 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
               111, 10001, true, RecoTauPiZero::kUndefined));
 
         // Now loop over the strip members
-        BOOST_FOREACH(const RecoTauPiZero::daughters::value_type& gamma,
-            first->daughterPtrVector()) {
+        for(auto const& gamma : first->daughterPtrVector()) {
           combinedStrips->addDaughter(gamma);
         }
-        BOOST_FOREACH(const RecoTauPiZero::daughters::value_type& gamma,
-            second->daughterPtrVector()) {
+        for(auto const& gamma : second->daughterPtrVector()) {
           combinedStrips->addDaughter(gamma);
         }
         // Update the vertex

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
@@ -19,9 +19,7 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
 #include "RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h"
 
-#include <boost/foreach.hpp>
-
-namespace reco { namespace tau {
+namespace reco::tau {
 
 class RecoTauPiZeroTrivialPlugin : public RecoTauPiZeroBuilderPlugin {
   public:
@@ -43,7 +41,7 @@ RecoTauPiZeroBuilderPlugin::return_type RecoTauPiZeroTrivialPlugin::operator()(
   PiZeroVector output;
   output.reserve(pfGammaCands.size());
 
-  BOOST_FOREACH(const PFCandidatePtr& gamma, pfGammaCands) {
+  for(auto const& gamma : pfGammaCands) {
     std::auto_ptr<RecoTauPiZero> piZero(new RecoTauPiZero(
             0, (*gamma).p4(), (*gamma).vertex(), 22, 1000, true,
             RecoTauPiZero::kTrivial));
@@ -53,7 +51,7 @@ RecoTauPiZeroBuilderPlugin::return_type RecoTauPiZeroTrivialPlugin::operator()(
   return output.release();
 }
 
-}} // end reco::tau
+} // end reco::tau
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_EDM_PLUGIN(RecoTauPiZeroBuilderPluginFactory,

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -18,7 +18,6 @@
  */
 #include "boost/bind.hpp"
 #include <boost/ptr_container/ptr_vector.hpp>
-#include <boost/foreach.hpp>
 
 #include <algorithm>
 #include <functional>
@@ -163,7 +162,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   output->reserve(jets.size());
   
   // Loop over the jets and build the taus for each jet
-  BOOST_FOREACH( reco::PFJetRef jetRef, jets ) {
+  for(auto const& jetRef : jets ) {
     // Get the jet with extra constituents from an area around the jet
     if(jetRef->pt() - minJetPt_ < 1e-5) continue;
     if(std::abs(jetRef->eta()) - maxJetAbsEta_ > -1e-5) continue;
@@ -211,7 +210,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
         nTausBuilt += taus.size();
       } else {
         // Copy only those that pass the selection.
-        BOOST_FOREACH( const reco::PFTau& tau, taus ) {
+        for(auto const& tau : taus ) {
           if ( (*outputSelector_)(tau) ) {
             nTausBuilt++;
             output->push_back(tau);

--- a/RecoTauTag/RecoTau/src/RecoTauBinnedIsolationPlugin.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauBinnedIsolationPlugin.cc
@@ -1,11 +1,10 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauBinnedIsolationPlugin.h"
-#include <boost/foreach.hpp>
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-namespace reco { namespace tau {
+namespace reco::tau {
 
 namespace {
 template<typename C>
@@ -24,7 +23,7 @@ RecoTauDiscriminationBinnedIsolation::RecoTauDiscriminationBinnedIsolation(
   // Configure the binning
   typedef std::vector<edm::ParameterSet> VPSet;
   VPSet binning = pset.getParameter<VPSet>("binning");
-  BOOST_FOREACH(const edm::ParameterSet& bincfg, binning) {
+  for(auto const& bincfg : binning) {
     std::vector<double> bins = bincfg.getParameter<std::vector<double> >(
         "binLowEdges");
     int nVtx = bincfg.getParameter<int>("nPUVtx");
@@ -75,7 +74,7 @@ std::vector<double> RecoTauDiscriminationBinnedIsolation::operator()(
   // Get the desired isolation objects
   std::vector<reco::PFCandidatePtr> isoObjects = extractIsoObjects(tau);
   // Loop over each and histogram their pt
-  BOOST_FOREACH(const reco::PFCandidatePtr& cand, isoObjects) {
+  for(auto const& cand : isoObjects) {
     int highestBinLessThan = -1;
     for (size_t ibin = 0; ibin < bins->size(); ++ibin) {
       if (cand->pt() > bins->at(ibin)) {
@@ -89,4 +88,4 @@ std::vector<double> RecoTauDiscriminationBinnedIsolation::operator()(
 }
 
 
-}} // end namespace reco::tau
+} // end namespace reco::tau

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -7,10 +7,7 @@
 
 #include "RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h"
 
-#include <boost/foreach.hpp>
-#include <boost/bind.hpp>
-
-namespace reco { namespace tau {
+namespace reco::tau {
 
 RecoTauConstructor::RecoTauConstructor(const PFJetRef& jet, const edm::Handle<PFCandidateCollection>& pfCands, 
 				       bool copyGammasFromPiZeros,
@@ -49,7 +46,7 @@ RecoTauConstructor::RecoTauConstructor(const PFJetRef& jet, const edm::Handle<PF
 
   // Build our temporary sorted collections, since you can't use stl sorts on
   // RefVectors
-  BOOST_FOREACH(const CollectionMap::value_type& colkey, collections_) {
+  for(auto const& colkey : collections_) {
     // Build an empty list for each collection
     sortedCollections_[colkey.first] = SortedListPtr(
         new SortedListPtr::element_type);
@@ -294,7 +291,7 @@ void RecoTauConstructor::sortAndCopyIntoTau() {
 
   // Sort each of our sortable collections, and copy them into the final
   // tau RefVector.
-  BOOST_FOREACH ( const CollectionMap::value_type& colkey, collections_ ) {
+  for (auto const& colkey : collections_ ) {
     SortedListPtr sortedCollection = sortedCollections_[colkey.first];
     std::sort(sortedCollection->begin(),
               sortedCollection->end(),
@@ -446,4 +443,4 @@ std::auto_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects)
   }
   return tau_;
 }
-}} // end namespace reco::tau
+} // end namespace reco::tau

--- a/RecoTauTag/RecoTau/src/RecoTauDiscriminantFunctions.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauDiscriminantFunctions.cc
@@ -1,11 +1,11 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauDiscriminantFunctions.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/angle.h"
-#include <algorithm>
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
-#include <boost/foreach.hpp>
+
+#include <algorithm>
 
 namespace reco { namespace tau { namespace disc {
 
@@ -61,7 +61,7 @@ std::vector<PFCandidatePtr> notMainTrack(Tau tau)
   const PFCandidatePtr& mainTrackPtr = mainTrack(tau);
   std::vector<PFCandidatePtr> output;
   output.reserve(tau.signalPFChargedHadrCands().size() - 1);
-  BOOST_FOREACH(const PFCandidatePtr& ptr, tau.signalPFChargedHadrCands()) {
+  for(auto const& ptr : tau.signalPFChargedHadrCands()) {
     if (ptr != mainTrackPtr)
       output.push_back(ptr);
   }
@@ -115,7 +115,7 @@ double IsolationECALPtFraction(Tau tau) {
 
 double IsolationNeutralHadronPtFraction(Tau tau) {
   double sum = 0.0;
-  BOOST_FOREACH(PFCandidatePtr cand, tau.isolationPFNeutrHadrCands()) {
+  for(auto const& cand : tau.isolationPFNeutrHadrCands()) {
     sum += cand->pt();
   }
   return sum/tau.jetRef()->pt();
@@ -129,7 +129,7 @@ double ScaledEtaJetCollimation(Tau tau) {
 double OpeningDeltaR(Tau tau) {
   double sumEt = 0;
   double weightedDeltaR = 0;
-  BOOST_FOREACH(const reco::PFCandidatePtr& cand, tau.signalPFCands()) {
+  for(auto const& cand : tau.signalPFCands()) {
     double candEt = cand->et();
     double candDeltaR = reco::deltaR(cand->p4(), tau.p4());
     sumEt += candEt;
@@ -141,7 +141,7 @@ double OpeningDeltaR(Tau tau) {
 double OpeningAngle3D(Tau tau) {
   double sumE = 0;
   double weightedAngle = 0;
-  BOOST_FOREACH(const reco::PFCandidatePtr& cand, tau.signalPFCands()) {
+  for(auto const& cand : tau.signalPFCands()) {
     double candE = cand->energy();
     double candAngle = angle(cand->p4(), tau.p4());
     sumE += candE;
@@ -191,12 +191,12 @@ VDouble Dalitz2(Tau tau) {
   VDouble output;
   output.reserve(otherSignalTracks.size() + pizeros.size());
   // Add combos with tracks
-  BOOST_FOREACH(PFCandidatePtr trk, otherSignalTracks) {
+  for(auto const& trk : otherSignalTracks) {
     reco::Candidate::LorentzVector p4 = theMainTrack->p4() + trk->p4();
     output.push_back(p4.mass());
   }
   // Add combos with pizeros
-  BOOST_FOREACH(const RecoTauPiZero &pizero, pizeros) {
+  for(auto const& pizero : pizeros) {
     reco::Candidate::LorentzVector p4 = theMainTrack->p4() + pizero.p4();
     output.push_back(p4.mass());
   }
@@ -207,7 +207,7 @@ double IsolationChargedSumHard(Tau tau) {
   VDouble isocands = extract(tau.isolationPFChargedHadrCands(),
                              std::mem_fun_ref(&PFCandidate::pt));
   double output = 0.0;
-  BOOST_FOREACH(double pt, isocands) {
+  for(double pt : isocands) {
     if (pt > 1.0)
       output += pt;
   }
@@ -218,7 +218,7 @@ double IsolationChargedSumSoft(Tau tau) {
   VDouble isocands = extract(tau.isolationPFChargedHadrCands(),
                              std::mem_fun_ref(&PFCandidate::pt));
   double output = 0.0;
-  BOOST_FOREACH(double pt, isocands) {
+  for(double pt : isocands) {
     if (pt < 1.0)
       output += pt;
   }
@@ -238,7 +238,7 @@ double IsolationECALSumHard(Tau tau) {
   VDouble isocands = extract(tau.isolationPFGammaCands(),
                              std::mem_fun_ref(&PFCandidate::pt));
   double output = 0.0;
-  BOOST_FOREACH(double pt, isocands) {
+  for(double pt : isocands) {
     if (pt > 1.5)
       output += pt;
   }
@@ -249,7 +249,7 @@ double IsolationECALSumSoft(Tau tau) {
   VDouble isocands = extract(tau.isolationPFGammaCands(),
                              std::mem_fun_ref(&PFCandidate::pt));
   double output = 0.0;
-  BOOST_FOREACH(double pt, isocands) {
+  for(double pt : isocands) {
     if (pt < 1.5)
       output += pt;
   }
@@ -267,7 +267,7 @@ double IsolationECALSumSoftRelative(Tau tau) {
 double EMFraction(Tau tau) {
   //double result = tau.emFraction();
   reco::Candidate::LorentzVector gammaP4;
-  BOOST_FOREACH(const reco::PFCandidatePtr& gamma, tau.signalPFGammaCands()) {
+  for(auto const& gamma : tau.signalPFGammaCands()) {
     gammaP4 += gamma->p4();
   }
   double result = gammaP4.pt()/tau.pt();
@@ -276,11 +276,11 @@ double EMFraction(Tau tau) {
     LogDebug("TauDiscFunctions") << "EM fraction = " << result
       << tau ;
       LogDebug("TauDiscFunctions") << "charged" ;
-    BOOST_FOREACH(const reco::PFCandidatePtr cand, tau.signalPFChargedHadrCands()) {
+    for(auto const& cand : tau.signalPFChargedHadrCands()) {
       LogDebug("TauDiscFunctions") << " pt: " << cand->pt() << " type: " << cand->particleId() <<  " key: " << cand.key() ;
     }
     LogDebug("TauDiscFunctions") << "gammas" ;
-    BOOST_FOREACH(const reco::PFCandidatePtr cand, tau.signalPFGammaCands()) {
+    for(auto const& cand : tau.signalPFGammaCands()) {
       LogDebug("TauDiscFunctions") << " pt: " << cand->pt() << " type: " << cand->particleId() <<  " key: " << cand.key() ;
     }
   }

--- a/RecoTauTag/RecoTau/src/RecoTauIsolationMasking.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauIsolationMasking.cc
@@ -1,4 +1,3 @@
-#include <boost/foreach.hpp>
 #include "RecoTauTag/RecoTau/interface/RecoTauIsolationMasking.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
@@ -6,7 +5,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyResolution.h"
 
-namespace reco { namespace tau {
+namespace reco::tau {
 
 namespace {
 class DRSorter {
@@ -36,7 +35,7 @@ class MultiTrackDRFilter {
       :deltaR_(deltaR),tracks_(trks){}
     template <typename T>
     bool operator()(const T& t) const {
-      BOOST_FOREACH(const reco::PFCandidatePtr& trk, tracks_) {
+      for(auto const& trk : tracks_) {
         if (reco::deltaR(trk->p4(), t->p4()) < deltaR_)
           return true;
       }
@@ -53,7 +52,7 @@ template<typename T>
 std::vector<reco::PFCandidatePtr> convertRefCollection(const T& coll) {
   std::vector<reco::PFCandidatePtr> output;
   output.reserve(coll.size());
-  BOOST_FOREACH(const reco::PFCandidatePtr cand, coll) {
+  for(auto const& cand : coll) {
     output.push_back(cand);
   }
   return output;
@@ -87,8 +86,7 @@ RecoTauIsolationMasking::mask(const reco::PFTau& tau) const {
   courses.push_back(&(output.h0s));
   courses.push_back(&(output.gammas));
   // Mask using each one of the tracks
-  BOOST_FOREACH(const reco::PFCandidatePtr& track,
-      tau.signalPFChargedHadrCands()) {
+  for(auto const& track : tau.signalPFChargedHadrCands()) {
     double trackerEnergy = track->energy();
     double linkedEcalEnergy = track->ecalEnergy();
     double linkedHcalEnergy = track->hcalEnergy();
@@ -108,7 +106,7 @@ RecoTauIsolationMasking::mask(const reco::PFTau& tau) const {
     //DRSorter sorter(track->p4());
     PtSorter sorter;
 
-    BOOST_FOREACH(PFCandList* course, courses) {
+    for(auto* course : courses) {
       // Sort by deltaR to the current track
       course->sort(sorter);
       PFCandList::iterator toEatIter = course->begin();
@@ -176,4 +174,4 @@ bool RecoTauIsolationMasking::inCone(const reco::PFCandidate& track,
   return -1;
 }
 
-}} // end namespace reco::tau
+} // end namespace reco::tau

--- a/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
@@ -4,9 +4,7 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-#include <boost/bind.hpp>
-
-namespace reco { namespace tau {
+namespace reco::tau {
 
 namespace {
   // Get the KF track if it exists.  Otherwise, see if PFCandidate has a GSF track.
@@ -194,7 +192,7 @@ bool trkChi2_cand(const PFCandidate& cand, double cut)
 // And a set of qcuts
 bool AND(const TrackBaseRef& track, const RecoTauQualityCuts::TrackQCutFuncCollection& cuts) 
 {
-  BOOST_FOREACH( const RecoTauQualityCuts::TrackQCutFunc& func, cuts ) {
+  for(auto const& func : cuts ) {
     if ( !func(track) ) return false;
   }
   return true;
@@ -202,7 +200,7 @@ bool AND(const TrackBaseRef& track, const RecoTauQualityCuts::TrackQCutFuncColle
 
 bool AND_cand(const PFCandidate& cand, const RecoTauQualityCuts::CandQCutFuncCollection& cuts) 
 {
-  BOOST_FOREACH( const RecoTauQualityCuts::CandQCutFunc& func, cuts ) {
+  for(auto const& func : cuts ) {
     if ( !func(cand) ) return false;
   }
   return true;
@@ -231,7 +229,7 @@ RecoTauQualityCuts::RecoTauQualityCuts(const edm::ParameterSet &qcuts)
   std::set<std::string> passedOptionSet;
   std::vector<std::string> passedOptions = qcuts.getParameterNames();
 
-  BOOST_FOREACH(const std::string& option, passedOptions) {
+  for(auto const& option : passedOptions) {
     passedOptionSet.insert(option);
   }
 
@@ -281,7 +279,7 @@ RecoTauQualityCuts::RecoTauQualityCuts(const edm::ParameterSet &qcuts)
   if ( !passedOptionSet.empty() ) {
     std::string unParsedOptions;
     bool thereIsABadParameter = false;
-    BOOST_FOREACH( const std::string& option, passedOptionSet ) {
+    for(auto const& option : passedOptionSet ) {
       // Workaround for HLT - TODO FIXME
       if ( option == "useTracksInsteadOfPFHadrons" ) {
         // Crash if true - no one should have this option enabled.
@@ -320,7 +318,7 @@ std::pair<edm::ParameterSet, edm::ParameterSet> factorizePUQCuts(const edm::Para
   edm::ParameterSet nonPUCuts;
 
   std::vector<std::string> inputNames = input.getParameterNames();
-  BOOST_FOREACH( const std::string& cut, inputNames ) {
+  for(auto const& cut : inputNames ) {
     if ( cut == "minTrackVertexWeight" || 
 	 cut == "maxDeltaZ"            ||
 	 cut == "maxDeltaZToLeadTrack" ) {
@@ -445,4 +443,4 @@ void RecoTauQualityCuts::setLeadTrack(const reco::PFCandidateRef& leadCand) cons
   }
 }
 
-}} // end namespace reco::tau
+} // end namespace reco::tau


### PR DESCRIPTION
Hi, another semi-automatic PR. This time I attack the BOOST_FOREACH macro which is made obsolete by the range based loops. About half of the occurrences are in this package, to I handle it separately.

I noticed in some example codes that BOOST_FOREACH is on one hand often slower than the range based loop, but on the other hand the optimizer often mitigates that so they are equal. So maybe this change actually makes the reco a bit faster, but probably not.

Could not test due to DAS failures today.