### PR TITLE
Added Mixing scenario for PU250 and PU300

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -158,6 +158,8 @@ addMixingScenario("AVE_200_BX_25ns_m12p3",{'file': 'SimGeneral.MixingModule.mix_
 addMixingScenario("AVE_200_BX_25ns_m6p6",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-6,6), 'N': 200})
 addMixingScenario("AVE_140_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-3,3), 'N': 140})
 addMixingScenario("AVE_140_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-3,3), 'N': 140})
+addMixingScenario("AVE_250_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-3,3), 'N': 250})
+addMixingScenario("AVE_300_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-3,3), 'N': 300})
 addMixingScenario("AVE_140_BX_25ns_m12p3",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 140})
 addMixingScenario("AVE_140_BX_25ns_m6p6",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-6,6), 'N': 140})
 addMixingScenario("flatPU_0_10",{'file': 'SimGeneral.MixingModule.mix_flat_0_10_cfi'})


### PR DESCRIPTION
Added mixing scenaring AVE_250_BX_25ns and AVE_300_BX_25ns for PU250, PU300 in Configuration/StandardSequences/python/Mixing.py with CMSSW_10_3_X. I want this change to backport to CMSSW_9_3_7. 
Thank you.