### PR TITLE
pat::Muon member function declaration bug  fix

### DIFF
--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -319,7 +319,7 @@ namespace pat {
       const pat::TriggerObjectStandAlone* hltObject(const size_t idx=0)  const { 
 	return triggerObjectMatchByType(trigger::TriggerMuon,idx);
       }
-      bool triggered( const char * pathName ){
+      bool triggered( const char * pathName ) const {
 	return triggerObjectMatchByPath(pathName,true,true)!=nullptr;
       }
 


### PR DESCRIPTION
- Just a bug fix to declare the triggered function as const.
- This would ensure the object is not altered when the method is called. 
Before:
bool triggered( const char * pathName ) {
        return triggerObjectMatchByPath(pathName,true,true)!=nullptr;
      }
after: 
 bool triggered( const char * pathName ) const {
        return triggerObjectMatchByPath(pathName,true,true)!=nullptr;
      }