### PR TITLE
use ofast-flag tool instead of directly CXXFLAGS=-Ofast

### DIFF
--- a/DataFormats/Math/test/BuildFile.xml
+++ b/DataFormats/Math/test/BuildFile.xml
@@ -35,7 +35,7 @@
 <bin   file="SSEVec_t.cpp" name="DataFormatsSSEVec_t">
 </bin>
 <bin   file="crossV4_t.cpp" name="DataFormatscrossV4_t">
-  <flags CXXFLAGS="-Ofast"/>
+  <use name="ofast-flag"/>
 </bin>
 <bin   file="sign_t.cpp" name="DataFormatsSign_t">
 </bin>
@@ -60,7 +60,7 @@
 <bin   file="Similarity_t.cpp" name="DataFormatsSimilarity_t">
 </bin>
 <bin   file="Similarity_t.cpp" name="DataFormatsSimilarityFast_t">
-<flags CXXFLAGS="-Ofast"/>
+  <use name="ofast-flag"/>
 </bin>
 
 <bin   file="MulSymMatrix_t.cpp" name="DataFormatsMulSymMatrix_t">

--- a/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
+<use   name="ofast-flag"/>
 <use   name="TrackingTools/MaterialEffects"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>

--- a/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
@@ -1,5 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
-
+<use   name="ofast-flag"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="Geometry/CaloGeometry"/>

--- a/RecoPixelVertexing/PixelTriplets/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/BuildFile.xml
@@ -16,5 +16,5 @@
 <export>
   <lib   name="1"/>
 </export>
-
-<flags   CXXFLAGS="-Ofast -fno-math-errno"/>
+<use   name="ofast-flag"/>
+<flags   CXXFLAGS="-fno-math-errno"/>

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -5,5 +5,5 @@
 <library   file="*.cc" name="RecoPixelVertexingPixelTripletsPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>
-
-<flags   CXXFLAGS="-Ofast -fno-math-errno"/>
+<use   name="ofast-flag"/>
+<flags   CXXFLAGS="-fno-math-errno"/>

--- a/RecoTracker/FinalTrackSelectors/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
+<use   name="ofast-flag"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/VertexReco"/>

--- a/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
+<use   name="ofast-flag"/>
 <use   name="RecoTracker/FinalTrackSelectors"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/DetId"/>

--- a/RecoTracker/TkDetLayers/BuildFile.xml
+++ b/RecoTracker/TkDetLayers/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
+<use   name="ofast-flag"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoTracker/TkHitPairs/BuildFile.xml
+++ b/RecoTracker/TkHitPairs/BuildFile.xml
@@ -1,5 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
-
+<use   name="ofast-flag"/>
 <use   name="clhep"/>
 <use   name="boost"/>
 <use   name="root"/>

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
+<use   name="ofast-flag"/>
 <use   name="DataFormats/BeamSpot"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="FWCore/Framework"/>

--- a/TrackingTools/GsfTools/BuildFile.xml
+++ b/TrackingTools/GsfTools/BuildFile.xml
@@ -1,5 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
-
+<use   name="ofast-flag"/>
 <use   name="boost"/>
 <use   name="CLHEP"/>
 <export>

--- a/TrackingTools/GsfTools/plugins/BuildFile.xml
+++ b/TrackingTools/GsfTools/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
+<use   name="ofast-flag"/>
 <use   name="TrackingTools/Records"/>
 <use   name="TrackingTools/GsfTools"/>
 <use   name="FWCore/Framework"/>

--- a/TrackingTools/GsfTools/test/BuildFile.xml
+++ b/TrackingTools/GsfTools/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
+<use   name="ofast-flag"/>
 <use   name="TrackingTools/GsfTools"/>
 <use   name="TrackingTools/AnalyticalJacobians"/>
 <use   name="rootmath"/>

--- a/TrackingTools/GsfTracking/BuildFile.xml
+++ b/TrackingTools/GsfTracking/BuildFile.xml
@@ -1,5 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
-
+<use   name="ofast-flag"/>
 <use   name="boost"/>
 <use   name="CLHEP"/>
 <export>

--- a/TrackingTools/KalmanUpdators/BuildFile.xml
+++ b/TrackingTools/KalmanUpdators/BuildFile.xml
@@ -1,4 +1,5 @@
-<flags   CXXFLAGS="-Ofast -funroll-all-loops"/>
+<flags   CXXFLAGS="-funroll-all-loops"/>
+<use   name="ofast-flag"/>
 <use   name="clhep"/>
 <use   name="RecoTracker/TransientTrackingRecHit"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>

--- a/TrackingTools/MaterialEffects/BuildFile.xml
+++ b/TrackingTools/MaterialEffects/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
+<use   name="ofast-flag"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>

--- a/TrackingTools/MaterialEffects/plugins/BuildFile.xml
+++ b/TrackingTools/MaterialEffects/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
+<use   name="ofast-flag"/>
 <use   name="TrackingTools/Records"/>
 <use   name="TrackingTools/MaterialEffects"/>
 <library   file="*.cc" name="TrackingToolsMaterialEffectsPlugins">

--- a/TrackingTools/TrackFitters/BuildFile.xml
+++ b/TrackingTools/TrackFitters/BuildFile.xml
@@ -1,5 +1,5 @@
-<flags   CXXFLAGS="-Ofast -ffp-contract=off"/>
-
+<flags   CXXFLAGS="-ffp-contract=off"/>
+<use   name="ofast-flag"/>
 <use   name="boost"/>
 <use   name="CLHEP"/>
 <export>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -1,5 +1,4 @@
-<flags   CXXFLAGS="-Ofast"/>
-
+<use   name="ofast-flag"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/GeometryVector"/>


### PR DESCRIPTION
-Ofast flag with clang on slc6 failed to compile due to missing `__[exp|log|pow]_finite` symbols (  https://github.com/cms-sw/cmssw/issues/24935 ) . This PR now make use of new tool ofast-flag which adds `--no-builtin` flag for  llvm/slc6  ( https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_10_4_X/gcc700/gcc-toolfile.spec#L132 ).