### PR TITLE
[10.4.X] add missing eventSetupPathsKey swap for HI 2018

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAG_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAG_cff.py
@@ -41,3 +41,10 @@ ALCARECOSiStripCalMinBiasAAG.TwoBodyDecaySelector.applyMissingETFilter    = Fals
 seqALCARECOSiStripCalMinBiasAAG = cms.Sequence(ALCARECOSiStripCalMinBiasAAGHLT*
                                                          DCSStatusForSiStripCalMinBiasAAG *
                                                          ALCARECOSiStripCalMinBiasAAG)
+
+## customizations for the pp_on_AA eras
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(ALCARECOSiStripCalMinBiasAAGHLT,
+                                           eventSetupPathsKey='SiStripCalMinBiasAAGHI'
+                                           )


### PR DESCRIPTION
Greetings, 
as the `HLT_HIZeroBias_FirstCollisionAfterAbortGap_v*` trigger has been confirmed for the HI HLT menu for 2018 PbPb data-taking, it would be good to use the HI trigger bit `eventSetupPathsKey`. This is part of the same campaign of adjusting the pp ALCARECO for the `pp_on_AA` era: https://github.com/cms-sw/cmssw/pull/24596. 
Once merged, an update of the Express GT will be needed as at the moment the key `SiStripCalMinBiasAAGHI` is not available.





