### PR TITLE
Added the capability to switch the mode of charge asymmetry evaluation

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/HFSimpleTimeCheck.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFSimpleTimeCheck.h
@@ -52,21 +52,28 @@ public:
     // algorithm cuts will be mapped to "OK". However, HFRecHit
     // will still be made using proper status flags.
     //
+    // If "alwaysCalculateChargeAsymmetry" is true, charge asymmetry
+    // status bit will be set whenever the data is available for both
+    // anodes. If "alwaysCalculateChargeAsymmetry" is false, the bit
+    // will be set only if the status of both anodes is "OK" (or mapped
+    // into "OK").
+    //
     HFSimpleTimeCheck(const std::pair<float,float> tlimits[2],
                       const float energyWeights[2*HFAnodeStatus::N_POSSIBLE_STATES-1][2],
                       unsigned soiPhase, float timeShift,
                       float triseIfNoTDC, float tfallIfNoTDC,
                       float minChargeForUndershoot, float minChargeForOvershoot,
-                      bool rejectAllFailures = true);
+                      bool rejectAllFailures = true,
+                      bool alwaysCalculateChargeAsymmetry = true);
 
     inline ~HFSimpleTimeCheck() override {}
 
     inline bool isConfigurable() const override {return false;}
 
     HFRecHit reconstruct(const HFPreRecHit& prehit,
-                                 const HcalCalibrations& calibs,
-                                 const bool flaggedBadInDB[2],
-                                 bool expectSingleAnodePMT) override;
+                         const HcalCalibrations& calibs,
+                         const bool flaggedBadInDB[2],
+                         bool expectSingleAnodePMT) override;
 
     inline unsigned soiPhase() const {return soiPhase_;}
     inline float timeShift() const {return timeShift_;}
@@ -75,6 +82,7 @@ public:
     inline float minChargeForUndershoot() const {return minChargeForUndershoot_;}
     inline float minChargeForOvershoot() const {return minChargeForOvershoot_;}
     inline bool rejectingAllFailures() const {return rejectAllFailures_;}
+    inline bool alwaysCalculatingQAsym() const {return alwaysQAsym_;}
 
 protected:
     virtual unsigned determineAnodeStatus(unsigned anodeNumber,
@@ -93,6 +101,7 @@ private:
     float minChargeForUndershoot_;
     float minChargeForOvershoot_;
     bool rejectAllFailures_;
+    bool alwaysQAsym_;
 };
 
 #endif // RecoLocalCalo_HcalRecAlgos_HFSimpleTimeCheck_h_

--- a/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
@@ -44,14 +44,16 @@ HFSimpleTimeCheck::HFSimpleTimeCheck(const std::pair<float,float> tlimits[2],
                                      const float i_tfallIfNoTDC,
                                      const float i_minChargeForUndershoot,
                                      const float i_minChargeForOvershoot,
-                                     const bool rejectAllFailures)
+                                     const bool rejectAllFailures,
+                                     const bool alwaysCalculateQAsymmetry)
     : soiPhase_(i_soiPhase),
       timeShift_(i_timeShift),
       triseIfNoTDC_(i_triseIfNoTDC),
       tfallIfNoTDC_(i_tfallIfNoTDC),
       minChargeForUndershoot_(i_minChargeForUndershoot),
       minChargeForOvershoot_(i_minChargeForOvershoot),
-      rejectAllFailures_(rejectAllFailures)
+      rejectAllFailures_(rejectAllFailures),
+      alwaysQAsym_(alwaysCalculateQAsymmetry)
 {
     tlimits_[0] = tlimits[0];
     tlimits_[1] = tlimits[1];

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
@@ -33,6 +33,8 @@ parseHFPhase1AlgoDescription(const edm::ParameterSet& ps)
             ps.getParameter<double>("minChargeForUndershoot");
         const float minChargeForOvershoot =
             ps.getParameter<double>("minChargeForOvershoot");
+        const bool alwaysCalculateQAsymmetry =
+            ps.getParameter<bool>("alwaysCalculateQAsymmetry");
 
         float energyWeights[2*HFAnodeStatus::N_POSSIBLE_STATES-1][2];
         const unsigned sz = sizeof(energyWeights)/sizeof(energyWeights[0][0]);
@@ -71,13 +73,13 @@ parseHFPhase1AlgoDescription(const edm::ParameterSet& ps)
                     new HFSimpleTimeCheck(tlimits, energyWeights, soiPhase,
                                           timeShift, triseIfNoTDC, tfallIfNoTDC,
                                           minChargeForUndershoot, minChargeForOvershoot,
-                                          rejectAllFailures));
+                                          rejectAllFailures, alwaysCalculateQAsymmetry));
             else
                 algo = std::unique_ptr<AbsHFPhase1Algo>(
                     new HFFlexibleTimeCheck(tlimits, energyWeights, soiPhase,
                                             timeShift, triseIfNoTDC, tfallIfNoTDC,
                                             minChargeForUndershoot, minChargeForOvershoot,
-                                            rejectAllFailures));
+                                            rejectAllFailures, alwaysCalculateQAsymmetry));
         }
     }
 
@@ -97,6 +99,7 @@ edm::ParameterSetDescription fillDescriptionForParseHFPhase1AlgoDescription()
     desc.add<double>("tfallIfNoTDC", -101.0);
     desc.add<double>("minChargeForUndershoot", 1.0e10);
     desc.add<double>("minChargeForOvershoot", 1.0e10);
+    desc.add<bool>("alwaysCalculateQAsymmetry", true);
 
     desc.ifValue(edm::ParameterDescription<std::string>("Class", "HFSimpleTimeCheck", true),
                  "HFSimpleTimeCheck" >> edm::ParameterDescription<bool>("rejectAllFailures", false, true) or

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -61,7 +61,11 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
         minChargeForOvershoot = cms.double(1.0e10),
 
         # Do not construct rechits with problems
-        rejectAllFailures = cms.bool(True)
+        rejectAllFailures = cms.bool(True),
+
+        # If False, calculate charge asymmetry only when both PMT
+        # anodes have "OK" status (or were mapped into "OK" status)
+        alwaysCalculateQAsymmetry = cms.bool(True)
     ),
 
     # Reconstruction algorithm data to fetch from DB, if any


### PR DESCRIPTION
The HF rechit charge asymmetry flag is currently calculated independently from the status of the HF PMT anodes. The original idea was that the downstream code should look both at the asymmetry flag and at the anode status values in order to figure out whether the rechit should be rejected. However, this was never done. Currently, the simplest solution appears to be to calculate the charge asymmetry in reco only when both anodes have the "OK" status. This pull request gives HF reco this capability, but it is not turned on yet. The plan is to turn it on after some additional validation is performed by the HF Noise Studies Group.

This pull request will not modify any MC or data results.
