### PR TITLE
Prepare for concurrent IOVs, L1Trigger

### DIFF
--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloConfigESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloConfigESProducer.cc
@@ -39,7 +39,7 @@ public:
   L1TCaloConfigESProducer(const edm::ParameterSet&);
   ~L1TCaloConfigESProducer() override;
 
-  typedef std::shared_ptr<CaloConfig> ReturnType;
+  using ReturnType = std::unique_ptr<CaloConfig>;
 
   ReturnType produce(const L1TCaloConfigRcd&);
 
@@ -90,7 +90,7 @@ L1TCaloConfigESProducer::ReturnType
 L1TCaloConfigESProducer::produce(const L1TCaloConfigRcd& iRecord)
 {
    using namespace edm::es;
-   return std::make_shared<CaloConfig>(m_params);
+   return std::make_unique<CaloConfig>(m_params);
 }
 
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloConfigESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloConfigESProducer.cc
@@ -89,11 +89,8 @@ L1TCaloConfigESProducer::~L1TCaloConfigESProducer()
 L1TCaloConfigESProducer::ReturnType
 L1TCaloConfigESProducer::produce(const L1TCaloConfigRcd& iRecord)
 {
-   using namespace edm::es;
    return std::make_unique<CaloConfig>(m_params);
 }
-
-
 
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(L1TCaloConfigESProducer);

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
@@ -46,7 +46,7 @@ public:
   L1TCaloParamsESProducer(const edm::ParameterSet&);
   ~L1TCaloParamsESProducer() override;
 
-  typedef std::shared_ptr<CaloParams> ReturnType;
+  using ReturnType = std::unique_ptr<CaloParams>;
 
   ReturnType produce(const L1TCaloParamsRcd&);
 
@@ -379,7 +379,7 @@ L1TCaloParamsESProducer::ReturnType
 L1TCaloParamsESProducer::produce(const L1TCaloParamsRcd& iRecord)
 {
    using namespace edm::es;
-   return std::make_shared<CaloParams>(m_params);
+   return std::make_unique<CaloParams>(m_params);
 }
 
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
@@ -378,11 +378,8 @@ L1TCaloParamsESProducer::~L1TCaloParamsESProducer()
 L1TCaloParamsESProducer::ReturnType
 L1TCaloParamsESProducer::produce(const L1TCaloParamsRcd& iRecord)
 {
-   using namespace edm::es;
    return std::make_unique<CaloParams>(m_params);
 }
-
-
 
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(L1TCaloParamsESProducer);

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
@@ -46,7 +46,7 @@ public:
   L1TCaloStage2ParamsESProducer(const edm::ParameterSet&);
   ~L1TCaloStage2ParamsESProducer() override;
 
-  typedef std::shared_ptr<CaloParams> ReturnType;
+  using ReturnType = std::unique_ptr<CaloParams>;
 
   ReturnType produce(const L1TCaloParamsRcd&);
 
@@ -385,14 +385,8 @@ L1TCaloStage2ParamsESProducer::~L1TCaloStage2ParamsESProducer()
 L1TCaloStage2ParamsESProducer::ReturnType
 L1TCaloStage2ParamsESProducer::produce(const L1TCaloParamsRcd& iRecord)
 {
-   using namespace edm::es;
-   std::shared_ptr<CaloParams> pCaloParams ;
-
-   pCaloParams = std::make_shared< CaloParams >(m_params);
-   return pCaloParams;
+  return std::make_unique<CaloParams>(m_params);
 }
-
-
 
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(L1TCaloStage2ParamsESProducer);

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
@@ -53,7 +53,7 @@ public:
   L1TGlobalPrescalesVetosESProducer(const edm::ParameterSet&);
   ~L1TGlobalPrescalesVetosESProducer() override;
 
-  typedef std::shared_ptr<L1TGlobalPrescalesVetos> ReturnType;
+  using ReturnType = std::unique_ptr<L1TGlobalPrescalesVetos>;
 
   ReturnType produce(const L1TGlobalPrescalesVetosRcd&);
 
@@ -397,9 +397,7 @@ L1TGlobalPrescalesVetosESProducer::produce(const L1TGlobalPrescalesVetosRcd& iRe
   // write the condition format to the event setup via the helper:
   using namespace edm::es;
   // Return copy so that we don't give away our owned pointer to framework
-  auto pMenu = std::make_shared<L1TGlobalPrescalesVetos>(*data_.getWriteInstance());
-
-  return pMenu;
+  return std::make_unique<L1TGlobalPrescalesVetos>(*data_.getWriteInstance());
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
@@ -394,8 +394,6 @@ L1TGlobalPrescalesVetosESProducer::produce(const L1TGlobalPrescalesVetosRcd& iRe
     }
   }
 
-  // write the condition format to the event setup via the helper:
-  using namespace edm::es;
   // Return copy so that we don't give away our owned pointer to framework
   return std::make_unique<L1TGlobalPrescalesVetos>(*data_.getWriteInstance());
 }

--- a/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuESProducer.cc
@@ -47,7 +47,7 @@ public:
   L1TUtmTriggerMenuESProducer(const edm::ParameterSet&);
   ~L1TUtmTriggerMenuESProducer() override;
 
-  typedef std::shared_ptr<L1TUtmTriggerMenu> ReturnType;
+  using ReturnType = std::unique_ptr<const L1TUtmTriggerMenu>;
 
   ReturnType produce(const L1TUtmTriggerMenuRcd&);
 
@@ -108,12 +108,7 @@ L1TUtmTriggerMenuESProducer::produce(const L1TUtmTriggerMenuRcd& iRecord)
 
   //const L1TUtmTriggerMenu * cmenu = reinterpret_cast<const L1TUtmTriggerMenu *>(tmeventsetup::getTriggerMenu("/afs/cern.ch/user/t/tmatsush/public/tmGui/test-menu.xml"));  
   const L1TUtmTriggerMenu * cmenu = reinterpret_cast<const L1TUtmTriggerMenu *>(tmeventsetup::getTriggerMenu(m_L1TriggerMenuFile));  
-  L1TUtmTriggerMenu * menu = const_cast<L1TUtmTriggerMenu *>(cmenu);
-
-  using namespace edm::es;
-  std::shared_ptr<L1TUtmTriggerMenu> pMenu ;
-  pMenu = std::shared_ptr< L1TUtmTriggerMenu >(menu);
-  return pMenu;
+  return ReturnType(cmenu);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TGlobal/plugins/StableParametersTrivialProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/StableParametersTrivialProducer.cc
@@ -34,7 +34,7 @@ public:
     /// public methods
 
     /// L1 GT parameters
-    std::shared_ptr<L1TGlobalParameters> produceGtStableParameters(
+    std::unique_ptr<L1TGlobalParameters> produceGtStableParameters(
         const L1TGlobalParametersRcd&);
 
 private:
@@ -157,13 +157,10 @@ StableParametersTrivialProducer::~StableParametersTrivialProducer() {
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1TGlobalParameters> StableParametersTrivialProducer::produceGtStableParameters(const L1TGlobalParametersRcd& iRecord) {
+std::unique_ptr<L1TGlobalParameters> StableParametersTrivialProducer::produceGtStableParameters(const L1TGlobalParametersRcd& iRecord) {
 
   // Return copy so that we don't give away our owned pointer to framework
-  auto pL1uGtStableParameters = std::make_shared<L1TGlobalParameters>(*data_.getWriteInstance());
-
-  return pL1uGtStableParameters;
-  
+  return std::make_unique<L1TGlobalParameters>(*data_.getWriteInstance());
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(StableParametersTrivialProducer);

--- a/L1Trigger/L1TMuon/plugins/L1TMuonGlobalParamsESProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonGlobalParamsESProducer.cc
@@ -44,7 +44,7 @@ class L1TMuonGlobalParamsESProducer : public edm::ESProducer {
       L1TMuonGlobalParamsESProducer(const edm::ParameterSet&);
       ~L1TMuonGlobalParamsESProducer() override;
 
-      typedef std::shared_ptr<L1TMuonGlobalParams> ReturnType;
+      using ReturnType = std::unique_ptr<L1TMuonGlobalParams>;
 
       ReturnType produce(const L1TMuonGlobalParamsRcd&);
    private:
@@ -325,7 +325,7 @@ L1TMuonGlobalParamsESProducer::produce(const L1TMuonGlobalParamsRcd& iRecord)
 {
    using namespace edm::es;
 
-   return std::make_shared<L1TMuonGlobalParams>(m_params);
+   return std::make_unique<L1TMuonGlobalParams>(m_params);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TMuon/plugins/L1TMuonGlobalParamsESProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonGlobalParamsESProducer.cc
@@ -323,8 +323,6 @@ L1TMuonGlobalParamsESProducer::~L1TMuonGlobalParamsESProducer()
 L1TMuonGlobalParamsESProducer::ReturnType
 L1TMuonGlobalParamsESProducer::produce(const L1TMuonGlobalParamsRcd& iRecord)
 {
-   using namespace edm::es;
-
    return std::make_unique<L1TMuonGlobalParams>(m_params);
 }
 

--- a/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelParamsESProducer.cc
+++ b/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelParamsESProducer.cc
@@ -45,7 +45,7 @@ class L1TMuonBarrelParamsESProducer : public edm::ESProducer {
       int load_ext(std::vector<L1TMuonBarrelParams::LUTParams::extLUT>&, unsigned short int, unsigned short int );
       //void print(std::vector<LUT>& , std::vector<int>& ) const;
       int getPtLutThreshold(int ,std::vector<int>& ) const;
-      typedef std::shared_ptr<L1TMuonBarrelParams> ReturnType;
+      using ReturnType = std::unique_ptr<L1TMuonBarrelParams>;
 
       ReturnType produce(const L1TMuonBarrelParamsRcd&);
    private:
@@ -701,7 +701,7 @@ L1TMuonBarrelParamsESProducer::produce(const L1TMuonBarrelParamsRcd& iRecord)
 {
    using namespace edm::es;
 
-   return std::make_shared<L1TMuonBarrelParams>(m_params_helper);
+   return std::make_unique<L1TMuonBarrelParams>(m_params_helper);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelParamsESProducer.cc
+++ b/L1Trigger/L1TMuonBarrel/plugins/L1TMuonBarrelParamsESProducer.cc
@@ -699,8 +699,6 @@ int L1TMuonBarrelParamsESProducer::load_ext(std::vector<L1TMuonBarrelParams::LUT
 L1TMuonBarrelParamsESProducer::ReturnType
 L1TMuonBarrelParamsESProducer::produce(const L1TMuonBarrelParamsRcd& iRecord)
 {
-   using namespace edm::es;
-
    return std::make_unique<L1TMuonBarrelParams>(m_params_helper);
 }
 

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapForestESProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapForestESProducer.cc
@@ -25,7 +25,7 @@ public:
   L1TMuonEndCapForestESProducer(const edm::ParameterSet&);
   ~L1TMuonEndCapForestESProducer() override {}
 
-  typedef std::shared_ptr<L1TMuonEndCapForest> ReturnType;
+  using ReturnType = std::unique_ptr<L1TMuonEndCapForest>;
 
   ReturnType produce(const L1TMuonEndCapForestRcd&);
 
@@ -108,7 +108,7 @@ L1TMuonEndCapForestESProducer::produce(const L1TMuonEndCapForestRcd& iRecord)
   std::array<emtf::Forest, 16> forests = pt_assign_engine_->getForests();
   std::vector<int> allowedModes = pt_assign_engine_->getAllowedModes();
   // construct empty cond payload
-  std::shared_ptr<L1TMuonEndCapForest> pEMTFForest(new L1TMuonEndCapForest());
+  auto pEMTFForest = std::make_unique<L1TMuonEndCapForest>();
   // pack the forests into the cond payload for each mode
   pEMTFForest->forest_coll_.resize(0);
   for (unsigned int i = 0; i < allowedModes.size(); i++) {

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapParamsESProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapParamsESProducer.cc
@@ -23,7 +23,7 @@ public:
   L1TMuonEndCapParamsESProducer(const edm::ParameterSet&);
   ~L1TMuonEndCapParamsESProducer() override;
 
-  typedef std::shared_ptr<L1TMuonEndCapParams> ReturnType;
+  using ReturnType = std::unique_ptr<L1TMuonEndCapParams>;
 
   ReturnType produce(const L1TMuonEndCapParamsRcd&);
 
@@ -57,10 +57,7 @@ L1TMuonEndCapParamsESProducer::~L1TMuonEndCapParamsESProducer()
 L1TMuonEndCapParamsESProducer::ReturnType
 L1TMuonEndCapParamsESProducer::produce(const L1TMuonEndCapParamsRcd& iRecord)
 {
-   using namespace edm::es;
-   auto pEMTFParams = std::make_shared<L1TMuonEndCapParams>(*data_.getWriteInstance());
-   return pEMTFParams;
-
+   return std::make_unique<L1TMuonEndCapParams>(*data_.getWriteInstance());
 }
 
 // Define this as a plug-in

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsESProducer.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsESProducer.cc
@@ -82,9 +82,7 @@ bool L1TMuonOverlapParamsESProducer::readPatternsXML(XMLConfigReader & aReader){
 L1TMuonOverlapParamsESProducer::ReturnType
 L1TMuonOverlapParamsESProducer::produceParams(const L1TMuonOverlapParamsRcd& iRecord)
 {
-   using namespace edm::es;
-  
-   return std::make_shared<L1TMuonOverlapParams>(params);
+   return std::make_unique<L1TMuonOverlapParams>(params);
 }
 ///////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsESProducer.h
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapParamsESProducer.h
@@ -19,7 +19,7 @@ class L1TMuonOverlapParamsESProducer : public edm::ESProducer {
       L1TMuonOverlapParamsESProducer(const edm::ParameterSet&);
       ~L1TMuonOverlapParamsESProducer() override;
 
-      typedef std::shared_ptr<L1TMuonOverlapParams> ReturnType;
+      using ReturnType = std::unique_ptr<L1TMuonOverlapParams>;
 
       ReturnType produceParams(const L1TMuonOverlapParamsRcd&);
 

--- a/L1Trigger/L1TTwinMux/plugins/L1TTwinMuxParamsESProducer.cc
+++ b/L1Trigger/L1TTwinMux/plugins/L1TTwinMuxParamsESProducer.cc
@@ -30,7 +30,7 @@ class L1TTwinMuxParamsESProducer : public edm::ESProducer {
       L1TTwinMuxParamsESProducer(const edm::ParameterSet&);
       ~L1TTwinMuxParamsESProducer() override;
 
-      typedef std::shared_ptr<L1TTwinMuxParams> ReturnType;
+      using ReturnType = std::unique_ptr<L1TTwinMuxParams>;
 
       ReturnType produce(const L1TTwinMuxParamsRcd&);
    private:
@@ -91,12 +91,7 @@ L1TTwinMuxParamsESProducer::~L1TTwinMuxParamsESProducer()
 L1TTwinMuxParamsESProducer::ReturnType
 L1TTwinMuxParamsESProducer::produce(const L1TTwinMuxParamsRcd& iRecord)
 {
-   using namespace edm::es;
-   // boost::shared_ptr<L1TwinMuxParams> pTMParams;
-
-   // pTMParams = boost::shared_ptr<L1TwinMuxParams>(new L1TwinMuxParams(m_params));
-   //return pTMParams;
-   return std::make_shared<L1TTwinMuxParams>(m_params);
+   return std::make_unique<L1TTwinMuxParams>(m_params);
 }
 
 //define this as a plug-in

--- a/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigProducers.h
+++ b/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigProducers.h
@@ -50,10 +50,10 @@ class L1GctConfigProducers : public edm::ESProducer {
  public:
   L1GctConfigProducers(const edm::ParameterSet&);
   ~L1GctConfigProducers() override;
-  
-  typedef std::shared_ptr<L1GctJetFinderParams>          JfParamsReturnType;
-  typedef std::shared_ptr<L1GctChannelMask>          ChanMaskReturnType;
-  
+
+  using JfParamsReturnType = std::unique_ptr<L1GctJetFinderParams>;
+  using ChanMaskReturnType = std::unique_ptr<L1GctChannelMask>;
+
   JfParamsReturnType produceJfParams(const L1GctJetFinderParamsRcd&);
   ChanMaskReturnType produceChanMask(const L1GctChannelMaskRcd&);
 

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctConfigProducers.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctConfigProducers.cc
@@ -130,7 +130,7 @@ L1GctConfigProducers::produceJfParams(const L1GctJetFinderParamsRcd& aRcd)
   geomRcd.get( geom ) ;
   
   // construct jet finder params object
-  auto pL1GctJetFinderParams = std::make_shared<L1GctJetFinderParams>(m_rgnEtLsb,
+  auto pL1GctJetFinderParams = std::make_unique<L1GctJetFinderParams>(m_rgnEtLsb,
 								      m_htLsb,
 								      m_CenJetSeed,
 								      m_FwdJetSeed,
@@ -161,7 +161,7 @@ L1GctConfigProducers::produceChanMask(const L1GctChannelMaskRcd&) {
     if (((m_thtEtaMask>>ieta)&0x1)==1) mask->maskTotalHt(ieta);
   }
 
-  return std::shared_ptr<L1GctChannelMask>(mask);
+  return std::unique_ptr<L1GctChannelMask>(mask);
 
 }
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTrivialProducer.h
@@ -46,7 +46,7 @@ public:
     /// public methods
 
     /// produce mappings of the L1 GT boards
-    std::shared_ptr<L1GtBoardMaps> produceBoardMaps(
+    std::unique_ptr<L1GtBoardMaps> produceBoardMaps(
         const L1GtBoardMapsRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
@@ -48,7 +48,7 @@ public:
     /// public methods
 
     /// L1 GT parameters
-    std::shared_ptr<L1GtParameters> produceGtParameters(
+    std::unique_ptr<L1GtParameters> produceGtParameters(
         const L1GtParametersRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigTrivialProducer.h
@@ -46,7 +46,7 @@ public:
 
     /// public methods
 
-    std::shared_ptr<L1GtPrescaleFactors> producePrescaleFactors(
+    std::unique_ptr<L1GtPrescaleFactors> producePrescaleFactors(
             const L1GtPrescaleFactorsAlgoTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigTrivialProducer.h
@@ -46,7 +46,7 @@ public:
 
     /// public methods
 
-    std::shared_ptr<L1GtPrescaleFactors> producePrescaleFactors(
+    std::unique_ptr<L1GtPrescaleFactors> producePrescaleFactors(
             const L1GtPrescaleFactorsTechTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTrivialProducer.h
@@ -46,7 +46,7 @@ public:
     /// public methods
 
     /// produce the setup for L1 GT PSB boards
-    std::shared_ptr<L1GtPsbSetup> producePsbSetup(
+    std::unique_ptr<L1GtPsbSetup> producePsbSetup(
         const L1GtPsbSetupRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
@@ -49,7 +49,7 @@ public:
     /// public methods
 
     /// L1 GT parameters
-    std::shared_ptr<L1GtStableParameters> produceGtStableParameters(
+    std::unique_ptr<L1GtStableParameters> produceGtStableParameters(
         const L1GtStableParametersRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigTrivialProducer.h
@@ -47,7 +47,7 @@ public:
 
     /// public methods
 
-    std::shared_ptr<L1GtTriggerMask> produceTriggerMask(
+    std::unique_ptr<L1GtTriggerMask> produceTriggerMask(
         const L1GtTriggerMaskAlgoTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigTrivialProducer.h
@@ -47,7 +47,7 @@ public:
 
     /// public methods
 
-    std::shared_ptr<L1GtTriggerMask> produceTriggerMask(
+    std::unique_ptr<L1GtTriggerMask> produceTriggerMask(
         const L1GtTriggerMaskTechTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.h
@@ -47,7 +47,7 @@ public:
 
     /// public methods
 
-    std::shared_ptr<L1GtTriggerMask> produceTriggerMask(
+    std::unique_ptr<L1GtTriggerMask> produceTriggerMask(
         const L1GtTriggerMaskVetoAlgoTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigTrivialProducer.h
@@ -47,7 +47,7 @@ public:
 
     /// public methods
 
-    std::shared_ptr<L1GtTriggerMask> produceTriggerMask(
+    std::unique_ptr<L1GtTriggerMask> produceTriggerMask(
         const L1GtTriggerMaskVetoTechTrigRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
@@ -49,7 +49,7 @@ public:
     /// public methods
 
     /// L1 GT parameters
-    std::shared_ptr<L1GtTriggerMenu> produceGtTriggerMenu(
+    std::unique_ptr<L1GtTriggerMenu> produceGtTriggerMenu(
         const L1GtTriggerMenuRcd&);
 
 private:

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtBoardMapsTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtBoardMapsTrivialProducer.cc
@@ -472,16 +472,12 @@ L1GtBoardMapsTrivialProducer::~L1GtBoardMapsTrivialProducer()
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtBoardMaps> L1GtBoardMapsTrivialProducer::produceBoardMaps(
+std::unique_ptr<L1GtBoardMaps> L1GtBoardMapsTrivialProducer::produceBoardMaps(
     const L1GtBoardMapsRcd& iRecord)
 {
-
-    using namespace edm::es;
-
-    auto pL1GtBoardMaps = std::make_shared<L1GtBoardMaps>();
+    auto pL1GtBoardMaps = std::make_unique<L1GtBoardMaps>();
 
     pL1GtBoardMaps->setGtBoardMaps(m_gtBoardMaps);
 
     return pL1GtBoardMaps ;
 }
-

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTrivialProducer.cc
@@ -93,15 +93,10 @@ L1GtParametersTrivialProducer::~L1GtParametersTrivialProducer()
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtParameters> L1GtParametersTrivialProducer::produceGtParameters(
+std::unique_ptr<L1GtParameters> L1GtParametersTrivialProducer::produceGtParameters(
     const L1GtParametersRcd& iRecord)
 {
-
-    using namespace edm::es;
-
-
-    auto pL1GtParameters = std::make_shared<L1GtParameters>();
-
+    auto pL1GtParameters = std::make_unique<L1GtParameters>();
 
     // set total Bx's in the event
     pL1GtParameters->setGtTotalBxInEvent(m_totalBxInEvent);
@@ -123,4 +118,3 @@ std::shared_ptr<L1GtParameters> L1GtParametersTrivialProducer::produceGtParamete
 
     return pL1GtParameters ;
 }
-

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAlgoTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAlgoTrigTrivialProducer.cc
@@ -66,10 +66,8 @@ L1GtPrescaleFactorsAlgoTrigTrivialProducer::~L1GtPrescaleFactorsAlgoTrigTrivialP
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsAlgoTrigTrivialProducer::producePrescaleFactors(
+std::unique_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsAlgoTrigTrivialProducer::producePrescaleFactors(
         const L1GtPrescaleFactorsAlgoTrigRcd& iRecord) {
 
-    auto pL1GtPrescaleFactors = std::make_shared<L1GtPrescaleFactors>(m_prescaleFactors);
-
-    return pL1GtPrescaleFactors;
+    return std::make_unique<L1GtPrescaleFactors>(m_prescaleFactors);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsTechTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsTechTrigTrivialProducer.cc
@@ -68,12 +68,9 @@ L1GtPrescaleFactorsTechTrigTrivialProducer::~L1GtPrescaleFactorsTechTrigTrivialP
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtPrescaleFactors> 
+std::unique_ptr<L1GtPrescaleFactors> 
     L1GtPrescaleFactorsTechTrigTrivialProducer::producePrescaleFactors(
         const L1GtPrescaleFactorsTechTrigRcd& iRecord)
 {
-
-    auto pL1GtPrescaleFactors = std::make_shared<L1GtPrescaleFactors>(m_prescaleFactors);
-
-    return pL1GtPrescaleFactors;
+    return std::make_unique<L1GtPrescaleFactors>(m_prescaleFactors);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupTrivialProducer.cc
@@ -113,16 +113,12 @@ L1GtPsbSetupTrivialProducer::~L1GtPsbSetupTrivialProducer()
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtPsbSetup> L1GtPsbSetupTrivialProducer::producePsbSetup(
+std::unique_ptr<L1GtPsbSetup> L1GtPsbSetupTrivialProducer::producePsbSetup(
         const L1GtPsbSetupRcd& iRecord)
 {
-
-    using namespace edm::es;
-
-    auto pL1GtPsbSetup = std::make_shared<L1GtPsbSetup>();
+    auto pL1GtPsbSetup = std::make_unique<L1GtPsbSetup>();
 
     pL1GtPsbSetup->setGtPsbSetup(m_gtPsbSetup);
 
     return pL1GtPsbSetup;
 }
-

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTrivialProducer.cc
@@ -117,11 +117,11 @@ L1GtStableParametersTrivialProducer::~L1GtStableParametersTrivialProducer() {
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtStableParameters> 
-    L1GtStableParametersTrivialProducer::produceGtStableParameters(
+std::unique_ptr<L1GtStableParameters> 
+L1GtStableParametersTrivialProducer::produceGtStableParameters(
         const L1GtStableParametersRcd& iRecord) {
 
-    auto pL1GtStableParameters = std::make_shared<L1GtStableParameters>();
+    auto pL1GtStableParameters = std::make_unique<L1GtStableParameters>();
 
     // set the number of physics trigger algorithms
     pL1GtStableParameters->setGtNumberPhysTriggers(m_numberPhysTriggers);
@@ -183,6 +183,4 @@ std::shared_ptr<L1GtStableParameters>
     //
     //
     return pL1GtStableParameters;
-
 }
-

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskAlgoTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskAlgoTrigTrivialProducer.cc
@@ -57,8 +57,8 @@ L1GtTriggerMaskAlgoTrigTrivialProducer::~L1GtTriggerMaskAlgoTrigTrivialProducer(
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskAlgoTrigTrivialProducer::produceTriggerMask(
+std::unique_ptr<L1GtTriggerMask> L1GtTriggerMaskAlgoTrigTrivialProducer::produceTriggerMask(
         const L1GtTriggerMaskAlgoTrigRcd& iRecord)
 {
-    return std::make_shared<L1GtTriggerMask>(m_triggerMask);
+    return std::make_unique<L1GtTriggerMask>(m_triggerMask);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskTechTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskTechTrigTrivialProducer.cc
@@ -57,8 +57,8 @@ L1GtTriggerMaskTechTrigTrivialProducer::~L1GtTriggerMaskTechTrigTrivialProducer(
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskTechTrigTrivialProducer::produceTriggerMask(
+std::unique_ptr<L1GtTriggerMask> L1GtTriggerMaskTechTrigTrivialProducer::produceTriggerMask(
         const L1GtTriggerMaskTechTrigRcd& iRecord)
 {
-    return std::make_shared<L1GtTriggerMask>(m_triggerMask);
+    return std::make_unique<L1GtTriggerMask>(m_triggerMask);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.cc
@@ -57,8 +57,8 @@ L1GtTriggerMaskVetoAlgoTrigTrivialProducer::~L1GtTriggerMaskVetoAlgoTrigTrivialP
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoAlgoTrigTrivialProducer::produceTriggerMask(
+std::unique_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoAlgoTrigTrivialProducer::produceTriggerMask(
         const L1GtTriggerMaskVetoAlgoTrigRcd& iRecord)
 {
-    return std::make_shared<L1GtTriggerMask>(m_triggerMask);
+    return std::make_unique<L1GtTriggerMask>(m_triggerMask);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoTechTrigTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoTechTrigTrivialProducer.cc
@@ -57,8 +57,8 @@ L1GtTriggerMaskVetoTechTrigTrivialProducer::~L1GtTriggerMaskVetoTechTrigTrivialP
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoTechTrigTrivialProducer::produceTriggerMask(
+std::unique_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoTechTrigTrivialProducer::produceTriggerMask(
         const L1GtTriggerMaskVetoTechTrigRcd& iRecord)
 {
-    return std::make_shared<L1GtTriggerMask>(m_triggerMask);
+    return std::make_unique<L1GtTriggerMask>(m_triggerMask);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlProducer.cc
@@ -68,7 +68,7 @@ L1GtTriggerMenuXmlProducer::L1GtTriggerMenuXmlProducer(
     // vme.xml file
     std::string vmeXmlFileName = parSet.getParameter<std::string>("VmeXmlFile");
 
-    if (vmeXmlFileName != "") {
+    if (!vmeXmlFileName.empty()) {
         edm::FileInPath f2("L1TriggerConfig/L1GtConfigProducers/data/Luminosity/" +
                            menuDir + "/" + vmeXmlFileName);
 
@@ -97,7 +97,7 @@ L1GtTriggerMenuXmlProducer::~L1GtTriggerMenuXmlProducer()
 // member functions
 
 // method called to produce the data
-std::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuXmlProducer::produceGtTriggerMenu(
+std::unique_ptr<L1GtTriggerMenu> L1GtTriggerMenuXmlProducer::produceGtTriggerMenu(
     const L1GtTriggerMenuRcd& l1MenuRecord)
 {
 
@@ -128,7 +128,7 @@ std::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuXmlProducer::produceGtTriggerMen
 
     // transfer the condition map and algorithm map from parser to L1GtTriggerMenu
 
-    auto pL1GtTriggerMenu = std::make_shared<L1GtTriggerMenu>(
+    auto pL1GtTriggerMenu = std::make_unique<L1GtTriggerMenu>(
                         gtXmlParser.gtTriggerMenuName(), numberConditionChips,
                         gtXmlParser.vecMuonTemplate(),
                         gtXmlParser.vecCaloTemplate(),

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesProducer.h
@@ -40,9 +40,9 @@ class L1CaloInputScalesProducer : public edm::ESProducer {
 
       //typedef std::shared_ptr<L1CaloInputScale> ReturnType;
 
-      std::shared_ptr<L1CaloEcalScale>
+      std::unique_ptr<L1CaloEcalScale>
 	produceEcalScale(const L1CaloEcalScaleRcd&);
-      std::shared_ptr<L1CaloHcalScale>
+      std::unique_ptr<L1CaloHcalScale>
 	produceHcalScale(const L1CaloHcalScaleRcd&);
    private:
       // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesProducer.cc
@@ -72,11 +72,11 @@ L1CaloInputScalesProducer::~L1CaloInputScalesProducer()
 //
 
 // ------------ method called to produce the data  ------------
-std::shared_ptr<L1CaloEcalScale>
+std::unique_ptr<L1CaloEcalScale>
 L1CaloInputScalesProducer::produceEcalScale(const L1CaloEcalScaleRcd& iRecord)
 {
    using namespace edm::es;
-   auto pL1CaloEcalScale = std::make_shared<L1CaloEcalScale>() ;
+   auto pL1CaloEcalScale = std::make_unique<L1CaloEcalScale>() ;
 
    std::vector< double >::const_iterator posItr =
      m_ecalEtThresholdsPosEta.begin() ;
@@ -103,11 +103,11 @@ L1CaloInputScalesProducer::produceEcalScale(const L1CaloEcalScaleRcd& iRecord)
 }
 
 // ------------ method called to produce the data  ------------
-std::shared_ptr<L1CaloHcalScale>
+std::unique_ptr<L1CaloHcalScale>
 L1CaloInputScalesProducer::produceHcalScale(const L1CaloHcalScaleRcd& iRecord)
 {
    using namespace edm::es;
-   auto pL1CaloHcalScale = std::make_shared<L1CaloHcalScale>() ;
+   auto pL1CaloHcalScale = std::make_unique<L1CaloHcalScale>() ;
 
    std::vector< double >::const_iterator posItr =
      m_hcalEtThresholdsPosEta.begin() ;

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesProducer.cc
@@ -106,7 +106,6 @@ L1CaloInputScalesProducer::produceEcalScale(const L1CaloEcalScaleRcd& iRecord)
 std::unique_ptr<L1CaloHcalScale>
 L1CaloInputScalesProducer::produceHcalScale(const L1CaloHcalScaleRcd& iRecord)
 {
-   using namespace edm::es;
    auto pL1CaloHcalScale = std::make_unique<L1CaloHcalScale>() ;
 
    std::vector< double >::const_iterator posItr =

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProxy.cc
@@ -10,7 +10,7 @@
 
 class L1TMuonEndCapForestOnlineProxy : public edm::ESProducer {
 public:
-    std::shared_ptr<L1TMuonEndCapForest> produce(const L1TMuonEndCapForestO2ORcd& record);
+    std::unique_ptr<L1TMuonEndCapForest> produce(const L1TMuonEndCapForestO2ORcd& record);
 
     L1TMuonEndCapForestOnlineProxy(const edm::ParameterSet&);
     ~L1TMuonEndCapForestOnlineProxy(void) override{}
@@ -20,15 +20,13 @@ L1TMuonEndCapForestOnlineProxy::L1TMuonEndCapForestOnlineProxy(const edm::Parame
     setWhatProduced(this);
 }
 
-std::shared_ptr<L1TMuonEndCapForest> L1TMuonEndCapForestOnlineProxy::produce(const L1TMuonEndCapForestO2ORcd& record) {
+std::unique_ptr<L1TMuonEndCapForest> L1TMuonEndCapForestOnlineProxy::produce(const L1TMuonEndCapForestO2ORcd& record) {
 
     const L1TMuonEndCapForestRcd& baseRcd = record.template getRecord< L1TMuonEndCapForestRcd >() ;
     edm::ESHandle< L1TMuonEndCapForest > baseSettings ;
     baseRcd.get( baseSettings ) ;
 
-    std::shared_ptr< L1TMuonEndCapForest > retval = std::make_shared< L1TMuonEndCapForest >( *(baseSettings.product()) );
-
-    return retval;
+    return std::make_unique< L1TMuonEndCapForest >( *(baseSettings.product()) );
 }
 
 //define this as a plug-in

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
@@ -11,7 +11,7 @@
 class L1TMuonOverlapParamsOnlineProxy : public edm::ESProducer {
 private:
 public:
-    std::shared_ptr<L1TMuonOverlapParams> produce(const L1TMuonOverlapParamsO2ORcd& record);
+    std::unique_ptr<L1TMuonOverlapParams> produce(const L1TMuonOverlapParamsO2ORcd& record);
 
     L1TMuonOverlapParamsOnlineProxy(const edm::ParameterSet&);
     ~L1TMuonOverlapParamsOnlineProxy(void) override{}
@@ -21,14 +21,13 @@ L1TMuonOverlapParamsOnlineProxy::L1TMuonOverlapParamsOnlineProxy(const edm::Para
     setWhatProduced(this);
 }
 
-std::shared_ptr<L1TMuonOverlapParams> L1TMuonOverlapParamsOnlineProxy::produce(const L1TMuonOverlapParamsO2ORcd& record) {
+std::unique_ptr<L1TMuonOverlapParams> L1TMuonOverlapParamsOnlineProxy::produce(const L1TMuonOverlapParamsO2ORcd& record) {
 
     const L1TMuonOverlapParamsRcd& baseRcd = record.template getRecord< L1TMuonOverlapParamsRcd >() ;
     edm::ESHandle< L1TMuonOverlapParams > baseSettings ;
     baseRcd.get( baseSettings ) ;
 
-    std::shared_ptr< L1TMuonOverlapParams > retval = std::make_shared< L1TMuonOverlapParams >( *(baseSettings.product()) );
-    return retval;
+    return std::make_unique< L1TMuonOverlapParams >( *(baseSettings.product()) );
 }
 
 //define this as a plug-in

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTOmdsFedVectorProducer.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTOmdsFedVectorProducer.cc
@@ -57,7 +57,7 @@ public:
   L1RCTOmdsFedVectorProducer(const edm::ParameterSet&);
   ~L1RCTOmdsFedVectorProducer() override;
   
-  typedef std::shared_ptr<RunInfo> ReturnType;
+  using ReturnType = std::unique_ptr<RunInfo>;
   
   ReturnType produce(const RunInfoRcd&);
 private:
@@ -111,9 +111,6 @@ L1RCTOmdsFedVectorProducer::produce(const RunInfoRcd& iRecord)
 {
   //  std::cout << "ENTERING L1RCTOmdsFedVectorProducer::produce()" << std::endl;
 
-  using namespace edm::es;
-  std::shared_ptr<RunInfo> pRunInfo ;
-
   //  std::cout << "GETTING FED VECTOR FROM OMDS" << std::endl;
   
   // GETTING ALREADY-EXISTING RUNINFO OUT OF ES TO FIND OUT RUN NUMBER
@@ -123,7 +120,7 @@ L1RCTOmdsFedVectorProducer::produce(const RunInfoRcd& iRecord)
   int runNumber = summary->m_run; 
   
   // CREATING NEW RUNINFO WHICH WILL GET NEW FED VECTOR AND BE RETURNED
-  pRunInfo = std::make_shared<RunInfo>(); 
+  auto pRunInfo = std::make_unique<RunInfo>(); 
   
   
   // DO THE DATABASE STUFF

--- a/L1TriggerConfig/RCTConfigProducers/src/RCTConfigProducers.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/RCTConfigProducers.cc
@@ -46,9 +46,9 @@ public:
   //typedef edm::ESProducts< std::shared_ptr<L1RCTParameters>, std::shared_ptr<L1RCTChannelMask> > ReturnType;
   
   //ReturnType produce(const L1RCTParametersRcd&);
-  std::shared_ptr<L1RCTParameters> produceL1RCTParameters(const L1RCTParametersRcd&);
-  std::shared_ptr<L1RCTChannelMask> produceL1RCTChannelMask(const L1RCTChannelMaskRcd&);
-  std::shared_ptr<L1RCTNoisyChannelMask> produceL1RCTNoisyChannelMask(const L1RCTNoisyChannelMaskRcd&);
+  std::unique_ptr<L1RCTParameters> produceL1RCTParameters(const L1RCTParametersRcd&);
+  std::unique_ptr<L1RCTChannelMask> produceL1RCTChannelMask(const L1RCTChannelMaskRcd&);
+  std::unique_ptr<L1RCTNoisyChannelMask> produceL1RCTNoisyChannelMask(const L1RCTNoisyChannelMaskRcd&);
 
 private:
   // ----------member data ---------------------------
@@ -172,26 +172,22 @@ RCTConfigProducers::~RCTConfigProducers()
 
 // ------------ method called to produce the data  ------------
 //RCTConfigProducers::ReturnType
-std::shared_ptr<L1RCTParameters>
+std::unique_ptr<L1RCTParameters>
 RCTConfigProducers::produceL1RCTParameters(const L1RCTParametersRcd& iRecord)
 {
-   using namespace edm::es;
-   return std::make_shared<L1RCTParameters>( rctParameters ) ;
-   //return products( pL1RCTParameters, pL1RCTChannelMask );
+   return std::make_unique<L1RCTParameters>( rctParameters ) ;
 }
 
-std::shared_ptr<L1RCTChannelMask>
+std::unique_ptr<L1RCTChannelMask>
 RCTConfigProducers::produceL1RCTChannelMask(const L1RCTChannelMaskRcd& iRecord)
 {
-  using namespace edm::es;
-   return std::make_shared<L1RCTChannelMask>( rctChannelMask ) ;
+   return std::make_unique<L1RCTChannelMask>( rctChannelMask ) ;
 }
 
-std::shared_ptr<L1RCTNoisyChannelMask>
+std::unique_ptr<L1RCTNoisyChannelMask>
 RCTConfigProducers::produceL1RCTNoisyChannelMask(const L1RCTNoisyChannelMaskRcd& iRecord)
 {
-  using namespace edm::es;
-   return std::make_shared<L1RCTNoisyChannelMask>( rctNoisyChannelMask ) ;
+   return std::make_unique<L1RCTNoisyChannelMask>( rctNoisyChannelMask ) ;
 }
 
 

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionProducer.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionProducer.cc
@@ -39,7 +39,7 @@ class L1RPCConeDefinitionProducer : public edm::ESProducer {
       L1RPCConeDefinitionProducer(const edm::ParameterSet&);
       ~L1RPCConeDefinitionProducer() override;
 
-      typedef std::shared_ptr<L1RPCConeDefinition> ReturnType;
+      using ReturnType = std::unique_ptr<L1RPCConeDefinition>;
 
       ReturnType produce(const L1RPCConeDefinitionRcd&);
    private:
@@ -188,8 +188,7 @@ L1RPCConeDefinitionProducer::~L1RPCConeDefinitionProducer(){}
 L1RPCConeDefinitionProducer::ReturnType
 L1RPCConeDefinitionProducer::produce(const L1RPCConeDefinitionRcd& iRecord)
 {
-   using namespace edm::es;
-   auto pL1RPCConeDefinition = std::make_shared<L1RPCConeDefinition>();
+   auto pL1RPCConeDefinition = std::make_unique<L1RPCConeDefinition>();
 
    pL1RPCConeDefinition->setFirstTower(m_towerBeg);
    pL1RPCConeDefinition->setLastTower(m_towerEnd);
@@ -197,8 +196,7 @@ L1RPCConeDefinitionProducer::produce(const L1RPCConeDefinitionRcd& iRecord)
    pL1RPCConeDefinition->setLPSizeVec(m_LPSizeVec);
    pL1RPCConeDefinition->setRingToLPVec(m_ringToLPVec);
    pL1RPCConeDefinition->setRingToTowerVec(m_ringToTowerVec);
-   
-   
+
    return pL1RPCConeDefinition ;
 }
 


### PR DESCRIPTION
Change the return type of ESProducer produce methods
from shared_ptr to unique_ptr.