### PR TITLE
(re)introduce hit pair limit in iterative tracking seeding

### DIFF
--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -13,7 +13,7 @@ hiConformalPixelTracksHitDoublets = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "PixelLayerTriplets",
     trackingRegions = "hiTrackingRegionWithVertex",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 

--- a/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
@@ -18,7 +18,7 @@ hiPixel3PrimTracksHitDoublets = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "PixelLayerTriplets",
     trackingRegions = "hiTrackingRegionWithVertex",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1

--- a/RecoHI/HiTracking/python/HIPixel3ProtoTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixel3ProtoTracks_cfi.py
@@ -14,7 +14,7 @@ hiPixel3ProtoTracksHitDoublets = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "PixelLayerTriplets",
     trackingRegions = "hiTrackingRegionFromClusterVtx",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 

--- a/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
@@ -56,7 +56,7 @@ hiDetachedQuadStepTracksHitDoubletsCA = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "hiDetachedQuadStepSeedLayers",
     trackingRegions = "hiDetachedQuadStepTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
     layerPairs = [0,1,2]
 )

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -62,7 +62,7 @@ hiDetachedTripletStepTracksHitDoublets = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "hiDetachedTripletStepSeedLayers",
     trackingRegions = "hiDetachedTripletStepTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *

--- a/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
@@ -54,7 +54,7 @@ hiHighPtTripletStepTracksHitDoubletsCA = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "hiHighPtTripletStepSeedLayers",
     trackingRegions = "hiHighPtTripletStepTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
     layerPairs = [0,1]
 )

--- a/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
@@ -54,7 +54,7 @@ hiLowPtQuadStepTracksHitDoubletsCA = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "hiLowPtQuadStepSeedLayers",
     trackingRegions = "hiLowPtQuadStepTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
     layerPairs = [0,1,2]
 )

--- a/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
@@ -57,7 +57,7 @@ hiLowPtTripletStepTracksHitDoublets = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "hiLowPtTripletStepSeedLayers",
     trackingRegions = "hiLowPtTripletStepTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -54,7 +54,7 @@ detachedQuadStepHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "detachedQuadStepSeedLayers",
     trackingRegions = "detachedQuadStepTrackingRegions",
     layerPairs = [0,1,2], # layer pairs (0,1), (1,2), (2,3),
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -68,7 +68,7 @@ from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _h
 detachedTripletStepHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "detachedTripletStepSeedLayers",
     trackingRegions = "detachedTripletStepTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletLargeTipEDProducer_cfi import pixelTripletLargeTipEDProducer as _pixelTripletLargeTipEDProducer

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -179,6 +179,7 @@ pixelPairElectronHitDoublets = _hitPairEDProducer.clone(
     trackingRegions = "pixelPairElectronTrackingRegions",
     maxElement = 1000000,
     produceSeedingHitSets = True,
+    maxElementTotal = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 pixelPairElectronSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
@@ -230,6 +231,7 @@ stripPairElectronHitDoublets = _hitPairEDProducer.clone(
     trackingRegions = "stripPairElectronTrackingRegions",
     maxElement = 1000000,
     produceSeedingHitSets = True,
+    maxElementTotal = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 stripPairElectronSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -107,7 +107,7 @@ from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _h
 tripletElectronHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "tripletElectronSeedLayers",
     trackingRegions = "tripletElectronTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -87,7 +87,7 @@ highPtTripletStepHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "highPtTripletStepSeedLayers",
     trackingRegions = "highPtTripletStepTrackingRegions",
     layerPairs = [0,1], # layer pairs (0,1), (1,2)
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -38,7 +38,7 @@ initialStepHitDoubletsPreSplitting = _hitPairEDProducer.clone(
     seedingLayers = "initialStepSeedLayersPreSplitting",
     trackingRegions = "initialStepTrackingRegionsPreSplitting",
     clusterCheck = "trackerClusterCheckPreSplitting",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -41,7 +41,7 @@ from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _h
 initialStepHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "initialStepSeedLayers",
     trackingRegions = "initialStepTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -76,6 +76,7 @@ jetCoreRegionalStepHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "jetCoreRegionalStepSeedLayers",
     trackingRegions = "jetCoreRegionalStepTrackingRegions",
     produceSeedingHitSets = True,
+    maxElementTotal = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 jetCoreRegionalStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -48,7 +48,7 @@ lowPtQuadStepHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "lowPtQuadStepSeedLayers",
     trackingRegions = "lowPtQuadStepTrackingRegions",
     layerPairs = [0,1,2], # layer pairs (0,1), (1,2), (2,3)
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -80,7 +80,7 @@ from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _h
 lowPtTripletStepHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "lowPtTripletStepSeedLayers",
     trackingRegions = "lowPtTripletStepTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -119,7 +119,7 @@ from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _h
 mixedTripletStepHitDoubletsA = _hitPairEDProducer.clone(
     seedingLayers = "mixedTripletStepSeedLayersA",
     trackingRegions = "mixedTripletStepTrackingRegionsA",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoPixelVertexing.PixelTriplets.pixelTripletLargeTipEDProducer_cfi import pixelTripletLargeTipEDProducer as _pixelTripletLargeTipEDProducer

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -139,7 +139,7 @@ from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _h
 pixelLessStepHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "pixelLessStepSeedLayers",
     trackingRegions = "pixelLessStepTrackingRegions",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoTracker.TkSeedGenerator.multiHitFromChi2EDProducer_cfi import multiHitFromChi2EDProducer as _multiHitFromChi2EDProducer

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -91,6 +91,7 @@ pixelPairStepHitDoublets = _hitPairEDProducer.clone(
     seedingLayers = "pixelPairStepSeedLayers",
     trackingRegions = "pixelPairStepTrackingRegions",
     produceSeedingHitSets = True,
+    maxElementTotal = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 pixelPairStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -158,6 +158,7 @@ tobTecStepHitDoubletsPair = _hitPairEDProducer.clone(
     seedingLayers = "tobTecStepSeedLayersPair",
     trackingRegions = "tobTecStepTrackingRegionsPair",
     produceSeedingHitSets = True,
+    maxElementTotal = 12000000,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 tobTecStepSeedsPair = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -71,7 +71,7 @@ from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _h
 tobTecStepHitDoubletsTripl = _hitPairEDProducer.clone(
     seedingLayers = "tobTecStepSeedLayersTripl",
     trackingRegions = "tobTecStepTrackingRegionsTripl",
-    maxElement = 0,
+    maxElement = 50000000,
     produceIntermediateHitDoublets = True,
 )
 from RecoTracker.TkSeedGenerator.multiHitFromChi2EDProducer_cfi import multiHitFromChi2EDProducer as _multiHitFromChi2EDProducer

--- a/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
+++ b/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
@@ -420,16 +420,16 @@ HitPairEDProducer::HitPairEDProducer(const edm::ParameterSet& iConfig) {
   auto layersTag = iConfig.getParameter<edm::InputTag>("seedingLayers");
   auto regionTag = iConfig.getParameter<edm::InputTag>("trackingRegions");
   auto regionLayerTag = iConfig.getParameter<edm::InputTag>("trackingRegionsSeedingLayers");
-  const bool useRegionLayers = regionLayerTag.label() != "";
+  const bool useRegionLayers = !regionLayerTag.label().empty();
   if(useRegionLayers) {
-    if(regionTag.label() != "") {
+    if(!regionTag.label().empty()) {
       throw cms::Exception("Configuration") << "HitPairEDProducer requires either trackingRegions or trackingRegionsSeedingLayers to be set, now both are set to non-empty value. Set the unneeded parameter to empty value.";
     }
-    if(layersTag.label() != "") {
+    if(!layersTag.label().empty()) {
       throw cms::Exception("Configuration") << "With non-empty trackingRegionsSeedingLayers, please set also seedingLayers to empty value to reduce confusion, because the parameter is not used";
     }
   }
-  if(regionTag.label() == "" && regionLayerTag.label() == "") {
+  if(regionTag.label().empty() && regionLayerTag.label().empty()) {
     throw cms::Exception("Configuration") << "HitPairEDProducer requires either trackingRegions or trackingRegionsSeedingLayers to be set, now both are set to empty value. Set the needed parameter to a non-empty value.";
   }
 
@@ -456,7 +456,7 @@ HitPairEDProducer::HitPairEDProducer(const edm::ParameterSet& iConfig) {
     throw cms::Exception("Configuration") << "HitPairEDProducer requires either produceIntermediateHitDoublets or produceSeedingHitSets to be True. If neither are needed, just remove this module from your sequence/path as it doesn't do anything useful";
 
   auto clusterCheckTag = iConfig.getParameter<edm::InputTag>("clusterCheck");
-  if(clusterCheckTag.label() != "")
+  if(!clusterCheckTag.label().empty())
     clusterCheckToken_ = consumes<bool>(clusterCheckTag);
 
   impl_->produces(*this);


### PR DESCRIPTION
This PR is somewhat inspired by issues reported in https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2014.html

The target module(s) in this PR are of HitPairEDProducer kind.
To define a limit I used a somewhat ad-hoc limit of \~0.5 GB of output data per event.
This leads to 
- a limit of 50M pairs for produceIntermediateHitDoublets = True (producing 2 ints per entry)
- a limit of 12M pairs for produceSeedingHitSets = True (producing 4 rechit pointers per entry)

As a specific case test, I used PromptReco_Run323420_EGamma from the HN thread and find that with this PR the job is expected to be processable:
- single thread RSS peak moves down from 22GB to 7GB
    - 8-thread RSS peak with this PR is around 13GB

Note that I made a guess for a bottom-up limit: for 10K real particles in an event (PU200 has about 10K tracking particles with pt>0.5 GeV and |eta|<4), for at worst \~50 layer pairs (as a still sensible large number)
- 12M limit would correspond to \~4% purity in created pairs
- 50M limit would correspond to \~1% purity in created pairs

This sounds safe enough from these "first principles".


@makortel @rovere @VinInn 
please let me know if you have any indications that these limits can actually be exceeded in processing of events with sensible physics content.
If such phase space exists and has to be tracked, perhaps some more creative configuration in the seeding can be made instead.

