### PR TITLE
Add pixel tracks to XeXe era

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -163,7 +163,7 @@ pp_on_AA_2018.toReplaceWith(highlevelreco,highlevelreco.copyAndExclude([PFTau]))
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoHI.HiTracking.HILowPtConformalPixelTracks_cfi import *
 _highlevelreco_HI_wPixTracks = highlevelreco.copy()
-pp_on_AA_2018.toReplaceWith(highlevelreco, cms.Sequence(_highlevelreco_HI_wPixTracks* hiConformalPixelTracksSequencePhase1))
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(highlevelreco, cms.Sequence(_highlevelreco_HI_wPixTracks* hiConformalPixelTracksSequencePhase1))
 
 # not commisoned and not relevant in FastSim (?):
 _fastSim_highlevelreco = highlevelreco.copyAndExclude([cosmicDCTracksSeq,muoncosmichighlevelreco])


### PR DESCRIPTION
Prevents a crash in relval workflow 148, observed after merging #24892 
 #24994 can now be closed.  
No 10_3_X backport is necessary, as this functionality was included in #24889 
@abaty @YeonjuGo 