### PR TITLE
SiStrip unpacker: update packet code check in cmMedian (for nonstandard ZS modes)

### DIFF
--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -1506,7 +1506,10 @@ namespace sistrip {
 
   uint16_t FEDChannel::cmMedian(const uint8_t apvIndex) const
   {
-    if (packetCode() != PACKET_CODE_ZERO_SUPPRESSED) {
+    const auto pCode = packetCode();
+    if ( ( pCode != PACKET_CODE_ZERO_SUPPRESSED ) && ( pCode != PACKET_CODE_ZERO_SUPPRESSED10 )
+      && ( pCode != PACKET_CODE_ZERO_SUPPRESSED8_BOTBOT ) && ( pCode != PACKET_CODE_ZERO_SUPPRESSED8_TOPBOT ) )
+    {
       std::ostringstream ss;
       ss << "Request for CM median from channel with non-ZS packet code. "
          << "Packet code is " << uint16_t(packetCode()) << "."


### PR DESCRIPTION
This is a bug fix for the method that extracts the CM medians from ZS raw data. It contains a protection to prevent extracting CM medians for non-ZS modes (because they are not present then), but that did not take the nonstandard packet codes into account yet, so an exception was thrown (and caught and converted into warning by the calling code) when unpacking with `UnpackCommonModeValues = True`.
As far as I know this feature is only used for specific studies of the zero-suppression settings, so there is no urgent need to have this in a release.

CC: @CesarBernardes @alesaggio 