### PR TITLE
Extend EventSetup produce method return types

### DIFF
--- a/FWCore/Framework/interface/produce_helpers.h
+++ b/FWCore/Framework/interface/produce_helpers.h
@@ -75,6 +75,16 @@ namespace edm::eventsetup {
       static auto getPointer(T& iPtr)-> decltype(&*iPtr) { return &*iPtr;}
     };
 
+    template<typename T> struct smart_pointer_traits<std::unique_ptr<const T>> {
+      using type = T;
+      static auto getPointer(std::unique_ptr<const T>& iPtr)-> decltype(&*iPtr) { return &*iPtr;}
+    };
+
+    template<typename T> struct smart_pointer_traits<std::shared_ptr<const T>> {
+      using type = T;
+      static auto getPointer(std::shared_ptr<const T>& iPtr)-> decltype(&*iPtr) { return &*iPtr;}
+    };
+
     template<typename T> struct smart_pointer_traits<std::optional<T>> {
       using type = T;
       static T* getPointer(std::optional<T>& iPtr) {

--- a/FWCore/Integration/test/WhatsItAnalyzer.cc
+++ b/FWCore/Integration/test/WhatsItAnalyzer.cc
@@ -49,6 +49,12 @@ class WhatsItAnalyzer : public edm::EDAnalyzer {
 
       virtual void analyze(const edm::Event&, const edm::EventSetup&);
    private:
+
+      void getAndTest(GadgetRcd const& record,
+                      edm::ESHandle<WhatsIt>& handle,
+                      int expectedValue,
+                      const char* label);
+
       // ----------member data ---------------------------
       std::vector<int> expectedValues_;
       unsigned int index_;
@@ -91,19 +97,29 @@ WhatsItAnalyzer::~WhatsItAnalyzer()
 void
 WhatsItAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup)
 {
-   using namespace edm;
-   ESHandle<WhatsIt> pSetup;
-   iSetup.get<GadgetRcd>().get(pSetup);
+   edm::ESHandle<WhatsIt> pSetup;
+   GadgetRcd const& gadgetRcd = iSetup.get<GadgetRcd>();
 
-   std::cout <<"WhatsIt "<<pSetup->a<<std::endl;
-   if(!expectedValues_.empty()) {
-      if(expectedValues_.at(index_) != pSetup->a) {
-         throw cms::Exception("TestFail")<<"expected value "<<expectedValues_[index_]
-         <<" but was got "<<pSetup->a;
-      }
+   if (index_ < expectedValues_.size()) {
+      int expectedValue = expectedValues_.at(index_);
+      getAndTest(gadgetRcd, pSetup, expectedValue, "");
+      getAndTest(gadgetRcd, pSetup, expectedValue, "A");
+      getAndTest(gadgetRcd, pSetup, expectedValue, "B");
+      getAndTest(gadgetRcd, pSetup, expectedValue, "C");
+      getAndTest(gadgetRcd, pSetup, expectedValue, "D");
       ++index_;
    }
-   
+}
+
+void WhatsItAnalyzer::getAndTest(GadgetRcd const& record,
+                                 edm::ESHandle<WhatsIt>& handle,
+                                 int expectedValue,
+                                 const char* label) {
+   record.get(label, handle);
+   if (expectedValue != handle->a) {
+      throw cms::Exception("TestFail") << label << ": expected value " << expectedValue
+         << " but got "<< handle->a;
+   }
 }
 }
 using namespace edmtest;

--- a/FWCore/Integration/test/WhatsItESProducer.cc
+++ b/FWCore/Integration/test/WhatsItESProducer.cc
@@ -19,6 +19,7 @@
 
 // system include files
 #include <memory>
+#include <optional>
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
@@ -45,14 +46,26 @@ class WhatsItESProducer : public edm::ESProducer {
       ~WhatsItESProducer();
 
       typedef std::unique_ptr<WhatsIt> ReturnType;
+      typedef std::unique_ptr<const WhatsIt> ReturnTypeA;
+      typedef std::shared_ptr<WhatsIt> ReturnTypeB;
+      typedef std::shared_ptr<const WhatsIt> ReturnTypeC;
+      typedef std::optional<WhatsIt> ReturnTypeD;
 
       ReturnType produce(const GadgetRcd &);
+      ReturnTypeA produceA(const GadgetRcd &);
+      ReturnTypeB produceB(const GadgetRcd &);
+      ReturnTypeC produceC(const GadgetRcd &);
+      ReturnTypeD produceD(const GadgetRcd &);
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
       // ----------member data ---------------------------
       edm::ESGetTokenT<edmtest::Doodad> token_;
+      edm::ESGetTokenT<edmtest::Doodad> tokenA_;
+      edm::ESGetTokenT<edmtest::Doodad> tokenB_;
+      edm::ESGetTokenT<edmtest::Doodad> tokenC_;
+      edm::ESGetTokenT<edmtest::Doodad> tokenD_;
 };
 
 //
@@ -71,17 +84,24 @@ WhatsItESProducer::WhatsItESProducer(edm::ParameterSet const& pset)
   if (pset.getUntrackedParameter<bool>("test", true)) {
      throw edm::Exception(edm::errors::Configuration, "Something is wrong with ESProducer validation\n")
        << "Or the test configuration parameter was set true (it should never be true unless you want this exception)\n";
-   }
+  }
 
   //the following line is needed to tell the framework what
   // data is being produced
   auto collector = setWhatProduced(this);
+  auto collectorA = setWhatProduced(this, &WhatsItESProducer::produceA, edm::es::Label("A"));
+  auto collectorB = setWhatProduced(this, &WhatsItESProducer::produceB, edm::es::Label("B"));
+  auto collectorC = setWhatProduced(this, &WhatsItESProducer::produceC, edm::es::Label("C"));
+  auto collectorD = setWhatProduced(this, &WhatsItESProducer::produceD, edm::es::Label("D"));
 
   //now do what ever other initialization is needed
   auto const data_label = pset.exists("doodadLabel") ? pset.getParameter<std::string>("doodadLabel"): std::string{};
   token_ = collector.consumes<edmtest::Doodad>(edm::ESInputTag{"", data_label});
+  tokenA_ = collectorA.consumes<edmtest::Doodad>(edm::ESInputTag{"", data_label});
+  tokenB_ = collectorB.consumes<edmtest::Doodad>(edm::ESInputTag{"", data_label});
+  tokenC_ = collectorC.consumes<edmtest::Doodad>(edm::ESInputTag{"", data_label});
+  tokenD_ = collectorD.consumes<edmtest::Doodad>(edm::ESInputTag{"", data_label});
 }
-
 
 WhatsItESProducer::~WhatsItESProducer()
 {
@@ -98,15 +118,50 @@ WhatsItESProducer::~WhatsItESProducer()
 WhatsItESProducer::ReturnType
 WhatsItESProducer::produce(const GadgetRcd& iRecord)
 {
-   using namespace edmtest;
-
    edm::ESHandle<Doodad> doodad;
-   iRecord.get(token_ ,doodad);
-
+   iRecord.get(token_, doodad);
    auto pWhatsIt = std::make_unique<WhatsIt>() ;
-
    pWhatsIt->a = doodad->a;
+   return pWhatsIt ;
+}
 
+WhatsItESProducer::ReturnTypeA
+WhatsItESProducer::produceA(const GadgetRcd& iRecord)
+{
+   edm::ESHandle<Doodad> doodad;
+   iRecord.get(tokenA_, doodad);
+   auto pWhatsIt = std::make_unique<WhatsIt>() ;
+   pWhatsIt->a = doodad->a;
+   return pWhatsIt ;
+}
+
+WhatsItESProducer::ReturnTypeB
+WhatsItESProducer::produceB(const GadgetRcd& iRecord)
+{
+   edm::ESHandle<Doodad> doodad;
+   iRecord.get(tokenB_ ,doodad);
+   auto pWhatsIt = std::make_shared<WhatsIt>() ;
+   pWhatsIt->a = doodad->a;
+   return pWhatsIt ;
+}
+
+WhatsItESProducer::ReturnTypeC
+WhatsItESProducer::produceC(const GadgetRcd& iRecord)
+{
+   edm::ESHandle<Doodad> doodad;
+   iRecord.get(tokenC_, doodad);
+   auto pWhatsIt = std::make_shared<WhatsIt>() ;
+   pWhatsIt->a = doodad->a;
+   return pWhatsIt ;
+}
+
+WhatsItESProducer::ReturnTypeD
+WhatsItESProducer::produceD(const GadgetRcd& iRecord)
+{
+   edm::ESHandle<Doodad> doodad;
+   iRecord.get(tokenD_, doodad);
+   auto pWhatsIt = std::make_optional<WhatsIt>() ;
+   pWhatsIt->a = doodad->a;
    return pWhatsIt ;
 }
 


### PR DESCRIPTION
Allow the produce functions of EventSetup ESProducers to
return unique_ptr &lt; const T &gt; and shared_ptr &lt; const T &gt;
without having to register const T in addition to registering T.
