### PR TITLE
Add a reco scenario to zero-suppress cosmics taken in hybrid mode

### DIFF
--- a/Configuration/DataProcessing/python/Impl/cosmicsHybrid.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsHybrid.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""
+_cosmicsHybrid_
+
+Scenario supporting cosmics data taking in hybrid mode
+"""
+
+from Configuration.DataProcessing.Impl.cosmics import cosmics
+
+class cosmicsHybrid(cosmics):
+    def __init__(self):
+        cosmics.__init__(self)
+        self.customs = [ "RecoLocalTracker/SiStripZeroSuppression/customiseHybrid.runOnHybridZS" ]
+    """
+    _cosmicsHybrid_
+
+    Implement configuration building for data processing for cosmic
+    data taking with the strip tracker in hybrid ZS mode
+
+    """
+
+    def promptReco(self, globalTag, **args):
+        if not "customs" in args:
+            args["customs"] = list(self.customs)
+        else:
+            args["customs"] += self.customs
+
+        return cosmics.promptReco(self, globalTag, **args)
+
+    def expressProcessing(self, globalTag, **args):
+        if not "customs" in args:
+            args["customs"] = list(self.customs)
+        else:
+            args["customs"] += self.customs
+
+        return cosmics.expressProcessing(self, globalTag, **args)
+
+    def visualizationProcessing(self, globalTag, **args):
+        if not "customs" in args:
+            args["customs"] = list(self.customs)
+        else:
+            args["customs"] += self.customs
+
+        return cosmics.visualizationProcessing(self, globalTag, **args)

--- a/Configuration/DataProcessing/python/Impl/cosmicsHybridEra_Run2_2018.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsHybridEra_Run2_2018.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""
+_cosmicsHybridEra_Run2_2018_
+
+Scenario supporting cosmic data taking
+
+"""
+
+import os
+import sys
+
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+from Configuration.DataProcessing.Impl.cosmicsHybrid import cosmicsHybrid
+
+class cosmicsHybridEra_Run2_2018(cosmicsHybrid):
+    def __init__(self):
+        cosmicsHybrid.__init__(self)
+        self.eras = Run2_2018
+    """
+    _cosmicsHybridEra_Run2_2018_
+
+    Implement configuration building for data processing for cosmic
+    data taking in Run2, during the 2018 heavy ion data taking period
+    (with the strip tracker in hybrid ZS mode)
+
+    """

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "cosmicsEra_Run2_2018" "ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA")
+declare -a arr=("cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "cosmicsEra_Run2_2018" "ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -32,13 +32,13 @@ do
 done
 
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
 done
 
-declare -a arr=("AlCaLumiPixels" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA")
+declare -a arr=("AlCaLumiPixels" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"


### PR DESCRIPTION
This is one possible solution to the problem reported in https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2029.html ; by setting up a scenario where the zero-suppression is run on the hybrid data as part of the reconstruction.
Please check the code, I verified that `scram b runtests` doesn't give errors, but that's all so far. cosmicsEra_Run2_2018_HI.py is adapted from existing scenario's (cosmics and pp), the corresponding unit test is cosmicsEra_Run2_2018_t.py with a search-and-replace to add "_HI".

CC: @mmusich @icali @erikbutz