### PR TITLE
Fix Relval steps for GEN workflow 535

### DIFF
--- a/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
+++ b/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
@@ -1,14 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-import FWCore.ParameterSet.Config as cms
-
-externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc630/13TeV/Powheg/V2/RelValidation/TTBar/hvq_slc6_amd64_gcc630_CMSSW_9_3_9_patch1_ttbar_new.tgz'),
-    nEvents = cms.untracked.uint32(5000),
-    numberOfParameters = cms.uint32(1),
-    outputFile = cms.string('cmsgrid_final.lhe'),
-    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
-)
+from Configuration.Generator.TTbar_Pow_LHE_13TeV_cff import externalLHEProducer
 
 generator = cms.EDFilter("Herwig7GeneratorFilter",
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1202,8 +1202,8 @@ step1LHEGenSimDefault = { '--relval':'9000,50',
                           '--era'         : 'Run2_2016',
                         }
 
-# LHE-GEN-SIM with DQM
-step1LHEGenSimDQM = merge([{'-s':'LHE,GEN,SIM','--datatier'    : 'GEN-SIM,LHE,DQMIO','--eventcontent': 'LHE,RAWSIM,DQM'},step1LHEGenSimDefault])
+# LHE-GEN with DQM
+step1LHEGenDQM = merge([{'-s':'LHE,GEN,VALIDATION:genvalid','--datatier'    : 'LHE,GEN,DQMIO','--eventcontent': 'LHE,RAWSIM,DQM'},step1LHEDefaults])
                         
 
 def lhegensim(fragment,howMuch):
@@ -1237,7 +1237,7 @@ steps['sherpa_ZtoEE_0j_BlackHat_13TeV_MASTER']=genvalid('sherpa_ZtoEE_0j_BlackHa
 steps['sherpa_ZtoEE_0j_OpenLoops_13TeV_MASTER']=genvalid('sherpa_ZtoEE_0j_OpenLoops_13TeV_MASTER_cff',step1GenDefaults)
 
 #Herwig7
-steps['TTbar_13TeV_Pow_herwig7']=genvalid('Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff',step1LHEGenSimDQM)
+steps['TTbar_13TeV_Pow_herwig7']=genvalid('Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff',step1LHEGenDQM)
 
 
 # Heavy Ion


### PR DESCRIPTION
Currently, GEN Relval workflow 535 produces corrupted DQM files, which makes RelMon comparison plot unavailable. For this GEN-only Relval workflow, SIM step is not needed and should be replaced by VALIDATION:genvalid step like other GEN-only workflows to make Relval works (see discussions in PR #23816 ).

Also, externalLHEProducer of the workflow 535 makes use of exactly same TTbar Powheg gridpack, hence made it imported for maintainability.

Fix of PR [#23802](https://github.com/cms-sw/cmssw/pull/23802).