### PR TITLE
Update rechit calibration: dEdX weights, fCPerMIP, thickness corrections

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -56,6 +56,61 @@ dEdX_weights = cms.vdouble(0.0,   # there is no layer zero
                            92.196,
                            46.098)
 
+dEdX_weights_v9 = cms.vdouble(0.0,      # there is no layer zero
+                              8.366557, # Mev
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              10.425456,  
+                              31.497849,  
+                              51.205434,  
+                              52.030486,  
+                              52.030486,  
+                              52.030486,  
+                              52.030486,  
+                              52.030486,  
+                              52.030486,  
+                              52.030486,  
+                              52.030486,  
+                              52.030486,  
+                              52.030486,  
+                              71.265149,  
+                              90.499812,  
+                              90.894274,  
+                              90.537470,  
+                              89.786205,  
+                              89.786205,  
+                              89.786205,  
+                              89.786205,  
+                              89.786205,  
+                              89.786205,  
+                              89.786205,  
+                              89.786205,  
+                              89.786205)
+
+
 # HGCAL rechit producer
 HGCalRecHit = cms.EDProducer(
     "HGCalRecHitProducer",
@@ -94,4 +149,6 @@ HGCalRecHit = cms.EDProducer(
 
     )
 
-
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify( HGCalRecHit , layerWeights = dEdX_weights_v9 ) 
+phase2_hgcalV9.toModify( HGCalRecHit , thicknessCorrection = cms.vdouble(0.759,0.760,0.773) ) #120um, 200um, 300um

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -47,3 +47,7 @@ HGCalUncalibRecHit = cms.EDProducer(
 
     algo = cms.string("HGCalUncalibRecHitWorkerWeights")
 )
+
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify( HGCalUncalibRecHit.HGCEEConfig , fCPerMIP = cms.vdouble(2.06,3.43,5.15) ) #120um, 200um, 300um
+phase2_hgcalV9.toModify( HGCalUncalibRecHit.HGCHEFConfig , fCPerMIP = cms.vdouble(2.06,3.43,5.15) ) #120um, 200um, 300um

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer
 
+fCPerMIP_v9 = cms.vdouble(2.06,3.43,5.15) #120um, 200um, 300um
+
 # HGCAL producer of rechits starting from digis
 HGCalUncalibRecHit = cms.EDProducer(
     "HGCalUncalibRecHitProducer",
@@ -49,5 +51,5 @@ HGCalUncalibRecHit = cms.EDProducer(
 )
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
-phase2_hgcalV9.toModify( HGCalUncalibRecHit.HGCEEConfig , fCPerMIP = cms.vdouble(2.06,3.43,5.15) ) #120um, 200um, 300um
-phase2_hgcalV9.toModify( HGCalUncalibRecHit.HGCHEFConfig , fCPerMIP = cms.vdouble(2.06,3.43,5.15) ) #120um, 200um, 300um
+phase2_hgcalV9.toModify( HGCalUncalibRecHit.HGCEEConfig , fCPerMIP = fCPerMIP_v9 ) 
+phase2_hgcalV9.toModify( HGCalUncalibRecHit.HGCHEFConfig , fCPerMIP = fCPerMIP_v9 ) 


### PR DESCRIPTION
This PR includes the work done with @rovere, @felicepantaleo, @amartelli, @clelange on the new dEdX weights, fCPerMIP and thickness correction factors in the context of the HGCal DPG. 

The slides describing the calculation can be seen in this [link](https://indico.cern.ch/event/763724/contributions/3170075/attachments/1729687/2794958/HGaldEdxandHitCalib_08_10_2018_CMG_HGCal.pdf).