### PR TITLE
Fixes for online beamspot, heavy-ion run in 2018

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -2,56 +2,76 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("BeamMonitor", eras.Run2_2018)
+#process = cms.Process("BeamMonitor", eras.Run2_2018) FIXME
+process = cms.Process("BeamMonitor", eras.Run2_2018_pp_on_AA)
 
-#----------------------------------------------                                                                                                                                    
-# Switch to change between firstStep and Pixel
-#-----------------------------------------------
+#
+process.MessageLogger = cms.Service("MessageLogger",
+    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING')
+    ),
+    destinations = cms.untracked.vstring('cerr')
+)
 
-runFirstStepTrk = False
+# switch
+live = True # FIXME
 
-#----------------------------
-# Common part for PP and H.I Running
-#-----------------------------
-# for live online DQM in P5
-process.load("DQM.Integration.config.inputsource_cfi")
-
-# for testing in lxplus
-#process.load("DQM.Integration.config.fileinputsource_cfi")
+#---------------
+# Input sources
+if (live):
+    process.load("DQM.Integration.config.inputsource_cfi")
+else:
+    process.load("DQM.Integration.config.fileinputsource_cfi")
 
 #--------------------------
 # HLT Filter
-# 0=random, 1=physics, 2=calibration, 3=technical
 process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
-    SelectedTriggerType = cms.int32(1)
+    SelectedTriggerType = cms.int32(1) # physics
 )
 
 #----------------------------
 # DQM Live Environment
-#-----------------------------
 process.load("DQM.Integration.config.environment_cfi")
 process.dqmEnv.subSystemFolder = 'BeamMonitor'
-process.dqmSaver.tag = 'BeamMonitor'
+process.dqmSaver.tag           = 'BeamMonitor'
 
 process.dqmEnvPixelLess = process.dqmEnv.clone()
 process.dqmEnvPixelLess.subSystemFolder = 'BeamMonitor_PixelLess'
 
+#---------------
+# Conditions
+if (live):
+    process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+else:
+    process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+    from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+    # you may need to set manually the GT in the line below
+    process.GlobalTag.globaltag = '100X_upgrade2018_realistic_v10'
+
 #----------------------------
 # BeamMonitor
-#-----------------------------
-
-if(runFirstStepTrk):
-  process.load("DQM.BeamMonitor.BeamMonitor_cff") # for reduced/firsStep/normal tracking
-else:
-  process.load("DQM.BeamMonitor.BeamMonitor_Pixel_cff") #for pixel tracks/vertices
-
+process.load("DQM.BeamMonitor.BeamMonitor_Pixel_cff")
 process.load("DQM.BeamMonitor.BeamSpotProblemMonitor_cff")
-#process.load("DQM.BeamMonitor.BeamMonitorBx_cff")
-#process.load("DQM.BeamMonitor.BeamMonitor_PixelLess_cff")
 process.load("DQM.BeamMonitor.BeamConditionsMonitor_cff")
 
+if process.dqmRunConfig.type.value() is "production":
+  process.dqmBeamMonitor.BeamFitter.WriteAscii = True
+  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResultsOld.txt'
+  process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
+  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsOld.txt'
+else:
+  process.dqmBeamMonitor.BeamFitter.WriteAscii = False
+  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResultsOld.txt'
+  process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
+  if (live):
+    process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmdev/BeamMonitorDQM/BeamFitResultsOld.txt'
+  else:
+    process.dqmBeamMonitor.BeamFitter.DIPFileName = 'BeamFitResultsOld.txt'
 
-####  SETUP TRACKING RECONSTRUCTION ####
+#----------------
+# Setup tracking
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
@@ -63,48 +83,11 @@ process.siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(
 )
 process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi")
 
-
-#---------------
-# Calibration
-#---------------
-# Condition for P5 cluster
-process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Condition for lxplus: change and possibly customise the GT
-#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
-
-# Change Beam Monitor variables
-if process.dqmRunConfig.type.value() is "production":
-  process.dqmBeamMonitor.BeamFitter.WriteAscii = True
-  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResultsOld.txt'
-  process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
-  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsOld.txt'
-else:
-  process.dqmBeamMonitor.BeamFitter.WriteAscii = False
-  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResultsOld.txt'
-  process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
-  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmdev/BeamMonitorDQM/BeamFitResultsOld.txt'
-
-
-#----------------------------
+#-----------------
 # TrackingMonitor
-#-----------------------------
-# first, tracks selection as in https://github.com/cms-sw/cmssw/blob/master/DQM/BeamMonitor/python/BeamMonitor_Pixel_cff.py
-# -MinimumPt = cms.untracked.double(1.0),
-# -MaximumEta = cms.untracked.double(2.4),
-# -MaximumImpactParameter = cms.untracked.double(1.0),
-# -MaximumZ = cms.untracked.double(60),
-# -MinimumTotalLayers = cms.untracked.int32(3),
-# -MinimumPixelLayers = cms.untracked.int32(3),
-# -MaximumNormChi2 = cms.untracked.double(30.0),
-
-#### while hitPattern().trackerLayersWithMeasurement() and hitPattern().pixelLayersWithMeasurement() !!!
-#### =>
-#### select tracks based on MaximumImpactParameter, MaximumZ, MinimumTotalLayers, MinimumPixelLayers and MaximumNormChi2
 process.pixelTracksCutClassifier = cms.EDProducer( "TrackCutClassifier",
     src = cms.InputTag( "pixelTracks" ),
     beamspot = cms.InputTag( "offlineBeamSpot" ),
-#    vertices = cms.InputTag( "pixelVertices" ),
     vertices = cms.InputTag( "" ),
     qualityCuts = cms.vdouble( -0.7, 0.1, 0.7 ),
     mva = cms.PSet(
@@ -133,6 +116,8 @@ process.pixelTracksCutClassifier = cms.EDProducer( "TrackCutClassifier",
     ),
     ignoreVertices = cms.bool( True ),
 )
+
+#
 process.pixelTracksHP = cms.EDProducer( "TrackCollectionFilterCloner",
     minQuality = cms.string( "highPurity" ),
     copyExtras = cms.untracked.bool( True ),
@@ -142,17 +127,18 @@ process.pixelTracksHP = cms.EDProducer( "TrackCollectionFilterCloner",
     originalMVAVals = cms.InputTag( 'pixelTracksCutClassifier','MVAValues' )
 )
 
+#-------------------------------------
+# PixelTracksMonitor
+
 import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
 process.pixelTracksMonitor = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-process.pixelTracksMonitor.FolderName                = 'BeamMonitor/Tracking/pixelTracks'
-if (runFirstStepTrk):
-  process.pixelTracksMonitor.TrackProducer             = 'initialStepTracksPreSplitting'
-  process.pixelTracksMonitor.allTrackProducer          = 'initialStepTracksPreSplitting'
-else:
-  process.pixelTracksMonitor.TrackProducer             = 'pixelTracks'
-  process.pixelTracksMonitor.allTrackProducer          = 'pixelTracks'
-process.pixelTracksMonitor.beamSpot                  = "offlineBeamSpot"
-process.pixelTracksMonitor.primaryVertex             = "pixelVertices"
+
+process.pixelTracksMonitor.FolderName       = 'BeamMonitor/Tracking/pixelTracks'
+process.pixelTracksMonitor.TrackProducer    = 'pixelTracks'
+process.pixelTracksMonitor.allTrackProducer = 'pixelTracks'
+process.pixelTracksMonitor.beamSpot         = "offlineBeamSpot"
+process.pixelTracksMonitor.primaryVertex    = "pixelVertices"
+
 process.pixelTracksMonitor.doAllPlots                = cms.bool(False)
 process.pixelTracksMonitor.doLumiAnalysis            = cms.bool(False)
 process.pixelTracksMonitor.doProfilesVsLS            = cms.bool(True)
@@ -164,357 +150,195 @@ process.pixelTracksMonitor.doEffFromHitPatternVsLUMI = cms.bool(False)
 process.pixelTracksMonitor.doPlotsVsGoodPVtx         = cms.bool(True)
 process.pixelTracksMonitor.doPlotsVsLUMI             = cms.bool(True)
 process.pixelTracksMonitor.doPlotsVsBX               = cms.bool(True)
+
 process.pixelTracksMonitor.AbsDxyMax  =   1.2
 process.pixelTracksMonitor.AbsDxyBin  =  12
+
 process.pixelTracksMonitor.DxyMin     =  -1.2
 process.pixelTracksMonitor.DxyMax     =   1.2
 process.pixelTracksMonitor.DxyBin     =  60
+
 process.pixelTracksMonitor.Chi2NDFMax =  35.
 process.pixelTracksMonitor.Chi2NDFMin =   0.
 process.pixelTracksMonitor.Chi2NDFBin =  70
-process.pixelTracksMonitor.VZBin      = 124
-process.pixelTracksMonitor.VZMin      = -62.
-process.pixelTracksMonitor.VZMax      =  62.
-process.pixelTracksMonitor.TrackPtMin =   0.
-process.pixelTracksMonitor.TrackPtMax =  50.
-process.pixelTracksMonitor.TrackPtBin = 250
 
+process.pixelTracksMonitor.VZBin      =  124
+process.pixelTracksMonitor.VZMin      =  -62.
+process.pixelTracksMonitor.VZMax      =   62.
+
+process.pixelTracksMonitor.TrackPtMin =    0.
+process.pixelTracksMonitor.TrackPtMax =   50.
+process.pixelTracksMonitor.TrackPtBin =  250
+
+#
 process.tracks2monitor = cms.EDFilter('TrackSelector',
     src = cms.InputTag('pixelTracks'),
     cut = cms.string("")
 )
 process.tracks2monitor.src = 'pixelTracksHP'
-process.tracks2monitor.cut = 'pt > 1 & abs(eta) < 2.4' # & normalizedChi2 < 30. abs(dxy) < 1. abs(dz) < 60.'
+process.tracks2monitor.cut = 'pt > 1 & abs(eta) < 2.4' 
 
 
+#
 process.selectedPixelTracksMonitor = process.pixelTracksMonitor.clone()
-process.selectedPixelTracksMonitor.FolderName                = 'BeamMonitor/Tracking/selectedPixelTracks'
-if (runFirstStepTrk):
-  process.selectedPixelTracksMonitor.TrackProducer             = 'initialStepTracksPreSplitting'
-  process.selectedPixelTracksMonitor.allTrackProducer          = 'initialStepTracksPreSplitting'
-else:
-  process.selectedPixelTracksMonitor.TrackProducer             = 'tracks2monitor'
-  process.selectedPixelTracksMonitor.allTrackProducer          = 'tracks2monitor'
+process.selectedPixelTracksMonitor.FolderName       = 'BeamMonitor/Tracking/selectedPixelTracks'
+process.selectedPixelTracksMonitor.TrackProducer    = 'tracks2monitor'
+process.selectedPixelTracksMonitor.allTrackProducer = 'tracks2monitor'
 
 process.selectedPixelTracksMonitorSequence = cms.Sequence(
-  process.pixelTracksCutClassifier
+    process.pixelTracksCutClassifier
   + process.pixelTracksHP
   + process.tracks2monitor
   + process.selectedPixelTracksMonitor
 )
 
 
-## TKStatus
+#---------------------------------
+# Putting together combined paths
+
+#
 process.dqmTKStatus = cms.EDAnalyzer("TKStatus",
-        BeamFitter = cms.PSet(
+    BeamFitter = cms.PSet(
         DIPFileName = process.dqmBeamMonitor.BeamFitter.DIPFileName
-        )
+    )
 )
 
-
+#
 process.dqmcommon = cms.Sequence(process.dqmEnv
-                                *process.dqmSaver)
+                               * process.dqmSaver)
 
-process.monitor = cms.Sequence(process.dqmBeamMonitor + process.selectedPixelTracksMonitorSequence)
+#
+process.monitor = cms.Sequence(process.dqmBeamMonitor
+                             + process.selectedPixelTracksMonitorSequence)
 
+#------------------------
+# BeamSpotProblemMonitor
 
-#------------------------------------------------------------
-# BeamSpotProblemMonitor Modules
-#-----------------------------------------------------------
-process.dqmBeamSpotProblemMonitor.monitorName       = "BeamMonitor/BeamSpotProblemMonitor"
-process.dqmBeamSpotProblemMonitor.AlarmONThreshold  = 15 # 10
-process.dqmBeamSpotProblemMonitor.AlarmOFFThreshold = 17 # 12
+#
+process.dqmBeamSpotProblemMonitor.monitorName = "BeamMonitor/BeamSpotProblemMonitor"
+process.dqmBeamSpotProblemMonitor.AlarmONThreshold  = 15 # was 10
+process.dqmBeamSpotProblemMonitor.AlarmOFFThreshold = 17 # was 12
 process.dqmBeamSpotProblemMonitor.nCosmicTrk        = 10
 process.dqmBeamSpotProblemMonitor.doTest            = False
-if (runFirstStepTrk):
-    process.dqmBeamSpotProblemMonitor.pixelTracks   = 'initialStepTracksPreSplitting'
-else:
-    process.dqmBeamSpotProblemMonitor.pixelTracks   = 'pixelTracks'
+process.dqmBeamSpotProblemMonitor.pixelTracks  = 'pixelTracks'
 
-
+#
 process.qTester = cms.EDAnalyzer("QualityTester",
-                                 qtList = cms.untracked.FileInPath('DQM/BeamMonitor/test/BeamSpotAvailableTest.xml'),
-                                 prescaleFactor = cms.untracked.int32(1),                               
-                                 qtestOnEndLumi = cms.untracked.bool(True),
-                                 testInEventloop = cms.untracked.bool(False),
-                                 verboseQT =  cms.untracked.bool(True)                 
-                                )
+    qtList = cms.untracked.FileInPath('DQM/BeamMonitor/test/BeamSpotAvailableTest.xml'),
+    prescaleFactor = cms.untracked.int32(1),                               
+    qtestOnEndLumi = cms.untracked.bool(True),
+    testInEventloop = cms.untracked.bool(False),
+    verboseQT =  cms.untracked.bool(True)                 
+)
 
-process.BeamSpotProblemModule = cms.Sequence( process.qTester
- 	  	                             *process.dqmBeamSpotProblemMonitor
-                                            )
+#
+process.BeamSpotProblemModule = cms.Sequence(process.qTester
+ 	  	                           * process.dqmBeamSpotProblemMonitor)
 
-#make it off for cosmic run
-if ( process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1):
-    process.dqmBeamSpotProblemMonitor.AlarmOFFThreshold = 5       #Should be < AlalrmONThreshold 
-#-----------------------------------------------------------
+# make it off for cosmic run
+if ( process.runType.getRunType() == process.runType.cosmic_run or
+     process.runType.getRunType() == process.runType.cosmic_run_stage1):
+    process.dqmBeamSpotProblemMonitor.AlarmOFFThreshold = 5 # <AlarmONThreshold
 
-### process customizations included here
+#------------------------
+# Process customizations
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
 
+#------------------------
+# Set rawDataRepacker (HI and live) or rawDataCollector (for all the rest)
+if (process.runType.getRunType() == process.runType.hi_run and live):
+    rawDataInputTag = cms.InputTag("rawDataRepacker")
+else:
+    rawDataInputTag = cms.InputTag("rawDataCollector")
 
-#--------------------------
-# Proton-Proton Stuff
-#--------------------------
+process.castorDigis.InputLabel           = rawDataInputTag
+process.csctfDigis.producer              = rawDataInputTag 
+process.dttfDigis.DTTF_FED_Source        = rawDataInputTag
+process.ecalDigis.InputLabel             = rawDataInputTag
+process.ecalPreshowerDigis.sourceTag     = rawDataInputTag
+process.gctDigis.inputLabel              = rawDataInputTag
+process.gtDigis.DaqGtInputTag            = rawDataInputTag
+process.hcalDigis.InputLabel             = rawDataInputTag
+process.muonCSCDigis.InputObjects        = rawDataInputTag
+process.muonDTDigis.inputLabel           = rawDataInputTag
+process.muonRPCDigis.InputLabel          = rawDataInputTag
+process.scalersRawToDigi.scalersInputTag = rawDataInputTag
+process.siPixelDigis.InputLabel          = rawDataInputTag
+process.siStripDigis.ProductLabel        = rawDataInputTag
 
-if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.pp_run_stage1 or
-    process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1 or 
-    process.runType.getRunType() == process.runType.hpu_run):
+process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
-    print("[beam_dqm_sourceclient-live_cfg]:: Running pp")
+process.dqmBeamMonitor.OnlineMode = True
 
-    process.castorDigis.InputLabel = cms.InputTag("rawDataCollector")
-    process.csctfDigis.producer = cms.InputTag("rawDataCollector")
-    process.dttfDigis.DTTF_FED_Source = cms.InputTag("rawDataCollector")
-    process.ecalDigis.InputLabel = cms.InputTag("rawDataCollector")
-    process.ecalPreshowerDigis.sourceTag = cms.InputTag("rawDataCollector")
-    process.gctDigis.inputLabel = cms.InputTag("rawDataCollector")
-    process.gtDigis.DaqGtInputTag = cms.InputTag("rawDataCollector")
-    process.hcalDigis.InputLabel = cms.InputTag("rawDataCollector")
-    process.muonCSCDigis.InputObjects = cms.InputTag("rawDataCollector")
-    process.muonDTDigis.inputLabel = cms.InputTag("rawDataCollector")
-    process.muonRPCDigis.InputLabel = cms.InputTag("rawDataCollector")
-    process.scalersRawToDigi.scalersInputTag = cms.InputTag("rawDataCollector")
-    process.siPixelDigis.InputLabel = cms.InputTag("rawDataCollector")
-    process.siStripDigis.ProductLabel = cms.InputTag("rawDataCollector")
+process.dqmBeamMonitor.resetEveryNLumi   = 5 # was 10 for HI
+process.dqmBeamMonitor.resetPVEveryNLumi = 5 # was 10 for HI
 
+process.dqmBeamMonitor.PVFitter.minNrVerticesForFit = 20
+process.dqmBeamMonitor.PVFitter.minVertexNdf = 10
+process.dqmBeamMonitor.PVFitter.errorScale = 1.22
 
-    process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
+#----------------------------
+# Pixel tracks/vertices reco
+process.load("RecoPixelVertexing.Configuration.RecoPixelVertexing_cff")
+process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
+process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 12
+process.pixelTracksTrackingRegions.RegionPSet.originXPos =  0.08
+process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
+process.pixelTracksTrackingRegions.RegionPSet.originZPos = 0.
 
-    process.dqmBeamMonitor.OnlineMode = True              
-    process.dqmBeamMonitor.resetEveryNLumi = 5
-    process.dqmBeamMonitor.resetPVEveryNLumi = 5
-    process.dqmBeamMonitor.PVFitter.minNrVerticesForFit = 20
-    process.dqmBeamMonitor.PVFitter.minVertexNdf = 10
-  
+process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
 
-    if (runFirstStepTrk): # for first Step Tracking
-        print("[beam_dqm_sourceclient-live_cfg]:: firstStepTracking")
-        # Import TrackerLocalReco sequence
-        process.load('RecoLocalTracker.Configuration.RecoLocalTracker_cff')
-        # Import MeasurementTrackerEvents used during patter recognition
-        process.load('RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi')
-        #Import stuff to run the initial step - PreSplitting - of the
-        #iterative tracking and remove Calo-related sequences
-        process.load('RecoTracker.IterativeTracking.InitialStepPreSplitting_cff')
-        process.InitialStepPreSplitting.remove(process.initialStepTrackRefsForJetsPreSplitting)
-        process.InitialStepPreSplitting.remove(process.caloTowerForTrkPreSplitting)
-        process.InitialStepPreSplitting.remove(process.ak4CaloJetsForTrkPreSplitting)
-        process.InitialStepPreSplitting.remove(process.jetsForCoreTrackingPreSplitting)
-        process.InitialStepPreSplitting.remove(process.siPixelClusters)
-        process.InitialStepPreSplitting.remove(process.siPixelRecHits)
-        process.InitialStepPreSplitting.remove(process.MeasurementTrackerEvent)
-        process.InitialStepPreSplitting.remove(process.siPixelClusterShapeCache)
-        # 2016-11-28 MK FIXME: I suppose I should migrate the lines below following the "new seeding framework"
-        #
-        # if z is very far due to bad fit
-        process.initialStepSeedsPreSplitting.RegionFactoryPSet.RegionPSet.originRadius = 1.5
-        process.initialStepSeedsPreSplitting.RegionFactoryPSet.RegionPSet.originHalfLength = cms.double(30.0)
-        #Increase pT threashold at seeding stage (not so accurate)                                                                                      
-        process.initialStepSeedsPreSplitting.RegionFactoryPSet.RegionPSet.ptMin = 0.9
+process.tracking_FirstStep = cms.Sequence(
+      process.siPixelDigis 
+    * process.siStripDigis
+    * process.striptrackerlocalreco
+    * process.offlineBeamSpot
+    * process.siPixelClustersPreSplitting
+    * process.siPixelRecHitsPreSplitting
+    * process.siPixelClusterShapeCachePreSplitting
+    * process.recopixelvertexing)
 
-        # some inputs to BeamMonitor
-        process.dqmBeamMonitor.BeamFitter.TrackCollection = 'initialStepTracksPreSplitting'         
-        process.dqmBeamMonitor.primaryVertex = 'firstStepPrimaryVerticesPreSplitting'
-        process.dqmBeamMonitor.PVFitter.VertexCollection = 'firstStepPrimaryVerticesPreSplitting'
+# triggerName for selecting pv for DIP publication, no wildcard needed here
+# it will pick all triggers which has these strings in theri name
+process.dqmBeamMonitor.jetTrigger  = cms.untracked.vstring(
+         "HLT_PAZeroBias_v", "HLT_ZeroBias_v", "HLT_QuadJet",
+         "HLT_ZeroBias_",
+         "HLT_HI")
 
-        process.dqmBeamMonitor.PVFitter.errorScale = 0.95 #keep checking this with new release expected close to 1
-
-        process.tracking_FirstStep  = cms.Sequence( process.siPixelDigis*
-                                                     process.siStripDigis*
-                                                     process.pixeltrackerlocalreco*
-                                                     process.striptrackerlocalreco*
-                                                     process.offlineBeamSpot*                          
-                                                     process.MeasurementTrackerEventPreSplitting*
-                                                     process.siPixelClusterShapeCachePreSplitting*
-                                                     process.InitialStepPreSplitting
-                                                     )
-    else: # pixel tracking
-        print("[beam_dqm_sourceclient-live_cfg]:: pixelTracking")
-
-
-        #pixel  track/vertices reco
-        process.load("RecoPixelVertexing.Configuration.RecoPixelVertexing_cff")
-        process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-        process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 12
-        process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
-        process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
-        process.pixelTracksTrackingRegions.RegionPSet.originZPos = 0.
-        process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
-
-        process.dqmBeamMonitor.PVFitter.errorScale = 1.22 #keep checking this with new release expected close to 1.2
- 
-        process.tracking_FirstStep  = cms.Sequence(process.siPixelDigis* 
-                                                   process.siStripDigis *
-                                                   process.striptrackerlocalreco *
-                                                   process.offlineBeamSpot*
-                                                   process.siPixelClustersPreSplitting*
-                                                   process.siPixelRecHitsPreSplitting*
-                                                   process.siPixelClusterShapeCachePreSplitting*
-                                                   process.recopixelvertexing
-                                                  )
- 
-
-    #TriggerName for selecting pv for DIP publication, NO wildcard needed here
-    #it will pick all triggers which has these strings in theri name
-    process.dqmBeamMonitor.jetTrigger  = cms.untracked.vstring("HLT_PAZeroBias_v",
-                                                               "HLT_ZeroBias_v", 
-                                                               "HLT_QuadJet")
-
-    process.dqmBeamMonitor.hltResults = cms.InputTag("TriggerResults","","HLT")
-
-
-    process.p = cms.Path(process.scalersRawToDigi
-                         *process.dqmTKStatus
-                         *process.hltTriggerTypeFilter
-                         *process.dqmcommon
-                         *process.tracking_FirstStep
-                         *process.monitor
-                         *process.BeamSpotProblemModule)
-
-
-
-
-
-#--------------------------------------------------
-# Heavy Ion Stuff
-#--------------------------------------------------
+# for HI only: select events based on the pixel cluster multiplicity
 if (process.runType.getRunType() == process.runType.hi_run):
-
-    print("beam_dqm_sourceclient-live_cfg:Running HI")
-    process.castorDigis.InputLabel = cms.InputTag("rawDataRepacker")
-    process.csctfDigis.producer = cms.InputTag("rawDataRepacker")
-    process.dttfDigis.DTTF_FED_Source = cms.InputTag("rawDataRepacker")
-    process.ecalDigis.InputLabel = cms.InputTag("rawDataRepacker")
-    process.ecalPreshowerDigis.sourceTag = cms.InputTag("rawDataRepacker")
-    process.gctDigis.inputLabel = cms.InputTag("rawDataRepacker")
-    process.gtDigis.DaqGtInputTag = cms.InputTag("rawDataRepacker")
-    process.hcalDigis.InputLabel = cms.InputTag("rawDataRepacker")
-    process.muonCSCDigis.InputObjects = cms.InputTag("rawDataRepacker")
-    process.muonDTDigis.inputLabel = cms.InputTag("rawDataRepacker")
-    process.muonRPCDigis.InputLabel = cms.InputTag("rawDataRepacker")
-    process.scalersRawToDigi.scalersInputTag = cms.InputTag("rawDataRepacker")
-    process.siPixelDigis.InputLabel = cms.InputTag("rawDataRepacker")
-    process.siStripDigis.ProductLabel = cms.InputTag("rawDataRepacker")
-
-    #----------------------------
-    # Event Source
-    #-----------------------------
-
-    process.dqmBeamMonitor.OnlineMode = True                  ## in MC the LS are not ordered??
-    process.dqmBeamMonitor.resetEveryNLumi = 10
-    process.dqmBeamMonitor.resetPVEveryNLumi = 10
-
-    process.dqmBeamMonitor.BeamFitter.MinimumTotalLayers = 3   ## using pixel triplets
-    process.dqmBeamMonitor.BeamFitter.MinimumPixelLayers = 3
-    process.dqmBeamMonitor.BeamFitter.MaximumNormChi2    = 30.0
-
-    process.dqmBeamMonitor.PVFitter.minVertexNdf = 4
-    process.dqmBeamMonitor.PVFitter.minNrVerticesForFit = 20
-    process.dqmBeamMonitor.PVFitter.errorScale = 1.25       ## taken from 2012 pixel vtx studies
-
-    process.dqmBeamMonitor.jetTrigger  = cms.untracked.vstring("HLT_HI")
-    process.dqmBeamMonitor.hltResults = cms.InputTag("TriggerResults","","HLT")
-    process.dqmBeamSpotProblemMonitor.pixelTracks = 'hiPixel3PrimTracks'
-
-    # copy from online
-    import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
-    offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
-
-    ## Load Heavy Ion Sequence
-    process.load("Configuration.StandardSequences.ReconstructionHeavyIons_cff") ## HI sequences
-    process.load('RecoLocalTracker.Configuration.RecoLocalTrackerHeavyIons_cff')
-    from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
-    from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
-    siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(
-       src = 'siPixelClustersPreSplitting'
-    )  
-       
-    # Select events based on the pixel cluster multiplicity
-    import  HLTrigger.special.hltPixelActivityFilter_cfi
+    import HLTrigger.special.hltPixelActivityFilter_cfi
     process.multFilter = HLTrigger.special.hltPixelActivityFilter_cfi.hltPixelActivityFilter.clone(
-      inputTag  = cms.InputTag('siPixelClustersPreSplitting'),
-      minClusters = cms.uint32(150),
-      maxClusters = cms.uint32(10000) #80% efficiency in HI MC
-      )
+        inputTag  = cms.InputTag('siPixelClustersPreSplitting'),
+        minClusters = cms.uint32(150),
+        maxClusters = cms.uint32(50000) # was 10000
+    )
        
     process.filter_step = cms.Sequence( process.siPixelDigis
-                                       *process.siPixelClustersPreSplitting
-                                       *process.multFilter
-                                  )
-       
-    from RecoHI.HiTracking.HIPixelVerticesPreSplitting_cff import *
-       
-    process.PixelLayerTriplets.BPix.HitProducer = cms.string('siPixelRecHitsPreSplitting')
-    process.PixelLayerTriplets.FPix.HitProducer = cms.string('siPixelRecHitsPreSplitting')
-
-    process.hiPixel3PrimTracksFilter = process.hiFilter.clone(
-        VertexCollection = "hiSelectedVertexPreSplitting",
-        chi2 = 1000.0,
-        clusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting",
-        lipMax = 0.3,
-        nSigmaLipMaxTolerance = 0,
-        nSigmaTipMaxTolerance = 6.0,
-        ptMin = 0.9,
-        tipMax = 0,
+                                      * process.siPixelClustersPreSplitting
+                                      * process.multFilter
     )
-    process.hiPixel3PrimTracks.Filter = "hiPixel3PrimTracksFilter"
-      
-    process.hiPixel3PrimTracks.RegionFactoryPSet = cms.PSet(
-        ComponentName = cms.string('GlobalTrackingRegionWithVerticesProducer'),
-        RegionPSet = cms.PSet(
-            VertexCollection = cms.InputTag("hiSelectedVertexPreSplitting"),
-            beamSpot = cms.InputTag("offlineBeamSpot"),
-            fixedError = cms.double(0.2),
-            nSigmaZ = cms.double(3.0),
-            originRadius = cms.double(0.1),
-            precise = cms.bool(True),
-            ptMin = cms.double(0.9),
-            sigmaZVertex = cms.double(3.0),
-            useFixedError = cms.bool(True),
-            useFoundVertices = cms.bool(True)
-        )
-        )
-    process.hiPixel3PrimTracks.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet.clusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCachePreSplitting')
-    process.hiPixel3PrimTracks.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet.clusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCachePreSplitting')
-    ## From HI group     
-    process.HIRecoForDQM = cms.Sequence( process.siPixelDigis
-                                        *process.siStripDigis
-                                        *process.offlineBeamSpot  #<-clone of onlineBS
-                                        *process.pixeltrackerlocalreco
-                                        *process.striptrackerlocalreco             
-                                        *process.MeasurementTrackerEventPreSplitting
-                                        *process.siPixelClusterShapeCachePreSplitting
-                                        *process.hiPixelVerticesPreSplitting
-                                        *process.PixelLayerTriplets 
-                                        *process.pixelFitterByHelixProjections
-                                        *process.hiPixel3PrimTracksFilter
-                                        *process.hiPixel3PrimTracks
-                                       )
-      
-    # use HI pixel tracking and vertexing
-    process.dqmBeamMonitor.BeamFitter.TrackCollection = cms.untracked.InputTag('hiPixel3PrimTracks')
-    process.dqmBeamMonitor.primaryVertex = cms.untracked.InputTag('hiSelectedVertexPreSplitting')
-    process.dqmBeamMonitor.PVFitter.VertexCollection = cms.untracked.InputTag('hiSelectedVertexPreSplitting')
 
-      
-    # make pixel VERTEXING less sensitive to incorrect beamspot
-    process.hiPixel3ProtoTracksPreSplitting.RegionFactoryPSet.RegionPSet.originRadius = 0.2 #default 0.2
-    process.hiPixel3ProtoTracksPreSplitting.RegionFactoryPSet.RegionPSet.fixedError = 0.5   #default 3.0
-    process.hiSelectedProtoTracksPreSplitting.maxD0Significance = 100                       #default 5.0
-    process.hiPixelAdaptiveVertexPreSplitting.TkFilterParameters.maxD0Significance = 100    #default 3.0
-    process.hiPixelAdaptiveVertexPreSplitting.vertexCollections.useBeamConstraint = False  #default False
-    process.hiPixelAdaptiveVertexPreSplitting.vertexCollections.maxDistanceToBeam = 1.0    #default 0.1
-      
-      
+process.dqmBeamMonitor.hltResults = cms.InputTag("TriggerResults","","HLT")
+
+#---------
+# Final path
+if (not process.runType.getRunType() == process.runType.hi_run):
     process.p = cms.Path(process.scalersRawToDigi
-                        *process.dqmTKStatus
-                        *process.hltTriggerTypeFilter
-                        *process.filter_step
-                        *process.HIRecoForDQM
-                        *process.dqmcommon
-                        *process.monitor
-                        *process.BeamSpotProblemModule)
-                                                        
+                       * process.dqmTKStatus
+                       * process.hltTriggerTypeFilter
+                       * process.dqmcommon
+                       * process.tracking_FirstStep
+                       * process.monitor
+                       * process.BeamSpotProblemModule)
+else:
+    process.p = cms.Path(process.scalersRawToDigi
+                       * process.dqmTKStatus
+                       * process.hltTriggerTypeFilter
+                       * process.filter_step # the only extra: pix-multi filter
+                       * process.dqmcommon
+                       * process.tracking_FirstStep
+                       * process.monitor
+                       * process.BeamSpotProblemModule)
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("BeamMonitor", eras.Run2_2018)
+#process = cms.Process("BeamMonitor", eras.Run2_2018) # FIMXE
+process = cms.Process("BeamMonitor", eras.Run2_2018_pp_on_AA)
 
 # Message logger
 #process.load("FWCore.MessageLogger.MessageLogger_cfi")
@@ -87,7 +88,8 @@ if (process.runType.getRunType() == process.runType.pp_run or
     process.runType.getRunType() == process.runType.pp_run_stage1 or
     process.runType.getRunType() == process.runType.cosmic_run or
     process.runType.getRunType() == process.runType.cosmic_run_stage1 or 
-    process.runType.getRunType() == process.runType.hpu_run):
+    process.runType.getRunType() == process.runType.hpu_run or
+    process.runType.getRunType() == process.runType.hi_run):
 
     print("[beamhlt_dqm_sourceclient-live_cfg]:: Running pp")
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -27,7 +27,10 @@ process.load("DQM.Integration.config.inputsource_cfi")
 #process.load("DQM.Integration.config.fileinputsource_cfi")
 
 # new stream label
-process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
+if(process.runType.getRunType() == process.runType.hi_run):
+  process.source.streamLabel = cms.untracked.string('streamHIDQMOnlineBeamspot')
+else:
+  process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
 
 #--------------------------
 # HLT Filter
@@ -106,9 +109,14 @@ if (process.runType.getRunType() == process.runType.pp_run or
     process.dqmBeamMonitor.PVFitter.minVertexNdf        = 10
   
     # some inputs to BeamMonitor
-    process.dqmBeamMonitor.BeamFitter.TrackCollection = 'hltPFMuonMerging'
-    process.dqmBeamMonitor.primaryVertex              = 'hltVerticesPFFilter'
-    process.dqmBeamMonitor.PVFitter.VertexCollection  = 'hltVerticesPFFilter'
+    if(process.runType.getRunType() == process.runType.hi_run):
+      process.dqmBeamMonitor.BeamFitter.TrackCollection = 'hltPFMuonMergingPPOnAA'
+      process.dqmBeamMonitor.primaryVertex              = 'hltVerticesPFFilterPPOnAA'
+      process.dqmBeamMonitor.PVFitter.VertexCollection  = 'hltVerticesPFFilterPPOnAA'
+    else:
+      process.dqmBeamMonitor.BeamFitter.TrackCollection = 'hltPFMuonMerging'
+      process.dqmBeamMonitor.primaryVertex              = 'hltVerticesPFFilter'
+      process.dqmBeamMonitor.PVFitter.VertexCollection  = 'hltVerticesPFFilter'
 
     # keep checking this with new release expected close to 1
     process.dqmBeamMonitor.PVFitter.errorScale = 0.95
@@ -116,8 +124,8 @@ if (process.runType.getRunType() == process.runType.pp_run or
     #TriggerName for selecting pv for DIP publication, NO wildcard needed here
     #it will pick all triggers which has these strings in theri name
     process.dqmBeamMonitor.jetTrigger = cms.untracked.vstring(
-        "HLT_HT300_Beamspot", "HLT_HT300_Beamspot")
-#        "HLT_PAZeroBias_v", "HLT_ZeroBias_v", "HLT_QuadJet")
+        "HLT_HT300_Beamspot", "HLT_HT300_Beamspot",
+        "HLT_PAZeroBias_v", "HLT_ZeroBias_v", "HLT_QuadJet")
 
     process.dqmBeamMonitor.hltResults = cms.InputTag("TriggerResults","","HLT")
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -122,7 +122,8 @@ if (process.runType.getRunType() == process.runType.pp_run or
     #it will pick all triggers which has these strings in theri name
     process.dqmBeamMonitor.jetTrigger = cms.untracked.vstring(
         "HLT_HT300_Beamspot", "HLT_HT300_Beamspot",
-        "HLT_PAZeroBias_v", "HLT_ZeroBias_v", "HLT_QuadJet")
+        "HLT_PAZeroBias_v", "HLT_ZeroBias_", "HLT_QuadJet",
+        "HLT_HI")
 
     process.dqmBeamMonitor.hltResults = cms.InputTag("TriggerResults","","HLT")
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -27,10 +27,7 @@ process.load("DQM.Integration.config.inputsource_cfi")
 #process.load("DQM.Integration.config.fileinputsource_cfi")
 
 # new stream label
-if(process.runType.getRunType() == process.runType.hi_run):
-  process.source.streamLabel = cms.untracked.string('streamHIDQMOnlineBeamspot')
-else:
-  process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
+process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
 
 #--------------------------
 # HLT Filter


### PR DESCRIPTION
The HI reconstruction now uses the same labels as pp, changes are inherited via eras.
The code for the legacy client (beam_*) was cleaned and straigthened out, better readability and similar or same cuts for pp and HI running
The code for HLT-based client (beamhlt_*) still needs a proper track and vertex collection for the HI run.
Documentation and background is at
https://twiki.cern.ch/twiki/bin/viewauth/CMS/OnlineBeamSpot#Sep_2018_legacy_and_or_HLT_based