### PR TITLE
[10.3.X][Change GT] Update HI MC ECAL GT + 2019 GT Geom. fix

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,15 +54,15 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' : '103X_upgrade2018_realistic_HI_v6',
+    'phase1_2018_realistic_hi' : '103X_upgrade2018_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail'    : '103X_upgrade2018_realistic_HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '103X_postLS2_design_v3', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '103X_postLS2_design_v4', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'    : '103X_postLS2_realistic_v3', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'    : '103X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '103X_upgrade2023_realistic_v2'
 }


### PR DESCRIPTION
# 2018 HI MC GT
.  6 Tags have been updated from ECAL:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2018_realistic_HI_v6/103X_upgrade2018_realistic_HI_v7

# 2019 GT
.  Geometry Fix for Ianna

In order to consider the ECAL Tag update in the HI Queue, these PR need to be integrated before the injection of the 10_3_0 PbPb MC relvals, as discussed today at the PPD coordination.