### PR TITLE
Temporarily remove failing unit tests due to external update

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -10,7 +10,7 @@
 <test name="testBottleneck" command="testBottleneck.py"/>
 <test name="testDeepDish" command="testDeepDish.py"/>
 <test name="testNumExpr" command="testNumExpr.py"/>
-<test name="testNumba" command="testNumba.py"/>
+#<test name="testNumba" command="testNumba.py"/>
 <test name="testTables" command="testTables.py"/>
 
 <test name="testDownhill" command="testDownhill.sh"/>
@@ -19,7 +19,7 @@
 
 <test name="testhep_ml" command="testhep_ml.sh"/>
 <test name="testUncertainties" command="testUncertainties.py"/>
-<test name="testImports" command="imports.sh"/>
+#<test name="testImports" command="imports.sh"/>
 <test name="testTheano" command="testTheano.sh"/>
 
 <bin name="test_PyMVA" file="test_PyMVA.cpp">


### PR DESCRIPTION
This PR is supposed to temporarily hide the failure in unit tests started in CMSSW_10_4_X_2018-10-11-1100 after  the merge of cms-sw/cmsdist#4359 . An issue should be opened to keep in mind to revert this as soon as the problem is fixed in the external, see https://github.com/cms-sw/cmsdist/pull/4359#pullrequestreview-164599643