### PR TITLE
[10.3.X] customize the DQM tracking only sequence when run in trackingOnlyEra_Run2_2018_pp_on_AA to remove hiConformalPixelTracks

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -95,8 +95,9 @@ def customisePostEra_Run2_2018_pp_on_AA(process):
 
 def customisePostEra_Run2_2018_pp_on_AA_express_trackingOnly(process):
     customisePostEra_Run2_2018_express_trackingOnly(process)
+    from DQM.TrackingMonitorSource.PPonAATrackingOnly_custom import customise_PPonAATrackingOnlyDQM as _customise_PPonAATrackingOnlyDQM
+    _customise_PPonAATrackingOnlyDQM(process)
     return process
-
 
 ##############################################################################
 def customisePPData(process):

--- a/DQM/TrackingMonitorSource/python/PPonAATrackingOnly_custom.py
+++ b/DQM/TrackingMonitorSource/python/PPonAATrackingOnly_custom.py
@@ -1,0 +1,18 @@
+"""
+_Utils_
+Tools to customise the DQM offline configuration run on the dedicated express-like stream during pp_on_AA
+"""
+
+import FWCore.ParameterSet.Config as cms
+
+def customise_PPonAATrackingOnlyDQM(process):
+    if hasattr(process,'dqmofflineOnPAT_step'):
+        process=customise_DQMSequenceHiConformalTracks(process)
+    return process   
+
+def customise_DQMSequenceHiConformalTracks(process):
+    process.TrackingDQMSourceTier0Common.remove(process.hiConformalPixelTracksQA)	
+    return process
+
+
+	


### PR DESCRIPTION
backport of #24996

Title says it all, should fix the issue:
```
----- Begin Fatal Exception 25-Oct-2018 12:51:43 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 325112 lumi: 6 event: 29430 stream: 0
   [1] Running path 'dqmofflineOnPAT_step'
   [2] Calling method for module TrackSelector/'hiConformalPixelTracksQA'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: std::vector<reco::Track>
Looking for module label: hiConformalPixelTracks
Looking for productInstanceName: 

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```
as reported here:
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2035/1/1/1/1/1/1/2/1/1/1.html

@ical @tocheng 