### PR TITLE
Bug fixes to Run2_2018_pp_on_AA in EI and DQM

### DIFF
--- a/CommonTools/ParticleFlow/python/EITopPAG_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_cff.py
@@ -175,3 +175,12 @@ EIsequence = cms.Sequence(
     pfCombinedInclusiveSecondaryVertexV2BJetTagsEI
     )
 
+## customizations for the pp_on_AA eras                                                                                                                                                        
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(pfPileUpJMEEI,
+                                           Vertices = "offlinePrimaryVertices"
+                                           )
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(pfJetsEI,
+                                           srcPVs = "offlinePrimaryVertices"
+                                           )

--- a/CommonTools/ParticleFlow/python/EITopPAG_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from CommonTools.ParticleFlow.goodOfflinePrimaryVertices_cfi import *
 from CommonTools.ParticleFlow.pfMET_cfi  import *
 from CommonTools.ParticleFlow.pfJets_cff import *
 from CommonTools.ParticleFlow.pfTaus_cff import *
@@ -151,6 +152,7 @@ pfMetEI = pfMET.clone(jets=cms.InputTag("pfJetsEI"))
 
 #EITopPAG = cms.Sequence(
 EIsequence = cms.Sequence(
+    goodOfflinePrimaryVertices +
     pfPileUpEI +
     pfPileUpJMEEI +
     pfNoPileUpEI +
@@ -175,12 +177,3 @@ EIsequence = cms.Sequence(
     pfCombinedInclusiveSecondaryVertexV2BJetTagsEI
     )
 
-## customizations for the pp_on_AA eras                                                                                                                                                        
-from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(pfPileUpJMEEI,
-                                           Vertices = "offlinePrimaryVertices"
-                                           )
-(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(pfJetsEI,
-                                           srcPVs = "offlinePrimaryVertices"
-                                           )

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -188,7 +188,8 @@ phase2_hcal.toReplaceWith( PostDQMOfflineMiniAOD, PostDQMOfflineMiniAOD.copyAndE
 ]))
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toReplaceWith(DQMOffline, DQMOffline.copyAndExclude([pfTauRunDQMValidation]))
+_pfTauRunDQMValidation = cms.Sequence()
+pp_on_AA_2018.toReplaceWith(pfTauRunDQMValidation, _pfTauRunDQMValidation)
 
 from PhysicsTools.NanoAOD.nanoDQM_cff import nanoDQM
 DQMOfflineNanoAOD = cms.Sequence(nanoDQM)

--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -10,6 +10,14 @@ bTagAnalysis.doJEC = True
 #Residual correction will be added inside the c++ code only for data (checking the presence of genParticles collection), not explicit here as this sequence also ran on MC FullSim
 bTagPlotsDATA = cms.Sequence(pfDeepCSVDiscriminatorsJetTags * bTagAnalysis)
 
+## customizations for the pp_on_AA eras
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(bTagAnalysis,
+                                           doJEC=False
+                                           )
+
+
 ########## MC ############
 #Matching
 from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import selectedHadronsAndPartons
@@ -46,6 +54,11 @@ bTagValidation.genJetsMatched = cms.InputTag("newpatJetGenJetMatch")
 #to run on fastsim
 prebTagSequenceMC = cms.Sequence(ak4GenJetsForPUid*newpatJetGenJetMatch*selectedHadronsAndPartons*myak4JetFlavourInfos*pfDeepCSVDiscriminatorsJetTags)
 bTagPlotsMC = cms.Sequence(bTagValidation)
+
+## customizations for the pp_on_AA eras
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(bTagValidation,
+                                           doJEC=False
+                                           )
 
 #to run on fullsim in the validation sequence, all histograms produced in the dqmoffline sequence
 bTagValidationNoall = bTagValidation.clone(flavPlots="bcl")

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -197,3 +197,4 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( globalValidation, _phase2_globalValidation )
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(globalValidation, globalValidation.copyAndExclude([pfTauRunDQMValidation]))
+

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -197,4 +197,3 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( globalValidation, _phase2_globalValidation )
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(globalValidation, globalValidation.copyAndExclude([pfTauRunDQMValidation]))
-


### PR DESCRIPTION
Crashes in a replay using the Run2_2018_pp_on_AA era were identified in:
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2031/1/1/1/1.html

These crashes are not spotted in the relevant MC workflow (158), as they only occur in data validation.
They were reproduced using the following driver command, which executes the real data version.
 cmsDriver.py reco --runUnscheduled --conditions auto:phase1_2018_realistic_hi -s RAW2DIGI,L1Reco,RECO,EI,VALIDATION:@standardValidation,DQM:@common+@standardDQM+@ExtraHLT --datatier AOD,DQMIO -n 2 --era Run2_2018_pp_on_AA --eventcontent AOD,DQM 

This can be tested on the DIGI output from wf 158

103X version coming.

@icali 