### PR TITLE
Bugfix: Make Use of the 2019 Geometry from DB

### DIFF
--- a/Configuration/Geometry/python/GeometryRecoDB_cff.py
+++ b/Configuration/Geometry/python/GeometryRecoDB_cff.py
@@ -31,4 +31,7 @@ def _loadGeometryESProducers( theProcess ) :
    theProcess.load('Geometry.GEMGeometryBuilder.gemGeometryDB_cfi')
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
-modifyGeometryConfiguration_cff_ = run2_GEM_2017.makeProcessModifier( _loadGeometryESProducers )
+modifyGeometryConfigurationRun2_cff_ = run2_GEM_2017.makeProcessModifier( _loadGeometryESProducers )
+
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+modifyGeometryConfigurationRun3_cff_ = run3_GEM.makeProcessModifier( _loadGeometryESProducers )

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -235,14 +235,14 @@ upgradeProperties[2017] = {
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
     },
     '2019' : {
-        'Geom' : 'Extended2019',
+        'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2019_realistic',
         'HLTmenu': '@relval2017',
         'Era' : 'Run3',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
     },
     '2019Design' : {
-        'Geom' : 'Extended2019',
+        'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2019_design',
         'HLTmenu': '@relval2017',
         'Era' : 'Run3',


### PR DESCRIPTION
* Both 2019 Geometry scenario and GEM reco geometry have been updated in the 2019 GTs in https://github.com/cms-sw/cmssw/pull/24782
* Replaces https://github.com/cms-sw/cmssw/pull/24768

There are issues in the local relval tests, for example:

* 11624.0 step2:
```
08-Oct-2018 14:56:53 CEST  Initiating request to open file file:step1.root
08-Oct-2018 14:56:54 CEST  Successfully opened file file:step1.root
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 08-Oct-2018 14:57:05.964 CEST
%MSG-e L1T:  L1TRawToDigi:hltGtStage2Digis 08-Oct-2018 14:57:22 CEST  Run: 1 Event: 1
Cannot unpack: no FEDRawDataCollection found
%MSG
----- Begin Fatal Exception 08-Oct-2018 14:57:22 CEST-----------------------
An exception of category 'Out of Range' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 0
   [1] Running path 'digitisation_step'
   [2] Calling method for module HcalTrigPrimDigiProducer/'simHcalTriggerPrimitiveDigis'
Exception Message:
LUT has 1024 entries for (HcalTrigTower v0: -4,36) but 1057 was requested.
----- End Fatal Exception -------------------------------------------------
Another exception was caught while trying to clean up files after the primary fatal exception.
08-Oct-2018 14:57:22 CEST  Closed file file:step1.root

```