### PR TITLE
[10_4_X] Fixed copy-paste typo in Spring15 photon MVA weight file names

### DIFF
--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_25ns_nonTrig_V0_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_25ns_nonTrig_V0_cff.py
@@ -27,7 +27,7 @@ mvaTag = "Run2Spring15NonTrig25nsV0"
 
 mvaSpring15NonTrigWeightFiles_V0 = cms.vstring(
     path.join(weightFileBaseDir, "Spring15/25ns_EB_V0.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Spring15/25ns_EB_V0.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Spring15/25ns_EE_V0.weights.xml.gz"),
     )
 
 # The locatoins of value maps with the actual MVA values and categories

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_25ns_nonTrig_V2_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_25ns_nonTrig_V2_cff.py
@@ -28,7 +28,7 @@ mvaTag = "Run2Spring15NonTrig25nsV2"
 
 mvaSpring15NonTrigWeightFiles_V2 = cms.vstring(
     path.join(weightFileBaseDir, "Spring15/25ns_EB_V2.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Spring15/25ns_EB_V2.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Spring15/25ns_EE_V2.weights.xml.gz"),
     )
 
 # The locatoins of value maps with the actual MVA values and categories

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_25ns_nonTrig_V2p1_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_25ns_nonTrig_V2p1_cff.py
@@ -30,7 +30,7 @@ mvaTag = "Run2Spring15NonTrig25nsV2p1"
 
 mvaSpring15NonTrigWeightFiles_V2p1 = cms.vstring(
     path.join(weightFileBaseDir, "Spring15/25ns_EB_V2.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Spring15/25ns_EB_V2.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Spring15/25ns_EE_V2.weights.xml.gz"),
     )
 
 # The locatoins of value maps with the actual MVA values and categories

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V0_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V0_cff.py
@@ -27,7 +27,7 @@ mvaTag = "Run2Spring15NonTrig50nsV0"
 
 mvaSpring15NonTrigWeightFiles_V0 = cms.vstring(
     path.join(weightFileBaseDir, "Spring15/50ns_EB_V0.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Spring15/50ns_EB_V0.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Spring15/50ns_EE_V0.weights.xml.gz"),
     )
 
 # The locatoins of value maps with the actual MVA values and categories

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V1_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V1_cff.py
@@ -27,7 +27,7 @@ mvaTag = "Run2Spring15NonTrig50nsV1"
 
 mvaSpring15NonTrigWeightFiles_V1 = cms.vstring(
     path.join(weightFileBaseDir, "Spring15/50ns_EB_V1.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Spring15/50ns_EB_V1.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Spring15/50ns_EE_V1.weights.xml.gz"),
     )
 
 # The locatoins of value maps with the actual MVA values and categories

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V2_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V2_cff.py
@@ -29,7 +29,7 @@ mvaTag = "Run2Spring15NonTrig50nsV2"
 
 mvaSpring15NonTrigWeightFiles_V2 = cms.vstring(
     path.join(weightFileBaseDir, "Spring15/50ns_EB_V2.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Spring15/50ns_EB_V2.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Spring15/50ns_EE_V2.weights.xml.gz"),
     )
 
 # The locatoins of value maps with the actual MVA values and categories

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V2p1_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V2p1_cff.py
@@ -31,7 +31,7 @@ mvaTag = "Run2Spring15NonTrig50nsV2p1"
 
 mvaSpring15NonTrigWeightFiles_V2p1 = cms.vstring(
     path.join(weightFileBaseDir, "Spring15/50ns_EB_V2.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Spring15/50ns_EB_V2.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Spring15/50ns_EE_V2.weights.xml.gz"),
     )
 
 # The locatoins of value maps with the actual MVA values and categories


### PR DESCRIPTION
Hi,

unfortunately I introduced a typo with #24131 in the Spring15 Photon MVA. This ID is not supported anymore and we only noticed it during the preparation of the Fall17 V2 ID backport to 9_4_X. It is not enabled by default, that's why we didn't catch this in #24131.

Even thought it's a deprecated ID, I think it's not appropriate to let it break in the 10_3_0 release in this ungraceful way, so I hope I'm still in time...

My personal validation workflow shows now agreement of the Spring15 photon MVAs between this PR and 9_4_9.

Jonas