### PR TITLE
MTD simulation: fix to the BTL digitization

### DIFF
--- a/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
@@ -72,9 +72,11 @@ class BTLElectronicsSim {
 
   // synthesized adc/tdc information
   const float adcSaturation_MIP_;
+  const uint32_t adcBitSaturation_;
   const float adcLSB_MIP_;
   const float adcThreshold_MIP_;
   const float toaLSB_ns_;
+  const uint32_t tdcBitSaturation_;
 
   const float CorrCoeff_;
   const float cosPhi_;


### PR DESCRIPTION
This is a small fix to the BTL digitization: there was an issue with the way the saturation of ADC and TDC counts was implemented, resulting in a loss of BTL hits.
The code was tested with100 events of workflows 22440.0 and 22434.0.