### PR TITLE
Further CaloL2 O2O updates **10_3_X BACKPORT**

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
@@ -34,7 +34,7 @@ namespace l1t {
            layer1HCal=18,
            layer1HF=19,
 	   jetCompressEta=20, jetCompressPt=21,
-	   etSumXCalibration=22, etSumYCalibration=23, etSumEttCalibration=24, etSumEcalSumCalibration=25,
+	   metCalibration=22, metHFCalibration=23, etSumEttCalibration=24, etSumEcalSumCalibration=25,
 	   tauIsolation2=26,
            egBypassEGVetosFlag=27,
            jetBypassPUSFlag=28,
@@ -57,7 +57,9 @@ namespace l1t {
 	   etSumCentralityLower=45,
 	   etSumCentralityUpper=46,
            jetPUSUsePhiRingFlag=47,
-	   NUM_CALOPARAMNODES=48
+	   metPhiCalibration=48,
+	   metHFPhiCalibration=49,
+	   NUM_CALOPARAMNODES=50
     };
 
     CaloParamsHelper() { pnode_.resize(NUM_CALOPARAMNODES); }
@@ -385,8 +387,8 @@ namespace l1t {
     std::string const& etSumMetPUSType() const { return pnode_[etSumMetPUS].type_; }
     std::string const& etSumEttPUSType() const { return pnode_[etSumEttPUS].type_; }
     std::string const& etSumEcalSumPUSType() const { return pnode_[etSumEcalSumPUS].type_; }
-    std::string const& etSumXCalibrationType() const { return pnode_[etSumXCalibration].type_; }
-    std::string const& etSumYCalibrationType() const { return pnode_[etSumYCalibration].type_; }
+    std::string const& metCalibrationType() const { return pnode_[metCalibration].type_; }
+    std::string const& metHFCalibrationType() const { return pnode_[metHFCalibration].type_; }
     std::string const& etSumEttCalibrationType() const { return pnode_[etSumEttCalibration].type_; }
     std::string const& etSumEcalSumCalibrationType() const { return pnode_[etSumEcalSumCalibration].type_; }
 
@@ -396,14 +398,18 @@ namespace l1t {
     l1t::LUT const* etSumEttPUSLUT() const { return &pnode_[etSumEttPUS].LUT_; }
     l1t::LUT* etSumEcalSumPUSLUT() { return &pnode_[etSumEcalSumPUS].LUT_; }
     l1t::LUT const* etSumEcalSumPUSLUT() const { return &pnode_[etSumEcalSumPUS].LUT_; }
-    l1t::LUT* etSumXCalibrationLUT() { return &pnode_[etSumXCalibration].LUT_; }
-    l1t::LUT const* etSumXCalibrationLUT() const { return &pnode_[etSumXCalibration].LUT_; }
-    l1t::LUT* etSumYCalibrationLUT() { return &pnode_[etSumYCalibration].LUT_; }
-    l1t::LUT const* etSumYCalibrationLUT() const { return &pnode_[etSumYCalibration].LUT_; }
+    l1t::LUT* metCalibrationLUT() { return &pnode_[metCalibration].LUT_; }
+    l1t::LUT const* metCalibrationLUT() const { return &pnode_[metCalibration].LUT_; }
+    l1t::LUT* metHFCalibrationLUT() { return &pnode_[metHFCalibration].LUT_; }
+    l1t::LUT const* metHFCalibrationLUT() const { return &pnode_[metHFCalibration].LUT_; }
     l1t::LUT* etSumEttCalibrationLUT() { return &pnode_[etSumEttCalibration].LUT_; }
     l1t::LUT const* etSumEttCalibrationLUT() const { return &pnode_[etSumEttCalibration].LUT_; }
     l1t::LUT* etSumEcalSumCalibrationLUT() { return &pnode_[etSumEcalSumCalibration].LUT_; }
     l1t::LUT const* etSumEcalSumCalibrationLUT() const { return &pnode_[etSumEcalSumCalibration].LUT_; }
+    l1t::LUT* metPhiCalibrationLUT() { return &pnode_[metPhiCalibration].LUT_; }
+    l1t::LUT const* metPhiCalibrationLUT() const { return &pnode_[metPhiCalibration].LUT_; }
+    l1t::LUT* metHFPhiCalibrationLUT() { return &pnode_[metHFPhiCalibration].LUT_; }
+    l1t::LUT const* metHFPhiCalibrationLUT() const { return &pnode_[metHFPhiCalibration].LUT_; }
 
     void setEtSumLsb(double lsb) { etSumLsb_ = lsb; }
     void setEtSumEtaMin(unsigned isum, int eta);
@@ -412,8 +418,8 @@ namespace l1t {
     void setEtSumMetPUSType(std::string type) { pnode_[etSumMetPUS].type_ = type; }
     void setEtSumEttPUSType(std::string type) { pnode_[etSumEttPUS].type_ = type; }
     void setEtSumEcalSumPUSType(std::string type) { pnode_[etSumEcalSumPUS].type_ = type; }
-    void setEtSumXCalibrationType(std::string type) { pnode_[etSumXCalibration].type_ = type; }
-    void setEtSumYCalibrationType(std::string type) { pnode_[etSumYCalibration].type_ = type; }
+    void setMetCalibrationType(std::string type) { pnode_[metCalibration].type_ = type; }
+    void setMetHFCalibrationType(std::string type) { pnode_[metHFCalibration].type_ = type; }
     void setEtSumEttCalibrationType(std::string type) { pnode_[etSumEttCalibration].type_ = type; }
     void setEtSumEcalSumCalibrationType(std::string type) { pnode_[etSumEcalSumCalibration].type_ = type; }
     void setEtSumBypassMetPUS(unsigned flag) { 
@@ -433,11 +439,12 @@ namespace l1t {
     void setEtSumMetPUSLUT(const l1t::LUT & lut) { pnode_[etSumMetPUS].LUT_ = lut; }
     void setEtSumEttPUSLUT(const l1t::LUT & lut) { pnode_[etSumEttPUS].LUT_ = lut; }
     void setEtSumEcalSumPUSLUT(const l1t::LUT & lut) { pnode_[etSumEcalSumPUS].LUT_ = lut; }
-    void setEtSumXCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumXCalibration].LUT_ = lut; }
-    void setEtSumYCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumYCalibration].LUT_ = lut; }
+    void setMetCalibrationLUT(const l1t::LUT & lut) { pnode_[metCalibration].LUT_ = lut; }
+    void setMetHFCalibrationLUT(const l1t::LUT & lut) { pnode_[metHFCalibration].LUT_ = lut; }
     void setEtSumEttCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumEttCalibration].LUT_ = lut; }
     void setEtSumEcalSumCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumEcalSumCalibration].LUT_ = lut; }
-
+    void setMetPhiCalibrationLUT(const l1t::LUT & lut) { pnode_[metPhiCalibration].LUT_ = lut; }
+    void setMetHFPhiCalibrationLUT(const l1t::LUT & lut) { pnode_[metHFPhiCalibration].LUT_ = lut; }
 
     // HI centrality
     int centralityRegionMask() const {

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
@@ -257,8 +257,8 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setEtSumMetPUSType(conf.getParameter<std::string>("etSumMetPUSType"));
   m_params_helper.setEtSumEttPUSType(conf.getParameter<std::string>("etSumEttPUSType"));
   m_params_helper.setEtSumEcalSumPUSType(conf.getParameter<std::string>("etSumEcalSumPUSType"));
-  m_params_helper.setEtSumXCalibrationType(conf.getParameter<std::string>("etSumXCalibrationType"));
-  m_params_helper.setEtSumYCalibrationType(conf.getParameter<std::string>("etSumYCalibrationType"));
+  m_params_helper.setMetCalibrationType(conf.getParameter<std::string>("metCalibrationType"));
+  m_params_helper.setMetHFCalibrationType(conf.getParameter<std::string>("metHFCalibrationType"));
   m_params_helper.setEtSumEttCalibrationType(conf.getParameter<std::string>("etSumEttCalibrationType"));
   m_params_helper.setEtSumEcalSumCalibrationType(conf.getParameter<std::string>("etSumEcalSumCalibrationType"));
 
@@ -288,15 +288,15 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   std::shared_ptr<LUT> etSumEcalSumPUSLUT( new LUT(etSumEcalSumPUSLUTStream) );
   m_params_helper.setEtSumEcalSumPUSLUT(*etSumEcalSumPUSLUT);
   
-  edm::FileInPath etSumXCalibrationLUTFile = conf.getParameter<edm::FileInPath>("etSumXCalibrationLUTFile");
-  std::ifstream etSumXCalibrationLUTStream(etSumXCalibrationLUTFile.fullPath());
-  std::shared_ptr<LUT> etSumXCalibrationLUT( new LUT(etSumXCalibrationLUTStream) );
-  m_params_helper.setEtSumXCalibrationLUT(*etSumXCalibrationLUT);
+  edm::FileInPath metCalibrationLUTFile = conf.getParameter<edm::FileInPath>("metCalibrationLUTFile");
+  std::ifstream metCalibrationLUTStream(metCalibrationLUTFile.fullPath());
+  std::shared_ptr<LUT> metCalibrationLUT( new LUT(metCalibrationLUTStream) );
+  m_params_helper.setMetCalibrationLUT(*metCalibrationLUT);
   
-  edm::FileInPath etSumYCalibrationLUTFile = conf.getParameter<edm::FileInPath>("etSumYCalibrationLUTFile");
-  std::ifstream etSumYCalibrationLUTStream(etSumYCalibrationLUTFile.fullPath());
-  std::shared_ptr<LUT> etSumYCalibrationLUT( new LUT(etSumYCalibrationLUTStream) );
-  m_params_helper.setEtSumYCalibrationLUT(*etSumYCalibrationLUT);
+  edm::FileInPath metHFCalibrationLUTFile = conf.getParameter<edm::FileInPath>("metHFCalibrationLUTFile");
+  std::ifstream metHFCalibrationLUTStream(metHFCalibrationLUTFile.fullPath());
+  std::shared_ptr<LUT> metHFCalibrationLUT( new LUT(metHFCalibrationLUTStream) );
+  m_params_helper.setMetHFCalibrationLUT(*metHFCalibrationLUT);
 
   edm::FileInPath etSumEttCalibrationLUTFile = conf.getParameter<edm::FileInPath>("etSumEttCalibrationLUTFile");
   std::ifstream etSumEttCalibrationLUTStream(etSumEttCalibrationLUTFile.fullPath());
@@ -307,6 +307,16 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   std::ifstream etSumEcalSumCalibrationLUTStream(etSumEcalSumCalibrationLUTFile.fullPath());
   std::shared_ptr<LUT> etSumEcalSumCalibrationLUT( new LUT(etSumEcalSumCalibrationLUTStream) );
   m_params_helper.setEtSumEcalSumCalibrationLUT(*etSumEcalSumCalibrationLUT);
+
+  edm::FileInPath metPhiCalibrationLUTFile = conf.getParameter<edm::FileInPath>("metPhiCalibrationLUTFile");
+  std::ifstream metPhiCalibrationLUTStream(metPhiCalibrationLUTFile.fullPath());
+  std::shared_ptr<LUT> metPhiCalibrationLUT( new LUT(metPhiCalibrationLUTStream) );
+  m_params_helper.setMetPhiCalibrationLUT(*metPhiCalibrationLUT);
+
+  edm::FileInPath metHFPhiCalibrationLUTFile = conf.getParameter<edm::FileInPath>("metHFPhiCalibrationLUTFile");
+  std::ifstream metHFPhiCalibrationLUTStream(metHFPhiCalibrationLUTFile.fullPath());
+  std::shared_ptr<LUT> metHFPhiCalibrationLUT( new LUT(metHFPhiCalibrationLUTStream) );
+  m_params_helper.setMetHFPhiCalibrationLUT(*metHFPhiCalibrationLUT);
 
   // HI centrality trigger
   std::vector<double> etSumCentLower = conf.getParameter<std::vector<double>>("etSumCentralityLower");

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
@@ -262,8 +262,8 @@ L1TCaloStage2ParamsESProducer::L1TCaloStage2ParamsESProducer(const edm::Paramete
   m_params_helper.setEtSumMetPUSType(conf.getParameter<std::string>("etSumMetPUSType"));
   m_params_helper.setEtSumEttPUSType(conf.getParameter<std::string>("etSumEttPUSType"));
   m_params_helper.setEtSumEcalSumPUSType(conf.getParameter<std::string>("etSumEcalSumPUSType"));
-  m_params_helper.setEtSumXCalibrationType(conf.getParameter<std::string>("etSumXCalibrationType"));
-  m_params_helper.setEtSumYCalibrationType(conf.getParameter<std::string>("etSumYCalibrationType"));
+  m_params_helper.setMetCalibrationType(conf.getParameter<std::string>("metCalibrationType"));
+  m_params_helper.setMetHFCalibrationType(conf.getParameter<std::string>("metHFCalibrationType"));
   m_params_helper.setEtSumEttCalibrationType(conf.getParameter<std::string>("etSumEttCalibrationType"));
   m_params_helper.setEtSumEcalSumCalibrationType(conf.getParameter<std::string>("etSumEcalSumCalibrationType"));
 
@@ -295,15 +295,15 @@ L1TCaloStage2ParamsESProducer::L1TCaloStage2ParamsESProducer(const edm::Paramete
   m_params_helper.setEtSumEcalSumPUSLUT(*etSumEcalSumPUSLUT);
   
 
-  edm::FileInPath etSumXCalibrationLUTFile = conf.getParameter<edm::FileInPath>("etSumXCalibrationLUTFile");
-  std::ifstream etSumXCalibrationLUTStream(etSumXCalibrationLUTFile.fullPath());
-  std::shared_ptr<LUT> etSumXCalibrationLUT( new LUT(etSumXCalibrationLUTStream) );
-  m_params_helper.setEtSumXCalibrationLUT(*etSumXCalibrationLUT);
+  edm::FileInPath metCalibrationLUTFile = conf.getParameter<edm::FileInPath>("metCalibrationLUTFile");
+  std::ifstream metCalibrationLUTStream(metCalibrationLUTFile.fullPath());
+  std::shared_ptr<LUT> metCalibrationLUT( new LUT(metCalibrationLUTStream) );
+  m_params_helper.setMetCalibrationLUT(*metCalibrationLUT);
   
-  edm::FileInPath etSumYCalibrationLUTFile = conf.getParameter<edm::FileInPath>("etSumYCalibrationLUTFile");
-  std::ifstream etSumYCalibrationLUTStream(etSumYCalibrationLUTFile.fullPath());
-  std::shared_ptr<LUT> etSumYCalibrationLUT( new LUT(etSumYCalibrationLUTStream) );
-  m_params_helper.setEtSumYCalibrationLUT(*etSumYCalibrationLUT);
+  edm::FileInPath metHFCalibrationLUTFile = conf.getParameter<edm::FileInPath>("metHFCalibrationLUTFile");
+  std::ifstream metHFCalibrationLUTStream(metHFCalibrationLUTFile.fullPath());
+  std::shared_ptr<LUT> metHFCalibrationLUT( new LUT(metHFCalibrationLUTStream) );
+  m_params_helper.setMetHFCalibrationLUT(*metHFCalibrationLUT);
 
   edm::FileInPath etSumEttCalibrationLUTFile = conf.getParameter<edm::FileInPath>("etSumEttCalibrationLUTFile");
   std::ifstream etSumEttCalibrationLUTStream(etSumEttCalibrationLUTFile.fullPath());
@@ -314,6 +314,17 @@ L1TCaloStage2ParamsESProducer::L1TCaloStage2ParamsESProducer(const edm::Paramete
   std::ifstream etSumEcalSumCalibrationLUTStream(etSumEcalSumCalibrationLUTFile.fullPath());
   std::shared_ptr<LUT> etSumEcalSumCalibrationLUT( new LUT(etSumEcalSumCalibrationLUTStream) );
   m_params_helper.setEtSumEcalSumCalibrationLUT(*etSumEcalSumCalibrationLUT);
+
+  edm::FileInPath metPhiCalibrationLUTFile = conf.getParameter<edm::FileInPath>("metPhiCalibrationLUTFile");
+  std::ifstream metPhiCalibrationLUTStream(metPhiCalibrationLUTFile.fullPath());
+  std::shared_ptr<LUT> metPhiCalibrationLUT( new LUT(metPhiCalibrationLUTStream) );
+  m_params_helper.setMetPhiCalibrationLUT(*metPhiCalibrationLUT);
+
+  edm::FileInPath metHFPhiCalibrationLUTFile = conf.getParameter<edm::FileInPath>("metHFPhiCalibrationLUTFile");
+  std::ifstream metHFPhiCalibrationLUTStream(metHFPhiCalibrationLUTFile.fullPath());
+  std::shared_ptr<LUT> metHFPhiCalibrationLUT( new LUT(metHFPhiCalibrationLUTStream) );
+  m_params_helper.setMetHFPhiCalibrationLUT(*metHFPhiCalibrationLUT);
+
 
   // HI centrality trigger
   std::vector<double> etSumCentLower = conf.getParameter<std::vector<double>>("etSumCentralityLower");

--- a/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_cfi.py
@@ -110,10 +110,12 @@ caloStage2Params.etSumCentralityUpper = cms.vdouble(8.0, 25.5, 208.0, 567.5, 134
 caloStage2Params.etSumMetPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_2017v7.txt")
 caloStage2Params.etSumEttPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt")
 caloStage2Params.etSumEcalSumPUSLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt")
-caloStage2Params.etSumXCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
-caloStage2Params.etSumYCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.metCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.metHFCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
 caloStage2Params.etSumEttCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
 caloStage2Params.etSumEcalSumCalibrationLUTFile   = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.metPhiCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.metHFPhiCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
 
 
 # Layer 1 SF

--- a/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
@@ -122,15 +122,16 @@ caloParams = cms.ESProducer(
     etSumMetPUSType          = cms.string("None"),
     etSumEttPUSType          = cms.string("None"),
     etSumEcalSumPUSType      = cms.string("None"),
-    etSumXCalibrationType    = cms.string("None"),
-    etSumYCalibrationType    = cms.string("None"),
+    metCalibrationType    = cms.string("None"),
+    metHFCalibrationType    = cms.string("None"),
     etSumEttCalibrationType  = cms.string("None"),
     etSumEcalSumCalibrationType = cms.string("None"),
-    etSumXCalibrationLUTFile  = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"),
-    etSumYCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"),
+    metCalibrationLUTFile  = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"),
+    metHFCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"),
     etSumEttCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"),
     etSumEcalSumCalibrationLUTFile   = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"),
-
+    metPhiCalibrationLUTFile  = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"),
+    metHFPhiCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"),
 
     # HI
     etSumCentralityLower =   cms.vdouble(0,200,400,600,800, 1000,1200,1400),

--- a/L1Trigger/L1TCalorimeter/python/convertParamsToOnlineFormat.py
+++ b/L1Trigger/L1TCalorimeter/python/convertParamsToOnlineFormat.py
@@ -146,10 +146,12 @@ def getFullListOfParameters(aModule):
       (('demux', 'algoRev'), None, 0xcafe),
       (('demux', 'ET_centralityLowerThresholds'), 'CentralityLowerThrs.mif', [ int(round(loBound / aModule.etSumLsb.value())) for loBound in aModule.etSumCentralityLower.value()]),
       (('demux', 'ET_centralityUpperThresholds'), 'CentralityUpperThrs.mif', [ int(round(upBound / aModule.etSumLsb.value())) for upBound in aModule.etSumCentralityUpper.value()])
-      (('demux', 'ET_energyCalibLUT'),            'M_ETMET_11to18.mif',      parseOfflineLUTfile(aModule.etSumEttCalibrationLUTFile.value(), 2048, aTruncate = True)),
-      (('demux', 'ecalET_energyCalibLUT'),        'M_ETMETecal_11to18.mif',  parseOfflineLUTfile(aModule.etSumEcalSumCalibrationLUTFile.value(), 2048, aTruncate = True)),
-      (('demux', 'METX_energyCalibLUT'),          'M_ETMETX_11to18.mif',     parseOfflineLUTfile(aModule.etSumXCalibrationLUTFile.value(), 2048, aTruncate = True)),
-      (('demux', 'METY_energyCalibLUT'),          'M_ETMETY_11to18.mif',     parseOfflineLUTfile(aModule.etSumYCalibrationLUTFile.value(), 2048, aTruncate = True)),
+      (('demux', 'MET_energyCalibLUT'),       'M_METnoHFenergyCalibration_12to18.mif',     parseOfflineLUTfile(aModule.metCalibrationLUTFile.value(), 2048, aTruncate = True)),
+      (('demux', 'METHF_energyCalibLUT'),     'M_METwithHFenergyCalibration_12to18.mif',   parseOfflineLUTfile(aModule.metHFCalibrationLUTFile.value(), 2048, aTruncate = True)),
+      (('demux', 'ET_energyCalibLUT'),        'S_ETcalibration_12to18.mif',       parseOfflineLUTfile(aModule.etSumEttCalibrationLUTFile.value(), 2048, aTruncate = True)),
+      (('demux', 'ecalET_energyCalibLUT'),    'R_EcalCalibration_12to18.mif',     parseOfflineLUTfile(aModule.etSumEcalSumCalibrationLUTFile.value(), 2048, aTruncate = True)),
+      (('demux', 'MET_phiCalibLUT'),          'Q_METnoHFphiCalibration_12to18.mif',     parseOfflineLUTfile(aModule.metPhiCalibrationLUTFile.value(), 2048, aTruncate = True)),
+      (('demux', 'METHF_phiCalibLUT'),        'Q_METwithHFphiCalibration_12to18.mif',   parseOfflineLUTfile(aModule.metHFPhiCalibrationLUTFile.value(), 2048, aTruncate = True)),
     ]
 
     result = [(a, b, parseOfflineLUTfile(c.value()) if isinstance(c, cms.FileInPath) else c) for a, b, c in result]

--- a/L1Trigger/L1TCalorimeter/python/convertParamsToOnlineFormat.py
+++ b/L1Trigger/L1TCalorimeter/python/convertParamsToOnlineFormat.py
@@ -146,12 +146,12 @@ def getFullListOfParameters(aModule):
       (('demux', 'algoRev'), None, 0xcafe),
       (('demux', 'ET_centralityLowerThresholds'), 'CentralityLowerThrs.mif', [ int(round(loBound / aModule.etSumLsb.value())) for loBound in aModule.etSumCentralityLower.value()]),
       (('demux', 'ET_centralityUpperThresholds'), 'CentralityUpperThrs.mif', [ int(round(upBound / aModule.etSumLsb.value())) for upBound in aModule.etSumCentralityUpper.value()])
-      (('demux', 'MET_energyCalibLUT'),       'M_METnoHFenergyCalibration_12to18.mif',     parseOfflineLUTfile(aModule.metCalibrationLUTFile.value(), 2048, aTruncate = True)),
-      (('demux', 'METHF_energyCalibLUT'),     'M_METwithHFenergyCalibration_12to18.mif',   parseOfflineLUTfile(aModule.metHFCalibrationLUTFile.value(), 2048, aTruncate = True)),
-      (('demux', 'ET_energyCalibLUT'),        'S_ETcalibration_12to18.mif',       parseOfflineLUTfile(aModule.etSumEttCalibrationLUTFile.value(), 2048, aTruncate = True)),
-      (('demux', 'ecalET_energyCalibLUT'),    'R_EcalCalibration_12to18.mif',     parseOfflineLUTfile(aModule.etSumEcalSumCalibrationLUTFile.value(), 2048, aTruncate = True)),
-      (('demux', 'MET_phiCalibLUT'),          'Q_METnoHFphiCalibration_12to18.mif',     parseOfflineLUTfile(aModule.metPhiCalibrationLUTFile.value(), 2048, aTruncate = True)),
-      (('demux', 'METHF_phiCalibLUT'),        'Q_METwithHFphiCalibration_12to18.mif',   parseOfflineLUTfile(aModule.metHFPhiCalibrationLUTFile.value(), 2048, aTruncate = True)),
+      (('demux', 'MET_energyCalibLUT'),       'M_METnoHFenergyCalibration_12to18.mif',     parseOfflineLUTfile(aModule.metCalibrationLUTFile.value(), 4096, aTruncate = True)),
+      (('demux', 'METHF_energyCalibLUT'),     'M_METwithHFenergyCalibration_12to18.mif',   parseOfflineLUTfile(aModule.metHFCalibrationLUTFile.value(), 4096, aTruncate = True)),
+      (('demux', 'ET_energyCalibLUT'),        'S_ETcalibration_12to18.mif',       parseOfflineLUTfile(aModule.etSumEttCalibrationLUTFile.value(), 4096, aTruncate = True)),
+      (('demux', 'ecalET_energyCalibLUT'),    'R_EcalCalibration_12to18.mif',     parseOfflineLUTfile(aModule.etSumEcalSumCalibrationLUTFile.value(), 4096, aTruncate = True)),
+      (('demux', 'MET_phiCalibLUT'),          'Q_METnoHFphiCalibration_12to18.mif',     parseOfflineLUTfile(aModule.metPhiCalibrationLUTFile.value(), 4096, aTruncate = True)),
+      (('demux', 'METHF_phiCalibLUT'),        'Q_METwithHFphiCalibration_12to18.mif',   parseOfflineLUTfile(aModule.metHFPhiCalibrationLUTFile.value(), 4096, aTruncate = True)),
     ]
 
     result = [(a, b, parseOfflineLUTfile(c.value()) if isinstance(c, cms.FileInPath) else c) for a, b, c in result]

--- a/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
+++ b/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
@@ -29,7 +29,7 @@ namespace l1t {
            layer1HCal=18,
            layer1HF=19,
 	   jetCompressEta=20, jetCompressPt=21,
-	   etSumXCalibration=22, etSumYCalibration=23, etSumEttCalibration=24, etSumEcalSumCalibration=25,
+	   metCalibration=22, metHFCalibration=23, etSumEttCalibration=24, etSumEcalSumCalibration=25,
 	   tauIsolation2=26,
            egBypassEGVetosFlag=27,
            jetBypassPUSFlag=28,
@@ -52,7 +52,9 @@ namespace l1t {
 	   etSumCentralityLower=45,
 	   etSumCentralityUpper=46,
 	   jetPUSUsePhiRingFlag=47,
-	   NUM_CALOPARAMNODES=48
+	   metPhiCalibration=48,
+	   metHFPhiCalibration=49,
+	   NUM_CALOPARAMNODES=50
     };
 
     CaloParamsHelperO2O() { pnode_.resize(NUM_CALOPARAMNODES); }
@@ -370,18 +372,20 @@ namespace l1t {
     std::string etSumMetPUSType() const { return pnode_[etSumMetPUS].type_; }
     std::string etSumEttPUSType() const { return pnode_[etSumEttPUS].type_; }
     std::string etSumEcalSumPUSType() const { return pnode_[etSumEcalSumPUS].type_; }
-    std::string etSumXCalibrationType() const { return pnode_[etSumXCalibration].type_; }
-    std::string etSumYCalibrationType() const { return pnode_[etSumYCalibration].type_; }
+    std::string metCalibrationType() const { return pnode_[metCalibration].type_; }
+    std::string metHFCalibrationType() const { return pnode_[metHFCalibration].type_; }
     std::string etSumEttCalibrationType() const { return pnode_[etSumEttCalibration].type_; }
     std::string etSumEcalSumCalibrationType() const { return pnode_[etSumEcalSumCalibration].type_; }
 
     l1t::LUT* etSumMetPUSLUT() { return &pnode_[etSumMetPUS].LUT_; }
     l1t::LUT* etSumEttPUSLUT() { return &pnode_[etSumEttPUS].LUT_; }
     l1t::LUT* etSumEcalSumPUSLUT() { return &pnode_[etSumEcalSumPUS].LUT_; }
-    l1t::LUT* etSumXCalibrationLUT() { return &pnode_[etSumXCalibration].LUT_; }
-    l1t::LUT* etSumYCalibrationLUT() { return &pnode_[etSumYCalibration].LUT_; }
+    l1t::LUT* metCalibrationLUT() { return &pnode_[metCalibration].LUT_; }
+    l1t::LUT* metHFCalibrationLUT() { return &pnode_[metHFCalibration].LUT_; }
     l1t::LUT* etSumEttCalibrationLUT() { return &pnode_[etSumEttCalibration].LUT_; }
     l1t::LUT* etSumEcalSumCalibrationLUT() { return &pnode_[etSumEcalSumCalibration].LUT_; }
+    l1t::LUT* metPhiCalibrationLUT() { return &pnode_[metPhiCalibration].LUT_; }
+    l1t::LUT* metHFPhiCalibrationLUT() { return &pnode_[metHFPhiCalibration].LUT_; }
 
     void setEtSumLsb(double lsb) { etSumLsb_ = lsb; }
     void setEtSumEtaMin(unsigned isum, int eta){
@@ -399,8 +403,8 @@ namespace l1t {
     void setEtSumMetPUSType(std::string type) { pnode_[etSumMetPUS].type_ = type; }
     void setEtSumEttPUSType(std::string type) { pnode_[etSumEttPUS].type_ = type; }
     void setEtSumEcalSumPUSType(std::string type) { pnode_[etSumEcalSumPUS].type_ = type; }
-    void setEtSumXCalibrationType(std::string type) { pnode_[etSumXCalibration].type_ = type; }
-    void setEtSumYCalibrationType(std::string type) { pnode_[etSumYCalibration].type_ = type; }
+    void setMetCalibrationType(std::string type) { pnode_[metCalibration].type_ = type; }
+    void setMetHFCalibrationType(std::string type) { pnode_[metHFCalibration].type_ = type; }
     void setEtSumEttCalibrationType(std::string type) { pnode_[etSumEttCalibration].type_ = type; }
     void setEtSumEcalSumCalibrationType(std::string type) { pnode_[etSumEcalSumCalibration].type_ = type; }
     void setEtSumBypassMetPUS(unsigned flag) { 
@@ -420,10 +424,12 @@ namespace l1t {
     void setEtSumMetPUSLUT(const l1t::LUT & lut) { pnode_[etSumMetPUS].LUT_ = lut; }
     void setEtSumEttPUSLUT(const l1t::LUT & lut) { pnode_[etSumEttPUS].LUT_ = lut; }
     void setEtSumEcalSumPUSLUT(const l1t::LUT & lut) { pnode_[etSumEcalSumPUS].LUT_ = lut; }
-    void setEtSumXCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumXCalibration].LUT_ = lut; }
-    void setEtSumYCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumYCalibration].LUT_ = lut; }
+    void setMetCalibrationLUT(const l1t::LUT & lut) { pnode_[metCalibration].LUT_ = lut; }
+    void setMetHFCalibrationLUT(const l1t::LUT & lut) { pnode_[metHFCalibration].LUT_ = lut; }
     void setEtSumEttCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumEttCalibration].LUT_ = lut; }
     void setEtSumEcalSumCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumEcalSumCalibration].LUT_ = lut; }
+    void setMetPhiCalibrationLUT(const l1t::LUT & lut) { pnode_[metPhiCalibration].LUT_ = lut; }
+    void setMetHFPhiCalibrationLUT(const l1t::LUT & lut) { pnode_[metHFPhiCalibration].LUT_ = lut; }
 
     double etSumCentLower(unsigned centClass) const {
       if (pnode_[etSumCentralityLower].dparams_.size()>centClass)

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -205,7 +205,6 @@ std::map<std::string, l1t::Mask>& ) {
 
   if( conf.find("P_TauTrimming_13to8.mif") != conf.end() )
     paramsHelper.setTauTrimmingShapeVetoLUT( l1t::convertToLUT( conf["P_TauTrimming_13to8.mif"].getVector<int>() ) );
->>>>>>> f52d23c58c4... More updates for O2O
 
   return true;
 }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -188,24 +188,6 @@ std::map<std::string, l1t::Mask>& ) {
   paramsHelper.setMetPhiCalibrationLUT      ( l1t::convertToLUT( conf["MET_phiCalibLUT"].getVector<int>() ) );
   paramsHelper.setMetHFPhiCalibrationLUT      ( l1t::convertToLUT( conf["METHF_phiCalibLUT"].getVector<int>() ) );
 
-  paramsHelper.setEgMaxPtHOverE((conf["egammaRelaxationThreshold"].getValue<int>())/2.);
-  paramsHelper.setEgEtaCut((conf["egammaMaxEta"].getValue<int>()));
-  paramsHelper.setEgCalibrationLUT  ( l1t::convertToLUT( conf["egammaEnergyCalibLUT"].getVector<int>() ) );
-  paramsHelper.setEgIsolationLUT    ( l1t::convertToLUT( conf["egammaIsoLUT1"].getVector<int>() ) );
-  paramsHelper.setEgIsolationLUT2   ( l1t::convertToLUT( conf["egammaIsoLUT2"].getVector<int>() ) );
-
-  paramsHelper.setIsoTauEtaMax((conf["tauMaxEta"].getValue<int>()));
-
-  paramsHelper.setTauCalibrationLUT( l1t::convertToLUT( conf["tauEnergyCalibLUT"].getVector<int>() ) );
-  paramsHelper.setTauIsolationLUT  ( l1t::convertToLUT( conf["tauIsoLUT1"].getVector<int>() ) );
-  if( conf.find("tauIsoLUT2") != conf.end() )
-    paramsHelper.setTauIsolationLUT2 ( l1t::convertToLUT( conf["tauIsoLUT2"].getVector<int>() ) );
-
-  paramsHelper.setEgBypassExtHOverE( conf["egammaBypassExtendedHOverE"].getValue<bool>() );
-
-  if( conf.find("P_TauTrimming_13to8.mif") != conf.end() )
-    paramsHelper.setTauTrimmingShapeVetoLUT( l1t::convertToLUT( conf["P_TauTrimming_13to8.mif"].getVector<int>() ) );
-
   return true;
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -114,8 +114,10 @@ std::map<std::string, l1t::Mask>& ) {
     "ET_centralityUpperThresholds",
     "ET_energyCalibLUT",
     "ecalET_energyCalibLUT",
-    "METX_energyCalibLUT",
-    "METY_energyCalibLUT"
+    "MET_energyCalibLUT",
+    "METHF_energyCalibLUT",
+    "MET_phiCalibLUT",
+    "METHF_phiCalibLUT",
   };
 
   for (const auto param : expectedParams) {
@@ -181,8 +183,29 @@ std::map<std::string, l1t::Mask>& ) {
   // demux tower sum calib LUTs
   paramsHelper.setEtSumEttCalibrationLUT    ( l1t::convertToLUT( conf["ET_energyCalibLUT"].getVector<int>() ) );
   paramsHelper.setEtSumEcalSumCalibrationLUT( l1t::convertToLUT( conf["ecalET_energyCalibLUT"].getVector<int>() ) );
-  paramsHelper.setEtSumXCalibrationLUT      ( l1t::convertToLUT( conf["METX_energyCalibLUT"].getVector<int>() ) );
-  paramsHelper.setEtSumYCalibrationLUT      ( l1t::convertToLUT( conf["METY_energyCalibLUT"].getVector<int>() ) );
+  paramsHelper.setMetCalibrationLUT      ( l1t::convertToLUT( conf["MET_energyCalibLUT"].getVector<int>() ) );
+  paramsHelper.setMetHFCalibrationLUT      ( l1t::convertToLUT( conf["METHF_energyCalibLUT"].getVector<int>() ) );
+  paramsHelper.setMetPhiCalibrationLUT      ( l1t::convertToLUT( conf["MET_phiCalibLUT"].getVector<int>() ) );
+  paramsHelper.setMetHFPhiCalibrationLUT      ( l1t::convertToLUT( conf["METHF_phiCalibLUT"].getVector<int>() ) );
+
+  paramsHelper.setEgMaxPtHOverE((conf["egammaRelaxationThreshold"].getValue<int>())/2.);
+  paramsHelper.setEgEtaCut((conf["egammaMaxEta"].getValue<int>()));
+  paramsHelper.setEgCalibrationLUT  ( l1t::convertToLUT( conf["egammaEnergyCalibLUT"].getVector<int>() ) );
+  paramsHelper.setEgIsolationLUT    ( l1t::convertToLUT( conf["egammaIsoLUT1"].getVector<int>() ) );
+  paramsHelper.setEgIsolationLUT2   ( l1t::convertToLUT( conf["egammaIsoLUT2"].getVector<int>() ) );
+
+  paramsHelper.setIsoTauEtaMax((conf["tauMaxEta"].getValue<int>()));
+
+  paramsHelper.setTauCalibrationLUT( l1t::convertToLUT( conf["tauEnergyCalibLUT"].getVector<int>() ) );
+  paramsHelper.setTauIsolationLUT  ( l1t::convertToLUT( conf["tauIsoLUT1"].getVector<int>() ) );
+  if( conf.find("tauIsoLUT2") != conf.end() )
+    paramsHelper.setTauIsolationLUT2 ( l1t::convertToLUT( conf["tauIsoLUT2"].getVector<int>() ) );
+
+  paramsHelper.setEgBypassExtHOverE( conf["egammaBypassExtendedHOverE"].getValue<bool>() );
+
+  if( conf.find("P_TauTrimming_13to8.mif") != conf.end() )
+    paramsHelper.setTauTrimmingShapeVetoLUT( l1t::convertToLUT( conf["P_TauTrimming_13to8.mif"].getVector<int>() ) );
+>>>>>>> f52d23c58c4... More updates for O2O
 
   return true;
 }

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
@@ -30,8 +30,8 @@ private:
     bool printEcalSF;
     bool printEtSumEttPUSLUT;
     bool printEtSumEcalSumPUSLUT;
-    bool printEtSumXCalibrationLUT;
-    bool printEtSumYCalibrationLUT;
+    bool printMetCalibrationLUT;
+    bool printMetHFCalibrationLUT;
     bool printEtSumEttCalibrationLUT;
     bool printEtSumEcalSumCalibrationLUT;
 
@@ -59,8 +59,8 @@ public:
         printEcalSF      = pset.getUntrackedParameter<bool>("printEcalSF",     false);
         printEtSumEttPUSLUT             = pset.getUntrackedParameter<bool>("printEtSumEttPUSLUT",             false);
         printEtSumEcalSumPUSLUT         = pset.getUntrackedParameter<bool>("printEtSumEcalSumPUSLUT",         false);
-        printEtSumXCalibrationLUT       = pset.getUntrackedParameter<bool>("printEtSumXCalibrationLUT",       false);
-        printEtSumYCalibrationLUT       = pset.getUntrackedParameter<bool>("printEtSumYCalibrationLUT",       false);
+        printMetCalibrationLUT       = pset.getUntrackedParameter<bool>("printMetCalibrationLUT",       false);
+        printMetHFCalibrationLUT       = pset.getUntrackedParameter<bool>("printMetHFCalibrationLUT",       false);
         printEtSumEttCalibrationLUT     = pset.getUntrackedParameter<bool>("printEtSumEttCalibrationLUT",     false);
         printEtSumEcalSumCalibrationLUT = pset.getUntrackedParameter<bool>("printEtSumEcalSumCalibrationLUT", false);
 
@@ -460,8 +460,8 @@ void L1TCaloParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetu
     cout<<"  etSumMetPUSType=        " << ptr1->etSumMetPUSType() << endl;
     cout<<"  etSumEttPUSType=        " << ptr1->etSumEttPUSType() << endl;
     cout<<"  etSumEcalSumPUSType=    " << ptr1->etSumEcalSumPUSType() << endl;
-    cout<<"  etSumXCalibrationType=  " << ptr1->etSumXCalibrationType() << endl;
-    cout<<"  etSumYCalibrationType=  " << ptr1->etSumYCalibrationType() << endl;
+    cout<<"  metCalibrationType=  " << ptr1->metCalibrationType() << endl;
+    cout<<"  metHFCalibrationType=  " << ptr1->metHFCalibrationType() << endl;
     cout<<"  etSumEttCalibrationType=" << ptr1->etSumEttCalibrationType() << endl;
     cout<<"  etSumEcalSumCalibrationType=" << ptr1->etSumEcalSumCalibrationType() << endl;
 
@@ -513,36 +513,36 @@ void L1TCaloParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetu
         cout<<"  etSumEcalSumPUSLUT=     [0]"<<endl;
     }
 
-    if( !ptr1->etSumXCalibrationLUT()->empty() ){
-        cout<<"  etSumXCalibrationLUT=   ["<<ptr1->etSumXCalibrationLUT()->maxSize()<<"] "<<flush;
-        int etSumXCalibrationLUT[ptr1->etSumXCalibrationLUT()->maxSize()];
-        for(unsigned int i=0; i<ptr1->etSumXCalibrationLUT()->maxSize(); i++)
-            etSumXCalibrationLUT[i] = ptr1->etSumXCalibrationLUT()->data(i);
+    if( !ptr1->metCalibrationLUT()->empty() ){
+        cout<<"  metCalibrationLUT=   ["<<ptr1->metCalibrationLUT()->maxSize()<<"] "<<flush;
+        int metCalibrationLUT[ptr1->metCalibrationLUT()->maxSize()];
+        for(unsigned int i=0; i<ptr1->metCalibrationLUT()->maxSize(); i++)
+            metCalibrationLUT[i] = ptr1->metCalibrationLUT()->data(i);
 
-        cout << hash( etSumXCalibrationLUT, sizeof(int)*ptr1->etSumXCalibrationLUT()->maxSize()  ) << endl;
+        cout << hash( metCalibrationLUT, sizeof(int)*ptr1->metCalibrationLUT()->maxSize()  ) << endl;
 
-        if( printEtSumXCalibrationLUT )
-            for(unsigned int i=0; i<ptr1->etSumXCalibrationLUT()->maxSize(); i++)
-            cout<<i<<" "<<etSumXCalibrationLUT[i]<<endl;
+        if( printMetCalibrationLUT )
+            for(unsigned int i=0; i<ptr1->metCalibrationLUT()->maxSize(); i++)
+            cout<<i<<" "<<metCalibrationLUT[i]<<endl;
 
     } else {
-        cout<<"  etSumXCalibrationLUT=   [0]"<<endl;
+        cout<<"  metCalibrationLUT=   [0]"<<endl;
     }
 
-    if( !ptr1->etSumYCalibrationLUT()->empty() ){
-        cout<<"  etSumYCalibrationLUT=   ["<<ptr1->etSumYCalibrationLUT()->maxSize()<<"] "<<flush;
-        int etSumYCalibrationLUT[ptr1->etSumYCalibrationLUT()->maxSize()];
-        for(unsigned int i=0; i<ptr1->etSumYCalibrationLUT()->maxSize(); i++)
-            etSumYCalibrationLUT[i] = ptr1->etSumYCalibrationLUT()->data(i);
+    if( !ptr1->metHFCalibrationLUT()->empty() ){
+        cout<<"  metHFCalibrationLUT=   ["<<ptr1->metHFCalibrationLUT()->maxSize()<<"] "<<flush;
+        int metHFCalibrationLUT[ptr1->metHFCalibrationLUT()->maxSize()];
+        for(unsigned int i=0; i<ptr1->metHFCalibrationLUT()->maxSize(); i++)
+            metHFCalibrationLUT[i] = ptr1->metHFCalibrationLUT()->data(i);
 
-        cout << hash( etSumYCalibrationLUT, sizeof(int)*ptr1->etSumYCalibrationLUT()->maxSize()  ) << endl;
+        cout << hash( metHFCalibrationLUT, sizeof(int)*ptr1->metHFCalibrationLUT()->maxSize()  ) << endl;
 
-        if( printEtSumYCalibrationLUT )
-            for(unsigned int i=0; i<ptr1->etSumYCalibrationLUT()->maxSize(); i++)
-            cout<<i<<" "<<etSumYCalibrationLUT[i]<<endl;
+        if( printMetHFCalibrationLUT )
+            for(unsigned int i=0; i<ptr1->metHFCalibrationLUT()->maxSize(); i++)
+            cout<<i<<" "<<metHFCalibrationLUT[i]<<endl;
 
     } else {
-        cout<<"  etSumYCalibrationLUT=   [0]"<<endl;
+        cout<<"  metHFCalibrationLUT=   [0]"<<endl;
     }
 
     if( !ptr1->etSumEttCalibrationLUT()->empty() ){

--- a/L1TriggerConfig/Utilities/test/viewCaloParams.py
+++ b/L1TriggerConfig/Utilities/test/viewCaloParams.py
@@ -76,8 +76,8 @@ process.l1cpv = cms.EDAnalyzer("L1TCaloParamsViewer",
                                printEcalSF = cms.untracked.bool(False),
                                printEtSumEttPUSLUT = cms.untracked.bool(False),
                                printEtSumEcalSumPUSLUT = cms.untracked.bool(False),
-                               printEtSumXCalibrationLUT = cms.untracked.bool(False),
-                               printEtSumYCalibrationLUT = cms.untracked.bool(False),
+                               printMetCalibrationLUT = cms.untracked.bool(False),
+                               printMetHFCalibrationLUT = cms.untracked.bool(False),
                                printEtSumEttCalibrationLUT = cms.untracked.bool(False),
                                printEtSumEcalSumCalibrationLUT = cms.untracked.bool(False)
 )


### PR DESCRIPTION
This PR brings the caloL2 O2O fully inline with the firmware. 

- Remove etSumX & etSumY calibration LUTs: these are replaced by met & metHF calibration LUTs
- Add metPhi & metHFPhi calibration LUTs
- Add demux LUTs to conversion script
- Update caloParams & helper class

NB. The etSumXCalibration & etSumYCalibration nodes that have been repurposed in CaloParamsHelper.h and CaloParamsHelperO2O.h were never used anywhere in CMSSW, so this is backwards compatible. 