### PR TITLE
Added a unique exception for missing secondary files

### DIFF
--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -58,6 +58,7 @@ namespace edm {
        NotFound = 8026,
        FormatIncompatibility = 8027,
        FallbackFileOpenError = 8028,
+       NoSecondaryFiles = 8029,
       
        ExceededResourceVSize = 8030,
        ExceededResourceRSS = 8031,

--- a/FWCore/Utilities/src/EDMException.cc
+++ b/FWCore/Utilities/src/EDMException.cc
@@ -38,6 +38,7 @@ namespace edm {
       FILLENTRY(NotFound),
       FILLENTRY(FormatIncompatibility),
       FILLENTRY(FallbackFileOpenError),
+      FILLENTRY(NoSecondaryFiles),
       FILLENTRY(ExceededResourceVSize),
       FILLENTRY(ExceededResourceRSS),
       FILLENTRY(ExceededResourceTime),

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -46,7 +46,7 @@ namespace edm {
     enablePrefetching_(false) {
 
     if(noFiles()) {
-      throw Exception(errors::Configuration) << "RootEmbeddedFileSequence no input files specified for secondary input source.\n";
+      throw Exception(errors::NoSecondaryFiles) << "RootEmbeddedFileSequence no input files specified for secondary input source.\n";
     }
     //
     // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.


### PR DESCRIPTION
Added a new EDMException category for the case where the secondary
source is given no input files. This exception happens alot in the
Release Validation tests so making it unique will help identify
the problem quicker.