### PR TITLE
HCALDQM: re-sync L1T-uHTR mismatch plot with L1T DQM (10_4_X)

### DIFF
--- a/DQM/HcalTasks/interface/TPTask.h
+++ b/DQM/HcalTasks/interface/TPTask.h
@@ -40,10 +40,12 @@ class TPTask : public hcaldqm::DQTask
 		edm::InputTag		_tagDataL1Rec;
 		edm::InputTag		_tagEmul;
 		edm::InputTag		_tagEmulNoTDCCut;
+		edm::InputTag		_tagFEDs;
 		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokData;
 		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokDataL1Rec;
 		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokEmul;
 		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokEmulNoTDCCut;
+		edm::EDGetTokenT<FEDRawDataCollection>	_tokFEDs;
 
 		//	flag vector
 		std::vector<hcaldqm::flag::Flag> _vflags;
@@ -64,6 +66,7 @@ class TPTask : public hcaldqm::DQTask
 			_thresh_FGMsmRate_high, _thresh_FGMsmRate_low,
 			_thresh_DataMsn, _thresh_EmulMsn;
 		std::vector<bool> _vFGBitsReady;
+		bool ignoreHFfbs_; 
 
 		//	hashes/FEDs vectors
 		std::vector<uint32_t> _vhashFEDs;


### PR DESCRIPTION
HCALDQM replicates a plot from L1T showing uHTR-L1T mismatches. There were a couple things not completely replicated that have now been included:

- Most importantly, if L1T caloLayer1 in not in the run, then ignore mismatches.
- Add some logic related to fine-grained bits.