### PR TITLE
Centrality reco modification 2 for 2018 heavy ion run

### DIFF
--- a/RecoHI/HiCentralityAlgos/python/HiCentrality_cfi.py
+++ b/RecoHI/HiCentralityAlgos/python/HiCentrality_cfi.py
@@ -36,11 +36,18 @@ hiCentrality = cms.EDProducer("CentralityProducer",
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toModify(hiCentrality,
+
+for p in [pp_on_AA_2018]:
+    p.toModify(hiCentrality,
                producePixelTracks = True,
                srcPixelTracks = "hiConformalPixelTracks",
-               srcTracks = cms.InputTag("generalTracks"),
-               srcVertex = cms.InputTag("offlinePrimaryVertices")
+               srcTracks = "generalTracks",
+               srcVertex = "offlinePrimaryVertices"
                )
 
+for e in [pp_on_XeXe_2017]:
+    e.toModify(hiCentrality,
+               producePixelTracks = False,
+               srcTracks = "generalTracks",
+               srcVertex = "offlinePrimaryVertices"
+               )


### PR DESCRIPTION
turned off pixel tracks flag for XeXe so it doesn't crash for XeXe pixel track collection.
It's the same changes with the last commit of PR #24889 