### PR TITLE
MET EE noise mitigation in 2017 data

### DIFF
--- a/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
@@ -1,0 +1,98 @@
+#include <string>
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Common/interface/RefToPtr.h" 
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "DataFormats/Candidate/interface/ShallowCloneCandidate.h"
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Math/interface/Point3D.h"
+
+namespace pat {
+  class BadPFCandidateJetsEEnoiseProducer : public edm::global::EDProducer<>{
+  public:
+    explicit BadPFCandidateJetsEEnoiseProducer(const edm::ParameterSet&);
+    ~BadPFCandidateJetsEEnoiseProducer() override;
+    
+    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  private:
+    edm::EDGetTokenT<edm::View<pat::PackedCandidate> > pfcandidatesrc_;
+    edm::EDGetTokenT<edm::View<pat::Jet> > jetsrc_;
+    double PtThreshold_;
+    double MinEtaThreshold_;
+    double MaxEtaThreshold_;
+    bool userawPt_;
+  };
+}
+
+
+pat::BadPFCandidateJetsEEnoiseProducer::BadPFCandidateJetsEEnoiseProducer(const edm::ParameterSet& iConfig) :
+  
+  pfcandidatesrc_(consumes<edm::View<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("pfcandidatesrc") )),
+  jetsrc_(consumes<edm::View<pat::Jet> >(iConfig.getParameter<edm::InputTag>("jetsrc") )),
+  PtThreshold_(iConfig.getParameter<double>("PtThreshold")),
+  MinEtaThreshold_(iConfig.getParameter<double>("MinEtaThreshold")),
+  MaxEtaThreshold_(iConfig.getParameter<double>("MaxEtaThreshold")),
+  userawPt_(iConfig.getParameter<bool>("userawPt"))
+{
+  
+  produces<edm::PtrVector<reco::Candidate> >();
+  
+}
+
+pat::BadPFCandidateJetsEEnoiseProducer::~BadPFCandidateJetsEEnoiseProducer() {}
+
+void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+
+  
+  std::unique_ptr<edm::PtrVector<reco::Candidate> > badPFCandidates(new edm::PtrVector<reco::Candidate>);
+  
+  edm::Handle<edm::View<pat::PackedCandidate> > pfcandidates;
+  iEvent.getByToken(pfcandidatesrc_, pfcandidates);
+  edm::Handle<edm::View<pat::Jet> > jetcandidates;
+  iEvent.getByToken(jetsrc_, jetcandidates);
+
+  //if( userawPt_  ) std::cout << "Caution: Uncorrected Jet Pt is being used" << std::endl;
+  //if( !userawPt_ ) std::cout << "Caution: Corrected Jet Pt is being used" << std::endl;
+  
+  int njets   = jetcandidates->size();
+  
+ 
+  for (int jetindex = 0; jetindex < njets; ++jetindex){
+    edm::Ptr<pat::Jet> candjet = jetcandidates->ptrAt(jetindex);
+
+    // find the bad jets
+    double PtJet;
+    // Corrected Pt or Uncorrected Pt (It is defined from cfi file)
+    if( userawPt_  ) PtJet = candjet->correctedJet("Uncorrected").pt();
+    if( !userawPt_ ) PtJet = candjet->pt();
+    
+    
+    if ( PtJet > PtThreshold_ )continue;
+    if (fabs(candjet->eta()) < MinEtaThreshold_ || fabs(candjet->eta()) > MaxEtaThreshold_)continue;
+    
+    
+    // now get a list of the PF candidates used to build this jet
+    for (unsigned int pfindex =0; pfindex < candjet->numberOfSourceCandidatePtrs(); pfindex++){
+      badPFCandidates -> push_back(candjet->sourceCandidatePtr(pfindex));
+    }
+  }
+  iEvent.put(std::move(badPFCandidates));
+  
+}
+using pat::BadPFCandidateJetsEEnoiseProducer;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(BadPFCandidateJetsEEnoiseProducer);

--- a/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
@@ -28,9 +28,9 @@ namespace pat {
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   private:
     edm::EDGetTokenT<edm::View<pat::Jet> > jetsrc_;
-    double PtThreshold_;
-    double MinEtaThreshold_;
-    double MaxEtaThreshold_;
+    double ptThreshold_;
+    double minEtaThreshold_;
+    double maxEtaThreshold_;
     bool userawPt_;
   };
 }
@@ -38,9 +38,9 @@ namespace pat {
 
 pat::BadPFCandidateJetsEEnoiseProducer::BadPFCandidateJetsEEnoiseProducer(const edm::ParameterSet& iConfig) :
   jetsrc_(consumes<edm::View<pat::Jet> >(iConfig.getParameter<edm::InputTag>("jetsrc") )),
-  PtThreshold_(iConfig.getParameter<double>("PtThreshold")),
-  MinEtaThreshold_(iConfig.getParameter<double>("MinEtaThreshold")),
-  MaxEtaThreshold_(iConfig.getParameter<double>("MaxEtaThreshold")),
+  ptThreshold_(iConfig.getParameter<double>("ptThreshold")),
+  minEtaThreshold_(iConfig.getParameter<double>("minEtaThreshold")),
+  maxEtaThreshold_(iConfig.getParameter<double>("maxEtaThreshold")),
   userawPt_(iConfig.getParameter<bool>("userawPt"))
 {
   
@@ -66,10 +66,10 @@ void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID, edm::Event& 
     edm::Ptr<pat::Jet> candjet = jetcandidates->ptrAt(jetindex);
 
     // Corrected Pt or Uncorrected Pt (It is defined from cfi file)
-    double PtJet = userawPt_ ? candjet->correctedJet("Uncorrected").pt() : candjet->pt();
-    double AbsEtaJet = std::abs(candjet->eta());
+    double ptJet = userawPt_ ? candjet->correctedJet("Uncorrected").pt() : candjet->pt();
+    double absEtaJet = std::abs(candjet->eta());
     
-    if ( PtJet > PtThreshold_ || AbsEtaJet < MinEtaThreshold_ || AbsEtaJet > MaxEtaThreshold_) {
+    if ( ptJet > ptThreshold_ || absEtaJet < minEtaThreshold_ || absEtaJet > maxEtaThreshold_) {
       // save good jets
       goodJets->emplace_back(candjet);
     }
@@ -88,9 +88,9 @@ void pat::BadPFCandidateJetsEEnoiseProducer::fillDescriptions(edm::Configuration
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("jetsrc",edm::InputTag("slimmedJets"));
   desc.add<bool>("userawPt",true);
-  desc.add<double>("PtThreshold",75.0);
-  desc.add<double>("MinEtaThreshold",2.65);
-  desc.add<double>("MaxEtaThreshold",3.139);
+  desc.add<double>("ptThreshold",75.0);
+  desc.add<double>("minEtaThreshold",2.65);
+  desc.add<double>("maxEtaThreshold",3.139);
 
   descriptions.add("BadPFCandidateJetsEEnoiseProducer",desc);
 }

--- a/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
@@ -88,7 +88,7 @@ void pat::BadPFCandidateJetsEEnoiseProducer::fillDescriptions(edm::Configuration
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("jetsrc",edm::InputTag("slimmedJets"));
   desc.add<bool>("userawPt",true);
-  desc.add<double>("ptThreshold",75.0);
+  desc.add<double>("ptThreshold",50.0);
   desc.add<double>("minEtaThreshold",2.65);
   desc.add<double>("maxEtaThreshold",3.139);
 

--- a/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
@@ -45,7 +45,7 @@ pat::BadPFCandidateJetsEEnoiseProducer::BadPFCandidateJetsEEnoiseProducer(const 
 {
   
   produces<edm::PtrVector<reco::Candidate> >();
-  produces<std::vector<pat::Jet> >();
+  produces<std::vector<pat::Jet> >("jets");
   
 }
 
@@ -81,7 +81,7 @@ void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID, edm::Event& 
     }
   }
   iEvent.put(std::move(badPFCandidates));
-  iEvent.put(std::move(goodJets));
+  iEvent.put(std::move(goodJets),"jets");
   
 }
 

--- a/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
@@ -44,8 +44,8 @@ pat::BadPFCandidateJetsEEnoiseProducer::BadPFCandidateJetsEEnoiseProducer(const 
   userawPt_(iConfig.getParameter<bool>("userawPt"))
 {
   
-  produces<std::vector<edm::Ptr<reco::Candidate>>>();
-  produces<std::vector<pat::Jet>>("jets");
+  produces<std::vector<pat::Jet>>("good");
+  produces<std::vector<pat::Jet>>("bad");
   
 }
 
@@ -53,8 +53,8 @@ pat::BadPFCandidateJetsEEnoiseProducer::~BadPFCandidateJetsEEnoiseProducer() {}
 
 void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   
-  auto badPFCandidates = std::make_unique<std::vector<edm::Ptr<reco::Candidate>>>();
   auto goodJets = std::make_unique<std::vector<pat::Jet>>();
+  auto badJets = std::make_unique<std::vector<pat::Jet>>();
   
   edm::Handle<edm::View<pat::Jet> > jetcandidates;
   iEvent.getByToken(jetsrc_, jetcandidates);
@@ -72,16 +72,15 @@ void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID, edm::Event& 
     if ( PtJet > PtThreshold_ || AbsEtaJet < MinEtaThreshold_ || AbsEtaJet > MaxEtaThreshold_) {
       // save good jets
       goodJets->emplace_back(candjet);
-      continue;
+    }
+    else {
+      // save bad jets
+      badJets->emplace_back(candjet);
     }
     
-    // now get a list of the PF candidates used to build this jet
-    for (unsigned int pfindex =0; pfindex < candjet->numberOfSourceCandidatePtrs(); pfindex++){
-      badPFCandidates -> push_back(candjet->sourceCandidatePtr(pfindex));
-    }
   }
-  iEvent.put(std::move(badPFCandidates));
-  iEvent.put(std::move(goodJets),"jets");
+  iEvent.put(std::move(goodJets),"good");
+  iEvent.put(std::move(badJets),"bad");
   
 }
 

--- a/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
@@ -44,8 +44,8 @@ pat::BadPFCandidateJetsEEnoiseProducer::BadPFCandidateJetsEEnoiseProducer(const 
   userawPt_(iConfig.getParameter<bool>("userawPt"))
 {
   
-  produces<edm::PtrVector<reco::Candidate> >();
-  produces<std::vector<pat::Jet> >("jets");
+  produces<std::vector<edm::Ptr<reco::Candidate>>>();
+  produces<std::vector<pat::Jet>>("jets");
   
 }
 
@@ -53,7 +53,7 @@ pat::BadPFCandidateJetsEEnoiseProducer::~BadPFCandidateJetsEEnoiseProducer() {}
 
 void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   
-  auto badPFCandidates = std::make_unique<edm::PtrVector<reco::Candidate>>();
+  auto badPFCandidates = std::make_unique<std::vector<edm::Ptr<reco::Candidate>>>();
   auto goodJets = std::make_unique<std::vector<pat::Jet>>();
   
   edm::Handle<edm::View<pat::Jet> > jetcandidates;

--- a/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
@@ -45,7 +45,7 @@ pat::BadPFCandidateJetsEEnoiseProducer::BadPFCandidateJetsEEnoiseProducer(const 
 {
   
   produces<edm::PtrVector<reco::Candidate> >();
-  produces<edm::PtrVector<pat::Jet> >();
+  produces<std::vector<pat::Jet> >();
   
 }
 
@@ -54,7 +54,7 @@ pat::BadPFCandidateJetsEEnoiseProducer::~BadPFCandidateJetsEEnoiseProducer() {}
 void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   
   auto badPFCandidates = std::make_unique<edm::PtrVector<reco::Candidate>>();
-  auto goodJets = std::make_unique<edm::PtrVector<pat::Jet>>();
+  auto goodJets = std::make_unique<std::vector<pat::Jet>>();
   
   edm::Handle<edm::View<pat::Jet> > jetcandidates;
   iEvent.getByToken(jetsrc_, jetcandidates);
@@ -71,7 +71,7 @@ void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID, edm::Event& 
     
     if ( PtJet > PtThreshold_ || AbsEtaJet < MinEtaThreshold_ || AbsEtaJet > MaxEtaThreshold_) {
       // save good jets
-      goodJets->push_back(candjet);
+      goodJets->emplace_back(candjet);
       continue;
     }
     

--- a/JetMETCorrections/Type1MET/plugins/UnclusteredBlobProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/UnclusteredBlobProducer.cc
@@ -1,0 +1,66 @@
+#include <string>
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "DataFormats/Common/interface/RefToPtr.h" 
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+namespace pat {
+  class UnclusteredBlobProducer : public edm::global::EDProducer<>{
+  public:
+    explicit UnclusteredBlobProducer(const edm::ParameterSet&);
+    ~UnclusteredBlobProducer() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  private:
+    edm::EDGetTokenT<edm::View<reco::Candidate> > candsrc_;
+  };
+}
+
+
+pat::UnclusteredBlobProducer::UnclusteredBlobProducer(const edm::ParameterSet& iConfig) :
+  candsrc_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("candsrc") ))
+{
+  produces<std::vector<reco::VertexCompositePtrCandidate>>();
+}
+
+pat::UnclusteredBlobProducer::~UnclusteredBlobProducer() {}
+
+void pat::UnclusteredBlobProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  
+  auto blob = std::make_unique<std::vector<reco::VertexCompositePtrCandidate>>();
+  
+  edm::Handle<edm::View<reco::Candidate>> candidates;
+  iEvent.getByToken(candsrc_, candidates);
+  
+  blob->emplace_back();
+
+  auto& c_blob = blob->back();
+
+  // combine all candidates into composite so they can be accessed properly by CandPtrSelector
+  for(unsigned i = 0; i < candidates->size(); ++i){
+    c_blob.addDaughter(candidates->ptrAt(i));
+  }
+
+  iEvent.put(std::move(blob));
+  
+}
+
+void pat::UnclusteredBlobProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("candsrc",edm::InputTag("badUnclustered"));
+
+  descriptions.add("UnclusteredBlobProducer",desc);
+}
+
+using pat::UnclusteredBlobProducer;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(UnclusteredBlobProducer);

--- a/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
+++ b/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
@@ -2,13 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 
 #______________________________________________________#
-PFCandidateJetsWithEEnoise = cms.EDProducer(
+pfCandidateJetsWithEEnoise = cms.EDProducer(
     "BadPFCandidateJetsEEnoiseProducer",
     jetsrc                     = cms.InputTag("slimmedJets"),
     userawPt                   = cms.bool(True),
-    PtThreshold                = cms.double(75.0),
-    MinEtaThreshold            = cms.double(2.65),
-    MaxEtaThreshold            = cms.double(3.139)
+    ptThreshold                = cms.double(75.0),
+    minEtaThreshold            = cms.double(2.65),
+    maxEtaThreshold            = cms.double(3.139)
     )
 
 
@@ -43,7 +43,7 @@ superbad = cms.EDProducer(
     "CandViewMerger",
     src = cms.VInputTag(
         cms.InputTag("badUnclustered"),
-        cms.InputTag("PFCandidateJetsWithEEnoise"))
+        cms.InputTag("pfCandidateJetsWithEEnoise"))
     )
 #___________________________________________________________#
 cleanPFCandidates = cms.EDProducer(
@@ -57,7 +57,7 @@ cleanPFCandidates = cms.EDProducer(
 #__________________________________________________________#
 
 
-fullsuperbadSequence = cms.Sequence(PFCandidateJetsWithEEnoise+
+fullsuperbadSequence = cms.Sequence(pfCandidateJetsWithEEnoise+
                                     pfcandidateClustered +
                                     pfcandidateForUnclusteredUnc +
                                     badUnclustered +

--- a/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
+++ b/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
@@ -6,7 +6,7 @@ pfCandidateJetsWithEEnoise = cms.EDProducer(
     "BadPFCandidateJetsEEnoiseProducer",
     jetsrc                     = cms.InputTag("slimmedJets"),
     userawPt                   = cms.bool(True),
-    ptThreshold                = cms.double(75.0),
+    ptThreshold                = cms.double(50.0),
     minEtaThreshold            = cms.double(2.65),
     maxEtaThreshold            = cms.double(3.139)
     )

--- a/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
+++ b/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
@@ -1,0 +1,81 @@
+import FWCore.ParameterSet.Config as cms
+
+
+#______________________________________________________#
+PFCandidateJetsWithEEnoise = cms.EDProducer(
+    "BadPFCandidateJetsEEnoiseProducer",
+    pfcandidatesrc             = cms.InputTag("packedPFCandidates"),
+    jetsrc                     = cms.InputTag("slimmedJets"),
+    userawPt                   = cms.bool(True),
+    PtThreshold                = cms.double(75.0),
+    MinEtaThreshold            = cms.double(2.65),
+    MaxEtaThreshold            = cms.double(3.139)
+    )
+
+
+#_______________________________________________________#
+# Construct the Unclustered PF Candidates
+
+# Jet projection:
+pfcandidateNojets = cms.EDProducer("CandPtrProjector",
+                                   src  = cms.InputTag("packedPFCandidates"),
+                                   veto = cms.InputTag("slimmedJets")
+                                   )
+# Electron projection:
+pfcandidateNojetsNoele = cms.EDProducer("CandPtrProjector",
+                                        src  = cms.InputTag("pfcandidateNojets"),
+                                        veto = cms.InputTag("slimmedElectrons")
+                                        )
+# Muon projection:
+pfcandidateNojetsNoeleNomu = cms.EDProducer("CandPtrProjector",
+                                            src  = cms.InputTag("pfcandidateNojetsNoele"),
+                                            veto = cms.InputTag("slimmedMuons")
+                                            )
+# Tau projection:
+pfcandidateNojetsNoeleNomuNotau = cms.EDProducer("CandPtrProjector",
+                                                 src  = cms.InputTag("pfcandidateNojetsNoeleNomu"),
+                                                 veto = cms.InputTag("slimmedTaus")
+                                                 )
+# Photon projection:
+pfcandidateForUnclusteredUnc = cms.EDProducer("CandPtrProjector",
+                                              src  = cms.InputTag("pfcandidateNojetsNoeleNomuNotau"),
+                                              veto = cms.InputTag("slimmedPhotons")
+                                              )
+
+
+#__________________________________________________________________#
+bad1 = cms.EDFilter(
+    "CandPtrSelector",
+    src = cms.InputTag("pfcandidateForUnclusteredUnc"),
+    cut = cms.string("abs(eta) > 2.65 && abs(eta) < 3.139")
+    )
+
+#_________________________________________________________#
+superbad = cms.EDProducer(
+    "CandViewMerger",
+    src = cms.VInputTag(
+        cms.InputTag("bad1"),
+        cms.InputTag("PFCandidateJetsWithEEnoise"))
+    )
+#___________________________________________________________#
+cleanPFCandidates = cms.EDProducer(
+    "CandPtrProjector",
+    src  = cms.InputTag("packedPFCandidates"),
+    veto = cms.InputTag("superbad")
+    )
+
+
+
+#__________________________________________________________#
+
+
+fullsuperbadSequence = cms.Sequence(PFCandidateJetsWithEEnoise+
+                                    pfcandidateNojets +
+                                    pfcandidateNojetsNoele +
+                                    pfcandidateNojetsNoeleNomu +
+                                    pfcandidateNojetsNoeleNomuNotau +
+                                    pfcandidateForUnclusteredUnc +
+                                    bad1 +
+                                    superbad +
+                                    cleanPFCandidates
+                                    )

--- a/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
+++ b/JetMETCorrections/Type1MET/python/cleanJetFromEEnoise_cfi.py
@@ -4,7 +4,6 @@ import FWCore.ParameterSet.Config as cms
 #______________________________________________________#
 PFCandidateJetsWithEEnoise = cms.EDProducer(
     "BadPFCandidateJetsEEnoiseProducer",
-    pfcandidatesrc             = cms.InputTag("packedPFCandidates"),
     jetsrc                     = cms.InputTag("slimmedJets"),
     userawPt                   = cms.bool(True),
     PtThreshold                = cms.double(75.0),

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1799,7 +1799,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         )
         addToProcessAndTask("pfCandidatesGoodEE2017"+postfix, pfCandidatesGoodEE2017, process, task)
         # return good cands and jets
-        return (cms.InputTag("pfCandidatesGoodEE2017"+postfix), cms.InputTag("PFCandidateJetsWithEEnoise"+postfix))
+        return (cms.InputTag("pfCandidatesGoodEE2017"+postfix), cms.InputTag("PFCandidateJetsWithEEnoise"+postfix,"jets"))
 
 #========================================================================================
 runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -85,7 +85,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                           "Switch on miniAOD configuration", Type=bool)
         self.addParameter(self._defaultParameters, 'postfix', '',
                           "Technical parameter to identify the resulting sequence and its modules (allows multiple calls in a job)", Type=str)
-
+        self.addParameter(self._defaultParameters,'fixEE2017', False,
+                          "Exclude jets and PF candidates with EE noise characteristics (fix for 2017 run)", Type=bool)
+        self.addParameter(self._defaultParameters,'fixEE2017Params', {'userawPt': True, 'PtThreshold': 75.0, 'MinEtaThreshold': 2.65, 'MaxEtaThreshold': 3.139},
+                          "Parameters dict for fixEE2017: userawPt, PtThreshold, MinEtaThreshold, MaxEtaThreshold", Type=dict)
 
         #private parameters
         self.addParameter(self._defaultParameters, 'Puppi', False,
@@ -128,6 +131,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                  CHS                     =None,
                  runOnData               =None,
                  onMiniAOD               =None,
+                 fixEE2017               =None,
+                 fixEE2017Params         =None,
                  postfix                 =None):
         electronCollection = self.initializeInputTag(electronCollection, 'electronCollection')
         photonCollection = self.initializeInputTag(photonCollection, 'photonCollection')
@@ -194,6 +199,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             onMiniAOD = self._defaultParameters['onMiniAOD'].value
         if postfix is None :
             postfix = self._defaultParameters['postfix'].value
+        if fixEE2017 is None :
+            fixEE2017 = self._defaultParameters['fixEE2017'].value
+        if fixEE2017Params is None :
+            fixEE2017Params = self._defaultParameters['fixEE2017Params'].value
 
         self.setParameter('metType',metType),
         self.setParameter('correctionLevel',correctionLevel),
@@ -224,6 +233,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.setParameter('runOnData',runOnData),
         self.setParameter('onMiniAOD',onMiniAOD),
         self.setParameter('postfix',postfix),
+        self.setParameter('fixEE2017',fixEE2017),
+        self.setParameter('fixEE2017Params',fixEE2017Params),
 
         #if mva/puppi MET, autoswitch to std jets
         if metType == "MVA" or metType == "Puppi":
@@ -287,7 +298,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         reclusterJets           = self._parameters['reclusterJets'].value
         onMiniAOD               = self._parameters['onMiniAOD'].value
         postfix                 = self._parameters['postfix'].value
-
+        fixEE2017               = self._parameters['fixEE2017'].value
+        fixEE2017Params         = self._parameters['fixEE2017Params'].value
+        
         #prepare jet configuration
         jetUncInfos = { "jCorrPayload":jetFlavor, "jCorLabelUpToL3":jetCorLabelUpToL3,
                         "jCorLabelL3Res":jetCorLabelL3Res, "jecUncFile":jecUncertaintyFile,
@@ -1844,6 +1857,8 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                CHS=False,
                                reapplyJEC=True,
                                jecUncFile="",
+                               fixEE2017=False,
+                               fixEE2017Params=None,
                                postfix=""):
 
     runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()
@@ -1874,6 +1889,8 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       jecUncertaintyFile=jecUncFile,
                                       CHS=CHS,
                                       postfix=postfix,
+                                      fixEE2017=fixEE2017,
+                                      fixEE2017Params=fixEE2017Params,
                                       )
 
     #MET T1+Txy / Smear
@@ -1902,6 +1919,8 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       jecUncertaintyFile=jecUncFile,
                                       CHS=CHS,
                                       postfix=postfix,
+                                      fixEE2017=fixEE2017,
+                                      fixEE2017Params=fixEE2017Params,
                                       )
     #MET T1+Smear + uncertainties
     runMETCorrectionsAndUncertainties(process, metType=metType,
@@ -1929,4 +1948,6 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       jecUncertaintyFile=jecUncFile,
                                       CHS=CHS,
                                       postfix=postfix,
+                                      fixEE2017=fixEE2017,
+                                      fixEE2017Params=fixEE2017Params,
                                       )

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -184,6 +184,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             manualJetConfig =  self._defaultParameters['manualJetConfig'].value
         if jetSelection is None :
             jetSelection = self._defaultParameters['jetSelection'].value
+        recoMetFromPFCsIsNone = (recoMetFromPFCs is None)
         if recoMetFromPFCs is None :
             recoMetFromPFCs =  self._defaultParameters['recoMetFromPFCs'].value
         if reapplyJEC is None :
@@ -256,6 +257,12 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
              #internal jet configuration
             self.jetConfiguration()
 
+        #defaults for 2017 fix
+        #(don't need to recluster, just uses a subset of the input jet coll)
+        if fixEE2017:
+            if recoMetFromPFCsIsNone: self.setParameter('recoMetFromPFCs',True)
+            if reclusterJetsIsNone: self.setParameter('reclusterJets',False)
+        
         #met reprocessing and jet reclustering
         if recoMetFromPFCs and reclusterJetsIsNone and not fixEE2017:
             self.setParameter('reclusterJets',True)
@@ -321,7 +328,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 pfCandCollection,
                 [electronCollection,muonCollection,tauCollection,photonCollection],
                 postfix,
-            )                
+            )
 
         # recompute the MET (and thus the jets as well for correction) from scratch
         if recoMetFromPFCs:
@@ -1901,7 +1908,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                manualJetConfig=False,
                                reclusterJets=None,
                                jetSelection="pt>15 && abs(eta)<9.9",
-                               recoMetFromPFCs=False,
+                               recoMetFromPFCs=None,
                                jetCorLabelL3="ak4PFCHSL1FastL2L3Corrector",
                                jetCorLabelRes="ak4PFCHSL1FastL2L3ResidualCorrector",
 ##                               jecUncFile="CondFormats/JetMETObjects/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt",

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -77,6 +77,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                   "Flag to enable/disable JEC update", Type=bool)
         self.addParameter(self._defaultParameters, 'reclusterJets', False,
                   "Flag to enable/disable the jet reclustering", Type=bool)
+        self.addParameter(self._defaultParameters, 'computeMETSignificance', True,
+                  "Flag to enable/disable the MET significance computation", Type=bool)
         self.addParameter(self._defaultParameters, 'CHS', False,
                   "Flag to enable/disable the CHS jets", Type=bool)
         self.addParameter(self._defaultParameters, 'runOnData', False,
@@ -128,6 +130,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                  recoMetFromPFCs         =None,
                  reapplyJEC              =None,
                  reclusterJets           =None,
+                 computeMETSignificance  =None,
                  CHS                     =None,
                  runOnData               =None,
                  onMiniAOD               =None,
@@ -192,6 +195,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         reclusterJetsIsNone = (reclusterJets is None)
         if reclusterJets is None :
             reclusterJets = self._defaultParameters['reclusterJets'].value
+        if computeMETSignificance is None :
+            computeMETSignificance = self._defaultParameters['computeMETSignificance'].value
         if CHS is None :
             CHS = self._defaultParameters['CHS'].value
         if runOnData is None :
@@ -229,6 +234,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         self.setParameter('jetSelection',jetSelection),
         self.setParameter('recoMetFromPFCs',recoMetFromPFCs),
         self.setParameter('reclusterJets',reclusterJets),
+        self.setParameter('computeMETSignificance',computeMETSignificance),
         self.setParameter('reapplyJEC',reapplyJEC),
         self.setParameter('CHS',CHS),
         self.setParameter('runOnData',runOnData),
@@ -304,6 +310,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         recoMetFromPFCs         = self._parameters['recoMetFromPFCs'].value
         reapplyJEC              = self._parameters['reapplyJEC'].value
         reclusterJets           = self._parameters['reclusterJets'].value
+        computeMETSignificance  = self._parameters['computeMETSignificance'].value
         onMiniAOD               = self._parameters['onMiniAOD'].value
         postfix                 = self._parameters['postfix'].value
         fixEE2017               = self._parameters['fixEE2017'].value
@@ -602,7 +609,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         #Enable MET significance if the type1 MET is computed
         if "T1" in correctionLevel:
-            getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(True)
+            getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
             getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = self._parameters["pfCandCollection"].value
             if postfix=="NoHF":
                 getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(False)
@@ -618,7 +625,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         #MET significance bypass for the patMETs from AOD
         if not self._parameters["onMiniAOD"].value and not postfix=="NoHF":
-            getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(True)
+            getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
             getattr(process, "patMETs"+postfix).srcPFCands=self._parameters["pfCandCollection"].value
 
         if hasattr(process, "patCaloMet"):
@@ -1367,7 +1374,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
                 addToProcessAndTask('patMETs'+postfix, getattr(process,'patMETs' ).clone(), process, task)
                 getattr(process, "patMETs"+postfix).metSource = cms.InputTag("pfMetT1"+postfix)
-                getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(True)
+                getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(self._parameters["computeMETSignificance"].value)
                 if postfix=="NoHF":
                     getattr(process, "patMETs"+postfix).computeMETSignificance = cms.bool(False)
 
@@ -1923,6 +1930,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                CHS=False,
                                reapplyJEC=True,
                                jecUncFile="",
+                               computeMETSignificance=True,
                                fixEE2017=False,
                                fixEE2017Params=None,
                                postfix=""):
@@ -1953,6 +1961,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       jetCorLabelUpToL3=jetCorLabelL3,
                                       jetCorLabelL3Res=jetCorLabelRes,
                                       jecUncertaintyFile=jecUncFile,
+                                      computeMETSignificance=computeMETSignificance,
                                       CHS=CHS,
                                       postfix=postfix,
                                       fixEE2017=fixEE2017,
@@ -1983,6 +1992,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       jetCorLabelUpToL3=jetCorLabelL3,
                                       jetCorLabelL3Res=jetCorLabelRes,
                                       jecUncertaintyFile=jecUncFile,
+                                      computeMETSignificance=computeMETSignificance,
                                       CHS=CHS,
                                       postfix=postfix,
                                       fixEE2017=fixEE2017,
@@ -2012,6 +2022,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                       jetCorLabelUpToL3=jetCorLabelL3,
                                       jetCorLabelL3Res=jetCorLabelRes,
                                       jecUncertaintyFile=jecUncFile,
+                                      computeMETSignificance=computeMETSignificance,
                                       CHS=CHS,
                                       postfix=postfix,
                                       fixEE2017=fixEE2017,

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1806,10 +1806,15 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         )
         addToProcessAndTask("badUnclustered"+postfix, badUnclustered, process, task)
         patMetModuleSequence += getattr(process,"badUnclustered"+postfix)
+        blobUnclustered = cms.EDProducer("UnclusteredBlobProducer",
+            candsrc = cms.InputTag("badUnclustered"+postfix),
+        )
+        addToProcessAndTask("blobUnclustered"+postfix, blobUnclustered, process, task)
+        patMetModuleSequence += getattr(process,"blobUnclustered"+postfix)
         superbad = cms.EDProducer("CandViewMerger",
             src = cms.VInputTag(
-                cms.InputTag("badUnclustered"+postfix),
-                cms.InputTag("PFCandidateJetsWithEEnoise"+postfix),
+                cms.InputTag("blobUnclustered"+postfix),
+                cms.InputTag("PFCandidateJetsWithEEnoise"+postfix,"bad"),
             )
         )
         addToProcessAndTask("superbad"+postfix, superbad, process, task)
@@ -1821,7 +1826,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         addToProcessAndTask("pfCandidatesGoodEE2017"+postfix, pfCandidatesGoodEE2017, process, task)
         patMetModuleSequence += getattr(process,"pfCandidatesGoodEE2017"+postfix)
         # return good cands and jets
-        return (cms.InputTag("pfCandidatesGoodEE2017"+postfix), cms.InputTag("PFCandidateJetsWithEEnoise"+postfix,"jets"))
+        return (cms.InputTag("pfCandidatesGoodEE2017"+postfix), cms.InputTag("PFCandidateJetsWithEEnoise"+postfix,"good"))
 
 #========================================================================================
 runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -276,6 +276,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if reclusterJets:
             self.setParameter('jetCollectionUnskimmed',cms.InputTag('patJets'))
 
+
         self.apply(process)
 
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1761,6 +1761,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
     # function to implement the 2017 EE fix
     def runFixEE2017(self,process,params,jets,cands,goodcolls,postfix):
+
+        task = getPatAlgosToolsTask(process)
+
         PFCandidateJetsWithEEnoise = cms.EDProducer("BadPFCandidateJetsEEnoiseProducer",
             jetsrc = jets,
             userawPt = cms.bool(params["userawPt"]),

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1763,10 +1763,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
     def runFixEE2017(self,process,params,jets,cands,goodcolls,postfix):
         PFCandidateJetsWithEEnoise = cms.EDProducer("BadPFCandidateJetsEEnoiseProducer",
             jetsrc = jets,
-            userawPt = params["userawPt"],
-            PtThreshold = params["PtThreshold"],
-            MinEtaThreshold = params["MinEtaThreshold"],
-            MaxEtaThreshold = params["MaxEtaThreshold"],
+            userawPt = cms.bool(params["userawPt"]),
+            PtThreshold = cms.double(params["PtThreshold"]),
+            MinEtaThreshold = cms.double(params["MinEtaThreshold"]),
+            MaxEtaThreshold = cms.double(params["MaxEtaThreshold"]),
         )
         addToProcessAndTask("PFCandidateJetsWithEEnoise"+postfix, PFCandidateJetsWithEEnoise, process, task)
         pfcandidateClustered = cms.EDProducer("CandViewMerger",

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1406,7 +1406,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors
 
         patJetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
-            src = cms.InputTag("slimmedJets" if not self._parameters["Puppi"].value else "slimmedJetsPuppi"),
+            src = jetCollection if not self._parameters["Puppi"].value else cms.InputTag("slimmedJetsPuppi"),
             levels = ['L1FastJet', 
                       'L2Relative', 
                       'L3Absolute'],
@@ -1417,7 +1417,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJets
         patJetsReapplyJEC = updatedPatJets.clone(
-            jetSource = cms.InputTag("slimmedJets" if not self._parameters["Puppi"].value else "slimmedJetsPuppi"),
+            jetSource = jetCollection if not self._parameters["Puppi"].value else cms.InputTag("slimmedJetsPuppi"),
             jetCorrFactorsSource = cms.VInputTag(cms.InputTag("patJetCorrFactorsReapplyJEC"+postfix))
             )
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -89,7 +89,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                           "Technical parameter to identify the resulting sequence and its modules (allows multiple calls in a job)", Type=str)
         self.addParameter(self._defaultParameters,'fixEE2017', False,
                           "Exclude jets and PF candidates with EE noise characteristics (fix for 2017 run)", Type=bool)
-        self.addParameter(self._defaultParameters,'fixEE2017Params', {'userawPt': True, 'PtThreshold': 75.0, 'MinEtaThreshold': 2.65, 'MaxEtaThreshold': 3.139},
+        self.addParameter(self._defaultParameters,'fixEE2017Params', {'userawPt': True, 'PtThreshold': 50.0, 'MinEtaThreshold': 2.65, 'MaxEtaThreshold': 3.139},
                           "Parameters dict for fixEE2017: userawPt, PtThreshold, MinEtaThreshold, MaxEtaThreshold", Type=dict)
 
         #private parameters

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -183,6 +183,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             recoMetFromPFCs =  self._defaultParameters['recoMetFromPFCs'].value
         if reapplyJEC is None :
             reapplyJEC = self._defaultParameters['reapplyJEC'].value
+        reclusterJetsIsNone = (reclusterJets is None)
         if reclusterJets is None :
             reclusterJets = self._defaultParameters['reclusterJets'].value
         if CHS is None :
@@ -245,7 +246,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             self.jetConfiguration()
 
         #met reprocessing and jet reclustering
-        if recoMetFromPFCs:
+        if recoMetFromPFCs and reclusterJetsIsNone:
             self.setParameter('reclusterJets',True)
 
         #ZD: puppi jet reclustering breaks the puppi jets
@@ -1834,7 +1835,7 @@ def runMetCorAndUncFromMiniAOD(process, metType="PF",
                                jetCleaning="LepClean",
                                isData=False,
                                manualJetConfig=False,
-                               reclusterJets=False,
+                               reclusterJets=None,
                                jetSelection="pt>15 && abs(eta)<9.9",
                                recoMetFromPFCs=False,
                                jetCorLabelL3="ak4PFCHSL1FastL2L3Corrector",

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -89,8 +89,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                           "Technical parameter to identify the resulting sequence and its modules (allows multiple calls in a job)", Type=str)
         self.addParameter(self._defaultParameters,'fixEE2017', False,
                           "Exclude jets and PF candidates with EE noise characteristics (fix for 2017 run)", Type=bool)
-        self.addParameter(self._defaultParameters,'fixEE2017Params', {'userawPt': True, 'PtThreshold': 50.0, 'MinEtaThreshold': 2.65, 'MaxEtaThreshold': 3.139},
-                          "Parameters dict for fixEE2017: userawPt, PtThreshold, MinEtaThreshold, MaxEtaThreshold", Type=dict)
+        self.addParameter(self._defaultParameters,'fixEE2017Params', {'userawPt': True, 'ptThreshold': 50.0, 'minEtaThreshold': 2.65, 'maxEtaThreshold': 3.139},
+                          "Parameters dict for fixEE2017: userawPt, ptThreshold, minEtaThreshold, maxEtaThreshold", Type=dict)
 
         #private parameters
         self.addParameter(self._defaultParameters, 'Puppi', False,
@@ -1780,15 +1780,15 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         task = getPatAlgosToolsTask(process)
 
-        PFCandidateJetsWithEEnoise = cms.EDProducer("BadPFCandidateJetsEEnoiseProducer",
+        pfCandidateJetsWithEEnoise = cms.EDProducer("BadPFCandidateJetsEEnoiseProducer",
             jetsrc = jets,
             userawPt = cms.bool(params["userawPt"]),
-            PtThreshold = cms.double(params["PtThreshold"]),
-            MinEtaThreshold = cms.double(params["MinEtaThreshold"]),
-            MaxEtaThreshold = cms.double(params["MaxEtaThreshold"]),
+            ptThreshold = cms.double(params["ptThreshold"]),
+            minEtaThreshold = cms.double(params["minEtaThreshold"]),
+            maxEtaThreshold = cms.double(params["maxEtaThreshold"]),
         )
-        addToProcessAndTask("PFCandidateJetsWithEEnoise"+postfix, PFCandidateJetsWithEEnoise, process, task)
-        patMetModuleSequence += getattr(process,"PFCandidateJetsWithEEnoise"+postfix)
+        addToProcessAndTask("pfCandidateJetsWithEEnoise"+postfix, pfCandidateJetsWithEEnoise, process, task)
+        patMetModuleSequence += getattr(process,"pfCandidateJetsWithEEnoise"+postfix)
         pfcandidateClustered = cms.EDProducer("CandViewMerger",
             src = cms.VInputTag(goodcolls+[jets])
         )
@@ -1802,7 +1802,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         patMetModuleSequence += getattr(process,"pfcandidateForUnclusteredUnc"+postfix)
         badUnclustered = cms.EDFilter("CandPtrSelector",
             src = cms.InputTag("pfcandidateForUnclusteredUnc"+postfix),
-            cut = cms.string("abs(eta) > "+str(params["MinEtaThreshold"])+" && abs(eta) < "+str(params["MaxEtaThreshold"])),
+            cut = cms.string("abs(eta) > "+str(params["minEtaThreshold"])+" && abs(eta) < "+str(params["maxEtaThreshold"])),
         )
         addToProcessAndTask("badUnclustered"+postfix, badUnclustered, process, task)
         patMetModuleSequence += getattr(process,"badUnclustered"+postfix)
@@ -1814,7 +1814,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         superbad = cms.EDProducer("CandViewMerger",
             src = cms.VInputTag(
                 cms.InputTag("blobUnclustered"+postfix),
-                cms.InputTag("PFCandidateJetsWithEEnoise"+postfix,"bad"),
+                cms.InputTag("pfCandidateJetsWithEEnoise"+postfix,"bad"),
             )
         )
         addToProcessAndTask("superbad"+postfix, superbad, process, task)
@@ -1826,7 +1826,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         addToProcessAndTask("pfCandidatesGoodEE2017"+postfix, pfCandidatesGoodEE2017, process, task)
         patMetModuleSequence += getattr(process,"pfCandidatesGoodEE2017"+postfix)
         # return good cands and jets
-        return (cms.InputTag("pfCandidatesGoodEE2017"+postfix), cms.InputTag("PFCandidateJetsWithEEnoise"+postfix,"good"))
+        return (cms.InputTag("pfCandidatesGoodEE2017"+postfix), cms.InputTag("pfCandidateJetsWithEEnoise"+postfix,"good"))
 
 #========================================================================================
 runMETCorrectionsAndUncertainties = RunMETCorrectionsAndUncertainties()


### PR DESCRIPTION
This Pull Request includes the recipe which was created for the EE noise mitigation in 2017 data. It removes bad pf candidates clustered to jets by adding new modules for fix EE in MET tool. It adds the fixEE2017 and fixEE2017Params parameters to MET tool.

This recipe creates a new pfcandidates collection which does not include the lower pt jets in the high-eta endcap region which are mostly affected by EE noise. It removes all jets and associated PF candidates with pt<50 GeV and 2.65 <|eta| < 3.139 before calculating MET.

More details of the recipe can be found here: https://indico.cern.ch/event/759372/contributions/3149378/attachments/1721436/2802416/metreport.pdf

cc: @peruzzim