### PR TITLE
Skip tests if no CUDA devices are present (10.2.x)

### DIFF
--- a/DataFormats/Math/test/cudaAtan2Test.cu
+++ b/DataFormats/Math/test/cudaAtan2Test.cu
@@ -18,28 +18,25 @@ echo $f; $f
 end
 */
 
-#include "DataFormats/Math/interface/approx_atan2.h"
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <random>
 
 #include "cuda/api_wrappers.h"
 
-#include <iostream>
-#include <iomanip>
-#include <memory>
-#include <algorithm>
-#include <chrono>
-#include <random>
-
-#include <cassert>
+#include "DataFormats/Math/interface/approx_atan2.h"
 
 constexpr float xmin=-100.001;  // avoid 0
 constexpr float incr = 0.04;
 constexpr int Nsteps = 2.*std::abs(xmin)/incr;
 
-
 template<int DEGREE>
-__global__ void diffAtan(int * diffs) {
-
-
+__global__ void diffAtan(int * diffs)
+{
   auto mdiff = &diffs[0];
   auto idiff = &diffs[1];
   auto sdiff = &diffs[2];
@@ -48,7 +45,7 @@ __global__ void diffAtan(int * diffs) {
   int j = blockDim.y * blockIdx.y + threadIdx.y;
 
   auto x = xmin +incr*i;
-  auto y = xmin	+incr*j;
+  auto y = xmin +incr*j;
 
   auto approx = unsafe_atan2f<DEGREE>(y,x);
   auto iapprox = unsafe_atan2i<DEGREE>(y,x);
@@ -59,7 +56,6 @@ __global__ void diffAtan(int * diffs) {
   atomicMax(idiff, std::abs(phi2int(std)-iapprox));
   short dd = std::abs(phi2short(std)-sapprox);
   atomicMax(sdiff,int(dd));
-
 }
 
 template<int DEGREE>
@@ -67,67 +63,63 @@ void go() {
   auto start = std::chrono::high_resolution_clock::now();
   auto delta = start - start;
 
-	if (cuda::device::count() == 0) {
-		std::cerr << "No CUDA devices on this system" << "\n";
-		exit(EXIT_FAILURE);
-	}
+  auto current_device = cuda::device::current::get(); 
 
-        auto current_device = cuda::device::current::get(); 
-        // atan2
-        delta -= (std::chrono::high_resolution_clock::now()-start);
+  // atan2
+  delta -= (std::chrono::high_resolution_clock::now()-start);
  
-        auto diff_d = cuda::memory::device::make_unique<int[]>(current_device,3);
+  auto diff_d = cuda::memory::device::make_unique<int[]>(current_device,3);
  
-        int diffs[3];
-        cuda::memory::device::zero(diff_d.get(),3*4);
+  int diffs[3];
+  cuda::memory::device::zero(diff_d.get(),3*4);
 
-        // Launch the diff CUDA Kernel
-        dim3 threadsPerBlock(32,32,1);
-        dim3 blocksPerGrid ( (Nsteps + threadsPerBlock.x - 1) / threadsPerBlock.x,
-                             (Nsteps + threadsPerBlock.y - 1) / threadsPerBlock.y,
-                            1
-                               );
-        std::cout
-                << "CUDA kernel 'diff' launch with " << blocksPerGrid.x
-                << " blocks of " << threadsPerBlock.y << " threads\n";
+  // Launch the diff CUDA Kernel
+  dim3 threadsPerBlock(32,32,1);
+  dim3 blocksPerGrid((Nsteps + threadsPerBlock.x - 1) / threadsPerBlock.x,
+                     (Nsteps + threadsPerBlock.y - 1) / threadsPerBlock.y,
+                     1);
+  std::cout
+    << "CUDA kernel 'diff' launch with " << blocksPerGrid.x
+    << " blocks of " << threadsPerBlock.y << " threads\n";
 
-        cuda::launch(
-                diffAtan<DEGREE>,
-                { blocksPerGrid, threadsPerBlock },
-                diff_d.get() );
+  cuda::launch(
+    diffAtan<DEGREE>,
+    { blocksPerGrid, threadsPerBlock },
+    diff_d.get());
 
-        cuda::memory::copy(diffs, diff_d.get(), 3*4);
-        delta += (std::chrono::high_resolution_clock::now()-start);
+  cuda::memory::copy(diffs, diff_d.get(), 3*4);
+  delta += (std::chrono::high_resolution_clock::now()-start);
  
-        float mdiff = diffs[0]*1.e-7;
-        int idiff = diffs[1];
-        int sdiff = diffs[2];
+  float mdiff = diffs[0]*1.e-7;
+  int idiff = diffs[1];
+  int sdiff = diffs[2];
 
-        std::cout << "for degree " << DEGREE << " max diff is " << mdiff 
-                             << ' ' << idiff << ' ' << int2phi(idiff) 
-                             << ' ' << sdiff << ' ' << short2phi(sdiff) <<  std::endl;
-
-
-        std::cout <<"cuda computation took "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
-              << " ms" << std::endl;
-
-	return;
+  std::cout << "for degree " << DEGREE << " max diff is " << mdiff 
+            << ' ' << idiff << ' ' << int2phi(idiff) 
+            << ' ' << sdiff << ' ' << short2phi(sdiff) <<  std::endl;
+  std::cout << "cuda computation took "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
+            << " ms" << std::endl;
 }
-
 
 int main() {
-try{
-  go<3>();
-  go<5>();
-  go<7>();
-  go<9>();
-} catch(cuda::runtime_error ex) {
-   std::cout << "cuda error " << ex.what() << std::endl;
-} catch(...) {
-   std::cout <<	"a non cuda error" << std::endl;
-}
+  if (cuda::device::count() == 0) {
+    std::cerr << "No CUDA devices on this system, the test will be skipped." << "\n";
+    exit(EXIT_SUCCESS);
+  }
 
+  try {
+    go<3>();
+    go<5>();
+    go<7>();
+    go<9>();
+  } catch(cuda::runtime_error ex) {
+    std::cerr << "CUDA error: " << ex.what() << std::endl;
+    exit(EXIT_FAILURE);
+  } catch(...) {
+    std::cerr << "A non-CUDA error occurred" << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/DataFormats/Math/test/cudaAtan2Test.cu
+++ b/DataFormats/Math/test/cudaAtan2Test.cu
@@ -103,7 +103,13 @@ void go() {
 }
 
 int main() {
-  if (cuda::device::count() == 0) {
+  int count = 0;
+  auto status = cudaGetDeviceCount(& count);
+  if (status != cudaSuccess) {
+    std::cerr << cudaGetErrorString(status) << ", the test will be skipped." << "\n";
+    exit(EXIT_SUCCESS);
+  }
+  if (count == 0) {
     std::cerr << "No CUDA devices on this system, the test will be skipped." << "\n";
     exit(EXIT_SUCCESS);
   }

--- a/DataFormats/Math/test/cudaAtan2Test.cu
+++ b/DataFormats/Math/test/cudaAtan2Test.cu
@@ -106,7 +106,7 @@ int main() {
   int count = 0;
   auto status = cudaGetDeviceCount(& count);
   if (status != cudaSuccess) {
-    std::cerr << cudaGetErrorString(status) << ", the test will be skipped." << "\n";
+    std::cerr << "Failed to initialise the CUDA runtime, the test will be skipped." << "\n";
     exit(EXIT_SUCCESS);
   }
   if (count == 0) {

--- a/DataFormats/Math/test/cudaMathTest.cu
+++ b/DataFormats/Math/test/cudaMathTest.cu
@@ -18,24 +18,31 @@ echo $f; $f
 end
 */
 
-#include "cuda/api_wrappers.h"
-
-#include <iostream>
-#include <iomanip>
-#include <memory>
 #include <algorithm>
+#include <cassert>
 #include <chrono>
-#include<random>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <random>
 
-#include<cassert>
-
-std::mt19937 eng;
-std::mt19937 eng2;
-std::uniform_real_distribution<float> rgen(0.,1.);
+#include "cuda/api_wrappers.h"
 
 #include<DataFormats/Math/interface/approx_log.h>
 #include<DataFormats/Math/interface/approx_exp.h>
 #include<DataFormats/Math/interface/approx_atan2.h>
+
+#ifdef __CUDACC__
+#define inline __host__ __device__ inline
+#include <vdt/sin.h>
+#undef inline
+#else
+#include <vdt/sin.h>
+#endif
+
+std::mt19937 eng;
+std::mt19937 eng2;
+std::uniform_real_distribution<float> rgen(0.,1.);
 
 constexpr float myExp(float x) {
   return  unsafe_expf<6>(x);
@@ -45,22 +52,12 @@ constexpr float myLog(float x) {
   return  unsafe_logf<6>(x);
 }
 
-
-#ifdef __NVCC__
-#define inline __host__ __device__ inline
-#include<vdt/sin.h>
-#undef inline
-#else
-#include<vdt/sin.h>
-#endif
-
 __host__ __device__
 inline float mySin(float x) {
   return vdt::fast_sinf(x);
 }
 
-
-constexpr int  USEEXP=0, USESIN=1, USELOG=2;
+constexpr int USEEXP=0, USESIN=1, USELOG=2;
 
 template<int USE, bool ADDY=false>
 // __host__ __device__
@@ -78,15 +75,20 @@ return ADDY ? ret+y : ret;
 template<int USE, bool ADDY>
 __global__ void vectorOp(const float *A, const float *B, float *C, int numElements)
 {
-	int i = blockDim.x * blockIdx.x + threadIdx.x;
-	if (i < numElements) { C[i] = testFunc<USE,ADDY>(A[i],B[i]); }
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < numElements)
+  {
+    C[i] = testFunc<USE,ADDY>(A[i],B[i]);
+  }
 }
 
 template<int USE, bool ADDY>
 void vectorOpH(const float *A, const float *B, float *C, int numElements)
 {
-        for (int i=0; i<numElements; ++i)
-           { C[i] = testFunc<USE,ADDY>(A[i],B[i]); }
+  for (int i=0; i<numElements; ++i)
+  {
+    C[i] = testFunc<USE,ADDY>(A[i],B[i]);
+  }
 }
 
 template<int USE, bool ADDY=false>
@@ -95,136 +97,132 @@ void go()
   auto start = std::chrono::high_resolution_clock::now();
   auto delta = start - start;
 
-	if (cuda::device::count() == 0) {
-		std::cerr << "No CUDA devices on this system" << "\n";
-		exit(EXIT_FAILURE);
-	}
+  auto current_device = cuda::device::current::get(); 
 
-        auto current_device = cuda::device::current::get(); 
+  int numElements = 200000;
+  size_t size = numElements * sizeof(float);
+  std::cout << "[Vector of " << numElements << " elements]\n";
 
-	int numElements = 200000;
-	size_t size = numElements * sizeof(float);
-	std::cout << "[Vector of " << numElements << " elements]\n";
+  auto h_A = std::make_unique<float[]>(numElements);
+  auto h_B = std::make_unique<float[]>(numElements);
+  auto h_C = std::make_unique<float[]>(numElements);
+  auto h_C2 = std::make_unique<float[]>(numElements);
 
-	auto h_A = std::make_unique<float[]>(numElements);
-	auto h_B = std::make_unique<float[]>(numElements);
-	auto h_C = std::make_unique<float[]>(numElements);
-        auto h_C2 = std::make_unique<float[]>(numElements);
+  std::generate(h_A.get(), h_A.get() + numElements, [&](){return rgen(eng);});
+  std::generate(h_B.get(), h_B.get() + numElements, [&](){return rgen(eng);});
 
-	std::generate(h_A.get(), h_A.get() + numElements, [&](){return rgen(eng);});
-	std::generate(h_B.get(), h_B.get() + numElements, [&](){return rgen(eng);});
+  delta -= (std::chrono::high_resolution_clock::now()-start);
+  auto d_A = cuda::memory::device::make_unique<float[]>(current_device, numElements);
+  auto d_B = cuda::memory::device::make_unique<float[]>(current_device, numElements);
+  auto d_C = cuda::memory::device::make_unique<float[]>(current_device, numElements);
 
+  cuda::memory::copy(d_A.get(), h_A.get(), size);
+  cuda::memory::copy(d_B.get(), h_B.get(), size);
+  delta += (std::chrono::high_resolution_clock::now()-start);
+  std::cout <<"cuda alloc+copy took "
+    << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
+    << " ms" << std::endl;
 
-        delta -= (std::chrono::high_resolution_clock::now()-start);
-	auto d_A = cuda::memory::device::make_unique<float[]>(current_device, numElements);
-	auto d_B = cuda::memory::device::make_unique<float[]>(current_device, numElements);
-	auto d_C = cuda::memory::device::make_unique<float[]>(current_device, numElements);
+  // Launch the Vector OP CUDA Kernel
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
+  std::cout
+    << "CUDA kernel launch with " << blocksPerGrid
+    << " blocks of " << threadsPerBlock << " threads\n";
 
-	cuda::memory::copy(d_A.get(), h_A.get(), size);
-	cuda::memory::copy(d_B.get(), h_B.get(), size);
-        delta += (std::chrono::high_resolution_clock::now()-start);
-        std::cout <<"cuda alloc+copy took "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
-              << " ms" << std::endl;
+  delta -= (std::chrono::high_resolution_clock::now()-start);
+  cuda::launch(
+    vectorOp<USE,ADDY>,
+    { blocksPerGrid, threadsPerBlock },
+    d_A.get(), d_B.get(), d_C.get(), numElements
+  );
+  delta += (std::chrono::high_resolution_clock::now()-start);
+  std::cout <<"cuda computation took "
+    << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
+    << " ms" << std::endl;
 
+  delta -= (std::chrono::high_resolution_clock::now()-start);
+  cuda::launch(
+      vectorOp<USE,ADDY>,
+      { blocksPerGrid, threadsPerBlock },
+      d_A.get(), d_B.get(), d_C.get(), numElements
+  );
+  delta += (std::chrono::high_resolution_clock::now()-start);
+  std::cout <<"cuda computation took "
+    << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
+    << " ms" << std::endl;
 
-	// Launch the Vector OP CUDA Kernel
-	int threadsPerBlock = 256;
-	int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
-	std::cout
-		<< "CUDA kernel launch with " << blocksPerGrid
-		<< " blocks of " << threadsPerBlock << " threads\n";
+  delta -= (std::chrono::high_resolution_clock::now()-start);
+  cuda::memory::copy(h_C.get(), d_C.get(), size);
+  delta += (std::chrono::high_resolution_clock::now()-start);
+  std::cout <<"cuda copy back took "
+    << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
+    << " ms" << std::endl;
 
-        delta -= (std::chrono::high_resolution_clock::now()-start);
-	cuda::launch(
-		vectorOp<USE,ADDY>,
-		{ blocksPerGrid, threadsPerBlock },
-		d_A.get(), d_B.get(), d_C.get(), numElements
-	);
-        delta += (std::chrono::high_resolution_clock::now()-start);
-        std::cout <<"cuda computation took "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
-              << " ms" << std::endl;
+  // on host now...
+  delta -= (std::chrono::high_resolution_clock::now()-start);
+  vectorOpH<USE,ADDY>(h_A.get(),h_B.get(),h_C2.get(),numElements);        
+  delta += (std::chrono::high_resolution_clock::now()-start);
+  std::cout <<"host computation took "
+    << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
+    << " ms" << std::endl;
 
-        delta -= (std::chrono::high_resolution_clock::now()-start);
-        cuda::launch(
-                vectorOp<USE,ADDY>,
-                { blocksPerGrid, threadsPerBlock },
-                d_A.get(), d_B.get(), d_C.get(), numElements
-        );
-        delta += (std::chrono::high_resolution_clock::now()-start);
-        std::cout <<"cuda computation took "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
-              << " ms" << std::endl;
+  delta -= (std::chrono::high_resolution_clock::now()-start);
+  vectorOpH<USE,ADDY>(h_A.get(),h_B.get(),h_C2.get(),numElements);
+  delta += (std::chrono::high_resolution_clock::now()-start);
+  std::cout <<"host computation took "
+    << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
+    << " ms" << std::endl;
 
-        delta -= (std::chrono::high_resolution_clock::now()-start);
-	cuda::memory::copy(h_C.get(), d_C.get(), size);
-        delta += (std::chrono::high_resolution_clock::now()-start);
-        std::cout <<"cuda copy back took "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
-              << " ms" << std::endl;
-
-
-        // on host now...
-        delta -= (std::chrono::high_resolution_clock::now()-start);
-        vectorOpH<USE,ADDY>(h_A.get(),h_B.get(),h_C2.get(),numElements);        
-        delta += (std::chrono::high_resolution_clock::now()-start);
-        std::cout <<"host computation took "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
-              << " ms" << std::endl;
-
-        delta -= (std::chrono::high_resolution_clock::now()-start);
-        vectorOpH<USE,ADDY>(h_A.get(),h_B.get(),h_C2.get(),numElements);
-        delta += (std::chrono::high_resolution_clock::now()-start);
-        std::cout <<"host computation took "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
-              << " ms" << std::endl;
-
-
-	// Verify that the result vector is correct
-        double ave = 0;
-        int maxDiff = 0;
-        long long ndiff=0;
-        double fave = 0;
-        float fmaxDiff = 0;
-	for (int i = 0; i < numElements; ++i) {
-                        approx_math::binary32 g,c;
-                        g.f = testFunc<USE,ADDY>(h_A[i],h_B[i]);
-                        c.f = h_C[i];
-                        auto diff = std::abs(g.i32-c.i32);
-                        maxDiff = std::max(diff,maxDiff);
-                        ave += diff;
-                        if (diff!=0) ++ndiff;
-                        auto fdiff = std::abs(g.f-c.f);
-                        fave += fdiff;
-                        fmaxDiff = std::max(fdiff,fmaxDiff);
-//           if (diff>7)
-//           std::cerr << "Large diff at element " << i << ' ' << diff << ' ' << std::hexfloat 
-//                                  << g.f << "!=" << c.f << "\n";
-	}
-        std::cout << "ndiff ave, max " << ndiff << ' ' << ave/numElements << ' ' << maxDiff << std::endl;
-        std::cout << "float ave, max " << fave/numElements << ' ' << fmaxDiff << std::endl;
-        if (! ndiff) {
-	  std::cout << "Test PASSED\n";
-	  std::cout << "SUCCESS"<< std::endl;
-        }
+  // Verify that the result vector is correct
+  double ave = 0;
+  int maxDiff = 0;
+  long long ndiff=0;
+  double fave = 0;
+  float fmaxDiff = 0;
+  for (int i = 0; i < numElements; ++i) {
+    approx_math::binary32 g,c;
+    g.f = testFunc<USE,ADDY>(h_A[i],h_B[i]);
+    c.f = h_C[i];
+    auto diff = std::abs(g.i32-c.i32);
+    maxDiff = std::max(diff,maxDiff);
+    ave += diff;
+    if (diff!=0) ++ndiff;
+    auto fdiff = std::abs(g.f-c.f);
+    fave += fdiff;
+    fmaxDiff = std::max(fdiff,fmaxDiff);
+    //           if (diff>7)
+    //           std::cerr << "Large diff at element " << i << ' ' << diff << ' ' << std::hexfloat 
+    //                                  << g.f << "!=" << c.f << "\n";
+  }
+  std::cout << "ndiff ave, max " << ndiff << ' ' << ave/numElements << ' ' << maxDiff << std::endl;
+  std::cout << "float ave, max " << fave/numElements << ' ' << fmaxDiff << std::endl;
+  if (! ndiff) {
+    std::cout << "Test PASSED\n";
+    std::cout << "SUCCESS"<< std::endl;
+  }
   cudaDeviceSynchronize();
 }
 
 int main() {
+  if (cuda::device::count() == 0) {
+    std::cerr << "No CUDA devices on this system, the test will be skipped." << "\n";
+    exit(EXIT_SUCCESS);
+  }
 
-try {
-  go<USEEXP>();
-  go<USESIN>();
-  go<USELOG>();
+  try {
+    go<USEEXP>();
+    go<USESIN>();
+    go<USELOG>();
 
-  go<USELOG,true>();
+    go<USELOG, true>();
+  } catch(cuda::runtime_error ex) {
+    std::cerr << "CUDA error: " << ex.what() << std::endl;
+    exit(EXIT_FAILURE);
+  } catch(...) {
+    std::cerr << "A non-CUDA error occurred" << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
-} catch(cuda::runtime_error ex) {
-   std::cout << "cuda error " << ex.what() << std::endl;
-} catch(...) {
-   std::cout << "a non cuda error" << std::endl;
-}
-
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/DataFormats/Math/test/cudaMathTest.cu
+++ b/DataFormats/Math/test/cudaMathTest.cu
@@ -208,7 +208,7 @@ int main() {
   int count = 0;
   auto status = cudaGetDeviceCount(& count);
   if (status != cudaSuccess) {
-    std::cerr << cudaGetErrorString(status) << ", the test will be skipped." << "\n";
+    std::cerr << "Failed to initialise the CUDA runtime, the test will be skipped." << "\n";
     exit(EXIT_SUCCESS);
   }
   if (count == 0) {

--- a/DataFormats/Math/test/cudaMathTest.cu
+++ b/DataFormats/Math/test/cudaMathTest.cu
@@ -205,7 +205,13 @@ void go()
 }
 
 int main() {
-  if (cuda::device::count() == 0) {
+  int count = 0;
+  auto status = cudaGetDeviceCount(& count);
+  if (status != cudaSuccess) {
+    std::cerr << cudaGetErrorString(status) << ", the test will be skipped." << "\n";
+    exit(EXIT_SUCCESS);
+  }
+  if (count == 0) {
     std::cerr << "No CUDA devices on this system, the test will be skipped." << "\n";
     exit(EXIT_SUCCESS);
   }


### PR DESCRIPTION
If no CUDA devices are present, skip the tests and return a success status, instead of failing.