### PR TITLE
EventSetup consumes interface

### DIFF
--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -92,6 +92,24 @@ namespace edm {
       m_consumer->consumesMany<B>(id);
     }
     
+    // For consuming event-setup products
+    template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
+    auto esConsumes()
+    {
+      return esConsumes<ESProduct, ESRecord, Tr>(ESInputTag{});
+    }
+
+    template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
+    auto esConsumes(ESInputTag const& tag)
+    {
+      return m_consumer->esConsumes<ESProduct, ESRecord, Tr>(tag);
+    }
+
+    template <typename ESProduct, Transition Tr = Transition::Event>
+    auto esConsumes(eventsetup::EventSetupRecordKey const& key, ESInputTag const& tag)
+    {
+      return m_consumer->esConsumes<ESProduct, Tr>(key, tag);
+    }
 
   private:
     //only EDConsumerBase is allowed to make an instance of this class

--- a/FWCore/Framework/interface/DataKey.h
+++ b/FWCore/Framework/interface/DataKey.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     DataKey
-// 
+//
 /**\class DataKey DataKey.h FWCore/Framework/interface/DataKey.h
 
  Description: Key used to identify data within a EventSetupRecord
@@ -25,81 +25,79 @@
 #include "FWCore/Framework/interface/HCTypeTag.h"
 
 // forward declarations
-namespace edm {
-   namespace eventsetup {
-class DataKey
-{
+namespace edm::eventsetup {
+  class DataKey
+  {
 
-   friend void swap(DataKey&, DataKey&);
-   public:
-   enum DoNotCopyMemory { kDoNotCopyMemory };
-   
-      DataKey();
-      DataKey(const TypeTag& iType, 
-               const IdTags& iId) :
-         type_(iType),
-         name_(iId),
-         ownMemory_() {
-           makeCopyOfMemory();
-         }
+    friend void swap(DataKey&, DataKey&);
+  public:
+    enum DoNotCopyMemory { kDoNotCopyMemory };
 
-      DataKey(const TypeTag& iType, 
-               const IdTags& iId,
-               DoNotCopyMemory) :
-         type_(iType),
-         name_(iId),
-         ownMemory_(false) {}
-      
-      DataKey(const DataKey& iRHS) : 
-         type_(iRHS.type_),
-         name_(iRHS.name_),
-         ownMemory_() {
-           makeCopyOfMemory();
-         }
-      
-      DataKey& operator=(const DataKey&); // stop default
-      
-      ~DataKey() { releaseMemory(); }
-      
-      // ---------- const member functions ---------------------
-      const TypeTag& type() const { return type_; }
-      const NameTag& name() const { return name_; }
-      
-      bool operator==(const DataKey& iRHS) const;
-      bool operator<(const DataKey& iRHS) const;
-      
-      // ---------- static member functions --------------------
-      template<class T>
-         static TypeTag makeTypeTag() {
-            return heterocontainer::HCTypeTag::make<T>();
-         }
-      
-      // ---------- member functions ---------------------------
-
-   private:
-      void makeCopyOfMemory();
-      void releaseMemory() {
-         if(ownMemory_) {
-            deleteMemory();
-            ownMemory_ = false;
-         }
-      }
-      void deleteMemory();
-      void swap(DataKey&);
-      
-      // ---------- member data --------------------------------
-      TypeTag type_;
-      NameTag name_;
-      bool ownMemory_;
-};
-
-    // Free swap function
-    inline
-    void
-    swap(DataKey& a, DataKey& b) 
-    {
-      a.swap(b);
+    DataKey();
+    DataKey(const TypeTag& iType,
+            const IdTags& iId) :
+      type_(iType),
+      name_(iId),
+      ownMemory_() {
+      makeCopyOfMemory();
     }
+
+    DataKey(const TypeTag& iType,
+            const IdTags& iId,
+            DoNotCopyMemory) :
+      type_(iType),
+      name_(iId),
+      ownMemory_(false) {}
+
+    DataKey(const DataKey& iRHS) :
+      type_(iRHS.type_),
+      name_(iRHS.name_),
+      ownMemory_() {
+      makeCopyOfMemory();
+    }
+
+    DataKey& operator=(const DataKey&);
+
+    ~DataKey() { releaseMemory(); }
+
+    // ---------- const member functions ---------------------
+    const TypeTag& type() const { return type_; }
+    const NameTag& name() const { return name_; }
+
+    bool operator==(const DataKey& iRHS) const;
+    bool operator<(const DataKey& iRHS) const;
+
+    // ---------- static member functions --------------------
+    template<class T>
+    static TypeTag makeTypeTag() {
+      return heterocontainer::HCTypeTag::make<T>();
+    }
+
+    // ---------- member functions ---------------------------
+
+  private:
+    void makeCopyOfMemory();
+    void releaseMemory() {
+      if(ownMemory_) {
+        deleteMemory();
+        ownMemory_ = false;
+      }
+    }
+    void deleteMemory();
+    void swap(DataKey&);
+
+    // ---------- member data --------------------------------
+    TypeTag type_{};
+    NameTag name_{};
+    bool ownMemory_{false};
+  };
+
+  // Free swap function
+  inline
+  void
+  swap(DataKey& a, DataKey& b)
+  {
+    a.swap(b);
   }
 }
 #endif

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -4,7 +4,7 @@
 //
 // Package:     FWCore/Framework
 // Class  :     EDConsumerBase
-// 
+//
 /**\class edm::EDConsumerBase
 
  Description: Allows declaration of what data is being consumed
@@ -23,15 +23,20 @@
 #include <string>
 #include <vector>
 #include <array>
+
 // user include files
+#include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/TypeToGet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/SoATuple.h"
-#include "DataFormats/Provenance/interface/BranchType.h"
+#include "FWCore/Utilities/interface/Transition.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/ProductLabels.h"
@@ -48,15 +53,15 @@ namespace edm {
 
   class EDConsumerBase
   {
-    
+
   public:
     EDConsumerBase() : frozen_(false), containsCurrentProcessAlias_(false) {}
     virtual ~EDConsumerBase() noexcept(false);
-    
+
     // disallow copying
     EDConsumerBase(EDConsumerBase const&) = delete;
     EDConsumerBase const& operator=(EDConsumerBase const&) = delete;
-    
+
     // allow moving
     EDConsumerBase(EDConsumerBase&&) = default;
     EDConsumerBase& operator=(EDConsumerBase&&) = default;
@@ -72,19 +77,19 @@ namespace edm {
 
     ///\return true if the product corresponding to the index was registered via consumes or mayConsume call
     bool registeredToConsume(ProductResolverIndex, bool, BranchType) const;
-    
+
     ///\return true of TypeID corresponds to a type specified in a consumesMany call
     bool registeredToConsumeMany(TypeID const&, BranchType) const;
     // ---------- static member functions --------------------
-    
+
     // ---------- member functions ---------------------------
     void updateLookup(BranchType iBranchType,
                       ProductResolverIndexHelper const&,
                       bool iPrefetchMayGet);
-    
+
     typedef ProductLabels Labels;
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
-    
+
     void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
                                          ProductRegistry const& preg,
                                          std::map<std::string, ModuleDescription const*> const& labelsToDesc,
@@ -100,7 +105,7 @@ namespace edm {
     template<typename T> friend class WillGetIfMatch;
     ///Use a ConsumesCollector to gather consumes information from helper functions
     ConsumesCollector consumesCollector();
-    
+
     template <typename ProductType, BranchType B=InEvent>
     EDGetTokenT<ProductType> consumes(edm::InputTag const& tag) {
       TypeToGet tid=TypeToGet::make<ProductType>();
@@ -144,6 +149,25 @@ namespace edm {
     template <BranchType B>
     void consumesMany(const TypeToGet& id) {
       recordConsumes(B,id,edm::InputTag{},true);
+    }
+
+    // For consuming event-setup products
+    template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
+    auto esConsumes()
+    {
+      return esConsumes<ESProduct, ESRecord, Tr>(ESInputTag{});
+    }
+
+    template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
+    auto esConsumes(ESInputTag const& tag)
+    {
+      return ESGetTokenT<ESProduct>{tag};
+    }
+
+    template <typename ESProduct, Transition Tr = Transition::Event>
+    auto esConsumes(eventsetup::EventSetupRecordKey const&, ESInputTag const& tag)
+    {
+      return ESGetTokenT<ESProduct>{tag};
     }
 
   private:

--- a/FWCore/Framework/interface/ESConsumesCollector.h
+++ b/FWCore/Framework/interface/ESConsumesCollector.h
@@ -61,7 +61,7 @@ namespace edm {
     }
 
   private:
-    //only EDConsumerBase is allowed to make an instance of this class
+    //only ESProducer is allowed to make an instance of this class
     friend class ESProducer;
 
     explicit ESConsumesCollector(ESProducer* const iConsumer) :

--- a/FWCore/Framework/interface/ESConsumesCollector.h
+++ b/FWCore/Framework/interface/ESConsumesCollector.h
@@ -1,0 +1,77 @@
+#ifndef FWCore_Framework_ESConsumesCollector_h
+#define FWCore_Framework_ESConsumesCollector_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::ConsumesCollector
+//
+/**\class edm::ESConsumesCollector ESConsumesCollector.h "FWCore/Framework/interface/ESConsumesCollector.h"
+
+ Description: Helper class to gather consumes information for the EventSetup.
+
+ Usage: The constructor of an ESProducer module can get an instance of
+        edm::ESConsumesCollector by calling consumesCollector()
+        method. This instance can then be passed to helper classes in
+        order to register the event-setup data the helper will request
+        from an Event, LuminosityBlock or Run on behalf of the module.
+
+ Caveat: The ESConsumesCollector should be used during the time that
+         modules are being constructed. It should not be saved and
+         used later. It will not work if it is used to call the
+         consumes function during beginJob, beginRun, beginLuminosity
+         block, event processing or at any later time. As of now, an
+         ESConsumesCollector is provided for only ESProducer
+         subclasses--i.e. those that call setWhatProduced(this, ...).
+*/
+//
+// Original Author:  Kyle Knoepfel
+//         Created:  Fri, 02 Oct 2018 12:44:47 GMT
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/Transition.h"
+
+namespace edm {
+  class ESConsumesCollector {
+  public:
+
+    ESConsumesCollector() = delete;
+    ESConsumesCollector(ESConsumesCollector const&) = default;
+    ESConsumesCollector(ESConsumesCollector&&) = default;
+    ESConsumesCollector& operator=(ESConsumesCollector const&) = default;
+    ESConsumesCollector& operator=(ESConsumesCollector&&) = default;
+
+    // ---------- member functions ---------------------------
+    template <typename Product>
+    auto consumes(ESInputTag const& tag) {
+      return ESGetTokenT<Product>{tag};
+    }
+
+    template <typename Product, typename Record>
+    auto consumes(ESInputTag const& tag) {
+      return ESGetTokenT<Product>{tag};
+    }
+
+    template <typename Product>
+    auto consumes(eventsetup::EventSetupRecordKey const&, ESInputTag const& tag) {
+      return ESGetTokenT<Product>{tag};
+    }
+
+  private:
+    //only EDConsumerBase is allowed to make an instance of this class
+    friend class ESProducer;
+
+    explicit ESConsumesCollector(ESProducer* const iConsumer) :
+      m_consumer{iConsumer}
+    {}
+
+    // ---------- member data --------------------------------
+    edm::propagate_const<ESProducer*> m_consumer{nullptr};
+  };
+}
+
+
+#endif

--- a/FWCore/Framework/interface/ESHandle.h
+++ b/FWCore/Framework/interface/ESHandle.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESHandle
-// 
+//
 /**\class ESHandle ESHandle.h FWCore/Framework/interface/ESHandle.h
 
  Description: <one line class summary>
@@ -32,18 +32,16 @@ namespace edm {
 
 class ESHandleBase {
    public:
-      ESHandleBase() : data_(nullptr), description_(nullptr) {}
-      ESHandleBase(void const* iData, edm::eventsetup::ComponentDescription const* desc) 
+      ESHandleBase() = default;
+      ESHandleBase(void const* iData, edm::eventsetup::ComponentDescription const* desc)
            : data_(iData), description_(desc) {}
 
       ///Used when the attempt to get the data failed
       ESHandleBase(std::shared_ptr<ESHandleExceptionFactory>&& iWhyFailed) :
-        data_(nullptr),
-        description_(nullptr),
         whyFailedFactory_(std::move(iWhyFailed)) {}
 
       edm::eventsetup::ComponentDescription const* description() const;
-      
+
       bool isValid() const { return nullptr != data_ && nullptr != description_; }
 
       bool failedToGet() const { return bool(whyFailedFactory_); }
@@ -67,17 +65,17 @@ class ESHandleBase {
 
    private:
       // ---------- member data --------------------------------
-      void const* data_; 
-      edm::eventsetup::ComponentDescription const* description_;
-      std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory_;
+      void const* data_{nullptr};
+      edm::eventsetup::ComponentDescription const* description_{nullptr};
+      std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory_{nullptr};
 };
 
 template<typename T>
 class ESHandle : public ESHandleBase {
    public:
       typedef T value_type;
-   
-      ESHandle() : ESHandleBase() {}
+
+      ESHandle() = default;
       ESHandle(T const* iData) : ESHandleBase(iData, nullptr) {}
       ESHandle(T const* iData, edm::eventsetup::ComponentDescription const* desc) : ESHandleBase(iData, desc) {}
       ESHandle(std::shared_ptr<ESHandleExceptionFactory> &&);
@@ -87,11 +85,10 @@ class ESHandle : public ESHandleBase {
       T const* operator->() const { return product(); }
       T const& operator*() const { return *product(); }
       // ---------- static member functions --------------------
-      static const bool transientAccessOnly = false;
+      static constexpr bool transientAccessOnly = false;
 
       // ---------- member functions ---------------------------
-      
-   private:
+
 };
 
 template <class T>
@@ -102,7 +99,7 @@ ESHandle<T>::ESHandle(std::shared_ptr<edm::ESHandleExceptionFactory> && iWhyFail
   // Free swap function
   inline
   void
-  swap(ESHandleBase& a, ESHandleBase& b) 
+  swap(ESHandleBase& a, ESHandleBase& b)
   {
     a.swap(b);
   }

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -73,6 +73,7 @@ Example: two algorithms each creating only one objects
 #include <string>
 
 // user include files
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
 #include "FWCore/Framework/interface/ESProxyFactoryProducer.h"
 #include "FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h"
 
@@ -112,22 +113,22 @@ namespace edm {
         method in order to do the registration with the EventSetup
     */
     template<typename T>
-    void setWhatProduced(T* iThis, const es::Label& iLabel = es::Label()) {
-      setWhatProduced(iThis , &T::produce, iLabel);
+    auto setWhatProduced(T* iThis, const es::Label& iLabel = {}) {
+      return setWhatProduced(iThis , &T::produce, iLabel);
     }
 
     template<typename T>
-    void setWhatProduced(T* iThis, const char* iLabel) {
-      setWhatProduced(iThis , es::Label(iLabel));
+    auto setWhatProduced(T* iThis, const char* iLabel) {
+      return setWhatProduced(iThis , es::Label(iLabel));
     }
     template<typename T>
-    void setWhatProduced(T* iThis, const std::string& iLabel) {
-      setWhatProduced(iThis , es::Label(iLabel));
+    auto setWhatProduced(T* iThis, const std::string& iLabel) {
+      return setWhatProduced(iThis , es::Label(iLabel));
     }
 
     template<typename T, typename TDecorator >
-    void setWhatProduced(T* iThis, const TDecorator& iDec, const es::Label& iLabel = es::Label()) {
-      setWhatProduced(iThis , &T::produce, iDec, iLabel);
+    auto setWhatProduced(T* iThis, const TDecorator& iDec, const es::Label& iLabel = {}) {
+      return setWhatProduced(iThis , &T::produce, iDec, iLabel);
     }
     /** \param iThis the 'this' pointer to an inheriting class instance
         \param iMethod a member method of then inheriting class
@@ -135,10 +136,10 @@ namespace edm {
         method in order to do the registration with the EventSetup
     */
     template<typename T, typename TReturn, typename TRecord>
-    void setWhatProduced(T* iThis,
+    auto setWhatProduced(T* iThis,
                          TReturn (T ::* iMethod)(const TRecord&),
-                         const es::Label& iLabel = es::Label()) {
-      setWhatProduced(iThis, iMethod, eventsetup::CallbackSimpleDecorator<TRecord>(),iLabel);
+                         const es::Label& iLabel = {}) {
+      return setWhatProduced(iThis, iMethod, eventsetup::CallbackSimpleDecorator<TRecord>(),iLabel);
     }
     /** \param iThis the 'this' pointer to an inheriting class instance
         \param iMethod a member method of then inheriting class
@@ -147,10 +148,10 @@ namespace edm {
         method in order to do the registration with the EventSetup
     */
     template<typename T, typename TReturn, typename TRecord, typename TArg>
-    void setWhatProduced(T* iThis,
+    ESConsumesCollector setWhatProduced(T* iThis,
                          TReturn (T ::* iMethod)(const TRecord&),
                          const TArg& iDec,
-                         const es::Label& iLabel = es::Label()) {
+                         const es::Label& iLabel = {}) {
       auto callback = std::make_shared<eventsetup::Callback<T,
                                                             TReturn,
                                                             TRecord,
@@ -163,7 +164,7 @@ namespace edm {
                        static_cast<const typename eventsetup::produce::product_traits<TReturn>::type *>(nullptr),
                        static_cast<const TRecord*>(nullptr),
                        iLabel);
-      //static_assert((std::is_base_of<ED, T>::type));
+      return ESConsumesCollector{iThis};
     }
 
     ESProducer(const ESProducer&) = delete; // stop default
@@ -177,11 +178,11 @@ namespace edm {
       registerProduct(iCallback, static_cast<const typename TList::tail_type*>(nullptr), iRecord, iLabel);
       registerProducts(iCallback, static_cast<const typename TList::head_type*>(nullptr), iRecord, iLabel);
     }
+
     template<typename T, typename TRecord>
     void registerProducts(std::shared_ptr<T>, const eventsetup::produce::Null*, const TRecord*,const es::Label&) {
       //do nothing
     }
-
 
     template<typename T, typename TProduct, typename TRecord>
     void registerProduct(std::shared_ptr<T> iCallback, const TProduct*, const TRecord*,const es::Label& iLabel) {

--- a/FWCore/Framework/interface/ESTransientHandle.h
+++ b/FWCore/Framework/interface/ESTransientHandle.h
@@ -4,7 +4,7 @@
 //
 // Package:     Framework
 // Class  :     ESTransientHandle
-// 
+//
 /**\class ESTransientHandle ESTransientHandle.h FWCore/Framework/interface/ESTransientHandle.h
 
  Description: Provides transient access to data in an EventSetup Record
@@ -12,15 +12,15 @@
  Usage:
     This handle is used to setup a memory optimization.  Data obtained via this handle are allowed to be discarded before
 the end of the actual IOV for the data.  In this way the system can claim back some memory
- 
+
     Only use this form of the EventSetup handle IF AND ONLY IF
  1) you do not plan on holding onto a pointer to the EventSetup data to which the handle refers
     (since the pointer may become invalid after returning from your function)
  2) you only access this EventSetup data once per IOV change of the Record [i.e. you do NOT read it every Event]
     (failure to do this will cause the EventSetup data to be created each access which can drastically slow the system)
- 
+
  If you are unsure whether to use this handle or not then it is best not to and just use the regular ESHandle.
- 
+
 */
 //
 // Author:      Chris Jones
@@ -41,7 +41,7 @@ template<typename T>
 class ESTransientHandle : public ESHandleBase {
    public:
       typedef T value_type;
-   
+
       ESTransientHandle() : ESHandleBase() {}
       ESTransientHandle(T const* iData) : ESHandleBase(iData, 0) {}
       ESTransientHandle(T const* iData, edm::eventsetup::ComponentDescription const* desc) : ESHandleBase(iData, desc) {}
@@ -52,10 +52,10 @@ class ESTransientHandle : public ESHandleBase {
       T const* operator->() const { return product(); }
       T const& operator*() const { return *product(); }
       // ---------- static member functions --------------------
-      static const bool transientAccessOnly = true;
+      static constexpr bool transientAccessOnly = true;
 
       // ---------- member functions ---------------------------
-      
+
    private:
 };
 

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -33,138 +33,132 @@
 #include "FWCore/Framework/interface/HCMethods.h"
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/data_default_record_trait.h"
+#include "FWCore/Utilities/interface/Transition.h"
 
 // forward declarations
 
 namespace edm {
-   class ActivityRegistry;
-   class ESInputTag;
+  class ActivityRegistry;
+  class ESInputTag;
+  template <class T>
+  class ESGetTokenT;
 
-   namespace eventsetup {
-      class EventSetupProvider;
-      class EventSetupRecord;
-      class EventSetupRecordImpl;
-      template<class T> struct data_default_record_trait;
-      class EventSetupKnownRecordsSupplier;
-   }
+  namespace eventsetup {
+    class EventSetupProvider;
+    class EventSetupRecord;
+    class EventSetupRecordImpl;
+    class EventSetupKnownRecordsSupplier;
+  }
 
   class EventSetup
   {
     ///Only EventSetupProvider allowed to create a EventSetup
     friend class eventsetup::EventSetupProvider;
-    public:
-      virtual ~EventSetup();
+  public:
+    virtual ~EventSetup();
 
-      // ---------- const member functions ---------------------
-      /** returns the Record of type T.  If no such record available
-          a eventsetup::NoRecordException<T> is thrown */
-      template< typename T>
-         T get() const {
-           using namespace eventsetup;
-           using namespace eventsetup::heterocontainer;
-            //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-            //  HOWEVER the error message under gcc 3.x is awful
-            static_assert(std::is_base_of<edm::eventsetup::EventSetupRecord, T>::value, "Trying to get a class that is not a Record from EventSetup");
+    EventSetup(EventSetup const&) = delete;
+    EventSetup& operator=(EventSetup const&) = delete;
 
-           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
-           if(nullptr == temp) {
-             throw eventsetup::NoRecordException<T>(recordDoesExist(*this, eventsetup::EventSetupRecordKey::makeKey<T>()));
-           }
-           T returnValue;
-           returnValue.setImpl(temp);
-           return returnValue;
-         }
-      /** returns the Record of type T.  If no such record available
-       a null pointer is returned */
-      template< typename T>
-        std::optional<T> tryToGet() const {
-           using namespace eventsetup;
-           using namespace eventsetup::heterocontainer;
+    // ---------- const member functions ---------------------
+    /** returns the Record of type T.  If no such record available
+        a eventsetup::NoRecordException<T> is thrown */
+    template< typename T>
+    T get() const {
+      using namespace eventsetup;
+      using namespace eventsetup::heterocontainer;
+      //NOTE: this will catch the case where T does not inherit from EventSetupRecord
+      //  HOWEVER the error message under gcc 3.x is awful
+      static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>, "Trying to get a class that is not a Record from EventSetup");
 
-           //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-           static_assert((std::is_base_of<edm::eventsetup::EventSetupRecord, T>::value),"Trying to get a class that is not a Record from EventSetup");
-           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
-           if(temp != nullptr) {
-              T rec;
-              rec.setImpl(temp);
-              return rec;
-           }
-           return std::nullopt;
-        }
-
-      /** can directly access data if data_default_record_trait<> is defined for this data type **/
-      template< typename T>
-         void getData(T& iHolder) const {
-            typedef typename T::value_type data_type;
-            typedef typename eventsetup::data_default_record_trait<data_type>::type RecordT;
-            const RecordT& rec = this->get<RecordT>();
-            rec.get(iHolder);
-         }
-      template< typename T>
-         void getData(const std::string& iLabel, T& iHolder) const {
-            typedef typename T::value_type data_type;
-            typedef typename eventsetup::data_default_record_trait<data_type>::type RecordT;
-            const RecordT& rec = this->get<RecordT>();
-            rec.get(iLabel,iHolder);
-         }
-
-      template< typename T>
-        void getData(const edm::ESInputTag& iTag, T& iHolder) const {
-           typedef typename T::value_type data_type;
-           typedef typename eventsetup::data_default_record_trait<data_type>::type RecordT;
-           const RecordT& rec = this->get<RecordT>();
-           rec.get(iTag,iHolder);
-        }
-
-      std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
-
-      ///clears the oToFill vector and then fills it with the keys for all available records
-      void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
-
-      ///returns true if the Record is provided by a Source or a Producer
-      /// a value of true does not mean this EventSetup object holds such a record
-      bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
-      // ---------- static member functions --------------------
-
-      // ---------- member functions ---------------------------
-      template< typename T>
-         void
-         getAvoidCompilerBug(const T*& iValue) const {
-            iValue = &(get<T>());
-         }
-
-      friend class eventsetup::EventSetupRecordImpl;
-
-    protected:
-      //Only called by EventSetupProvider
-      void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
-        knownRecords_ = iSupplier;
+      auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
+      if(nullptr == temp) {
+        throw eventsetup::NoRecordException<T>(recordDoesExist(*this, eventsetup::EventSetupRecordKey::makeKey<T>()));
       }
+      T returnValue;
+      returnValue.setImpl(temp);
+      return returnValue;
+    }
 
-      void add(const eventsetup::EventSetupRecordImpl& iRecord);
+    /** returns the Record of type T.  If no such record available
+        a null pointer is returned */
+    template< typename T>
+    std::optional<T> tryToGet() const {
+      using namespace eventsetup;
+      using namespace eventsetup::heterocontainer;
 
-      void clear();
+      //NOTE: this will catch the case where T does not inherit from EventSetupRecord
+      static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,"Trying to get a class that is not a Record from EventSetup");
+      auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
+      if(temp != nullptr) {
+        T rec;
+        rec.setImpl(temp);
+        return rec;
+      }
+      return std::nullopt;
+    }
 
-    private:
-      EventSetup(ActivityRegistry*);
+    /** can directly access data if data_default_record_trait<> is defined for this data type **/
+    template< typename T>
+    bool getData(T& iHolder) const {
+      return getData("", iHolder);
+    }
 
-      EventSetup(EventSetup const&) = delete; // stop default
+    template< typename T>
+    bool getData(const std::string& iLabel, T& iHolder) const {
+      auto const& rec = this->get<eventsetup::default_record_t<T>>();
+      return rec.get(iLabel, iHolder);
+    }
 
-      EventSetup const& operator=(EventSetup const&) = delete; // stop default
+    template< typename T>
+    bool getData(const ESInputTag& iTag, T& iHolder) const {
+      auto const& rec = this->get<eventsetup::default_record_t<T>>();
+      return rec.get(iTag, iHolder);
+    }
 
-      ActivityRegistry* activityRegistry() const { return activityRegistry_; }
-      eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
+    template <typename T>
+    bool getData(const ESGetTokenT<T>& iToken, ESHandle<T>& iHolder) const {
+      return getData(iToken.tag(), iHolder);
+    }
 
+    std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
 
-      void insert(const eventsetup::EventSetupRecordKey&,
-                  const eventsetup::EventSetupRecordImpl*);
+    ///clears the oToFill vector and then fills it with the keys for all available records
+    void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
 
-      // ---------- member data --------------------------------
+    ///returns true if the Record is provided by a Source or a Producer
+    /// a value of true does not mean this EventSetup object holds such a record
+    bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
+    // ---------- static member functions --------------------
 
-      //NOTE: the records are not owned
-      std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const *> recordMap_;
-      eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
-      ActivityRegistry* activityRegistry_;
+    friend class eventsetup::EventSetupRecordImpl;
+
+  protected:
+    //Only called by EventSetupProvider
+    void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
+      knownRecords_ = iSupplier;
+    }
+
+    void add(const eventsetup::EventSetupRecordImpl& iRecord);
+
+    void clear();
+
+  private:
+    EventSetup(ActivityRegistry*);
+
+    ActivityRegistry* activityRegistry() const { return activityRegistry_; }
+    eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
+
+    void insert(const eventsetup::EventSetupRecordKey&,
+                const eventsetup::EventSetupRecordImpl*);
+
+    // ---------- member data --------------------------------
+
+    //NOTE: the records are not owned
+    std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const*> recordMap_;
+    eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
+    ActivityRegistry* activityRegistry_;
   };
 
   // Free functions to retrieve an object from the EventSetup.
@@ -176,7 +170,7 @@ namespace edm {
     // throw if the record is not available
     setup.get<R>().get(handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
   template <typename T, typename R = typename eventsetup::data_default_record_trait<typename T::value_type>::type, typename L>
@@ -185,7 +179,7 @@ namespace edm {
     // throw if the record is not available
     setup.get<R>().get(std::forward(label), handle);
     // throw if the handle is not valid
-    return * handle.product();
+    return *handle.product();
   }
 
 }

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -39,126 +39,126 @@
 // forward declarations
 
 namespace edm {
-  class ActivityRegistry;
-  class ESInputTag;
-  template <class T>
-  class ESGetTokenT;
+   class ActivityRegistry;
+   class ESInputTag;
+   template <class T>
+   class ESGetTokenT;
 
-  namespace eventsetup {
-    class EventSetupProvider;
-    class EventSetupRecord;
-    class EventSetupRecordImpl;
-    class EventSetupKnownRecordsSupplier;
-  }
+   namespace eventsetup {
+      class EventSetupProvider;
+      class EventSetupRecord;
+      class EventSetupRecordImpl;
+      class EventSetupKnownRecordsSupplier;
+   }
 
   class EventSetup
   {
     ///Only EventSetupProvider allowed to create a EventSetup
     friend class eventsetup::EventSetupProvider;
-  public:
-    virtual ~EventSetup();
+    public:
+      virtual ~EventSetup();
 
-    EventSetup(EventSetup const&) = delete;
-    EventSetup& operator=(EventSetup const&) = delete;
+      EventSetup(EventSetup const&) = delete;
+      EventSetup& operator=(EventSetup const&) = delete;
 
-    // ---------- const member functions ---------------------
-    /** returns the Record of type T.  If no such record available
-        a eventsetup::NoRecordException<T> is thrown */
-    template< typename T>
-    T get() const {
-      using namespace eventsetup;
-      using namespace eventsetup::heterocontainer;
-      //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-      //  HOWEVER the error message under gcc 3.x is awful
-      static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>, "Trying to get a class that is not a Record from EventSetup");
+      // ---------- const member functions ---------------------
+      /** returns the Record of type T.  If no such record available
+          a eventsetup::NoRecordException<T> is thrown */
+      template< typename T>
+         T get() const {
+           using namespace eventsetup;
+           using namespace eventsetup::heterocontainer;
+            //NOTE: this will catch the case where T does not inherit from EventSetupRecord
+            //  HOWEVER the error message under gcc 3.x is awful
+            static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>, "Trying to get a class that is not a Record from EventSetup");
 
-      auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
-      if(nullptr == temp) {
-        throw eventsetup::NoRecordException<T>(recordDoesExist(*this, eventsetup::EventSetupRecordKey::makeKey<T>()));
+           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
+           if(nullptr == temp) {
+             throw eventsetup::NoRecordException<T>(recordDoesExist(*this, eventsetup::EventSetupRecordKey::makeKey<T>()));
+           }
+           T returnValue;
+           returnValue.setImpl(temp);
+           return returnValue;
+         }
+
+      /** returns the Record of type T.  If no such record available
+       a null pointer is returned */
+      template< typename T>
+        std::optional<T> tryToGet() const {
+           using namespace eventsetup;
+           using namespace eventsetup::heterocontainer;
+
+           //NOTE: this will catch the case where T does not inherit from EventSetupRecord
+           static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,"Trying to get a class that is not a Record from EventSetup");
+           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
+           if(temp != nullptr) {
+              T rec;
+              rec.setImpl(temp);
+              return rec;
+           }
+           return std::nullopt;
+        }
+
+      /** can directly access data if data_default_record_trait<> is defined for this data type **/
+      template< typename T>
+         bool getData(T& iHolder) const {
+            return getData("", iHolder);
+         }
+
+      template< typename T>
+         bool getData(const std::string& iLabel, T& iHolder) const {
+            auto const& rec = this->get<eventsetup::default_record_t<T>>();
+            return rec.get(iLabel, iHolder);
+         }
+
+      template< typename T>
+        bool getData(const ESInputTag& iTag, T& iHolder) const {
+           auto const& rec = this->get<eventsetup::default_record_t<T>>();
+           return rec.get(iTag, iHolder);
+        }
+
+      template <typename T>
+      bool getData(const ESGetTokenT<T>& iToken, ESHandle<T>& iHolder) const {
+        return getData(iToken.m_tag, iHolder);
       }
-      T returnValue;
-      returnValue.setImpl(temp);
-      return returnValue;
-    }
 
-    /** returns the Record of type T.  If no such record available
-        a null pointer is returned */
-    template< typename T>
-    std::optional<T> tryToGet() const {
-      using namespace eventsetup;
-      using namespace eventsetup::heterocontainer;
+      std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
 
-      //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-      static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,"Trying to get a class that is not a Record from EventSetup");
-      auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
-      if(temp != nullptr) {
-        T rec;
-        rec.setImpl(temp);
-        return rec;
+      ///clears the oToFill vector and then fills it with the keys for all available records
+      void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
+
+      ///returns true if the Record is provided by a Source or a Producer
+      /// a value of true does not mean this EventSetup object holds such a record
+      bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
+      // ---------- static member functions --------------------
+
+      friend class eventsetup::EventSetupRecordImpl;
+
+    protected:
+      //Only called by EventSetupProvider
+      void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
+        knownRecords_ = iSupplier;
       }
-      return std::nullopt;
-    }
 
-    /** can directly access data if data_default_record_trait<> is defined for this data type **/
-    template< typename T>
-    bool getData(T& iHolder) const {
-      return getData("", iHolder);
-    }
+      void add(const eventsetup::EventSetupRecordImpl& iRecord);
 
-    template< typename T>
-    bool getData(const std::string& iLabel, T& iHolder) const {
-      auto const& rec = this->get<eventsetup::default_record_t<T>>();
-      return rec.get(iLabel, iHolder);
-    }
+      void clear();
 
-    template< typename T>
-    bool getData(const ESInputTag& iTag, T& iHolder) const {
-      auto const& rec = this->get<eventsetup::default_record_t<T>>();
-      return rec.get(iTag, iHolder);
-    }
+    private:
+      EventSetup(ActivityRegistry*);
 
-    template <typename T>
-    bool getData(const ESGetTokenT<T>& iToken, ESHandle<T>& iHolder) const {
-      return getData(iToken.tag(), iHolder);
-    }
+      ActivityRegistry* activityRegistry() const { return activityRegistry_; }
+      eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
 
-    std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
+      void insert(const eventsetup::EventSetupRecordKey&,
+                  const eventsetup::EventSetupRecordImpl*);
 
-    ///clears the oToFill vector and then fills it with the keys for all available records
-    void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
+      // ---------- member data --------------------------------
 
-    ///returns true if the Record is provided by a Source or a Producer
-    /// a value of true does not mean this EventSetup object holds such a record
-    bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
-    // ---------- static member functions --------------------
-
-    friend class eventsetup::EventSetupRecordImpl;
-
-  protected:
-    //Only called by EventSetupProvider
-    void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
-      knownRecords_ = iSupplier;
-    }
-
-    void add(const eventsetup::EventSetupRecordImpl& iRecord);
-
-    void clear();
-
-  private:
-    EventSetup(ActivityRegistry*);
-
-    ActivityRegistry* activityRegistry() const { return activityRegistry_; }
-    eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
-
-    void insert(const eventsetup::EventSetupRecordKey&,
-                const eventsetup::EventSetupRecordImpl*);
-
-    // ---------- member data --------------------------------
-
-    //NOTE: the records are not owned
-    std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const*> recordMap_;
-    eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
-    ActivityRegistry* activityRegistry_;
+      //NOTE: the records are not owned
+      std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const *> recordMap_;
+      eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
+      ActivityRegistry* activityRegistry_;
   };
 
   // Free functions to retrieve an object from the EventSetup.
@@ -170,7 +170,7 @@ namespace edm {
     // throw if the record is not available
     setup.get<R>().get(handle);
     // throw if the handle is not valid
-    return *handle.product();
+    return * handle.product();
   }
 
   template <typename T, typename R = typename eventsetup::data_default_record_trait<typename T::value_type>::type, typename L>
@@ -179,7 +179,7 @@ namespace edm {
     // throw if the record is not available
     setup.get<R>().get(std::forward(label), handle);
     // throw if the handle is not valid
-    return *handle.product();
+    return * handle.product();
   }
 
 }

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -102,7 +102,7 @@ namespace edm {
       /** can directly access data if data_default_record_trait<> is defined for this data type **/
       template< typename T>
          bool getData(T& iHolder) const {
-            return getData("", iHolder);
+            return getData(std::string{}, iHolder);
          }
 
       template< typename T>

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -67,160 +67,160 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 
 // forward declarations
 namespace cms {
-  class Exception;
+   class Exception;
 }
 
 class testEventsetup;
 class testEventsetupRecord;
 
 namespace edm {
-  template<typename T>
-  class ESHandle;
-  class ESHandleExceptionFactory;
-  class ESInputTag;
-  class EventSetup;
+   template<typename T>
+   class ESHandle;
+   class ESHandleExceptionFactory;
+   class ESInputTag;
+   class EventSetup;
 
-  namespace eventsetup {
-    struct ComponentDescription;
-    class DataProxy;
-    class EventSetupRecordKey;
+   namespace eventsetup {
+      struct ComponentDescription;
+      class DataProxy;
+      class EventSetupRecordKey;
 
-    class EventSetupRecord {
+      class EventSetupRecord {
 
-      friend class ::testEventsetup;
-      friend class ::testEventsetupRecord;
-    public:
-      EventSetupRecord();
-      EventSetupRecord(EventSetupRecord&&) = default;
-      EventSetupRecord& operator=(EventSetupRecord&&) = default;
+        friend class ::testEventsetup;
+        friend class ::testEventsetupRecord;
+      public:
+         EventSetupRecord();
+         EventSetupRecord(EventSetupRecord&&) = default;
+         EventSetupRecord& operator=(EventSetupRecord&&) = default;
 
-      EventSetupRecord(EventSetupRecord const&) = default;
-      EventSetupRecord& operator=(EventSetupRecord const&) = default;
-      virtual ~EventSetupRecord();
+         EventSetupRecord(EventSetupRecord const&) = default;
+         EventSetupRecord& operator=(EventSetupRecord const&) = default;
+         virtual ~EventSetupRecord();
 
-      // ---------- const member functions ---------------------
-      ValidityInterval const& validityInterval() const {
-        return impl_->validityInterval();
-      }
+         // ---------- const member functions ---------------------
+         ValidityInterval const& validityInterval() const {
+            return impl_->validityInterval();
+         }
 
-      void setImpl( EventSetupRecordImpl const* iImpl ) { impl_ = iImpl; }
+        void setImpl( EventSetupRecordImpl const* iImpl ) { impl_ = iImpl; }
 
-      template<typename HolderT>
-      bool get(HolderT& iHolder) const {
-        return get("", iHolder);
-      }
+         template<typename HolderT>
+         bool get(HolderT& iHolder) const {
+            return get("", iHolder);
+         }
 
-      template<typename HolderT>
-      bool get(char const* iName, HolderT& iHolder) const {
-        typename HolderT::value_type const* value = nullptr;
-        ComponentDescription const* desc = nullptr;
-        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-        impl_->getImplementation(value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory);
+         template<typename HolderT>
+         bool get(char const* iName, HolderT& iHolder) const {
+            typename HolderT::value_type const* value = nullptr;
+            ComponentDescription const* desc = nullptr;
+            std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
+            impl_->getImplementation(value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory);
 
-        if(value) {
-          iHolder = HolderT(value, desc);
-          return true;
-        } else {
-          iHolder = HolderT(std::move(whyFailedFactory));
-          return false;
-        }
-      }
-      template<typename HolderT>
-      bool get(std::string const& iName, HolderT& iHolder) const {
-        return get(iName.c_str(), iHolder);
-      }
+            if(value) {
+              iHolder = HolderT(value, desc);
+              return true;
+            } else {
+              iHolder = HolderT(std::move(whyFailedFactory));
+              return false;
+            }
+         }
+         template<typename HolderT>
+         bool get(std::string const& iName, HolderT& iHolder) const {
+           return get(iName.c_str(), iHolder);
+         }
 
-      template<typename HolderT>
-      bool get(ESInputTag const& iTag, HolderT& iHolder) const {
-        typename HolderT::value_type const* value = nullptr;
-        ComponentDescription const* desc = nullptr;
-        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-        impl_->getImplementation(value, iTag.data().c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
+         template<typename HolderT>
+         bool get(ESInputTag const& iTag, HolderT& iHolder) const {
+            typename HolderT::value_type const* value = nullptr;
+            ComponentDescription const* desc = nullptr;
+            std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
+            impl_->getImplementation(value, iTag.data().c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
 
-        if(value) {
-          validate(desc, iTag);
-          iHolder = HolderT(value, desc);
-          return true;
-        } else {
-          iHolder = HolderT(std::move(whyFailedFactory));
-          return false;
-        }
-      }
+            if(value) {
+              validate(desc, iTag);
+              iHolder = HolderT(value, desc);
+              return true;
+            } else {
+              iHolder = HolderT(std::move(whyFailedFactory));
+              return false;
+            }
+         }
 
-      template<typename T>
-      bool get(ESGetTokenT<T> const& iToken, ESHandle<T>& iHandle) const {
-        return get(iToken.tag(), iHandle);
-      }
+         template<typename T>
+         bool get(ESGetTokenT<T> const& iToken, ESHandle<T>& iHandle) const {
+            return get(iToken.m_tag, iHandle);
+         }
 
-      ///returns false if no data available for key
-      bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
+         ///returns false if no data available for key
+         bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
 
-      /**returns true only if someone has already requested data for this key
-         and the data was retrieved
-      */
-      bool wasGotten(DataKey const& aKey) const;
+         /**returns true only if someone has already requested data for this key
+          and the data was retrieved
+          */
+         bool wasGotten(DataKey const& aKey) const;
 
-      /**returns the ComponentDescription for the module which creates the data or 0
-         if no module has been registered for the data. This does not cause the data to
-         actually be constructed.
-      */
-      ComponentDescription const* providerDescription(DataKey const& aKey) const;
+         /**returns the ComponentDescription for the module which creates the data or 0
+          if no module has been registered for the data. This does not cause the data to
+          actually be constructed.
+          */
+         ComponentDescription const* providerDescription(DataKey const& aKey) const;
 
-      virtual EventSetupRecordKey key() const = 0;
+         virtual EventSetupRecordKey key() const = 0;
 
-      /**If you are caching data from the Record, you should also keep
-         this number.  If this number changes then you know that
-         the data you have cached is invalid. This is NOT true if
-         if the validityInterval() hasn't changed since it is possible that
-         the job has gone to a new Record and then come back to the
-         previous SyncValue and your algorithm didn't see the intervening
-         Record.
-         The value of '0' will never be returned so you can use that to
-         denote that you have not yet checked the value.
-      */
-      unsigned long long cacheIdentifier() const {
-        return impl_->cacheIdentifier();
-      }
+         /**If you are caching data from the Record, you should also keep
+          this number.  If this number changes then you know that
+          the data you have cached is invalid. This is NOT true if
+          if the validityInterval() hasn't changed since it is possible that
+          the job has gone to a new Record and then come back to the
+          previous SyncValue and your algorithm didn't see the intervening
+          Record.
+          The value of '0' will never be returned so you can use that to
+          denote that you have not yet checked the value.
+          */
+         unsigned long long cacheIdentifier() const {
+            return impl_->cacheIdentifier();
+         }
 
-      ///clears the oToFill vector and then fills it with the keys for all registered data keys
-      void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const {
-        impl_->fillRegisteredDataKeys(oToFill);
-      }
-    protected:
+         ///clears the oToFill vector and then fills it with the keys for all registered data keys
+         void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const {
+           impl_->fillRegisteredDataKeys(oToFill);
+         }
+      protected:
 
-      DataProxy const* find(DataKey const& aKey) const ;
+         DataProxy const* find(DataKey const& aKey) const ;
 
-      EventSetup const& eventSetup() const {
-        return impl_->eventSetup();
-      }
+         EventSetup const& eventSetup() const {
+            return impl_->eventSetup();
+         }
 
-      void validate(ComponentDescription const*, ESInputTag const&) const;
+         void validate(ComponentDescription const*, ESInputTag const&) const;
 
-      void addTraceInfoToCmsException(cms::Exception& iException, char const* iName, ComponentDescription const*, DataKey const&) const;
-      void changeStdExceptionToCmsException(char const* iExceptionWhatMessage, char const* iName, ComponentDescription const*, DataKey const&) const;
+         void addTraceInfoToCmsException(cms::Exception& iException, char const* iName, ComponentDescription const*, DataKey const&) const;
+         void changeStdExceptionToCmsException(char const* iExceptionWhatMessage, char const* iName, ComponentDescription const*, DataKey const&) const;
 
-      EventSetupRecordImpl const* impl() const { return impl_;}
-    private:
+        EventSetupRecordImpl const* impl() const { return impl_;}
+      private:
 
-      void const* getFromProxy(DataKey const& iKey ,
-                               ComponentDescription const*& iDesc,
-                               bool iTransientAccessOnly) const;
+         void const* getFromProxy(DataKey const& iKey ,
+                                  ComponentDescription const*& iDesc,
+                                  bool iTransientAccessOnly) const;
 
 
-      // ---------- member data --------------------------------
-      EventSetupRecordImpl const* impl_ = nullptr;
-    };
+         // ---------- member data --------------------------------
+         EventSetupRecordImpl const* impl_ = nullptr;
+      };
 
-    class EventSetupRecordGeneric : public EventSetupRecord {
-    public:
-      EventSetupRecordGeneric(EventSetupRecordImpl const* iImpl) {
-        setImpl(iImpl);
-      }
+     class EventSetupRecordGeneric : public EventSetupRecord {
+     public:
+       EventSetupRecordGeneric(EventSetupRecordImpl const* iImpl) {
+         setImpl(iImpl);
+       }
 
-      EventSetupRecordKey key() const final {
-        return impl()->key();
-      }
-    };
-  }
+       EventSetupRecordKey key() const final {
+         return impl()->key();
+       }
+     };
+   }
 }
 #endif

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -54,6 +54,7 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 #include "FWCore/Framework/interface/NoProxyException.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
 #include "FWCore/Framework/interface/EventSetupRecordImpl.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/ESInputTag.h"
 
 // system include files
@@ -66,166 +67,182 @@ using the 'setEventSetup' and 'clearEventSetup' functions.
 
 // forward declarations
 namespace cms {
-   class Exception;
+  class Exception;
 }
 
 class testEventsetup;
 class testEventsetupRecord;
 
 namespace edm {
-   class ESHandleExceptionFactory;
-   class ESInputTag;
-   class EventSetup;
+  template<typename T>
+  class ESHandle;
+  class ESHandleExceptionFactory;
+  class ESInputTag;
+  class EventSetup;
 
-   namespace eventsetup {
-      struct ComponentDescription;
-      class DataProxy;
-      class EventSetupRecordKey;
+  namespace eventsetup {
+    struct ComponentDescription;
+    class DataProxy;
+    class EventSetupRecordKey;
 
-      class EventSetupRecord {
+    class EventSetupRecord {
 
-        friend class ::testEventsetup;
-        friend class ::testEventsetupRecord;
-      public:
-         EventSetupRecord();
-         EventSetupRecord(EventSetupRecord&&) = default;
-         EventSetupRecord& operator=(EventSetupRecord&&) = default;
+      friend class ::testEventsetup;
+      friend class ::testEventsetupRecord;
+    public:
+      EventSetupRecord();
+      EventSetupRecord(EventSetupRecord&&) = default;
+      EventSetupRecord& operator=(EventSetupRecord&&) = default;
 
-         EventSetupRecord(EventSetupRecord const&) = default;
-         EventSetupRecord& operator=(EventSetupRecord const&) = default;
-         virtual ~EventSetupRecord();
+      EventSetupRecord(EventSetupRecord const&) = default;
+      EventSetupRecord& operator=(EventSetupRecord const&) = default;
+      virtual ~EventSetupRecord();
 
-         // ---------- const member functions ---------------------
-         ValidityInterval const& validityInterval() const {
-            return impl_->validityInterval();
-         }
+      // ---------- const member functions ---------------------
+      ValidityInterval const& validityInterval() const {
+        return impl_->validityInterval();
+      }
 
-        void setImpl( EventSetupRecordImpl const* iImpl ) { impl_ = iImpl; }
-         template<typename HolderT>
-         void get(HolderT& iHolder) const {
-            typename HolderT::value_type const* value = nullptr;
-            ComponentDescription const* desc = nullptr;
-            std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-            impl_->getImplementation(value, "", desc, iHolder.transientAccessOnly, whyFailedFactory);
+      void setImpl( EventSetupRecordImpl const* iImpl ) { impl_ = iImpl; }
 
-            if(value) {
-              iHolder = HolderT(value, desc);
-            } else {
-              iHolder = HolderT(std::move(whyFailedFactory));
-            }
-         }
+      template<typename HolderT>
+      bool get(HolderT& iHolder) const {
+        typename HolderT::value_type const* value = nullptr;
+        ComponentDescription const* desc = nullptr;
+        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
+        impl_->getImplementation(value, "", desc, iHolder.transientAccessOnly, whyFailedFactory);
 
-         template<typename HolderT>
-         void get(char const* iName, HolderT& iHolder) const {
-            typename HolderT::value_type const* value = nullptr;
-            ComponentDescription const* desc = nullptr;
-            std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-            impl_->getImplementation(value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory);
+        if(value) {
+          iHolder = HolderT(value, desc);
+          return true;
+        } else {
+          iHolder = HolderT(std::move(whyFailedFactory));
+          return false;
+        }
+      }
 
-            if(value) {
-              iHolder = HolderT(value, desc);
-            } else {
-              iHolder = HolderT(std::move(whyFailedFactory));
-            }
-         }
-         template<typename HolderT>
-         void get(std::string const& iName, HolderT& iHolder) const {
-            typename HolderT::value_type const* value = nullptr;
-            ComponentDescription const* desc = nullptr;
-            std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-            impl_->getImplementation(value, iName.c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
+      template<typename HolderT>
+      bool get(char const* iName, HolderT& iHolder) const {
+        typename HolderT::value_type const* value = nullptr;
+        ComponentDescription const* desc = nullptr;
+        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
+        impl_->getImplementation(value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory);
 
-            if(value) {
-              iHolder = HolderT(value, desc);
-            } else {
-              iHolder = HolderT(std::move(whyFailedFactory));
-            }
-         }
+        if(value) {
+          iHolder = HolderT(value, desc);
+          return true;
+        } else {
+          iHolder = HolderT(std::move(whyFailedFactory));
+          return false;
+        }
+      }
+      template<typename HolderT>
+      bool get(std::string const& iName, HolderT& iHolder) const {
+        typename HolderT::value_type const* value = nullptr;
+        ComponentDescription const* desc = nullptr;
+        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
+        impl_->getImplementation(value, iName.c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
 
-         template<typename HolderT>
-         void get(ESInputTag const& iTag, HolderT& iHolder) const {
-            typename HolderT::value_type const* value = nullptr;
-            ComponentDescription const* desc = nullptr;
-            std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-            impl_->getImplementation(value, iTag.data().c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
+        if(value) {
+          iHolder = HolderT(value, desc);
+          return true;
+        } else {
+          iHolder = HolderT(std::move(whyFailedFactory));
+          return false;
+        }
+      }
 
-            if(value) {
-              validate(desc, iTag);
-              iHolder = HolderT(value, desc);
-            } else {
-              iHolder = HolderT(std::move(whyFailedFactory));
-            }
-         }
+      template<typename HolderT>
+      bool get(ESInputTag const& iTag, HolderT& iHolder) const {
+        typename HolderT::value_type const* value = nullptr;
+        ComponentDescription const* desc = nullptr;
+        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
+        impl_->getImplementation(value, iTag.data().c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
 
-         ///returns false if no data available for key
-         bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
+        if(value) {
+          validate(desc, iTag);
+          iHolder = HolderT(value, desc);
+          return true;
+        } else {
+          iHolder = HolderT(std::move(whyFailedFactory));
+          return false;
+        }
+      }
 
-         /**returns true only if someone has already requested data for this key
-          and the data was retrieved
-          */
-         bool wasGotten(DataKey const& aKey) const;
+      template<typename T>
+      bool get(ESGetTokenT<T> const& iToken, ESHandle<T>& iHandle) const {
+        return get(iToken.tag(), iHandle);
+      }
 
-         /**returns the ComponentDescription for the module which creates the data or 0
-          if no module has been registered for the data. This does not cause the data to
-          actually be constructed.
-          */
-         ComponentDescription const* providerDescription(DataKey const& aKey) const;
+      ///returns false if no data available for key
+      bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
 
-         virtual EventSetupRecordKey key() const = 0;
+      /**returns true only if someone has already requested data for this key
+         and the data was retrieved
+      */
+      bool wasGotten(DataKey const& aKey) const;
 
-         /**If you are caching data from the Record, you should also keep
-          this number.  If this number changes then you know that
-          the data you have cached is invalid. This is NOT true if
-          if the validityInterval() hasn't changed since it is possible that
-          the job has gone to a new Record and then come back to the
-          previous SyncValue and your algorithm didn't see the intervening
-          Record.
-          The value of '0' will never be returned so you can use that to
-          denote that you have not yet checked the value.
-          */
-         unsigned long long cacheIdentifier() const {
-            return impl_->cacheIdentifier();
-         }
+      /**returns the ComponentDescription for the module which creates the data or 0
+         if no module has been registered for the data. This does not cause the data to
+         actually be constructed.
+      */
+      ComponentDescription const* providerDescription(DataKey const& aKey) const;
 
-         ///clears the oToFill vector and then fills it with the keys for all registered data keys
-         void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const {
-           impl_->fillRegisteredDataKeys(oToFill);
-         }
-      protected:
+      virtual EventSetupRecordKey key() const = 0;
 
-         DataProxy const* find(DataKey const& aKey) const ;
+      /**If you are caching data from the Record, you should also keep
+         this number.  If this number changes then you know that
+         the data you have cached is invalid. This is NOT true if
+         if the validityInterval() hasn't changed since it is possible that
+         the job has gone to a new Record and then come back to the
+         previous SyncValue and your algorithm didn't see the intervening
+         Record.
+         The value of '0' will never be returned so you can use that to
+         denote that you have not yet checked the value.
+      */
+      unsigned long long cacheIdentifier() const {
+        return impl_->cacheIdentifier();
+      }
 
-         EventSetup const& eventSetup() const {
-            return impl_->eventSetup();
-         }
+      ///clears the oToFill vector and then fills it with the keys for all registered data keys
+      void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const {
+        impl_->fillRegisteredDataKeys(oToFill);
+      }
+    protected:
 
-         void validate(ComponentDescription const*, ESInputTag const&) const;
+      DataProxy const* find(DataKey const& aKey) const ;
 
-         void addTraceInfoToCmsException(cms::Exception& iException, char const* iName, ComponentDescription const*, DataKey const&) const;
-         void changeStdExceptionToCmsException(char const* iExceptionWhatMessage, char const* iName, ComponentDescription const*, DataKey const&) const;
+      EventSetup const& eventSetup() const {
+        return impl_->eventSetup();
+      }
 
-        EventSetupRecordImpl const* impl() const { return impl_;}
-      private:
+      void validate(ComponentDescription const*, ESInputTag const&) const;
 
-         void const* getFromProxy(DataKey const& iKey ,
-                                  ComponentDescription const*& iDesc,
-                                  bool iTransientAccessOnly) const;
+      void addTraceInfoToCmsException(cms::Exception& iException, char const* iName, ComponentDescription const*, DataKey const&) const;
+      void changeStdExceptionToCmsException(char const* iExceptionWhatMessage, char const* iName, ComponentDescription const*, DataKey const&) const;
+
+      EventSetupRecordImpl const* impl() const { return impl_;}
+    private:
+
+      void const* getFromProxy(DataKey const& iKey ,
+                               ComponentDescription const*& iDesc,
+                               bool iTransientAccessOnly) const;
 
 
-         // ---------- member data --------------------------------
-         EventSetupRecordImpl const* impl_ = nullptr;
-      };
-     
-     class EventSetupRecordGeneric : public EventSetupRecord {
-     public:
-       EventSetupRecordGeneric(EventSetupRecordImpl const* iImpl) {
-         setImpl(iImpl);
-       }
-       
-       EventSetupRecordKey key() const final {
-         return impl()->key();
-       }
-     };
-   }
+      // ---------- member data --------------------------------
+      EventSetupRecordImpl const* impl_ = nullptr;
+    };
+
+    class EventSetupRecordGeneric : public EventSetupRecord {
+    public:
+      EventSetupRecordGeneric(EventSetupRecordImpl const* iImpl) {
+        setImpl(iImpl);
+      }
+
+      EventSetupRecordKey key() const final {
+        return impl()->key();
+      }
+    };
+  }
 }
 #endif

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -107,18 +107,7 @@ namespace edm {
 
       template<typename HolderT>
       bool get(HolderT& iHolder) const {
-        typename HolderT::value_type const* value = nullptr;
-        ComponentDescription const* desc = nullptr;
-        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-        impl_->getImplementation(value, "", desc, iHolder.transientAccessOnly, whyFailedFactory);
-
-        if(value) {
-          iHolder = HolderT(value, desc);
-          return true;
-        } else {
-          iHolder = HolderT(std::move(whyFailedFactory));
-          return false;
-        }
+        return get("", iHolder);
       }
 
       template<typename HolderT>
@@ -138,18 +127,7 @@ namespace edm {
       }
       template<typename HolderT>
       bool get(std::string const& iName, HolderT& iHolder) const {
-        typename HolderT::value_type const* value = nullptr;
-        ComponentDescription const* desc = nullptr;
-        std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
-        impl_->getImplementation(value, iName.c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
-
-        if(value) {
-          iHolder = HolderT(value, desc);
-          return true;
-        } else {
-          iHolder = HolderT(std::move(whyFailedFactory));
-          return false;
-        }
+        return get(iName.c_str(), iHolder);
       }
 
       template<typename HolderT>

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -82,7 +82,7 @@ namespace edm {
       class EventSetupRecordImpl {
 
         friend class EventSetupRecord;
-        
+
       public:
          EventSetupRecordImpl(const EventSetupRecordKey& iKey);
 
@@ -177,7 +177,7 @@ namespace edm {
             void const* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly);
             if(nullptr == pValue) {
               whyFailedFactory =
-                makeESHandleExceptionFactory([=]()->std::exception_ptr {
+                makeESHandleExceptionFactory([=] {
                     NoProxyException<DataT> ex(this->key(), dataKey);
                     return std::make_exception_ptr(ex);
                 });

--- a/FWCore/Framework/interface/HCTypeTag.h
+++ b/FWCore/Framework/interface/HCTypeTag.h
@@ -30,60 +30,44 @@
 
 // forward declarations
 namespace edm {
-   namespace eventsetup {
-      namespace heterocontainer {
+  namespace eventsetup {
+    namespace heterocontainer {
 
-         using typelookup::className;
+      using typelookup::className;
 
-         class HCTypeTag : public TypeIDBase {
-            // ---------- friend classes and functions ---------------
-         public:
-            // ---------- constants, enums and typedefs --------------
+      class HCTypeTag : public TypeIDBase {
+      public:
 
-            // ---------- Constructors and destructor ----------------
-            HCTypeTag() : m_name("") {}
-            //virtual ~HCTypeTag();
+        HCTypeTag() = default;
 
-            // ---------- member functions ---------------------------
+        // ---------- member functions ---------------------------
 
-            // ---------- const member functions ---------------------
-            std::type_info const& value() const { return typeInfo(); }
-            char const* name() const { return m_name; }
+        // ---------- const member functions ---------------------
+        std::type_info const& value() const { return typeInfo(); }
+        char const* name() const { return m_name; }
 
-            ///find a type based on the types name, if not found will return default HCTypeTag
-            static HCTypeTag findType(char const* iTypeName);
-            static HCTypeTag findType(std::string const& iTypeName);
+        ///find a type based on the types name, if not found will return default HCTypeTag
+        static HCTypeTag findType(char const* iTypeName);
+        static HCTypeTag findType(std::string const& iTypeName);
 
-            template <typename T>
-            static HCTypeTag make() {
-               return HCTypeTag(typelookup::classTypeInfo<T>(),typelookup::className<T>());
-            }
+        template <typename T>
+        static HCTypeTag make() {
+          return HCTypeTag(typelookup::classTypeInfo<T>(),typelookup::className<T>());
+        }
 
-         protected:
-            // ---------- protected member functions -----------------
-            HCTypeTag(std::type_info const& iValue, char const* iName) :
-            TypeIDBase(iValue), m_name(iName) {}
+      protected:
+        // ---------- protected member functions -----------------
+        HCTypeTag(std::type_info const& iValue, char const* iName) :
+          TypeIDBase(iValue), m_name(iName) {}
 
-            HCTypeTag(TypeIDBase const& iValue, const char* iName) :
-            TypeIDBase(iValue), m_name(iName) {}
+        HCTypeTag(TypeIDBase const& iValue, const char* iName) :
+          TypeIDBase(iValue), m_name(iName) {}
 
-            // ---------- protected const member functions -----------
-
-            // ---------- protected static member functions ----------
-
-         private:
-            // ---------- Constructors and destructor ----------------
-            //HCTypeTag(HCTypeTag const&); // use default
-
-            // ---------- assignment operator(s) ---------------------
-            //HCTypeTag const& operator=(HCTypeTag const&); // use default
-
-
-            // ---------- data members -------------------------------
-            char const* m_name;
-         };
-      }
-   }
+      private:
+        char const* m_name{""};
+      };
+    }
+  }
 }
 #define HCTYPETAG_HELPER_METHODS(_dataclass_) TYPELOOKUP_METHODS(_dataclass_)
 

--- a/FWCore/Framework/interface/data_default_record_trait.h
+++ b/FWCore/Framework/interface/data_default_record_trait.h
@@ -40,12 +40,14 @@
 // Created:     Thu Apr  7 07:59:56 CDT 2005
 //
 
-// system include files
-
-// user include files
-
-// forward declarations
 namespace edm {
+
+  template <typename T>
+  class ESHandle;
+
+  // Special class to denote that the default record should be used.
+  struct DefaultRecord {};
+
    namespace eventsetup {
       template< class T> struct MUST_GET_RECORD_FROM_EVENTSETUP_TO_GET_DATA;
       
@@ -55,11 +57,19 @@ namespace edm {
          //NOTE: by default, a data item does not have a default record
          typedef MUST_GET_RECORD_FROM_EVENTSETUP_TO_GET_DATA<DataT> type;
       };
+
+    template <typename T>
+    struct default_record {
+      using data_type = typename T::value_type;
+      using RecordT = typename eventsetup::data_default_record_trait<data_type>::type;
+    };
+
+    template <typename T>
+    using default_record_t = typename default_record<T>::RecordT;
    }
 }
 
-
 #define EVENTSETUP_DATA_DEFAULT_RECORD(_data_, _record_) \
-namespace edm { namespace eventsetup { template<> struct data_default_record_trait<_data_>{ typedef _record_ type; }; } }
+  namespace edm::eventsetup { template<> struct data_default_record_trait<_data_>{ typedef _record_ type; }; }
 
 #endif

--- a/FWCore/Framework/src/DataKey.cc
+++ b/FWCore/Framework/src/DataKey.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Framework
 // Class  :     DataKey
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -22,132 +22,100 @@
 // constants, enums and typedefs
 //
 
-static const char kBlank[] = {'\0'};
-
-namespace edm {
-   namespace eventsetup {
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-DataKey::DataKey(): type_(), name_(), ownMemory_(false)
-{
+namespace {
+  constexpr char kBlank[] = {'\0'};
 }
 
-// DataKey::DataKey(const DataKey& rhs)
-// {
-//    // do actual copying here;
-// }
+namespace edm::eventsetup {
 
-//DataKey::~DataKey()
-//{
-//}
+  DataKey::DataKey() = default;
 
-//
-// assignment operators
-//
-DataKey& DataKey::operator=(const DataKey& rhs)
-{
-   //An exception safe implementation is
-   DataKey temp(rhs);
-   swap(temp);
+  DataKey& DataKey::operator=(const DataKey& rhs)
+  {
+    //An exception safe implementation is
+    DataKey temp(rhs);
+    swap(temp);
 
-   return *this;
-}
+    return *this;
+  }
 
-//
-// member functions
-//
-void
-DataKey::swap(DataKey& iOther)
-{
-   std::swap(ownMemory_, iOther.ownMemory_);
-   // unqualified swap is used for user defined classes.
-   // The using directive is needed so that std::swap will be used if there is no other matching swap.
-   using std::swap;
-   swap(type_, iOther.type_);
-   swap(name_, iOther.name_);
-}
+  //
+  // member functions
+  //
+  void
+  DataKey::swap(DataKey& iOther)
+  {
+    std::swap(ownMemory_, iOther.ownMemory_);
+    // unqualified swap is used for user defined classes.
+    // The using directive is needed so that std::swap will be used if there is no other matching swap.
+    using std::swap;
+    swap(type_, iOther.type_);
+    swap(name_, iOther.name_);
+  }
 
-      namespace {
-         //used for exception safety
-         class ArrayHolder {
-         public:
-            ArrayHolder():ptr_(nullptr){}
-            
-            void swap(ArrayHolder& iOther) {
-               const char* t = iOther.ptr_;
-               iOther.ptr_ = ptr_;
-               ptr_ = t;
-            }
-            ArrayHolder(const char* iPtr): ptr_(iPtr) {}
-            ~ArrayHolder() { delete [] ptr_; }
-            void release() { ptr_=nullptr;}
-         private:
-            const char* ptr_;
-         };
+  namespace {
+    //used for exception safety
+    class ArrayHolder {
+    public:
+      ArrayHolder() = default;
+
+      void swap(ArrayHolder& iOther) {
+        const char* t = iOther.ptr_;
+        iOther.ptr_ = ptr_;
+        ptr_ = t;
       }
-void 
-DataKey::makeCopyOfMemory()
-{
-   //empty string is the most common case, so handle it special
-   
-   char* pName = const_cast<char*>(kBlank);
-   //NOTE: if in the future additional tags are added then 
-   // I should make sure that pName gets deleted in the case
-   // where an exception is thrown
-   ArrayHolder pNameHolder;
-   if(kBlank[0] != name().value()[0]) {
+      ArrayHolder(const char* iPtr): ptr_(iPtr) {}
+      ~ArrayHolder() { delete [] ptr_; }
+      void release() { ptr_=nullptr;}
+    private:
+      const char* ptr_{nullptr};
+    };
+  }
+
+  void
+  DataKey::makeCopyOfMemory()
+  {
+    //empty string is the most common case, so handle it special
+
+    char* pName = const_cast<char*>(kBlank);
+    //NOTE: if in the future additional tags are added then
+    // I should make sure that pName gets deleted in the case
+    // where an exception is thrown
+    ArrayHolder pNameHolder;
+    if(kBlank[0] != name().value()[0]) {
       size_t const nBytes = std::strlen(name().value()) + 1;
       pName = new char[nBytes];
       ArrayHolder t(pName);
       pNameHolder.swap(t);
       std::strncpy(pName, name().value(), nBytes);
-   }
-   name_ = NameTag(pName);
-   ownMemory_ = true;
-   pNameHolder.release();
-}
+    }
+    name_ = NameTag(pName);
+    ownMemory_ = true;
+    pNameHolder.release();
+  }
 
-void
-DataKey::deleteMemory()
-{
-   if(kBlank[0] != name().value()[0]) {
+  void
+  DataKey::deleteMemory()
+  {
+    if(kBlank[0] != name().value()[0]) {
       delete [] const_cast<char*>(name().value());
-   }
-}
+    }
+  }
 
-//
-// const member functions
-//
-bool
-DataKey::operator==(const DataKey& iRHS) const 
-{
-   return ((type_ == iRHS.type_) &&
+  //
+  // const member functions
+  //
+  bool
+  DataKey::operator==(const DataKey& iRHS) const
+  {
+    return ((type_ == iRHS.type_) &&
             (name_ == iRHS.name_));
-}
+  }
 
-bool
-DataKey::operator<(const DataKey& iRHS) const 
-{
-   return (type_ < iRHS.type_) ||
-   ((type_ == iRHS.type_) && (name_ < iRHS.name_));
-/*
-   if(type_ < iRHS.type_) {
-      return true;
-   } else if (type_ == iRHS.type_) {
-      if(name_ < iRHS.name_) {
-         return true;
-   }
-   return false;
-      */
-}
-
-//
-// static member functions
-//
-   }
+  bool
+  DataKey::operator<(const DataKey& iRHS) const
+  {
+    return (type_ < iRHS.type_) ||
+      ((type_ == iRHS.type_) && (name_ < iRHS.name_));
+  }
 }

--- a/FWCore/Framework/src/DataKey.cc
+++ b/FWCore/Framework/src/DataKey.cc
@@ -23,99 +23,99 @@
 //
 
 namespace {
-  constexpr char kBlank[] = {'\0'};
+constexpr char kBlank[] = {'\0'};
 }
 
 namespace edm::eventsetup {
 
-  DataKey::DataKey() = default;
+DataKey::DataKey() = default;
 
-  DataKey& DataKey::operator=(const DataKey& rhs)
-  {
-    //An exception safe implementation is
-    DataKey temp(rhs);
-    swap(temp);
+DataKey& DataKey::operator=(const DataKey& rhs)
+{
+   //An exception safe implementation is
+   DataKey temp(rhs);
+   swap(temp);
 
-    return *this;
-  }
+   return *this;
+}
 
-  //
-  // member functions
-  //
-  void
-  DataKey::swap(DataKey& iOther)
-  {
-    std::swap(ownMemory_, iOther.ownMemory_);
-    // unqualified swap is used for user defined classes.
-    // The using directive is needed so that std::swap will be used if there is no other matching swap.
-    using std::swap;
-    swap(type_, iOther.type_);
-    swap(name_, iOther.name_);
-  }
+//
+// member functions
+//
+void
+DataKey::swap(DataKey& iOther)
+{
+   std::swap(ownMemory_, iOther.ownMemory_);
+   // unqualified swap is used for user defined classes.
+   // The using directive is needed so that std::swap will be used if there is no other matching swap.
+   using std::swap;
+   swap(type_, iOther.type_);
+   swap(name_, iOther.name_);
+}
 
-  namespace {
-    //used for exception safety
-    class ArrayHolder {
-    public:
-      ArrayHolder() = default;
+      namespace {
+         //used for exception safety
+         class ArrayHolder {
+         public:
+            ArrayHolder() = default;
 
-      void swap(ArrayHolder& iOther) {
-        const char* t = iOther.ptr_;
-        iOther.ptr_ = ptr_;
-        ptr_ = t;
+            void swap(ArrayHolder& iOther) {
+               const char* t = iOther.ptr_;
+               iOther.ptr_ = ptr_;
+               ptr_ = t;
+            }
+            ArrayHolder(const char* iPtr): ptr_(iPtr) {}
+            ~ArrayHolder() { delete [] ptr_; }
+            void release() { ptr_=nullptr;}
+         private:
+            const char* ptr_{nullptr};
+         };
       }
-      ArrayHolder(const char* iPtr): ptr_(iPtr) {}
-      ~ArrayHolder() { delete [] ptr_; }
-      void release() { ptr_=nullptr;}
-    private:
-      const char* ptr_{nullptr};
-    };
-  }
 
-  void
-  DataKey::makeCopyOfMemory()
-  {
-    //empty string is the most common case, so handle it special
+void
+DataKey::makeCopyOfMemory()
+{
+   //empty string is the most common case, so handle it special
 
-    char* pName = const_cast<char*>(kBlank);
-    //NOTE: if in the future additional tags are added then
-    // I should make sure that pName gets deleted in the case
-    // where an exception is thrown
-    ArrayHolder pNameHolder;
-    if(kBlank[0] != name().value()[0]) {
+   char* pName = const_cast<char*>(kBlank);
+   //NOTE: if in the future additional tags are added then
+   // I should make sure that pName gets deleted in the case
+   // where an exception is thrown
+   ArrayHolder pNameHolder;
+   if(kBlank[0] != name().value()[0]) {
       size_t const nBytes = std::strlen(name().value()) + 1;
       pName = new char[nBytes];
       ArrayHolder t(pName);
       pNameHolder.swap(t);
       std::strncpy(pName, name().value(), nBytes);
-    }
-    name_ = NameTag(pName);
-    ownMemory_ = true;
-    pNameHolder.release();
-  }
+   }
+   name_ = NameTag(pName);
+   ownMemory_ = true;
+   pNameHolder.release();
+}
 
-  void
-  DataKey::deleteMemory()
-  {
-    if(kBlank[0] != name().value()[0]) {
+void
+DataKey::deleteMemory()
+{
+   if(kBlank[0] != name().value()[0]) {
       delete [] const_cast<char*>(name().value());
-    }
-  }
+   }
+}
 
-  //
-  // const member functions
-  //
-  bool
-  DataKey::operator==(const DataKey& iRHS) const
-  {
-    return ((type_ == iRHS.type_) &&
+//
+// const member functions
+//
+bool
+DataKey::operator==(const DataKey& iRHS) const
+{
+   return ((type_ == iRHS.type_) &&
             (name_ == iRHS.name_));
-  }
+}
 
-  bool
-  DataKey::operator<(const DataKey& iRHS) const
-  {
-    return (type_ < iRHS.type_) ||
-      ((type_ == iRHS.type_) && (name_ < iRHS.name_));
-  }
+bool
+DataKey::operator<(const DataKey& iRHS) const
+{
+   return (type_ < iRHS.type_) ||
+   ((type_ == iRHS.type_) && (name_ < iRHS.name_));
+}
 }

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -1,5 +1,5 @@
 /*
- *  proxyfactoryproducer_t.cc
+ *  esproducer_t.cppunit.cc
  *  EDMProto
  *
  *  Created by Chris Jones on 4/8/05.
@@ -25,25 +25,25 @@ using edm::ESProducer;
 using edm::EventSetupRecordIntervalFinder;
 
 namespace {
-edm::ActivityRegistry activityRegistry;
+  edm::ActivityRegistry activityRegistry;
 }
 
-class testEsproducer: public CppUnit::TestFixture 
+class testEsproducer: public CppUnit::TestFixture
 {
-CPPUNIT_TEST_SUITE(testEsproducer);
+  CPPUNIT_TEST_SUITE(testEsproducer);
 
-CPPUNIT_TEST(registerTest);
-CPPUNIT_TEST(getFromTest);
-CPPUNIT_TEST(getfromShareTest);
-CPPUNIT_TEST(getfromUniqueTest);
-CPPUNIT_TEST(getfromOptionalTest);
-CPPUNIT_TEST(decoratorTest);
-CPPUNIT_TEST(dependsOnTest);
-CPPUNIT_TEST(labelTest);
-CPPUNIT_TEST_EXCEPTION(failMultipleRegistration,cms::Exception);
-CPPUNIT_TEST(forceCacheClearTest);
-   
-CPPUNIT_TEST_SUITE_END();
+  CPPUNIT_TEST(registerTest);
+  CPPUNIT_TEST(getFromTest);
+  CPPUNIT_TEST(getfromShareTest);
+  CPPUNIT_TEST(getfromUniqueTest);
+  CPPUNIT_TEST(getfromOptionalTest);
+  CPPUNIT_TEST(decoratorTest);
+  CPPUNIT_TEST(dependsOnTest);
+  CPPUNIT_TEST(labelTest);
+  CPPUNIT_TEST_EXCEPTION(failMultipleRegistration,cms::Exception);
+  CPPUNIT_TEST(forceCacheClearTest);
+
+  CPPUNIT_TEST_SUITE_END();
 public:
   void setUp(){}
   void tearDown(){}
@@ -60,24 +60,22 @@ public:
   void forceCacheClearTest();
 
 private:
-class Test1Producer : public ESProducer {
-public:
-   Test1Producer() : ESProducer(), data_() {
-      data_.value_ = 0;
+  class Test1Producer : public ESProducer {
+  public:
+    Test1Producer() {
       setWhatProduced(this);
-   }
-  std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
-    ++data_.value_;
-    return std::shared_ptr<DummyData>(&data_,edm::do_nothing_deleter{});
-   }
-private:
-   DummyData data_;
-};
+    }
+    std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+      ++data_.value_;
+      return std::shared_ptr<DummyData>(&data_,edm::do_nothing_deleter{});
+    }
+  private:
+    DummyData data_{0};
+  };
 
   class OptionalProducer : public ESProducer {
   public:
-    OptionalProducer() : ESProducer(), data_() {
-      data_.value_ = 0;
+    OptionalProducer() {
       setWhatProduced(this);
     }
     std::optional<DummyData> produce(const DummyRecord& /*iRecord*/) {
@@ -85,79 +83,76 @@ private:
       return data_;
     }
   private:
+    DummyData data_{0};
+  };
+
+  class MultiRegisterProducer : public ESProducer {
+  public:
+    MultiRegisterProducer() {
+      setWhatProduced(this);
+      setWhatProduced(this);
+    }
+    std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+      return std::shared_ptr<DummyData>(&data_, edm::do_nothing_deleter{});
+    }
+  private:
+    DummyData data_{0};
+  };
+
+  class ShareProducer : public ESProducer {
+  public:
+    ShareProducer() {
+      setWhatProduced(this);
+    }
+    std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+      ++ptr_->value_;
+      return ptr_;
+    }
+  private:
+    std::shared_ptr<DummyData> ptr_{std::make_shared<DummyData>(0)};
+  };
+
+  class UniqueProducer : public ESProducer {
+  public:
+    UniqueProducer() {
+      setWhatProduced(this);
+    }
+    std::unique_ptr<DummyData> produce(const DummyRecord&) {
+      ++data_.value_;
+      return std::make_unique<DummyData>(data_);
+    }
+  private:
     DummyData data_;
   };
 
-class MultiRegisterProducer : public ESProducer {
-public:
-   MultiRegisterProducer() : ESProducer(), data_() {
-      setWhatProduced(this);
-      setWhatProduced(this);
-   }
-   std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
-     return std::shared_ptr<DummyData>(&data_, edm::do_nothing_deleter{});
-   }
-private:
-   DummyData data_;
-};
-
-class ShareProducer : public ESProducer {
-public:
-   ShareProducer(): ptr_(new DummyData){
-      ptr_->value_ = 0;
-      setWhatProduced(this);
-   }
-   std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
-      ++ptr_->value_;
-      return ptr_;
-   }
-private:
-   std::shared_ptr<DummyData> ptr_;
-};
-
-class UniqueProducer : public ESProducer {
-public:
-   UniqueProducer() {
-      setWhatProduced(this);
-   }
-   std::unique_ptr<DummyData> produce(const DummyRecord&) {
-      ++data_.value_;
-      return std::make_unique<DummyData>(data_);
-   }
-private:
-   DummyData data_;
-};
-
-class LabelledProducer : public ESProducer {
-public:
-   enum {kFi, kFum};
-  typedef edm::ESProducts< edm::es::L<DummyData,kFi>, edm::es::L<DummyData,kFum> > ReturnProducts;
-   LabelledProducer(): ptr_(new DummyData), fi_(new DummyData){
-      ptr_->value_ = 0;
-      fi_->value_=0;
+  class LabelledProducer : public ESProducer {
+  public:
+    enum {kFi, kFum};
+    typedef edm::ESProducts< edm::es::L<DummyData,kFi>, edm::es::L<DummyData,kFum> > ReturnProducts;
+    LabelledProducer() {
       setWhatProduced(this,"foo");
       setWhatProduced(this, &LabelledProducer::produceMore, edm::es::label("fi",kFi)("fum",kFum));
-   }
-   
-   std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+    }
+
+    std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
       ++ptr_->value_;
       return ptr_;
-   }
-   
-   ReturnProducts produceMore(const DummyRecord&){
+    }
+
+    ReturnProducts produceMore(const DummyRecord&){
       using edm::es::L;
       using namespace edm;
       ++fi_->value_;
 
       L<DummyData,kFum> fum( std::make_shared<DummyData>());
       fum->value_ = fi_->value_;
-      
+
       return edm::es::products(fum, es::l<kFi>(fi_) );
-   }
-private:
-   std::shared_ptr<DummyData> ptr_;
-   std::shared_ptr<DummyData> fi_;
-};
+    }
+  private:
+    std::shared_ptr<DummyData> ptr_{std::make_shared<DummyData>(0)};
+    std::shared_ptr<DummyData> fi_{std::make_shared<DummyData>(0)};
+  };
 
 };
 
@@ -167,89 +162,85 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testEsproducer);
 
 void testEsproducer::registerTest()
 {
-   Test1Producer testProd;
-   EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
-   CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
+  Test1Producer testProd;
+  EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
+  CPPUNIT_ASSERT(testProd.isUsingRecord(dummyRecordKey));
 
-   const DataProxyProvider::KeyedProxies& keyedProxies =
-      testProd.keyedProxies(dummyRecordKey);
+  const DataProxyProvider::KeyedProxies& keyedProxies =
+    testProd.keyedProxies(dummyRecordKey);
 
-   CPPUNIT_ASSERT(keyedProxies.size() == 1);
+  CPPUNIT_ASSERT(keyedProxies.size() == 1);
 }
 
 void testEsproducer::getFromTest()
 {
   EventSetupProvider provider(&activityRegistry);
-   
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<Test1Producer>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
-   
-   for(int iTime=1; iTime != 6; ++iTime) {
-      const edm::Timestamp time(iTime);
-      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
-      edm::ESHandle<DummyData> pDummy;
-      eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      CPPUNIT_ASSERT(iTime == pDummy->value_);
-   }
+  provider.add(std::make_shared<Test1Producer>());
+
+  auto pFinder = std::make_shared<DummyFinder>();
+  provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+
+  for(int iTime=1; iTime != 6; ++iTime) {
+    const edm::Timestamp time(iTime);
+    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
+    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    edm::ESHandle<DummyData> pDummy;
+    eventSetup.get<DummyRecord>().get(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+    CPPUNIT_ASSERT(iTime == pDummy->value_);
+  }
 }
 
 void testEsproducer::getfromShareTest()
 {
   EventSetupProvider provider(&activityRegistry);
-   
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<ShareProducer>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
-   
-   for(int iTime=1; iTime != 6; ++iTime) {
-      const edm::Timestamp time(iTime);
-      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
-      edm::ESHandle<DummyData> pDummy;
-      eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      CPPUNIT_ASSERT(iTime == pDummy->value_);
-   }
+
+  std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<ShareProducer>();
+  provider.add(pProxyProv);
+
+  auto pFinder = std::make_shared<DummyFinder>();
+  provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+
+  for(int iTime=1; iTime != 6; ++iTime) {
+    const edm::Timestamp time(iTime);
+    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
+    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    edm::ESHandle<DummyData> pDummy;
+    eventSetup.get<DummyRecord>().get(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+    CPPUNIT_ASSERT(iTime == pDummy->value_);
+  }
 }
 
 void testEsproducer::getfromUniqueTest()
 {
-   EventSetupProvider provider(&activityRegistry);
-   
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<UniqueProducer>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
-   
-   for(int iTime=1; iTime != 6; ++iTime) {
-      const edm::Timestamp time(iTime);
-      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
-      edm::ESHandle<DummyData> pDummy;
-      eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      CPPUNIT_ASSERT(iTime == pDummy->value_);
-   }
+  EventSetupProvider provider(&activityRegistry);
+
+  std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<UniqueProducer>();
+  provider.add(pProxyProv);
+
+  auto pFinder = std::make_shared<DummyFinder>();
+  provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+
+  for(int iTime=1; iTime != 6; ++iTime) {
+    const edm::Timestamp time(iTime);
+    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
+    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    edm::ESHandle<DummyData> pDummy;
+    eventSetup.get<DummyRecord>().get(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+    CPPUNIT_ASSERT(iTime == pDummy->value_);
+  }
 }
 
 void testEsproducer::getfromOptionalTest()
 {
   EventSetupProvider provider(&activityRegistry);
-  
-  std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<OptionalProducer>();
-  provider.add(pProxyProv);
-  
-  std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
+  provider.add(std::make_shared<OptionalProducer>());
+
+  auto pFinder = std::make_shared<DummyFinder>();
   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
-  
+
   for(int iTime=1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
@@ -263,16 +254,16 @@ void testEsproducer::getfromOptionalTest()
 
 void testEsproducer::labelTest()
 {
-   try {
-   EventSetupProvider provider(&activityRegistry);
-   
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<LabelledProducer>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
-   
-   for(int iTime=1; iTime != 6; ++iTime) {
+  try {
+    EventSetupProvider provider(&activityRegistry);
+
+    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<LabelledProducer>();
+    provider.add(pProxyProv);
+
+    auto pFinder = std::make_shared<DummyFinder>();
+    provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+
+    for(int iTime=1; iTime != 6; ++iTime) {
       const edm::Timestamp time(iTime);
       pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
       const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
@@ -280,32 +271,32 @@ void testEsproducer::labelTest()
       eventSetup.get<DummyRecord>().get("foo",pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
       CPPUNIT_ASSERT(iTime == pDummy->value_);
-      
+
       eventSetup.get<DummyRecord>().get("fi",pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
       CPPUNIT_ASSERT(iTime == pDummy->value_);
-      
+
       eventSetup.get<DummyRecord>().get("fum",pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
       CPPUNIT_ASSERT(iTime == pDummy->value_);
-   }
-   } catch(const cms::Exception& iException) {
-      std::cout <<"caught exception "<<iException.explainSelf()<<std::endl;
-      throw;
-   }
+    }
+  } catch(const cms::Exception& iException) {
+    std::cout <<"caught exception "<<iException.explainSelf()<<std::endl;
+    throw;
+  }
 }
 
 struct TestDecorator {
-   static int s_pre;
-   static int s_post;
-   
-   void pre(const DummyRecord&) {
-      ++s_pre;
-   }
+  static int s_pre;
+  static int s_post;
 
-   void post(const DummyRecord&) {
-      ++s_post;
-   }   
+  void pre(const DummyRecord&) {
+    ++s_pre;
+  }
+
+  void post(const DummyRecord&) {
+    ++s_post;
+  }
 };
 
 int TestDecorator::s_pre = 0;
@@ -313,121 +304,112 @@ int TestDecorator::s_post = 0;
 
 class DecoratorProducer : public ESProducer {
 public:
-   DecoratorProducer(): ptr_(new DummyData){
-      ptr_->value_ = 0;
-      setWhatProduced(this, TestDecorator());
-   }
-   std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
-      ++ptr_->value_;
-      return ptr_;
-   }
+  DecoratorProducer() {
+    setWhatProduced(this, TestDecorator{});
+  }
+  std::shared_ptr<DummyData> produce(const DummyRecord& /*iRecord*/) {
+    ++ptr_->value_;
+    return ptr_;
+  }
 private:
-   std::shared_ptr<DummyData> ptr_;
+  std::shared_ptr<DummyData> ptr_{std::make_shared<DummyData>(0)};
 };
 
 void testEsproducer::decoratorTest()
 {
-   EventSetupProvider provider(&activityRegistry);
-   
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DecoratorProducer>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
-   
-   for(int iTime=1; iTime != 6; ++iTime) {
-      const edm::Timestamp time(iTime);
-      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
-      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
-      edm::ESHandle<DummyData> pDummy;
-      
-      CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_pre);
-      CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_post);
-      eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      CPPUNIT_ASSERT(iTime == TestDecorator::s_pre);
-      CPPUNIT_ASSERT(iTime == TestDecorator::s_post);
-      CPPUNIT_ASSERT(iTime == pDummy->value_);
-   }
+  EventSetupProvider provider(&activityRegistry);
+  provider.add(std::make_shared<DecoratorProducer>());
+
+  auto pFinder = std::make_shared<DummyFinder>();
+  provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+
+  for(int iTime=1; iTime != 6; ++iTime) {
+    const edm::Timestamp time(iTime);
+    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
+    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    edm::ESHandle<DummyData> pDummy;
+
+    CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_pre);
+    CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_post);
+    eventSetup.get<DummyRecord>().get(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+    CPPUNIT_ASSERT(iTime == TestDecorator::s_pre);
+    CPPUNIT_ASSERT(iTime == TestDecorator::s_post);
+    CPPUNIT_ASSERT(iTime == pDummy->value_);
+  }
 }
 
 class DepProducer : public ESProducer {
 public:
-   DepProducer(): ptr_(new DummyData){
-      ptr_->value_ = 0;
-      setWhatProduced(this , dependsOn(&DepProducer::callWhenDummyChanges, 
-                                        &DepProducer::callWhenDummyChanges2,
-                                        &DepProducer::callWhenDummyChanges3));
-   }
-   std::shared_ptr<DummyData> produce(const DepRecord& /*iRecord*/) {
-      return ptr_;
-   }
-   void callWhenDummyChanges(const DummyRecord&) {
-      ++ptr_->value_;
-   }
-   void callWhenDummyChanges2(const DummyRecord&) {
-      ++ptr_->value_;
-   }
-   void callWhenDummyChanges3(const DummyRecord&) {
-      ++ptr_->value_;
-   }
-   
+  DepProducer() {
+    setWhatProduced(this , dependsOn(&DepProducer::callWhenDummyChanges,
+                                     &DepProducer::callWhenDummyChanges2,
+                                     &DepProducer::callWhenDummyChanges3));
+  }
+  std::shared_ptr<DummyData> produce(const DepRecord& /*iRecord*/) {
+    return ptr_;
+  }
+  void callWhenDummyChanges(const DummyRecord&) {
+    ++ptr_->value_;
+  }
+  void callWhenDummyChanges2(const DummyRecord&) {
+    ++ptr_->value_;
+  }
+  void callWhenDummyChanges3(const DummyRecord&) {
+    ++ptr_->value_;
+  }
+
 private:
-   std::shared_ptr<DummyData> ptr_;
+  std::shared_ptr<DummyData> ptr_{std::make_shared<DummyData>(0)};
 };
 
 void testEsproducer::dependsOnTest()
 {
-   EventSetupProvider provider(&activityRegistry);
-   
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DepProducer>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
-   
-   for(int iTime=1; iTime != 6; ++iTime) {
-      const edm::Timestamp time(iTime);
-      pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
-      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
-      edm::ESHandle<DummyData> pDummy;
-      
-      eventSetup.get<DepRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      CPPUNIT_ASSERT(3*iTime == pDummy->value_);
-   }
+  EventSetupProvider provider(&activityRegistry);
+  provider.add(std::make_shared<DepProducer>());
+
+  auto pFinder = std::make_shared<DummyFinder>();
+  provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+
+  for(int iTime=1; iTime != 6; ++iTime) {
+    const edm::Timestamp time(iTime);
+    pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
+    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    edm::ESHandle<DummyData> pDummy;
+
+    eventSetup.get<DepRecord>().get(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+    CPPUNIT_ASSERT(3*iTime == pDummy->value_);
+  }
 }
 
 void testEsproducer::failMultipleRegistration()
 {
-   MultiRegisterProducer dummy;
+  MultiRegisterProducer dummy;
 }
 
 void testEsproducer::forceCacheClearTest()
 {
-   EventSetupProvider provider(&activityRegistry);
-   
-   std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<Test1Producer>();
-   provider.add(pProxyProv);
-   
-   std::shared_ptr<DummyFinder> pFinder = std::make_shared<DummyFinder>();
-   provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
-   
-   const edm::Timestamp time(1);
-   pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-   const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
-   {
-      edm::ESHandle<DummyData> pDummy;
-      eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      CPPUNIT_ASSERT(1 == pDummy->value_);
-   }
-   provider.forceCacheClear();
-   {
-      edm::ESHandle<DummyData> pDummy;
-      eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != pDummy.product());
-      CPPUNIT_ASSERT(2 == pDummy->value_);
-   }
-}
+  EventSetupProvider provider(&activityRegistry);
+  provider.add(std::make_shared<Test1Producer>());
 
+  auto pFinder = std::make_shared<DummyFinder>();
+  provider.add(std::shared_ptr<EventSetupRecordIntervalFinder>(pFinder));
+
+  const edm::Timestamp time(1);
+  pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
+  const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+  {
+    edm::ESHandle<DummyData> pDummy;
+    eventSetup.get<DummyRecord>().get(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+    CPPUNIT_ASSERT(1 == pDummy->value_);
+  }
+  provider.forceCacheClear();
+  {
+    edm::ESHandle<DummyData> pDummy;
+    eventSetup.get<DummyRecord>().get(pDummy);
+    CPPUNIT_ASSERT(0 != pDummy.product());
+    CPPUNIT_ASSERT(2 == pDummy->value_);
+  }
+}

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -489,7 +489,7 @@ void testEventsetup::getDataWithESInputTagTest()
     {
       edm::ESHandle<DummyData> data;
       edm::ESInputTag badTag("DoesNotExist","blah");
-      CPPUNIT_ASSERT_THROW(eventSetup.getData(badTag,data), cms::Exception);
+      CPPUNIT_ASSERT_THROW(eventSetup.getData(badTag, data), cms::Exception);
     }
 
 

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -160,9 +160,7 @@ void testEventsetup::recordProviderTest()
 {
   DummyEventSetupProvider provider(&activityRegistry);
   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
-  auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
-
-  provider.insert(std::move(dummyRecordProvider));
+  provider.insert(std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass()));
 
   //NOTE: use 'invalid' timestamp since the default 'interval of validity'
   //       for a Record is presently an 'invalid' timestamp on both ends.
@@ -204,8 +202,7 @@ void testEventsetup::recordValidityTest()
   DummyEventSetupProvider provider(&activityRegistry);
   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
-
-  std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
+  auto finder = std::make_shared<DummyFinder>();
   dummyRecordProvider->addFinder(finder);
 
   provider.insert(std::move(dummyRecordProvider));
@@ -238,9 +235,7 @@ void testEventsetup::recordValidityExcTest()
   DummyEventSetupProvider provider(&activityRegistry);
   typedef eventsetup::EventSetupRecordProvider DummyRecordProvider;
   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>(DummyRecord::keyForClass());
-
-  std::shared_ptr<DummyFinder> finder = std::make_shared<DummyFinder>();
-  dummyRecordProvider->addFinder(finder);
+  dummyRecordProvider->addFinder(std::make_shared<DummyFinder>());
 
   provider.insert(std::move(dummyRecordProvider));
 
@@ -272,8 +267,7 @@ static eventsetup::RecordDependencyRegister<DummyRecord> s_factory;
 void testEventsetup::proxyProviderTest()
 {
   eventsetup::EventSetupProvider provider(&activityRegistry);
-  std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
-  provider.add(dummyProv);
+  provider.add(std::make_shared<DummyProxyProvider>());
 
   EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
@@ -286,12 +280,12 @@ void testEventsetup::producerConflictTest()
   using edm::eventsetup::test::DummyProxyProvider;
   eventsetup::EventSetupProvider provider(&activityRegistry);
   {
-    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    auto dummyProv = std::make_shared<DummyProxyProvider>();
     dummyProv->setDescription(description);
     provider.add(dummyProv);
   }
   {
-    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    auto dummyProv = std::make_shared<DummyProxyProvider>();
     dummyProv->setDescription(description);
     provider.add(dummyProv);
   }
@@ -305,12 +299,12 @@ void testEventsetup::sourceConflictTest()
   using edm::eventsetup::test::DummyProxyProvider;
   eventsetup::EventSetupProvider provider(&activityRegistry);
   {
-    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    auto dummyProv = std::make_shared<DummyProxyProvider>();
     dummyProv->setDescription(description);
     provider.add(dummyProv);
   }
   {
-    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    auto dummyProv = std::make_shared<DummyProxyProvider>();
     dummyProv->setDescription(description);
     provider.add(dummyProv);
   }
@@ -326,12 +320,12 @@ void testEventsetup::twoSourceTest()
   using edm::eventsetup::test::DummyProxyProvider;
   eventsetup::EventSetupProvider provider(&activityRegistry);
   {
-    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
+    auto dummyProv = std::make_shared<DummyProxyProvider>();
     dummyProv->setDescription(description);
     provider.add(dummyProv);
   }
   {
-    std::shared_ptr<edm::DummyEventSetupRecordRetriever> dummyProv = std::make_shared<edm::DummyEventSetupRecordRetriever>();
+    auto dummyProv = std::make_shared<edm::DummyEventSetupRecordRetriever>();
     std::shared_ptr<eventsetup::DataProxyProvider> providerPtr(dummyProv);
     std::shared_ptr<edm::EventSetupRecordIntervalFinder> finderPtr(dummyProv);
     edm::eventsetup::ComponentDescription description2("DummyEventSetupRecordRetriever","",true);
@@ -347,8 +341,8 @@ void testEventsetup::provenanceTest()
 {
   using edm::eventsetup::test::DummyProxyProvider;
   using edm::eventsetup::test::DummyData;
-  DummyData kGood; kGood.value_ = 1;
-  DummyData kBad; kBad.value_=0;
+  DummyData kGood{1};
+  DummyData kBad{0};
 
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
@@ -358,7 +352,7 @@ void testEventsetup::provenanceTest()
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
       description.pid_ = ps.id();
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
@@ -368,7 +362,7 @@ void testEventsetup::provenanceTest()
       ps.addParameter<std::string>("name", "test22");
       ps.registerIt();
       description.pid_ = ps.id();
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
@@ -388,8 +382,8 @@ void testEventsetup::getDataWithLabelTest()
 {
   using edm::eventsetup::test::DummyProxyProvider;
   using edm::eventsetup::test::DummyData;
-  DummyData kGood; kGood.value_ = 1;
-  DummyData kBad; kBad.value_=0;
+  DummyData kGood{1};
+  DummyData kBad{0};
 
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
@@ -399,7 +393,7 @@ void testEventsetup::getDataWithLabelTest()
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
       description.pid_ = ps.id();
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
@@ -410,7 +404,7 @@ void testEventsetup::getDataWithLabelTest()
       ps.addParameter<std::string>("appendToDataLabel","blah");
       ps.registerIt();
       description.pid_ = ps.id();
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       dummyProv->setAppendToDataLabel(ps);
       provider.add(dummyProv);
@@ -431,8 +425,8 @@ void testEventsetup::getDataWithESInputTagTest()
 {
   using edm::eventsetup::test::DummyProxyProvider;
   using edm::eventsetup::test::DummyData;
-  DummyData kGood; kGood.value_ = 1;
-  DummyData kBad; kBad.value_=0;
+  DummyData kGood{1};
+  DummyData kBad{0};
 
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
@@ -442,7 +436,7 @@ void testEventsetup::getDataWithESInputTagTest()
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
       description.pid_ = ps.id();
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
@@ -453,7 +447,7 @@ void testEventsetup::getDataWithESInputTagTest()
       ps.addParameter<std::string>("appendToDataLabel","blah");
       ps.registerIt();
       description.pid_ = ps.id();
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       dummyProv->setAppendToDataLabel(ps);
       provider.add(dummyProv);
@@ -505,20 +499,20 @@ void testEventsetup::sourceProducerResolutionTest()
 {
   using edm::eventsetup::test::DummyProxyProvider;
   using edm::eventsetup::test::DummyData;
-  DummyData kGood; kGood.value_ = 1;
-  DummyData kBad; kBad.value_=0;
+  DummyData kGood{1};
+  DummyData kBad{0};
 
   {
     eventsetup::EventSetupProvider provider(&activityRegistry);
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
@@ -538,13 +532,13 @@ void testEventsetup::sourceProducerResolutionTest()
     eventsetup::EventSetupProvider provider(&activityRegistry);
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
     {
       edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
@@ -567,8 +561,8 @@ void testEventsetup::preferTest()
   try {
     using edm::eventsetup::test::DummyProxyProvider;
     using edm::eventsetup::test::DummyData;
-    DummyData kGood; kGood.value_ = 1;
-    DummyData kBad; kBad.value_=0;
+    DummyData kGood{1};
+    DummyData kBad{0};
 
     {
       using namespace edm::eventsetup;
@@ -580,13 +574,13 @@ void testEventsetup::preferTest()
       eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
       {
         edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",false);
-        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+        auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
       {
         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
-        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+        auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
@@ -611,13 +605,13 @@ void testEventsetup::preferTest()
       eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
       {
         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+        auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
       {
         edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
-        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+        auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
@@ -643,13 +637,13 @@ void testEventsetup::preferTest()
       eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
       {
         edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
-        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+        auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
       {
         edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",true);
-        std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+        auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
@@ -674,8 +668,8 @@ void testEventsetup::introspectionTest()
 {
   using edm::eventsetup::test::DummyProxyProvider;
   using edm::eventsetup::test::DummyData;
-  DummyData kGood; kGood.value_ = 1;
-  DummyData kBad; kBad.value_=0;
+  DummyData kGood{1};
+  DummyData kBad{0};
 
   eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
@@ -685,7 +679,7 @@ void testEventsetup::introspectionTest()
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
       description.pid_ = ps.id();
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
@@ -695,7 +689,7 @@ void testEventsetup::introspectionTest()
       ps.addParameter<std::string>("name", "test22");
       ps.registerIt();
       description.pid_ = ps.id();
-      std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
+      auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }

--- a/FWCore/Framework/test/stubs/TestESDummyDataAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestESDummyDataAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    Framework
 // Class:      TestESDummyDataAnalyzer
-// 
+//
 /**\class TestESDummyDataAnalyzer TestESDummyDataAnalyzer.cc FWCore/Framework/test/stubs/TestESDummyDataAnalyzer.cc
 
  Description: <one line class summary>
@@ -32,97 +32,61 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-//
-// class decleration
-//
-
 class TestESDummyDataAnalyzer : public edm::EDAnalyzer {
-   public:
-      explicit TestESDummyDataAnalyzer(const edm::ParameterSet&);
-      ~TestESDummyDataAnalyzer();
+public:
+  explicit TestESDummyDataAnalyzer(const edm::ParameterSet&);
 
+private:
+  virtual void endJob();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-   private:
-         virtual void endJob();
-         int m_expectedValue;
-         int m_nEventsValue;
-         int m_counter;
-         int m_totalCounter;
-         int m_totalNEvents;
-      // ----------member data ---------------------------
+  int m_expectedValue;
+  int const m_nEventsValue;
+  int m_counter{};
+  int m_totalCounter{};
+  int const m_totalNEvents;
+  edm::ESGetTokenT<edm::eventsetup::test::DummyData> const m_esToken;
 };
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 TestESDummyDataAnalyzer::TestESDummyDataAnalyzer(const edm::ParameterSet& iConfig) :
-m_expectedValue(iConfig.getParameter<int>("expected")),
-m_nEventsValue(iConfig.getUntrackedParameter<int>("nEvents",0)),
-m_counter(0),
-m_totalCounter(0),
-m_totalNEvents(iConfig.getUntrackedParameter<int>("totalNEvents",-1) )
-{
-   //now do what ever initialization is needed
-
-}
+  m_expectedValue{iConfig.getParameter<int>("expected")},
+  m_nEventsValue{iConfig.getUntrackedParameter<int>("nEvents",0)},
+  m_totalNEvents{iConfig.getUntrackedParameter<int>("totalNEvents",-1)},
+  m_esToken{esConsumes<edm::eventsetup::test::DummyData, edm::DefaultRecord>()}
+{}
 
 
-TestESDummyDataAnalyzer::~TestESDummyDataAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
-}
-
-
-//
-// member functions
-//
-
-// ------------ method called to produce the data  ------------
 void
 TestESDummyDataAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup)
 {
-   using namespace edm;
+  using namespace edm;
 
-   ++m_totalCounter;
-//   std::cout<<"before "<<m_expectedValue<<std::endl;
-   if(m_nEventsValue) {
-      ++m_counter;
-      if(m_nEventsValue<m_counter) {
-         ++m_expectedValue;
-         m_counter=0;
-      }
-   }
-   
-   ESHandle<edm::eventsetup::test::DummyData> pData;
-   iSetup.getData(pData);
-//   std::cout<<"after "<<m_expectedValue<<" pData "<<pData->value_<<std::endl;
+  ++m_totalCounter;
+  if(m_nEventsValue) {
+    ++m_counter;
+    if(m_nEventsValue<m_counter) {
+      ++m_expectedValue;
+      m_counter=0;
+    }
+  }
 
-   if(m_expectedValue != pData->value_) {
-      throw cms::Exception("WrongValue")<<"got value "<<pData->value_<<" but expected "<<m_expectedValue;
-   }
-   
+  ESHandle<edm::eventsetup::test::DummyData> pData;
+  iSetup.getData(m_esToken, pData);
+
+  if(m_expectedValue != pData->value_) {
+    throw cms::Exception("WrongValue")<<"got value "<<pData->value_<<" but expected "<<m_expectedValue;
+  }
+
 }
 
-void 
+void
 TestESDummyDataAnalyzer::endJob()
 {
   if (-1 != m_totalNEvents &&
       m_totalNEvents != m_totalCounter) {
     throw cms::Exception("WrongNumberOfEvents")<<"expected "<<m_totalNEvents<<" but instead saw "<<m_totalCounter
-					       <<"\n";
+                                               <<"\n";
   }
 }
-//define this as a plug-in
+
 DEFINE_FWK_MODULE(TestESDummyDataAnalyzer);

--- a/FWCore/Integration/test/WhatsItESProducer.cc
+++ b/FWCore/Integration/test/WhatsItESProducer.cc
@@ -79,7 +79,7 @@ WhatsItESProducer::WhatsItESProducer(edm::ParameterSet const& pset)
   // data is being produced
   auto collector = setWhatProduced(this);
   //now do what ever other initialization is needed
-  token_ = collector.consumes<edmtest::Doodad>(dataLabel_);
+  token_ = collector.consumes<edmtest::Doodad>(edm::ESInputTag{"", dataLabel_});
 }
 
 

--- a/FWCore/Integration/test/WhatsItESProducer.cc
+++ b/FWCore/Integration/test/WhatsItESProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    WhatsItESProducer
 // Class:      WhatsItESProducer
-// 
+//
 /**\class WhatsItESProducer WhatsItESProducer.h test/WhatsItESProducer/interface/WhatsItESProducer.h
 
  Description: <one line class summary>
@@ -32,6 +32,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 //
 // class decleration
@@ -52,6 +53,7 @@ class WhatsItESProducer : public edm::ESProducer {
    private:
       // ----------member data ---------------------------
       std::string dataLabel_;
+      edm::ESGetTokenT<edmtest::Doodad> token_;
 };
 
 //
@@ -66,27 +68,25 @@ class WhatsItESProducer : public edm::ESProducer {
 // constructors and destructor
 //
 WhatsItESProducer::WhatsItESProducer(edm::ParameterSet const& pset)
-: dataLabel_(pset.exists("doodadLabel")? pset.getParameter<std::string>("doodadLabel"):std::string(""))
+  : dataLabel_{pset.exists("doodadLabel") ? pset.getParameter<std::string>("doodadLabel"): std::string{}}
 {
   if (pset.getUntrackedParameter<bool>("test", true)) {
      throw edm::Exception(edm::errors::Configuration, "Something is wrong with ESProducer validation\n")
        << "Or the test configuration parameter was set true (it should never be true unless you want this exception)\n";
    }
 
-   //the following line is needed to tell the framework what
-   // data is being produced
-   setWhatProduced(this);
-
-   //now do what ever other initialization is needed
+  //the following line is needed to tell the framework what
+  // data is being produced
+  auto collector = setWhatProduced(this);
+  //now do what ever other initialization is needed
+  token_ = collector.consumes<edmtest::Doodad>(dataLabel_);
 }
 
 
 WhatsItESProducer::~WhatsItESProducer()
 {
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
 
@@ -101,8 +101,8 @@ WhatsItESProducer::produce(const GadgetRcd& iRecord)
    using namespace edmtest;
 
    edm::ESHandle<Doodad> doodad;
-   iRecord.get(dataLabel_,doodad);
-   
+   iRecord.get(token_ ,doodad);
+
    auto pWhatsIt = std::make_unique<WhatsIt>() ;
 
    pWhatsIt->a = doodad->a;
@@ -115,7 +115,7 @@ WhatsItESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   edm::ParameterSetDescription desc;
   desc.addOptional<std::string>("doodadLabel");
   desc.addUntracked<bool>("test", false)->
-    setComment("This parameter exists only to test the parameter set validation for ESSources"); 
+    setComment("This parameter exists only to test the parameter set validation for ESSources");
   descriptions.add("WhatsItESProducer", desc);
 }
 }

--- a/FWCore/Integration/test/WhatsItESProducer.cc
+++ b/FWCore/Integration/test/WhatsItESProducer.cc
@@ -52,7 +52,6 @@ class WhatsItESProducer : public edm::ESProducer {
 
    private:
       // ----------member data ---------------------------
-      std::string dataLabel_;
       edm::ESGetTokenT<edmtest::Doodad> token_;
 };
 
@@ -68,7 +67,6 @@ class WhatsItESProducer : public edm::ESProducer {
 // constructors and destructor
 //
 WhatsItESProducer::WhatsItESProducer(edm::ParameterSet const& pset)
-  : dataLabel_{pset.exists("doodadLabel") ? pset.getParameter<std::string>("doodadLabel"): std::string{}}
 {
   if (pset.getUntrackedParameter<bool>("test", true)) {
      throw edm::Exception(edm::errors::Configuration, "Something is wrong with ESProducer validation\n")
@@ -78,8 +76,10 @@ WhatsItESProducer::WhatsItESProducer(edm::ParameterSet const& pset)
   //the following line is needed to tell the framework what
   // data is being produced
   auto collector = setWhatProduced(this);
+
   //now do what ever other initialization is needed
-  token_ = collector.consumes<edmtest::Doodad>(edm::ESInputTag{"", dataLabel_});
+  auto const data_label = pset.exists("doodadLabel") ? pset.getParameter<std::string>("doodadLabel"): std::string{};
+  token_ = collector.consumes<edmtest::Doodad>(edm::ESInputTag{"", data_label});
 }
 
 

--- a/FWCore/Utilities/interface/ESGetToken.h
+++ b/FWCore/Utilities/interface/ESGetToken.h
@@ -20,6 +20,10 @@ namespace edm {
   class EDConsumerBase;
   class ESProducer;
   class ESConsumesCollector;
+  class EventSetup;
+  namespace eventsetup {
+    class EventSetupRecord;
+  }
 
   // A ESGetToken is created by calls to 'esConsumes' from an EDM
   // module.
@@ -28,10 +32,11 @@ namespace edm {
     friend class EDConsumerBase;
     friend class ESProducer;
     friend class ESConsumesCollector;
+    friend class EventSetup;
+    friend class eventsetup::EventSetupRecord;
 
   public:
     ESGetTokenT() = default;
-    ESInputTag const& tag() const noexcept { return m_tag; }
 
   private:
     explicit ESGetTokenT(ESInputTag const& tag) : m_tag{tag} {}

--- a/FWCore/Utilities/interface/ESGetToken.h
+++ b/FWCore/Utilities/interface/ESGetToken.h
@@ -1,0 +1,44 @@
+#ifndef FWCore_Utilities_ESGetToken_h
+#define FWCore_Utilities_ESGetToken_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     ESGetToken
+//
+/**\class ESGetToken ESGetToken.h "FWCore/Utilities/interface/ESGetToken.h"
+
+ Description: A token used to get data from the event setup system
+
+ Usage:
+    An ESGetToken is created by calls to 'esConsumes' from an ED module
+    or via a ConsumesCollector::consumes.
+*/
+
+#include "FWCore/Utilities/interface/ESInputTag.h"
+
+namespace edm {
+  class EDConsumerBase;
+  class ESProducer;
+  class ESConsumesCollector;
+
+  // A ESGetToken is created by calls to 'esConsumes' from an EDM
+  // module.
+  template<typename ESProduct>
+  class ESGetTokenT {
+    friend class EDConsumerBase;
+    friend class ESProducer;
+    friend class ESConsumesCollector;
+
+  public:
+    ESGetTokenT() = default;
+    ESInputTag const& tag() const noexcept { return m_tag; }
+
+  private:
+    explicit ESGetTokenT(ESInputTag const& tag) : m_tag{tag} {}
+
+    ESInputTag m_tag{};
+  };
+
+}
+
+#endif

--- a/FWCore/Utilities/interface/ESInputTag.h
+++ b/FWCore/Utilities/interface/ESInputTag.h
@@ -90,8 +90,6 @@ namespace edm {
       ESInputTag(const std::string& iModuleLabel, const std::string& iDataLabel);
       ESInputTag(const std::string& iEncodedValue);
       
-      //virtual ~ESInputTag();
-      
       // ---------- const member functions ---------------------
       
       /**Returns the label assigned to the module for the data to be retrieved.
@@ -108,19 +106,12 @@ namespace edm {
       bool operator==(const edm::ESInputTag& iRHS) const;
       
       std::string encode() const;
-      // ---------- static member functions --------------------
-      
-      // ---------- member functions ---------------------------
       
    private:
-      //ESInputTag(const ESInputTag&); // allow default
-      
-      //const ESInputTag& operator=(const ESInputTag&); // allow default
       
       // ---------- member data --------------------------------
       std::string module_;
       std::string data_;
-   
    };
    
 }

--- a/FWCore/Utilities/interface/ESInputTag.h
+++ b/FWCore/Utilities/interface/ESInputTag.h
@@ -86,20 +86,9 @@
 namespace edm {
    class ESInputTag {
    public:
-      constexpr static struct {} Encoded{};
-      using Encoded_t = decltype(Encoded);
       ESInputTag();
-
-     // Single-argument version allows users to specify a
-      // string-based, data label that assigns no module label.  The
-      // single-argument constructor will throw if a ':' character is
-      // included in the specification.
-      ESInputTag(const std::string& iDataLabel);
       ESInputTag(const std::string& iModuleLabel, const std::string& iDataLabel);
-
-      // The Encoded tag should be provided if users desire to specify
-      // "<module-label>:<data-label>".
-      ESInputTag(const std::string& iEncodedValue, Encoded_t);
+      ESInputTag(const std::string& iEncodedValue);
 
       // ---------- const member functions ---------------------
 

--- a/FWCore/Utilities/interface/ESInputTag.h
+++ b/FWCore/Utilities/interface/ESInputTag.h
@@ -4,7 +4,7 @@
 //
 // Package:     Utilities
 // Class  :     ESInputTag
-// 
+//
 /**\class ESInputTag ESInputTag.h FWCore/Utilities/interface/ESInputTag.h
 
  Description: Parameter type used to denote how data should be obtained from the EventSetup
@@ -13,10 +13,10 @@
     The ESInputTag can be used in conjunction with an EventSetup Record to retrieve a particular data
  item from the Record.  The EventSetup uses two pieces of information to find data in a Record
     1) the C++ class type of the data
-    2) an optional string which we will refer to as the 'dataLabel' 
+    2) an optional string which we will refer to as the 'dataLabel'
  The dataLabel is used to differentiate objects of the same type placed in the same Record.
- 
- In addition, every piece of data in the EventSetup comes from either an ESSource or an ESProducer.  Every 
+
+ In addition, every piece of data in the EventSetup comes from either an ESSource or an ESProducer.  Every
  ESSource and ESProducer is assigned a label (referred to here as the moduleLabel) in the configuration of
  the job.  This label may be explicitly set or it may just be the C++ class type of the ESSource/ESProducer.
  For example, say there is an ESProducer of C++ class type FooESProd. If the python configuration has
@@ -28,7 +28,7 @@
  However, if the python configuration has
        process.foos = cms.ESProducer("FooESProd",...)
  then the module label is 'foos'.
- 
+
  The ESInputTag allows one to specify both the dataLabel and moduleLabel.  The dataLabel is used to find the data
  being requested.  The moduleLabel is only used to determine if the data that was found comes from the specified
  module.  If the data does not come from the module then an error has occurred.  If the moduleLabel is set to the
@@ -77,6 +77,7 @@
 //
 
 // system include files
+#include <iosfwd>
 #include <string>
 
 // user include files
@@ -84,37 +85,47 @@
 // forward declarations
 namespace edm {
    class ESInputTag {
-      
    public:
+      constexpr static struct {} Encoded{};
+      using Encoded_t = decltype(Encoded);
       ESInputTag();
+
+     // Single-argument version allows users to specify a
+      // string-based, data label that assigns no module label.  The
+      // single-argument constructor will throw if a ':' character is
+      // included in the specification.
+      ESInputTag(const std::string& iDataLabel);
       ESInputTag(const std::string& iModuleLabel, const std::string& iDataLabel);
-      ESInputTag(const std::string& iEncodedValue);
-      
+
+      // The Encoded tag should be provided if users desire to specify
+      // "<module-label>:<data-label>".
+      ESInputTag(const std::string& iEncodedValue, Encoded_t);
+
       // ---------- const member functions ---------------------
-      
+
       /**Returns the label assigned to the module for the data to be retrieved.
        If the value matches the defaultModule value (which is the empty string)
        Then no match is attempted with the module label.
        */
       const std::string& module() const { return module_;}
-      
+
       /**Returns the label used to access the data from the EventSetup.
        The empty string is an allowed (and default) value.
        */
       const std::string& data() const {return data_;}
-      
+
       bool operator==(const edm::ESInputTag& iRHS) const;
-      
+
       std::string encode() const;
-      
+
    private:
-      
+
       // ---------- member data --------------------------------
       std::string module_;
       std::string data_;
    };
-   
-}
 
+   std::ostream& operator<<(std::ostream&, ESInputTag const&);
+}
 
 #endif

--- a/FWCore/Utilities/src/ESInputTag.cc
+++ b/FWCore/Utilities/src/ESInputTag.cc
@@ -19,20 +19,8 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 
 using namespace edm;
-//
-// constants, enums and typedefs
-//
 
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-ESInputTag::ESInputTag()
-{
-}
+ESInputTag::ESInputTag() = default;
 
 ESInputTag::ESInputTag(const std::string& moduleLabel, const std::string& dataLabel):
 module_(moduleLabel),
@@ -52,31 +40,6 @@ ESInputTag::ESInputTag( const std::string& iEncodedValue)
    if(nwords > 0) module_ = tokens[0];
    if(nwords > 1) data_ = tokens[1];
 }
-// ESInputTag::ESInputTag(const ESInputTag& rhs)
-// {
-//    // do actual copying here;
-// }
-
-//ESInputTag::~ESInputTag()
-//{
-//}
-
-//
-// assignment operators
-//
-// const ESInputTag& ESInputTag::operator=(const ESInputTag& rhs)
-// {
-//   //An exception safe implementation is
-//   ESInputTag temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
-
 //
 // const member functions
 //

--- a/FWCore/Utilities/src/ESInputTag.cc
+++ b/FWCore/Utilities/src/ESInputTag.cc
@@ -23,32 +23,23 @@ using namespace edm;
 
 ESInputTag::ESInputTag() = default;
 
-ESInputTag::ESInputTag(const std::string& dataLabel):
-  data_(dataLabel)
+ESInputTag::ESInputTag(const std::string& moduleLabel, const std::string& dataLabel):
+module_(moduleLabel),
+data_(dataLabel)
 {
-  if(dataLabel.find(":") != std::string::npos) {
-    throw edm::Exception(errors::Configuration,"ESInputTag")
-      << "The one-parameter ESInputTag constructor with value " << dataLabel << " has at least one ':' character in it.\n"
-      << "Please use the ESInputTag(std::string const&, Encoded) constructor, which is used for encoded specifications.";
-  }
 }
 
-ESInputTag::ESInputTag(const std::string& moduleLabel, const std::string& dataLabel):
-  module_(moduleLabel),
-  data_(dataLabel)
-{}
-
-ESInputTag::ESInputTag(const std::string& iEncodedValue, Encoded_t)
+ESInputTag::ESInputTag(const std::string& iEncodedValue)
 {
-  // string is delimited by colons
-  std::vector<std::string> tokens = tokenize(iEncodedValue, ":");
-  int nwords = tokens.size();
-  if(nwords > 2) {
-    throw edm::Exception(errors::Configuration,"ESInputTag")
+   // string is delimited by colons
+   std::vector<std::string> tokens = tokenize(iEncodedValue, ":");
+   int nwords = tokens.size();
+   if(nwords > 2) {
+      throw edm::Exception(errors::Configuration,"ESInputTag")
       << "ESInputTag " << iEncodedValue << " has " << nwords << " tokens but only up two 2 are allowed.";
-  }
-  if(nwords > 0) module_ = tokens[0];
-  if(nwords > 1) data_ = tokens[1];
+   }
+   if(nwords > 0) module_ = tokens[0];
+   if(nwords > 1) data_ = tokens[1];
 }
 
 //
@@ -62,12 +53,12 @@ ESInputTag::operator==(const edm::ESInputTag& iRHS) const
 }
 
 std::string ESInputTag::encode() const {
-  static std::string const separator(":");
-  std::string result = module_;
-  if(!data_.empty()) {
-    result += separator + data_;
-  }
-  return result;
+   static std::string const separator(":");
+   std::string result = module_;
+   if(!data_.empty()) {
+      result += separator + data_;
+   }
+   return result;
 }
 
 namespace edm {

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -31,7 +31,7 @@
 <bin   file="MallocOpts_t.cpp">
   <use   name="cppunit"/>
 </bin>
-<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp,reusableobjectholder_t.cppunit.cpp,propagate_const_t.cppunit.cpp,indexset.cppunit.cpp">
+<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,esinputtag.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp,reusableobjectholder_t.cppunit.cpp,propagate_const_t.cppunit.cpp,indexset.cppunit.cpp">
   <use   name="cppunit"/>
 </bin>
 
@@ -45,4 +45,3 @@
 <bin   file="RunningAverage_t.cpp">
   <use name="tbb"/>
 </bin>
-

--- a/FWCore/Utilities/test/esinputtag.cppunit.cpp
+++ b/FWCore/Utilities/test/esinputtag.cppunit.cpp
@@ -1,0 +1,110 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <string>
+
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+
+class testESInputTag: public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testESInputTag);
+  CPPUNIT_TEST(emptyTags);
+  CPPUNIT_TEST(oneStringConstructor);
+  CPPUNIT_TEST(twoStringConstructor);
+  CPPUNIT_TEST(encodedTags);
+  CPPUNIT_TEST(mixedConstructors);
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void emptyTags();
+  void oneStringConstructor();
+  void twoStringConstructor();
+  void encodedTags();
+  void mixedConstructors();
+};
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(testESInputTag);
+
+using edm::ESInputTag;
+using namespace std::string_literals;
+
+void testESInputTag::emptyTags()
+{
+  auto require_empty = [](ESInputTag const& tag) {
+    CPPUNIT_ASSERT(tag.module().empty());
+    CPPUNIT_ASSERT(tag.data().empty());
+  };
+
+  ESInputTag const empty1{};
+  ESInputTag const empty2{""};
+  ESInputTag const empty3{"", ""};
+  ESInputTag const empty4{"", ESInputTag::Encoded};
+  ESInputTag const empty5{":", ESInputTag::Encoded};
+
+  require_empty(empty1);
+  require_empty(empty2);
+  require_empty(empty3);
+  require_empty(empty4);
+  require_empty(empty5);
+
+  // Equivalence
+  CPPUNIT_ASSERT_EQUAL(empty1, empty2);
+  CPPUNIT_ASSERT_EQUAL(empty1, empty3);
+  CPPUNIT_ASSERT_EQUAL(empty1, empty4);
+  CPPUNIT_ASSERT_EQUAL(empty1, empty5);
+}
+
+void testESInputTag::oneStringConstructor()
+{
+  ESInputTag const tag{"DL"};
+  CPPUNIT_ASSERT(tag.module().empty());
+  CPPUNIT_ASSERT_EQUAL(tag.data(), "DL"s);
+
+  // Cannot have colons for the one-argument constructor
+  CPPUNIT_ASSERT_THROW(ESInputTag{":DL"}, cms::Exception);
+}
+
+void testESInputTag::twoStringConstructor()
+{
+  ESInputTag const tag{"ML", "DL"};
+  CPPUNIT_ASSERT_EQUAL(tag.module(), "ML"s);
+  CPPUNIT_ASSERT_EQUAL(tag.data(), "DL"s);
+}
+
+void testESInputTag::encodedTags()
+{
+  auto require_labels = [](ESInputTag const& tag,
+                           std::string const& module_label,
+                           std::string const& data_label) {
+    CPPUNIT_ASSERT_EQUAL(tag.module(), module_label);
+    CPPUNIT_ASSERT_EQUAL(tag.data(), data_label);
+  };
+
+  ESInputTag const moduleOnly{"ML", ESInputTag::Encoded};
+  ESInputTag const moduleOnlywToken{"ML:", ESInputTag::Encoded};
+  ESInputTag const dataOnlywToken{":DL", ESInputTag::Encoded};
+  ESInputTag const bothFields{"ML:DL", ESInputTag::Encoded};
+
+  require_labels(moduleOnly, "ML", "");
+  require_labels(moduleOnlywToken, "ML", "");
+  require_labels(dataOnlywToken, "", "DL");
+  require_labels(bothFields, "ML", "DL");
+
+  // Too many colons
+  CPPUNIT_ASSERT_THROW((ESInputTag{"ML:DL:", ESInputTag::Encoded}), cms::Exception);
+}
+
+void testESInputTag::mixedConstructors()
+{
+  // No module label
+  ESInputTag const data_only_label{"DL"};
+  CPPUNIT_ASSERT_EQUAL(data_only_label, (ESInputTag{"", "DL"}));
+  CPPUNIT_ASSERT_EQUAL(data_only_label, (ESInputTag{":DL", ESInputTag::Encoded}));
+
+  // No data label
+  CPPUNIT_ASSERT_EQUAL((ESInputTag{"ML", ""}), (ESInputTag{"ML:", ESInputTag::Encoded}));
+
+  // With module label
+  CPPUNIT_ASSERT_EQUAL((ESInputTag{"ML", "DL"}), (ESInputTag{"ML:DL", ESInputTag::Encoded}));
+}

--- a/FWCore/Utilities/test/esinputtag.cppunit.cpp
+++ b/FWCore/Utilities/test/esinputtag.cppunit.cpp
@@ -7,7 +7,6 @@
 class testESInputTag: public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testESInputTag);
   CPPUNIT_TEST(emptyTags);
-  CPPUNIT_TEST(oneStringConstructor);
   CPPUNIT_TEST(twoStringConstructor);
   CPPUNIT_TEST(encodedTags);
   CPPUNIT_TEST(mixedConstructors);
@@ -17,7 +16,6 @@ public:
   void tearDown() {}
 
   void emptyTags();
-  void oneStringConstructor();
   void twoStringConstructor();
   void encodedTags();
   void mixedConstructors();
@@ -38,31 +36,18 @@ void testESInputTag::emptyTags()
 
   ESInputTag const empty1{};
   ESInputTag const empty2{""};
-  ESInputTag const empty3{"", ""};
-  ESInputTag const empty4{"", ESInputTag::Encoded};
-  ESInputTag const empty5{":", ESInputTag::Encoded};
+  ESInputTag const empty3{":"};
+  ESInputTag const empty4{"", ""};
 
   require_empty(empty1);
   require_empty(empty2);
   require_empty(empty3);
   require_empty(empty4);
-  require_empty(empty5);
 
   // Equivalence
   CPPUNIT_ASSERT_EQUAL(empty1, empty2);
   CPPUNIT_ASSERT_EQUAL(empty1, empty3);
   CPPUNIT_ASSERT_EQUAL(empty1, empty4);
-  CPPUNIT_ASSERT_EQUAL(empty1, empty5);
-}
-
-void testESInputTag::oneStringConstructor()
-{
-  ESInputTag const tag{"DL"};
-  CPPUNIT_ASSERT(tag.module().empty());
-  CPPUNIT_ASSERT_EQUAL(tag.data(), "DL"s);
-
-  // Cannot have colons for the one-argument constructor
-  CPPUNIT_ASSERT_THROW(ESInputTag{":DL"}, cms::Exception);
 }
 
 void testESInputTag::twoStringConstructor()
@@ -81,10 +66,10 @@ void testESInputTag::encodedTags()
     CPPUNIT_ASSERT_EQUAL(tag.data(), data_label);
   };
 
-  ESInputTag const moduleOnly{"ML", ESInputTag::Encoded};
-  ESInputTag const moduleOnlywToken{"ML:", ESInputTag::Encoded};
-  ESInputTag const dataOnlywToken{":DL", ESInputTag::Encoded};
-  ESInputTag const bothFields{"ML:DL", ESInputTag::Encoded};
+  ESInputTag const moduleOnly{"ML"};
+  ESInputTag const moduleOnlywToken{"ML:"};
+  ESInputTag const dataOnlywToken{":DL"};
+  ESInputTag const bothFields{"ML:DL"};
 
   require_labels(moduleOnly, "ML", "");
   require_labels(moduleOnlywToken, "ML", "");
@@ -92,19 +77,17 @@ void testESInputTag::encodedTags()
   require_labels(bothFields, "ML", "DL");
 
   // Too many colons
-  CPPUNIT_ASSERT_THROW((ESInputTag{"ML:DL:", ESInputTag::Encoded}), cms::Exception);
+  CPPUNIT_ASSERT_THROW((ESInputTag{"ML:DL:"}), cms::Exception);
 }
 
 void testESInputTag::mixedConstructors()
 {
   // No module label
-  ESInputTag const data_only_label{"DL"};
-  CPPUNIT_ASSERT_EQUAL(data_only_label, (ESInputTag{"", "DL"}));
-  CPPUNIT_ASSERT_EQUAL(data_only_label, (ESInputTag{":DL", ESInputTag::Encoded}));
+  CPPUNIT_ASSERT_EQUAL((ESInputTag{"", "DL"}), (ESInputTag{":DL"}));
 
   // No data label
-  CPPUNIT_ASSERT_EQUAL((ESInputTag{"ML", ""}), (ESInputTag{"ML:", ESInputTag::Encoded}));
+  CPPUNIT_ASSERT_EQUAL((ESInputTag{"ML", ""}), (ESInputTag{"ML:"}));
 
   // With module label
-  CPPUNIT_ASSERT_EQUAL((ESInputTag{"ML", "DL"}), (ESInputTag{"ML:DL", ESInputTag::Encoded}));
+  CPPUNIT_ASSERT_EQUAL((ESInputTag{"ML", "DL"}), (ESInputTag{"ML:DL"}));
 }

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -87,7 +87,7 @@ namespace edm {
       }
       
       template<>
-      void EventSetupRecord::get<fwliteeswriter::Handle>(const std::string& iName, fwliteeswriter::Handle& iHolder) const {
+      bool EventSetupRecord::get<fwliteeswriter::Handle>(const std::string& iName, fwliteeswriter::Handle& iHolder) const {
          fwliteeswriter::DummyType t;
          t.m_tag = &(iHolder.m_info->m_tag);
          const fwliteeswriter::DummyType* value = &t;
@@ -96,6 +96,7 @@ namespace edm {
          impl_->getImplementation(value, iName.c_str(),desc,true, dummy);
          iHolder.m_data = t.m_data;
          iHolder.m_desc = desc;
+         return true;
       }
       
    }


### PR DESCRIPTION
This PR introduces an interface that mirrors the consumes system for modules.  It provides the `edm::ESGetTokenT<MyESProduct>` token, which can be used for retrieving event-setup products.

**N.B.** This PR does include quite a few whitespace changes, primarily from using nested namespaces.  Although clicking on the individual commit and specifying a trailing "?w=1" in the URL should be sufficient to suppress them, please let me know if you'd prefer me to revert.

**Module interface**

    class MyModule : public ... {
      edm::ESInputTag esTag_;
      edm::ESGetTokenT<ESProduct> token_;
      edm::ESGetTokenT<OtherESProduct> otherToken_;
      ...
    public:
      MyModule(ParameterSet const&) : 
        esTag_{...},
        // Indication to consume the ESProduct during the event
        token_{esConsumes<ESProduct, ESRecord>(esTag_)},
        // Tell system to consume at begin SubRun
        otherToken_{esConsumes<OtherESProduct, OtherESRecord, edm::Transition::BeginSubRun>(esTag_)}
      {}
    };

**ESProducer interface**

    class MyESProducer: public edm::ESProducer {
    public:
      MyESProducer() {
        edm::ESConsumesCollector cc = setWhatProduced(this);
        edm::ESGetTokenT<Foos> foos = cc.consumes<Foos>(); // gets from same record
        edm::ESGetTokenT<Bars> bars = cc.consumes<Bars, BarRecord, edm::Transition::EndSubRun>();
      }
    };

**Additional comments**

- The `edm::EventRecord::get()` calls now return `bool` instead of `void`.  A return value of `true` implies that the event-record retrieval was successful, and the handle can be safely dereferenced.
- The `edm::ESInputTag` constructor overload set has been expanded to better match user expectations for constructions via single strings (representing data labels) and those via encoded representations, which require an additional `edm::ESInputTag::Encoded` constructor argument.