### PR TITLE
RPCMonitorClient: Re-get geometry every LS

### DIFF
--- a/DQM/RPCMonitorClient/src/RPCEfficiencySecond.cc
+++ b/DQM/RPCMonitorClient/src/RPCEfficiencySecond.cc
@@ -32,14 +32,9 @@ void RPCEfficiencySecond::beginJob(){}
 
 void RPCEfficiencySecond::dqmEndLuminosityBlock(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter,  edm::LuminosityBlock const & lb, edm::EventSetup const& iSetup){
 
-  if(!init_){
-    
     LogDebug("rpcefficiencysecond")<<"Getting the RPC Geometry";    
-  
     iSetup.get<MuonGeometryRecord>().get(rpcGeo_);   
     init_= true;
-
-  }
 }
 
 


### PR DESCRIPTION
It should be a pretty cheap operation, and prevents the handle from going stale in multi-run harvesting.

This causes a crash in #24920 when backported to a 10_2 release. Not sure why it did not happen in 10_3, maybe depends on the data used.