### PR TITLE
Removing more binary_functions

### DIFF
--- a/Alignment/SurveyAnalysis/interface/SurveyPxbDicer.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyPxbDicer.h
@@ -67,8 +67,7 @@ private:
 	coord_t transform(const coord_t &x, const value_t &a0, const value_t &a1, const value_t &a2, const value_t &a3);
 
 	//! Function object for searching for a parameter in the VPSet
-	struct findParByName: public std::binary_function< std::string, edm::ParameterSet, bool >
-	{
+	struct findParByName {
 		bool operator () ( const std::string &name, const edm::ParameterSet &parset )
 			const {	return (parset.getParameter<std::string>("name") == name);}
 	};

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
@@ -5,7 +5,6 @@
 #include <string>
 #include <iostream>
 #include <fstream>
-#include <functional>
 
 
 #include "CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h"
@@ -47,8 +46,7 @@
 
 #include<list>
 
-class DetIdLess 
-  : public std::binary_function< const SiStripRecHit2D*,const SiStripRecHit2D*,bool> {
+class DetIdLess {
 public:
   
   DetIdLess() {}

--- a/CommonTools/ParticleFlow/interface/PFCandidateFwdPtrFactory.h
+++ b/CommonTools/ParticleFlow/interface/PFCandidateFwdPtrFactory.h
@@ -14,15 +14,14 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
 namespace reco {
-  class PFCandidateFwdPtrFactory : public std::binary_function<edm::FwdPtr<reco::PFCandidate>, edm::View<reco::PFCandidate>, unsigned int > {
-  public :
+  struct PFCandidateFwdPtrFactory {
     edm::FwdPtr<reco::PFCandidate> operator() (edm::View<reco::PFCandidate> const & view, unsigned int i)  const  { 
       edm::Ptr<reco::PFCandidate> ptr = view.ptrAt(i);
       edm::Ptr<reco::PFCandidate> backPtr = ptr;
       if ( ptr.isNonnull() && ptr.isAvailable() && ptr->numberOfSourceCandidatePtrs() > 0 ) {
-	edm::Ptr<reco::Candidate> basePtr = ptr->sourceCandidatePtr(0);
-	if (basePtr.isNonnull() && basePtr.isAvailable())
-	  backPtr = edm::Ptr<reco::PFCandidate>( basePtr );//this cast works only for available stuff
+        edm::Ptr<reco::Candidate> basePtr = ptr->sourceCandidatePtr(0);
+        if (basePtr.isNonnull() && basePtr.isAvailable())
+          backPtr = edm::Ptr<reco::PFCandidate>( basePtr );//this cast works only for available stuff
       }
       return edm::FwdPtr<reco::PFCandidate>(ptr,backPtr); 
     }

--- a/CommonTools/UtilAlgos/interface/FwdPtrConversionFactory.h
+++ b/CommonTools/UtilAlgos/interface/FwdPtrConversionFactory.h
@@ -13,15 +13,13 @@
 #include "DataFormats/Common/interface/FwdPtr.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 
-#include <functional>
 
 namespace edm {
   /// Factory class template for how to produce products
   /// from a FwdPtr. This particular example is for copy
   /// construction, but the same signature can be used elsewhere. 
   template<class T>
-    class ProductFromFwdPtrFactory : public std::unary_function<edm::FwdPtr<T>, T > {
-  public :
+  struct ProductFromFwdPtrFactory {
     T operator() (edm::FwdPtr<T> const &r)  const  { return T(*r); }
   };
 
@@ -31,8 +29,7 @@ namespace edm {
   /// Factory class template for how to produce FwdPtrs
   /// from a View. 
   template<class T>
-    class FwdPtrFromProductFactory : public std::binary_function<edm::View<T>, unsigned int, edm::FwdPtr<T> > {
-  public :
+  struct FwdPtrFromProductFactory {
     edm::FwdPtr<T> operator() (edm::View<T> const & view, unsigned int i)  const  { return edm::FwdPtr<T>(view.ptrAt(i),view.ptrAt(i)); }
   };
 

--- a/DQM/L1TMonitor/interface/L1TCompare.h
+++ b/DQM/L1TMonitor/interface/L1TCompare.h
@@ -18,7 +18,6 @@
 
 // system include files
 #include <memory>
-#include <functional>
 #include <unistd.h>
 
 
@@ -135,29 +134,24 @@ private:
   };
   typedef std::vector<L1TCompare::RctObject> RctObjectCollection;
 
-  // functor for sorting the above collection based on rank.
+  // function for sorting the above collection based on rank.
   // note it's then reverse-sorted (low to high) so you have to use
   // the rbegin() and rend() and reverse_iterators.
-  class RctObjectComp: public std::binary_function<L1TCompare::RctObject, 
-						   L1TCompare::RctObject, bool>
+  static bool rctObjectComp(const RctObject &a, const RctObject &b)
   {
-  public:
-    bool operator()(const RctObject &a, const RctObject &b) const
-    {
-      // for equal rank I don't know what the appropriate sorting is.
-      if ( a.rank_ == b.rank_ ) {
-	if ( a.eta_ == b.eta_ ) {
-	  return a.phi_ < b.phi_;
-	}
-	else {
-	  return a.eta_ < b.eta_;
-	}
+    // for equal rank I don't know what the appropriate sorting is.
+    if ( a.rank_ == b.rank_ ) {
+      if ( a.eta_ == b.eta_ ) {
+        return a.phi_ < b.phi_;
       }
       else {
-	return a.rank_ < b.rank_;
+        return a.eta_ < b.eta_;
       }
     }
-  };
+    else {
+      return a.rank_ < b.rank_;
+    }
+  }
 
 
 };

--- a/DQM/L1TMonitor/src/L1TCompare.cc
+++ b/DQM/L1TMonitor/src/L1TCompare.cc
@@ -310,9 +310,9 @@ void L1TCompare::analyze(const Event & e, const EventSetup & c)
     rcj.push_back(h);
   }
   // not so smart but ...
-  std::sort(rcj.begin(), rcj.end(), RctObjectComp());
-  std::sort(rcj_non_iso.begin(), rcj_non_iso.end(), RctObjectComp());
-  std::sort(rcj_iso.begin(), rcj_iso.end(), RctObjectComp());
+  std::sort(rcj.begin(), rcj.end(), rctObjectComp);
+  std::sort(rcj_non_iso.begin(), rcj_non_iso.end(), rctObjectComp);
+  std::sort(rcj_iso.begin(), rcj_iso.end(), rctObjectComp);
   if ( verbose() ) {
     for (RctObjectCollection::reverse_iterator ij = rcj_iso.rbegin();
 	 ij != rcj_iso.rend() && ij != rcj_iso.rbegin()+8; ++ij) {
@@ -379,7 +379,7 @@ void L1TCompare::analyze(const Event & e, const EventSetup & c)
 				 ieTP->id().iphi(), 
 				 ieTP->compressedEt()));
   }
-  std::sort(ecalobs.begin(), ecalobs.end(), RctObjectComp());
+  std::sort(ecalobs.begin(), ecalobs.end(), rctObjectComp);
   if ( verbose() ) {
     for (RctObjectCollection::reverse_iterator ij = ecalobs.rbegin();
 	 ij != ecalobs.rend() && ij != ecalobs.rbegin()+8; ++ij) {

--- a/DQMOffline/RecoB/src/Matching.h
+++ b/DQMOffline/RecoB/src/Matching.h
@@ -1,7 +1,6 @@
 #ifndef RecoBTag_Analysis_Matching_h
 #define RecoBTag_Analysis_Matching_h
 
-#include <functional>
 #include <algorithm>
 #include <vector>
 #include <set>
@@ -49,7 +48,7 @@ class Matching {
 
     private:
 	template<class SortComparator>
-	struct Comparator : public std::binary_function<Delta, Delta, bool> {
+	struct Comparator {
 		typedef typename Matching::index_type index_type;
 
 		inline Comparator(const SimpleMatrix<Delta> &matrix,

--- a/DQMOffline/Trigger/interface/EgHLTEleHLTFilterMon.h
+++ b/DQMOffline/Trigger/interface/EgHLTEleHLTFilterMon.h
@@ -38,20 +38,23 @@ namespace egHLT {
   struct BinData;
   struct CutMasks;
   class EleHLTFilterMon {
-    
+
   public:
-    
-    
+
+
     //comparision functor for EleHLTFilterMon
     //short for: pointer compared with string
-    struct ptrCompStr : public std::binary_function<const EleHLTFilterMon*,const std::string&,bool> {
-      bool operator()(const EleHLTFilterMon* lhs,const std::string& rhs){return lhs->filterName()<rhs;}
-      bool operator()(const std::string& lhs,const EleHLTFilterMon* rhs){return lhs<rhs->filterName();}
-    };
+    static bool ptrCompStr (const EleHLTFilterMon* lhs,const std::string& rhs) {
+        return lhs->filterName()<rhs;
+    }
+    static bool ptrCompStr (const std::string& lhs,const EleHLTFilterMon* rhs) {
+        return lhs<rhs->filterName();
+    }
     //yes I am aware that such a function undoubtably exists but it was quicker to write it than look it up
-    template<class T> struct ptrLess : public std::binary_function<const T*,const T*,bool> {
-      bool operator()(const T* lhs,const T* rhs){return *lhs<*rhs;}
-    };
+    template<class T>
+    static bool ptrLess (const T* lhs,const T* rhs) {
+        return *lhs<*rhs;
+    }
     
   private:
     std::string filterName_;
@@ -89,7 +92,5 @@ namespace egHLT {
     
   };
 }
-
-
 
 #endif

--- a/DQMOffline/Trigger/plugins/EgHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/EgHLTOfflineSource.cc
@@ -176,7 +176,7 @@ void EgHLTOfflineSource::addEleTrigPath(MonElemFuncs& monElemFuncs,const std::st
 {
   auto* filterMon = new EleHLTFilterMon(monElemFuncs,name,trigCodes->getCode(name.c_str()),binData_,cutMasks_,dohep_);  
   eleFilterMonHists_.push_back(filterMon);
-  std::sort(eleFilterMonHists_.begin(),eleFilterMonHists_.end(),EleHLTFilterMon::ptrLess<EleHLTFilterMon>()); //takes a minor efficiency hit at initalisation to ensure that the vector is always sorted
+  std::sort(eleFilterMonHists_.begin(),eleFilterMonHists_.end(),EleHLTFilterMon::ptrLess<EleHLTFilterMon>); //takes a minor efficiency hit at initalisation to ensure that the vector is always sorted
 }
 
 void EgHLTOfflineSource::addPhoTrigPath(MonElemFuncs& monElemFuncs,const std::string& name)

--- a/DQMOffline/Trigger/plugins/EgHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/EgHLTOfflineSource.cc
@@ -176,14 +176,18 @@ void EgHLTOfflineSource::addEleTrigPath(MonElemFuncs& monElemFuncs,const std::st
 {
   auto* filterMon = new EleHLTFilterMon(monElemFuncs,name,trigCodes->getCode(name.c_str()),binData_,cutMasks_,dohep_);  
   eleFilterMonHists_.push_back(filterMon);
-  std::sort(eleFilterMonHists_.begin(),eleFilterMonHists_.end(),EleHLTFilterMon::ptrLess<EleHLTFilterMon>); //takes a minor efficiency hit at initalisation to ensure that the vector is always sorted
+
+  //takes a minor efficiency hit at initalisation to ensure that the vector is always sorted
+  std::sort(eleFilterMonHists_.begin(),eleFilterMonHists_.end(),EleHLTFilterMon::ptrLess<EleHLTFilterMon>);
 }
 
 void EgHLTOfflineSource::addPhoTrigPath(MonElemFuncs& monElemFuncs,const std::string& name)
 {
   PhoHLTFilterMon* filterMon = new PhoHLTFilterMon(monElemFuncs,name,trigCodes->getCode(name.c_str()),binData_,cutMasks_,dohep_);
   phoFilterMonHists_.push_back(filterMon);
-  std::sort(phoFilterMonHists_.begin(),phoFilterMonHists_.end(),PhoHLTFilterMon::ptrLess<PhoHLTFilterMon>()); //takes a minor efficiency hit at initalisation to ensure that the vector is always sorted
+
+  //takes a minor efficiency hit at initalisation to ensure that the vector is always sorted
+  std::sort(phoFilterMonHists_.begin(),phoFilterMonHists_.end(),PhoHLTFilterMon::ptrLess<PhoHLTFilterMon>());
 }
 
 //this function puts every filter name used in a std::vector

--- a/DQMOffline/Trigger/plugins/TopMonitor.h
+++ b/DQMOffline/Trigger/plugins/TopMonitor.h
@@ -66,8 +66,7 @@ protected:
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
 
   // Marina
-  struct JetRefCompare :
-    public std::binary_function<edm::RefToBase<reco::Jet>, edm::RefToBase<reco::Jet>, bool> {
+  struct JetRefCompare {
     inline bool operator () (const edm::RefToBase<reco::Jet> &j1, const edm::RefToBase<reco::Jet> &j2)
       const {return j1.id() < j2.id() || (j1.id() == j2.id() && j1.key() < j2.key());}
   };

--- a/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h
+++ b/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h
@@ -123,7 +123,7 @@ class L1MuGMTExtendedCand : public L1MuGMTCand {
     friend std::ostream& operator<<(std::ostream&, const L1MuGMTExtendedCand&);
 
     /// define a rank for muon candidates
-    static bool rank( const L1MuGMTExtendedCand* first, const L1MuGMTExtendedCand* second ) {
+    static bool compareRank( const L1MuGMTExtendedCand* first, const L1MuGMTExtendedCand* second ) {
       unsigned int rank_f = (first) ? first->rank(): 0;
       unsigned int rank_s = (second) ? second->rank() : 0;
       return rank_f > rank_s;

--- a/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h
+++ b/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h
@@ -27,7 +27,6 @@
 //---------------
 
 #include <iosfwd>
-#include <functional>
 #include <string>
 
 //----------------------
@@ -124,24 +123,18 @@ class L1MuGMTExtendedCand : public L1MuGMTCand {
     friend std::ostream& operator<<(std::ostream&, const L1MuGMTExtendedCand&);
 
     /// define a rank for muon candidates
-    class Rank : std::binary_function< const L1MuGMTExtendedCand*, const L1MuGMTExtendedCand*, bool> {
-      public :
-        bool operator()( const L1MuGMTExtendedCand* first, const L1MuGMTExtendedCand* second ) const {
-          unsigned int rank_f = (first) ? first->rank(): 0;
-          unsigned int rank_s = (second) ? second->rank() : 0;
-	  return rank_f > rank_s;
-        }
-    };
+    static bool rank( const L1MuGMTExtendedCand* first, const L1MuGMTExtendedCand* second ) {
+      unsigned int rank_f = (first) ? first->rank(): 0;
+      unsigned int rank_s = (second) ? second->rank() : 0;
+      return rank_f > rank_s;
+    }
 
     /// define a rank for muon candidates
-    class RankRef : std::binary_function< const L1MuGMTExtendedCand&, const L1MuGMTExtendedCand&, bool> {
-      public :
-        bool operator()( const L1MuGMTExtendedCand& first, const L1MuGMTExtendedCand& second ) const {
-          unsigned int rank_f = first.rank();
-          unsigned int rank_s = second.rank();
-	  return rank_f > rank_s;
-        }
-    };
+    static bool rankRef( const L1MuGMTExtendedCand& first, const L1MuGMTExtendedCand& second ) {
+      unsigned int rank_f = first.rank();
+      unsigned int rank_s = second.rank();
+      return rank_f > rank_s;
+    }
 
   private:
     unsigned int m_rank;

--- a/DataFormats/L1GlobalMuonTrigger/src/L1MuGMTReadoutRecord.cc
+++ b/DataFormats/L1GlobalMuonTrigger/src/L1MuGMTReadoutRecord.cc
@@ -102,7 +102,7 @@ vector<L1MuGMTExtendedCand>  L1MuGMTReadoutRecord::getGMTCands() const {
   }
     
   // sort by rank
-  stable_sort( cands.begin(), cands.end(), L1MuGMTExtendedCand::RankRef() );
+  stable_sort( cands.begin(), cands.end(), L1MuGMTExtendedCand::rankRef );
 
 
   return cands;
@@ -350,23 +350,3 @@ void L1MuGMTReadoutRecord::setQuietbit(int eta, int phi) {
   m_Quietbits[idx_word] |= mask;
 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/DataFormats/L1TMuon/interface/L1MuBMTrack.h
+++ b/DataFormats/L1TMuon/interface/L1MuBMTrack.h
@@ -21,7 +21,6 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
-#include <functional>
 
 //----------------------
 // Base Class Headers --
@@ -192,16 +191,13 @@ class L1MuBMTrack : public l1t::RegionalMuonCand {
     friend std::ostream& operator<<(std::ostream&, const L1MuBMTrack&);
 
     /// define a rank for muon candidates
-    class Rank : std::binary_function< const L1MuBMTrack*, const L1MuBMTrack*, bool> {
-      public :
-        bool operator()( const L1MuBMTrack* first, const L1MuBMTrack* second ) const {
-         unsigned short int rank_f = 0;  // rank of first
-         unsigned short int rank_s = 0;  // rank of second
-         if ( first )  rank_f = first->pt()  + 512 * first->quality();
-         if ( second ) rank_s = second->pt() + 512 * second->quality();
-         return rank_f > rank_s;
-       }
-    };
+    static bool rank( const L1MuBMTrack* first, const L1MuBMTrack* second ) {
+     unsigned short int rank_f = 0;  // rank of first
+     unsigned short int rank_s = 0;  // rank of second
+     if ( first )  rank_f = first->pt()  + 512 * first->quality();
+     if ( second ) rank_s = second->pt() + 512 * second->quality();
+     return rank_f > rank_s;
+   }
 
 
   private:

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTSorter.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTSorter.cc
@@ -26,6 +26,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <functional>
 
 //-------------------------------
 // Collaborating Class Headers --
@@ -91,7 +92,9 @@ void L1MuGMTSorter::run() {
     iter++;
   }
   // sort by rank
-  stable_sort( my_brl_cands.begin(), my_brl_cands.end(), L1MuGMTExtendedCand::Rank() );
+  std::function<bool(const L1MuGMTExtendedCand* first,
+                     const L1MuGMTExtendedCand* second)> rankFunction{L1MuGMTExtendedCand::compareRank};
+  stable_sort( my_brl_cands.begin(), my_brl_cands.end(), rankFunction );
 
   // copy best four of brl to main sorter
   iter = my_brl_cands.begin();
@@ -119,7 +122,7 @@ void L1MuGMTSorter::run() {
     iter++;
   }
    // sort by rank
-  stable_sort( my_fwd_cands.begin(), my_fwd_cands.end(), L1MuGMTExtendedCand::Rank() );
+  stable_sort( my_fwd_cands.begin(), my_fwd_cands.end(), rankFunction );
 
 
   // copy best four of fwd to main sorter
@@ -147,7 +150,7 @@ void L1MuGMTSorter::run() {
   }
   
   // sort by rank
-  stable_sort( mycands.begin(), mycands.end(), L1MuGMTExtendedCand::Rank() );
+  stable_sort( mycands.begin(), mycands.end(), rankFunction );
 
   // copy the best 4 candidates
   int number_of_cands = 0;

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMMuonSorter.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMMuonSorter.cc
@@ -110,7 +110,7 @@ void L1MuBMMuonSorter::run() {
   }
 
   // sort pt and quality
-  stable_sort( mycands.begin(), mycands.end(), L1MuBMTrack::Rank() );
+  stable_sort( mycands.begin(), mycands.end(), L1MuBMTrack::rank );
 
   // copy the best 4 candidates
   int number_of_tracks = 0;

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMWedgeSorter.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMWedgeSorter.cc
@@ -126,7 +126,7 @@ void L1MuBMWedgeSorter::run() {
   // sort candidates by pt and quality and copy the 2 best candidates
   partial_sort_copy( wedgecands.begin(), wedgecands.end(),
                      m_TrackCands.begin(), m_TrackCands.end(),
-                     L1MuBMTrack::Rank() );
+                     L1MuBMTrack::rank );
 
   if ( L1MuBMTFConfig::Debug(4) ) {
     cout << "Wedge Sorter " << m_wsid << " output: " << endl;

--- a/PhysicsTools/JetCharge/test/JetChargeAnalyzer.cc
+++ b/PhysicsTools/JetCharge/test/JetChargeAnalyzer.cc
@@ -22,8 +22,7 @@
 
 class JetChargeAnalyzer : public edm::EDAnalyzer {
     public:
-  struct JetRefCompare :
-       public std::binary_function<edm::RefToBase<reco::Jet>, edm::RefToBase<reco::Jet>, bool> {
+  struct JetRefCompare {
     inline bool operator () (const edm::RefToBase<reco::Jet> &j1,
                              const edm::RefToBase<reco::Jet> &j2) const
     { return j1.id() < j2.id() || (j1.id() == j2.id() && j1.key() < j2.key()); }

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
@@ -61,13 +61,6 @@ namespace std{
         return h1 ^ (h2 << 1);
       }
     };
-  template<>
-    struct equal_to<std::pair<const GeomDet*,GlobalPoint> > : public std::binary_function<std::pair<const GeomDet*,GlobalPoint>,std::pair<const GeomDet*,GlobalPoint>,bool> {
-      bool operator()(const std::pair<const GeomDet*,GlobalPoint>& a, 
-		      const std::pair<const GeomDet*,GlobalPoint>& b)  const {
-	return (a.first == b.first) & (a.second == b.second);
-      }
-    };
 }
 
 class RecHitWithDist

--- a/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
@@ -65,13 +65,6 @@ namespace std{
       return h1 ^ (h2 << 1);
       }
   };
-  template<>
-  struct equal_to<std::pair<int,GlobalPoint> > : public std::binary_function<std::pair<int,GlobalPoint>,std::pair<int,GlobalPoint>,bool> {
-    bool operator()(const std::pair<int,GlobalPoint>& a, 
-		    const std::pair<int,GlobalPoint>& b)  const {
-      return (a.first == b.first) & (a.second == b.second);
-    }
-  };
 }
 
 class TrajSeedMatcher {

--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTNxNClusterProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTNxNClusterProducer.h
@@ -33,17 +33,6 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-// Less than operator for sorting EcalRecHits according to energy.
-class ecalRecHitSort : public std::binary_function<EcalRecHit, EcalRecHit, bool> 
-{
- public:
-  bool operator()(EcalRecHit x, EcalRecHit y) 
-  { 
-    return (x.energy() > y.energy()); 
-  }
-};
-
-
 class EgammaHLTNxNClusterProducer : public edm::stream::EDProducer<> {
  public:
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
@@ -199,7 +199,9 @@ void EgammaHLTNxNClusterProducer::makeNxNClusters(edm::Event &evt, const edm::Ev
   std::vector<DetId> usedXtals;
   
   // sort seed according to Energy
-  sort(seeds.begin(), seeds.end(), ecalRecHitSort());
+  sort(seeds.begin(), seeds.end(), [](auto const& x, auto const& y){
+                                       return (x.energy() > y.energy());
+                                     });
   
   
   

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
@@ -207,7 +207,6 @@ void EgammaHLTNxNClusterProducer::makeNxNClusters(edm::Event &evt, const edm::Ev
   
   for (std::vector<EcalRecHit>::iterator itseed=seeds.begin(); itseed!=seeds.end(); itseed++) {
     DetId seed_id = itseed->id();
-    std::vector<DetId>::const_iterator usedIds;
     
     std::vector<DetId>::iterator  itdet = find(usedXtals.begin(),usedXtals.end(),seed_id);
     if(itdet != usedXtals.end()) continue; 

--- a/RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h
+++ b/RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h
@@ -104,13 +104,8 @@ protected:
 
 
 
-class GreaterByEtPseudoJet : 
-  public std::binary_function<fastjet::PseudoJet const &, fastjet::PseudoJet const &, bool> {
-  
-public:
-  bool operator()( fastjet::PseudoJet const & j1, fastjet::PseudoJet const & j2 ) {
-    return j1.perp() > j2.perp();
-  }
-};
+bool greaterByEtPseudoJet( fastjet::PseudoJet const & j1, fastjet::PseudoJet const & j2 ) {
+  return j1.perp() > j2.perp();
+}
 
 #endif

--- a/RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h
+++ b/RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h
@@ -104,7 +104,7 @@ protected:
 
 
 
-bool greaterByEtPseudoJet( fastjet::PseudoJet const & j1, fastjet::PseudoJet const & j2 ) {
+inline bool greaterByEtPseudoJet( fastjet::PseudoJet const & j1, fastjet::PseudoJet const & j2 ) {
   return j1.perp() > j2.perp();
 }
 

--- a/RecoJets/JetAlgorithms/src/CATopJetAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/CATopJetAlgorithm.cc
@@ -89,8 +89,7 @@ void CATopJetAlgorithm::run( const vector<fastjet::PseudoJet> & cell_particles,
 		}
 	}
 	// Sort the transient central jets in Et
-	GreaterByEtPseudoJet compEt;
-	sort( centralJets.begin(), centralJets.end(), compEt );
+	sort( centralJets.begin(), centralJets.end(), greaterByEtPseudoJet );
 	
 	// These will store the 4-vectors of each hard jet
 	vector<math::XYZTLorentzVector> p4_hardJets;
@@ -231,7 +230,7 @@ void CATopJetAlgorithm::run( const vector<fastjet::PseudoJet> & cell_particles,
 			hardSubjets.push_back(subjet3);
 		if ( subjet4.pt() > 0.0001 )
 			hardSubjets.push_back(subjet4);
-		sort(hardSubjets.begin(), hardSubjets.end(), compEt );
+		sort(hardSubjets.begin(), hardSubjets.end(), greaterByEtPseudoJet );
 
 		// Use new fastjet functionality to create a Pseudojet from constituents
 		fastjet::PseudoJet candidate = join(hardSubjets);

--- a/RecoJets/JetAlgorithms/src/CMSInsideOutAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/CMSInsideOutAlgorithm.cc
@@ -62,8 +62,7 @@ CMSInsideOutAlgorithm::run(const std::vector<fastjet::PseudoJet>& fInput, std::v
       }
       fOutput.push_back(final);
    } // end loop over seeds
-   GreaterByEtPseudoJet compJets;
-   sort (fOutput.begin (), fOutput.end (), compJets);
+   sort (fOutput.begin (), fOutput.end (), greaterByEtPseudoJet);
 }
          
 

--- a/RecoJets/JetAssociationAlgorithms/interface/JetSignalVertexCompatibilityAlgo.h
+++ b/RecoJets/JetAssociationAlgorithms/interface/JetSignalVertexCompatibilityAlgo.h
@@ -1,7 +1,6 @@
 #ifndef JetSignalVertexCompatibilityAlgo_h
 #define JetSignalVertexCompatibilityAlgo_h
 
-#include <functional>
 #include <vector>
 #include <map>
 
@@ -26,9 +25,7 @@ class JetSignalVertexCompatibilityAlgo {
 
     private:
 	template<typename T>
-	struct RefToBaseLess : public std::binary_function<edm::RefToBase<T>,
-	                                                   edm::RefToBase<T>,
-                                                           bool> {
+	struct RefToBaseLess {
 		bool operator()(const edm::RefToBase<T> &r1,
 		                const edm::RefToBase<T> &r2) const;
 	};

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHETimeProfileStatusBitSetter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHETimeProfileStatusBitSetter.h
@@ -49,16 +49,14 @@ private:
   double SlopeMin_,SlopeMax_;
   double OuterMin_,OuterMax_;
   double EnergyThreshold_;
-  struct compare_digi_energy : public std::binary_function<HBHEDataFrame, HBHEDataFrame, bool> {
-    bool operator()(const HBHEDataFrame& x, const HBHEDataFrame& y) {
-      double TotalX=0, TotalY=0;
-      for(int i=0; i!=x.size(); TotalX += x.sample(i++).nominal_fC());
-      for(int i=0; i!=y.size(); TotalY += y.sample(i++).nominal_fC());
+  static bool compare_digi_energy(const HBHEDataFrame& x, const HBHEDataFrame& y) {
+    double TotalX=0, TotalY=0;
+    for(int i=0; i!=x.size(); TotalX += x.sample(i++).nominal_fC());
+    for(int i=0; i!=y.size(); TotalY += y.sample(i++).nominal_fC());
 
-      return (TotalX>TotalY) ;
+    return (TotalX>TotalY) ;
 
-    }
-  };
+  }
  
   double TotalEnergyInDataFrame(const HBHEDataFrame& x) {
     double Total=0;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHETimeProfileStatusBitSetter.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHETimeProfileStatusBitSetter.h
@@ -49,14 +49,6 @@ private:
   double SlopeMin_,SlopeMax_;
   double OuterMin_,OuterMax_;
   double EnergyThreshold_;
-  static bool compare_digi_energy(const HBHEDataFrame& x, const HBHEDataFrame& y) {
-    double TotalX=0, TotalY=0;
-    for(int i=0; i!=x.size(); TotalX += x.sample(i++).nominal_fC());
-    for(int i=0; i!=y.size(); TotalY += y.sample(i++).nominal_fC());
-
-    return (TotalX>TotalY) ;
-
-  }
  
   double TotalEnergyInDataFrame(const HBHEDataFrame& x) {
     double Total=0;

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHETimeProfileStatusBitSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHETimeProfileStatusBitSetter.cc
@@ -47,19 +47,21 @@ HBHETimeProfileStatusBitSetter::HBHETimeProfileStatusBitSetter(double R1Min, dou
 HBHETimeProfileStatusBitSetter::~HBHETimeProfileStatusBitSetter(){}
 
 
+bool compareDigiEnergy(const HBHEDataFrame& x, const HBHEDataFrame& y)
+{
+  double TotalX=0, TotalY=0;
+  for(int i=0; i!=x.size(); TotalX += x.sample(i++).nominal_fC());
+  for(int i=0; i!=y.size(); TotalY += y.sample(i++).nominal_fC());
 
-
-
-
-
-
+  return (TotalX>TotalY) ;
+}
 
 void HBHETimeProfileStatusBitSetter::hbheSetTimeFlagsFromDigi(HBHERecHitCollection * hbhe, const std::vector<HBHEDataFrame>& udigi, const std::vector<int>& RecHitIndex)
 {
   
   bool Bits[4]={false, false, false, false};
   std::vector<HBHEDataFrame> digi(udigi);
-  std::sort(digi.begin(), digi.end(), compare_digi_energy); // sort digis according to energies
+  std::sort(digi.begin(), digi.end(), compareDigiEnergy); // sort digis according to energies
   std::vector<double> PulseShape; // store fC values for each time slice
   int DigiSize=0;
   //  int LeadingEta=0;

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHETimeProfileStatusBitSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHETimeProfileStatusBitSetter.cc
@@ -47,13 +47,16 @@ HBHETimeProfileStatusBitSetter::HBHETimeProfileStatusBitSetter(double R1Min, dou
 HBHETimeProfileStatusBitSetter::~HBHETimeProfileStatusBitSetter(){}
 
 
-bool compareDigiEnergy(const HBHEDataFrame& x, const HBHEDataFrame& y)
-{
-  double TotalX=0, TotalY=0;
-  for(int i=0; i!=x.size(); TotalX += x.sample(i++).nominal_fC());
-  for(int i=0; i!=y.size(); TotalY += y.sample(i++).nominal_fC());
+namespace {
+  bool compareDigiEnergy(const HBHEDataFrame& x, const HBHEDataFrame& y)
+  {
+    double totalX = 0;
+    double totalY = 0;
+    for(int i=0; i!=x.size(); totalX += x.sample(i++).nominal_fC());
+    for(int i=0; i!=y.size(); totalY += y.sample(i++).nominal_fC());
 
-  return (TotalX>TotalY) ;
+    return totalX > totalY;
+  }
 }
 
 void HBHETimeProfileStatusBitSetter::hbheSetTimeFlagsFromDigi(HBHERecHitCollection * hbhe, const std::vector<HBHEDataFrame>& udigi, const std::vector<int>& RecHitIndex)

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHETimeProfileStatusBitSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHETimeProfileStatusBitSetter.cc
@@ -59,7 +59,7 @@ void HBHETimeProfileStatusBitSetter::hbheSetTimeFlagsFromDigi(HBHERecHitCollecti
   
   bool Bits[4]={false, false, false, false};
   std::vector<HBHEDataFrame> digi(udigi);
-  std::sort(digi.begin(), digi.end(), compare_digi_energy()); // sort digis according to energies
+  std::sort(digi.begin(), digi.end(), compare_digi_energy); // sort digis according to energies
   std::vector<double> PulseShape; // store fC values for each time slice
   int DigiSize=0;
   //  int LeadingEta=0;

--- a/RecoLocalMuon/DTSegment/src/DTSegmentCand.h
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentCand.h
@@ -132,8 +132,7 @@ class DTSegmentCand{
     /// convert this DTSegmentCand into a DTChamberRecSegment2D
     operator DTChamberRecSegment2D*() const;
 
-    struct AssPointLessZ : 
-      public std::binary_function<const AssPoint&, const AssPoint&, bool> {
+    struct AssPointLessZ {
         public:
           bool operator()(const AssPoint& pt1, 
                           const AssPoint& pt2) const ; 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShape.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShape.cc
@@ -76,18 +76,6 @@ bool ClusterShape::processColumn(pair<int,int> pos, bool inTheLoop)
 }
 
 /*****************************************************************************/
-struct lessPixel : public binary_function<SiPixelCluster::Pixel,
-                                          SiPixelCluster::Pixel,bool>
-{
-  bool operator()(const SiPixelCluster::Pixel& a,
-                  const SiPixelCluster::Pixel& b) const
-  {
-    // slightly faster by avoiding branches
-    return (a.x < b.x) | ((a.x == b.x) & (a.y < b.y));
-  }
-};
-
-/*****************************************************************************/
 void ClusterShape::determineShape
   (const PixelGeomDetUnit& pixelDet,
    const SiPixelRecHit& recHit, ClusterData& data)
@@ -119,7 +107,10 @@ void ClusterShape::determineShape
   for(size_t i=0; i<npixels; ++i) {
     pixels_.push_back(cluster.pixel(i));
   }
-  sort(pixels_.begin(),pixels_.end(),lessPixel());
+  sort(pixels_.begin(),pixels_.end(),[](auto const& a, auto const& b){
+              // slightly faster by avoiding branches
+              return (a.x < b.x) | ((a.x == b.x) & (a.y < b.y));
+          });
 
   // Look at all the pixels
   for(const auto& pixel: pixels_)

--- a/RecoTauTag/RecoTau/interface/RecoTauCleaningTools.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCleaningTools.h
@@ -2,13 +2,11 @@
 #define RecoTauTag_RecoTau_RecoTauCleaningTools_h
 
 #include <algorithm>
-#include <functional>
 
-namespace reco { namespace tau {
+namespace reco::tau {
 
 template<typename RankingList, typename Type>
-  class RecoTauLexicographicalRanking :
-      public std::binary_function<Type, Type, bool> {
+  class RecoTauLexicographicalRanking {
     public:
       // Store our list of ranking functions and intialize the vectors
       // that hold the comparison result
@@ -60,6 +58,6 @@ class SortByDescendingPt {
     }
 };
 
-}}  // end reco::tau namespace
+}  // end reco::tau namespace
 
 #endif

--- a/RecoTracker/CkfPattern/interface/TrajCandLess.h
+++ b/RecoTracker/CkfPattern/interface/TrajCandLess.h
@@ -12,8 +12,7 @@
  *  is likely to be considered "better".
  */
 template <class TR>
-class TrajCandLess {
-public:
+struct TrajCandLess {
 
   TrajCandLess( float p=5) : penalty(p) {}
 

--- a/RecoTracker/CkfPattern/interface/TrajCandLess.h
+++ b/RecoTracker/CkfPattern/interface/TrajCandLess.h
@@ -1,7 +1,6 @@
 #ifndef TrajCandLess_H
 #define TrajCandLess_H
 
-#include <functional>
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
 /** Defines an ordering of Trajectories in terms of "goodness"
@@ -13,9 +12,7 @@
  *  is likely to be considered "better".
  */
 template <class TR>
-class TrajCandLess : public std::binary_function< const TR&,
-		     const TR&, bool>
-{
+class TrajCandLess {
 public:
 
   TrajCandLess( float p=5) : penalty(p) {}

--- a/TrackingTools/DetLayers/interface/TkLayerLess.h
+++ b/TrackingTools/DetLayers/interface/TkLayerLess.h
@@ -6,14 +6,12 @@
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "DataFormats/GeometrySurface/interface/BoundCylinder.h"
 #include "DataFormats/GeometrySurface/interface/BoundDisk.h"
-#include <functional>
 
 /** Defines order of layers in the Tracker as seen by straight tracks
  *  coming from the interaction region.
  */
 
-class TkLayerLess 
-  : public std::binary_function< const DetLayer*,const DetLayer*,bool> {
+class TkLayerLess {
 public:
 
     TkLayerLess( NavigationDirection dir = insideOut, const DetLayer * fromLayer = nullptr) :

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
@@ -34,8 +34,7 @@ class BTagPerformanceAnalyzerMC : public DQMEDAnalyzer {
 
    private:
 
-  struct JetRefCompare :
-       public std::binary_function<edm::RefToBase<reco::Jet>, edm::RefToBase<reco::Jet>, bool> {
+  struct JetRefCompare {
     inline bool operator () (const edm::RefToBase<reco::Jet> &j1,
                              const edm::RefToBase<reco::Jet> &j2) const
     { return j1.id() < j2.id() || (j1.id() == j2.id() && j1.key() < j2.key()); }


### PR DESCRIPTION
Follow up to https://github.com/cms-sw/cmssw/pull/24549, with the aim of removing the deprecated `std::binary_function` and `std::unary_function`.

This PR encompasses most of the easier cases, where the inheritance from the unary or binary function could be just removed because it was not necessary.

One other day I will do the "harder" cases in a different PR.