### PR TITLE
Add Workflow for multi-run harvesting

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -386,6 +386,9 @@ workflows[136.894] = ['',['RunNoBPTX2018D','HLTDR2_2018','RECODR2_2018reHLTAlCaT
 workflows[136.895] = ['',['RunDisplacedJet2018D','HLTDR2_2018','RECODR2_2018reHLT_skimDisplacedJet_Prompt','HARVEST2018']]
 workflows[136.896] = ['',['RunCharmonium2018D','HLTDR2_2018','RECODR2_2018reHLT_skimCharmonium_Prompt','HARVEST2018']]
 
+# multi-run harvesting
+workflows[137.8] = ['',['RunEGamma2018C','HLTDR2_2018','RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM',
+                        'RunEGamma2018D','HLTDR2_2018','RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM','HARVEST2018_L1TEgDQM_MULTIRUN']]
 
 ### fastsim ###
 workflows[5.1] = ['TTbar', ['TTbarFS','HARVESTFS']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2233,6 +2233,12 @@ steps['HARVEST2018_hBStar'] = merge([ {'--era' : 'Run2_2018_highBetaStar'}, step
 steps['HARVEST2018_HEfail'] = merge([ {'--conditions':'auto:run2_data_promptlike_HEfail'}, steps['HARVEST2018'] ])
 steps['HARVEST2018_BadHcalMitig'] = merge([ {'--era' : 'Run2_2018,pf_badHcalMitigation','--conditions':'auto:run2_data_promptlike_HEfail'}, steps['HARVEST2018'] ])
 
+steps['HARVEST2018_L1TEgDQM_MULTIRUN'] = merge([ {
+        '--customise':"Configuration/StandardSequences/DQMSaverAtJobEnd_cff",
+        # hardcode the input files since we need multiple, from each of the RECO steps.
+        '--filein':"file:step6_inDQM.root,file:step3_inDQM.root",
+    }, steps['HARVEST2018_L1TEgDQM'] ])
+
 steps['DQMHLTonAOD_2017']={
     '-s':'DQM:offlineHLTSourceOnAOD', ### DQM-only workflow on AOD input: for HLT
     '--conditions':'auto:run2_data_promptlike',

--- a/Configuration/StandardSequences/python/DQMSaverAtJobEnd_cff.py
+++ b/Configuration/StandardSequences/python/DQMSaverAtJobEnd_cff.py
@@ -15,6 +15,11 @@ DQMStore.collateHistograms = True
 
 dqmSaver.saveByRun = -1
 dqmSaver.saveAtJobEnd = True  
-dqmSaver.forceRunNumber = 1
+dqmSaver.forceRunNumber = 999999
 
 DQMSaver = cms.Sequence(dqmSaver)
+
+# configuration is modified as a side effect, this is just a placeholder
+# to allow using this file as a customisation for cmsDriver.
+def customise(process):
+    return process


### PR DESCRIPTION
This PR adds a workflow that exercises multi-run HARVESTING on DQMIO files as number 137.8.

It is based on the 136 data relvals and mixes 2018C and D data; I think this is not guaranteed to work, but it saves us from adding a second run to the relval data.  Currently, I only added it for one PD and 2018C/D data, that should be enough to catch the obvious problems. We could do the full combinatoric expansion as for the 136 WFs as well.

As expected, this WF fails at the moment, as far as I see for a different issue than the ones that @cerminar observed. PRs to fix the crashes will follow. We can wait with integrating this until all plugins are fixed for multi-run harvesting.