### PR TITLE
Do not build/run cuda tests if cuda does not support gcc version

### DIFF
--- a/DataFormats/CaloRecHit/test/BuildFile.xml
+++ b/DataFormats/CaloRecHit/test/BuildFile.xml
@@ -5,11 +5,9 @@
   <use   name="cppunit"/>
 </bin>
 <iftool name="cuda-gcc-support">
-<architecture match="_amd64_">
 <bin name="test_calo_rechit" file="test_calo_rechit.cu">
     <use name="DataFormats/CaloRecHit"/>
     <use name="DataFormats/DetId"/>
     <use name="cuda"/>
 </bin>
-</architecture>
 </iftool>

--- a/DataFormats/CaloRecHit/test/BuildFile.xml
+++ b/DataFormats/CaloRecHit/test/BuildFile.xml
@@ -4,6 +4,7 @@
   <use   name="DataFormats/Math"/>
   <use   name="cppunit"/>
 </bin>
+<iftool name="cuda-gcc-support">
 <architecture match="_amd64_">
 <bin name="test_calo_rechit" file="test_calo_rechit.cu">
     <use name="DataFormats/CaloRecHit"/>
@@ -11,3 +12,4 @@
     <use name="cuda"/>
 </bin>
 </architecture>
+</iftool>

--- a/DataFormats/DetId/test/BuildFile.xml
+++ b/DataFormats/DetId/test/BuildFile.xml
@@ -1,6 +1,8 @@
+<iftool name="cuda-gcc-support">
 <architecture match="_amd64_">
 <bin name="test_detid" file="test_detid.cu">
     <use name="DataFormats/DetId"/>
     <use name="cuda"/>
 </bin>
 </architecture>
+</iftool>

--- a/DataFormats/DetId/test/BuildFile.xml
+++ b/DataFormats/DetId/test/BuildFile.xml
@@ -1,8 +1,6 @@
 <iftool name="cuda-gcc-support">
-<architecture match="_amd64_">
 <bin name="test_detid" file="test_detid.cu">
     <use name="DataFormats/DetId"/>
     <use name="cuda"/>
 </bin>
-</architecture>
 </iftool>

--- a/DataFormats/HcalDetId/test/BuildFile.xml
+++ b/DataFormats/HcalDetId/test/BuildFile.xml
@@ -1,8 +1,6 @@
 <iftool name="cuda-gcc-support">
-<architecture match="_amd64_">
 <bin name="test_hcal_detid" file="test_hcal_detid.cu">
     <use name="DataFormats/DetId"/>
     <use name="DataFormats/HcalDetId"/>
 </bin>
-</architecture>
 </iftool>

--- a/DataFormats/HcalDetId/test/BuildFile.xml
+++ b/DataFormats/HcalDetId/test/BuildFile.xml
@@ -1,6 +1,8 @@
+<iftool name="cuda-gcc-support">
 <architecture match="_amd64_">
 <bin name="test_hcal_detid" file="test_hcal_detid.cu">
     <use name="DataFormats/DetId"/>
     <use name="DataFormats/HcalDetId"/>
 </bin>
 </architecture>
+</iftool>

--- a/DataFormats/HcalDigi/test/BuildFile.xml
+++ b/DataFormats/HcalDigi/test/BuildFile.xml
@@ -6,12 +6,10 @@
   <use   name="FWCore/ParameterSet"/>
 </library>
 <iftool name="cuda-gcc-support">
-<architecture match="_amd64_">
 <bin name="test_hcal_digi" file="test_hcal_digi.cu">
     <use name="DataFormats/DetId"/>
     <use name="DataFormats/HcalDetId"/>
     <use name="DataFormats/HcalDigi"/>
     <use name="DataFormats/Common"/>
 </bin>
-</architecture>
 </iftool>

--- a/DataFormats/HcalDigi/test/BuildFile.xml
+++ b/DataFormats/HcalDigi/test/BuildFile.xml
@@ -5,6 +5,7 @@
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
 </library>
+<iftool name="cuda-gcc-support">
 <architecture match="_amd64_">
 <bin name="test_hcal_digi" file="test_hcal_digi.cu">
     <use name="DataFormats/DetId"/>
@@ -13,3 +14,4 @@
     <use name="DataFormats/Common"/>
 </bin>
 </architecture>
+</iftool>

--- a/DataFormats/Math/test/BuildFile.xml
+++ b/DataFormats/Math/test/BuildFile.xml
@@ -73,7 +73,6 @@
   <use   name="cppunit"/>
 </bin>
 <iftool name="cuda-gcc-support">
-<architecture match="_amd64_">
 <bin file="cudaAtan2Test.cu" name="DFM_Atan2">
   <use name="cuda"/>
   <use name="cuda-api-wrappers"/>
@@ -97,5 +96,4 @@
   <flags CUDA_FLAGS="--expt-relaxed-constexpr -fmad=false -ftz=false -prec-div=true -prec-sqrt=true"/>
   <flags CXXFLAGS="-ffp-contract=off"/>
 </bin>
-</architecture>
 </iftool>

--- a/DataFormats/Math/test/BuildFile.xml
+++ b/DataFormats/Math/test/BuildFile.xml
@@ -72,7 +72,7 @@
 <bin name="testDataFormatsMathPacking" file="testMiniFloat.cpp,testlogintpack.cpp,testRunner.cpp">
   <use   name="cppunit"/>
 </bin>
-
+<iftool name="cuda-gcc-support">
 <architecture match="_amd64_">
 <bin file="cudaAtan2Test.cu" name="DFM_Atan2">
   <use name="cuda"/>
@@ -98,3 +98,4 @@
   <flags CXXFLAGS="-ffp-contract=off"/>
 </bin>
 </architecture>
+</iftool>

--- a/Utilities/General/test/BuildFile.xml
+++ b/Utilities/General/test/BuildFile.xml
@@ -9,10 +9,8 @@
   <use name="google-benchmark-main"/>
 </bin>
 
-<ifarchitecture name="_amd64_">
-  <iftool name="cuda-gcc-support">
+<iftool name="cuda-gcc-support">
     <test name="CudaGCCSupport" command="echo Supported GCC version"/>
-  <else/>
+<else/>
     <test name="CudaGCCSupport" command="echo ERROR: Unsupported GCC version && exit 1"/>
-  </iftool>
-</ifarchitecture>
+</iftool>

--- a/Utilities/General/test/BuildFile.xml
+++ b/Utilities/General/test/BuildFile.xml
@@ -8,3 +8,11 @@
 <bin file="google-benchmark-pass-argv.cpp" name="google-benchmark-pass-argv">
   <use name="google-benchmark-main"/>
 </bin>
+
+<ifarchitecture name="_amd64_">
+  <iftool name="!cuda-gcc-support">
+    <test name="CudaGCCSupport" command="echo ERROR: Unsupported GCC version && exit 1"/>
+  <else/>
+    <test name="CudaGCCSupport" command="echo Supported GCC version"/>
+  </iftool>
+</ifarchitecture>

--- a/Utilities/General/test/BuildFile.xml
+++ b/Utilities/General/test/BuildFile.xml
@@ -10,9 +10,9 @@
 </bin>
 
 <ifarchitecture name="_amd64_">
-  <iftool name="!cuda-gcc-support">
-    <test name="CudaGCCSupport" command="echo ERROR: Unsupported GCC version && exit 1"/>
-  <else/>
+  <iftool name="cuda-gcc-support">
     <test name="CudaGCCSupport" command="echo Supported GCC version"/>
+  <else/>
+    <test name="CudaGCCSupport" command="echo ERROR: Unsupported GCC version && exit 1"/>
   </iftool>
 </ifarchitecture>


### PR DESCRIPTION
This make use of new cuda-gcc-support tool to build/run unit tests based in cuda gcc support. This should allow us to build error free GCC 820 IBs and releases.