### PR TITLE
Fixed JetMET summary plot for HI DQM

### DIFF
--- a/DQMOffline/JetMET/interface/DataCertificationJetMET.h
+++ b/DQMOffline/JetMET/interface/DataCertificationJetMET.h
@@ -84,6 +84,8 @@ class DataCertificationJetMET : public DQMEDHarvester {
    bool jetTests[5][2];  //one for each type of jet certification/test type
    bool metTests[5][2];  //one for each type of met certification/test type
 
+   bool isHI;
+
   //MET: filter efficiencies, started from uncleaned directories
    MonitorElement* mMET_EffHBHENoiseFilter;
    MonitorElement* mMET_EffCSCTightHaloFilter;

--- a/DQMOffline/JetMET/python/dataCertificationJetMET_cff.py
+++ b/DQMOffline/JetMET/python/dataCertificationJetMET_cff.py
@@ -3,3 +3,9 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.JetMET.dataCertificationJetMET_cfi import *
 
 dataCertificationJetMETSequence = cms.Sequence(qTesterJet + qTesterMET + dataCertificationJetMET)
+
+dataCertificationJetMETSequenceHI = cms.Sequence(qTesterJet + qTesterMET + dataCertificationJetMETHI)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+
+pp_on_AA_2018.toReplaceWith( dataCertificationJetMETSequence, dataCertificationJetMETSequenceHI )

--- a/DQMOffline/JetMET/python/dataCertificationJetMET_cfi.py
+++ b/DQMOffline/JetMET/python/dataCertificationJetMET_cfi.py
@@ -61,6 +61,10 @@ dataCertificationJetMET = DQMEDHarvester('DataCertificationJetMET',
                               tcMETMeanTest           = cms.untracked.bool(False),
                               tcMETKSTest             = cms.untracked.bool(False),
 
+                              isHI                    = cms.untracked.bool(False),
 )
 
-
+dataCertificationJetMETHI = dataCertificationJetMET.clone(
+    isHI    = cms.untracked.bool(True),
+    jetAlgo = cms.untracked.string("ak"),
+)

--- a/DQMOffline/JetMET/src/DataCertificationJetMET.cc
+++ b/DQMOffline/JetMET/src/DataCertificationJetMET.cc
@@ -605,7 +605,7 @@ DataCertificationJetMET::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter&
   MonitorElement *meJetEMFrac[4];
   MonitorElement *meJetConstituents[4];
   RunDir = "";
-  if (RunDir == "") newHistoName = "JetMET/Jet/";
+  if (RunDir.empty()) newHistoName = "JetMET/Jet/";
   else              newHistoName = RunDir+"/JetMET/Runsummary/Jet/";
   std::string cleaningdir = "";
     cleaningdir = "Cleaned";
@@ -931,7 +931,7 @@ DataCertificationJetMET::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter&
   MonitorElement *meMETPhi[2];
  
   RunDir = "";
-  if (RunDir == "") newHistoName = "JetMET/MET/";
+  if (RunDir.empty()) newHistoName = "JetMET/MET/";
   else              newHistoName = RunDir+"/JetMET/Runsummary/MET/";
 
     metFolder = "Cleaned";

--- a/DQMOffline/JetMET/src/DataCertificationJetMET.cc
+++ b/DQMOffline/JetMET/src/DataCertificationJetMET.cc
@@ -655,14 +655,12 @@ DataCertificationJetMET::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter&
     meJetPhi[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Phi_EndCap");
     meJetPhi[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Phi_Forward");
     meJetPhi[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Phi");
-    //meJetPhi[4] = iget_.get(newHistoName+cleaningdir+"JetPlusTrackZSPCorJetAntiKt5/Phi");
 
     //Jet Eta histos
     meJetEta[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Eta");
     meJetEta[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Eta");
     meJetEta[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/EtaFirst");
     meJetEta[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Eta");
-    //meJetEta[4] = iget_.get(newHistoName+cleaningdir+"JetPlusTrackZSPCorJetAntiKt5/Eta");
 
     //Jet Pt histos
     meJetPt[0]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Pt_Barrel");

--- a/DQMOffline/JetMET/src/DataCertificationJetMET.cc
+++ b/DQMOffline/JetMET/src/DataCertificationJetMET.cc
@@ -61,6 +61,8 @@ DataCertificationJetMET::DataCertificationJetMET(const edm::ParameterSet& iConfi
   metTests[1][1] = conf_.getUntrackedParameter<bool>("pfMETKSTest",false);
   metTests[2][0] = conf_.getUntrackedParameter<bool>("tcMETMeanTest",true);
   metTests[2][1] = conf_.getUntrackedParameter<bool>("tcMETKSTest",false);
+
+  isHI = conf_.getUntrackedParameter<bool>("isHI",false);
  
   if (verbose_) std::cout << ">>> Constructor (DataCertificationJetMET) <<<" << std::endl;
 
@@ -608,38 +610,79 @@ DataCertificationJetMET::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter&
   std::string cleaningdir = "";
     cleaningdir = "Cleaned";
  
- //Jet Phi histos
-  meJetPhi[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Phi_Barrel");
-  meJetPhi[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Phi_EndCap");
-  meJetPhi[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Phi_Forward");
-  meJetPhi[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Phi");
-  //meJetPhi[4] = iget_.get(newHistoName+cleaningdir+"JetPlusTrackZSPCorJetAntiKt5/Phi");
+  // Read different histograms for PbPb and pp collisions
 
-  //Jet Eta histos
-  meJetEta[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Eta");
-  meJetEta[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Eta");
-  meJetEta[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/EtaFirst");
-  meJetEta[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Eta");
-  //meJetEta[4] = iget_.get(newHistoName+cleaningdir+"JetPlusTrackZSPCorJetAntiKt5/Eta");
+  if(isHI){ // Histograms for heavy ions
 
-  //Jet Pt histos
-  meJetPt[0]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Pt_Barrel");
-  meJetPt[1]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Pt_EndCap");
-  meJetPt[2]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Pt_Forward");
-  meJetPt[3]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Pt_2");
+    newHistoName = "JetMET/HIJetValidation/";
+    cleaningdir = "";
 
-  ////Jet Constituents histos
-  meJetConstituents[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Constituents_Barrel");
-  meJetConstituents[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Constituents_EndCap");
-  meJetConstituents[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Constituents_Forward");
-  meJetConstituents[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Constituents");
-  //
-  ////Jet EMFrac histos
-  meJetEMFrac[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/EFrac_Barrel");
-  meJetEMFrac[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/EFrac_EndCap");
-  meJetEMFrac[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/EFrac_Forward");
-  meJetEMFrac[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/EFrac");
+    //Jet Phi histos
+    meJetPhi[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Cs4PFJets/Phi");
+    meJetPhi[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu3PFJets/Phi");
+    meJetPhi[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu4PFJets/Phi");
+    meJetPhi[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu4CaloJets/Phi");
 
+    //Jet Eta histos
+    meJetEta[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Cs4PFJets/Eta");
+    meJetEta[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu3PFJets/Eta");
+    meJetEta[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu4PFJets/Eta");
+    meJetEta[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu4CaloJets/Eta");
+
+    //Jet Pt histos
+    meJetPt[0]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"Cs4PFJets/Pt");
+    meJetPt[1]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu3PFJets/Pt");
+    meJetPt[2]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu4PFJets/Pt");
+    meJetPt[3]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu4CaloJets/Pt");
+
+    //Jet Constituents histos
+    meJetConstituents[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Cs4PFJets/Constituents");
+    meJetConstituents[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu3PFJets/Constituents");
+    meJetConstituents[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu4PFJets/Constituents");
+    meJetConstituents[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"Pu4CaloJets/Constituents");
+    
+    //There are no jet EMFrac histograms for HI. Dummy paths will pass the tests by default
+    meJetEMFrac[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"dummy/dummy");
+    meJetEMFrac[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"dummy/dummy");
+    meJetEMFrac[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"dummy/dummy");
+    meJetEMFrac[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"dummy/dummy");
+
+
+  } else { // Histograms for protons
+
+    //Jet Phi histos
+    meJetPhi[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Phi_Barrel");
+    meJetPhi[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Phi_EndCap");
+    meJetPhi[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Phi_Forward");
+    meJetPhi[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Phi");
+    //meJetPhi[4] = iget_.get(newHistoName+cleaningdir+"JetPlusTrackZSPCorJetAntiKt5/Phi");
+
+    //Jet Eta histos
+    meJetEta[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Eta");
+    meJetEta[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Eta");
+    meJetEta[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/EtaFirst");
+    meJetEta[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Eta");
+    //meJetEta[4] = iget_.get(newHistoName+cleaningdir+"JetPlusTrackZSPCorJetAntiKt5/Eta");
+
+    //Jet Pt histos
+    meJetPt[0]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Pt_Barrel");
+    meJetPt[1]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Pt_EndCap");
+    meJetPt[2]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Pt_Forward");
+    meJetPt[3]  = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Pt_2");
+
+    //Jet Constituents histos
+    meJetConstituents[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Constituents_Barrel");
+    meJetConstituents[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Constituents_EndCap");
+    meJetConstituents[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/Constituents_Forward");
+    meJetConstituents[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/Constituents");
+    
+    //Jet EMFrac histos
+    meJetEMFrac[0] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/EFrac_Barrel");
+    meJetEMFrac[1] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/EFrac_EndCap");
+    meJetEMFrac[2] = iget_.get(newHistoName+cleaningdir+jetAlgo+"PFJets/EFrac_Forward");
+    meJetEMFrac[3] = iget_.get(newHistoName+cleaningdir+jetAlgo+"CaloJets/EFrac");
+
+  }
 				   
   //------------------------------------------------------------------------------
   //--- Extract quality test results and fill data certification results for Jets
@@ -870,6 +913,12 @@ DataCertificationJetMET::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter&
     reportSummaryMap->Fill(2, 4-jtyp, dc_Jet[jtyp]);
   }
 
+  // There is nothing on the first row for HI, so mark the unfilled
+  if(isHI){
+    CertificationSummaryMap->Fill(2, 0, -2);
+    reportSummaryMap->Fill(2, 0, -2);
+  }
+
   //-----------------------------
   // MET DQM Data Certification
   //-----------------------------
@@ -1090,6 +1139,13 @@ DataCertificationJetMET::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter&
     reportSummaryMap->Fill(1, 4-mtyp, dc_MET[mtyp]);
   }
 
+  // There is nothing on the first three rows for HI, so mark them unfilled
+  if(isHI){
+    for(int i = 0; i < 3; i++){
+      CertificationSummaryMap->Fill(1, i, -2);
+      reportSummaryMap->Fill(1, i, -2);
+    }
+  }
 				   
   //----------------------------------------------------------------------------
   //--- Extract quality test results and fill data certification results for MET

--- a/DQMOffline/JetMET/test/JetQualityTests.xml
+++ b/DQMOffline/JetMET/test/JetQualityTests.xml
@@ -48,11 +48,24 @@
    <TestName activate="true">KolmogorovTest</TestName>
 </LINK>
 
+<LINK name="JetMET/HIJetValidation/*/Eta*">
+   <TestName activate="true">KolmogorovTest</TestName>
+</LINK>
+
 <LINK name="JetMET/Jet/*/Phi*">
    <TestName activate="true">KolmogorovTest</TestName>
 </LINK>
 
+<LINK name="JetMET/HIJetValidation/*/Phi*">
+   <TestName activate="true">KolmogorovTest</TestName>
+</LINK>
+
 <LINK name="JetMET/Jet/*/Pt*">
+   <TestName activate="true">KolmogorovTest</TestName>
+   <TestName activate="true">meanJetPtTest</TestName>
+</LINK>
+
+<LINK name="JetMET/HIJetValidation/*/Pt*">
    <TestName activate="true">KolmogorovTest</TestName>
    <TestName activate="true">meanJetPtTest</TestName>
 </LINK>


### PR DESCRIPTION
Backport #24993 to 10_3_X.

Connected histograms from HIJetValidation to the JetMET summary plot in case of pp_on_AA_2018 era. The JetMET summary plot was by default reading the pp histograms, which are disabled for HI. To give green light for jets in the summary plot, it is required that the mean pT is lower than 50 GeV. Also show "Not set" instead of "Bad" for blocks that are not connected for HI.