### PR TITLE
Prepare for concurrent IOVs

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -80,7 +80,7 @@ public:
   TotemDAQMappingESSourceXML(const edm::ParameterSet &);
   ~TotemDAQMappingESSourceXML() override;
 
-  edm::ESProducts< std::shared_ptr<TotemDAQMapping>, std::shared_ptr<TotemAnalysisMask> > produce( const TotemReadoutRcd & );
+  edm::ESProducts< std::unique_ptr<TotemDAQMapping>, std::unique_ptr<TotemAnalysisMask> > produce( const TotemReadoutRcd & );
 
 private:
   unsigned int verbosity;
@@ -119,19 +119,19 @@ private:
   enum ParseType { pMapping, pMask };
 
   /// parses XML file
-  void ParseXML(ParseType, const string &file, const std::shared_ptr<TotemDAQMapping>&, const std::shared_ptr<TotemAnalysisMask>&);
+  void ParseXML(ParseType, const string &file, const std::unique_ptr<TotemDAQMapping>&, const std::unique_ptr<TotemAnalysisMask>&);
 
   /// recursive method to extract RP-related information from the DOM tree
   void ParseTreeRP(ParseType, xercesc::DOMNode *, NodeType, unsigned int parentID,
-    const std::shared_ptr<TotemDAQMapping>&, const std::shared_ptr<TotemAnalysisMask>&);
+    const std::unique_ptr<TotemDAQMapping>&, const std::unique_ptr<TotemAnalysisMask>&);
 
   /// recursive method to extract RP-related information from the DOM tree
   void ParseTreeDiamond(ParseType, xercesc::DOMNode *, NodeType, unsigned int parentID,
-    const std::shared_ptr<TotemDAQMapping>&, const std::shared_ptr<TotemAnalysisMask>&);
+    const std::unique_ptr<TotemDAQMapping>&, const std::unique_ptr<TotemAnalysisMask>&);
 
   /// recursive method to extract RP-related information from the DOM tree
   void ParseTreeTotemTiming(ParseType, xercesc::DOMNode *, NodeType, unsigned int parentID,
-    const std::shared_ptr<TotemDAQMapping>&, const std::shared_ptr<TotemAnalysisMask>&);
+    const std::unique_ptr<TotemDAQMapping>&, const std::unique_ptr<TotemAnalysisMask>&);
 
 private:
   /// adds the path prefix, if needed
@@ -305,13 +305,13 @@ string TotemDAQMappingESSourceXML::CompleteFileName(const string &fn)
 
 //----------------------------------------------------------------------------------------------------
 
-edm::ESProducts< std::shared_ptr<TotemDAQMapping>, std::shared_ptr<TotemAnalysisMask> >
+edm::ESProducts< std::unique_ptr<TotemDAQMapping>, std::unique_ptr<TotemAnalysisMask> >
   TotemDAQMappingESSourceXML::produce( const TotemReadoutRcd & )
 {
   assert(currentBlockValid);
 
-  auto mapping = std::make_shared<TotemDAQMapping>();
-  auto mask = std::make_shared<TotemAnalysisMask>();
+  auto mapping = std::make_unique<TotemDAQMapping>();
+  auto mask = std::make_unique<TotemAnalysisMask>();
 
   // initialize Xerces
   try
@@ -335,13 +335,13 @@ edm::ESProducts< std::shared_ptr<TotemDAQMapping>, std::shared_ptr<TotemAnalysis
   XMLPlatformUtils::Terminate();
 
   // commit the products
-  return edm::es::products(mapping, mask);
+  return edm::es::products(std::move(mapping), std::move(mask));
 }
 
 //----------------------------------------------------------------------------------------------------
 
 void TotemDAQMappingESSourceXML::ParseXML(ParseType pType, const string &file,
-  const std::shared_ptr<TotemDAQMapping> &mapping, const std::shared_ptr<TotemAnalysisMask> &mask)
+  const std::unique_ptr<TotemDAQMapping> &mapping, const std::unique_ptr<TotemAnalysisMask> &mask)
 {
   unique_ptr<XercesDOMParser> parser(new XercesDOMParser());
   parser->parse(file.c_str());
@@ -368,8 +368,8 @@ void TotemDAQMappingESSourceXML::ParseXML(ParseType pType, const string &file,
 //-----------------------------------------------------------------------------------------------------------
 
 void TotemDAQMappingESSourceXML::ParseTreeRP(ParseType pType, xercesc::DOMNode * parent, NodeType parentType,
-  unsigned int parentID, const std::shared_ptr<TotemDAQMapping>& mapping,
-  const std::shared_ptr<TotemAnalysisMask>& mask)
+  unsigned int parentID, const std::unique_ptr<TotemDAQMapping>& mapping,
+  const std::unique_ptr<TotemAnalysisMask>& mask)
 {
 #ifdef DEBUG
   printf(">> TotemDAQMappingESSourceXML::ParseTreeRP(%s, %u, %u)\n", cms::xerces::toString(parent->getNodeName()),
@@ -502,8 +502,8 @@ void TotemDAQMappingESSourceXML::ParseTreeRP(ParseType pType, xercesc::DOMNode *
 //----------------------------------------------------------------------------------------------------
 
 void TotemDAQMappingESSourceXML::ParseTreeDiamond(ParseType pType, xercesc::DOMNode * parent, NodeType parentType,
-  unsigned int parentID, const std::shared_ptr<TotemDAQMapping>& mapping,
-  const std::shared_ptr<TotemAnalysisMask>& mask)
+  unsigned int parentID, const std::unique_ptr<TotemDAQMapping>& mapping,
+  const std::unique_ptr<TotemAnalysisMask>& mask)
 {
 
 #ifdef DEBUG
@@ -628,8 +628,8 @@ void TotemDAQMappingESSourceXML::ParseTreeDiamond(ParseType pType, xercesc::DOMN
 //----------------------------------------------------------------------------------------------------
 
 void TotemDAQMappingESSourceXML::ParseTreeTotemTiming(ParseType pType, xercesc::DOMNode * parent, NodeType parentType,
-  unsigned int parentID, const std::shared_ptr<TotemDAQMapping>& mapping,
-  const std::shared_ptr<TotemAnalysisMask>& mask)
+  unsigned int parentID, const std::unique_ptr<TotemDAQMapping>& mapping,
+  const std::unique_ptr<TotemAnalysisMask>& mask)
 {
   DOMNodeList *children = parent->getChildNodes();
 

--- a/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
@@ -21,11 +21,11 @@ class L1ObjectKeysOnlineProdBaseExt : public edm::ESProducer {
       L1ObjectKeysOnlineProdBaseExt(const edm::ParameterSet&);
       ~L1ObjectKeysOnlineProdBaseExt() override;
 
-      typedef std::shared_ptr<L1TriggerKeyExt> ReturnType;
+      using ReturnType = std::unique_ptr<L1TriggerKeyExt>;
 
       ReturnType produce(const L1TriggerKeyExtRcd&);
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) = 0 ;
+      virtual void fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ) = 0 ;
    private:
       // ----------member data ---------------------------
  protected:

--- a/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.cc
@@ -44,7 +44,7 @@ L1SubsystemKeysOnlineProdExt::ReturnType
 L1SubsystemKeysOnlineProdExt::produce(const L1TriggerKeyExtRcd& iRecord)
 {
    using namespace edm::es;
-   std::shared_ptr<L1TriggerKeyExt> pL1TriggerKey ;
+   std::unique_ptr<L1TriggerKeyExt> pL1TriggerKey ;
 
    // Get L1TriggerKeyListExt
    L1TriggerKeyListExt keyList ;
@@ -64,11 +64,11 @@ if( !m_forceGeneration ){
    std::string m_Key = m_tscKey + delimeter + m_rsKey;
 
    // If L1TriggerKeyListExt does not contain TSC key, token is empty
-   if( keyList.token( m_Key ) == std::string() ||
+   if( keyList.token( m_Key ).empty() ||
        m_forceGeneration )
      {
        // Instantiate new L1TriggerKey
-       pL1TriggerKey = std::make_shared< L1TriggerKeyExt >();
+       pL1TriggerKey = std::make_unique< L1TriggerKeyExt >();
 
        pL1TriggerKey->setTSCKey( m_Key ) ;
 

--- a/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.h
@@ -17,7 +17,7 @@ class L1SubsystemKeysOnlineProdExt : public edm::ESProducer {
       L1SubsystemKeysOnlineProdExt(const edm::ParameterSet&);
       ~L1SubsystemKeysOnlineProdExt() override;
 
-      typedef std::shared_ptr<L1TriggerKeyExt> ReturnType;
+      using ReturnType = std::unique_ptr<L1TriggerKeyExt>;
 
       ReturnType produce(const L1TriggerKeyExtRcd&);
    private:

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.cc
@@ -60,7 +60,7 @@ L1TriggerKeyDummyProdExt::ReturnType
 L1TriggerKeyDummyProdExt::produce(const L1TriggerKeyExtRcd& iRecord)
 {
    using namespace edm::es;
-   return std::make_shared< L1TriggerKeyExt >(m_key) ;
+   return std::make_unique< L1TriggerKeyExt >(m_key) ;
 }
 
 //define this as a plug-in

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.h
@@ -16,7 +16,7 @@ class L1TriggerKeyDummyProdExt : public edm::ESProducer {
       L1TriggerKeyDummyProdExt(const edm::ParameterSet&);
       ~L1TriggerKeyDummyProdExt() override;
 
-      typedef std::shared_ptr<L1TriggerKeyExt> ReturnType;
+      using ReturnType = std::unique_ptr<L1TriggerKeyExt>;
 
       ReturnType produce(const L1TriggerKeyExtRcd&);
    private:

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.cc
@@ -28,7 +28,7 @@ L1TriggerKeyListDummyProdExt::ReturnType
 L1TriggerKeyListDummyProdExt::produce(const L1TriggerKeyListExtRcd& iRecord)
 {
    using namespace edm::es;
-   return std::make_shared< L1TriggerKeyListExt >() ;
+   return std::make_unique< L1TriggerKeyListExt >() ;
 }
 
 //define this as a plug-in

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.h
@@ -16,7 +16,7 @@ class L1TriggerKeyListDummyProdExt : public edm::ESProducer {
       L1TriggerKeyListDummyProdExt(const edm::ParameterSet&);
       ~L1TriggerKeyListDummyProdExt() override;
 
-      typedef std::shared_ptr<L1TriggerKeyListExt> ReturnType;
+      using ReturnType = std::unique_ptr<L1TriggerKeyListExt>;
 
       ReturnType produce(const L1TriggerKeyListExtRcd&);
    private:

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
@@ -48,7 +48,7 @@ L1TriggerKeyOnlineProdExt::produce(const L1TriggerKeyExtRcd& iRecord)
        throw ex ;
      }
 
-   std::shared_ptr<L1TriggerKeyExt> pL1TriggerKey = std::make_shared< L1TriggerKeyExt >(*subsystemKeys) ;
+   auto pL1TriggerKey = std::make_unique< L1TriggerKeyExt >(*subsystemKeys) ;
 
   // Collate object keys
   std::vector< std::string >::const_iterator itr = m_subsystemLabels.begin() ;

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.h
@@ -17,7 +17,7 @@ class L1TriggerKeyOnlineProdExt : public edm::ESProducer {
       L1TriggerKeyOnlineProdExt(const edm::ParameterSet&);
       ~L1TriggerKeyOnlineProdExt() override;
 
-      typedef std::shared_ptr<L1TriggerKeyExt> ReturnType;
+      using ReturnType = std::unique_ptr<L1TriggerKeyExt>;
 
       ReturnType produce(const L1TriggerKeyExtRcd&);
    private:

--- a/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
+++ b/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
@@ -49,10 +49,10 @@ L1ObjectKeysOnlineProdBaseExt::produce(const L1TriggerKeyExtRcd& iRecord)
     }
 
   // Copy L1TriggerKeyExt to new object.
-  std::shared_ptr<L1TriggerKeyExt> pL1TriggerKey = std::make_shared< L1TriggerKeyExt >( *subsystemKeys ) ;
+  auto pL1TriggerKey = std::make_unique< L1TriggerKeyExt >( *subsystemKeys ) ;
 
   // Get object keys.
-  fillObjectKeys( pL1TriggerKey ) ;
+  fillObjectKeys( pL1TriggerKey.get() ) ;
 
   return pL1TriggerKey ;
 }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsObjectKeysOnlineProd.cc
@@ -6,7 +6,7 @@ class L1TCaloParamsObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
 private:
 
 public:
-    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ) override ;
 
     L1TCaloParamsObjectKeysOnlineProd(const edm::ParameterSet&);
     ~L1TCaloParamsObjectKeysOnlineProd(void) override{}
@@ -17,7 +17,7 @@ L1TCaloParamsObjectKeysOnlineProd::L1TCaloParamsObjectKeysOnlineProd(const edm::
 }
 
 
-void L1TCaloParamsObjectKeysOnlineProd::fillObjectKeys( ReturnType pL1TriggerKey ){
+void L1TCaloParamsObjectKeysOnlineProd::fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ){
 
     std::string CALOKey = pL1TriggerKey->subsystemKey( L1TriggerKeyExt::kCALO ) ;
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosObjectKeysOnlineProd.cc
@@ -6,7 +6,7 @@ class L1TGlobalPrescalesVetosObjectKeysOnlineProd : public L1ObjectKeysOnlinePro
 private:
 
 public:
-    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ) override ;
 
     L1TGlobalPrescalesVetosObjectKeysOnlineProd(const edm::ParameterSet&);
     ~L1TGlobalPrescalesVetosObjectKeysOnlineProd(void) override{}
@@ -17,7 +17,7 @@ L1TGlobalPrescalesVetosObjectKeysOnlineProd::L1TGlobalPrescalesVetosObjectKeysOn
 }
 
 
-void L1TGlobalPrescalesVetosObjectKeysOnlineProd::fillObjectKeys( ReturnType pL1TriggerKey ){
+void L1TGlobalPrescalesVetosObjectKeysOnlineProd::fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ){
 
     std::string uGTKey = pL1TriggerKey->subsystemKey( L1TriggerKeyExt::kuGT ) ;
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelObjectKeysOnlineProd.cc
@@ -6,7 +6,7 @@ class L1TMuonBarrelObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
 private:
 
 public:
-    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ) override ;
 
     L1TMuonBarrelObjectKeysOnlineProd(const edm::ParameterSet&);
     ~L1TMuonBarrelObjectKeysOnlineProd(void) override{}
@@ -17,7 +17,7 @@ L1TMuonBarrelObjectKeysOnlineProd::L1TMuonBarrelObjectKeysOnlineProd(const edm::
 }
 
 
-void L1TMuonBarrelObjectKeysOnlineProd::fillObjectKeys( ReturnType pL1TriggerKey ){
+void L1TMuonBarrelObjectKeysOnlineProd::fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ){
 
     std::string BMTFKey = pL1TriggerKey->subsystemKey( L1TriggerKeyExt::kBMTF ) ;
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapObjectKeysOnlineProd.cc
@@ -9,7 +9,7 @@ class L1TMuonEndCapObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
 private:
     bool transactionSafe;
 public:
-    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ) override ;
 
     L1TMuonEndCapObjectKeysOnlineProd(const edm::ParameterSet&);
     ~L1TMuonEndCapObjectKeysOnlineProd(void) override{}
@@ -22,7 +22,7 @@ L1TMuonEndCapObjectKeysOnlineProd::L1TMuonEndCapObjectKeysOnlineProd(const edm::
 }
 
 
-void L1TMuonEndCapObjectKeysOnlineProd::fillObjectKeys( ReturnType pL1TriggerKey ){
+void L1TMuonEndCapObjectKeysOnlineProd::fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ){
 
     std::string EMTFKey = pL1TriggerKey->subsystemKey( L1TriggerKeyExt::kEMTF ) ;
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalObjectKeysOnlineProd.cc
@@ -6,7 +6,7 @@ class L1TMuonGlobalObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
 private:
 
 public:
-    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ) override ;
 
     L1TMuonGlobalObjectKeysOnlineProd(const edm::ParameterSet&);
     ~L1TMuonGlobalObjectKeysOnlineProd(void) override{}
@@ -17,7 +17,7 @@ L1TMuonGlobalObjectKeysOnlineProd::L1TMuonGlobalObjectKeysOnlineProd(const edm::
 }
 
 
-void L1TMuonGlobalObjectKeysOnlineProd::fillObjectKeys( ReturnType pL1TriggerKey ){
+void L1TMuonGlobalObjectKeysOnlineProd::fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ){
 
     std::string uGMTKey = pL1TriggerKey->subsystemKey( L1TriggerKeyExt::kuGMT ) ;
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
@@ -6,7 +6,7 @@ class L1TMuonOverlapObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt 
 private:
     bool transactionSafe;
 public:
-    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ) override ;
 
     L1TMuonOverlapObjectKeysOnlineProd(const edm::ParameterSet&);
     ~L1TMuonOverlapObjectKeysOnlineProd(void) override{}
@@ -18,7 +18,7 @@ L1TMuonOverlapObjectKeysOnlineProd::L1TMuonOverlapObjectKeysOnlineProd(const edm
 }
 
 
-void L1TMuonOverlapObjectKeysOnlineProd::fillObjectKeys( ReturnType pL1TriggerKey ){
+void L1TMuonOverlapObjectKeysOnlineProd::fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ){
 
     std::string OMTFKey = pL1TriggerKey->subsystemKey( L1TriggerKeyExt::kOMTF ) ;
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuObjectKeysOnlineProd.cc
@@ -6,7 +6,7 @@ class L1TUtmTriggerMenuObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseE
 private:
 
 public:
-    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ) override ;
 
     L1TUtmTriggerMenuObjectKeysOnlineProd(const edm::ParameterSet&);
     ~L1TUtmTriggerMenuObjectKeysOnlineProd(void) override{}
@@ -17,7 +17,7 @@ L1TUtmTriggerMenuObjectKeysOnlineProd::L1TUtmTriggerMenuObjectKeysOnlineProd(con
 }
 
 
-void L1TUtmTriggerMenuObjectKeysOnlineProd::fillObjectKeys( ReturnType pL1TriggerKey ){
+void L1TUtmTriggerMenuObjectKeysOnlineProd::fillObjectKeys( L1TriggerKeyExt* pL1TriggerKey ){
 
     std::string uGTKey = pL1TriggerKey->subsystemKey( L1TriggerKeyExt::kuGT ) ;
 


### PR DESCRIPTION
Change return type of produce from shared_ptr to
unique_ptr.  Slightly improves performance also.
Also one fix added by 'scram b code-checks'.
