### PR TITLE
streamline addition of centrality and pixel tracks for HI

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -152,18 +152,15 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
 # AA data with pp reco
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from RecoHI.HiTracking.HILowPtConformalPixelTracks_cfi import *
 from RecoHI.HiCentralityAlgos.HiCentrality_cfi import hiCentrality
 from RecoHI.HiCentralityAlgos.HiClusterCompatibility_cfi import hiClusterCompatibility
 _highlevelreco_HI = highlevelreco.copy()
+_highlevelreco_HI += hiConformalPixelTracksSequencePhase1
 _highlevelreco_HI += hiCentrality
 _highlevelreco_HI += hiClusterCompatibility
 (pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(highlevelreco, _highlevelreco_HI)
 pp_on_AA_2018.toReplaceWith(highlevelreco,highlevelreco.copyAndExclude([PFTau]))
-
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-from RecoHI.HiTracking.HILowPtConformalPixelTracks_cfi import *
-_highlevelreco_HI_wPixTracks = highlevelreco.copy()
-(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(highlevelreco, cms.Sequence(_highlevelreco_HI_wPixTracks* hiConformalPixelTracksSequencePhase1))
 
 # not commisoned and not relevant in FastSim (?):
 _fastSim_highlevelreco = highlevelreco.copyAndExclude([cosmicDCTracksSeq,muoncosmichighlevelreco])


### PR DESCRIPTION
after the centrality was updated to consume the hi pixel tracks, the configuration went out of order
this PR puts them in the order of production

this should also fix https://github.com/cms-sw/cmssw/pull/25004#issuecomment-433205200
