### PR TITLE
Add missing seeding producer for FastSim

### DIFF
--- a/FastSimulation/Tracking/python/SeedingMigration.py
+++ b/FastSimulation/Tracking/python/SeedingMigration.py
@@ -14,6 +14,7 @@ def _hitSetProducerToFactoryPSet(producer):
         "MultiHitFromChi2EDProducer": "MultiHitGeneratorFromChi2",
         "CAHitTripletEDProducer": "CAHitTripletGenerator",
         "CAHitQuadrupletEDProducer": "CAHitQuadrupletGenerator",   
+        "PixelQuadrupletEDProducer": "none",
         }
     ret = cms.PSet()
     _copy(producer, ret)


### PR DESCRIPTION
The backport of Fastsim developments #24624 has triggered the failure of two test workflows 10024.4 and 10024.5, as discussed in #24783. This PR implements the suggestion of @makortel to prevent the problem without removing already existing test workflows from the cycle. 