### PR TITLE
Prepare for concurrent IOVs, miscellaneous packages

### DIFF
--- a/JetMETCorrections/Modules/interface/JetCorrectionESSource.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionESSource.h
@@ -60,7 +60,7 @@ public:
 
   ~JetCorrectionESSource() override {}
 
-  std::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& iRecord) 
+  std::unique_ptr<JetCorrector> produce(JetCorrectionsRecord const& iRecord) 
   {
     std::string fileName("CondFormats/JetMETObjects/data/");
     if (!mEra.empty())
@@ -74,7 +74,7 @@ public:
       std::cout << "Parameter File: " << fileName << std::endl;
     edm::FileInPath fip(fileName);
     JetCorrectorParameters *tmpJetCorPar = new JetCorrectorParameters(fip.fullPath(), mSection);
-    return std::make_shared<Corrector>(*tmpJetCorPar, mParameterSet);
+    return std::make_unique<Corrector>(*tmpJetCorPar, mParameterSet);
   }
 
   void setIntervalFor(edm::eventsetup::EventSetupRecordKey const&, edm::IOVSyncValue const&, edm::ValidityInterval& fIOV) override

--- a/PhysicsTools/MVAComputer/interface/MVAComputerESSourceBase.h
+++ b/PhysicsTools/MVAComputer/interface/MVAComputerESSourceBase.h
@@ -16,7 +16,7 @@ namespace PhysicsTools {
 
 class MVAComputerESSourceBase : public edm::ESProducer {
     public:
-	typedef std::shared_ptr<Calibration::MVAComputerContainer> ReturnType;
+	using ReturnType = std::unique_ptr<Calibration::MVAComputerContainer>;
 
 	MVAComputerESSourceBase(const edm::ParameterSet &params);
 	~MVAComputerESSourceBase() override;

--- a/PhysicsTools/MVAComputer/src/MVAComputerESSourceBase.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputerESSourceBase.cc
@@ -44,7 +44,7 @@ MVAComputerESSourceBase::~MVAComputerESSourceBase()
 MVAComputerESSourceBase::ReturnType
 MVAComputerESSourceBase::produce() const
 {
-	ReturnType container(new Calibration::MVAComputerContainer);
+	auto container = std::make_unique<Calibration::MVAComputerContainer>();
 
 	for(LabelFileMap::const_iterator iter = mvaCalibrations.begin();
 	    iter != mvaCalibrations.end(); iter++) {

--- a/RecoLocalCalo/EcalRecProducers/test/stubs/EcalSampleMaskRecordESProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/test/stubs/EcalSampleMaskRecordESProducer.cc
@@ -21,7 +21,7 @@ class EcalSampleMaskRecordESProducer : public edm::ESProducer {
 public:
   EcalSampleMaskRecordESProducer(const edm::ParameterSet& iConfig);
   
-  typedef std::shared_ptr<EcalSampleMask> ReturnType;
+  using ReturnType = std::unique_ptr<EcalSampleMask>;
   
   ReturnType produce(const EcalSampleMaskRcd& iRecord);
   
@@ -46,10 +46,7 @@ EcalSampleMaskRecordESProducer::EcalSampleMaskRecordESProducer(const edm::Parame
 EcalSampleMaskRecordESProducer::ReturnType
 EcalSampleMaskRecordESProducer::produce(const EcalSampleMaskRcd& iRecord){
 
-  ReturnType returnRcd (new EcalSampleMask(maskeb_,maskee_));
-
-  return returnRcd ;
-
+  return std::make_unique<EcalSampleMask>(maskeb_,maskee_);
 }
 
 

--- a/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.cc
+++ b/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.cc
@@ -32,11 +32,11 @@ MTDDetLayerGeometryESProducer::MTDDetLayerGeometryESProducer(const edm::Paramete
 MTDDetLayerGeometryESProducer::~MTDDetLayerGeometryESProducer(){}
 
 
-std::shared_ptr<MTDDetLayerGeometry>
+std::unique_ptr<MTDDetLayerGeometry>
 MTDDetLayerGeometryESProducer::produce(const MTDRecoGeometryRecord & record) {
 
   const std::string metname = "MTD|RecoMTD|RecoMTDDetLayers|MTDDetLayerGeometryESProducer";
-  auto mtdDetLayerGeometry = std::make_shared<MTDDetLayerGeometry>();
+  auto mtdDetLayerGeometry = std::make_unique<MTDDetLayerGeometry>();
   
   edm::ESHandle<MTDGeometry> mtd;
   record.getRecord<MTDDigiGeometryRecord>().get(mtd);

--- a/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.h
+++ b/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.h
@@ -24,7 +24,7 @@ class  MTDDetLayerGeometryESProducer: public edm::ESProducer{
   ~MTDDetLayerGeometryESProducer() override; 
 
   /// Produce MuonDeLayerGeometry.
-  std::shared_ptr<MTDDetLayerGeometry> produce(const MTDRecoGeometryRecord & record);
+  std::unique_ptr<MTDDetLayerGeometry> produce(const MTDRecoGeometryRecord & record);
 
  private:
 };

--- a/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.h
+++ b/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.h
@@ -16,7 +16,7 @@ class  CloseComponentsMergerESProducer: public edm::ESProducer{
  public:
   CloseComponentsMergerESProducer(const edm::ParameterSet & p);
   ~CloseComponentsMergerESProducer() override; 
-  std::shared_ptr< MultiGaussianStateMerger<N> > produce(const TrackingComponentsRecord &);
+  std::unique_ptr< MultiGaussianStateMerger<N> > produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.icc
+++ b/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.icc
@@ -44,7 +44,7 @@ CloseComponentsMergerESProducer<N>::~CloseComponentsMergerESProducer() {
 }
 
 template <unsigned int N>
-typename std::shared_ptr< MultiGaussianStateMerger<N> > 
+typename std::unique_ptr< MultiGaussianStateMerger<N> > 
 CloseComponentsMergerESProducer<N>::produce(const TrackingComponentsRecord & iRecord){ 
 
   int maxComp = pset_.getParameter<int>("MaxComponents");
@@ -54,7 +54,7 @@ CloseComponentsMergerESProducer<N>::produce(const TrackingComponentsRecord & iRe
   iRecord.get(distName,distProducer);
   
   return 
-    std::shared_ptr< MultiGaussianStateMerger<N> >
+    std::unique_ptr< MultiGaussianStateMerger<N> >
     (new CloseComponentsMerger<N>(maxComp,distProducer.product()));
 }
 

--- a/TrackingTools/GsfTools/plugins/DistanceBetweenComponentsESProducer.h
+++ b/TrackingTools/GsfTools/plugins/DistanceBetweenComponentsESProducer.h
@@ -16,7 +16,7 @@ class  DistanceBetweenComponentsESProducer : public edm::ESProducer{
  public:
   DistanceBetweenComponentsESProducer(const edm::ParameterSet & p);
   ~DistanceBetweenComponentsESProducer() override; 
-  std::shared_ptr< DistanceBetweenComponents<N> > produce(const TrackingComponentsRecord &);
+  std::unique_ptr< DistanceBetweenComponents<N> > produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/GsfTools/plugins/DistanceBetweenComponentsESProducer.icc
+++ b/TrackingTools/GsfTools/plugins/DistanceBetweenComponentsESProducer.icc
@@ -23,16 +23,16 @@ template <unsigned int N>
 DistanceBetweenComponentsESProducer<N>::~DistanceBetweenComponentsESProducer() {}
 
 template <unsigned int N>
-typename std::shared_ptr< DistanceBetweenComponents<N> > 
+typename std::unique_ptr< DistanceBetweenComponents<N> > 
 DistanceBetweenComponentsESProducer<N>::produce(const TrackingComponentsRecord & iRecord){ 
 
   std::string distName = pset_.getParameter<std::string>("DistanceMeasure");
   
-  std::shared_ptr< DistanceBetweenComponents<N> > distance;
+  std::unique_ptr< DistanceBetweenComponents<N> > distance;
   if ( distName == "KullbackLeibler" )
-    distance = std::shared_ptr< DistanceBetweenComponents<N> >(new KullbackLeiblerDistance<N>());
+    distance = std::unique_ptr< DistanceBetweenComponents<N> >(new KullbackLeiblerDistance<N>());
 // //   else if ( distName == "Mahalanobis" )
-// //     distance = std::shared_ptr<DistanceBetweenComponents>(new MahalanobisDistance());
+// //     distance = std::unique_ptr<DistanceBetweenComponents>(new MahalanobisDistance());
   
   return distance;
 }

--- a/TrackingTools/TrackFitters/plugins/FlexibleKFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/FlexibleKFFittingSmootherESProducer.cc
@@ -84,7 +84,7 @@ namespace {
       descriptions.add("FlexibleKFFittingSmoother", desc);
     }
     
-    std::shared_ptr<TrajectoryFitter> 
+    std::unique_ptr<TrajectoryFitter> 
     produce(const TrajectoryFitterRecord & iRecord){ 
       
       edm::ESHandle<TrajectoryFitter> standardFitter;
@@ -93,9 +93,8 @@ namespace {
       iRecord.get(pset_.getParameter<std::string>("standardFitter"),standardFitter);
       iRecord.get(pset_.getParameter<std::string>("looperFitter"),looperFitter);
       
-      return std::shared_ptr<TrajectoryFitter>(new FlexibleKFFittingSmoother(*standardFitter.product(),
-									       *looperFitter.product())
-						 );
+      return std::unique_ptr<TrajectoryFitter>(new FlexibleKFFittingSmoother(*standardFitter.product(),
+                                                                             *looperFitter.product()));
     }
     
     


### PR DESCRIPTION
Change the return type of produce functions of ESProducers
from shared_ptr to unique_ptr.