### PR TITLE
print date before executing gdb

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -948,7 +948,7 @@ namespace edm {
         //In that case, we are already all setup
         return;
       }
-      if (snprintf(pidString_, pidStringLength_-1, "gdb -quiet -p %d 2>&1 <<EOF |\n"
+      if (snprintf(pidString_, pidStringLength_-1, "date; gdb -quiet -p %d 2>&1 <<EOF |\n"
         "set width 0\n"
         "set height 0\n"
         "set pagination no\n"


### PR DESCRIPTION
Trivial PR to add a "date" command before running gdb on the parent process.  Useful for determining how much time elapsed between the last message logged and the stack trace.

I did check the length of pidString_, and it shouldn't need any expansion to accommodate the additional characters.

While we could call time() in the signal handler to get a more immediate timestamp, there are no async-signal safe functions for formatting a time stamp.  Running the 'date' command is not as precise, but much easier.