### PR TITLE
[102X] Change GT. Update offline GTs.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,9 +24,9 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '102X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '102X_dataRun2_v5',
+    'run1_data'         :   '102X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '102X_dataRun2_v5',
+    'run2_data'         :   '102X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '102X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '102X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '102X_dataRun2_v4',
+    'run1_data'         :   '102X_dataRun2_v5',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '102X_dataRun2_v4',
+    'run2_data'         :   '102X_dataRun2_v5',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '102X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '102X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '102X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
# Offline Data
102X_dataRun2_v6 is identical to the validated GT for the 2018 ReReco
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_v4/102X_dataRun2_v6

# Offline Data Relval
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_relval_v6/102X_dataRun2_relval_v7