### PR TITLE
Configure DtCalib AlCaReco for heavy Ion 2018

### DIFF
--- a/CalibMuon/DTCalibration/python/ALCARECODtCalib_Output_cff.py
+++ b/CalibMuon/DTCalibration/python/ALCARECODtCalib_Output_cff.py
@@ -46,7 +46,9 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 
 OutALCARECODtCalibHI = copy.deepcopy(OutALCARECODtCalib_noDrop)
 OutALCARECODtCalibHI.outputCommands.insert(0, "drop *")
-OutALCARECODtCalibHI.outputCommands.append("keep *_hiSelectedVertex_*_*")
+OutALCARECODtCalibHI.outputCommands.append("keep *_offlinePrimaryVertices__*")
+OutALCARECODtCalibHI.outputCommands.append("keep *_offlinePrimaryVerticesWithBS_*_*")
+OutALCARECODtCalibHI.outputCommands.append("keep *_offlinePrimaryVerticesFromCosmicTracks_*_*")
 
 #Specify to use HI output for the pp_on_AA_2018 eras
 pp_on_AA_2018.toReplaceWith(OutALCARECODtCalib,OutALCARECODtCalibHI)

--- a/CalibMuon/DTCalibration/python/ALCARECODtCalib_Output_cff.py
+++ b/CalibMuon/DTCalibration/python/ALCARECODtCalib_Output_cff.py
@@ -40,3 +40,13 @@ OutALCARECODtCalib_noDrop = cms.PSet(
 import copy
 OutALCARECODtCalib = copy.deepcopy(OutALCARECODtCalib_noDrop)
 OutALCARECODtCalib.outputCommands.insert(0, "drop *")
+
+## customizations for the pp_on_AA_2018 eras
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+
+OutALCARECODtCalibHI = copy.deepcopy(OutALCARECODtCalib_noDrop)
+OutALCARECODtCalibHI.outputCommands.insert(0, "drop *")
+OutALCARECODtCalibHI.outputCommands.append("keep *_hiSelectedVertex_*_*")
+
+#Specify to use HI output for the pp_on_AA_2018 eras
+pp_on_AA_2018.toReplaceWith(OutALCARECODtCalib,OutALCARECODtCalibHI)

--- a/CalibMuon/DTCalibration/python/ALCARECODtCalib_cff.py
+++ b/CalibMuon/DTCalibration/python/ALCARECODtCalib_cff.py
@@ -21,3 +21,14 @@ dt4DSegmentsNoWire.Reco4DAlgoConfig.Reco2DAlgoConfig.recAlgoConfig.tTrigModeConf
 from RecoMET.METFilters.metFilters_cff import primaryVertexFilter, noscraping
 
 seqALCARECODtCalib = cms.Sequence(primaryVertexFilter * noscraping * ALCARECODtCalibHLTFilter * DTCalibMuonSelection * dt4DSegmentsNoWire) 
+
+## customizations for the pp_on_AA_2018 eras
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(ALCARECODtCalibHLTFilter,
+                       eventSetupPathsKey='DtCalibHI'
+)
+
+seqALCARECODtCalibHI = cms.Sequence(ALCARECODtCalibHLTFilter * dt4DSegmentsNoWire)
+
+#Specify to use HI sequence for the pp_on_AA_2018 eras
+pp_on_AA_2018.toReplaceWith(seqALCARECODtCalib,seqALCARECODtCalibHI)


### PR DESCRIPTION
Greetings,

The PR is to add DtCalibHI into the AlCaReco stream.
The DtCalib in the AlCaReco stream is replaced by sequence in DtCalibHI using the pp_on_AA_2018 era.
Also the DtCalibOutput is replaced by the DtCalibHIOut using the pp_on_AA_2018 era.

The configuration is checked using 
python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunExpressProcessing.py --scenario ppEra_Run2_2018_pp_on_AA --global-tag 103X_dataRun2_Express_v1 --lfn /store/whatever --fevt --dqmio  --alcareco DtCalib

After changing pickle to python config,
one can see that the DtCalib path and output is replaced  by the path and output in DtCalibHI