### PR TITLE
MTD: fix TimingSD calculation of post-step local point and time slice unit definition, add SD geometry dump module

### DIFF
--- a/Geometry/MTDCommonData/test/BuildFile.xml
+++ b/Geometry/MTDCommonData/test/BuildFile.xml
@@ -7,3 +7,5 @@
 <flags   EDM_PLUGIN="1"/>
 <library   file="TestMTDNumbering.cc">
 </library>
+<library   file="TestMTDPosition.cc">
+</library>

--- a/Geometry/MTDCommonData/test/TestMTDNumbering.cc
+++ b/Geometry/MTDCommonData/test/TestMTDNumbering.cc
@@ -129,6 +129,7 @@ void TestMTDNumbering::checkMTD ( const DDCompactView& cpv, std::string fname, i
     
     size_t num = epv.geoHistory().size();
 
+    if ( num <= limit ) { write = false; }
     if ( epv.geoHistory()[num-1].logicalPart().name() == "btl:BarrelTimingLayer" ) {
       isBarrel = true;
       limit = num;

--- a/Geometry/MTDCommonData/test/TestMTDPosition.cc
+++ b/Geometry/MTDCommonData/test/TestMTDPosition.cc
@@ -1,0 +1,206 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
+#include <cmath>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "DetectorDescription/Core/interface/DDValue.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/Core/interface/DDExpandedNode.h"
+#include "DetectorDescription/Core/interface/DDExpandedView.h"
+#include "DetectorDescription/Core/interface/DDLogicalPart.h"
+#include "DetectorDescription/Core/interface/DDSolid.h"
+#include "DetectorDescription/Core/interface/DDSolidShapes.h"
+
+//#define EDM_ML_DEBUG
+
+class TestMTDPosition : public edm::one::EDAnalyzer<> {
+public:
+  explicit TestMTDPosition( const edm::ParameterSet& );
+  ~TestMTDPosition() override;
+
+  void beginJob() override {}
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void endJob() override {}
+
+  void theBaseNumber( const DDGeoHistory& gh );
+
+  void checkMTD( const DDCompactView& cpv, std::string fname = "GeoHistory", int nVols = 0 , std::string ddtop_ = "mtd:BarrelTimingLayer" );
+
+private:
+
+  std::string label_;
+  bool isMagField_;
+  std::string fname_;
+  int nNodes_;
+  std::string ddTopNodeName_;
+
+  static constexpr double rad2deg = 180./M_PI;
+
+};
+
+TestMTDPosition::TestMTDPosition( const edm::ParameterSet& iConfig ) :
+  label_(iConfig.getUntrackedParameter<std::string>("label","")),
+  isMagField_(iConfig.getUntrackedParameter<bool>("isMagField",false)),
+  fname_(iConfig.getUntrackedParameter<std::string>("outFileName", "GeoHistory")),
+  nNodes_(iConfig.getUntrackedParameter<uint32_t>("numNodesToDump", 0)),
+  ddTopNodeName_(iConfig.getUntrackedParameter<std::string>("ddTopNodeName", "btl:BarrelTimingLayer"))
+{
+  if ( isMagField_ ) {
+    label_ = "magfield";
+  }
+}
+
+TestMTDPosition::~TestMTDPosition()
+{
+}
+
+void
+TestMTDPosition::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+   using namespace edm;
+
+   edm::ESTransientHandle<DDCompactView> pDD;
+   if (!isMagField_) {
+     iSetup.get<IdealGeometryRecord>().get(label_, pDD );
+   } else {
+     iSetup.get<IdealMagneticFieldRecord>().get(label_, pDD );
+   }
+   if (pDD.description()) {
+     edm::LogInfo("TestMTDPosition") << pDD.description()->type_ << " label: " << pDD.description()->label_;
+   } else {
+     edm::LogWarning("TestMTDPosition") << "NO label found pDD.description() returned false.";
+   }
+   if (!pDD.isValid()) {
+     edm::LogError("TestMTDPosition") << "ESTransientHandle<DDCompactView> pDD is not valid!";
+   }
+
+   if ( ddTopNodeName_ != "btl:BarrelTimingLayer" && ddTopNodeName_ != "etl:EndcapTimingLayer" ) {
+     edm::LogWarning("TestMTDPosition") << ddTopNodeName_ << "Not valid top MTD volume";
+     return;
+   }
+     
+   checkMTD( *pDD , fname_ , nNodes_ , ddTopNodeName_ );
+
+}
+
+void TestMTDPosition::checkMTD ( const DDCompactView& cpv, std::string fname, int nVols , std::string ddtop_ ) {
+
+  fname = "dump" + fname;
+  DDExpandedView epv(cpv);
+  edm::LogInfo("TestMTDPosition") << "Top Most LogicalPart = " << epv.logicalPart();
+  typedef DDExpandedView::nav_type nav_type;
+  typedef std::map<nav_type,int> id_type;
+  id_type idMap;
+  int id=0;
+  std::ofstream dump(fname.c_str());
+  bool notReachedDepth(true);
+  
+  bool write = false;
+  size_t limit = 0;
+
+  do {
+    nav_type pos = epv.navPos();
+    idMap[pos]=id;
+    
+    size_t num = epv.geoHistory().size();
+
+    if ( num <= limit ) { write = false; }
+    if ( epv.geoHistory()[num-1].logicalPart().name() == "btl:BarrelTimingLayer" || 
+         epv.geoHistory()[num-1].logicalPart().name() == "etl:EndcapTimingLayer" ) {
+      limit = num;
+      write = true;
+    }
+
+    // Actions for MTD volumes: searchg for sensitive detectors
+
+    if ( write && epv.geoHistory()[limit-1].logicalPart().name() == ddtop_ ) { 
+
+      dump << " - " << epv.geoHistory();
+      dump << "\n";
+
+      bool isSens = false;
+
+      if ( epv.geoHistory()[num-1].logicalPart().specifics().size() > 0 ) { 
+        for ( auto elem : *(epv.geoHistory()[num-1].logicalPart().specifics()[0]) ) {
+          if ( elem.second.name() == "SensitiveDetector" ) { isSens = true; break; }
+        }
+      }
+      
+
+      // Check of numbering scheme for sensitive detectors
+
+      if ( isSens ) { 
+        
+        DDBox mySens = epv.geoHistory()[num-1].logicalPart().solid();
+        dump << "Solid shape name: " << DDSolidShapesName::name(mySens.shape()) << "\n";
+        if ( static_cast<int>(mySens.shape()) != 1 ) { throw cms::Exception("TestMTDPosition") << "MTD sensitive element not a DDBox"; break; }
+        dump << "Box dimensions: " << mySens.halfX() << " " << mySens.halfY() << " " << mySens.halfZ() << "\n";
+        
+        char buf[256];
+        DD3Vector x, y, z;
+        epv.rotation().GetComponents(x,y,z);
+        size_t s = snprintf(buf, 256, ",%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f",
+                            epv.translation().x(),  epv.translation().y(),  epv.translation().z(),
+                            x.X(), y.X(), z.X(), 
+                            x.Y(), y.Y(), z.Y(),
+                            x.Z(), y.Z(), z.Z());
+        assert(s < 256);
+        dump << "Translation vector and Rotation components: " << buf;
+        dump << "\n";
+
+        DD3Vector zeroLocal(0.,0.,0.);
+        DD3Vector cn1Local(mySens.halfX(),mySens.halfY(),mySens.halfZ());
+        double distLocal = cn1Local.R();
+        DD3Vector zeroGlobal = (epv.rotation())(zeroLocal) + epv.translation();
+        DD3Vector cn1Global = (epv.rotation())(cn1Local) + epv.translation();;
+        double distGlobal = std::sqrt(std::pow(zeroGlobal.X()-cn1Global.X(),2)
+                                      +std::pow(zeroGlobal.Y()-cn1Global.Y(),2)
+                                      +std::pow(zeroGlobal.Z()-cn1Global.Z(),2));
+
+        dump << "Center global   = " << std::setw(14) << std::fixed << zeroGlobal.X() 
+             << std::setw(14) << std::fixed << zeroGlobal.Y() 
+             << std::setw(14) << std::fixed << zeroGlobal.Z() 
+             << " r = " << std::setw(14) << std::fixed << zeroGlobal.Rho() 
+             << " phi = " << std::setw(14) << std::fixed << zeroGlobal.Phi()*rad2deg << "\n";
+
+        dump << "Corner 1 local  = " << std::setw(14) << std::fixed << cn1Local.X() 
+             << std::setw(14) << std::fixed << cn1Local.Y() 
+             << std::setw(14) << std::fixed << cn1Local.Z() 
+             << " DeltaR = " << std::setw(14) << std::fixed << distLocal << "\n";
+
+        dump << "Corner 1 global = " << std::setw(14) << std::fixed << cn1Global.X() 
+             << std::setw(14) << std::fixed << cn1Global.Y() 
+             << std::setw(14) << std::fixed << cn1Global.Z() 
+             << " DeltaR = " << std::setw(14) << std::fixed << distGlobal << "\n";
+
+        dump << "\n";
+        if ( std::fabs(distGlobal - distLocal) > 1.e-6 ) { dump << "DIFFERENCE IN DISTANCE \n"; }
+        
+      }
+
+    }
+    ++id;
+    if ( nVols != 0 && id > nVols ) notReachedDepth = false;
+  } while (epv.next() && notReachedDepth);
+  dump << std::flush;
+  dump.close();
+}
+
+
+
+
+DEFINE_FWK_MODULE(TestMTDPosition);

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -33,18 +33,35 @@ process.testETL = cms.EDAnalyzer("TestMTDNumbering",
                                ddTopNodeName = cms.untracked.string('etl:EndcapTimingLayer')
                                )
 
+
+process.testBTLpos = cms.EDAnalyzer("TestMTDPosition",
+                               label = cms.untracked.string(''),
+                               isMagField = cms.untracked.bool(False),
+                               outFileName = cms.untracked.string('BTLpos'),
+                               numNodesToDump = cms.untracked.uint32(0),
+                               ddTopNodeName = cms.untracked.string('btl:BarrelTimingLayer')
+                               )
+
+process.testETLpos = cms.EDAnalyzer("TestMTDPosition",
+                               label = cms.untracked.string(''),
+                               isMagField = cms.untracked.bool(False),
+                               outFileName = cms.untracked.string('ETLpos'),
+                               numNodesToDump = cms.untracked.uint32(0),
+                               ddTopNodeName = cms.untracked.string('etl:EndcapTimingLayer')
+                               )
+
 process.MessageLogger = cms.Service("MessageLogger",
                                     cout = cms.untracked.PSet( INFO = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
                                                                noLineBreaks = cms.untracked.bool(True),
                                                                threshold = cms.untracked.string('INFO'),
                                                                ),
                                     # For LogDebug/LogTrace output...
-                                    categories = cms.untracked.vstring('TestMTDNumbering','MTDGeom'),
+                                    categories = cms.untracked.vstring('TestMTDNumbering','MTDGeom','TestMTDPosition'),
                                     destinations = cms.untracked.vstring('cout')
                                     )
 
 process.Timing = cms.Service("Timing")
 
-process.p1 = cms.Path(process.testBTL+process.testETL)
+process.p1 = cms.Path(process.testBTL+process.testETL+process.testBTLpos+process.testETLpos)
 
 process.e1 = cms.EndPath(process.myprint)

--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -23,7 +23,7 @@
 
 #include <iostream>
 
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 //-------------------------------------------------------------------
 MtdSD::MtdSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg, 

--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -23,7 +23,7 @@
 
 #include <iostream>
 
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 //-------------------------------------------------------------------
 MtdSD::MtdSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg, 
@@ -54,11 +54,13 @@ MtdSD::MtdSD(const std::string& name, const DDCompactView & cpv,
     isETL=true;
   } else {
     scheme = nullptr;
-    edm::LogWarning("EcalSim") << "MtdSD: ReadoutName not supported";
+    edm::LogWarning("MtdSim") << "MtdSD: ReadoutName not supported";
   }
   if (scheme)  setNumberingScheme(scheme);
 
-  setTimeFactor(100.);
+  double newTimeFactor = 1./m_p.getParameter<double>("TimeSliceUnit");
+  edm::LogInfo("MtdSim") << "New time factor = " << newTimeFactor;
+  setTimeFactor(newTimeFactor);
 
   edm::LogVerbatim("MtdSim") << "MtdSD: Instantiation completed for "
 			     << name << " of type " << type;

--- a/SimG4CMS/Forward/src/TimingSD.cc
+++ b/SimG4CMS/Forward/src/TimingSD.cc
@@ -30,7 +30,7 @@
 #include <vector>
 #include <iostream>
 
-#define debug
+//#define debug
 
 static const float invgev = 1.0/CLHEP::GeV;
 static const double invns = 1.0/CLHEP::nanosecond;
@@ -114,7 +114,7 @@ void TimingSD::getStepInfo(const G4Step* aStep) {
   preStepPoint = aStep->GetPreStepPoint(); 
   postStepPoint= aStep->GetPostStepPoint(); 
   hitPointExit = postStepPoint->GetPosition();	
-  setToLocal(postStepPoint, hitPointExit, hitPointLocalExit);  
+  setToLocal(preStepPoint, hitPointExit, hitPointLocalExit);  
   const G4Track* newTrack = aStep->GetTrack();   
 
   // neutral particles deliver energy post step 
@@ -130,11 +130,20 @@ void TimingSD::getStepInfo(const G4Step* aStep) {
   }
 
 #ifdef debug
-  edm::LogInfo("TimingSim") << "TimingSD:" 
-                            << "\n Global entry point: " << hitPoint 
-                            << "\n Global exit  point: " << hitPointExit
-                            << "\n Local  entry point: " << hitPointLocal 
-                            << "\n Local  exit  point: " << hitPointLocalExit; 
+  double distGlobal = std::sqrt(std::pow(hitPoint.x()-hitPointExit.x(),2)+
+                                std::pow(hitPoint.y()-hitPointExit.y(),2)+
+                                std::pow(hitPoint.z()-hitPointExit.z(),2));
+  double distLocal = std::sqrt(std::pow(hitPointLocal.x()-hitPointLocalExit.x(),2)+
+                                std::pow(hitPointLocal.y()-hitPointLocalExit.y(),2)+
+                                std::pow(hitPointLocal.z()-hitPointLocalExit.z(),2));
+  LogDebug("TimingSim") << "TimingSD:" 
+                        << "\n Global entry point: " << hitPoint 
+                        << "\n Global exit  point: " << hitPointExit
+                        << "\n Global step length: " << distGlobal
+                        << "\n Local  entry point: " << hitPointLocal 
+                        << "\n Local  exit  point: " << hitPointLocalExit 
+                        << "\n Local  step length: " << distLocal;
+  if ( std::fabs(distGlobal - distLocal) > 1.e-6 ) { LogDebug("TimingSim") << "DIFFERENCE IN DISTANCE \n"; }
 #endif
 
 

--- a/SimG4CMS/Forward/src/TimingSD.cc
+++ b/SimG4CMS/Forward/src/TimingSD.cc
@@ -30,7 +30,7 @@
 #include <vector>
 #include <iostream>
 
-//#define debug
+#define debug
 
 static const float invgev = 1.0/CLHEP::GeV;
 static const double invns = 1.0/CLHEP::nanosecond;
@@ -77,6 +77,7 @@ void TimingSD::Initialize(G4HCofThisEvent * HCE) {
 void TimingSD::setTimeFactor(double val)
 {
   if(val <= 0.0) { return; }
+  timeFactor = val;
 #ifdef debug
   edm::LogVerbatim("TimingSim") 
     << "TimingSD : for " << GetName()
@@ -127,6 +128,15 @@ void TimingSD::getStepInfo(const G4Step* aStep) {
     setToLocal(preStepPoint, hitPoint, hitPointLocal);  
     tof = (float)(preStepPoint->GetGlobalTime()*invns);
   }
+
+#ifdef debug
+  edm::LogInfo("TimingSim") << "TimingSD:" 
+                            << "\n Global entry point: " << hitPoint 
+                            << "\n Global exit  point: " << hitPointExit
+                            << "\n Local  entry point: " << hitPointLocal 
+                            << "\n Local  exit  point: " << hitPointLocalExit; 
+#endif
+
 
   incidentEnergy = preStepPoint->GetKineticEnergy();
 
@@ -228,12 +238,12 @@ void TimingSD::storeHit(BscG4Hit* hit){
 void TimingSD::createNewHit(const G4Step* aStep) {
 
 #ifdef debug
-  const G4VPhysicsVolume* currentPV = preStepPoint->GetPhysicalVolume();
+  const G4VPhysicalVolume* currentPV = preStepPoint->GetPhysicalVolume();
   edm::LogVerbatim("TimingSim") 
     << "TimingSD CreateNewHit for " << GetName()
     << " PV "     << currentPV->GetName()
     << " PVid = " << currentPV->GetCopyNo()
-    << " Unit "   << unitID <<
+    << " Unit "   << unitID 
     << "\n primary " << primaryID
     << " Tof(ns)= " << tof
     << " time slice " << tSliceID
@@ -315,6 +325,13 @@ void TimingSD::EndOfEvent(G4HCofThisEvent* ) {
     BscG4Hit* aHit = (*theHC)[j];
     Local3DPoint locEntryPoint= ConvertToLocal3DPoint(aHit->getEntryLocalP());
     Local3DPoint locExitPoint = ConvertToLocal3DPoint(aHit->getExitLocalP());
+
+#ifdef debug
+    edm::LogInfo("TimingSim") << "TimingSD: Hit for storage \n" << *aHit 
+                              << "\n Entry point: " << locEntryPoint
+                              << "\n Exit  point: " << locExitPoint << "\n";
+#endif
+
 
     slave->processHits(PSimHit(locEntryPoint,locExitPoint,
 			       aHit->getPabs(),

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -417,8 +417,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     ),
     MtdSD = cms.PSet(
         Verbosity = cms.untracked.int32(0),
-        # TimeSliceUnit    = cms.double(0.01), #stepping = 10 ps (for timing)
-        TimeSliceUnit    = cms.double(1.), 
+        TimeSliceUnit    = cms.double(0.01), #stepping = 10 ps (for timing)
         IgnoreTrackID    = cms.bool(False),
         EminHit          = cms.double(0.0),
         CheckID          = cms.untracked.bool(True),

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -417,7 +417,8 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     ),
     MtdSD = cms.PSet(
         Verbosity = cms.untracked.int32(0),
-        TimeSliceUnit    = cms.double(0.001), #stepping = 1 ps (for timing)
+        # TimeSliceUnit    = cms.double(0.01), #stepping = 10 ps (for timing)
+        TimeSliceUnit    = cms.double(1.), 
         IgnoreTrackID    = cms.bool(False),
         EminHit          = cms.double(0.0),
         CheckID          = cms.untracked.bool(True),


### PR DESCRIPTION
During studies for the choice of the optimal layout, a problem in the PSImHit geometrical information has been reported by @abenagli . The exit point looks to be incompatible with the phsyical dimension of the crystals.

This is caused by a bug introduced at the time of the code cleaning in #23625 , as the conversion to local coordinates for post-step points is done using the post-step reference frame, that might be not the one of the crystal but of the mother volume in case the border is crossed during the step. The original functionality of MtdSD is now restored.

During the investigation I realized that the possibility to define the time slice unit was foreseen in the configuration but not really implemented in the code. This is now fixed, and the value is set back to the 10 ps (originally hardcoded in the code, now a parameter that can be changed through the MtdSD PSet in g4SimHits).

During the debugging, I have implemented a new geometry test module TestMTDPosition that dumps the position of centers and one corner of the crystals. It can be used to quickly inspect the DD description of the sensitive detectors and compare it with the dump of the Geant4 import provided by SimG4Core/PrintGeomInfo utilities. At the same time a minor fix has been done to the TestMTDNumbering module (were CaloSD was always incorrectly printed at the end).

With this fix the reported problem has disappeared (checking 100 events of wf 22407.0, it was appearing already at event 2). It has also been verified that the value of the time slice unit is correctly set depending on the choice.