### PR TITLE
TriggerMatch Monitor to Watch the Trigger matching feature in pat::Muon

### DIFF
--- a/DQMOffline/Muon/interface/TriggerMatchEfficiencyPlotter.h
+++ b/DQMOffline/Muon/interface/TriggerMatchEfficiencyPlotter.h
@@ -1,0 +1,67 @@
+#ifndef TriggerMatchEfficiencyPlotter_H
+#define TriggerMatchEfficiencyPlotter_H
+/** \class TriggerMatch monitor
+ *  *
+ *   *  DQM monitoring source for Trigger matching efficiency plotter  feature added to miniAOD
+ *    *
+ *     *  \author Bibhuprasad Mahakud (Purdue University, West Lafayette, USA)
+ *      */
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include <FWCore/Framework/interface/ESHandle.h>
+#include <FWCore/Framework/interface/Event.h>
+#include <FWCore/Framework/interface/MakerMacros.h>
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <FWCore/Framework/interface/LuminosityBlock.h>
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/Run.h"
+
+#include <memory>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+#include "TH1F.h"
+
+class TriggerMatchEfficiencyPlotter: public DQMEDHarvester {
+
+public:
+
+  /// Constructor
+  TriggerMatchEfficiencyPlotter(const edm::ParameterSet& ps);
+  
+  /// Destructor
+  ~TriggerMatchEfficiencyPlotter() override;
+
+protected:
+
+  /// DQM Client Diagnostic
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; //performed in the endJob
+
+
+private:
+  
+  DQMStore* theDbe;
+  edm::ParameterSet parameters;
+
+  std::string triggerhistName1_;
+  std::string triggerhistName2_;
+
+  // efficiency histograms
+  MonitorElement* h_eff_Path1_eta_tight;
+  MonitorElement* h_eff_Path1_pt_tight;
+  MonitorElement* h_eff_Path1_phi_tight;
+
+  MonitorElement* h_eff_Path2_eta_tight;
+  MonitorElement* h_eff_Path2_pt_tight;
+  MonitorElement* h_eff_Path2_phi_tight;
+
+  std::string theFolder;
+};
+
+#endif

--- a/DQMOffline/Muon/interface/TriggerMatchMonitor.h
+++ b/DQMOffline/Muon/interface/TriggerMatchMonitor.h
@@ -1,0 +1,95 @@
+#ifndef TriggerMatchMonitor_H
+#define TriggerMatchMonitor_H
+/** \class TriggerMatch monitor
+ *
+ *  DQM monitoring source for Trigger matching feature added to miniAOD
+ *
+ *  \author Bibhuprasad Mahakud (Purdue University, West Lafayette, USA)
+ */
+
+#include <memory>
+#include <fstream>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h" 
+#include "DataFormats/MuonReco/interface/MuonEnergy.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+
+
+class TriggerMatchMonitor : public DQMEDAnalyzer {
+ public:
+  
+  /// Constructor
+  TriggerMatchMonitor(const edm::ParameterSet& pSet);
+  
+  /// Destructor
+  ~TriggerMatchMonitor() override;
+  
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+
+ private:
+  
+  // ----------member data ---------------------------
+  MuonServiceProxy *theService;
+  DQMStore* theDbe;
+  edm::ParameterSet parameters;
+ 
+  // triggerNames to be passed from config
+  std::string triggerPathName1_;
+  std::string triggerHistName1_;
+  double triggerPtThresholdPath1_;
+  std::string triggerPathName2_;
+  std::string triggerHistName2_;
+  double triggerPtThresholdPath2_;
+
+  //Vertex requirements
+  edm::EDGetTokenT<edm::View<reco::Muon> >   theMuonCollectionLabel_;
+  edm::EDGetTokenT<edm::View<pat::Muon> >   thePATMuonCollectionLabel_;
+  edm::EDGetTokenT<reco::VertexCollection> theVertexLabel_;
+  edm::EDGetTokenT<reco::BeamSpot>         theBeamSpotLabel_;
+  edm::EDGetTokenT<edm::TriggerResults > triggerResultsToken_;
+  edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> triggerObjects_;
+
+  edm::EDGetTokenT<reco::BeamSpot > beamSpotToken_;
+  edm::EDGetTokenT<std::vector<reco::Vertex> > primaryVerticesToken_;
+
+  // histograms
+  std::vector<MonitorElement*> matchHists;
+  MonitorElement* h_passHLTPath1_eta_Tight;
+  MonitorElement* h_passHLTPath1_pt_Tight;
+  MonitorElement* h_passHLTPath1_phi_Tight; 
+  MonitorElement* h_totalHLTPath1_eta_Tight; 
+  MonitorElement* h_totalHLTPath1_pt_Tight; 
+  MonitorElement* h_totalHLTPath1_phi_Tight;
+
+  MonitorElement* h_passHLTPath2_eta_Tight; 
+  MonitorElement* h_passHLTPath2_pt_Tight; 
+  MonitorElement* h_passHLTPath2_phi_Tight;
+  MonitorElement* h_totalHLTPath2_eta_Tight;
+  MonitorElement* h_totalHLTPath2_pt_Tight;
+  MonitorElement* h_totalHLTPath2_phi_Tight;
+
+  std::string theFolder;
+};
+#endif

--- a/DQMOffline/Muon/python/TriggerMatchEfficencyPlotter_cfi.py
+++ b/DQMOffline/Muon/python/TriggerMatchEfficencyPlotter_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+triggerMatchEffPlotterTightMiniAOD = DQMEDHarvester("TriggerMatchEfficiencyPlotter",
+                                          folder = cms.string("Muons_miniAOD/TriggerMatchMonitor"),
+                                          triggerhistName1 = cms.string('IsoMu24'),
+                                          triggerhistName2 = cms.string('Mu50')
+                                          )
+
+

--- a/DQMOffline/Muon/python/muonAnalyzer_cff.py
+++ b/DQMOffline/Muon/python/muonAnalyzer_cff.py
@@ -9,6 +9,7 @@ from DQMOffline.Muon.muonEnergyDepositAnalyzer_cfi import *
 from DQMOffline.Muon.segmentTrackAnalyzer_cfi import *
 from DQMOffline.Muon.muonSeedsAnalyzer_cfi import *
 from DQMOffline.Muon.muonPFAnalyzer_cfi import *
+from DQMOffline.Muon.triggerMatchMonitor_cfi import *
 
 muonAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
                             muonSeedsAnalyzer*
@@ -34,7 +35,8 @@ muonAnalyzer_miniAOD = cms.Sequence(muonRecoAnalyzer_miniAOD*
                                     diMuonHistos_miniAOD*
                                     LooseMuonEfficiencyAnalyzer_miniAOD*
                                     MediumMuonEfficiencyAnalyzer_miniAOD*
-                                    TightMuonEfficiencyAnalyzer_miniAOD)
+                                    TightMuonEfficiencyAnalyzer_miniAOD*
+                                    triggerMatchMonitor_miniAOD)
 
 muonAnalyzer_noHLT = cms.Sequence(muonEnergyDepositAnalyzer*
                                   muonSeedsAnalyzer*

--- a/DQMOffline/Muon/python/muonQualityTests_cff.py
+++ b/DQMOffline/Muon/python/muonQualityTests_cff.py
@@ -8,6 +8,7 @@ from DQMOffline.Muon.muonRecoTest_cfi import *
 from DQMOffline.Muon.muonTestSummary_cfi import *
 from DQMOffline.Muon.muonTestSummaryCosmics_cfi import *
 from DQMOffline.Muon.EfficencyPlotter_cfi import *
+from DQMOffline.Muon.TriggerMatchEfficencyPlotter_cfi import *
 
 muonSourcesQualityTests = cms.EDAnalyzer("QualityTester",
     prescaleFactor = cms.untracked.int32(1),
@@ -57,6 +58,7 @@ muonQualityTests_miniAOD = cms.Sequence(muonSourcesQualityTests*
                                         muonClientsQualityTests*
                                         muonComp2RefQualityTests*
                                         muonComp2RefKolmoQualityTests*
-                                        muonTestSummary)
+                                        muonTestSummary*
+                                        triggerMatchEffPlotterTightMiniAOD)
 
 

--- a/DQMOffline/Muon/python/triggerMatchMonitor_cfi.py
+++ b/DQMOffline/Muon/python/triggerMatchMonitor_cfi.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoMuon.TrackingTools.MuonServiceProxy_cff import *
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+triggerMatchMonitor_miniAOD = DQMEDAnalyzer('TriggerMatchMonitor',
+                                              MuonServiceProxy,
+                                              offlineBeamSpot = cms.untracked.InputTag("offlineBeamSpot"),
+                                              offlinePrimaryVertices = cms.untracked.InputTag("offlinePrimaryVertices"),
+                                              MuonCollection  = cms.InputTag("slimmedMuons"),
+                                              patMuonCollection  = cms.InputTag("slimmedMuons"),
+                                              VertexLabel     = cms.InputTag("offlineSlimmedPrimaryVertices"),
+                                              BeamSpotLabel   = cms.InputTag("offlineBeamSpot"),
+                                              triggerResults = cms.untracked.InputTag("TriggerResults","","HLT"),
+                                              triggerObjects = cms.InputTag("slimmedPatTrigger"),
+                                              hltCollectionFilters = cms.vstring('*'),
+                                              triggerNameList = cms.vstring('HLT_Mu27_v*'),
+                                              triggerPathName1 = cms.string('HLT_IsoMu24_v*'),
+                                              triggerHistName1 = cms.string('IsoMu24'),
+                                              triggerPtThresholdPath1 = cms.double(20.0),
+                                              triggerPathName2 = cms.string('HLT_Mu50_v*'),
+                                              triggerHistName2 = cms.string('Mu50'),
+                                              triggerPtThresholdPath2 = cms.double(40.0),
+                                              folder = cms.string("Muons_miniAOD/TriggerMatchMonitor")
+                                              )

--- a/DQMOffline/Muon/src/SealModule.cc
+++ b/DQMOffline/Muon/src/SealModule.cc
@@ -19,6 +19,10 @@
 
 #include "DQMOffline/Muon/interface/MuonMiniAOD.h"
 
+#include "DQMOffline/Muon/interface/TriggerMatchMonitor.h"
+#include "DQMOffline/Muon/interface/TriggerMatchEfficiencyPlotter.h"
+
+
 DEFINE_FWK_MODULE(MuonTrackResidualsTest);
 DEFINE_FWK_MODULE(MuonRecoTest);
 DEFINE_FWK_MODULE(EfficiencyPlotter);
@@ -34,6 +38,8 @@ DEFINE_FWK_MODULE(SegmentTrackAnalyzer);
 DEFINE_FWK_MODULE(MuonEnergyDepositAnalyzer);
 DEFINE_FWK_MODULE(MuonSeedsAnalyzer);
 DEFINE_FWK_MODULE(MuonMiniAOD);
+DEFINE_FWK_MODULE(TriggerMatchMonitor);
+DEFINE_FWK_MODULE(TriggerMatchEfficiencyPlotter);
 
 
 

--- a/DQMOffline/Muon/src/TriggerMatchEfficiencyPlotter.cc
+++ b/DQMOffline/Muon/src/TriggerMatchEfficiencyPlotter.cc
@@ -1,0 +1,173 @@
+#include "DQMOffline/Muon/interface/TriggerMatchEfficiencyPlotter.h"
+/** \class TriggerMatch monitor
+ *  *  *
+ *   *   *  DQM monitoring source for Trigger matching efficiency plotter  feature added to miniAOD
+ *    *    *
+ *     *     *  \author Bibhuprasad Mahakud (Purdue University, West Lafayette, USA)
+ *      *      */
+
+
+// Framework
+#include <FWCore/Framework/interface/Event.h>
+#include "DataFormats/Common/interface/Handle.h" 
+#include <FWCore/Framework/interface/ESHandle.h>
+#include <FWCore/Framework/interface/MakerMacros.h>
+#include <FWCore/Framework/interface/EventSetup.h>
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/Run.h"
+
+#include <iostream>
+#include <cstdio>
+#include <string>
+#include <cmath>
+#include "TF1.h"
+#include "TH1F.h"
+
+using namespace edm;
+using namespace std;
+
+//#define DEBUG
+
+TriggerMatchEfficiencyPlotter::TriggerMatchEfficiencyPlotter(const edm::ParameterSet& ps){
+#ifdef DEBUG
+  cout << "TriggerMatchEfficiencyPlotter(): Constructor " << endl;
+#endif
+  parameters = ps;
+
+  triggerhistName1_ = parameters.getParameter<string>("triggerhistName1");
+  triggerhistName2_ = parameters.getParameter<string>("triggerhistName2"); 
+  theFolder = parameters.getParameter<string>("folder");
+}
+TriggerMatchEfficiencyPlotter::~TriggerMatchEfficiencyPlotter(){}
+
+void TriggerMatchEfficiencyPlotter::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter & igetter) {
+  
+  ibooker.setCurrentFolder(theFolder);
+  
+  // efficiency plot
+  h_eff_Path1_eta_tight      = ibooker.book1D("matchingEff_eta_"+triggerhistName1_+"_tight",triggerhistName1_+":matching Eff. vs #eta",8, -2.5, 2.5);
+  h_eff_Path1_pt_tight      = ibooker.book1D("matchingEff_pt_"+triggerhistName1_+"_tight",triggerhistName1_+":matching Eff. vs pt",10, 20, 220);
+  h_eff_Path1_phi_tight      = ibooker.book1D("matchingEff_phi_"+triggerhistName1_+"_tight",triggerhistName1_+":matching Eff. vs #phi", 8, -3.0, 3.0);
+  h_eff_Path2_eta_tight      = ibooker.book1D("matchingEff_eta_"+triggerhistName2_+"_tight",triggerhistName2_+":matching Eff. vs #eta",8, -2.5, 2.5);
+  h_eff_Path2_pt_tight      = ibooker.book1D("matchingEff_pt_"+triggerhistName2_+"_tight",triggerhistName2_+":matching Eff. vs pt",10, 20, 220);
+  h_eff_Path2_phi_tight      = ibooker.book1D("matchingEff_phi_"+triggerhistName2_+"_tight",triggerhistName2_+":matching Eff. vs #phi", 8, -3.0, 3.0);
+
+
+
+  // This prevents this ME to be normalized when drawn into the GUI
+  h_eff_Path1_eta_tight->setEfficiencyFlag();
+  h_eff_Path1_pt_tight->setEfficiencyFlag();
+  h_eff_Path1_phi_tight->setEfficiencyFlag();
+  h_eff_Path2_eta_tight->setEfficiencyFlag();
+  h_eff_Path2_pt_tight->setEfficiencyFlag();
+  h_eff_Path2_phi_tight->setEfficiencyFlag();
+
+  // AXIS TITLES....
+  h_eff_Path1_eta_tight      ->setAxisTitle("#eta",         1);  
+  h_eff_Path1_pt_tight       ->setAxisTitle("pt",         1);
+  h_eff_Path1_phi_tight       ->setAxisTitle("#phi",         1);  
+  h_eff_Path2_eta_tight      ->setAxisTitle("#eta",         1);
+  h_eff_Path2_pt_tight       ->setAxisTitle("pt",         1);
+  h_eff_Path2_phi_tight       ->setAxisTitle("#phi",         1);
+
+
+
+  /// --- Tight Muon trigger mathcing efficiency  
+  string inputdir = "Muons_miniAOD/TriggerMatchMonitor/EfficiencyInput";
+  string numpath_eta_path1 = inputdir+"/passHLT"+triggerhistName1_+"_eta_Tight";
+  string denpath_eta_path1 = inputdir+"/totalHLT"+triggerhistName1_+"_eta_Tight";
+
+  string numpath_pt_path1 = inputdir+"/passHLT"+triggerhistName1_+"_pt_Tight";
+  string denpath_pt_path1 = inputdir+"/totalHLT"+triggerhistName1_+"_pt_Tight";
+  
+  string numpath_phi_path1 = inputdir+"/passHLT"+triggerhistName1_+"_phi_Tight";
+  string denpath_phi_path1 = inputdir+"/totalHLT"+triggerhistName1_+"_phi_Tight"; 
+
+  string numpath_eta_path2 = inputdir+"/passHLT"+triggerhistName2_+"_eta_Tight";
+  string denpath_eta_path2 = inputdir+"/totalHLT"+triggerhistName2_+"_eta_Tight";
+
+  string numpath_pt_path2 = inputdir+"/passHLT"+triggerhistName2_+"_pt_Tight";
+  string denpath_pt_path2 = inputdir+"/totalHLT"+triggerhistName2_+"_pt_Tight";
+
+  string numpath_phi_path2 = inputdir+"/passHLT"+triggerhistName2_+"_phi_Tight";
+  string denpath_phi_path2 = inputdir+"/totalHLT"+triggerhistName2_+"_phi_Tight";
+  
+  MonitorElement *Numerator_eta_path1   = igetter.get(numpath_eta_path1);
+  MonitorElement *Denominator_eta_path1 = igetter.get(denpath_eta_path1);
+
+  MonitorElement *Numerator_pt_path1   = igetter.get(numpath_pt_path1);
+  MonitorElement *Denominator_pt_path1 = igetter.get(denpath_pt_path1);
+
+  MonitorElement *Numerator_phi_path1   = igetter.get(numpath_phi_path1);
+  MonitorElement *Denominator_phi_path1 = igetter.get(denpath_phi_path1);
+
+  MonitorElement *Numerator_eta_path2   = igetter.get(numpath_eta_path2);
+  MonitorElement *Denominator_eta_path2 = igetter.get(denpath_eta_path2);
+
+  MonitorElement *Numerator_pt_path2   = igetter.get(numpath_pt_path2);
+  MonitorElement *Denominator_pt_path2 = igetter.get(denpath_pt_path2);
+
+  MonitorElement *Numerator_phi_path2   = igetter.get(numpath_phi_path2);
+  MonitorElement *Denominator_phi_path2 = igetter.get(denpath_phi_path2); 
+
+  if (Numerator_eta_path1 && Denominator_eta_path1){
+    TH1F *h_numerator_eta_path1   = Numerator_eta_path1->getTH1F();
+    TH1F *h_denominator_eta_path1 = Denominator_eta_path1->getTH1F();
+    TH1F *h_eff_eta_path1         = h_eff_Path1_eta_tight->getTH1F();
+    
+    if (h_eff_eta_path1->GetSumw2N() == 0) h_eff_eta_path1->Sumw2();  
+    h_eff_eta_path1->Divide(h_numerator_eta_path1, h_denominator_eta_path1, 1., 1., "B");
+  }
+
+  if (Numerator_pt_path1 && Denominator_pt_path1){
+    TH1F *h_numerator_pt_path1   = Numerator_pt_path1->getTH1F();
+    TH1F *h_denominator_pt_path1 = Denominator_pt_path1->getTH1F();
+    TH1F *h_eff_pt_path1         = h_eff_Path1_pt_tight->getTH1F();
+
+    if (h_eff_pt_path1->GetSumw2N() == 0) h_eff_pt_path1->Sumw2();
+    h_eff_pt_path1->Divide(h_numerator_pt_path1, h_denominator_pt_path1, 1., 1., "B");
+  }
+
+  if (Numerator_phi_path1 && Denominator_phi_path1){
+    TH1F *h_numerator_phi_path1   = Numerator_phi_path1->getTH1F();
+    TH1F *h_denominator_phi_path1 = Denominator_phi_path1->getTH1F();
+    TH1F *h_eff_phi_path1         = h_eff_Path1_phi_tight->getTH1F();
+
+    if (h_eff_phi_path1->GetSumw2N() == 0) h_eff_phi_path1->Sumw2();
+    h_eff_phi_path1->Divide(h_numerator_phi_path1, h_denominator_phi_path1, 1., 1., "B");
+  }
+ 
+  //trigger path2
+  if (Numerator_eta_path2 && Denominator_eta_path2){
+    TH1F *h_numerator_eta_path2   = Numerator_eta_path2->getTH1F();
+    TH1F *h_denominator_eta_path2 = Denominator_eta_path2->getTH1F();
+    TH1F *h_eff_eta_path2         = h_eff_Path2_eta_tight->getTH1F();
+
+    if (h_eff_eta_path2->GetSumw2N() == 0) h_eff_eta_path2->Sumw2();
+    h_eff_eta_path2->Divide(h_numerator_eta_path2, h_denominator_eta_path2, 1., 1., "B");
+  }
+
+  if (Numerator_pt_path2 && Denominator_pt_path2){
+    TH1F *h_numerator_pt_path2   = Numerator_pt_path2->getTH1F();
+    TH1F *h_denominator_pt_path2 = Denominator_pt_path2->getTH1F();
+    TH1F *h_eff_pt_path2         = h_eff_Path2_pt_tight->getTH1F();
+
+    if (h_eff_pt_path2->GetSumw2N() == 0) h_eff_pt_path2->Sumw2();
+    h_eff_pt_path2->Divide(h_numerator_pt_path2, h_denominator_pt_path2, 1., 1., "B");
+  }
+
+  if (Numerator_phi_path2 && Denominator_phi_path2){
+    TH1F *h_numerator_phi_path2   = Numerator_phi_path2->getTH1F();
+    TH1F *h_denominator_phi_path2 = Denominator_phi_path2->getTH1F();
+    TH1F *h_eff_phi_path2         = h_eff_Path2_phi_tight->getTH1F();
+
+    if (h_eff_phi_path2->GetSumw2N() == 0) h_eff_phi_path2->Sumw2();
+    h_eff_phi_path2->Divide(h_numerator_phi_path2, h_denominator_phi_path2, 1., 1., "B");
+  }
+
+
+}
+  

--- a/DQMOffline/Muon/src/TriggerMatchMonitor.cc
+++ b/DQMOffline/Muon/src/TriggerMatchMonitor.cc
@@ -1,0 +1,216 @@
+/*
+ *  See header file for a description of this class.
+ *
+ *  \author Bibhuprasad Mahakud (Purdue University, West Lafayette, USA)
+ */
+#include "DQMOffline/Muon/interface/TriggerMatchMonitor.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "TLorentzVector.h"
+
+#include <string>
+#include <TMath.h>
+using namespace std;
+using namespace edm;
+
+//#define DEBUG
+
+TriggerMatchMonitor::TriggerMatchMonitor(const edm::ParameterSet& pSet) {
+  LogTrace(metname)<<"[TriggerMatchMonitor] Parameters initialization";
+  
+  parameters = pSet;
+
+  // the services
+  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
+  theDbe = edm::Service<DQMStore>().operator->();
+  
+  beamSpotToken_ = consumes<reco::BeamSpot >(parameters.getUntrackedParameter<edm::InputTag>("offlineBeamSpot")),
+  primaryVerticesToken_ = consumes<std::vector<reco::Vertex> >(parameters.getUntrackedParameter<edm::InputTag>("offlinePrimaryVertices")),
+  theMuonCollectionLabel_ = consumes<edm::View<reco::Muon> >  (parameters.getParameter<edm::InputTag>("MuonCollection"));
+  thePATMuonCollectionLabel_ = consumes<edm::View<pat::Muon> >  (parameters.getParameter<edm::InputTag>("patMuonCollection"));
+  theVertexLabel_          = consumes<reco::VertexCollection>(parameters.getParameter<edm::InputTag>("VertexLabel"));
+  theBeamSpotLabel_        = mayConsume<reco::BeamSpot>      (parameters.getParameter<edm::InputTag>("BeamSpotLabel"));
+  triggerResultsToken_ = consumes<edm::TriggerResults>(parameters.getUntrackedParameter<edm::InputTag>("triggerResults"));
+  triggerObjects_ = consumes<std::vector<pat::TriggerObjectStandAlone>>(parameters.getParameter<edm::InputTag>("triggerObjects"));
+
+  triggerPathName1_ = parameters.getParameter<string>("triggerPathName1");
+  triggerHistName1_ = parameters.getParameter<string>("triggerHistName1");
+  triggerPtThresholdPath1_ = parameters.getParameter<double>("triggerPtThresholdPath1");
+  triggerPathName2_ = parameters.getParameter<string>("triggerPathName2");
+  triggerHistName2_ = parameters.getParameter<string>("triggerHistName2");
+  triggerPtThresholdPath2_ = parameters.getParameter<double>("triggerPtThresholdPath2");
+  theFolder = parameters.getParameter<string>("folder");
+}
+TriggerMatchMonitor::~TriggerMatchMonitor() { 
+  delete theService;
+}
+
+void TriggerMatchMonitor::bookHistograms(DQMStore::IBooker & ibooker,
+					  edm::Run const & /*iRun*/,
+					  edm::EventSetup const& /*iSetup*/){
+  ibooker.cd();
+  ibooker.setCurrentFolder(theFolder);
+
+  // monitoring of trigger match parameter
+   
+  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v1", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 500, 0.0, 0.5));
+  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v2", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 1000, 0.0, 1.0));
+  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v3", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 5000, 0.0, 5.0));
+  matchHists.push_back(ibooker.book1D("PtRatio_HLT_"+triggerHistName1_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName1_, 200, -5., 5.0));
+  
+  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName1_+"_v1", "DeltaR_(offline, L1)_triggerPass("+triggerHistName1_+")", 500, 0.0, 1.0));
+  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName1_+"_v2", "DeltaR_(offline, L1)_triggerPass("+triggerHistName1_+")", 1000, 0.0, 2.0));
+  matchHists.push_back(ibooker.book1D("PtRatio_L1_"+triggerHistName1_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName1_, 200, -5., 5.0));
+   
+  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName2_+"_v1", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName2_+")", 500, 0.0, 0.5));
+  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName2_+"_v2", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName2_+")", 1000, 0.0, 1.0));
+  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName2_+"_v3", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName2_+")", 5000, 0.0, 5.0));
+  matchHists.push_back(ibooker.book1D("PtRatio_HLT_"+triggerHistName2_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName2_, 200, -5., 5.0));
+
+  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName2_+"_v1", "DeltaR_(offline, L1)_triggerPass("+triggerHistName2_+")", 500, 0.0, 1.0));
+  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName2_+"_v2", "DeltaR_(offline, L1)_triggerPass("+triggerHistName2_+")", 1000, 0.0, 2.0));
+  matchHists.push_back(ibooker.book1D("PtRatio_L1_"+triggerHistName2_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName2_, 200, -5., 5.0));
+
+  ibooker.cd();
+  ibooker.setCurrentFolder(theFolder+"/EfficiencyInput");
+ 
+  h_passHLTPath1_eta_Tight          = ibooker.book1D("passHLT"+triggerHistName1_+"_eta_Tight", " HLT("+triggerHistName1_+") pass #eta", 8, -2.5, 2.5);
+  h_passHLTPath1_pt_Tight          = ibooker.book1D("passHLT"+triggerHistName1_+"_pt_Tight", " HLT("+triggerHistName1_+") pass pt", 10, 20, 220);
+  h_passHLTPath1_phi_Tight          = ibooker.book1D("passHLT"+triggerHistName1_+"_phi_Tight", " HLT("+triggerHistName1_+") pass phi", 8, -3.0, 3.0);
+  h_totalHLTPath1_eta_Tight          = ibooker.book1D("totalHLT"+triggerHistName1_+"_eta_Tight", " HLT("+triggerHistName1_+") total #eta", 8, -2.5, 2.5);
+  h_totalHLTPath1_pt_Tight          = ibooker.book1D("totalHLT"+triggerHistName1_+"_pt_Tight", " HLT("+triggerHistName1_+") total pt", 10, 20., 220);
+  h_totalHLTPath1_phi_Tight          = ibooker.book1D("totalHLT"+triggerHistName1_+"_phi_Tight", " HLT("+triggerHistName1_+") total phi", 8, -3.0, 3.0);
+
+  h_passHLTPath2_eta_Tight          = ibooker.book1D("passHLT"+triggerHistName2_+"_eta_Tight", " HLT("+triggerHistName2_+") pass #eta", 8, -2.5, 2.5);
+  h_passHLTPath2_pt_Tight          = ibooker.book1D("passHLT"+triggerHistName2_+"_pt_Tight", " HLT("+triggerHistName2_+") pass pt", 10, 20., 220);
+  h_passHLTPath2_phi_Tight          = ibooker.book1D("passHLT"+triggerHistName2_+"_phi_Tight", " HLT("+triggerHistName2_+") pass phi", 8, -3.0, 3.0);
+  h_totalHLTPath2_eta_Tight          = ibooker.book1D("totalHLT"+triggerHistName2_+"_eta_Tight", " HLT("+triggerHistName2_+") total #eta", 8, -2.5, 2.5);
+  h_totalHLTPath2_pt_Tight          = ibooker.book1D("totalHLT"+triggerHistName2_+"_pt_Tight", " HLT("+triggerHistName2_+") total pt", 10, 20, 220);
+  h_totalHLTPath2_phi_Tight          = ibooker.book1D("totalHLT"+triggerHistName2_+"_phi_Tight", " HLT("+triggerHistName2_+") total phi", 8, -3.0, 3.0);
+
+
+}
+void TriggerMatchMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup){
+  
+  LogTrace(metname)<<"[TriggerMatchMonitor] Analyze the mu in different eta regions";
+  theService->update(iSetup);
+  
+  edm::Handle<edm::View<reco::Muon> > muons; 
+  iEvent.getByToken(theMuonCollectionLabel_,muons);
+
+  edm::Handle<edm::View<pat::Muon> > PATmuons;
+  iEvent.getByToken(thePATMuonCollectionLabel_,PATmuons);
+
+  edm::Handle<std::vector<pat::TriggerObjectStandAlone> > triggerObjects;
+  iEvent.getByToken(triggerObjects_, triggerObjects);
+
+  Handle<edm::TriggerResults> triggerResults;
+  iEvent.getByToken(triggerResultsToken_, triggerResults);
+
+  reco::Vertex::Point posVtx;
+  reco::Vertex::Error errVtx;
+  Handle<std::vector<reco::Vertex> > recVtxs;
+  iEvent.getByToken(primaryVerticesToken_,recVtxs);
+  unsigned int theIndexOfThePrimaryVertex = 999.;
+  for (unsigned int ind = 0; ind < recVtxs->size(); ++ind) {
+     if ( (*recVtxs)[ind].isValid() && !((*recVtxs)[ind].isFake()) ) {
+       theIndexOfThePrimaryVertex = ind;
+       break;
+     }
+  }
+  if (theIndexOfThePrimaryVertex<100) {
+     posVtx = ((*recVtxs)[theIndexOfThePrimaryVertex]).position();
+     errVtx = ((*recVtxs)[theIndexOfThePrimaryVertex]).error();
+  }
+  else {
+     LogInfo("RecoMuonValidator") << "reco::PrimaryVertex not found, use BeamSpot position instead\n";
+     Handle<reco::BeamSpot> recoBeamSpotHandle;
+     iEvent.getByToken(beamSpotToken_,recoBeamSpotHandle);
+     reco::BeamSpot bs = *recoBeamSpotHandle;
+     posVtx = bs.position();
+     errVtx(0,0) = bs.BeamWidthX();
+     errVtx(1,1) = bs.BeamWidthY();
+     errVtx(2,2) = bs.sigmaZ();
+  }
+  const reco::Vertex thePrimaryVertex(posVtx,errVtx);
+
+  if(PATmuons.isValid()){//valid pat Muon
+    for(const auto & patMuon : *PATmuons){//pat muon loop
+      bool Isolated=patMuon.pfIsolationR04().sumChargedHadronPt + TMath::Max(0., patMuon.pfIsolationR04().sumNeutralHadronEt + patMuon.pfIsolationR04().sumPhotonEt - 0.5*patMuon.pfIsolationR04().sumPUPt)  / patMuon.pt() < 0.25;
+
+      if(patMuon.isGlobalMuon() && Isolated && patMuon.isTightMuon(thePrimaryVertex)){//isolated tight muon
+
+        TLorentzVector offlineMuon;
+        offlineMuon.SetPtEtaPhiM(patMuon.pt(), patMuon.eta(), patMuon.phi(),0.0);
+
+        const char *ptrmuPath1 = triggerPathName1_.c_str();        // 
+        const char *ptrmuPath2 = triggerPathName2_.c_str();        // 
+        if(patMuon.pt() > triggerPtThresholdPath1_){
+        h_totalHLTPath1_eta_Tight->Fill(patMuon.eta());
+        h_totalHLTPath1_pt_Tight->Fill(patMuon.pt());
+        h_totalHLTPath1_phi_Tight->Fill(patMuon.phi());
+        }
+        if(patMuon.pt() > triggerPtThresholdPath2_){
+        h_totalHLTPath2_eta_Tight->Fill(patMuon.eta());
+        h_totalHLTPath2_pt_Tight->Fill(patMuon.pt());
+        h_totalHLTPath2_phi_Tight->Fill(patMuon.phi());
+        }
+        if(patMuon.triggered(ptrmuPath1) && patMuon.hltObject() !=nullptr){
+          TLorentzVector hltMuon;
+          hltMuon.SetPtEtaPhiM(patMuon.hltObject()->pt(),patMuon.hltObject()->eta(),patMuon.hltObject()->phi(),0.0);
+          double DelRrecoHLT=offlineMuon.DeltaR(hltMuon);
+
+          matchHists[0]->Fill(DelRrecoHLT);   
+          matchHists[1]->Fill(DelRrecoHLT);
+          matchHists[2]->Fill(DelRrecoHLT);
+          matchHists[3]->Fill(patMuon.hltObject()->pt()/patMuon.pt());
+          if(DelRrecoHLT<0.2 && patMuon.pt() > triggerPtThresholdPath1_){
+            h_passHLTPath1_eta_Tight->Fill(patMuon.eta());
+            h_passHLTPath1_pt_Tight->Fill(patMuon.pt());
+            h_passHLTPath1_phi_Tight->Fill(patMuon.phi());
+          }
+          if(patMuon.l1Object() !=nullptr){
+            TLorentzVector L1Muon;
+            L1Muon.SetPtEtaPhiM(patMuon.l1Object()->pt(),patMuon.l1Object()->eta(),patMuon.l1Object()->phi(),0.0);
+            double DelRrecoL1=offlineMuon.DeltaR(L1Muon);
+            matchHists[4]->Fill(DelRrecoL1);
+            matchHists[5]->Fill(DelRrecoL1);
+            matchHists[6]->Fill(patMuon.l1Object()->pt()/patMuon.pt());     
+          }
+
+        }
+
+        /// Mu50 test
+        if(patMuon.triggered(ptrmuPath2)){
+          TLorentzVector hltMuon50;
+          hltMuon50.SetPtEtaPhiM(patMuon.hltObject()->pt(),patMuon.hltObject()->eta(),patMuon.hltObject()->phi(),0.0);
+          double DelRrecoHLT50=offlineMuon.DeltaR(hltMuon50);
+
+          matchHists[7]->Fill(DelRrecoHLT50);
+          matchHists[8]->Fill(DelRrecoHLT50);
+          matchHists[9]->Fill(DelRrecoHLT50);
+          matchHists[10]->Fill(patMuon.hltObject()->pt()/patMuon.pt());
+          if(DelRrecoHLT50<0.2 && patMuon.pt() > triggerPtThresholdPath2_ ){
+            h_passHLTPath2_eta_Tight->Fill(patMuon.eta());
+            h_passHLTPath2_pt_Tight->Fill(patMuon.pt());
+            h_passHLTPath2_phi_Tight->Fill(patMuon.phi());
+          }
+
+
+          if(patMuon.l1Object() !=nullptr){
+            TLorentzVector L1Muon50;
+            L1Muon50.SetPtEtaPhiM(patMuon.l1Object()->pt(),patMuon.l1Object()->eta(),patMuon.l1Object()->phi(),0.0);
+            double DelRrecoL150=offlineMuon.DeltaR(L1Muon50);
+            matchHists[11]->Fill(DelRrecoL150);
+            matchHists[12]->Fill(DelRrecoL150);
+            matchHists[13]->Fill(patMuon.l1Object()->pt()/patMuon.pt());
+          }
+        }
+      }//isolated tight muon
+    } //pat muon loop
+  } //valid pat muon
+ 
+}

--- a/DQMOffline/Muon/src/TriggerMatchMonitor.cc
+++ b/DQMOffline/Muon/src/TriggerMatchMonitor.cc
@@ -57,8 +57,7 @@ void TriggerMatchMonitor::bookHistograms(DQMStore::IBooker & ibooker,
   // monitoring of trigger match parameter
    
   matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v1", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 500, 0.0, 0.5));
-  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v2", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 1000, 0.0, 1.0));
-  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v3", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 400, 0.0, 8.0));  
+  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v2", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 100, 0.5, 1.5));
   matchHists.push_back(ibooker.book1D("PtRatio_HLT_"+triggerHistName1_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName1_, 200, -5., 5.0));
   
   matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName1_+"_v1", "DeltaR_(offline, L1)_triggerPass("+triggerHistName1_+")", 500, 0.0, 1.0));
@@ -66,12 +65,11 @@ void TriggerMatchMonitor::bookHistograms(DQMStore::IBooker & ibooker,
   matchHists.push_back(ibooker.book1D("PtRatio_L1_"+triggerHistName1_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName1_, 200, -5., 5.0));
    
   matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName2_+"_v1", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName2_+")", 500, 0.0, 0.5));
-  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName2_+"_v2", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName2_+")", 1000, 0.0, 1.0));
-  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName2_+"_v3", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName2_+")", 5000, 0.0, 5.0));
+  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName2_+"_v2", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName2_+")", 100, 0.5, 1.5));
   matchHists.push_back(ibooker.book1D("PtRatio_HLT_"+triggerHistName2_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName2_, 200, -5., 5.0));
 
-  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName2_+"_v1", "DeltaR_(offline, L1)_triggerPass("+triggerHistName2_+")", 500, 0.0, 1.0));
-  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName2_+"_v2", "DeltaR_(offline, L1)_triggerPass("+triggerHistName2_+")", 1000, 0.0, 2.0));
+  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName2_+"_v1", "DeltaR_(offline, L1)_triggerPass("+triggerHistName2_+")", 250, 0.0, 0.5));
+  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName2_+"_v2", "DeltaR_(offline, L1)_triggerPass("+triggerHistName2_+")", 100, 0.5, 1.5));
   matchHists.push_back(ibooker.book1D("PtRatio_L1_"+triggerHistName2_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName2_, 200, -5., 5.0));
 
   ibooker.cd();
@@ -165,8 +163,7 @@ void TriggerMatchMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
 
           matchHists[0]->Fill(DelRrecoHLT);   
           matchHists[1]->Fill(DelRrecoHLT);
-          matchHists[2]->Fill(DelRrecoHLT);
-          matchHists[3]->Fill(patMuon.hltObject()->pt()/patMuon.pt());
+          matchHists[2]->Fill(patMuon.hltObject()->pt()/patMuon.pt());
           if(DelRrecoHLT<0.2 && patMuon.pt() > triggerPtThresholdPath1_){
             h_passHLTPath1_eta_Tight->Fill(patMuon.eta());
             h_passHLTPath1_pt_Tight->Fill(patMuon.pt());
@@ -176,9 +173,9 @@ void TriggerMatchMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
             TLorentzVector L1Muon;
             L1Muon.SetPtEtaPhiM(patMuon.l1Object()->pt(),patMuon.l1Object()->eta(),patMuon.l1Object()->phi(),0.0);
             double DelRrecoL1=offlineMuon.DeltaR(L1Muon);
+            matchHists[3]->Fill(DelRrecoL1);
             matchHists[4]->Fill(DelRrecoL1);
-            matchHists[5]->Fill(DelRrecoL1);
-            matchHists[6]->Fill(patMuon.l1Object()->pt()/patMuon.pt());     
+            matchHists[5]->Fill(patMuon.l1Object()->pt()/patMuon.pt());     
           }
 
         }
@@ -189,10 +186,9 @@ void TriggerMatchMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
           hltMuon50.SetPtEtaPhiM(patMuon.hltObject()->pt(),patMuon.hltObject()->eta(),patMuon.hltObject()->phi(),0.0);
           double DelRrecoHLT50=offlineMuon.DeltaR(hltMuon50);
 
+          matchHists[6]->Fill(DelRrecoHLT50);
           matchHists[7]->Fill(DelRrecoHLT50);
-          matchHists[8]->Fill(DelRrecoHLT50);
-          matchHists[9]->Fill(DelRrecoHLT50);
-          matchHists[10]->Fill(patMuon.hltObject()->pt()/patMuon.pt());
+          matchHists[8]->Fill(patMuon.hltObject()->pt()/patMuon.pt());
           if(DelRrecoHLT50<0.2 && patMuon.pt() > triggerPtThresholdPath2_ ){
             h_passHLTPath2_eta_Tight->Fill(patMuon.eta());
             h_passHLTPath2_pt_Tight->Fill(patMuon.pt());
@@ -204,9 +200,9 @@ void TriggerMatchMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
             TLorentzVector L1Muon50;
             L1Muon50.SetPtEtaPhiM(patMuon.l1Object()->pt(),patMuon.l1Object()->eta(),patMuon.l1Object()->phi(),0.0);
             double DelRrecoL150=offlineMuon.DeltaR(L1Muon50);
-            matchHists[11]->Fill(DelRrecoL150);
-            matchHists[12]->Fill(DelRrecoL150);
-            matchHists[13]->Fill(patMuon.l1Object()->pt()/patMuon.pt());
+            matchHists[9]->Fill(DelRrecoL150);
+            matchHists[10]->Fill(DelRrecoL150);
+            matchHists[11]->Fill(patMuon.l1Object()->pt()/patMuon.pt());
           }
         }
       }//isolated tight muon

--- a/DQMOffline/Muon/src/TriggerMatchMonitor.cc
+++ b/DQMOffline/Muon/src/TriggerMatchMonitor.cc
@@ -58,11 +58,11 @@ void TriggerMatchMonitor::bookHistograms(DQMStore::IBooker & ibooker,
    
   matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v1", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 500, 0.0, 0.5));
   matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v2", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 1000, 0.0, 1.0));
-  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v3", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 5000, 0.0, 5.0));
+  matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName1_+"_v3", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName1_+")", 400, 0.0, 8.0));  
   matchHists.push_back(ibooker.book1D("PtRatio_HLT_"+triggerHistName1_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName1_, 200, -5., 5.0));
   
   matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName1_+"_v1", "DeltaR_(offline, L1)_triggerPass("+triggerHistName1_+")", 500, 0.0, 1.0));
-  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName1_+"_v2", "DeltaR_(offline, L1)_triggerPass("+triggerHistName1_+")", 1000, 0.0, 2.0));
+  matchHists.push_back(ibooker.book1D("DelR_L1_"+triggerHistName1_+"_v2", "DeltaR_(offline, L1)_triggerPass("+triggerHistName1_+")", 500, 0.0, 2.0));  
   matchHists.push_back(ibooker.book1D("PtRatio_L1_"+triggerHistName1_, "PtRatio_(HLTPt/OfflinePt)_"+triggerHistName1_, 200, -5., 5.0));
    
   matchHists.push_back(ibooker.book1D("DelR_HLT_"+triggerHistName2_+"_v1", "DeltaR_(offline,HLT)_triggerPass("+triggerHistName2_+")", 500, 0.0, 0.5));


### PR DESCRIPTION
- Recently trigger matching features has been added in the pat::Muon 
- This DQM analyzer monitors how the matching works by plotting several variables 
- Variables include  delta R between offline muon and HLT objects
- DeltaR between offline muon and L1 objects
- Matching efficiency between offline and online objects