### PR TITLE
Remove const_cast from SiPixelESProducers

### DIFF
--- a/CalibTracker/SiPixelESProducers/interface/SiPixel2DTemplateDBObjectESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixel2DTemplateDBObjectESProducer.h
@@ -28,6 +28,6 @@ public:
 
 	SiPixel2DTemplateDBObjectESProducer(const edm::ParameterSet& iConfig);
         ~SiPixel2DTemplateDBObjectESProducer() override;
-	std::shared_ptr<SiPixel2DTemplateDBObject> produce(const SiPixel2DTemplateDBObjectESProducerRcd &);
+	std::shared_ptr<const SiPixel2DTemplateDBObject> produce(const SiPixel2DTemplateDBObjectESProducerRcd &);
  };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGenErrorDBObjectESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGenErrorDBObjectESProducer.h
@@ -26,8 +26,8 @@ class SiPixelGenErrorDBObjectESProducer : public edm::ESProducer  {
 
 public:
 
-	SiPixelGenErrorDBObjectESProducer(const edm::ParameterSet& iConfig);
+  SiPixelGenErrorDBObjectESProducer(const edm::ParameterSet& iConfig);
   ~SiPixelGenErrorDBObjectESProducer() override;
-	std::shared_ptr<SiPixelGenErrorDBObject> produce(const SiPixelGenErrorDBObjectESProducerRcd &);
- };
+  std::shared_ptr<const SiPixelGenErrorDBObject> produce(const SiPixelGenErrorDBObjectESProducerRcd &);
+};
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelTemplateDBObjectESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelTemplateDBObjectESProducer.h
@@ -26,8 +26,8 @@ class SiPixelTemplateDBObjectESProducer : public edm::ESProducer  {
 
 public:
 
-	SiPixelTemplateDBObjectESProducer(const edm::ParameterSet& iConfig);
+  SiPixelTemplateDBObjectESProducer(const edm::ParameterSet& iConfig);
   ~SiPixelTemplateDBObjectESProducer() override;
-	std::shared_ptr<SiPixelTemplateDBObject> produce(const SiPixelTemplateDBObjectESProducerRcd &);
- };
+  std::shared_ptr<const SiPixelTemplateDBObject> produce(const SiPixelTemplateDBObjectESProducerRcd &);
+};
 #endif

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -31,7 +31,7 @@ SiPixel2DTemplateDBObjectESProducer::~SiPixel2DTemplateDBObjectESProducer(){
 
 
 
-std::shared_ptr<SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProducer::produce(const SiPixel2DTemplateDBObjectESProducerRcd & iRecord) {
+std::shared_ptr<const SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProducer::produce(const SiPixel2DTemplateDBObjectESProducerRcd & iRecord) {
 	
 	ESHandle<MagneticField> magfield;
 	iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield);
@@ -58,7 +58,7 @@ std::shared_ptr<SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProducer::
 	if(std::fabs(theMagField-dbobject->sVector()[22])>0.1)
 		edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixel2DTemplate") << "Magnetic field is " << theMagField << " Template Magnetic field is " << dbobject->sVector()[22];
 	
-	return std::shared_ptr<SiPixel2DTemplateDBObject>(const_cast<SiPixel2DTemplateDBObject*>(&(*dbobject)), edm::do_nothing_deleter());
+	return std::shared_ptr<const SiPixel2DTemplateDBObject>(&(*dbobject), edm::do_nothing_deleter());
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(SiPixel2DTemplateDBObjectESProducer);

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelGenErrorDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelGenErrorDBObjectESProducer.cc
@@ -31,7 +31,7 @@ SiPixelGenErrorDBObjectESProducer::~SiPixelGenErrorDBObjectESProducer(){
 
 
 
-std::shared_ptr<SiPixelGenErrorDBObject> SiPixelGenErrorDBObjectESProducer::produce(const SiPixelGenErrorDBObjectESProducerRcd & iRecord) {
+std::shared_ptr<const SiPixelGenErrorDBObject> SiPixelGenErrorDBObjectESProducer::produce(const SiPixelGenErrorDBObjectESProducerRcd & iRecord) {
 	
 	ESHandle<MagneticField> magfield;
 	iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield);
@@ -56,7 +56,7 @@ std::shared_ptr<SiPixelGenErrorDBObject> SiPixelGenErrorDBObjectESProducer::prod
 	if(std::fabs(theMagField-dbobject->sVector()[22])>0.1)
 		edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixelGenError") << "Magnetic field is " << theMagField << " GenError Magnetic field is " << dbobject->sVector()[22];
 	
-	return std::shared_ptr<SiPixelGenErrorDBObject>(const_cast<SiPixelGenErrorDBObject*>(&(*dbobject)), edm::do_nothing_deleter());
+	return std::shared_ptr<const SiPixelGenErrorDBObject>(&(*dbobject), edm::do_nothing_deleter());
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(SiPixelGenErrorDBObjectESProducer);

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
@@ -31,7 +31,7 @@ SiPixelTemplateDBObjectESProducer::~SiPixelTemplateDBObjectESProducer(){
 
 
 
-std::shared_ptr<SiPixelTemplateDBObject> SiPixelTemplateDBObjectESProducer::produce(const SiPixelTemplateDBObjectESProducerRcd & iRecord) {
+std::shared_ptr<const SiPixelTemplateDBObject> SiPixelTemplateDBObjectESProducer::produce(const SiPixelTemplateDBObjectESProducerRcd & iRecord) {
 	
 	ESHandle<MagneticField> magfield;
 	iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield);
@@ -56,7 +56,7 @@ std::shared_ptr<SiPixelTemplateDBObject> SiPixelTemplateDBObjectESProducer::prod
 	if(std::fabs(theMagField-dbobject->sVector()[22])>0.1)
 		edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixelTemplate") << "Magnetic field is " << theMagField << " Template Magnetic field is " << dbobject->sVector()[22];
 	
-	return std::shared_ptr<SiPixelTemplateDBObject>(const_cast<SiPixelTemplateDBObject*>(&(*dbobject)), edm::do_nothing_deleter());
+	return std::shared_ptr<const SiPixelTemplateDBObject>(&(*dbobject), edm::do_nothing_deleter());
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(SiPixelTemplateDBObjectESProducer);


### PR DESCRIPTION
Note these const_cast's were necessary before
PR #24844 was merged.