### PR TITLE
[10_3_X] SiStrip unpacker: update packet code check in cmMedian (for nonstandard ZS modes)

### DIFF
--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -1506,7 +1506,10 @@ namespace sistrip {
 
   uint16_t FEDChannel::cmMedian(const uint8_t apvIndex) const
   {
-    if (packetCode() != PACKET_CODE_ZERO_SUPPRESSED) {
+    const auto pCode = packetCode();
+    if ( ( pCode != PACKET_CODE_ZERO_SUPPRESSED ) && ( pCode != PACKET_CODE_ZERO_SUPPRESSED10 )
+      && ( pCode != PACKET_CODE_ZERO_SUPPRESSED8_BOTBOT ) && ( pCode != PACKET_CODE_ZERO_SUPPRESSED8_TOPBOT ) )
+    {
       std::ostringstream ss;
       ss << "Request for CM median from channel with non-ZS packet code. "
          << "Packet code is " << uint16_t(packetCode()) << "."


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/24812
As mentioned in the original PR, this fixes a bug that only affects specific studies where the patch can be applied on top of the release - but since these are most notably @CesarBernardes ' hybrid mode studies, and 10_3_X will be used for HI data taking (and therefore possibly also for future HI studies), it may be good to have it included anyway.

CC: @CesarBernardes @icali 