### PR TITLE
Disabling BeamSpot EventDisplay filters

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -381,7 +381,8 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.p = cms.Path(process.scalersRawToDigi
                          *process.dqmTKStatus
                          *process.hltTriggerTypeFilter
-                         *process.filter_step
+                         # The following filter was used during 2018 high pile up (HPU) run.
+                         #*process.filter_step
                          *process.dqmcommon
                          *process.tracking_FirstStep
                          *process.monitor

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -70,6 +70,7 @@ process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi")
 # Condition for P5 cluster
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
+#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
@@ -363,11 +364,24 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
                                                                "HLT_QuadJet")
 
     process.dqmBeamMonitor.hltResults = cms.InputTag("TriggerResults","","HLT")
+ 
+    # Select events based on the pixel cluster multiplicity
+    import  HLTrigger.special.hltPixelActivityFilter_cfi
+    process.multFilter = HLTrigger.special.hltPixelActivityFilter_cfi.hltPixelActivityFilter.clone(
+       inputTag  = cms.InputTag('siPixelClustersPreSplitting'),
+       minClusters = cms.uint32(10000),
+       maxClusters = cms.uint32(50000)
+    )
 
+    process.filter_step = cms.Sequence( process.siPixelDigis
+                                       *process.siPixelClustersPreSplitting
+                                       *process.multFilter
+                                  )
 
     process.p = cms.Path(process.scalersRawToDigi
                          *process.dqmTKStatus
                          *process.hltTriggerTypeFilter
+                         *process.filter_step
                          *process.dqmcommon
                          *process.tracking_FirstStep
                          *process.monitor

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -39,8 +39,10 @@ kwds = {
 }
 
 # example of how to add a filer IN FRONT of all the paths, eg for HLT selection
-#kwds['preFilter'] = 'DQM/Integration/python/config/visualizationPreFilter.hltfilter'
-kwds['preFilter'] = 'DQM/Integration/config/visualizationPreFilter.pixelClusterFilter'
+#kwds['preFilter'] = 'DQM/Integration/config/visualizationPreFilter.hltfilter'
+
+# The following filter was used during 2018 high pile up (HPU) run.
+#kwds['preFilter'] = 'DQM/Integration/config/visualizationPreFilter.pixelClusterFilter'
 
 process = scenario.visualizationProcessing(writeTiers=['FEVT'], **kwds)
 

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -40,6 +40,7 @@ kwds = {
 
 # example of how to add a filer IN FRONT of all the paths, eg for HLT selection
 #kwds['preFilter'] = 'DQM/Integration/python/config/visualizationPreFilter.hltfilter'
+kwds['preFilter'] = 'DQM/Integration/config/visualizationPreFilter.pixelClusterFilter'
 
 process = scenario.visualizationProcessing(writeTiers=['FEVT'], **kwds)
 
@@ -74,6 +75,7 @@ oldo = process._Process__outputmodules["FEVToutput"]
 del process._Process__outputmodules["FEVToutput"]
 
 process.FEVToutput = cms.OutputModule("JsonWritingTimeoutPoolOutputModule",
+    SelectEvents = oldo.SelectEvents,
     splitLevel = oldo.splitLevel,
     outputCommands = oldo.outputCommands,
     fileName = oldo.fileName,

--- a/DQM/Integration/python/config/visualizationPreFilter.py
+++ b/DQM/Integration/python/config/visualizationPreFilter.py
@@ -17,6 +17,23 @@ hltHighLevel = cms.EDFilter("HLTHighLevel",
 
 hltfilter = cms.Sequence(hltHighLevel)
 
+from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters
+filtersiPixelClusters = siPixelClusters.clone()
+filtersiPixelClusters.src = cms.InputTag("filtersiPixelDigis")
+
+from EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi import siPixelDigis
+filtersiPixelDigis = siPixelDigis.clone()
+filtersiPixelDigis.InputLabel = cms.InputTag("rawDataCollector")
+
+import  HLTrigger.special.hltPixelActivityFilter_cfi
+multFilter = HLTrigger.special.hltPixelActivityFilter_cfi.hltPixelActivityFilter.clone(
+    inputTag  = cms.InputTag('filtersiPixelClusters'),
+    minClusters = cms.uint32(10000),
+    maxClusters = cms.uint32(50000)
+)
+
+pixelClusterFilter = cms.Sequence(filtersiPixelDigis * filtersiPixelClusters * multFilter)
+
 # process.hltfilter=cms.Path(process.hltHighLevel)
 
 


### PR DESCRIPTION
Including and disabling (commenting out) Event Display and Beam Spot filters used in 2018 high pileup (HPU) run.