### PR TITLE
Utilities/StaticAnalyzer: include dablooms library header as extern "C"

### DIFF
--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -22,9 +22,11 @@
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // PGartung needed for bloom filter loading
+extern "C" {
 #include "dablooms.h"
 #define CAPACITY 5000
 #define ERROR_RATE .0002
+}
 
 using namespace clang;
 using namespace llvm;

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -152,7 +152,7 @@ bool clangcms::support::isSafeClassName(const std::string &cname) {
 
 bool clangcms::support::isDataClass(const std::string & name) {
      CMS_THREAD_SAFE static std::string iname("");
-     if ( iname == "") {
+     if ( iname.empty()) {
           clang::FileSystemOptions FSO;
           clang::FileManager FM(FSO);
           const char * lPath = std::getenv("LOCALRT");

--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.h
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.h
@@ -11,13 +11,14 @@
 #include <clang/StaticAnalyzer/Core/Checker.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "CmsException.h" 
 
 namespace clangcms {
 
 class ConstCastAwayChecker: public clang::ento::Checker< clang::ento::check::PreStmt< clang::ExplicitCastExpr> > {
 public:
-	mutable std::unique_ptr<clang::ento::BugType> BT;
+	CMS_THREAD_SAFE mutable std::unique_ptr<clang::ento::BugType> BT;
 	void checkPreStmt(const clang::ExplicitCastExpr *CE, clang::ento::CheckerContext &C) const;
 
 private:

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.h
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.h
@@ -11,12 +11,14 @@
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
 #include "CmsException.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
 
 namespace clangcms {
 
 class ConstCastChecker: public clang::ento::Checker< clang::ento::check::PreStmt< clang::CXXConstCastExpr> > {
 public:
-	mutable std::unique_ptr<clang::ento::BugType> BT;
+	CMS_THREAD_SAFE mutable std::unique_ptr<clang::ento::BugType> BT;
 	void checkPreStmt(const clang::CXXConstCastExpr *CE, clang::ento::CheckerContext &C) const;
 
 private:

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.h
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.h
@@ -4,12 +4,12 @@
 #include <clang/StaticAnalyzer/Core/Checker.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
-
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "CmsException.h"
 
 namespace clangcms {
 class FiniteMathChecker : public clang::ento::Checker<clang::ento::check::PreStmt<clang::CallExpr> > {
-  mutable std::unique_ptr<clang::ento::BugType> BT;
+  CMS_THREAD_SAFE mutable std::unique_ptr<clang::ento::BugType> BT;
 public:
   void checkPreStmt(const clang::CallExpr *ref, clang::ento::CheckerContext &C) const;
 };  

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -189,8 +189,8 @@ void FunctionChecker::checkASTDecl(const FunctionTemplateDecl *TD, AnalysisManag
    	if (!support::isCmsLocalFile(sfile)) return;
 	std::string fname(sfile);
 	if ( !support::isInterestingLocation(fname) ) return;
-	for (FunctionTemplateDecl::spec_iterator I = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_begin(), 
-			E = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_end(); I != E; ++I) 
+	for (auto I = TD->spec_begin(), 
+			E = TD->spec_end(); I != E; ++I) 
 		{
 			if (I->doesThisDeclarationHaveABody()) {
 				FWalker walker(this,BR, mgr.getAnalysisDeclContext(*I));

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -40,7 +40,7 @@ public:
 
   const clang::Stmt * ParentStmt(const Stmt *S) {
   	const Stmt * P = AC->getParentMap().getParentIgnoreParens(S);
-	if (!P) return 0;
+	if (!P) return nullptr;
 	return P;
   }
 

--- a/Utilities/StaticAnalyzers/src/FunctionDumper.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionDumper.cpp
@@ -213,8 +213,8 @@ void FunctionDumper::checkASTDecl(const FunctionTemplateDecl *TD, AnalysisManage
      std::string sname(sfile);
      if ( ! support::isInterestingLocation(sname) ) return;
      if ( ! support::isCmsLocalFile(sfile) ) return;
-     for (FunctionTemplateDecl::spec_iterator I = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_begin(), 
-               E = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_end(); I != E; ++I) 
+     for (auto I = TD->spec_begin(), 
+               E = TD->spec_end(); I != E; ++I) 
           {
                if (I->doesThisDeclarationHaveABody()) {
                    FDumper walker(BR, mgr.getAnalysisDeclContext(*I), (*I));

--- a/Utilities/StaticAnalyzers/src/FunctionDumper.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionDumper.cpp
@@ -64,7 +64,7 @@ public:
 
   const clang::Stmt * ParentStmt(const Stmt *S) {
   const Stmt * P = AC->getParentMap().getParentIgnoreParens(S);
-  if (!P) return 0;
+  if (!P) return nullptr;
   return P;
   }
 
@@ -74,7 +74,7 @@ public:
           const char* fname = BR.getSourceManager().getPresumedLoc(AD->getLocation()).getFilename();
           const char* sname = "/src/";
           const char* filename = std::strstr(fname, sname);
-          if (filename != NULL) name = name.substr(0, anon_ns.size() - 1)+" in "+filename+")"+name.substr(anon_ns.size());
+          if (filename != nullptr) name = name.substr(0, anon_ns.size() - 1)+" in "+filename+")"+name.substr(anon_ns.size());
           }
       return;
   }

--- a/Utilities/StaticAnalyzers/src/GlobalStaticChecker.h
+++ b/Utilities/StaticAnalyzers/src/GlobalStaticChecker.h
@@ -9,13 +9,13 @@
 #include <clang/StaticAnalyzer/Core/Checker.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
-
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "CmsException.h"
 
 
 namespace clangcms {
 class GlobalStaticChecker : public clang::ento::Checker< clang::ento::check::ASTDecl< clang::VarDecl> > {
-  mutable std::unique_ptr< clang::ento::BuiltinBug> BT;
+  CMS_THREAD_SAFE mutable std::unique_ptr< clang::ento::BuiltinBug> BT;
 
 public:
   void checkASTDecl(const clang::VarDecl *D,

--- a/Utilities/StaticAnalyzers/src/MutableMemberChecker.h
+++ b/Utilities/StaticAnalyzers/src/MutableMemberChecker.h
@@ -10,13 +10,13 @@
 #include <clang/StaticAnalyzer/Core/Checker.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
-
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "CmsException.h"
 #include "CmsSupport.h"
 
 namespace clangcms {
 class MutableMemberChecker : public clang::ento::Checker< clang::ento::check::ASTDecl< clang::FieldDecl> > {
-  mutable std::unique_ptr< clang::ento::BuiltinBug> BT;
+  CMS_THREAD_SAFE mutable std::unique_ptr< clang::ento::BuiltinBug> BT;
 
 public:
   void checkASTDecl(const clang::FieldDecl *D,

--- a/Utilities/StaticAnalyzers/src/StaticLocalChecker.h
+++ b/Utilities/StaticAnalyzers/src/StaticLocalChecker.h
@@ -10,13 +10,13 @@
 #include <clang/StaticAnalyzer/Core/Checker.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
-
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "CmsException.h"
 
 
 namespace clangcms {
 class StaticLocalChecker : public clang::ento::Checker< clang::ento::check::ASTDecl< clang::VarDecl> > {
-  mutable std::unique_ptr<clang::ento::BuiltinBug> BT;
+  CMS_THREAD_SAFE mutable std::unique_ptr<clang::ento::BuiltinBug> BT;
 
 public:
   void checkASTDecl(const clang::VarDecl *D,

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -79,8 +79,8 @@ void ThrUnsafeFCallChecker::checkASTDecl(const FunctionTemplateDecl *TD, Analysi
 	clang::ento::PathDiagnosticLocation DLoc =clang::ento::PathDiagnosticLocation::createBegin( TD, SM );
 	if ( SM.isInSystemHeader(DLoc.asLocation()) || SM.isInExternCSystemHeader(DLoc.asLocation()) ) return;
 
-	for (FunctionTemplateDecl::spec_iterator I = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_begin(), 
-			E = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_end(); I != E; ++I) 
+	for (auto I = TD->spec_begin(), 
+			    E = TD->spec_end(); I != E; ++I) 
 		{
 			if (I->doesThisDeclarationHaveABody()) {
 				clangcms::TUFWalker walker(this,BR, mgr.getAnalysisDeclContext(*I));

--- a/Utilities/StaticAnalyzers/src/TrunCastChecker.h
+++ b/Utilities/StaticAnalyzers/src/TrunCastChecker.h
@@ -5,12 +5,13 @@
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
 #include "CmsException.h" 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace clangcms {
 
 class TrunCastChecker: public clang::ento::Checker< clang::ento::check::ASTDecl<clang::CXXRecordDecl> > {
 public:
-     mutable std::unique_ptr<clang::ento::BugType> BT;
+     CMS_THREAD_SAFE mutable std::unique_ptr<clang::ento::BugType> BT;
      void checkASTDecl(const clang::CXXRecordDecl *D, clang::ento::AnalysisManager& Mgr, clang::ento::BugReporter &BR) const; 
 
 private:

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -160,8 +160,8 @@ void getByChecker::checkASTDecl(const FunctionTemplateDecl *TD, AnalysisManager&
 	clang::ento::PathDiagnosticLocation DLoc =clang::ento::PathDiagnosticLocation::createBegin( TD, SM );
 	if ( SM.isInSystemHeader(DLoc.asLocation()) || SM.isInExternCSystemHeader(DLoc.asLocation()) ) return;
 
-	for (FunctionTemplateDecl::spec_iterator I = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_begin(), 
-			E = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_end(); I != E; ++I) 
+	for (auto I = TD->spec_begin(), 
+			E = TD->spec_end(); I != E; ++I) 
 		{
 			if (I->doesThisDeclarationHaveABody()) {
 				clangcms::Walker walker(this,BR, mgr.getAnalysisDeclContext(*I));

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -55,7 +55,7 @@ void Walker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 //				llvm::errs()<<"\n";
 //				}
 			os<<"function '";
-			llvm::dyn_cast<CXXMethodDecl>(D)->getNameForDiagnostic(os,Policy,1);
+			llvm::dyn_cast<CXXMethodDecl>(D)->getNameForDiagnostic(os,Policy,true);
 			os<<"' ";
 //			os<<"call expression '";
 //			CE->printPretty(os,0,Policy);
@@ -81,7 +81,7 @@ void Walker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 				}
 				else { 
 					os<<" "<< qtname <<" ";
-					(*I)->printPretty(os,0,Policy);
+					(*I)->printPretty(os,nullptr,Policy);
 					os <<", ";
 				}
 			}
@@ -122,7 +122,7 @@ void Walker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 				std::string tname;
 				os<<"function '"<<dname<<"' ";
 				os<<"calls '";
-				MD->getNameForDiagnostic(os,Policy,1);
+				MD->getNameForDiagnostic(os,Policy,true);
 				os<<"' with argument of type '"<<qtname<<"'\n";
 //				llvm::errs()<<"\n";
 //				llvm::errs()<<"call expression passed edm::Event ";


### PR DESCRIPTION
… so that symbols are generated correctly. Clean up static analyzer warnings.