### PR TITLE
Prepare for concurrent IOVs in FWCore

### DIFF
--- a/FWCore/Integration/test/ESTestProducers.cc
+++ b/FWCore/Integration/test/ESTestProducers.cc
@@ -14,18 +14,18 @@ namespace edmtest {
   class ESTestProducerA : public edm::ESProducer {
   public:
     ESTestProducerA(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataA> produce(ESTestRecordA const&);
+    std::unique_ptr<ESTestDataA> produce(ESTestRecordA const&);
   private:
-    std::shared_ptr<ESTestDataA> data_;
+    int value_;
   };
 
-  ESTestProducerA::ESTestProducerA(edm::ParameterSet const&) : data_(new ESTestDataA(0)) {
+  ESTestProducerA::ESTestProducerA(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataA> ESTestProducerA::produce(ESTestRecordA const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataA> ESTestProducerA::produce(ESTestRecordA const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataA>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -33,18 +33,18 @@ namespace edmtest {
   class ESTestProducerB : public edm::ESProducer {
   public:
     ESTestProducerB(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataB> produce(ESTestRecordB const&);
+    std::unique_ptr<ESTestDataB> produce(ESTestRecordB const&);
   private:
-    std::shared_ptr<ESTestDataB> data_;
+    int value_;
   };
 
-  ESTestProducerB::ESTestProducerB(edm::ParameterSet const&) : data_(new ESTestDataB(0)) {
+  ESTestProducerB::ESTestProducerB(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataB> ESTestProducerB::produce(ESTestRecordB const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataB> ESTestProducerB::produce(ESTestRecordB const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataB>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -53,6 +53,7 @@ namespace edmtest {
   class ESTestProducerBUsingHost : public edm::ESProducer {
   public:
     ESTestProducerBUsingHost(edm::ParameterSet const&);
+    // Must use shared_ptr if using ReusableObjectHolder
     std::shared_ptr<ESTestDataB> produce(ESTestRecordB const&);
   private:
 
@@ -103,18 +104,18 @@ namespace edmtest {
   class ESTestProducerC : public edm::ESProducer {
   public:
     ESTestProducerC(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataC> produce(ESTestRecordC const&);
+    std::unique_ptr<ESTestDataC> produce(ESTestRecordC const&);
   private:
-    std::shared_ptr<ESTestDataC> data_;
+    int value_;
   };
 
-  ESTestProducerC::ESTestProducerC(edm::ParameterSet const&) : data_(new ESTestDataC(0)) {
+  ESTestProducerC::ESTestProducerC(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataC> ESTestProducerC::produce(ESTestRecordC const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataC> ESTestProducerC::produce(ESTestRecordC const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataC>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -122,18 +123,18 @@ namespace edmtest {
   class ESTestProducerD : public edm::ESProducer {
   public:
     ESTestProducerD(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataD> produce(ESTestRecordD const&);
+    std::unique_ptr<ESTestDataD> produce(ESTestRecordD const&);
   private:
-    std::shared_ptr<ESTestDataD> data_;
+    int value_;
   };
 
-  ESTestProducerD::ESTestProducerD(edm::ParameterSet const&) : data_(new ESTestDataD(0)) {
+  ESTestProducerD::ESTestProducerD(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataD> ESTestProducerD::produce(ESTestRecordD const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataD> ESTestProducerD::produce(ESTestRecordD const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataD>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -141,18 +142,18 @@ namespace edmtest {
   class ESTestProducerE : public edm::ESProducer {
   public:
     ESTestProducerE(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataE> produce(ESTestRecordE const&);
+    std::unique_ptr<ESTestDataE> produce(ESTestRecordE const&);
   private:
-    std::shared_ptr<ESTestDataE> data_;
+    int value_;
   };
 
-  ESTestProducerE::ESTestProducerE(edm::ParameterSet const&) : data_(new ESTestDataE(0)) {
+  ESTestProducerE::ESTestProducerE(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataE> ESTestProducerE::produce(ESTestRecordE const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataE> ESTestProducerE::produce(ESTestRecordE const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataE>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -160,18 +161,18 @@ namespace edmtest {
   class ESTestProducerF : public edm::ESProducer {
   public:
     ESTestProducerF(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataF> produce(ESTestRecordF const&);
+    std::unique_ptr<ESTestDataF> produce(ESTestRecordF const&);
   private:
-    std::shared_ptr<ESTestDataF> data_;
+    int value_;
   };
 
-  ESTestProducerF::ESTestProducerF(edm::ParameterSet const&) : data_(new ESTestDataF(0)) {
+  ESTestProducerF::ESTestProducerF(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataF> ESTestProducerF::produce(ESTestRecordF const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataF> ESTestProducerF::produce(ESTestRecordF const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataF>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -179,18 +180,18 @@ namespace edmtest {
   class ESTestProducerG : public edm::ESProducer {
   public:
     ESTestProducerG(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataG> produce(ESTestRecordG const&);
+    std::unique_ptr<ESTestDataG> produce(ESTestRecordG const&);
   private:
-    std::shared_ptr<ESTestDataG> data_;
+    int value_;
   };
 
-  ESTestProducerG::ESTestProducerG(edm::ParameterSet const&) : data_(new ESTestDataG(0)) {
+  ESTestProducerG::ESTestProducerG(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataG> ESTestProducerG::produce(ESTestRecordG const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataG> ESTestProducerG::produce(ESTestRecordG const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataG>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -198,18 +199,18 @@ namespace edmtest {
   class ESTestProducerH : public edm::ESProducer {
   public:
     ESTestProducerH(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataH> produce(ESTestRecordH const&);
+    std::unique_ptr<ESTestDataH> produce(ESTestRecordH const&);
   private:
-    std::shared_ptr<ESTestDataH> data_;
+    int value_;
   };
 
-  ESTestProducerH::ESTestProducerH(edm::ParameterSet const&) : data_(new ESTestDataH(0)) {
+  ESTestProducerH::ESTestProducerH(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataH> ESTestProducerH::produce(ESTestRecordH const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataH> ESTestProducerH::produce(ESTestRecordH const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataH>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -217,18 +218,18 @@ namespace edmtest {
   class ESTestProducerI : public edm::ESProducer {
   public:
     ESTestProducerI(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataI> produce(ESTestRecordI const&);
+    std::unique_ptr<ESTestDataI> produce(ESTestRecordI const&);
   private:
-    std::shared_ptr<ESTestDataI> data_;
+    int value_;
   };
 
-  ESTestProducerI::ESTestProducerI(edm::ParameterSet const&) : data_(new ESTestDataI(0)) {
+  ESTestProducerI::ESTestProducerI(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataI> ESTestProducerI::produce(ESTestRecordI const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataI> ESTestProducerI::produce(ESTestRecordI const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataI>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -236,18 +237,18 @@ namespace edmtest {
   class ESTestProducerJ : public edm::ESProducer {
   public:
     ESTestProducerJ(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataJ> produce(ESTestRecordJ const&);
+    std::unique_ptr<ESTestDataJ> produce(ESTestRecordJ const&);
   private:
-    std::shared_ptr<ESTestDataJ> data_;
+    int value_;
   };
 
-  ESTestProducerJ::ESTestProducerJ(edm::ParameterSet const&) : data_(new ESTestDataJ(0)) {
+  ESTestProducerJ::ESTestProducerJ(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataJ> ESTestProducerJ::produce(ESTestRecordJ const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataJ> ESTestProducerJ::produce(ESTestRecordJ const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataJ>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -255,18 +256,18 @@ namespace edmtest {
   class ESTestProducerK : public edm::ESProducer {
   public:
     ESTestProducerK(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataK> produce(ESTestRecordK const&);
+    std::unique_ptr<ESTestDataK> produce(ESTestRecordK const&);
   private:
-    std::shared_ptr<ESTestDataK> data_;
+    int value_;
   };
 
-  ESTestProducerK::ESTestProducerK(edm::ParameterSet const&) : data_(new ESTestDataK(0)) {
+  ESTestProducerK::ESTestProducerK(edm::ParameterSet const&) : value_(0) {
     setWhatProduced(this);
   }
 
-  std::shared_ptr<ESTestDataK> ESTestProducerK::produce(ESTestRecordK const& rec) {
-    ++data_->value();
-    return data_;
+  std::unique_ptr<ESTestDataK> ESTestProducerK::produce(ESTestRecordK const& rec) {
+    ++value_;
+    return std::make_unique<ESTestDataK>(value_);
   }
 
   // ---------------------------------------------------------------------
@@ -274,28 +275,28 @@ namespace edmtest {
   class ESTestProducerAZ : public edm::ESProducer {
   public:
     ESTestProducerAZ(edm::ParameterSet const&);
-    std::shared_ptr<ESTestDataA> produceA(ESTestRecordA const&);
-    std::shared_ptr<ESTestDataZ> produceZ(ESTestRecordZ const&);
+    std::unique_ptr<ESTestDataA> produceA(ESTestRecordA const&);
+    std::unique_ptr<ESTestDataZ> produceZ(ESTestRecordZ const&);
   private:
-    std::shared_ptr<ESTestDataA> dataA_;
-    std::shared_ptr<ESTestDataZ> dataZ_;
+    int valueA_;
+    int valueZ_;
   };
 
   ESTestProducerAZ::ESTestProducerAZ(edm::ParameterSet const&) :
-    dataA_(new ESTestDataA(0)),
-    dataZ_(new ESTestDataZ(0)) {
+    valueA_(0),
+    valueZ_(0) {
     setWhatProduced(this, &edmtest::ESTestProducerAZ::produceA, edm::es::Label("foo"));
     setWhatProduced(this, &edmtest::ESTestProducerAZ::produceZ, edm::es::Label("foo"));
   }
 
-  std::shared_ptr<ESTestDataA> ESTestProducerAZ::produceA(ESTestRecordA const& rec) {
-    ++dataA_->value();
-    return dataA_;
+  std::unique_ptr<ESTestDataA> ESTestProducerAZ::produceA(ESTestRecordA const& rec) {
+    ++valueA_;
+    return std::make_unique<ESTestDataA>(valueA_);
   }
 
-  std::shared_ptr<ESTestDataZ> ESTestProducerAZ::produceZ(ESTestRecordZ const& rec) {
-    ++dataZ_->value();
-    return dataZ_;
+  std::unique_ptr<ESTestDataZ> ESTestProducerAZ::produceZ(ESTestRecordZ const& rec) {
+    ++valueZ_;
+    return std::make_unique<ESTestDataZ>(valueZ_);
   }
 
 }

--- a/FWCore/Skeletons/scripts/mkTemplates/ESProducer/ESProducer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/ESProducer/ESProducer.cc
@@ -3,7 +3,7 @@
 // Package:    __subsys__/__pkgname__
 // Class:      __class__
 // 
-/**\class __class__ __class__.h __subsys__/__pkgname__/plugins/__class__.cc
+/**\class __class__
 
  Description: [one line class summary]
 
@@ -16,6 +16,9 @@
 //
 //
 
+// PLEASE DELETE COMMENTS THAT THE SKELETON METHOD (mkesprod)
+// GENERATES THAT ARE NOT USEFUL FOR LONG TERM CODE MAINTENANCE
+// AND UNDERSTANDING. (For example, please delete this comment)
 
 // system include files
 #include <memory>
@@ -26,8 +29,13 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "FWCore/Framework/interface/ESProducts.h"
+#python_begin
+    if  len(__datatypes__) > 1:
+        print('#include "FWCore/Framework/interface/ESProducts.h"')
+#python_end
 
+// Need to add #include statements for definitions of
+// the data type and record type here
 
 //
 // class declaration
@@ -42,10 +50,10 @@ class __class__ : public edm::ESProducer {
     if  len(__datatypes__) > 1:
         datatypes = []
         for dtype in __datatypes__:
-            datatypes.append("std::shared_ptr<%s>" % dtype)
-        print "      typedef edm::ESProducts<%s> ReturnType;" % ','.join(datatypes)
+            datatypes.append("std::unique_ptr<%s>" % dtype)
+        print("      using ReturnType = edm::ESProducts<%s>;" % ','.join(datatypes))
     elif len(__datatypes__) == 1:
-        print "      typedef std::shared_ptr<%s> ReturnType;" % __datatypes__[0]
+        print("      using ReturnType = std::unique_ptr<%s>;" % __datatypes__[0])
 #python_end
 
       ReturnType produce(const __record__&);
@@ -77,11 +85,10 @@ __class__::__class__(const edm::ParameterSet& iConfig)
 __class__::~__class__()
 {
  
-   // do anything here that needs to be done at desctruction time
+   // do anything here that needs to be done at destruction time
    // (e.g. close files, deallocate resources etc.)
 
 }
-
 
 //
 // member functions
@@ -91,18 +98,28 @@ __class__::~__class__()
 __class__::ReturnType
 __class__::produce(const __record__& iRecord)
 {
-   using namespace edm::es;
+   // You can add arguments to the make_unique function call
+   // and they will be forwarded to the constructor of the
+   // data object. Also you can call functions that modify
+   // the data object after creating it. Often, before this
+   // you will retrieve data from the EventSetup through the
+   // record.
 #python_begin
-    out1 = []
-    out2 = []
-    for dtype in __datatypes__:
-        out1.append("   std::shared_ptr<%s> p%s;" % (dtype, dtype))
-        out2.append("p%s" % dtype)
-    output  = '\n'.join(out1)
-    output += "\n   return products(%s);" % ','.join(out2)
-    print output
+    if  len(__datatypes__) > 1:
+        out1 = []
+        out2 = []
+        i = 1
+        for dtype in __datatypes__:
+            out1.append("   auto p%s = std::make_unique<%s>();" % (i, dtype))
+            out2.append("std::move(p%s)" % i)
+            i = i + 1
+        output  = '\n'.join(out1)
+        output += "\n   return edm::es::products(%s);" % ','.join(out2)
+        print(output)
+    elif len(__datatypes__) == 1:
+        print("   auto product = std::make_unique<%s>();" % __datatypes__[0])
+        print("   return product;")
 #python_end
-
 }
 
 //define this as a plug-in


### PR DESCRIPTION
In preparation for concurrent IOVs, convert ESProducer
produce methods to return unique_ptr.

This affects modules used in Framework unit tests.
Also modifies the Skeletons script that will generate
a template for a new ESProducer.

Note that Skeletons script had been broken by the
changes to calls to the Python print function which
were preparing for the migration to Python 3. This
fixes that problem also.