### PR TITLE
Use SimHits instead of digis for muon detectors in premixing

### DIFF
--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # Start with Standard Digitization:
 
 from SimCalorimetry.Configuration.SimCalorimetry_cff import *
+from SimMuon.Configuration.SimMuon_cff import *
 
 from SimGeneral.PreMixingModule.mixOne_premix_on_sim_cfi import *
 
@@ -55,15 +56,7 @@ DMHcalTTPDigis.HFDigiCollection = cms.InputTag("mixData")
 
 hcalDigiSequenceDM = cms.Sequence(DMHcalTriggerPrimitiveDigis+DMHcalDigis*DMHcalTTPDigis)
 
-postDMDigi = cms.Sequence(ecalDigiSequenceDM+hcalDigiSequenceDM)
-
-# GEM and ME0 have additional digi sequences
-from SimMuon.GEMDigitizer.muonGEMDigi_cff import muonGEMDigiDM
-from SimMuon.GEMDigitizer.muonME0Digi_cff import muonME0DigiDM
-_phase2_postDMDigi = postDMDigi.copy()
-_phase2_postDMDigi += (muonGEMDigiDM+muonME0DigiDM)
-from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toReplaceWith(postDMDigi, _phase2_postDMDigi)
+postDMDigi = cms.Sequence(ecalDigiSequenceDM+hcalDigiSequenceDM+muonDigi)
 
 # disable adding noise to HCAL cells with no MC signal
 #mixData.doEmpty = False

--- a/Configuration/StandardSequences/python/DigiToRawDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawDM_cff.py
@@ -1,8 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.DigiToRaw_cff import *
-#
+
 # Re-define inputs to look at the DataMixer output
+#
+# In premixing stage2, need to use the original ones for muons
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 #
 siPixelRawData.InputLabel = "mixData:siPixelDigisDM"
 SiStripDigiToRaw.InputDigis = "mixData:siStripDigisDM"
@@ -21,12 +24,13 @@ hcalRawDataVME.HO = "DMHcalDigis"
 hcalRawDataVME.ZDC = "mixData"
 hcalRawDataVME.TRIG = "DMHcalTriggerPrimitiveDigis"
 #
-cscpacker.wireDigiTag = "mixData:MuonCSCWireDigisDM"
-cscpacker.stripDigiTag = "mixData:MuonCSCStripDigisDM"
-cscpacker.comparatorDigiTag = "mixData:MuonCSCComparatorDigisDM"
-dtpacker.digiColl = 'mixData'
-#dtpacker.digiColl = 'simMuonDTDigis'
-rpcpacker.InputLabel = "mixData"
+(~premix_stage2).toModify(cscpacker,
+    wireDigiTag = "mixData:MuonCSCWireDigisDM",
+    stripDigiTag = "mixData:MuonCSCStripDigisDM",
+    comparatorDigiTag = "mixData:MuonCSCComparatorDigisDM"
+)
+(~premix_stage2).toModify(dtpacker, digiColl = 'mixData')
+(~premix_stage2).toModify(rpcpacker, InputLabel = "mixData")
 
 DigiToRaw.remove(castorRawData)
 

--- a/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
@@ -2,13 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.SimL1Emulator_cff import *
 
+# In premixing stage2, need to use the original ones for muons
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+
 # Modifications for DataMixer input:
-simDtTriggerPrimitiveDigis.digiTag = 'mixData'
-simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag("mixData","MuonCSCComparatorDigisDM")
-simCscTriggerPrimitiveDigis.CSCWireDigiProducer = cms.InputTag("mixData","MuonCSCWireDigisDM")
+(~premix_stage2).toModify(simDtTriggerPrimitiveDigis, digiTag = 'mixData')
+(~premix_stage2).toModify(simCscTriggerPrimitiveDigis, CSCComparatorDigiProducer = "mixData:MuonCSCComparatorDigisDM")
+(~premix_stage2).toModify(simCscTriggerPrimitiveDigis, CSCWireDigiProducer = "mixData:MuonCSCWireDigisDM")
 #
 #
-simRpcTechTrigDigis.RPCDigiLabel = 'mixData'
+(~premix_stage2).toModify(simRpcTechTrigDigis, RPCDigiLabel = 'mixData')
 #
 simHcalTechTrigDigis.ttpDigiCollection = "DMHcalTTPDigis"
 #
@@ -18,12 +21,12 @@ hgcalTriggerPrimitiveDigiProducer.bhDigis = "mixData:HGCDigisHEback"
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 if not stage2L1Trigger.isChosen():
-    simRpcTriggerDigis.label = 'mixData'
+    (~premix_stage2).toModify(simRpcTriggerDigis, label = 'mixData')
     simRctDigis.hcalDigis=cms.VInputTag(cms.InputTag("DMHcalTriggerPrimitiveDigis"))   
     simRctDigis.ecalDigis=cms.VInputTag(cms.InputTag("DMEcalTriggerPrimitiveDigis"))   
 else:
     #seems likely that this code does not support 2015 MC...
-    simTwinMuxDigis.RPC_Source = cms.InputTag('mixData')
-    simOmtfDigis.srcRPC = cms.InputTag('mixData')
+    (~premix_stage2).toModify(simTwinMuxDigis, RPC_Source = 'mixData')
+    (~premix_stage2).toModify(simOmtfDigis, srcRPC = 'mixData')
     simCaloStage2Layer1Digis.ecalToken = cms.InputTag("DMEcalTriggerPrimitiveDigis")
     simCaloStage2Layer1Digis.hcalToken = cms.InputTag("DMHcalTriggerPrimitiveDigis")

--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -99,8 +99,7 @@ def loadDigiAliases(process, premix=False):
           )
 
     process.muonDTDigis = cms.EDAlias(
-        **{"simMuonDTDigis" if nopremix else "mixData" :
-               cms.VPSet(
+        simMuonDTDigis = cms.VPSet(
                 cms.PSet(
                     type = cms.string("DTLayerIdDTDigiMuonDigiCollection")
                     ),
@@ -108,12 +107,10 @@ def loadDigiAliases(process, premix=False):
                 #    type = cms.string("DTLayerIdDTDigiSimLinkMuonDigiCollection")
                 #    )
                 )
-           }
           )
 
     process.muonRPCDigis = cms.EDAlias(
-        **{"simMuonRPCDigis" if nopremix else "mixData" :
-               cms.VPSet(
+        simMuonRPCDigis = cms.VPSet(
                 cms.PSet(
                     type = cms.string("RPCDetIdRPCDigiMuonDigiCollection")
                     ),
@@ -121,25 +118,22 @@ def loadDigiAliases(process, premix=False):
                 #    type = cms.string("RPCDigiSimLinkedmDetSetVector")
                 #    )
                 )
-           }
           )
 
     process.muonCSCDigis = cms.EDAlias(
-        **{"simMuonCSCDigis" if nopremix else "mixData" :
-               cms.VPSet(
+        simMuonCSCDigis = cms.VPSet(
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCWireDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCWireDigi" if nopremix else "MuonCSCWireDigisDM"),
+                    fromProductInstance = cms.string("MuonCSCWireDigi"),
                     toProductInstance = cms.string("MuonCSCWireDigi")),
                 cms.PSet(
                     type = cms.string("CSCDetIdCSCStripDigiMuonDigiCollection"),
-                    fromProductInstance = cms.string("MuonCSCStripDigi" if nopremix else "MuonCSCStripDigisDM"),
+                    fromProductInstance = cms.string("MuonCSCStripDigi"),
                     toProductInstance = cms.string("MuonCSCStripDigi")),
                 #cms.PSet(
                 #    type = cms.string('StripDigiSimLinkedmDetSetVector')
                 #    ),
                 )
-           }
           )
     
 def loadTriggerDigiAliases(process):

--- a/RecoLocalMuon/RPCRecHit/python/rpcRecHits_cfi.py
+++ b/RecoLocalMuon/RPCRecHit/python/rpcRecHits_cfi.py
@@ -16,7 +16,3 @@ rpcRecHits = cms.EDProducer("RPCRecHitProducer",
 #disabling DIGI2RAW,RAW2DIGI chain for Phase2
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(rpcRecHits, rpcDigiLabel = cms.InputTag('simMuonRPCDigis'))
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-(premix_stage2 & phase2_muon).toModify(rpcRecHits,
-    rpcDigiLabel = "mixData"
-)

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -49,6 +49,14 @@ mixSimHits = cms.PSet(
     #    'TotemHitsT2Gem')
     pcrossingFrames = cms.untracked.vstring()
 )
+from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
+premix_stage1.toModify(mixSimHits,
+    pcrossingFrames = [
+        'MuonCSCHits',
+        'MuonDTHits',
+        'MuonRPCHits',
+    ]
+)
 
 # fastsim customs
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
@@ -223,12 +231,22 @@ run2_GEM_2017.toModify( theMixObjects,
         crossingFrames = theMixObjects.mixSH.crossingFrames + [ 'MuonGEMHits' ]
     )
 )
+(premix_stage1 & run2_GEM_2017).toModify(theMixObjects,
+    mixSH = dict(
+        pcrossingFrames = theMixObjects.mixSH.pcrossingFrames + [ 'MuonGEMHits' ]
+    )
+)
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( theMixObjects,
     mixSH = dict(
         input = theMixObjects.mixSH.input + [ cms.InputTag("g4SimHits","MuonGEMHits") ],
         subdets = theMixObjects.mixSH.subdets + [ 'MuonGEMHits' ],
         crossingFrames = theMixObjects.mixSH.crossingFrames + [ 'MuonGEMHits' ]
+    )
+)
+(premix_stage1 & run3_GEM).toModify(theMixObjects,
+    mixSH = dict(
+        pcrossingFrames = theMixObjects.mixSH.pcrossingFrames + [ 'MuonGEMHits' ]
     )
 )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
@@ -239,7 +257,6 @@ phase2_muon.toModify( theMixObjects,
         crossingFrames = theMixObjects.mixSH.crossingFrames + [ 'MuonME0Hits' ]
     )
 )
-from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 (premix_stage1 & phase2_muon).toModify(theMixObjects,
     mixSH = dict(
         pcrossingFrames = theMixObjects.mixSH.pcrossingFrames + [ 'MuonME0Hits' ]

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -110,34 +110,22 @@ mixData = cms.EDProducer("PreMixingModule",
             ZDCDigiCollectionDM  = cms.string('')
         ),
         dt = cms.PSet(
-            workerType = cms.string("PreMixingDTWorker"),
-            digiTagSig = cms.InputTag("simMuonDTDigis"),
-            pileInputTag = cms.InputTag("simMuonDTDigis"),
-            collectionDM = cms.string(''),
+            workerType = cms.string("PreMixingCrossingFramePSimHitWorker"),
+            labelSig = cms.InputTag("mix", "g4SimHitsMuonDTHits"),
+            pileInputTag = cms.InputTag("mix", "g4SimHitsMuonDTHits"),
+            collectionDM = cms.string("g4SimHitsMuonDTHits"),
         ),
         rpc = cms.PSet(
-            workerType = cms.string("PreMixingRPCWorker"),
-            digiTagSig = cms.InputTag("simMuonRPCDigis"),                   
-            pileInputTag = cms.InputTag("simMuonRPCDigis"),
-            collectionDM = cms.string(''),
+            workerType = cms.string("PreMixingCrossingFramePSimHitWorker"),
+            labelSig = cms.InputTag("mix", "g4SimHitsMuonRPCHits"),
+            pileInputTag = cms.InputTag("mix", "g4SimHitsMuonRPCHits"),
+            collectionDM = cms.string("g4SimHitsMuonRPCHits"),
         ),
         csc = cms.PSet(
-            workerType = cms.string("PreMixingCSCWorker"),
-            strip = cms.PSet(
-                digiTagSig = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigi"),
-                pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigi"),
-                collectionDM = cms.string('MuonCSCStripDigisDM'),
-            ),
-            wire = cms.PSet(
-                digiTagSig = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigi"),
-                pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigi"),
-                collectionDM = cms.string('MuonCSCWireDigisDM'),
-            ),
-            comparator = cms.PSet(
-                digiTagSig = cms.InputTag("simMuonCSCDigis","MuonCSCComparatorDigi"),
-                pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCComparatorDigi"),
-                collectionDM = cms.string('MuonCSCComparatorDigisDM'),
-            ),
+            workerType = cms.string("PreMixingCrossingFramePSimHitWorker"),
+            labelSig = cms.InputTag("mix", "g4SimHitsMuonCSCHits"),
+            pileInputTag = cms.InputTag("mix", "g4SimHitsMuonCSCHits"),
+            collectionDM = cms.string("g4SimHitsMuonCSCHits"),
         ),
         trackingTruth = cms.PSet(
             workerType = cms.string("PreMixingTrackingParticleWorker"),
@@ -157,30 +145,6 @@ mixData = cms.EDProducer("PreMixingModule",
             pileInputTag = cms.InputTag("simSiStripDigis"),
             collectionDM = cms.string('StripDigiSimLink'),
         ),
-        dtSimLink = cms.PSet(
-            workerType = cms.string("PreMixingDTDigiSimLinkWorker"),
-            labelSig = cms.InputTag("simMuonDTDigis"),
-            pileInputTag = cms.InputTag("simMuonDTDigis"),
-            collectionDM = cms.string('simMuonDTDigis'),
-        ),
-        rpcSimLink = cms.PSet(
-            workerType = cms.string("PreMixingRPCDigiSimLinkWorker"),
-            labelSig = cms.InputTag("simMuonRPCDigis","RPCDigiSimLink"),
-            pileInputTag = cms.InputTag("simMuonRPCDigis","RPCDigiSimLink"),
-            collectionDM = cms.string('RPCDigiSimLink'),
-        ),
-        cscStripSimLink = cms.PSet(
-            workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
-            labelSig = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigiSimLinks"),
-            pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigiSimLinks"),
-            collectionDM = cms.string('MuonCSCStripDigiSimLinks'),
-        ),
-        cscWireSimLink = cms.PSet(
-            workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
-            labelSig = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigiSimLinks"),
-            pileInputTag = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigiSimLinks"),
-            collectionDM = cms.string('MuonCSCWireDigiSimLinks'),
-        ),
     ),
 )
 
@@ -199,8 +163,37 @@ fastSim.toModify(mixData,
             accumulator = _recoTrackAccumulator.clone(
                 pileUpTracks = "mix:generalTracks"
             )
-        )
+        ),
+        dt = dict(
+            labelSig = "mix:MuonSimHitsMuonDTHits",
+            pileInputTag = "mix:MuonSimHitsMuonDTHits",
+            collectionDM = "MuonSimHitsMuonDTHits",
+        ),
+        rpc = dict(
+            labelSig = "mix:MuonSimHitsMuonRPCHits",
+            pileInputTag = "mix:MuonSimHitsMuonRPCHits",
+            collectionDM = "MuonSimHitsMuonRPCHits",
+        ),
+        csc = dict(
+            labelSig = "mix:MuonSimHitsMuonRPCHits",
+            pileInputTag = "mix:MuonSimHitsMuonCSCHits",
+            collectionDM = "MuonSimHitsMuonCSCHits",
+        ),
     ),
+)
+
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+(run2_GEM_2017 | run3_GEM).toModify(
+    mixData,
+    workers = dict(
+        gem = cms.PSet(
+            workerType = cms.string("PreMixingCrossingFramePSimHitWorker"),
+            labelSig = cms.InputTag("mix", "g4SimHitsMuonGEMHits"),
+            pileInputTag = cms.InputTag("mix", "g4SimHitsMuonGEMHits"),
+            collectionDM = cms.string("g4SimHitsMuonGEMHits"),
+        ),
+    )
 )
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
@@ -290,47 +283,11 @@ phase2_hfnose.toModify(mixData,
 # Muon
 phase2_muon.toModify(mixData,
     workers = dict(
-        gem = cms.PSet(
-            workerType = cms.string("PreMixingGEMWorker"),
-            digiTagSig = cms.InputTag("simMuonGEMDigis"),
-            pileInputTag = cms.InputTag("simMuonGEMDigis",""),
-            collectionDM = cms.string(''),
-        ),
         me0 = cms.PSet(
-            workerType = cms.string("PreMixingME0Worker"),
-            digiTagSig = cms.InputTag("simMuonME0Digis"),
-            pileInputTag = cms.InputTag("simMuonME0Digis",""),
-            collectionDM = cms.string(''),
-        ),
-        me0SimHit = cms.PSet(
             workerType = cms.string("PreMixingCrossingFramePSimHitWorker"),
             labelSig = cms.InputTag("mix", "g4SimHitsMuonME0Hits"),
             pileInputTag = cms.InputTag("mix", "g4SimHitsMuonME0Hits"),
             collectionDM = cms.string("g4SimHitsMuonME0Hits"),
-        ),
-        gemSimLink = cms.PSet(
-            workerType = cms.string("PreMixingGEMDigiSimLinkWorker"),
-            labelSig = cms.InputTag("simMuonGEMDigis"),
-            pileInputTag = cms.InputTag("simMuonGEMDigis"),
-            collectionDM = cms.string('GEMDigiSimLink'),
-        ),
-        gemStripSimLink = cms.PSet(
-            workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
-            labelSig = cms.InputTag("simMuonGEMDigis"),
-            pileInputTag = cms.InputTag("simMuonGEMDigis"),
-            collectionDM = cms.string('GEMStripDigiSimLink'),
-        ),
-        me0SimLink = cms.PSet(
-            workerType = cms.string("PreMixingME0DigiSimLinkWorker"),
-            labelSig = cms.InputTag("simMuonMe0Digis"),
-            pileInputTag = cms.InputTag("simMuonME0Digis"),
-            collectionDM = cms.string('ME0DigiSimLink'),
-        ),
-        me0StripSimLink = cms.PSet(
-            workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
-            labelSig = cms.InputTag("simMuonME0Digis"),
-            pileInputTag = cms.InputTag("simMuonME0Digis"),
-            collectionDM = cms.string('ME0StripDigiSimLink'),
         ),
     )
 )

--- a/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
+++ b/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
@@ -91,3 +91,6 @@ run2_common.toModify( simMuonCSCDigis.wires, bunchTimingOffsets=[0.0, 22.88, 22.
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(simMuonCSCDigis, InputCollection = 'MuonSimHitsMuonCSCHits')
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(simMuonCSCDigis, mixLabel = "mixData")

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -28,46 +28,12 @@ from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify( SimMuonRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simMuonCSCDigis_*_*') )
 run2_common.toModify( SimMuonRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simMuonRPCDigis_*_*') )
 
-# The merged SimDigi collections have mixData label, drop the signal-only ones
-# Eventually (if/when we switch muon premixing to use SimHits) this whole customization
-#   can be removed as the collection names become the standard ones
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(SimMuonFEVTDEBUG, outputCommands = [
-        'keep CSCDetIdCSCComparatorDigiMuonDigiCollection_mixData_*_*',
-        'keep CSCDetIdCSCStripDigiMuonDigiCollection_mixData_*_*',
-        'keep CSCDetIdCSCWireDigiMuonDigiCollection_mixData_*_*',
-        'keep DTLayerIdDTDigiMuonDigiCollection_mixData_*_*',
-        'keep RPCDetIdRPCDigiMuonDigiCollection_mixData_*_*',
-])
-# Almost same (without DT) for SimMuonRAW following the run2_common customization
-premix_stage2.toModify(SimMuonRAW, outputCommands = [
-        'keep *_mixData_MuonCSCStripDigiSimLinks_*',
-        'keep DTLayerIdDTDigiSimLinkMuonDigiCollection_mixData_*_*',
-        'keep *_mixData_RPCDigiSimLink_*',
-])
-(run2_common & premix_stage2).toModify(SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + [
-        'drop *_simMuonCSCDigis_*_*',
-        'drop *_simMuonRPCDigis_*_*',
-        'keep *_mixData_MuonCSCWireDigiSimLinks_*',
-        'keep CSCDetIdCSCComparatorDigiMuonDigiCollection_mixData_*_*',
-        'keep CSCDetIdCSCStripDigiMuonDigiCollection_mixData_*_*',
-        'keep CSCDetIdCSCWireDigiMuonDigiCollection_mixData_*_*',
-        'keep RPCDetIdRPCDigiMuonDigiCollection_mixData_*_*',
-])
-
 #RECO content
 SimMuonRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep StripDigiSimLinkedmDetSetVector_simMuonCSCDigis_*_*', 
         'keep DTLayerIdDTDigiSimLinkMuonDigiCollection_simMuonDTDigis_*_*', 
         'keep RPCDigiSimLinkedmDetSetVector_simMuonRPCDigis_*_*')
 )
-# The merged DigiSimLink collections have mixData label, drop the signal-only ones
-premix_stage2.toModify(SimMuonRECO, outputCommands = [
-        'keep *_mixData_MuonCSCStripDigiSimLinks_*',
-        'keep *_mixData_MuonCSCWireDigiSimLinks_*',
-        'keep *_mixData_RPCDigiSimLink_*',
-        'keep DTLayerIdDTDigiSimLinkMuonDigiCollection_mixData_*_*',
-])
 
 #AOD content
 SimMuonAOD = cms.PSet(
@@ -81,10 +47,9 @@ SimMuonRECO.outputCommands.extend(SimMuonAOD.outputCommands)
 # Event content for premixing library
 SimMuonPREMIX = cms.PSet(
     outputCommands = cms.untracked.vstring(
-        'keep *_simMuonDTDigis_*_*',
-        'keep *_simMuonCSCDigis_*_*',
-        'keep *_simMuonCscTriggerPrimitiveDigis_*_*',
-        'keep *_simMuonRPCDigis_*_*',
+        'keep *_mix_g4SimHitsMuonDTHits_*',
+        'keep *_mix_g4SimHitsMuonCSCHits_*',
+        'keep *_mix_g4SimHitsMuonRPCHits_*',
     )
 )
 
@@ -94,9 +59,7 @@ run2_GEM_2017.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outp
                                                                                               'keep *_simMuonGEMPadDigiClusters_*_*'] )
 run2_GEM_2017.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 run2_GEM_2017.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
-run2_GEM_2017.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_simMuonGEMDigis_*_*',
-                                                                                        'keep *_*_GEMDigiSimLink_*',
-                                                                                        'keep *_*_GEMStripDigiSimLink_*'] )
+run2_GEM_2017.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_mix_g4SimHitsMuonGEMHits_*'] )
 
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
@@ -105,9 +68,7 @@ run3_GEM.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCom
                                                                                          'keep *_simMuonGEMPadDigiClusters_*_*'] )
 run3_GEM.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 run3_GEM.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
-run3_GEM.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_simMuonGEMDigis_*_*',
-                                                                                   'keep *_*_GEMDigiSimLink_*',
-                                                                                   'keep *_*_GEMStripDigiSimLink_*'] )
+run3_GEM.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_mix_g4SimHitsMuonGEMHits_*'] )
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonME0PseudoDigis_*_*',
@@ -117,16 +78,11 @@ phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.output
                                                                                             'keep *_simMuonME0PadDigiClusters_*_*'] )
 phase2_muon.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
 phase2_muon.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
-phase2_muon.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_simMuonME0Digis_*_*',
-                                                                                      'keep *_mix_g4SimHitsMuonME0Hits_*',
-                                                                                      'keep *_*_ME0DigiSimLink_*',
-                                                                                      'keep *_*_ME0StripDigiSimLink_*'] )
+phase2_muon.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_mix_g4SimHitsMuonME0Hits_*'] )
 
 
-# For phase2 premixing switch the sim digi collections to the ones including pileup
-(premix_stage2 & phase2_muon).toModify(SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + [
-    'drop *_simMuonGEMDigis_*_*',
-    'keep GEMDetIdGEMDigiMuonDigiCollection_mixData_*_*',
-    'drop *_simMuonME0Digis_*_*',
-    'keep ME0DetIdME0DigiMuonDigiCollection_mixData_*_*',
-])
+# FastSim uses different naming convention
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+def _renameForFastsim(s):
+    return s.replace("_g4Sim", "_MuonSim")
+fastSim.toModify(SimMuonPREMIX, outputCommands = map(_renameForFastsim, SimMuonPREMIX.outputCommands.value()))

--- a/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
+++ b/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
@@ -40,4 +40,5 @@ simMuonDTDigis = cms.EDProducer("DTDigitizer",
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(simMuonDTDigis, InputCollection = 'MuonSimHitsMuonDTHits')
     
-
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(simMuonDTDigis, mixLabel = "mixData")

--- a/SimMuon/GEMDigitizer/python/muonGEMDigi_cff.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigi_cff.py
@@ -5,10 +5,3 @@ from SimMuon.GEMDigitizer.muonGEMPadDigis_cfi import *
 from SimMuon.GEMDigitizer.muonGEMPadDigiClusters_cfi import *
 
 muonGEMDigi = cms.Sequence(simMuonGEMDigis*simMuonGEMPadDigis*simMuonGEMPadDigiClusters)
-
-# In phase2 premixing we use simMuonGEMDigis for the overlay, and the rest are run after that
-from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-(premix_stage2 & phase2_muon).toReplaceWith(muonGEMDigi, cms.Sequence(simMuonGEMDigis))
-
-muonGEMDigiDM = cms.Sequence(simMuonGEMPadDigis*simMuonGEMPadDigiClusters)

--- a/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
@@ -40,6 +40,9 @@ gemDigiCommonParameters = cms.PSet(
     GE21ModNeuBkgParam2 = cms.double(0.0103078)
 )
 
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(gemDigiCommonParameters, mixLabel = "mixData")
+
 # Module to create simulated GEM digis.
 simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
     gemDigiCommonParameters

--- a/SimMuon/GEMDigitizer/python/muonGEMPadDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMPadDigis_cfi.py
@@ -4,7 +4,3 @@ import FWCore.ParameterSet.Config as cms
 simMuonGEMPadDigis = cms.EDProducer("GEMPadDigiProducer",
     InputCollection = cms.InputTag('simMuonGEMDigis'),
 )
-
-from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-(premix_stage2 & phase2_muon).toModify(simMuonGEMPadDigis, InputCollection = "mixData")

--- a/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
+++ b/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
@@ -11,9 +11,3 @@ muonME0RealDigi = cms.Sequence(simMuonME0Digis * simMuonME0PadDigis + simMuonME0
 muonME0PseudoDigi = cms.Sequence(simMuonME0PseudoDigis * simMuonME0PseudoReDigis)
 
 muonME0Digi = cms.Sequence(muonME0RealDigi * muonME0PseudoDigi)
-
-# In premixing we use simMuonME0Digis for the overlay, and the rest are run after that
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toReplaceWith(muonME0Digi, cms.Sequence(simMuonME0Digis))
-
-muonME0DigiDM = cms.Sequence(simMuonME0PadDigis + simMuonME0PadDigiClusters + muonME0PseudoDigi)

--- a/SimMuon/GEMDigitizer/python/muonME0Digis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0Digis_cfi.py
@@ -38,6 +38,9 @@ me0DigiCommonParameters = cms.PSet(
     ME0NeuBkgParam3 = cms.double(-102098)
 )
 
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(me0DigiCommonParameters, mixLabel = "mixData")
+
 # Module to create simulated ME0 digis.
 simMuonME0Digis = cms.EDProducer("ME0DigiProducer",
     me0DigiCommonParameters

--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -117,14 +117,9 @@ fastSim.toModify(muonAssociatorByHitsCommonParameters,
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(muonAssociatorByHitsCommonParameters,
-    DTdigisimlinkTag = "mixData:simMuonDTDigis",
-    CSClinksTag = "mixData:MuonCSCStripDigiSimLinks",
-    CSCwireLinksTag = "mixData:MuonCSCWireDigiSimLinks",
-    RPCdigisimlinkTag = "mixData:RPCDigiSimLink",
     pixelSimLinkSrc = "mixData:PixelDigiSimLink",
     stripSimLinkSrc = "mixData:StripDigiSimLink",
     phase2TrackerSimLinkSrc = "mixData:Phase2OTDigiSimLink",
-    GEMdigisimlinkTag = "mixData:GEMStripDigiSimLink",
 )
   
 muonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",

--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -93,5 +93,5 @@ _simMuonRPCDigisPhaseII = cms.EDProducer("RPCandIRPCDigiProducer",
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( simMuonRPCDigis, _simMuonRPCDigisPhaseII )
 
-from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
-premix_stage1.toModify(simMuonRPCDigis, doBkgNoise = False)
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(simMuonRPCDigis, mixLabel = "mixData")

--- a/Validation/GlobalDigis/python/globaldigis_analyze_cfi.py
+++ b/Validation/GlobalDigis/python/globaldigis_analyze_cfi.py
@@ -30,11 +30,3 @@ globaldigisanalyze = DQMEDAnalyzer('GlobalDigisAnalyzer',
     #InputTag HCalDigi  = simHcalUnsuppressedDigis
     HCalDigi = cms.InputTag("simHcalDigis")
 )
-
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(globaldigisanalyze,
-    MuCSCStripSrc = "mixData:MuonCSCStripDigisDM",
-    MuCSCWireSrc = "mixData:MuonCSCWireDigisDM",
-    MuDTSrc = "mixData",
-    MuRPCSrc = "mixData",
-)

--- a/Validation/MuonCSCDigis/python/cscDigiValidation_cfi.py
+++ b/Validation/MuonCSCDigis/python/cscDigiValidation_cfi.py
@@ -14,11 +14,3 @@ cscDigiValidation = DQMEDAnalyzer('CSCDigiValidation',
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(cscDigiValidation, simHitsTag = "mix:MuonSimHitsMuonCSCHits")
-
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(cscDigiValidation,
-    wireDigiTag = "mixData:MuonCSCWireDigisDM",
-    stripDigiTag = "mixData:MuonCSCStripDigisDM",
-    comparatorDigiTag = "mixData:MuonCSCComparatorDigisDM",
-)
-

--- a/Validation/MuonDTDigis/python/dtDigiValidation_cfi.py
+++ b/Validation/MuonDTDigis/python/dtDigiValidation_cfi.py
@@ -14,6 +14,3 @@ muondtdigianalyzer = DQMEDAnalyzer('MuonDTDigis',
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(muondtdigianalyzer, SimHitLabel = "MuonSimHits:MuonDTHits")
-
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(muondtdigianalyzer, DigiLabel = "mixData")

--- a/Validation/MuonGEMDigis/python/MuonGEMDigis_cff.py
+++ b/Validation/MuonGEMDigis/python/MuonGEMDigis_cff.py
@@ -52,11 +52,6 @@ gemDigiTrackValidation = DQMEDAnalyzer('GEMDigiTrackMatch',
   detailPlot = cms.bool(False), 
 )
 
-from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-(premix_stage2 & phase2_muon).toModify(gemStripValidation, stripLabel = "mixData")
-(premix_stage2 & phase2_muon).toModify(gemDigiTrackValidation, gemDigiInput = "mixData")
-
 gemGeometryChecker = DQMEDAnalyzer('GEMCheckGeometry',
   detailPlot = cms.bool(False), 
 )

--- a/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
+++ b/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
@@ -14,6 +14,3 @@ validationMuonRPCDigis = DQMEDAnalyzer('RPCDigiValid',
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(validationMuonRPCDigis, simHitTag = "MuonSimHits:MuonRPCHits")
-
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(validationMuonRPCDigis, rpcDigiTag = "mixData")


### PR DESCRIPTION
This PR changes the treatment of muon detectors in premixing to use SimHits instead of SimDigis in the premixing library and in the pileup overlay. This change brings the treatment of muon detectors in premixing closer to classical mixing (where SimHits are mixed, and SimDigi producers are run with the signal+pileup SimHit input). In phase2 the SimHits were needed anyway for ME0 in addition to digis (see #23065 and https://indico.cern.ch/event/711343/#54-phase-2-premixing-status).

The effect on the event size is a slight decrease. Below is a detailed comparison for 2018 (100 TTbar events with average pileup 50)

| subdetector | IB (kB) | this PR (kB) | effect |
| --- | --- | --- | --- |
| DT | 0.67 | 5.4 | + 8x |
| CSC | 64 | 35 | - 45 % |
| RPC | 0.44 | 1.3 | + 3x |
| GEM | 0.38 | 0.53 | + 40 % |
| total | 65.5 | 41.6 | - 36 % |

The total pileup event size decreases by 0.7 % (production, i.e. without tracking MC truth). 

Since the stage where the digitization is done in changed completely, changes are expected for anything depending on muon detectors, but they should be (close to) statistical fluctuations. For GEM in phase2 workflows larger differences are seen (caused by premixing treatment becoming closer to classical mixing), see comments below for details. In fact earlier GEM was disabled for < phase2 premixing, and this PR enables it in premixing everywhere GEM is enabled.

Here are links to 100 event comparison of 250202.181 (2018 ttbar+PU FullSim) (to my private DQM GUI using an ssh tunnel recipe shown further below; black is the IB and blue this PR)
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU50_2018_premixing_100ev_orig_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU50_2018_premixing_100ev_dev_v2-v1/DQMIO%3A%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;

10-event for 250202.171 (2017)
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU35_2017_premixing_10ev_orig_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU35_2017_premixing_10ev_dev_v2-v1/DQMIO%3A%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;

for 250202.1 (2016)
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU35_2016_premixing_10ev_orig_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU35_2016_premixing_10ev_dev_v2-v1/DQMIO%3A%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;

for 20234.99 (2023 D17 PU35)
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU35_2023d17_premixing_10ev_orig_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU35_2023d17_premixing_10ev_dev_v2-v1/DQMIO%3A%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;

for 250402.1 (2016 FastSim)
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU35_2016_fastsim_premixing_10ev_orig_v1-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_3_X_2018_09_26_1100-PU35_2016_fastsim_premixing_10ev_orig_v1-v1/DQMIO%3A%3A;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;

with the following SSH tunnel recipe

```
ssh -L8081:mkdev7.cern.ch:8081 lxplus.cern.ch
http://127.0.0.1:8081/dqm/relval/
```

Tested in CMSSW_10_3_X_2018-09-26-1100 (rebased on top of 10_3_0_pre6), expecting changes in muon detectors etc. in premxing workflows. Because the premixing library format changes (for muons), this PR breaks all stage2-only premixing workflows.

@kpedro88 @mdhildreth 