### PR TITLE
Calo Layer 2 saturation fixes **10_3_X BACKPORT**

### DIFF
--- a/EventFilter/L1TRawToDigi/utils/unpackBuffers-CaloStage2.py
+++ b/EventFilter/L1TRawToDigi/utils/unpackBuffers-CaloStage2.py
@@ -288,7 +288,8 @@ if (options.doDemux):
 
 process.stage2DemuxRaw.nFramesPerEvent    = cms.untracked.int32(options.dmFramesPerEvent)
 process.stage2DemuxRaw.nFramesOffset    = cms.untracked.vuint32(dmOffset)
-process.stage2DemuxRaw.nFramesLatency   = cms.untracked.vuint32(options.dmLatency)
+# add 1 to demux latency to take account of header, match online definition of latency
+process.stage2DemuxRaw.nFramesLatency   = cms.untracked.vuint32(options.dmLatency+1)
 process.stage2DemuxRaw.rxFile = cms.untracked.string("demux_rx_summary.txt")
 process.stage2DemuxRaw.txFile = cms.untracked.string("demux_tx_summary.txt")
 process.stage2DemuxRaw.fwVersion = cms.untracked.int32(options.demuxFWVersion)

--- a/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_cfi.py
@@ -104,8 +104,8 @@ caloStage2Params.etSumYCalibrationType    = cms.string("None")
 caloStage2Params.etSumEttCalibrationType  = cms.string("None")
 caloStage2Params.etSumEcalSumCalibrationType = cms.string("None")
 
-caloStage2Params.etSumCentralityLower = cms.vdouble(0.0, 2.5,  13.5,  133.0, 411.5,  1101.5, 2494.5, 65535.0)
-caloStage2Params.etSumCentralityUpper = cms.vdouble(8.0, 25.5, 208.0, 567.5, 1349.5, 2790.5, 5114.0, 65535.0)
+caloStage2Params.etSumCentralityLower = cms.vdouble(0.5, 1.5, 7.0, 71.0, 219.5, 583.5, 1310.5, 65535.0)
+caloStage2Params.etSumCentralityUpper = cms.vdouble(4.0, 13.5, 111.0, 302.0, 713.5, 1464.5, 2664.0, 65535.0)
 
 caloStage2Params.etSumMetPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_2017v7.txt")
 caloStage2Params.etSumEttPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt")

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxJetAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxJetAlgoFirmwareImp1.cc
@@ -51,7 +51,7 @@ void l1t::Stage2Layer2DemuxJetAlgoFirmwareImp1::processEvent(const std::vector<l
   // convert eta to GT coordinates
   for(auto& jet : outputJets){
 
-    int gtEt = jet.hwPt() == 0xFFFF ? 0x7FF :  jet.hwPt();
+    int gtEt = jet.hwPt() > 0x7FF ? 0x7FF :  jet.hwPt();
     int gtEta = CaloTools::gtEta(CaloTools::mpEta(jet.hwEta()));
     int gtPhi = CaloTools::gtPhi(CaloTools::mpEta(jet.hwEta()),jet.hwPhi());
     

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -111,10 +111,16 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::create(const std::vector<l1t::Ca
 	  
 	  int seedEt = tow.hwPt();
 	  int iEt = seedEt;
+	  bool satSeed = false;
 	  bool vetoCandidate = false;
 	  
 	  // check it passes the seed threshold
 	  if(iEt < floor(params_->jetSeedThreshold()/params_->towerLsbSum())) continue;
+
+	  if (seedEt == CaloTools::kSatHcal ||
+	      seedEt == CaloTools::kSatEcal ||
+	      seedEt == CaloTools::kSatTower)
+	    satSeed=true;
 	  
 	  // loop over towers in this jet
 	  for( int deta = -4; deta < 5; ++deta ) {
@@ -157,7 +163,8 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::create(const std::vector<l1t::Ca
 	    int caloEta = CaloTools::caloEta(ieta);
 	    l1t::Jet jet( p4, -999, caloEta, iphi, 0);
 
-	    if(!params_->jetBypassPUS()){
+	    if(!params_->jetBypassPUS()
+	       && !satSeed){
 	      if (PUSubMethod == "Donut") {
 		puEt = donutPUEstimate(ieta, iphi, 5, towers);	    
 		iEt -= puEt;


### PR DESCRIPTION
- Fix saturation handling for HI centrality and asymmetry algorithms
- Update centrality classes in HI caloParams config 
- Fix MP & Demux jet saturation handling
- Fix Demux MET & MHT saturation handling
- Correct buffer unpacker to use same demux latency convention as online

Apart from the HI specific changes, the rest are edge cases in saturation handling that were discovered by running events with many high energy towers through the MP firmware and checking MP & demux output vs. emulator.