### PR TITLE
OfflineDQM: Offline L1T muon DQM bugfix for muon resolution plots CMSLITDPG-763

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
@@ -41,7 +41,7 @@ l1tMuonDQMOffline = DQMEDAnalyzer('L1TMuonDQMOffline',
     tagPtCut = cms.untracked.double(26.),
     recoToL1PtCutFactor = cms.untracked.double(1.2),
     cuts = cms.untracked.VPSet(cutsPSets),
-    useL1AtVtxCoord = cms.untracked.bool(True),
+    useL1AtVtxCoord = cms.untracked.bool(False),
 
     muonInputTag = cms.untracked.InputTag("muons"),
     gmtInputTag  = cms.untracked.InputTag("gmtStage2Digis","Muon"),


### PR DESCRIPTION
Bugfix
This PR disables the extrapolation of L1T muons in the offline L1T DQM, since offline muons are extrapolated now to the muon stations. Requested in https://its.cern.ch/jira/browse/CMSLITDPG-763