### PR TITLE
Bug fixes for new PluginDescription code

### DIFF
--- a/FWCore/Integration/test/PluginUsingProducer.cc
+++ b/FWCore/Integration/test/PluginUsingProducer.cc
@@ -76,7 +76,7 @@ namespace edmtest {
   putToken_{produces<int>()}
   {
     auto pluginPSet = pset.getParameter<edm::ParameterSet>("plugin");
-    maker_.reset( IntFactory::get()->create(pluginPSet.getParameter<std::string>("type"), pset));
+    maker_.reset( IntFactory::get()->create(pluginPSet.getParameter<std::string>("type"), pluginPSet));
   }
 
   void PluginUsingProducer::produce(edm::StreamID, edm::Event& event, edm::EventSetup const&)  const{

--- a/FWCore/ParameterSet/interface/PluginDescription.h
+++ b/FWCore/ParameterSet/interface/PluginDescription.h
@@ -183,8 +183,13 @@ protected:
 
     //loop over all possible plugins
     unsigned int pluginCount = 0;
+    std::string previousName;
     for(auto const& info: edmplugin::PluginManager::get()->categoryToInfos().find(Factory::get()->category())->second) {
 
+      // We only want to print the first instance of each plugin name
+      if (previousName == info.name_) {
+        continue;
+      }
 
       std::stringstream ss;
       ss << dfh.section() << "." << dfh.counter();
@@ -199,6 +204,8 @@ protected:
       new_dfh.setSection(newSection);
 
       loadDescription(info.name_)->print(os,new_dfh);
+
+      previousName = info.name_;
     }
   }
   
@@ -215,12 +222,12 @@ protected:
   }
 
 private:
+
   std::string findType(edm::ParameterSet const& iPSet) const {
     if(typeLabelIsTracked_) {
-      if(defaultType_.empty()) {
+      if(iPSet.existsAs<std::string>(typeLabel_) || defaultType_.empty()) {
         return iPSet.getParameter<std::string>(typeLabel_);
-      }
-      if(not iPSet.existsAs<std::string>(typeLabel_) ) {
+      } else {
         return defaultType_;
       }
     }


### PR DESCRIPTION
One will cause an exception in the case where there is
a default type and the type is specified. The second
causes edmPluginHelp to print multiple descriptions for
the plugin. The third only affects the test module.

Note it is unlikely this will cause problems in the release as
the only thing currently using the PluginDescription code is
Framework unit tests, but it would be nice to get this merged
quickly as we are encouraging developers to try PluginDescription
and these fixes will help the first users avoid problems.
