### PR TITLE
[DQMOffline/Validation] BTV Updates

### DIFF
--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
@@ -250,7 +250,6 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
     for (JetTagCollection::const_iterator tagI = tagColl.begin(); tagI != tagColl.end(); ++tagI) {
       
       //JEC
-      reco::Jet correctedJet = *(tagI->first);     
       double jec = 1.0;
       if(doJEC && corrector) {
         jec = corrector->correction(*(tagI->first));
@@ -285,7 +284,6 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
     int plotterSize = binTagCorrelationPlotters[iJetLabel].size();
     for (JetTagCollection::const_iterator tagI = tagColl1.begin(); tagI != tagColl1.end(); ++tagI) {
       //JEC
-      reco::Jet correctedJet = *(tagI->first);     
       double jec = 1.0;
       if(doJEC && corrector) {
         jec = corrector->correction(*(tagI->first));
@@ -359,7 +357,6 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
       }
 
       //JEC
-      reco::Jet correctedJet = *(jetRef);     
       double jec = 1.0;
       if(doJEC && corrector) {
         jec = corrector->correction(*(jetRef));

--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -12,6 +12,7 @@ from DQMOffline.RecoB.bTagGenericAnalysis_cff import *
 from DQMOffline.RecoB.bTagSimpleSVAnalysis_cff import *
 from DQMOffline.RecoB.bTagSoftLeptonAnalysis_cff import *
 from DQMOffline.RecoB.cTagGenericAnalysis_cff import *
+from DQMOffline.RecoB.cTagSymmetricAnalysis_cff import *
 from DQMOffline.RecoB.cTagCombinedSVVariables_cff import *
 from DQMOffline.RecoB.cTagCombinedSVAnalysis_cff import *
 from DQMOffline.RecoB.cTagCorrelationAnalysis_cff import *
@@ -92,55 +93,20 @@ bTagCommonBlock = cms.PSet(
             label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
             folder = cms.string("CSVv2"),
             differentialPlots = cms.bool(True),
-            discrCut = cms.double(0.5426)
+            discrCut = cms.double(0.5803)
         ),
         cms.PSet(
             bTagSymmetricAnalysisBlock,
             label = cms.InputTag("pfCombinedMVAV2BJetTags"),
             folder = cms.string("combMVAv2"),
-            differentialPlots = cms.bool(True),
-            discrCut = cms.double(-0.5884)
         ), 
         cms.PSet(
             bTagGenericAnalysisBlock,
-            label = cms.InputTag("pfDeepCSVJetTags:probb"),
-            folder = cms.string("deepCSV_probb")
+            label = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:BvsAll"),
+            folder = cms.string("deepCSV_BvsAll"),
+            differentialPlots = cms.bool(True),
+            discrCut = cms.double(0.1522)
         ),
-        cms.PSet(
-            bTagGenericAnalysisBlock,
-            label = cms.InputTag("pfDeepCSVJetTags:probc"),
-            folder = cms.string("deepCSV_probc")
-        ),
-        cms.PSet(
-            bTagGenericAnalysisBlock,
-            label = cms.InputTag("pfDeepCSVJetTags:probudsg"),
-            folder = cms.string("deepCSV_probudsg")
-        ),
-        cms.PSet(
-            bTagGenericAnalysisBlock,
-            label = cms.InputTag("pfDeepCSVJetTags:probbb"),
-            folder = cms.string("deepCSV_probbb")
-        ),
-        #cms.PSet(
-        #    bTagGenericAnalysisBlock,
-        #    label = cms.InputTag("pfDeepCMVAJetTags:probb"),
-        #    folder = cms.string("deepCMVA_probb")
-        #),
-        #cms.PSet(
-        #    bTagGenericAnalysisBlock,
-        #    label = cms.InputTag("pfDeepCMVAJetTags:probc"),
-        #    folder = cms.string("deepCMVA_probc")
-        #),
-        #cms.PSet(
-        #    bTagGenericAnalysisBlock,
-        #    label = cms.InputTag("pfDeepCMVAJetTags:probudsg"),
-        #    folder = cms.string("deepCMVA_probudsg")
-        #),
-        #cms.PSet(
-        #    bTagGenericAnalysisBlock,
-        #    label = cms.InputTag("pfDeepCMVAJetTags:probbb"),
-        #    folder = cms.string("deepCMVA_probbb")
-        #),
        cms.PSet(
             bTagSoftLeptonAnalysisBlock,
             label = cms.InputTag("softPFMuonBJetTags"),
@@ -164,20 +130,36 @@ bTagCommonBlock = cms.PSet(
            folder = cms.string("CtaggerTag")
         ),
         cms.PSet(
-            cTagGenericAnalysisBlock,
+            cTagSymmetricAnalysisBlock,
             label = cms.InputTag("pfCombinedCvsLJetTags"),
             folder = cms.string("Ctagger_CvsL"),
             doCTagPlots = cms.bool(True),
             differentialPlots = cms.bool(True),
-            discrCut = cms.double(-0.1)
+            discrCut = cms.double(0.07)
         ),
         cms.PSet(
-            cTagGenericAnalysisBlock,
+            cTagSymmetricAnalysisBlock,
             label = cms.InputTag("pfCombinedCvsBJetTags"),
             folder = cms.string("Ctagger_CvsB"),
             doCTagPlots = cms.bool(True),
             differentialPlots = cms.bool(True),
-            discrCut = cms.double(0.08)
+            discrCut = cms.double(-0.10)
+        ),
+        cms.PSet(
+            cTagGenericAnalysisBlock,
+            label = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:CvsL"),
+            folder = cms.string("deepCSV_CvsL"),
+            doCTagPlots = cms.bool(True),
+            differentialPlots = cms.bool(True),
+            discrCut = cms.double(0.15)
+        ),
+        cms.PSet(
+            cTagGenericAnalysisBlock,
+            label = cms.InputTag("pfDeepCSVDiscriminatorsJetTags:CvsB"),
+            folder = cms.string("deepCSV_CvsB"),
+            doCTagPlots = cms.bool(True),
+            differentialPlots = cms.bool(True),
+            discrCut = cms.double(0.28)
         ),
         cms.PSet(
             cTagCorrelationAnalysisBlock,

--- a/DQMOffline/RecoB/python/cTagSymmetricAnalysis_cff.py
+++ b/DQMOffline/RecoB/python/cTagSymmetricAnalysis_cff.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-# Generic jetTag configuration
-cTagGenericAnalysisBlock = cms.PSet(
+# For discriminators with output in the range [-1,1]
+cTagSymmetricAnalysisBlock = cms.PSet(
     parameters = cms.PSet(
-        discriminatorStart = cms.double(-0.01),
+        discriminatorStart = cms.double(-1.011),
         nBinEffPur = cms.int32(200),
         # the constant b-efficiency for the differential plots versus pt and eta
         effBConst = cms.double(0.5),
@@ -12,4 +12,5 @@ cTagGenericAnalysisBlock = cms.PSet(
         startEffPur = cms.double(0.005)
     )
 )
+
 

--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -1,12 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoBTag.Combined.pfDeepCSVDiscriminatorsJetTags_cfi import pfDeepCSVDiscriminatorsJetTags
+
 ######### DATA ############
 from DQMOffline.RecoB.bTagAnalysisData_cfi import *
 bTagAnalysis.ptRanges = cms.vdouble(0.0)
 bTagAnalysis.doJetID = True
 bTagAnalysis.doJEC = True
 #Residual correction will be added inside the c++ code only for data (checking the presence of genParticles collection), not explicit here as this sequence also ran on MC FullSim
-bTagPlotsDATA = cms.Sequence(bTagAnalysis)
+bTagPlotsDATA = cms.Sequence(pfDeepCSVDiscriminatorsJetTags * bTagAnalysis)
 
 ########## MC ############
 #Matching
@@ -42,7 +44,7 @@ bTagValidation.doJetID = True
 bTagValidation.doJEC = True
 bTagValidation.genJetsMatched = cms.InputTag("newpatJetGenJetMatch")
 #to run on fastsim
-prebTagSequenceMC = cms.Sequence(ak4GenJetsForPUid*newpatJetGenJetMatch*selectedHadronsAndPartons*myak4JetFlavourInfos)
+prebTagSequenceMC = cms.Sequence(ak4GenJetsForPUid*newpatJetGenJetMatch*selectedHadronsAndPartons*myak4JetFlavourInfos*pfDeepCSVDiscriminatorsJetTags)
 bTagPlotsMC = cms.Sequence(bTagValidation)
 
 #to run on fullsim in the validation sequence, all histograms produced in the dqmoffline sequence

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
@@ -281,12 +281,12 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
 
   //Get JEC
   const JetCorrector* corrector = nullptr;
-  if(doJEC) {
+  if (doJEC) {
     edm::Handle<GenEventInfoProduct> genInfoHandle; //check if data or MC
     iEvent.getByToken(genToken, genInfoHandle);
     edm::Handle<JetCorrector> corrHandle;
-    if( !genInfoHandle.isValid() ) iEvent.getByToken( jecDataToken, corrHandle);
-    else iEvent.getByToken( jecMCToken, corrHandle);
+    if ( !genInfoHandle.isValid() ) iEvent.getByToken(jecDataToken, corrHandle);
+    else iEvent.getByToken(jecMCToken, corrHandle);
     corrector = corrHandle.product();
   }
   //
@@ -309,14 +309,15 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
            (muonPlots && !leptons[tagI->first].muon) ||
            (tauPlots && !leptons[tagI->first].tau)))
          continue;
-      //JEC
-      reco::Jet correctedJet = *(tagI->first);
+      // JEC
       double jec = 1.0;
+      /*reco::Jet correctedJet = *(tagI->first);
       if(doJEC && corrector) {
         jec = corrector->correction(*(tagI->first));
-      }
+      }*/
 
       JetWithFlavour jetWithFlavour;
+      // also applies JEC to jet
       if (!getJetWithFlavour(iEvent, tagI->first, flavours, jetWithFlavour, corrector, genJetsMatched))
         continue;
       if (!jetSelector(jetWithFlavour.first, std::abs(jetWithFlavour.second.getPartonFlavour()), infoHandle, jec))
@@ -356,13 +357,14 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
         continue;
       
       //JEC
-      reco::Jet correctedJet = *(tagI->first);
       double jec = 1.0;
+      /*reco::Jet correctedJet = *(tagI->first);
       if(doJEC && corrector) {
         jec = corrector->correction(*(tagI->first));
-      }
+      }*/
 
       JetWithFlavour jetWithFlavour;
+      // also applies JEC to jet
       if (!getJetWithFlavour(iEvent, tagI->first, flavours, jetWithFlavour, corrector, genJetsMatched))
         continue;
       if (!jetSelector(jetWithFlavour.first, std::abs(jetWithFlavour.second.getPartonFlavour()), infoHandle, jec))
@@ -440,13 +442,14 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
          continue;
       
       //JEC
-      reco::Jet correctedJet = *(jetRef);
       double jec = 1.0;
+      /*reco::Jet correctedJet = *(jetRef);
       if(doJEC && corrector) {
         jec = corrector->correction(*(jetRef));
-      }
+      }*/
 
       JetWithFlavour jetWithFlavour;
+      // also applies JEC to jet
       if (!getJetWithFlavour(iEvent, jetRef, flavours, jetWithFlavour, corrector, genJetsMatched))
         continue;
       if (!jetSelector(jetWithFlavour.first, std::abs(jetWithFlavour.second.getPartonFlavour()), infoHandle, jec))
@@ -503,6 +506,7 @@ bool  BTagPerformanceAnalyzerMC::getJetWithFlavour(const edm::Event& iEvent,
       return false;
   }
 
+  // apply JEC
   jetWithFlavour.first = jetCorrector(*jetRef);
 
   auto itFound = flavours.find(jetRef);


### PR DESCRIPTION
- Small bugfix: for some reason the JEC was applied twice. The only effect of the JEC on the BTV validation is through the Pt cut applied when filling the histograms.

- Update the Loose working point for taggers where we monitor the efficiency vs. eta and phi

- For deepCSV we now validate the B, CvsL and CvsB discriminators instead of the individual probabilities