### PR TITLE
HCAL DQClient: Reset _vhashCrates for each run.

### DIFF
--- a/DQM/HcalCommon/src/DQClient.cc
+++ b/DQM/HcalCommon/src/DQClient.cc
@@ -18,6 +18,7 @@ namespace hcaldqm
 	{
 		//	TEMPORARY
 		_vhashFEDs.clear(); _vcdaqEids.clear();
+		_vhashCrates.clear();
 
 		//	get various FED lists
 		edm::ESHandle<HcalDbService> dbs;


### PR DESCRIPTION
Seems to be done for the other vectors as well, and else crashes in multi-run harvesting.

This is required for #24920 to pass, but independent as a PR. Behavior in non multi-run jobs should not change at all.