### PR TITLE
Configure HcalMinBias AlCaReco for heavy Ion 2018

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_Output_cff.py
@@ -23,3 +23,12 @@ OutALCARECOHcalCalMinBias_noDrop = cms.PSet(
 import copy
 OutALCARECOHcalCalMinBias=copy.deepcopy(OutALCARECOHcalCalMinBias_noDrop)
 OutALCARECOHcalCalMinBias.outputCommands.insert(0, "drop *")
+
+## customizations for the pp_on_AA_2018 eras
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+OutALCARECOHcalCalMinBiasHI = copy.deepcopy(OutALCARECOHcalCalMinBias_noDrop)
+OutALCARECOHcalCalMinBiasHI.outputCommands.insert(0, "drop *")
+OutALCARECOHcalCalMinBiasHI.outputCommands.insert(6, "keep HFRecHitsSorted_hfreco_*_*")
+
+#Specify to use HI output for the pp_on_AA_2018 eras
+pp_on_AA_2018.toReplaceWith(OutALCARECOHcalCalMinBias,OutALCARECOHcalCalMinBiasHI)

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
@@ -13,6 +13,13 @@ hcalminbiasHLT =  HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
     throw = False #dont throw except on unknown path name 
 )
 
+## customizations for the pp_on_AA_2018 eras
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(hcalminbiasHLT,
+                       eventSetupPathsKey='HcalCalMinBiasHI'
+)
+
+
 import RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi
 hbherecoMBNZS = RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi.hbheprereco.clone(
     digiLabelQIE8  = cms.InputTag("hcalDigiAlCaMB"),
@@ -59,6 +66,12 @@ seqALCARECOHcalCalMinBiasDigi = cms.Sequence(hcalminbiasHLT*hcalDigiAlCaMB*gtDig
 seqALCARECOHcalCalMinBiasDigiNoHLT = cms.Sequence(hcalDigiAlCaMB*gtDigisAlCaMB)
 
 seqALCARECOHcalCalMinBias = cms.Sequence(hbherecoMBNZS*horecoMBNZS*hbherecoNoise*hfrecoNoise*hfrecoMBNZS*horecoNoise)
+
+#Specify to use HI output for the pp_on_AA_2018 eras
+seqALCARECOHcalCalMinBiasHI = cms.Sequence(hbherecoNoise*hfrecoNoise*hfrecoMBNZS*horecoNoise)
+pp_on_AA_2018.toReplaceWith(seqALCARECOHcalCalMinBias,
+                            seqALCARECOHcalCalMinBiasHI
+)
 
 import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 hfprerecoNoise = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(

--- a/DQMOffline/Configuration/python/ALCARECOHcalCalDQM_cff.py
+++ b/DQMOffline/Configuration/python/ALCARECOHcalCalDQM_cff.py
@@ -17,3 +17,10 @@ ALCARECOHcalCalIsolatedBunchDQM =  DQMOffline.CalibCalo.MonitorHcalIsolatedBunch
 
 ALCARECOHcalCalHODQM =  DQMOffline.CalibCalo.MonitorHOAlCaRecoStream_cfi.MonitorHOAlCaRecoStream.clone()
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+
+pp_on_AA_2018.toModify(ALCARECOHcalCalPhisymDQM,
+                       hbheInputMB = "hbhereco",
+                       hoInputMB = "horeco"
+)
+


### PR DESCRIPTION
Greetings,

The PR is to add HcalMinBiasHI into the AlCaReco stream.
The HcalMinBias in the AlCaReco stream is replaced by sequence in HcalMinBiasHI using the pp_on_AA_2018 era.
Also the HcalMinBiasOutput is replaced by the HcalMinBiasHIOut using the pp_on_AA_2018 era.

The configuration is checked using
python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario hcalnzsEra_Run2_2018_pp_on_AA --reco --aod --dqmio --global-tag 103X_dataRun2_Prompt_v2 --lfn=/store/whatever  --alcareco HcalCalMinBias

After changing pickle to python config,
one can see that the HcalCalMinBias path and output is replaced by the path and output in HcalCalMinBiasHI

And one can also use streamer file from HI test
process.source = cms.Source("NewEventStreamFileReader",
    fileNames = cms.untracked.vstring('file:/eos/cms/store/t0streamer/Data/HIPhysicsCommissioning/000/325/112/run325112_ls0006_streamHIPhysicsCommissioning_StorageManager.dat')
)
I ran 10 events without crash.