### PR TITLE
SiStripMonitorClient: Fix caching logic in SiStripBadComponentInfo

### DIFF
--- a/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
@@ -21,7 +21,6 @@
 // -- Contructor
 //
 SiStripBadComponentInfo::SiStripBadComponentInfo(edm::ParameterSet const& pSet) : 
-    m_cacheID_(0),
     bookedStatus_(false),
     nSubSystem_(6),
     qualityLabel_(pSet.getParameter<std::string>("StripQualityLabel"))
@@ -54,15 +53,9 @@ void SiStripBadComponentInfo::checkBadComponents(edm::EventSetup const& eSetup) 
   eSetup.get<TrackerTopologyRcd>().get(tTopoHandle_);
   const TrackerTopology* const topo = tTopoHandle_.product();
  
-  unsigned long long cacheID = eSetup.get<SiStripQualityRcd>().cacheIdentifier();
-  if (m_cacheID_ == !cacheID) { 
-    m_cacheID_ = cacheID; 
-    LogDebug("SiStripBadComponentInfo") <<"SiStripBadchannelInfoNew::readCondition : "
-					<<" Change in Cache";
-    eSetup.get<SiStripQualityRcd>().get(qualityLabel_,siStripQuality_);
-  }    
+  eSetup.get<SiStripQualityRcd>().get(qualityLabel_,siStripQuality_);
  
-  std::vector<SiStripQuality::BadComponent> BC = siStripQuality_->getBadComponentList();
+  auto const& BC = siStripQuality_->getBadComponentList();
   
   for (size_t i=0;i<BC.size();++i){
     int subdet=-999; int component=-999;
@@ -211,7 +204,7 @@ void SiStripBadComponentInfo::bookBadComponentHistos(DQMStore::IBooker &ibooker,
     ibooker.cd();
   }
 }
-void SiStripBadComponentInfo::fillBadComponentMaps(int xbin,int component,SiStripQuality::BadComponent& BC){
+void SiStripBadComponentInfo::fillBadComponentMaps(int xbin,int component,SiStripQuality::BadComponent const& BC){
 
   auto index = std::make_pair(xbin,component);
 

--- a/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.h
+++ b/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.h
@@ -56,7 +56,7 @@ protected:
 private:
   void checkBadComponents(edm::EventSetup const& eSetup);
   void bookBadComponentHistos(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);
-  void fillBadComponentMaps(int xbin, int component,SiStripQuality::BadComponent& BC);
+  void fillBadComponentMaps(int xbin, int component,SiStripQuality::BadComponent const& BC);
   void createSummary(MonitorElement* me,const std::map<std::pair<int,int>,float >& map);
 
   MonitorElement * badAPVME_;
@@ -67,7 +67,6 @@ private:
   std::map<std::pair<int,int>,float > mapBadFiber;
   std::map<std::pair<int,int>,float > mapBadStrip;
 
-  unsigned long long m_cacheID_;
   bool bookedStatus_;
   int nSubSystem_;
   std::string qualityLabel_;


### PR DESCRIPTION
... by removing it. Also avoid a needless copy.

Thanks to @Dr15Jones and @makortel in #24924 for pointing out that this logic seems to be quite broken.

@mmusich this seems to fix the crash with multi-run harvesting, but it is hard to validate for me if the basic behavior changed. But, the change seems safe from the technical side.

Required for #24920, but independent.