### PR TITLE
Update anti-e tau discriminant

### DIFF
--- a/RecoTauTag/RecoTau/interface/AntiElectronIDMVA6.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronIDMVA6.h
@@ -123,15 +123,15 @@ class AntiElectronIDMVA6
 
    // this function can be called for all categories
    double MVAValue(const reco::PFTau& thePFTau, 
-		   const reco::GsfElectron& theGsfEle, bool usePhiAtEcalEntranceExtrapolation);
+		   const reco::GsfElectron& theGsfEle);
    // this function can be called for category 1 only !!
-   double MVAValue(const reco::PFTau& thePFTau, bool usePhiAtEcalEntranceExtrapolation);
+   double MVAValue(const reco::PFTau& thePFTau);
 
    // this function can be called for all categories
    double MVAValue(const pat::Tau& theTau, 
-		   const pat::Electron& theEle, bool usePhiAtEcalEntranceExtrapolation);
+		   const pat::Electron& theEle);
    // this function can be called for category 1 only !!
-   double MVAValue(const pat::Tau& theTau, bool usePhiAtEcalEntranceExtrapolation);
+   double MVAValue(const pat::Tau& theTau);
    // track extrapolation to ECAL entrance (used to re-calculate varibales that might not be available on miniAOD)
    bool atECalEntrance(const reco::Candidate* part, math::XYZPoint &pos);    
 
@@ -153,7 +153,9 @@ class AntiElectronIDMVA6
    std::string mvaName_NoEleMatch_wGwoGSF_EC_;
    std::string mvaName_woGwGSF_EC_;
    std::string mvaName_wGwGSF_EC_;
-   
+
+   bool usePhiAtEcalEntranceExtrapolation_;
+
    Float_t* Var_NoEleMatch_woGwoGSF_Barrel_;
    Float_t* Var_NoEleMatch_wGwoGSF_Barrel_;
    Float_t* Var_woGwGSF_Barrel_;

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronMVA6.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronMVA6.cc
@@ -31,7 +31,6 @@ class PATTauDiscriminationAgainstElectronMVA6 : public PATTauDiscriminationProdu
   {
     mva_ = std::make_unique<AntiElectronIDMVA6>(cfg);
 
-    usePhiAtEcalEntranceExtrapolation_ = cfg.getParameter<bool>("usePhiAtEcalEntranceExtrapolation");
     srcElectrons = cfg.getParameter<edm::InputTag>("srcElectrons");
     electronToken = consumes<pat::ElectronCollection>(srcElectrons);
     verbosity_ = ( cfg.exists("verbosity") ) ?
@@ -61,7 +60,6 @@ private:
   edm::Handle<TauCollection> taus_;
 
   std::unique_ptr<PATTauDiscriminator> category_output_;
-  bool usePhiAtEcalEntranceExtrapolation_;
 		
   int verbosity_;
 };
@@ -104,7 +102,7 @@ double PATTauDiscriminationAgainstElectronMVA6::discriminate(const TauRef& theTa
 	double deltaREleTau = deltaR(theElectron.p4(), theTauRef->p4());
 	deltaRDummy = deltaREleTau;
 	if( deltaREleTau < 0.3 ){ 	
-	  double mva_match = mva_->MVAValue(*theTauRef, theElectron, usePhiAtEcalEntranceExtrapolation_);	  
+	  double mva_match = mva_->MVAValue(*theTauRef, theElectron);
 	  bool hasGsfTrack = false;
           pat::PackedCandidate const* packedLeadTauCand = dynamic_cast<pat::PackedCandidate const*>(theTauRef->leadChargedHadrCand().get());
           if( abs(packedLeadTauCand->pdgId()) == 11 ) 
@@ -142,7 +140,7 @@ double PATTauDiscriminationAgainstElectronMVA6::discriminate(const TauRef& theTa
      } // end of loop over electrons
 
     if ( !isGsfElectronMatched ) {
-      mvaValue = mva_->MVAValue(*theTauRef, usePhiAtEcalEntranceExtrapolation_);
+      mvaValue = mva_->MVAValue(*theTauRef);
       bool hasGsfTrack = false;
       pat::PackedCandidate const* packedLeadTauCand = dynamic_cast<pat::PackedCandidate const*>(theTauRef->leadChargedHadrCand().get());
       if( abs(packedLeadTauCand->pdgId()) == 11 ) hasGsfTrack = true;

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronMVA6.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronMVA6.cc
@@ -87,8 +87,8 @@ double PATTauDiscriminationAgainstElectronMVA6::discriminate(const TauRef& theTa
   if( (*theTauRef).leadChargedHadrCand().isNonnull()) {
     int numSignalPFGammaCandsInSigCone = 0;
     const reco::CandidatePtrVector signalGammaCands = theTauRef->signalGammaCands();
-    for( reco::CandidatePtrVector::const_iterator gamma = signalGammaCands.begin(); gamma != signalGammaCands.end(); ++gamma ){
-      double dR = deltaR((*gamma)->p4(), theTauRef->leadChargedHadrCand()->p4());
+    for ( const auto & gamma : signalGammaCands ) {
+      double dR = deltaR(gamma->p4(), theTauRef->leadChargedHadrCand()->p4());
       double signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTauRef->pt())));      
       // gammas inside the tau signal cone
       if (dR < signalrad) {
@@ -96,8 +96,7 @@ double PATTauDiscriminationAgainstElectronMVA6::discriminate(const TauRef& theTa
       }
     }
     // loop over the electrons
-    for( unsigned int ie = 0; ie < Electrons->size(); ++ie ){
-      const pat::Electron& theElectron = Electrons->at(ie);
+    for ( const auto & theElectron : *Electrons ) {
       if ( theElectron.pt() > 10. ) { // CV: only take electrons above some minimal energy/Pt into account...	
 	double deltaREleTau = deltaR(theElectron.p4(), theTauRef->p4());
 	deltaRDummy = deltaREleTau;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
@@ -29,10 +29,10 @@ class PFRecoTauDiscriminationAgainstElectronMVA6 : public PFTauDiscriminationPro
  public:
   explicit PFRecoTauDiscriminationAgainstElectronMVA6(const edm::ParameterSet& cfg)
     : PFTauDiscriminationProducerBase(cfg),
-      mva_(nullptr),
+      mva_(),
       category_output_()
   {
-    mva_ = new AntiElectronIDMVA6(cfg);
+    mva_ = std::make_unique<AntiElectronIDMVA6>(cfg);
 
     usePhiAtEcalEntranceExtrapolation_ = cfg.getParameter<bool>("usePhiAtEcalEntranceExtrapolation");
     srcGsfElectrons_ = cfg.getParameter<edm::InputTag>("srcGsfElectrons");
@@ -51,18 +51,13 @@ class PFRecoTauDiscriminationAgainstElectronMVA6 : public PFTauDiscriminationPro
 
   void endEvent(edm::Event&) override;
 
-  ~PFRecoTauDiscriminationAgainstElectronMVA6() override
-  {
-    delete mva_;
-  }
+  ~PFRecoTauDiscriminationAgainstElectronMVA6() override {}
 
 private:
   bool isInEcalCrack(double) const;
 
   std::string moduleLabel_;
-
-  AntiElectronIDMVA6* mva_;
-  float* mvaInput_;
+  std::unique_ptr<AntiElectronIDMVA6> mva_;
 
   edm::InputTag srcGsfElectrons_;
   edm::EDGetTokenT<reco::GsfElectronCollection> GsfElectrons_token;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
@@ -34,7 +34,6 @@ class PFRecoTauDiscriminationAgainstElectronMVA6 : public PFTauDiscriminationPro
   {
     mva_ = std::make_unique<AntiElectronIDMVA6>(cfg);
 
-    usePhiAtEcalEntranceExtrapolation_ = cfg.getParameter<bool>("usePhiAtEcalEntranceExtrapolation");
     srcGsfElectrons_ = cfg.getParameter<edm::InputTag>("srcGsfElectrons");
     GsfElectrons_token = consumes<reco::GsfElectronCollection>(srcGsfElectrons_);
 
@@ -65,7 +64,6 @@ private:
   edm::Handle<TauCollection> taus_;
 
   std::unique_ptr<PFTauDiscriminator> category_output_;
-  bool usePhiAtEcalEntranceExtrapolation_;
 
   int verbosity_;
 };
@@ -144,7 +142,7 @@ double PFRecoTauDiscriminationAgainstElectronMVA6::discriminate(const PFTauRef& 
 	double deltaREleTau = deltaR(theGsfElectron->p4(), thePFTauRef->p4());
 	deltaRDummy = deltaREleTau;
 	if ( deltaREleTau < 0.3 ) {
-	  double mva_match = mva_->MVAValue(*thePFTauRef, *theGsfElectron, usePhiAtEcalEntranceExtrapolation_);
+	  double mva_match = mva_->MVAValue(*thePFTauRef, *theGsfElectron);
 	  bool hasGsfTrack = thePFTauRef->leadPFChargedHadrCand()->gsfTrackRef().isNonnull();
 	  if ( !hasGsfTrack )
             hasGsfTrack = theGsfElectron->gsfTrack().isNonnull();
@@ -181,7 +179,7 @@ double PFRecoTauDiscriminationAgainstElectronMVA6::discriminate(const PFTauRef& 
     } // end of loop over electrons
 
     if ( !isGsfElectronMatched ) {
-      mvaValue = mva_->MVAValue(*thePFTauRef, usePhiAtEcalEntranceExtrapolation_);
+      mvaValue = mva_->MVAValue(*thePFTauRef);
       bool hasGsfTrack = thePFTauRef->leadPFChargedHadrCand()->gsfTrackRef().isNonnull();
       
       //// Veto taus that go to Ecal crack

--- a/RecoTauTag/RecoTau/python/PATTauDiscriminationAgainstElectronMVA6_cfi.py
+++ b/RecoTauTag/RecoTau/python/PATTauDiscriminationAgainstElectronMVA6_cfi.py
@@ -4,7 +4,7 @@ from RecoTauTag.RecoTau.TauDiscriminatorTools import requireLeadTrack
 
 patTauDiscriminationAgainstElectronMVA6 = cms.EDProducer("PATTauDiscriminationAgainstElectronMVA6",
     # tau collection to discriminate
-    PFTauProducer = cms.InputTag('slimmedTaus'),
+    PATTauProducer = cms.InputTag('slimmedTaus'),
 
     # Require leading pion ensures that:
     #  1) these is at least one track above threshold (0.5 GeV) in the signal cone

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
@@ -393,12 +393,12 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
   else if ( TauSignalPFGammaCandsIn == 0 && TauHasGsf > 0.5 ) {
     if ( std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder ) {
       Var_woGwGSF_Barrel_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_woGwGSF_Barrel_[1]  = std::log(ElecChi2NormGSF);
+      Var_woGwGSF_Barrel_[1]  = std::log(std::max(float(0.01), ElecChi2NormGSF));
       Var_woGwGSF_Barrel_[2]  = ElecGSFNumHits;
-      Var_woGwGSF_Barrel_[3]  = std::log(std::max(float(0.1), ElecGSFTrackResol));
+      Var_woGwGSF_Barrel_[3]  = std::log(std::max(float(0.01), ElecGSFTrackResol));
       Var_woGwGSF_Barrel_[4]  = ElecGSFTracklnPt;
       Var_woGwGSF_Barrel_[5]  = ElecNumHitsDiffOverSum;
-      Var_woGwGSF_Barrel_[6]  = std::log(std::max(float(0.1), ElecChi2NormKF));
+      Var_woGwGSF_Barrel_[6]  = std::log(std::max(float(0.01), ElecChi2NormKF));
       Var_woGwGSF_Barrel_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
       Var_woGwGSF_Barrel_[8]  = std::min(ElecEecalOverPout, float(20.));
       Var_woGwGSF_Barrel_[9]  = ElecDeltaEta;
@@ -419,12 +419,12 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       mvaValue = mva_woGwGSF_BL_->GetClassifier(Var_woGwGSF_Barrel_);
     } else {
       Var_woGwGSF_Endcap_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_woGwGSF_Endcap_[1]  = std::log(std::max(float(0.1), ElecChi2NormGSF));
+      Var_woGwGSF_Endcap_[1]  = std::log(std::max(float(0.01), ElecChi2NormGSF));
       Var_woGwGSF_Endcap_[2]  = ElecGSFNumHits;
-      Var_woGwGSF_Endcap_[3]  = std::log(std::max(float(0.1), ElecGSFTrackResol));
+      Var_woGwGSF_Endcap_[3]  = std::log(std::max(float(0.01), ElecGSFTrackResol));
       Var_woGwGSF_Endcap_[4]  = ElecGSFTracklnPt;
       Var_woGwGSF_Endcap_[5]  = ElecNumHitsDiffOverSum;
-      Var_woGwGSF_Endcap_[6]  = std::log(std::max(float(0.1), ElecChi2NormKF));
+      Var_woGwGSF_Endcap_[6]  = std::log(std::max(float(0.01), ElecChi2NormKF));
       Var_woGwGSF_Endcap_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
       Var_woGwGSF_Endcap_[8]  = std::min(ElecEecalOverPout, float(20.));
       Var_woGwGSF_Endcap_[9]  = ElecDeltaEta;
@@ -447,12 +447,12 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
   else if ( TauSignalPFGammaCandsIn > 0 && TauHasGsf > 0.5 ) {
     if ( std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder ) {
       Var_wGwGSF_Barrel_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_wGwGSF_Barrel_[1]  = std::log(std::max(float(0.1), ElecChi2NormGSF));
+      Var_wGwGSF_Barrel_[1]  = std::log(std::max(float(0.01), ElecChi2NormGSF));
       Var_wGwGSF_Barrel_[2]  = ElecGSFNumHits;
-      Var_wGwGSF_Barrel_[3]  = std::log(std::max(float(0.1), ElecGSFTrackResol));
+      Var_wGwGSF_Barrel_[3]  = std::log(std::max(float(0.01), ElecGSFTrackResol));
       Var_wGwGSF_Barrel_[4]  = ElecGSFTracklnPt;
       Var_wGwGSF_Barrel_[5]  = ElecNumHitsDiffOverSum;
-      Var_wGwGSF_Barrel_[6]  = std::log(std::max(float(0.1), ElecChi2NormKF));
+      Var_wGwGSF_Barrel_[6]  = std::log(std::max(float(0.01), ElecChi2NormKF));
       Var_wGwGSF_Barrel_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
       Var_wGwGSF_Barrel_[8]  = std::min(ElecEecalOverPout, float(20.));
       Var_wGwGSF_Barrel_[9]  = ElecDeltaEta;
@@ -481,12 +481,12 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       mvaValue = mva_wGwGSF_BL_->GetClassifier(Var_wGwGSF_Barrel_);
     } else {
       Var_wGwGSF_Endcap_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_wGwGSF_Endcap_[1]  = std::log(std::max(float(0.1), ElecChi2NormGSF));
+      Var_wGwGSF_Endcap_[1]  = std::log(std::max(float(0.01), ElecChi2NormGSF));
       Var_wGwGSF_Endcap_[2]  = ElecGSFNumHits;
-      Var_wGwGSF_Endcap_[3]  = std::log(std::max(float(0.1), ElecGSFTrackResol));
+      Var_wGwGSF_Endcap_[3]  = std::log(std::max(float(0.01), ElecGSFTrackResol));
       Var_wGwGSF_Endcap_[4]  = ElecGSFTracklnPt;
       Var_wGwGSF_Endcap_[5]  = ElecNumHitsDiffOverSum;
-      Var_wGwGSF_Endcap_[6]  = std::log(std::max(float(0.1), ElecChi2NormKF));
+      Var_wGwGSF_Endcap_[6]  = std::log(std::max(float(0.01), ElecChi2NormKF));
       Var_wGwGSF_Endcap_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
       Var_wGwGSF_Endcap_[8]  = std::min(ElecEecalOverPout, float(20.));
       Var_wGwGSF_Endcap_[9]  = ElecDeltaEta;

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
@@ -393,10 +393,10 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       Var_woGwGSF_Barrel_[0]  = std::max(float(-0.1), ElecEtotOverPin);
       Var_woGwGSF_Barrel_[1]  = std::log(ElecChi2NormGSF);
       Var_woGwGSF_Barrel_[2]  = ElecGSFNumHits;
-      Var_woGwGSF_Barrel_[3]  = std::log(ElecGSFTrackResol);
+      Var_woGwGSF_Barrel_[3]  = std::log(std::max(float(0.1), ElecGSFTrackResol));
       Var_woGwGSF_Barrel_[4]  = ElecGSFTracklnPt;
       Var_woGwGSF_Barrel_[5]  = ElecNumHitsDiffOverSum;
-      Var_woGwGSF_Barrel_[6]  = std::log(ElecChi2NormKF);
+      Var_woGwGSF_Barrel_[6]  = std::log(std::max(float(0.1), ElecChi2NormKF));
       Var_woGwGSF_Barrel_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
       Var_woGwGSF_Barrel_[8]  = std::min(ElecEecalOverPout, float(20.));
       Var_woGwGSF_Barrel_[9]  = ElecDeltaEta;
@@ -417,12 +417,12 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       mvaValue = mva_woGwGSF_BL_->GetClassifier(Var_woGwGSF_Barrel_);
     } else {
       Var_woGwGSF_Endcap_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_woGwGSF_Endcap_[1]  = std::log(ElecChi2NormGSF);
+      Var_woGwGSF_Endcap_[1]  = std::log(std::max(float(0.1), ElecChi2NormGSF));
       Var_woGwGSF_Endcap_[2]  = ElecGSFNumHits;
-      Var_woGwGSF_Endcap_[3]  = std::log(ElecGSFTrackResol);
+      Var_woGwGSF_Endcap_[3]  = std::log(std::max(float(0.1), ElecGSFTrackResol));
       Var_woGwGSF_Endcap_[4]  = ElecGSFTracklnPt;
       Var_woGwGSF_Endcap_[5]  = ElecNumHitsDiffOverSum;
-      Var_woGwGSF_Endcap_[6]  = std::log(ElecChi2NormKF);
+      Var_woGwGSF_Endcap_[6]  = std::log(std::max(float(0.1), ElecChi2NormKF));
       Var_woGwGSF_Endcap_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
       Var_woGwGSF_Endcap_[8]  = std::min(ElecEecalOverPout, float(20.));
       Var_woGwGSF_Endcap_[9]  = ElecDeltaEta;
@@ -445,12 +445,12 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
   else if ( TauSignalPFGammaCandsIn > 0 && TauHasGsf > 0.5 ) {
     if ( std::abs(TauEtaAtEcalEntrance) < ECALBarrelEndcapEtaBorder ) {
       Var_wGwGSF_Barrel_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_wGwGSF_Barrel_[1]  = std::log(ElecChi2NormGSF);
+      Var_wGwGSF_Barrel_[1]  = std::log(std::max(float(0.1), ElecChi2NormGSF));
       Var_wGwGSF_Barrel_[2]  = ElecGSFNumHits;
-      Var_wGwGSF_Barrel_[3]  = std::log(ElecGSFTrackResol);
+      Var_wGwGSF_Barrel_[3]  = std::log(std::max(float(0.1), ElecGSFTrackResol));
       Var_wGwGSF_Barrel_[4]  = ElecGSFTracklnPt;
       Var_wGwGSF_Barrel_[5]  = ElecNumHitsDiffOverSum;
-      Var_wGwGSF_Barrel_[6]  = std::log(ElecChi2NormKF);
+      Var_wGwGSF_Barrel_[6]  = std::log(std::max(float(0.1), ElecChi2NormKF));
       Var_wGwGSF_Barrel_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
       Var_wGwGSF_Barrel_[8]  = std::min(ElecEecalOverPout, float(20.));
       Var_wGwGSF_Barrel_[9]  = ElecDeltaEta;
@@ -479,12 +479,12 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
       mvaValue = mva_wGwGSF_BL_->GetClassifier(Var_wGwGSF_Barrel_);
     } else {
       Var_wGwGSF_Endcap_[0]  = std::max(float(-0.1), ElecEtotOverPin);
-      Var_wGwGSF_Endcap_[1]  = std::log(ElecChi2NormGSF);
+      Var_wGwGSF_Endcap_[1]  = std::log(std::max(float(0.1), ElecChi2NormGSF));
       Var_wGwGSF_Endcap_[2]  = ElecGSFNumHits;
-      Var_wGwGSF_Endcap_[3]  = std::log(ElecGSFTrackResol);
+      Var_wGwGSF_Endcap_[3]  = std::log(std::max(float(0.1), ElecGSFTrackResol));
       Var_wGwGSF_Endcap_[4]  = ElecGSFTracklnPt;
       Var_wGwGSF_Endcap_[5]  = ElecNumHitsDiffOverSum;
-      Var_wGwGSF_Endcap_[6]  = std::log(ElecChi2NormKF);
+      Var_wGwGSF_Endcap_[6]  = std::log(std::max(float(0.1), ElecChi2NormKF));
       Var_wGwGSF_Endcap_[7]  = std::min(ElecDeltaPinPoutOverPin, float(1.));
       Var_wGwGSF_Endcap_[8]  = std::min(ElecEecalOverPout, float(20.));
       Var_wGwGSF_Endcap_[9]  = ElecDeltaEta;

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
@@ -526,10 +526,9 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
   float sumEtaTimesEnergy = 0.;
   float sumEnergy = 0.;
   const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
-	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    sumEtaTimesEnergy += (*pfCandidate)->positionAtECALEntrance().eta()*(*pfCandidate)->energy();
-    sumEnergy += (*pfCandidate)->energy();
+  for ( const auto & pfCandidate : signalPFCands ) {
+    sumEtaTimesEnergy += pfCandidate->positionAtECALEntrance().eta()*pfCandidate->energy();
+    sumEnergy += pfCandidate->energy();
   }
   if ( sumEnergy > 0. ) {
     TauEtaAtEcalEntrance = sumEtaTimesEnergy/sumEnergy;
@@ -537,17 +536,16 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
   
   float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
   float TauLeadChargedPFCandPt = -99.;
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
-	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
+  for ( const auto & pfCandidate : signalPFCands ) {
     const reco::Track* track = nullptr;
-    if ( (*pfCandidate)->trackRef().isNonnull() ) track = (*pfCandidate)->trackRef().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->innerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->innerTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->globalTrack().isNonnull() ) track = (*pfCandidate)->muonRef()->globalTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->outerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->outerTrack().get();
-    else if ( (*pfCandidate)->gsfTrackRef().isNonnull() ) track = (*pfCandidate)->gsfTrackRef().get();
+    if ( pfCandidate->trackRef().isNonnull() ) track = pfCandidate->trackRef().get();
+    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->innerTrack().isNonnull()  ) track = pfCandidate->muonRef()->innerTrack().get();
+    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->globalTrack().isNonnull() ) track = pfCandidate->muonRef()->globalTrack().get();
+    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->outerTrack().isNonnull()  ) track = pfCandidate->muonRef()->outerTrack().get();
+    else if ( pfCandidate->gsfTrackRef().isNonnull() ) track = pfCandidate->gsfTrackRef().get();
     if ( track ) {
       if ( track->pt() > TauLeadChargedPFCandPt ) {
-	TauLeadChargedPFCandEtaAtEcalEntrance = (*pfCandidate)->positionAtECALEntrance().eta();
+	TauLeadChargedPFCandEtaAtEcalEntrance = pfCandidate->positionAtECALEntrance().eta();
 	TauLeadChargedPFCandPt = track->pt();
       }
     }
@@ -571,8 +569,7 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
   reco::Candidate::LorentzVector pfGammaSum(0,0,0,0);
   reco::Candidate::LorentzVector pfChargedSum(0,0,0,0);
   
-  for ( unsigned i = 0 ; i < thePFTau.signalPFGammaCands().size(); ++i ) {
-    reco::PFCandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
+  for ( const auto & gamma : thePFTau.signalPFGammaCands() ) {
     float dR = deltaR(gamma->p4(), thePFTau.leadPFChargedHadrCand()->p4());
     float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, thePFTau.pt())));
 
@@ -603,8 +600,7 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
     }
   }
   
-  for ( unsigned i = 0 ; i < thePFTau.signalPFChargedHadrCands().size(); ++i ) {
-    reco::PFCandidatePtr charged = thePFTau.signalPFChargedHadrCands().at(i);
+  for ( const auto & charged : thePFTau.signalPFChargedHadrCands() ) {
     float dR = deltaR(charged->p4(), thePFTau.leadPFChargedHadrCand()->p4());
     float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, thePFTau.pt())));
   
@@ -621,16 +617,16 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
   Float_t TauPhi = thePFTau.phi();
   float sumPhiTimesEnergy = 0.;
   float sumEnergyPhi = 0.;
-  if ( !usePhiAtEcalEntranceExtrapolation_ ){
-    for (auto const& pfc : signalPFCands){
+  if ( !usePhiAtEcalEntranceExtrapolation_ ) {
+    for ( const auto & pfc : signalPFCands ) {
       sumPhiTimesEnergy += pfc->positionAtECALEntrance().phi()*pfc->energy();
       sumEnergyPhi += pfc->energy();
     }
   }
   else{
     TauPhi= -99.;
-    for (unsigned int o = 0; o < signalPFCands.size(); ++o ) {
-      reco::Candidate const*  signalCand = signalPFCands[o].get();
+    for ( const auto & signalPFCand : signalPFCands ) {
+      reco::Candidate const*  signalCand = signalPFCand.get();
       float phi = thePFTau.phi();
       math::XYZPoint aPos; 
       if ( atECalEntrance(signalCand, aPos) ) phi = aPos.Phi();
@@ -741,10 +737,9 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
   float sumEtaTimesEnergy = 0.;
   float sumEnergy = 0.;
   const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
-	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    sumEtaTimesEnergy += (*pfCandidate)->positionAtECALEntrance().eta()*(*pfCandidate)->energy();
-    sumEnergy += (*pfCandidate)->energy();
+  for ( const auto & pfCandidate : signalPFCands ) {
+    sumEtaTimesEnergy += pfCandidate->positionAtECALEntrance().eta()*pfCandidate->energy();
+    sumEnergy += pfCandidate->energy();
   }
   if ( sumEnergy > 0. ) {
     TauEtaAtEcalEntrance = sumEtaTimesEnergy/sumEnergy;
@@ -752,17 +747,16 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
   
   float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
   float TauLeadChargedPFCandPt = -99.;
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
-	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
+  for ( const auto & pfCandidate : signalPFCands ) {
     const reco::Track* track = nullptr;
-    if ( (*pfCandidate)->trackRef().isNonnull() ) track = (*pfCandidate)->trackRef().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->innerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->innerTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->globalTrack().isNonnull() ) track = (*pfCandidate)->muonRef()->globalTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->outerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->outerTrack().get();
-    else if ( (*pfCandidate)->gsfTrackRef().isNonnull() ) track = (*pfCandidate)->gsfTrackRef().get();
+    if ( pfCandidate->trackRef().isNonnull() ) track = pfCandidate->trackRef().get();
+    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->innerTrack().isNonnull()  ) track = pfCandidate->muonRef()->innerTrack().get();
+    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->globalTrack().isNonnull() ) track = pfCandidate->muonRef()->globalTrack().get();
+    else if ( pfCandidate->muonRef().isNonnull() && pfCandidate->muonRef()->outerTrack().isNonnull()  ) track = pfCandidate->muonRef()->outerTrack().get();
+    else if ( pfCandidate->gsfTrackRef().isNonnull() ) track = pfCandidate->gsfTrackRef().get();
     if ( track ) {
       if ( track->pt() > TauLeadChargedPFCandPt ) {
-	TauLeadChargedPFCandEtaAtEcalEntrance = (*pfCandidate)->positionAtECALEntrance().eta();
+	TauLeadChargedPFCandEtaAtEcalEntrance = pfCandidate->positionAtECALEntrance().eta();
 	TauLeadChargedPFCandPt = track->pt();
       }
     }
@@ -786,8 +780,7 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
   reco::Candidate::LorentzVector pfGammaSum(0,0,0,0);
   reco::Candidate::LorentzVector pfChargedSum(0,0,0,0);
   
-  for ( unsigned i = 0 ; i < thePFTau.signalPFGammaCands().size(); ++i ) {
-    reco::PFCandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
+  for ( const auto & gamma : thePFTau.signalPFGammaCands() ) {
     float dR = deltaR(gamma->p4(), thePFTau.leadPFChargedHadrCand()->p4());
     float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, thePFTau.pt())));
 
@@ -818,8 +811,7 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
     }
   }
   
-  for ( unsigned i = 0 ; i < thePFTau.signalPFChargedHadrCands().size(); ++i ) {
-    reco::PFCandidatePtr charged = thePFTau.signalPFChargedHadrCands().at(i);
+  for ( const auto & charged : thePFTau.signalPFChargedHadrCands() ) {
     float dR = deltaR(charged->p4(), thePFTau.leadPFChargedHadrCand()->p4());
     float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, thePFTau.pt())));
   
@@ -837,16 +829,15 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
   float sumPhiTimesEnergy = 0.;
   float sumEnergyPhi = 0.;
   if ( !usePhiAtEcalEntranceExtrapolation_ ){
-    for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
-	  pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-      sumPhiTimesEnergy += (*pfCandidate)->positionAtECALEntrance().phi()*(*pfCandidate)->energy();
-      sumEnergyPhi += (*pfCandidate)->energy();
+    for ( const auto & pfCandidate : signalPFCands ) {
+      sumPhiTimesEnergy += pfCandidate->positionAtECALEntrance().phi()*pfCandidate->energy();
+      sumEnergyPhi += pfCandidate->energy();
     }
   }
   else{
     TauPhi= -99.;
-    for (unsigned int o = 0; o < signalPFCands.size(); o++ ) {
-      reco::Candidate const*  signalCand = signalPFCands[o].get();
+    for ( const auto & signalPFCand : signalPFCands ) {
+      reco::Candidate const*  signalCand = signalPFCand.get();
       float phi = thePFTau.phi();
       math::XYZPoint aPos;
       if ( atECalEntrance(signalCand, aPos) == true ) phi = aPos.Phi();
@@ -932,53 +923,53 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron&
   reco::Candidate::LorentzVector pfChargedSum(0,0,0,0);
   
   const reco::CandidatePtrVector signalGammaCands = theTau.signalGammaCands();
-  for ( reco::CandidatePtrVector::const_iterator gamma = signalGammaCands.begin(); gamma != signalGammaCands.end(); ++gamma ){
-    float dR = deltaR((*gamma)->p4(), theTau.leadChargedHadrCand()->p4());
+  for ( const auto & gamma : signalGammaCands ) {
+    float dR = deltaR(gamma->p4(), theTau.leadChargedHadrCand()->p4());
     float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTau.pt())));
 
     // pfGammas inside the tau signal cone
     if (dR < signalrad) {
       if ( theTau.leadChargedHadrCand().isNonnull() ) {
-        GammasdEtaInSigCone.push_back((*gamma)->eta() - theTau.leadChargedHadrCand()->eta());
-        GammasdPhiInSigCone.push_back((*gamma)->phi() - theTau.leadChargedHadrCand()->phi());
+        GammasdEtaInSigCone.push_back(gamma->eta() - theTau.leadChargedHadrCand()->eta());
+        GammasdPhiInSigCone.push_back(gamma->phi() - theTau.leadChargedHadrCand()->phi());
 	//A.-C. please check whether this change is safe against future trainings
         //GammasdPhiInSigCone.push_back(deltaPhi((*gamma)->phi(), theTau.leadChargedHadrCand()->phi()));
       }
       else {
-        GammasdEtaInSigCone.push_back((*gamma)->eta() - theTau.eta());
-        GammasdPhiInSigCone.push_back((*gamma)->phi() - theTau.phi());
+        GammasdEtaInSigCone.push_back(gamma->eta() - theTau.eta());
+        GammasdPhiInSigCone.push_back(gamma->phi() - theTau.phi());
 	//A.-C. please check whether this change is safe against future trainings	
-        //GammasdPhiInSigCone.push_back(deltaPhi((*gamma)->phi(), theTau.phi()));
+        //GammasdPhiInSigCone.push_back(deltaPhi(gamma->phi(), theTau.phi()));
       }
-      GammasPtInSigCone.push_back((*gamma)->pt());
-      pfGammaSum += (*gamma)->p4();
+      GammasPtInSigCone.push_back(gamma->pt());
+      pfGammaSum += gamma->p4();
     }
     // pfGammas outside the tau signal cone
     else {
       if ( theTau.leadChargedHadrCand().isNonnull() ) {
-        GammasdEtaOutSigCone.push_back((*gamma)->eta() - theTau.leadChargedHadrCand()->eta());
-        GammasdPhiOutSigCone.push_back((*gamma)->phi() - theTau.leadChargedHadrCand()->phi());
+        GammasdEtaOutSigCone.push_back(gamma->eta() - theTau.leadChargedHadrCand()->eta());
+        GammasdPhiOutSigCone.push_back(gamma->phi() - theTau.leadChargedHadrCand()->phi());
 	//A.-C. please check whether this change is safe against future trainings		
-        //GammasdPhiOutSigCone.push_back(deltaPhi((*gamma)->phi(), theTau.leadChargedHadrCand()->phi()));
+        //GammasdPhiOutSigCone.push_back(deltaPhi(gamma->phi(), theTau.leadChargedHadrCand()->phi()));
       } 
       else {
-        GammasdEtaOutSigCone.push_back((*gamma)->eta() - theTau.eta());
-        GammasdPhiOutSigCone.push_back((*gamma)->phi() - theTau.phi());
+        GammasdEtaOutSigCone.push_back(gamma->eta() - theTau.eta());
+        GammasdPhiOutSigCone.push_back(gamma->phi() - theTau.phi());
 	//A.-C. please chaekc whether this change is safe against future trainings		
-        //GammasdPhiOutSigCone.push_back(deltaPhi((*gamma)->phi(), theTau.phi()));
+        //GammasdPhiOutSigCone.push_back(deltaPhi(gamma->phi(), theTau.phi()));
       }
-      GammasPtOutSigCone.push_back((*gamma)->pt());
+      GammasPtOutSigCone.push_back(gamma->pt());
     }
   }
   
   const reco::CandidatePtrVector signalChargedCands = theTau.signalChargedHadrCands();
-  for ( reco::CandidatePtrVector::const_iterator charged  = signalChargedCands.begin(); charged  != signalChargedCands.end(); ++charged ){    
-    float dR = deltaR((*charged)->p4(), theTau.leadChargedHadrCand()->p4());
+  for ( const auto & charged : signalChargedCands ) {
+    float dR = deltaR(charged->p4(), theTau.leadChargedHadrCand()->p4());
     float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTau.pt())));
   
     // charged particles inside the tau signal cone
     if (dR < signalrad) {
-      pfChargedSum += (*charged)->p4();
+      pfChargedSum += charged->p4();
     }
   }
   
@@ -990,8 +981,8 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron&
     float sumPhiTimesEnergy = 0.;
     float sumEnergy = 0.;
     const reco::CandidatePtrVector signalCands = theTau.signalCands();
-    for (unsigned int o = 0; o < signalCands.size(); o++ ) {
-      reco::Candidate const* signalCand = signalCands[o].get();
+    for ( const auto & signalCandPtr : signalCands ) {
+      reco::Candidate const* signalCand = signalCandPtr.get();
       float phi = theTau.phi();
       math::XYZPoint aPos;
       if ( atECalEntrance(signalCand, aPos) == true ) phi = aPos.Phi();
@@ -1128,45 +1119,45 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau)
   reco::Candidate::LorentzVector pfChargedSum(0,0,0,0);
   
   const reco::CandidatePtrVector signalGammaCands = theTau.signalGammaCands();
-  for ( reco::CandidatePtrVector::const_iterator gamma = signalGammaCands.begin(); gamma != signalGammaCands.end(); ++gamma ) {
-    float dR = deltaR((*gamma)->p4(), theTau.leadChargedHadrCand()->p4());
+  for ( const auto & gamma : signalGammaCands ) {
+    float dR = deltaR(gamma->p4(), theTau.leadChargedHadrCand()->p4());
     float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTau.pt())));
 
     // pfGammas inside the tau signal cone
     if (dR < signalrad) {
       if ( theTau.leadChargedHadrCand().isNonnull() ) {
-        GammasdEtaInSigCone.push_back((*gamma)->eta() - theTau.leadChargedHadrCand()->eta());
-        GammasdPhiInSigCone.push_back((*gamma)->phi() - theTau.leadChargedHadrCand()->phi());
+        GammasdEtaInSigCone.push_back(gamma->eta() - theTau.leadChargedHadrCand()->eta());
+        GammasdPhiInSigCone.push_back(gamma->phi() - theTau.leadChargedHadrCand()->phi());
       }
       else {
-        GammasdEtaInSigCone.push_back((*gamma)->eta() - theTau.eta());
-        GammasdPhiInSigCone.push_back((*gamma)->phi() - theTau.phi());
+        GammasdEtaInSigCone.push_back(gamma->eta() - theTau.eta());
+        GammasdPhiInSigCone.push_back(gamma->phi() - theTau.phi());
       }
-      GammasPtInSigCone.push_back((*gamma)->pt());
-      pfGammaSum += (*gamma)->p4();
+      GammasPtInSigCone.push_back(gamma->pt());
+      pfGammaSum += gamma->p4();
     }
     // pfGammas outside the tau signal cone
     else {
       if ( theTau.leadChargedHadrCand().isNonnull() ) {
-        GammasdEtaOutSigCone.push_back((*gamma)->eta() - theTau.leadChargedHadrCand()->eta());
-        GammasdPhiOutSigCone.push_back((*gamma)->phi() - theTau.leadChargedHadrCand()->phi());
+        GammasdEtaOutSigCone.push_back(gamma->eta() - theTau.leadChargedHadrCand()->eta());
+        GammasdPhiOutSigCone.push_back(gamma->phi() - theTau.leadChargedHadrCand()->phi());
       } 
       else {
-        GammasdEtaOutSigCone.push_back((*gamma)->eta() - theTau.eta());
-        GammasdPhiOutSigCone.push_back((*gamma)->phi() - theTau.phi());
+        GammasdEtaOutSigCone.push_back(gamma->eta() - theTau.eta());
+        GammasdPhiOutSigCone.push_back(gamma->phi() - theTau.phi());
       }
-      GammasPtOutSigCone.push_back((*gamma)->pt());
+      GammasPtOutSigCone.push_back(gamma->pt());
     }
   }
   
   const reco::CandidatePtrVector signalChargedCands = theTau.signalChargedHadrCands();
-  for ( reco::CandidatePtrVector::const_iterator charged  = signalChargedCands.begin(); charged  != signalChargedCands.end(); ++charged ) {
-    float dR = deltaR((*charged)->p4(), theTau.leadChargedHadrCand()->p4());
+  for ( const auto & charged : signalChargedCands ) {
+    float dR = deltaR(charged->p4(), theTau.leadChargedHadrCand()->p4());
     float signalrad = std::max(0.05, std::min(0.10, 3.0/std::max(1.0, theTau.pt())));
   
     // charged particles inside the tau signal cone
     if (dR < signalrad) {
-        pfChargedSum += (*charged)->p4();
+        pfChargedSum += charged->p4();
     }
   }
   
@@ -1178,8 +1169,8 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau)
     float sumPhiTimesEnergy = 0.;
     float sumEnergy = 0.;
     const reco::CandidatePtrVector signalCands = theTau.signalCands();
-    for (unsigned int o = 0; o < signalCands.size(); o++ ) {
-      reco::Candidate const* signalCand = signalCands[o].get();
+    for ( const auto & signalCandPtr : signalCands ) {
+      reco::Candidate const* signalCand = signalCandPtr.get();
       float phi = theTau.phi();
       math::XYZPoint aPos;
       if ( atECalEntrance(signalCand, aPos) == true ) phi = aPos.Phi();
@@ -1258,9 +1249,10 @@ namespace {
    std::array<double,18> cPhi;
    // IN: define locations of the 18 phi-cracks
    cPhi[0] = 2.97025;
-   for ( unsigned iCrack = 1; iCrack <= 17; ++iCrack )
-      cPhi[iCrack] = cPhi[0] - 2.*iCrack*pi/18;
-  return cPhi;
+   for ( unsigned iCrack = 1; iCrack <= 17; ++iCrack ) {
+     cPhi[iCrack] = cPhi[0] - 2.*iCrack*pi/18;
+   }
+   return cPhi;
  }
      
   const std::array<double,18> cPhi = fill_cPhi();

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
@@ -46,6 +46,8 @@ AntiElectronIDMVA6::AntiElectronIDMVA6(const edm::ParameterSet& cfg)
   mvaName_woGwGSF_EC_ = cfg.getParameter<std::string>("mvaName_woGwGSF_EC");
   mvaName_wGwGSF_EC_ = cfg.getParameter<std::string>("mvaName_wGwGSF_EC");
 
+  usePhiAtEcalEntranceExtrapolation_ = cfg.getParameter<bool>("usePhiAtEcalEntranceExtrapolation");
+
   Var_NoEleMatch_woGwoGSF_Barrel_ = new Float_t[10];
   Var_NoEleMatch_wGwoGSF_Barrel_ = new Float_t[18];
   Var_woGwGSF_Barrel_ = new Float_t[24];
@@ -516,7 +518,7 @@ double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
 }
 
 double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
-				    const reco::GsfElectron& theGsfEle, bool usePhiAtEcalEntranceExtrapolation)
+				    const reco::GsfElectron& theGsfEle)
 
 {
   // === tau variables ===
@@ -619,7 +621,7 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
   Float_t TauPhi = thePFTau.phi();
   float sumPhiTimesEnergy = 0.;
   float sumEnergyPhi = 0.;
-  if ( !usePhiAtEcalEntranceExtrapolation ){
+  if ( !usePhiAtEcalEntranceExtrapolation_ ){
     for (auto const& pfc : signalPFCands){
       sumPhiTimesEnergy += pfc->positionAtECALEntrance().phi()*pfc->energy();
       sumEnergyPhi += pfc->energy();
@@ -732,7 +734,7 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau,
                   ElecMvaInDeltaEta);
 }
 
-double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau, bool usePhiAtEcalEntranceExtrapolation)
+double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau)
 {
   // === tau variables ===
   float TauEtaAtEcalEntrance = -99.;
@@ -834,7 +836,7 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau, bool usePhiAtEc
   Float_t TauPhi = thePFTau.phi();
   float sumPhiTimesEnergy = 0.;
   float sumEnergyPhi = 0.;
-  if ( !usePhiAtEcalEntranceExtrapolation ){
+  if ( !usePhiAtEcalEntranceExtrapolation_ ){
     for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
 	  pfCandidate != signalPFCands.end(); ++pfCandidate ) {
       sumPhiTimesEnergy += (*pfCandidate)->positionAtECALEntrance().phi()*(*pfCandidate)->energy();
@@ -902,7 +904,7 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau, bool usePhiAtEc
                   0.);
 }
 
-double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron& theEle, bool usePhiAtEcalEntranceExtrapolation)
+double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron& theEle)
 {
   // === tau variables ===
   float TauEtaAtEcalEntrance = theTau.etaAtEcalEntrance();
@@ -984,7 +986,7 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron&
   Int_t TauSignalPFGammaCandsOut = GammasPtOutSigCone.size();
   Float_t TauVisMassIn = (pfGammaSum + pfChargedSum).mass();
   Float_t TauPhi = -99.;
-  if ( usePhiAtEcalEntranceExtrapolation ) {
+  if ( usePhiAtEcalEntranceExtrapolation_ ) {
     float sumPhiTimesEnergy = 0.;
     float sumEnergy = 0.;
     const reco::CandidatePtrVector signalCands = theTau.signalCands();
@@ -1098,7 +1100,7 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron&
                   ElecMvaInDeltaEta);
 }
 
-double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, bool usePhiAtEcalEntranceExtrapolation)
+double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau)
 {
   // === tau variables ===
   float TauEtaAtEcalEntrance = theTau.etaAtEcalEntrance();
@@ -1172,7 +1174,7 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, bool usePhiAtEcalEnt
   Int_t TauSignalPFGammaCandsOut = GammasPtOutSigCone.size();
   Float_t TauVisMassIn = (pfGammaSum + pfChargedSum).mass();
   Float_t TauPhi = -99.;
-  if ( usePhiAtEcalEntranceExtrapolation ) {
+  if ( usePhiAtEcalEntranceExtrapolation_ ) {
     float sumPhiTimesEnergy = 0.;
     float sumEnergy = 0.;
     const reco::CandidatePtrVector signalCands = theTau.signalCands();


### PR DESCRIPTION
This PR is to update an MVA anti-e tau discriminant as preparation to introduction of discriminants with a new training with current data. The updated consists of
* values of a set of MVA input parameters are constrained against unphysical outliers (key change for the new MVA training),
* making `usePhiAtEcalEntranceExtrapolation` parameter an internal parameter of the MVA algorithm to which it belongs rather than of the producer which calls the algorithm,
* a few other fixes to the code, e.g. range-based loops, a modern pointer instead of bare C pointer, etc.

The changes are not expected to change result, i.e. returned value of the MVA anti-e tau discriminant (together with related WPs) with the current training, or the changes will be marginal, i.e. below precision of performed tests with ~100k of ZLL (L=e,mu,tau) events.

A PR with additional changes in configuration files to introduce the new training will be send when the training fully validated and related payloads loaded to CondDB.
