### PR TITLE
L1 trigger - TTTrack - stub pt consistency

### DIFF
--- a/L1Trigger/TrackTrigger/interface/StubPtConsistency.h
+++ b/L1Trigger/TrackTrigger/interface/StubPtConsistency.h
@@ -1,0 +1,22 @@
+#ifndef StubPtConsistency_HH
+#define StubPtConsistency_HH
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyBuilder.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+
+namespace StubPtConsistency {
+  float getConsistency(TTTrack < Ref_Phase2TrackerDigi_ > aTrack, const TrackerGeometry* theTrackerGeom, const TrackerTopology* tTopo, double mMagneticFieldStrength, int nPar);
+}
+#endif

--- a/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
+++ b/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <memory>
+
+#include "L1Trigger/TrackTrigger/interface/StubPtConsistency.h"
+
+namespace StubPtConsistency {
+
+  float getConsistency(TTTrack< Ref_Phase2TrackerDigi_ > aTrack, const TrackerGeometry* theTrackerGeom, const TrackerTopology* tTopo, double mMagneticFieldStrength, int nPar) {
+    double trk_bendchi2 = 0.0;
+
+    if ( !(nPar==4 || nPar==5)) {
+      std::cerr << "Not a valid nPar option!" << std::endl;
+      return trk_bendchi2;
+    }
+
+    double bend_resolution = 0.483;
+    // Need the pT signed in order to determine if bend is positive or negative
+    float trk_signedPt = 0.3*3.811202/100.0/(aTrack.getRInv(nPar));
+
+    // loop over stubs
+    std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > stubRefs = aTrack.getStubRefs();
+    int nStubs = stubRefs.size();
+
+    for (int is=0; is<nStubs; is++) {
+      DetId detIdStub = theTrackerGeom->idToDet( (stubRefs.at(is)->getClusterRef(0))->getDetId() )->geographicalId();
+      MeasurementPoint coords = stubRefs.at(is)->getClusterRef(0)->findAverageLocalCoordinatesCentered();
+      const GeomDet* theGeomDet = theTrackerGeom->idToDet(detIdStub);
+      Global3DPoint posStub = theGeomDet->surface().toGlobal( theGeomDet->topology().localPosition(coords) );
+
+      float stub_r = posStub.perp();
+      float stub_z = posStub.z();
+
+      bool isBarrel = false;
+      if ( detIdStub.subdetId()==StripSubdetector::TOB ) {
+        isBarrel = true;
+      }
+
+      //input tilted module correction
+      const GeomDetUnit* det0 = theTrackerGeom->idToDetUnit( detIdStub );
+      const GeomDetUnit* det1 = theTrackerGeom->idToDetUnit( tTopo->partnerDetId( detIdStub ) );
+      const PixelGeomDetUnit* unit = reinterpret_cast<const PixelGeomDetUnit*>( det0 );
+      const PixelTopology& topo = unit->specificTopology();
+
+      //Calculation of snesor spacing obtained from TMTT: https://github.com/CMS-TMTT/cmssw/blob/TMTT_938/L1Trigger/TrackFindingTMTT/src/Stub.cc#L138-L146
+      float stripPitch = topo.pitch().first;
+
+      float modMinR = std::min(det0->position().perp(),det1->position().perp());
+      float modMaxR = std::max(det0->position().perp(),det1->position().perp());
+      float modMinZ = std::min(det0->position().z(),det1->position().z());
+      float modMaxZ = std::max(det0->position().z(),det1->position().z());
+      float sensorSpacing = sqrt((modMaxR-modMinR)*(modMaxR-modMinR) + (modMaxZ-modMinZ)*(modMaxZ-modMinZ));
+
+      //Approximation of phiOverBendCorrection, from TMTT: https://github.com/CMS-TMTT/cmssw/blob/TMTT_938/L1Trigger/TrackFindingTMTT/src/Stub.cc#L440-L448
+      bool tiltedBarrel = (isBarrel && tTopo->tobSide(detIdStub)!=3);
+      float correction;
+      if (tiltedBarrel) correction= 0.886454*fabs(stub_z)/stub_r+0.504148;
+      else if (isBarrel) correction=1;
+      else correction= fabs(stub_z)/stub_r;
+
+      float stubBend = stubRefs.at(is)->getTriggerBend();
+      if (!isBarrel && stub_z<0.0) stubBend=-stubBend;
+      float trackBend = -(sensorSpacing*stub_r*mMagneticFieldStrength*(3.0E8/2.0E11))/(stripPitch*trk_signedPt*correction);
+      float bendDiff = trackBend-stubBend;
+
+      trk_bendchi2 += (bendDiff*bendDiff)/(bend_resolution*bend_resolution);
+    }// end loop over stubs
+
+    float bendchi2 = trk_bendchi2/nStubs;
+    return bendchi2;
+  } //end getConsistency()
+}

--- a/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
+++ b/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
@@ -18,7 +18,7 @@ namespace StubPtConsistency {
     float trk_signedPt = (speedOfLight/UnitConversion)*mMagneticFieldStrength/aTrack.getRInv(nPar); // P(MeV/c) = (c/10^9)·Q·B(kG)·R(cm)
 
     // loop over stubs
-    std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > stubRefs = aTrack.getStubRefs();
+    const auto& stubRefs = aTrack.getStubRefs();
     int nStubs = stubRefs.size();
 
     for ( const auto& stubRef : stubRefs) {

--- a/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
+++ b/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
@@ -6,42 +6,38 @@
 namespace StubPtConsistency {
 
   float getConsistency(TTTrack< Ref_Phase2TrackerDigi_ > aTrack, const TrackerGeometry* theTrackerGeom, const TrackerTopology* tTopo, double mMagneticFieldStrength, int nPar) {
+
+    if( !(nPar==4 || nPar==5) ) throw cms::Exception("IncorrectInput") << "Not a valid nPar option!";
+
     double trk_bendchi2 = 0.0;
-
-    if ( !(nPar==4 || nPar==5)) {
-      std::cerr << "Not a valid nPar option!" << std::endl;
-      return trk_bendchi2;
-    }
-
     double bend_resolution = 0.483;
+    float speedOfLight = 3.0E8; //in m/s
+    float UnitConversion = 1.0E11;
+
     // Need the pT signed in order to determine if bend is positive or negative
-    float trk_signedPt = 0.3*3.811202/100.0/(aTrack.getRInv(nPar));
+    float trk_signedPt = (speedOfLight/UnitConversion)*mMagneticFieldStrength/aTrack.getRInv(nPar); // P(MeV/c) = (c/10^9)·Q·B(kG)·R(cm)
 
     // loop over stubs
     std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > stubRefs = aTrack.getStubRefs();
     int nStubs = stubRefs.size();
 
-    for (int is=0; is<nStubs; is++) {
-      DetId detIdStub = theTrackerGeom->idToDet( (stubRefs.at(is)->getClusterRef(0))->getDetId() )->geographicalId();
-      MeasurementPoint coords = stubRefs.at(is)->getClusterRef(0)->findAverageLocalCoordinatesCentered();
+    for ( const auto& stubRef : stubRefs) {
+      DetId detIdStub = theTrackerGeom->idToDet( (stubRef->getClusterRef(0))->getDetId() )->geographicalId();
+      MeasurementPoint coords = stubRef->getClusterRef(0)->findAverageLocalCoordinatesCentered();
       const GeomDet* theGeomDet = theTrackerGeom->idToDet(detIdStub);
       Global3DPoint posStub = theGeomDet->surface().toGlobal( theGeomDet->topology().localPosition(coords) );
 
       float stub_r = posStub.perp();
       float stub_z = posStub.z();
 
-      bool isBarrel = false;
-      if ( detIdStub.subdetId()==StripSubdetector::TOB ) {
-        isBarrel = true;
-      }
+      bool isBarrel = (detIdStub.subdetId()==StripSubdetector::TOB);
 
-      //input tilted module correction
       const GeomDetUnit* det0 = theTrackerGeom->idToDetUnit( detIdStub );
       const GeomDetUnit* det1 = theTrackerGeom->idToDetUnit( tTopo->partnerDetId( detIdStub ) );
       const PixelGeomDetUnit* unit = reinterpret_cast<const PixelGeomDetUnit*>( det0 );
       const PixelTopology& topo = unit->specificTopology();
 
-      //Calculation of snesor spacing obtained from TMTT: https://github.com/CMS-TMTT/cmssw/blob/TMTT_938/L1Trigger/TrackFindingTMTT/src/Stub.cc#L138-L146
+      // Calculation of snesor spacing obtained from TMTT: https://github.com/CMS-TMTT/cmssw/blob/TMTT_938/L1Trigger/TrackFindingTMTT/src/Stub.cc#L138-L146
       float stripPitch = topo.pitch().first;
 
       float modMinR = std::min(det0->position().perp(),det1->position().perp());
@@ -50,16 +46,20 @@ namespace StubPtConsistency {
       float modMaxZ = std::max(det0->position().z(),det1->position().z());
       float sensorSpacing = sqrt((modMaxR-modMinR)*(modMaxR-modMinR) + (modMaxZ-modMinZ)*(modMaxZ-modMinZ));
 
-      //Approximation of phiOverBendCorrection, from TMTT: https://github.com/CMS-TMTT/cmssw/blob/TMTT_938/L1Trigger/TrackFindingTMTT/src/Stub.cc#L440-L448
+      // Approximation of phiOverBendCorrection, from TMTT: https://github.com/CMS-TMTT/cmssw/blob/TMTT_938/L1Trigger/TrackFindingTMTT/src/Stub.cc#L440-L448
       bool tiltedBarrel = (isBarrel && tTopo->tobSide(detIdStub)!=3);
+      float gradient = 0.886454;
+      float intercept = 0.504148;
       float correction;
-      if (tiltedBarrel) correction= 0.886454*fabs(stub_z)/stub_r+0.504148;
-      else if (isBarrel) correction=1;
-      else correction= fabs(stub_z)/stub_r;
+      if (tiltedBarrel) correction = gradient*fabs(stub_z)/stub_r + intercept;
+      else if (isBarrel) correction = 1;
+      else correction = fabs(stub_z)/stub_r;
 
-      float stubBend = stubRefs.at(is)->getTriggerBend();
-      if (!isBarrel && stub_z<0.0) stubBend=-stubBend;
-      float trackBend = -(sensorSpacing*stub_r*mMagneticFieldStrength*(3.0E8/2.0E11))/(stripPitch*trk_signedPt*correction);
+      float stubBend = stubRef->getTriggerBend();
+      if (!isBarrel && stub_z<0.0) stubBend=-stubBend; // flip sign of bend if in negative end cap
+
+      // B*c/2E11 - converts q/pt to track angle at some radius from beamline
+      float trackBend = -(sensorSpacing*stub_r*mMagneticFieldStrength*(speedOfLight/UnitConversion/2))/(stripPitch*trk_signedPt*correction);
       float bendDiff = trackBend-stubBend;
 
       trk_bendchi2 += (bendDiff*bendDiff)/(bend_resolution*bend_resolution);

--- a/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
+++ b/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
@@ -2,6 +2,7 @@
 #include <memory>
 
 #include "L1Trigger/TrackTrigger/interface/StubPtConsistency.h"
+#include "CLHEP/Units/PhysicalConstants.h"
 
 namespace StubPtConsistency {
 
@@ -11,11 +12,10 @@ namespace StubPtConsistency {
 
     double trk_bendchi2 = 0.0;
     double bend_resolution = 0.483;
-    float speedOfLight = 3.0E8; //in m/s
-    float UnitConversion = 1.0E11;
+    float speedOfLightConverted = CLHEP::c_light/1.0E5; // B*c/2E11 - converts q/pt to track angle at some radius from beamline
 
     // Need the pT signed in order to determine if bend is positive or negative
-    float trk_signedPt = (speedOfLight/UnitConversion)*mMagneticFieldStrength/aTrack.getRInv(nPar); // P(MeV/c) = (c/10^9)·Q·B(kG)·R(cm)
+    float trk_signedPt = speedOfLightConverted*mMagneticFieldStrength/aTrack.getRInv(nPar); // P(MeV/c) = (c/10^9)·Q·B(kG)·R(cm)
 
     // loop over stubs
     const auto& stubRefs = aTrack.getStubRefs();
@@ -58,8 +58,7 @@ namespace StubPtConsistency {
       float stubBend = stubRef->getTriggerBend();
       if (!isBarrel && stub_z<0.0) stubBend=-stubBend; // flip sign of bend if in negative end cap
 
-      // B*c/2E11 - converts q/pt to track angle at some radius from beamline
-      float trackBend = -(sensorSpacing*stub_r*mMagneticFieldStrength*(speedOfLight/UnitConversion/2))/(stripPitch*trk_signedPt*correction);
+      float trackBend = -(sensorSpacing*stub_r*mMagneticFieldStrength*(speedOfLightConverted/2))/(stripPitch*trk_signedPt*correction);
       float bendDiff = trackBend-stubBend;
 
       trk_bendchi2 += (bendDiff*bendDiff)/(bend_resolution*bend_resolution);


### PR DESCRIPTION
Hello,
I have updated the module StubPtConsistency that used to live in SLHCUpgradeSimulations in CMSSW_6_2_X (https://github.com/skinnari/cmssw/blob/L1TK_62X_SLHC28/SLHCUpgradeSimulations/L1TrackTrigger/src/StubPtConsistency.cc).

The module is a track parameter that makes use of the stub bend information, and a part of the TTTrack object.

A talk on the variable (including definition, implementation, and performance) can be found here: https://indico.cern.ch/event/761293/contributions/3176150/attachments/1734157/2804056/UsingStubBend.pdf
NOTE: the talk shows the difference between two variables that use the bend information. The variable termed "bend chi2," which has better performance, is the variable that has been input into the empty StubPtConsistency module.