### PR TITLE
FWCore/Framework: suppress warnings about mutable member accessed via a const pointer.

### DIFF
--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -31,6 +31,7 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // forward declarations
 namespace edm {
@@ -116,7 +117,7 @@ template<typename T>
       const ComponentFactory& operator=(const ComponentFactory&); // stop default
 
       // ---------- member data --------------------------------
-      mutable MakerMap makers_;
+      CMS_THREAD_SAFE mutable MakerMap makers_;
 };
 
    }

--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -92,8 +92,8 @@ namespace edm {
 
          // ---------- member data --------------------------------
          CMS_THREAD_SAFE mutable void const* cache_; //protected by a global mutex
-         mutable std::atomic<bool> cacheIsValid_;
-         mutable std::atomic<bool> nonTransientAccessRequested_;
+         CMS_THREAD_SAFE mutable std::atomic<bool> cacheIsValid_;
+         CMS_THREAD_SAFE mutable std::atomic<bool> nonTransientAccessRequested_;
          ComponentDescription const* description_;
       };
    }

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -40,6 +40,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/Likely.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <memory>
 #include <string>
@@ -334,8 +335,8 @@ namespace edm {
     // merely a cache reflecting what has been retrieved from the
     // Principal class.
     typedef std::unordered_set<BranchID::value_type> BranchIDSet;
-    mutable BranchIDSet gotBranchIDs_;
-    mutable std::vector<bool> gotBranchIDsFromPrevious_;
+    CMS_THREAD_SAFE mutable BranchIDSet gotBranchIDs_;
+    CMS_THREAD_SAFE mutable std::vector<bool> gotBranchIDsFromPrevious_;
     std::vector<BranchID>* previousBranchIDs_ = nullptr;
     std::vector<BranchID>* gotBranchIDsFromAcquire_ = nullptr;
 
@@ -343,7 +344,7 @@ namespace edm {
     void addToGotBranchIDs(BranchID const& branchID) const;
 
     // We own the retrieved Views, and have to destroy them.
-    mutable std::vector<std::shared_ptr<ViewBase> > gotViews_;
+    CMS_THREAD_SAFE mutable std::vector<std::shared_ptr<ViewBase> > gotViews_;
 
     StreamID streamID_;
     ModuleCallingContext const* moduleCallingContext_;

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -52,6 +52,7 @@ Some examples of InputSource subclasses may be:
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <memory>
 #include <string>
@@ -421,12 +422,12 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     std::string processGUID_;
     Timestamp time_;
-    mutable bool newRun_;
-    mutable bool newLumi_;
+    CMS_THREAD_SAFE mutable bool newRun_;
+    CMS_THREAD_SAFE mutable bool newLumi_;
     bool eventCached_;
-    mutable ItemType state_;
-    mutable std::shared_ptr<RunAuxiliary> runAuxiliary_;
-    mutable std::shared_ptr<LuminosityBlockAuxiliary>  lumiAuxiliary_;
+    CMS_THREAD_SAFE mutable ItemType state_;
+    CMS_THREAD_SAFE mutable std::shared_ptr<RunAuxiliary> runAuxiliary_;
+    CMS_THREAD_SAFE mutable std::shared_ptr<LuminosityBlockAuxiliary>  lumiAuxiliary_;
     std::string statusFileName_;
 
     unsigned int numberOfEventsBeforeBigSkip_;

--- a/FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h
+++ b/FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h
@@ -25,6 +25,7 @@
 // user include files
 #include "FWCore/Framework/interface/ProxyFactoryBase.h"
 #include "FWCore/Framework/interface/DataKey.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // forward declarations
 namespace edm {
@@ -59,7 +60,7 @@ class ProxyArgumentFactoryTemplate : public ProxyFactoryBase
       const ProxyArgumentFactoryTemplate& operator=(const ProxyArgumentFactoryTemplate&) = delete; // stop default
 
       // ---------- member data --------------------------------
-      mutable ArgT arg_;
+      CMS_THREAD_SAFE mutable ArgT arg_;
 };
 
    }

--- a/FWCore/Framework/interface/SharedResourcesAcquirer.h
+++ b/FWCore/Framework/interface/SharedResourcesAcquirer.h
@@ -20,7 +20,7 @@
 
 // system include files
 #include "FWCore/Concurrency/interface/SerialTaskQueueChain.h"
-
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 // user include files
 
 // forward declarations
@@ -55,7 +55,7 @@ namespace edm {
   private:
     
     // ---------- member data --------------------------------
-    mutable SerialTaskQueueChain m_queues;
+    CMS_THREAD_SAFE mutable SerialTaskQueueChain m_queues;
   };
 }
 

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -17,6 +17,7 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 
@@ -290,7 +291,7 @@ namespace edm {
     //EventSelection
     bool wantAllEvents_;
     ParameterSetID selector_config_id_;
-    mutable detail::TriggerResultsBasedEventSelector selectors_;
+    CMS_THREAD_SAFE mutable detail::TriggerResultsBasedEventSelector selectors_;
 
     // needed because of possible EDAliases.
     // filled in only if key and value are different.

--- a/FWCore/Framework/interface/es_Label.h
+++ b/FWCore/Framework/interface/es_Label.h
@@ -27,6 +27,7 @@
 // user include files
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // forward declarations
 
@@ -43,7 +44,7 @@ namespace edm::es {
 
     T& operator*() { return *product_;}
     T* operator->() { return product_.get(); }
-    mutable std::shared_ptr<T> product_{nullptr};
+    CMS_THREAD_SAFE mutable std::shared_ptr<T> product_{nullptr};
   };
 
   template<int ILabel, typename T>

--- a/FWCore/Framework/src/Factory.h
+++ b/FWCore/Framework/src/Factory.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace edm {
   typedef edmplugin::PluginFactory<Maker* ()> MakerPluginFactory;
@@ -35,7 +36,7 @@ namespace edm {
     Factory();
     Maker* findMaker(const MakeModuleParams& p) const;
     static Factory const singleInstance_;
-    mutable MakerMap makers_;
+    CMS_THREAD_SAFE mutable MakerMap makers_;
   };
 
 }

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -16,6 +16,7 @@ a set of related EDProducts. This is the storage unit of such information.
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <memory>
 #include <atomic>
@@ -91,7 +92,7 @@ namespace edm {
     bool singleProduct_() const final;
 
     ProductData productData_;
-    mutable std::atomic<ProductStatus> theStatus_;
+    CMS_THREAD_SAFE mutable std::atomic<ProductStatus> theStatus_;
     ProductStatus const defaultStatus_;
   };
 
@@ -128,8 +129,8 @@ namespace edm {
 
       void resetProductData_(bool deleteEarly) override;
 
-      mutable std::atomic<bool> m_prefetchRequested;
-      mutable WaitingTaskList m_waitingTasks;
+      CMS_THREAD_SAFE mutable std::atomic<bool> m_prefetchRequested;
+      CMS_THREAD_SAFE mutable WaitingTaskList m_waitingTasks;
       UnscheduledAuxiliary const* aux_; //provides access to the delayedGet signals
 
 
@@ -168,9 +169,9 @@ namespace edm {
     void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
     void resetProductData_(bool deleteEarly) override;
 
-    mutable WaitingTaskList m_waitingTasks;
+    CMS_THREAD_SAFE mutable WaitingTaskList m_waitingTasks;
     Worker* worker_;
-    mutable std::atomic<bool> prefetchRequested_;
+    CMS_THREAD_SAFE mutable std::atomic<bool> prefetchRequested_;
 
   };
 
@@ -198,10 +199,10 @@ namespace edm {
 
       void resetProductData_(bool deleteEarly) override;
 
-      mutable WaitingTaskList waitingTasks_;
+      CMS_THREAD_SAFE mutable WaitingTaskList waitingTasks_;
       UnscheduledAuxiliary const* aux_;
       Worker* worker_;
-      mutable std::atomic<bool> prefetchRequested_;
+      CMS_THREAD_SAFE mutable std::atomic<bool> prefetchRequested_;
   };
 
   class AliasProductResolver : public ProductResolverBase {
@@ -377,12 +378,12 @@ namespace edm {
 
       std::vector<ProductResolverIndex> matchingHolders_;
       std::vector<bool> ambiguous_;
-      mutable WaitingTaskList waitingTasks_;
-      mutable WaitingTaskList skippingWaitingTasks_;
-      mutable std::atomic<unsigned int> lastCheckIndex_;
-      mutable std::atomic<unsigned int> lastSkipCurrentCheckIndex_;
-      mutable std::atomic<bool> prefetchRequested_;
-      mutable std::atomic<bool> skippingPrefetchRequested_;
+      CMS_THREAD_SAFE mutable WaitingTaskList waitingTasks_;
+      CMS_THREAD_SAFE mutable WaitingTaskList skippingWaitingTasks_;
+      CMS_THREAD_SAFE mutable std::atomic<unsigned int> lastCheckIndex_;
+      CMS_THREAD_SAFE mutable std::atomic<unsigned int> lastSkipCurrentCheckIndex_;
+      CMS_THREAD_SAFE mutable std::atomic<bool> prefetchRequested_;
+      CMS_THREAD_SAFE mutable std::atomic<bool> skippingPrefetchRequested_;
       const bool madeAtEnd_;
   };
 

--- a/FWCore/ParameterSet/interface/ParameterSetEntry.h
+++ b/FWCore/ParameterSet/interface/ParameterSetEntry.h
@@ -8,6 +8,7 @@
   */
 
 #include "FWCore/Utilities/interface/atomic_value_ptr.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
 namespace cms {
@@ -58,7 +59,7 @@ namespace edm {
     bool isTracked_;
     // can be internally reconstituted from the ID, in an
     // ostensibly const function
-    mutable atomic_value_ptr<ParameterSet> thePSet_;
+    CMS_THREAD_SAFE mutable atomic_value_ptr<ParameterSet> thePSet_;
 
     ParameterSetID theID_;
   };

--- a/FWCore/ParameterSet/interface/VParameterSetEntry.h
+++ b/FWCore/ParameterSet/interface/VParameterSetEntry.h
@@ -10,6 +10,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetEntry.h"
 #include "FWCore/Utilities/interface/value_ptr.h"
 #include "FWCore/Utilities/interface/atomic_value_ptr.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <iosfwd>
 #include <string>
@@ -56,7 +57,7 @@ namespace edm {
   private:
 
     bool tracked_;
-    mutable atomic_value_ptr<std::vector<ParameterSet> > theVPSet_;
+    CMS_THREAD_SAFE mutable atomic_value_ptr<std::vector<ParameterSet> > theVPSet_;
     value_ptr<std::vector<ParameterSetID> > theIDs_;
   };
 }

--- a/FWCore/PluginManager/interface/PluginFactoryBase.h
+++ b/FWCore/PluginManager/interface/PluginFactoryBase.h
@@ -28,6 +28,7 @@
 #include "tbb/concurrent_vector.h"
 
 #include "FWCore/Utilities/interface/Signal.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 // user include files
 #include "FWCore/PluginManager/interface/PluginInfo.h"
 
@@ -76,7 +77,7 @@ class PluginFactoryBase
       virtual const std::string& category() const = 0;
       
       ///signal containing plugin category, and  plugin info for newly added plugin
-      mutable edm::signalslot::Signal<void(const std::string&, const PluginInfo&)> newPluginAdded_;
+      CMS_THREAD_SAFE mutable edm::signalslot::Signal<void(const std::string&, const PluginInfo&)> newPluginAdded_;
 
       // ---------- static member functions --------------------
 

--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -26,6 +26,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/TypeIDBase.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // system include files
 #include <memory>
@@ -51,7 +52,7 @@ public:
             edm::propagate_const<std::shared_ptr<ServiceMakerBase>> maker_;
             ParameterSet* pset_;
             ActivityRegistry* registry_; // We do not use propagate_const because the registry itself is mutable
-            mutable bool wasAdded_;
+            CMS_THREAD_SAFE mutable bool wasAdded_;
          };
          typedef std::map<TypeIDBase, std::shared_ptr<ServiceWrapperBase> > Type2Service;
          typedef std::map<TypeIDBase, MakerHolder> Type2Maker;

--- a/FWCore/Utilities/interface/Exception.h
+++ b/FWCore/Utilities/interface/Exception.h
@@ -39,6 +39,7 @@
 #include <type_traits>
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace cms {
 
@@ -191,7 +192,7 @@ namespace cms {
     // data members
     std::ostringstream ost_;
     std::string category_;
-    mutable std::string what_;
+    CMS_THREAD_SAFE mutable std::string what_;
     std::list<std::string> context_;
     std::list<std::string> additionalInfo_;
     bool alreadyPrinted_;


### PR DESCRIPTION
FWCore/Framework: suppress warnings about mutable member accessed via a const pointer.

These warnings make up 50k of the 80k reported by the static analyzer.