### PR TITLE
Fix APV shot cleaner for 10bit

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/src/SiStripApvShotCleaner.cc
+++ b/RecoLocalTracker/SiStripClusterizer/src/SiStripApvShotCleaner.cc
@@ -133,9 +133,10 @@ void SiStripApvShotCleaner::subtractCM(){
     return;
 
   //Subtract the median
+  const bool is10bit = apvDigis[0].adc() > 255; // approximation; definitely 10bit in this case
   size_t i=0;
   for(;i<stripsForMedian&&apvDigis[i].adc()>CM;++i){
-    uint16_t adc=apvDigis[i].adc()>253?apvDigis[i].adc():(uint16_t)(apvDigis[i].adc()-CM);
+    const uint16_t adc = ( ( apvDigis[i].adc() > 253 ) && !is10bit ) ? apvDigis[i].adc() : (uint16_t)(apvDigis[i].adc()-CM);
     apvDigis[i]=SiStripDigi(apvDigis[i].strip(),adc);
   }
   apvDigis.resize(i);


### PR DESCRIPTION
As discussed in https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2029/1/1/1/2/1/1/1/1.html point 4: a fix for the APV shot cleaner (which performs an "emergency zero-suppression") for 10bit data.
The problem was that 254 and 255 have special meanings in 8-bit truncation, see https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripFedZeroSuppression.h#L38 (saturated strips, 254-1022 or even above), so values above 253 were not CM-subtracted here.
The fix exploits this by concluding that if any digi is larger than 255, the 8bit scheme is not used, and all digis can be CM-subtracted (for typical hybrid data the baseline is above 500). The hypothetical case of 10bit data with all digis below 254 is also handled correctly; only if the largest digi is 254 or 255 the detection doesn't work (but this should not happen in practice).
Changes expected: none, expect for data taken in hybrid mode on which the (hybrid-adjusted) zero-suppression and repacking was not run in the HLT (like 324623, possibly also cosmics during the HI run).

CC: @icali 