### PR TITLE
Prepare for concurrent IOVs, Fireworks & FastSimulation

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimGeometryESProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimGeometryESProducer.cc
@@ -15,11 +15,9 @@ FastSimGeometryESProducer::FastSimGeometryESProducer(const edm::ParameterSet & p
 
 FastSimGeometryESProducer::~FastSimGeometryESProducer() {}
 
-std::shared_ptr<fastsim::Geometry>
-FastSimGeometryESProducer::produce(const GeometryRecord & iRecord){  
-    _tracker = std::make_shared<fastsim::Geometry>(theTrackerMaterial);
-    return _tracker;
+std::unique_ptr<fastsim::Geometry>
+FastSimGeometryESProducer::produce(const GeometryRecord & iRecord){
+    return std::make_unique<fastsim::Geometry>(theTrackerMaterial);
 }
-
 
 DEFINE_FWK_EVENTSETUP_MODULE(FastSimGeometryESProducer);

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimGeometryESProducer.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimGeometryESProducer.h
@@ -12,9 +12,8 @@ class FastSimGeometryESProducer: public edm::ESProducer{
     public:
     FastSimGeometryESProducer(const edm::ParameterSet & p);
     ~FastSimGeometryESProducer() override; 
-    std::shared_ptr<fastsim::Geometry> produce(const GeometryRecord &);
+    std::unique_ptr<fastsim::Geometry> produce(const GeometryRecord &);
     private:
-    std::shared_ptr<fastsim::Geometry> _tracker;
     edm::ParameterSet theTrackerMaterial;
 };
 

--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -27,43 +27,45 @@ public:
   FWRecoGeometryESProducer( const edm::ParameterSet& );
   ~FWRecoGeometryESProducer( void ) override;
   
-  std::shared_ptr<FWRecoGeometry> produce( const FWRecoGeometryRecord& );
+  std::unique_ptr<FWRecoGeometry> produce( const FWRecoGeometryRecord& );
 
 private:
   FWRecoGeometryESProducer( const FWRecoGeometryESProducer& ) = delete;
   const FWRecoGeometryESProducer& operator=( const FWRecoGeometryESProducer& ) = delete;
   
-  void addCSCGeometry( void );
-  void addDTGeometry( void );
-  void addRPCGeometry( void );
-  void addGEMGeometry( void );
-  void addME0Geometry( void );
-  void addPixelBarrelGeometry( void );
-  void addPixelForwardGeometry( void );
-  void addTIBGeometry( void );
-  void addTOBGeometry( void );
-  void addTIDGeometry( void );
-  void addTECGeometry( void );
-  void addCaloGeometry( void );
+  void addCSCGeometry( FWRecoGeometry& );
+  void addDTGeometry( FWRecoGeometry& );
+  void addRPCGeometry( FWRecoGeometry& );
+  void addGEMGeometry( FWRecoGeometry& );
+  void addME0Geometry( FWRecoGeometry& );
+  void addPixelBarrelGeometry( FWRecoGeometry& );
+  void addPixelForwardGeometry( FWRecoGeometry& );
+  void addTIBGeometry( FWRecoGeometry& );
+  void addTOBGeometry( FWRecoGeometry& );
+  void addTIDGeometry( FWRecoGeometry& );
+  void addTECGeometry( FWRecoGeometry& );
+  void addCaloGeometry( FWRecoGeometry& );
 
-  void addFTLGeometry( void );
+  void addFTLGeometry( FWRecoGeometry& );
   
 
    
-  void ADD_PIXEL_TOPOLOGY( unsigned int rawid, const GeomDet* detUnit );
+  void ADD_PIXEL_TOPOLOGY( unsigned int rawid, const GeomDet* detUnit, FWRecoGeometry& );
    
 
-  unsigned int insert_id( unsigned int id );
-  void fillPoints( unsigned int id, std::vector<GlobalPoint>::const_iterator begin, std::vector<GlobalPoint>::const_iterator end );
-  void fillShapeAndPlacement( unsigned int id, const GeomDet *det );
-  void writeTrackerParametersXML();
+  unsigned int insert_id( unsigned int id, FWRecoGeometry& );
+  void fillPoints( unsigned int id,
+                   std::vector<GlobalPoint>::const_iterator begin,
+                   std::vector<GlobalPoint>::const_iterator end,
+                   FWRecoGeometry& );
+  void fillShapeAndPlacement( unsigned int id, const GeomDet *det, FWRecoGeometry& );
+  void writeTrackerParametersXML(FWRecoGeometry&);
    
   edm::ESHandle<GlobalTrackingGeometry>      m_geomRecord;
   const CaloGeometry*                        m_caloGeom;
   edm::ESHandle<FastTimeGeometry>            m_ftlBarrelGeom,m_ftlEndcapGeom;
   std::vector<edm::ESHandle<HGCalGeometry> > m_hgcalGeoms;
   const TrackerGeometry*                     m_trackerGeom;
-  std::shared_ptr<FWRecoGeometry>            m_fwGeometry;
   
   unsigned int m_current;
   bool m_tracker;

--- a/Fireworks/Geometry/interface/FWTGeoRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWTGeoRecoGeometryESProducer.h
@@ -37,7 +37,7 @@ public:
    FWTGeoRecoGeometryESProducer( const edm::ParameterSet& );
    ~FWTGeoRecoGeometryESProducer( void ) override;
   
-   std::shared_ptr<FWTGeoRecoGeometry> produce( const FWTGeoRecoGeometryRecord& );
+   std::unique_ptr<FWTGeoRecoGeometry> produce( const FWTGeoRecoGeometryRecord& );
 
 private:
    FWTGeoRecoGeometryESProducer( const FWTGeoRecoGeometryESProducer& );
@@ -81,8 +81,6 @@ private:
    const TrackerGeometry* m_trackerGeom;
    const TrackerTopology* m_trackerTopology;
   
-   std::shared_ptr<FWTGeoRecoGeometry> m_fwGeometry;
-
    TGeoMedium* m_dummyMedium;
 
    bool m_tracker;

--- a/Fireworks/Geometry/interface/TGeoMgrFromDdd.h
+++ b/Fireworks/Geometry/interface/TGeoMgrFromDdd.h
@@ -50,7 +50,7 @@ public:
    TGeoMgrFromDdd(const edm::ParameterSet&);
    ~TGeoMgrFromDdd() override;
 
-   typedef std::shared_ptr<TGeoManager> ReturnType;
+   using ReturnType = std::unique_ptr<TGeoManager>;
 
    // ---------- const member functions ---------------------
 

--- a/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
@@ -258,12 +258,12 @@ FWTGeoRecoGeometryESProducer::GetMedium(ERecoDet det)
 
 
 
-std::shared_ptr<FWTGeoRecoGeometry> 
+std::unique_ptr<FWTGeoRecoGeometry> 
 FWTGeoRecoGeometryESProducer::produce( const FWTGeoRecoGeometryRecord& record )
 {
    using namespace edm;
 
-   m_fwGeometry = std::make_shared<FWTGeoRecoGeometry>();
+   auto fwTGeoRecoGeometry = std::make_unique<FWTGeoRecoGeometry>();
   
    if( m_calo ) {
      edm::ESHandle<CaloGeometry> caloH;
@@ -277,7 +277,7 @@ FWTGeoRecoGeometryESProducer::produce( const FWTGeoRecoGeometryRecord& record )
       gGeoIdentity = new TGeoIdentity( "Identity" );
    }
 
-   m_fwGeometry->manager( geom );
+   fwTGeoRecoGeometry->manager( geom );
   
    // Default material is Vacuum
    TGeoMaterial *vacuum = new TGeoMaterial( "Vacuum", 0 ,0 ,0 );
@@ -287,7 +287,7 @@ FWTGeoRecoGeometryESProducer::produce( const FWTGeoRecoGeometryRecord& record )
   
    if( nullptr == top )
    {
-      return std::shared_ptr<FWTGeoRecoGeometry>();
+      return std::unique_ptr<FWTGeoRecoGeometry>();
    }
    geom->SetTopVolume( top );
    // ROOT chokes unless colors are assigned
@@ -342,7 +342,7 @@ FWTGeoRecoGeometryESProducer::produce( const FWTGeoRecoGeometryRecord& record )
    // printf("==== geo manager NNodes = %d \n", geom->GetNNodes());
    geom->CloseGeometry();
 
-   return m_fwGeometry;
+   return fwTGeoRecoGeometry;
 }
 
 /** Create TGeo shape for GeomDet */

--- a/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
+++ b/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
@@ -94,7 +94,7 @@ TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRecord)
    iRecord.getRecord<IdealGeometryRecord>().get(viewH);
 
    if ( ! viewH.isValid()) {
-      return std::shared_ptr<TGeoManager>();
+      return std::unique_ptr<TGeoManager>();
    }
 
    TGeoManager *geo_mgr = new TGeoManager("cmsGeo","CMS Detector");
@@ -114,7 +114,7 @@ TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRecord)
    // geometry AND the magnetic field volumes!
    walker.firstChild();
    if( ! walker.firstChild()) {
-      return std::shared_ptr<TGeoManager>();
+      return std::unique_ptr<TGeoManager>();
    }
 
    TGeoVolume *top = createVolume(info.first.name().fullname(),
@@ -122,7 +122,7 @@ TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRecord)
                                   info.first.material());
 
    if (top == nullptr) {
-      return std::shared_ptr<TGeoManager>();
+      return std::unique_ptr<TGeoManager>();
    }
 
    geo_mgr->SetTopVolume(top);
@@ -213,7 +213,7 @@ TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRecord)
    nameToMaterial_.clear();
    nameToMedium_.clear();
 
-   return std::shared_ptr<TGeoManager>(geo_mgr);
+   return std::unique_ptr<TGeoManager>(geo_mgr);
 }
 
 


### PR DESCRIPTION
Change return type of produce functions from shared_ptr
to unique_ptr. Note that for the TGeo related classes
this moves them in the right direction, but because of
their dependence on TGeo they still will not work
with concurrent IOVs. More work would need to be done.