### PR TITLE
Regional strip unpacker: support for legacy modes and bugfix for virgin raw

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -109,11 +109,13 @@ namespace {
                   StripClusterizerAlgorithm & iclusterizer, 
                   SiStripRawProcessingAlgorithms & irawAlgos, 
                   bool idoAPVEmulatorCheck, 
+                  bool legacy,
                   bool hybridZeroSuppressed):
       rawColl(irawColl),
       clusterizer(iclusterizer),
       rawAlgos(irawAlgos),
       doAPVEmulatorCheck(idoAPVEmulatorCheck),
+      legacy_(legacy),
       hybridZeroSuppressed_(hybridZeroSuppressed){
         incTot(clusterizer.allDetIds().size());
         for (auto & d : done) d=nullptr;
@@ -140,6 +142,7 @@ namespace {
     // March 2012: add flag for disabling APVe check in configuration
     bool doAPVEmulatorCheck; 
 
+    bool legacy_;
     bool hybridZeroSuppressed_;
     
     
@@ -203,6 +206,7 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
     clusterizer_(StripClusterizerAlgorithmFactory::create(conf.getParameter<edm::ParameterSet>("Clusterizer"))),
     rawAlgos_(SiStripRawProcessingFactory::create(conf.getParameter<edm::ParameterSet>("Algorithms"))),
     doAPVEmulatorCheck_(conf.existsAs<bool>("DoAPVEmulatorCheck") ? conf.getParameter<bool>("DoAPVEmulatorCheck") : true),
+    legacy_(conf.existsAs<bool>("LegacyUnpacker") ? conf.getParameter<bool>("LegacyUnpacker") : false),
     hybridZeroSuppressed_(conf.getParameter<bool>("HybridZeroSuppressed"))
       {
 	productToken_ = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("ProductLabel"));
@@ -231,7 +235,7 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
         new edmNew::DetSetVector<SiStripCluster>(
           std::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(
               std::make_shared<ClusterFiller>(*rawData, *clusterizer_, *rawAlgos_,
-                                              doAPVEmulatorCheck_, hybridZeroSuppressed_)),
+                                              doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_)),
           clusterizer_->allDetIds())
       : new edmNew::DetSetVector<SiStripCluster>()
       );
@@ -275,6 +279,7 @@ private:
   // March 2012: add flag for disabling APVe check in configuration
   bool doAPVEmulatorCheck_; 
 
+  bool legacy_;
   bool hybridZeroSuppressed_;
 };
 
@@ -295,7 +300,7 @@ void SiStripClusterizerFromRaw::initialize(const edm::EventSetup& es) {
 void SiStripClusterizerFromRaw::run(const FEDRawDataCollection& rawColl,
 				     edmNew::DetSetVector<SiStripCluster> & output) {
   
-  ClusterFiller filler(rawColl, *clusterizer_, *rawAlgos_, doAPVEmulatorCheck_, hybridZeroSuppressed_);
+  ClusterFiller filler(rawColl, *clusterizer_, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_);
   
   // loop over good det in cabling
   for ( auto idet : clusterizer_->allDetIds()) {
@@ -429,6 +434,8 @@ try { // edmNew::CapacityExaustedException
     }
     assert(buffer);
 
+    buffer->setLegacyMode(legacy_);
+
     // check channel
     const uint8_t fedCh = conn->fedCh();
     
@@ -446,8 +453,9 @@ try { // edmNew::CapacityExaustedException
     
     
     const sistrip::FEDReadoutMode mode = buffer->readoutMode();
+    const sistrip::FEDLegacyReadoutMode lmode = legacy_ ? buffer->legacyReadoutMode() : sistrip::READOUT_MODE_LEGACY_INVALID;
 
-    if LIKELY( ( mode > sistrip::READOUT_MODE_VIRGIN_RAW ) && ( mode < sistrip::READOUT_MODE_SPY ) && ( mode != sistrip::READOUT_MODE_PROC_RAW ) ) {
+    if LIKELY( (!legacy_) && ( mode > sistrip::READOUT_MODE_VIRGIN_RAW ) && ( mode < sistrip::READOUT_MODE_SPY ) && ( mode != sistrip::READOUT_MODE_PROC_RAW ) ) {
       // ZS modes
       try {
         auto perStripAdder = StripByStripAdder(clusterizer, state, record);
@@ -471,8 +479,16 @@ try { // edmNew::CapacityExaustedException
         }
         continue;
       }
-
-    } else if ( mode == sistrip::READOUT_MODE_VIRGIN_RAW ) {
+    } else if ( legacy_ && ( lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL || lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE ) ) {
+      auto unpacker = sistrip::FEDZSChannelUnpacker::zeroSuppressedModeUnpacker(buffer->channel(fedCh));
+      clusterizer.addFed(state, unpacker, ipair, record);
+    } else if ( legacy_ && ( lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_REAL || lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_FAKE ) ) {
+      auto unpacker = sistrip::FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(buffer->channel(fedCh));
+      while (unpacker.hasData()) {
+        clusterizer.stripByStripAdd(state, ipair*256+unpacker.sampleNumber(), unpacker.adc(), record);
+        unpacker++;
+      }
+    } else if ( !legacy_ ? ( mode == sistrip::READOUT_MODE_VIRGIN_RAW ) : ( lmode == sistrip::READOUT_MODE_LEGACY_VIRGIN_RAW_REAL || lmode == sistrip::READOUT_MODE_LEGACY_VIRGIN_RAW_FAKE ) ) {
 
       std::vector<int16_t> samples;
       switch ( buffer->channel(fedCh).packetCode() ) {
@@ -514,7 +530,7 @@ try { // edmNew::CapacityExaustedException
         clusterizer.stripByStripAdd(state, digi.strip(), digi.adc(), record);
       }
 
-    } else if ( mode == sistrip::READOUT_MODE_PROC_RAW ) {
+    } else if ( !legacy_ ? ( mode == sistrip::READOUT_MODE_PROC_RAW ) : ( lmode == sistrip::READOUT_MODE_LEGACY_PROC_RAW_REAL || lmode == sistrip::READOUT_MODE_LEGACY_PROC_RAW_FAKE ) ) {
 
       // create unpacker
       sistrip::FEDRawChannelUnpacker unpacker = sistrip::FEDRawChannelUnpacker::procRawModeUnpacker(buffer->channel(fedCh));

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -184,14 +184,6 @@ namespace {
 #endif
     
   };
-
-  uint16_t physicalToReadoutOrder( uint16_t physical_order )
-  {
-    auto phys_float = static_cast<float>(physical_order);
-    return ( 4*(static_cast<uint16_t>(phys_float/ 8.0)%4)
-           +    static_cast<uint16_t>(phys_float/32.0)
-           + 16*(physical_order%8) );
-  }
 } // namespace
 
 
@@ -515,7 +507,8 @@ try { // edmNew::CapacityExaustedException
       // un-multiplex the digis (from readout to physical order)
       std::vector<int16_t> digis;
       for ( uint16_t i = 0; i != samples.size(); ++i ) {
-        const auto readout = physicalToReadoutOrder(i%128)*2 + ( (i/128) ? 1 : 0);
+        // move bits around:   2-0->7-5   ,   4-3->4-3   ,      6-5->2-1     ,      7->0
+        const auto readout = ((i&0x7)<<5) + (i&(0x3<<3)) + ((i&(0x3<<5))>>4) + ((i&(0x1<<7))>>7);
         digis.push_back(samples[readout]);
       }
       //process raw


### PR DESCRIPTION
These are two fixes, adapted from https://github.com/CMS-HIN-dilepton/cmssw/commit/2742728c4ae203936ebbd31d50934d9b1938d0cb?w=1 (prepared some time ago but never submitted), to make the regional unpacker (used in some HLT paths) work also with legacy readout modes, and with virgin raw data (the corresponding code in the full unpacker is in https://github.com/cms-sw/cmssw/blob/master/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc#L436-L440 ). This scenario is not considered by any relval, as far as I know, so the HI group should confirm that this works as expected.
As I understood, there is no plan to use virgin raw for the upcoming HI run, but we are submitting this bugfix to have it in place just in case.

CC: @icali (I cannot find Andre on github, could you ping him?) @alesaggio 