### PR TITLE
Fix numerical bug that causes NaNs in DeepCSV output

### DIFF
--- a/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
@@ -221,10 +221,13 @@ void CombinedSVComputer::fillCommonVariables(reco::TaggingVariableList & vars, r
                 vars.insert(btau::trackMomentum, trackMag, true);
                 vars.insert(btau::trackEta, trackMom.Eta(), true);
 
-                vars.insert(btau::trackPtRel, VectorUtil::Perp(trackMom, jetDir), true);
+                // check for erroneous Perp^2 values before evaluating Perp (fix for DeepCSV NaN outputs)
+                double Perp_trackMom_jetDir = VectorUtil::Perp2(trackMom, jetDir) > 0. ? VectorUtil::Perp(trackMom, jetDir) : 0.;
+
+                vars.insert(btau::trackPtRel, Perp_trackMom_jetDir, true);
                 vars.insert(btau::trackPPar, jetDir.Dot(trackMom), true);
                 vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
-                vars.insert(btau::trackPtRatio, VectorUtil::Perp(trackMom, jetDir) / trackMag, true);
+                vars.insert(btau::trackPtRatio, Perp_trackMom_jetDir / trackMag, true);
                 vars.insert(btau::trackPParRatio, jetDir.Dot(trackMom) / trackMag, true);
         }
 

--- a/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
@@ -222,12 +222,13 @@ void CombinedSVComputer::fillCommonVariables(reco::TaggingVariableList & vars, r
                 vars.insert(btau::trackEta, trackMom.Eta(), true);
 
                 // check for erroneous Perp^2 values before evaluating Perp (fix for DeepCSV NaN outputs)
-                double Perp_trackMom_jetDir = VectorUtil::Perp2(trackMom, jetDir) > 0. ? VectorUtil::Perp(trackMom, jetDir) : 0.;
+                double perp_trackMom_jetDir = VectorUtil::Perp2(trackMom, jetDir);
+                perp_trackMom_jetDir = (perp_trackMom_jetDir > 0. ? std::sqrt(perp_trackMom_jetDir ) : 0. );
 
-                vars.insert(btau::trackPtRel, Perp_trackMom_jetDir, true);
+                vars.insert(btau::trackPtRel, perp_trackMom_jetDir, true);
                 vars.insert(btau::trackPPar, jetDir.Dot(trackMom), true);
                 vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
-                vars.insert(btau::trackPtRatio, Perp_trackMom_jetDir / trackMag, true);
+                vars.insert(btau::trackPtRatio, perp_trackMom_jetDir / trackMag, true);
                 vars.insert(btau::trackPParRatio, jetDir.Dot(trackMom) / trackMag, true);
         }
 


### PR DESCRIPTION
Running b-tagging sequence in 94X and later stores NaNs in DeepCSV outputs for some jets. The problem can be traced to NaNs being fed as inputs to the NN. Specifically, the inputs trackPtRel and trackPtRatio are are returned as NaNs for certain tracks whenever the square of a quantity is evaluated as negative due to floating point errors. This is fixed by setting the quantity to zero whenever its square is evaluated as negative (=> the square is small enough to be affected by floating point errors).