### PR TITLE
Prepare for concurrent IOVs, L1ConfigOnlineProdBase

### DIFF
--- a/CondCore/CSCPlugins/src/plugin.cc
+++ b/CondCore/CSCPlugins/src/plugin.cc
@@ -62,17 +62,17 @@
 
 
 namespace cond {
-  template <> std::shared_ptr<CSCReadoutMapping> deserialize<CSCReadoutMapping>( const std::string& payloadType,
-										   const Binary& payloadData,
-										   const Binary& streamerInfoData ){
+  template <> std::unique_ptr<CSCReadoutMapping> deserialize<CSCReadoutMapping>( const std::string& payloadType,
+                                                                                 const Binary& payloadData,
+                                                                                 const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( CSCReadoutMapping ); abstract
     DESERIALIZE_POLIMORPHIC_CASE( CSCReadoutMapping, CSCReadoutMappingFromFile );
     // here we come if none of the deserializations above match the payload type:
     throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"", "deserialize<>" );
   }
-  template <> std::shared_ptr<CSCReadoutMappingForSliceTest> deserialize<CSCReadoutMappingForSliceTest>( const std::string& payloadType,
-													   const Binary& payloadData,
-													   const Binary& streamerInfoData ){
+  template <> std::unique_ptr<CSCReadoutMappingForSliceTest> deserialize<CSCReadoutMappingForSliceTest>( const std::string& payloadType,
+                                                                                                         const Binary& payloadData,
+                                                                                                         const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( CSCReadoutMappingForSliceTest ); abstract
     DESERIALIZE_POLIMORPHIC_CASE( CSCReadoutMappingForSliceTest, CSCReadoutMappingFromFile );
     // here we come if none of the deserializations above match the payload type:

--- a/CondCore/CalibPlugins/src/plugin.cc
+++ b/CondCore/CalibPlugins/src/plugin.cc
@@ -22,9 +22,9 @@
 
 
 namespace cond {
-  template <> std::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
-                                                                                     const Binary& payloadData,
-                                                                                     const Binary& streamerInfoData ){
+  template <> std::unique_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
+                                                                                   const Binary& payloadData,
+                                                                                   const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( condex::Efficiency ); abstract 
     DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInPt );
     DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInEta );
@@ -36,9 +36,9 @@ namespace cond {
 
 
 namespace cond {
-  template <> std::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
-								   const Binary& payloadData,
-								   const Binary& streamerInfoData ){
+  template <> std::unique_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
+                                                                 const Binary& payloadData,
+                                                                 const Binary& streamerInfoData ){
     DESERIALIZE_BASE_CASE( BaseKeyed );
     DESERIALIZE_POLIMORPHIC_CASE( BaseKeyed, condex::ConfI );
     DESERIALIZE_POLIMORPHIC_CASE( BaseKeyed, condex::ConfI );

--- a/CondCore/CondDB/interface/Serialization.h
+++ b/CondCore/CondDB/interface/Serialization.h
@@ -78,10 +78,10 @@ namespace cond {
   }
 
   // generates an instance of T from the binary serialized data. 
-  template <typename T> std::shared_ptr<T> default_deserialize( const std::string& payloadType, 
-								  const Binary& payloadData, 
-								  const Binary& streamerInfoData ){
-    std::shared_ptr<T> payload;
+  template <typename T> std::unique_ptr<T> default_deserialize( const std::string& payloadType, 
+                                                                const Binary& payloadData, 
+                                                                const Binary& streamerInfoData ){
+    std::unique_ptr<T> payload;
     std::stringbuf sstreamerInfoBuf;
     sstreamerInfoBuf.pubsetbuf( static_cast<char*>(const_cast<void*>(streamerInfoData.data())), streamerInfoData.size() );
     std::string streamerInfo = sstreamerInfoBuf.str();
@@ -110,9 +110,9 @@ namespace cond {
   }
 
   // default specialization
-  template <typename T> std::shared_ptr<T> deserialize( const std::string& payloadType, 
-							  const Binary& payloadData, 
-							  const Binary& streamerInfoData ){
+  template <typename T> std::unique_ptr<T> deserialize( const std::string& payloadType,
+                                                        const Binary& payloadData,
+                                                        const Binary& streamerInfoData ) {
     return default_deserialize<T>( payloadType, payloadData, streamerInfoData );
  }
 
@@ -125,7 +125,7 @@ namespace cond {
 
 #define DESERIALIZE_POLIMORPHIC_CASE( BASETYPENAME, DERIVEDTYPENAME )	\
   if( payloadType == #DERIVEDTYPENAME ){ \
-    return std::dynamic_pointer_cast<BASETYPENAME>( default_deserialize<DERIVEDTYPENAME>( payloadType, payloadData, streamerInfoData ) ); \
+    return default_deserialize<DERIVEDTYPENAME>( payloadType, payloadData, streamerInfoData ); \
   }
  
 #endif

--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -138,7 +138,7 @@ namespace cond {
       template <typename T> cond::Hash storePayload( const T& payload, 
 						     const boost::posix_time::ptime& creationTime = boost::posix_time::microsec_clock::universal_time() );
 
-      template <typename T> std::shared_ptr<T> fetchPayload( const cond::Hash& payloadHash );
+      template <typename T> std::unique_ptr<T> fetchPayload( const cond::Hash& payloadHash );
       
       cond::Hash storePayloadData( const std::string& payloadObjectType,
                                    const std::pair<Binary,Binary>& payloadAndStreamerInfoData,
@@ -212,14 +212,14 @@ namespace cond {
       return ret;
     }
     
-    template <typename T> inline std::shared_ptr<T> Session::fetchPayload( const cond::Hash& payloadHash ){
+    template <typename T> inline std::unique_ptr<T> Session::fetchPayload( const cond::Hash& payloadHash ){
       cond::Binary payloadData;
       cond::Binary streamerInfoData;
       std::string payloadType;
       if(! fetchPayloadData( payloadHash, payloadType, payloadData, streamerInfoData ) ) 
 	throwException( "Payload with id "+payloadHash+" has not been found in the database.",
 			"Session::fetchPayload" );
-      std::shared_ptr<T> ret;
+      std::unique_ptr<T> ret;
       try{ 
 	ret = deserialize<T>(  payloadType, payloadData, streamerInfoData );
       } catch ( const cond::persistency::Exception& e ){

--- a/CondCore/DTPlugins/src/plugin.cc
+++ b/CondCore/DTPlugins/src/plugin.cc
@@ -52,9 +52,9 @@
 #include <memory>
 
 namespace cond {
-  template <> std::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
-						 const Binary& payloadData,
-						 const Binary& streamerInfoData ){
+  template <> std::unique_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
+                                                                 const Binary& payloadData,
+                                                                 const Binary& streamerInfoData ){
     DESERIALIZE_BASE_CASE( BaseKeyed );                                                                                                                                                                                                             
     DESERIALIZE_POLIMORPHIC_CASE( BaseKeyed, DTKeyedConfig );
 

--- a/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
+++ b/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
@@ -14,9 +14,9 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 
 namespace cond {
-  template <> std::shared_ptr<PerformancePayload> deserialize<PerformancePayload>( const std::string& payloadType, 
-										     const Binary& payloadData, 
-										     const Binary& streamerInfoData ){
+  template <> std::unique_ptr<PerformancePayload> deserialize<PerformancePayload>( const std::string& payloadType,
+                                                                                   const Binary& payloadData, 
+                                                                                   const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( PerformancePayload );  abstract 
     DESERIALIZE_POLIMORPHIC_CASE( PerformancePayload, PerformancePayloadFromTFormula ); 
     DESERIALIZE_POLIMORPHIC_CASE( PerformancePayload, PerformancePayloadFromBinnedTFormula ); 

--- a/CondCore/PopCon/test/stubs/EffSourceHandler.cc
+++ b/CondCore/PopCon/test/stubs/EffSourceHandler.cc
@@ -56,7 +56,7 @@ void popcon::ExEffSource::getNewObjects() {
   if (tagInfo().size>0) {
     Ref payload = lastPayload();
     edm::LogInfo   ("ExEffsSource")<<" type of last payload  "<< 
-      typeid(*payload).name()<<std::endl;
+      typeid(value_type).name()<<std::endl;
   }
 
 

--- a/CondCore/PopCon/test/stubs/EffSourceHandler.cc
+++ b/CondCore/PopCon/test/stubs/EffSourceHandler.cc
@@ -14,9 +14,9 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 
 namespace cond {
-  template <> std::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
-                                                                                     const Binary& payloadData,
-                                                                                     const Binary& streamerInfoData ){
+  template <> std::unique_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
+                                                                                   const Binary& payloadData,
+                                                                                   const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( condex::Efficiency );  abstract
     DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInPt );
     DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInEta );

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -2,8 +2,7 @@
 
 #define FETCH_PAYLOAD_CASE( TYPENAME ) \
   if( payloadTypeName == #TYPENAME ){ \
-    auto payload = deserialize<TYPENAME>( payloadTypeName, data, streamerInfo ); \
-    payloadPtr = payload; \
+    payloadPtr = deserialize<TYPENAME>( payloadTypeName, data, streamerInfo ); \
     match = true; \
   }
 
@@ -305,18 +304,15 @@ namespace cond {
 
       //   
       if( payloadTypeName == "PhysicsTools::Calibration::Histogram3D<double,double,double,double>" ){    
-	auto payload = deserialize<PhysicsTools::Calibration::Histogram3D<double,double,double,double> >(payloadTypeName, data, streamerInfo );
-	payloadPtr = payload;
+	payloadPtr = deserialize<PhysicsTools::Calibration::Histogram3D<double,double,double,double> >(payloadTypeName, data, streamerInfo );
 	match = true;
       }
       if( payloadTypeName == "PhysicsTools::Calibration::Histogram2D<double,double,double>" ){    
-	auto payload = deserialize<PhysicsTools::Calibration::Histogram2D<double,double,double> >(payloadTypeName, data, streamerInfo );
-	payloadPtr = payload;
+	payloadPtr = deserialize<PhysicsTools::Calibration::Histogram2D<double,double,double> >(payloadTypeName, data, streamerInfo );
 	match = true;
       }
       if( payloadTypeName == "std::vector<unsignedlonglong,std::allocator<unsignedlonglong>>" ){
-	auto payload = deserialize<std::vector<unsigned long long> >( payloadTypeName, data, streamerInfo );
-	payloadPtr = payload;
+	payloadPtr = deserialize<std::vector<unsigned long long> >( payloadTypeName, data, streamerInfo );
 	match = true;
       }
   

--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -54,9 +54,9 @@ class L1ConfigOnlineProdBase : public edm::ESProducer {
       L1ConfigOnlineProdBase(const edm::ParameterSet&);
       ~L1ConfigOnlineProdBase() override;
 
-      virtual std::shared_ptr< TData > produce(const TRcd& iRecord);
+      virtual std::unique_ptr< TData > produce(const TRcd& iRecord);
 
-      virtual std::shared_ptr< TData > newObject(
+      virtual std::unique_ptr< TData > newObject(
 	const std::string& objectKey ) = 0 ;
 
    private:
@@ -71,7 +71,6 @@ class L1ConfigOnlineProdBase : public edm::ESProducer {
       // If bool is false, produce method should throw
       // DataAlreadyPresentException.
       bool getObjectKey( const TRcd& record,
-                         std::shared_ptr< TData > data,
                          std::string& objectKey ) ;
 
       // For reading object directly from a CondDB w/o PoolDBOutputService
@@ -125,15 +124,14 @@ L1ConfigOnlineProdBase<TRcd, TData>::~L1ConfigOnlineProdBase()
 }
 
 template< class TRcd, class TData >
-std::shared_ptr< TData >
+std::unique_ptr< TData >
 L1ConfigOnlineProdBase<TRcd, TData>::produce( const TRcd& iRecord )
 {
-   using namespace edm::es;
-   std::shared_ptr< TData > pData ;
+   std::unique_ptr< TData > pData ;
 
    // Get object key and check if already in ORCON
    std::string key ;
-   if( getObjectKey( iRecord, pData, key ) || m_forceGeneration )
+   if( getObjectKey( iRecord, key ) || m_forceGeneration )
    {
      if( m_copyFromCondDB )
        {
@@ -171,7 +169,7 @@ L1ConfigOnlineProdBase<TRcd, TData>::produce( const TRcd& iRecord )
        }
 
      //     if( pData.get() == 0 )
-     if( pData == std::shared_ptr< TData >() )
+     if( pData == std::unique_ptr< TData >() )
        {
 	 std::string dataType = edm::typelookup::className<TData>();
 
@@ -196,7 +194,6 @@ template< class TRcd, class TData >
 bool 
 L1ConfigOnlineProdBase<TRcd, TData>::getObjectKey(
   const TRcd& record,
-  std::shared_ptr< TData > data,
   std::string& objectKey )
 {
    // Get L1TriggerKey

--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -238,7 +238,7 @@ L1ConfigOnlineProdBase<TRcd, TData>::getObjectKey(
 
    // If L1TriggerKeyList does not contain object key, token is empty
    return
-      keyList.token( recordName, dataType, objectKey ) == std::string() ;
+      keyList.token( recordName, dataType, objectKey ).empty() ;
 }
 
 #endif

--- a/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.cc
+++ b/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.cc
@@ -92,7 +92,7 @@ L1SubsystemKeysOnlineProd::produce(const L1TriggerKeyRcd& iRecord)
      }
 
    // If L1TriggerKeyList does not contain TSC key, token is empty
-   if( keyList.token( m_tscKey ) == std::string() ||
+   if( keyList.token( m_tscKey ).empty() ||
        m_forceGeneration )
      {
        // Instantiate new L1TriggerKey

--- a/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.cc
+++ b/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.cc
@@ -80,7 +80,6 @@ L1SubsystemKeysOnlineProd::~L1SubsystemKeysOnlineProd()
 L1SubsystemKeysOnlineProd::ReturnType
 L1SubsystemKeysOnlineProd::produce(const L1TriggerKeyRcd& iRecord)
 {
-   using namespace edm::es;
    std::unique_ptr<L1TriggerKey> pL1TriggerKey ;
 
    // Get L1TriggerKeyList

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyDummyProd.cc
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyDummyProd.cc
@@ -105,7 +105,6 @@ L1TriggerKeyDummyProd::~L1TriggerKeyDummyProd()
 L1TriggerKeyDummyProd::ReturnType
 L1TriggerKeyDummyProd::produce(const L1TriggerKeyRcd& iRecord)
 {
-   using namespace edm::es;
    return std::make_unique< L1TriggerKey >(m_key) ;
 }
 

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyListDummyProd.cc
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyListDummyProd.cc
@@ -65,7 +65,6 @@ L1TriggerKeyListDummyProd::~L1TriggerKeyListDummyProd()
 L1TriggerKeyListDummyProd::ReturnType
 L1TriggerKeyListDummyProd::produce(const L1TriggerKeyListRcd& iRecord)
 {
-   using namespace edm::es;
    std::unique_ptr<L1TriggerKeyList> pL1TriggerKeyList ;
    pL1TriggerKeyList = std::make_unique< L1TriggerKeyList >() ;
    return pL1TriggerKeyList ;

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
@@ -73,8 +73,6 @@ L1TriggerKeyOnlineProd::~L1TriggerKeyOnlineProd()
 L1TriggerKeyOnlineProd::ReturnType
 L1TriggerKeyOnlineProd::produce(const L1TriggerKeyRcd& iRecord)
 {
-   using namespace edm::es;
-
    // Start with "SubsystemKeysOnly"
    edm::ESHandle< L1TriggerKey > subsystemKeys ;
    try

--- a/CondTools/L1Trigger/src/L1ObjectKeysOnlineProdBase.cc
+++ b/CondTools/L1Trigger/src/L1ObjectKeysOnlineProdBase.cc
@@ -80,8 +80,6 @@ L1ObjectKeysOnlineProdBase::~L1ObjectKeysOnlineProdBase()
 L1ObjectKeysOnlineProdBase::ReturnType
 L1ObjectKeysOnlineProdBase::produce(const L1TriggerKeyRcd& iRecord)
 {
-   using namespace edm::es;
-
   // Get L1TriggerKey with label "SubsystemKeysOnly".  Re-throw exception if
   // not present.
   edm::ESHandle< L1TriggerKey > subsystemKeys ;

--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -35,9 +35,9 @@ class L1ConfigOnlineProdBaseExt : public edm::ESProducer {
       L1ConfigOnlineProdBaseExt(const edm::ParameterSet&);
       ~L1ConfigOnlineProdBaseExt() override;
 
-      std::shared_ptr< TData > produce(const TRcd& iRecord);
+      std::unique_ptr< const TData > produce(const TRcd& iRecord);
 
-      virtual std::shared_ptr< TData > newObject(
+      virtual std::unique_ptr< const TData > newObject(
 	const std::string& objectKey, const TRcd& iRecord) = 0 ;
 
    private:
@@ -52,7 +52,6 @@ class L1ConfigOnlineProdBaseExt : public edm::ESProducer {
       // If bool is false, produce method should throw
       // DataAlreadyPresentException.
       bool getObjectKey( const TRcd& record,
-                         std::shared_ptr< TData > data,
                          std::string& objectKey ) ;
 
       // For reading object directly from a CondDB w/o PoolDBOutputService
@@ -106,15 +105,14 @@ L1ConfigOnlineProdBaseExt<TRcd, TData>::~L1ConfigOnlineProdBaseExt()
 }
 
 template< class TRcd, class TData >
-std::shared_ptr< TData >
+std::unique_ptr< const TData >
 L1ConfigOnlineProdBaseExt<TRcd, TData>::produce( const TRcd& iRecord )
 {
-   using namespace edm::es;
-   std::shared_ptr< TData > pData ;
+   std::unique_ptr< const TData > pData ;
 
    // Get object key and check if already in ORCON
    std::string key ;
-   if( getObjectKey( iRecord, pData, key ) || m_forceGeneration )
+   if( getObjectKey( iRecord, key ) || m_forceGeneration )
    {
      if( m_copyFromCondDB )
        {
@@ -157,7 +155,7 @@ L1ConfigOnlineProdBaseExt<TRcd, TData>::produce( const TRcd& iRecord )
        }
 
      //     if( pData.get() == 0 )
-     if( pData == std::shared_ptr< TData >() )
+     if( pData == std::unique_ptr< const TData >() )
        {
 	 std::string dataType = edm::typelookup::className<TData>();
 
@@ -182,7 +180,6 @@ template< class TRcd, class TData >
 bool 
 L1ConfigOnlineProdBaseExt<TRcd, TData>::getObjectKey(
   const TRcd& record,
-  std::shared_ptr< TData > data,
   std::string& objectKey )
 {
    // Get L1TriggerKeyExt

--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -229,7 +229,7 @@ L1ConfigOnlineProdBaseExt<TRcd, TData>::getObjectKey(
    // If L1TriggerKeyList does not contain object key, token is empty
 
    return
-      keyList.token( recordName, dataType, objectKey ) == std::string() ;
+      keyList.token( recordName, dataType, objectKey ).empty() ;
 }
 
 #endif

--- a/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.cc
@@ -43,7 +43,6 @@ L1SubsystemKeysOnlineProdExt::~L1SubsystemKeysOnlineProdExt()
 L1SubsystemKeysOnlineProdExt::ReturnType
 L1SubsystemKeysOnlineProdExt::produce(const L1TriggerKeyExtRcd& iRecord)
 {
-   using namespace edm::es;
    std::unique_ptr<L1TriggerKeyExt> pL1TriggerKey ;
 
    // Get L1TriggerKeyListExt

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyDummyProdExt.cc
@@ -59,7 +59,6 @@ L1TriggerKeyDummyProdExt::~L1TriggerKeyDummyProdExt()
 L1TriggerKeyDummyProdExt::ReturnType
 L1TriggerKeyDummyProdExt::produce(const L1TriggerKeyExtRcd& iRecord)
 {
-   using namespace edm::es;
    return std::make_unique< L1TriggerKeyExt >(m_key) ;
 }
 

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyListDummyProdExt.cc
@@ -27,7 +27,6 @@ L1TriggerKeyListDummyProdExt::~L1TriggerKeyListDummyProdExt()
 L1TriggerKeyListDummyProdExt::ReturnType
 L1TriggerKeyListDummyProdExt::produce(const L1TriggerKeyListExtRcd& iRecord)
 {
-   using namespace edm::es;
    return std::make_unique< L1TriggerKeyListExt >() ;
 }
 

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
@@ -35,8 +35,6 @@ L1TriggerKeyOnlineProdExt::~L1TriggerKeyOnlineProdExt()
 L1TriggerKeyOnlineProdExt::ReturnType
 L1TriggerKeyOnlineProdExt::produce(const L1TriggerKeyExtRcd& iRecord)
 {
-   using namespace edm::es;
-
    // Start with "SubsystemKeysOnly"
    edm::ESHandle< L1TriggerKeyExt > subsystemKeys ;
    try

--- a/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
+++ b/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
@@ -34,8 +34,6 @@ L1ObjectKeysOnlineProdBaseExt::~L1ObjectKeysOnlineProdBaseExt()
 L1ObjectKeysOnlineProdBaseExt::ReturnType
 L1ObjectKeysOnlineProdBaseExt::produce(const L1TriggerKeyExtRcd& iRecord)
 {
-   using namespace edm::es;
-
   // Get L1TriggerKeyExt with label "SubsystemKeysOnly".  Re-throw exception if
   // not present.
   edm::ESHandle< L1TriggerKeyExt > subsystemKeys ;

--- a/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFAlignmentOnlineProd.h
+++ b/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFAlignmentOnlineProd.h
@@ -7,7 +7,7 @@ class CSCTFAlignmentOnlineProd : public L1ConfigOnlineProdBase< L1MuCSCTFAlignme
       CSCTFAlignmentOnlineProd(const edm::ParameterSet& iConfig)
          : L1ConfigOnlineProdBase< L1MuCSCTFAlignmentRcd, L1MuCSCTFAlignment >( iConfig ) {}
       ~CSCTFAlignmentOnlineProd() override {}
-      std::shared_ptr< L1MuCSCTFAlignment > newObject( const std::string& objectKey ) override ;
+      std::unique_ptr< L1MuCSCTFAlignment > newObject( const std::string& objectKey ) override ;
    private:
 };
 

--- a/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFConfigOnlineProd.h
+++ b/L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFConfigOnlineProd.h
@@ -8,7 +8,7 @@ class CSCTFConfigOnlineProd : public L1ConfigOnlineProdBase< L1MuCSCTFConfigurat
          : L1ConfigOnlineProdBase< L1MuCSCTFConfigurationRcd, L1MuCSCTFConfiguration >( iConfig ) {}
       ~CSCTFConfigOnlineProd() override {}
 
-      std::shared_ptr< L1MuCSCTFConfiguration > newObject( const std::string& objectKey ) override ;
+      std::unique_ptr< L1MuCSCTFConfiguration > newObject( const std::string& objectKey ) override ;
    private:
 };
 

--- a/L1TriggerConfig/CSCTFConfigProducers/interface/L1MuCSCPtLutConfigOnlineProd.h
+++ b/L1TriggerConfig/CSCTFConfigProducers/interface/L1MuCSCPtLutConfigOnlineProd.h
@@ -8,7 +8,7 @@ class L1MuCSCPtLutConfigOnlineProd : public L1ConfigOnlineProdBase< L1MuCSCPtLut
          : L1ConfigOnlineProdBase< L1MuCSCPtLutRcd, L1MuCSCPtLut >( iConfig ) {}
       ~L1MuCSCPtLutConfigOnlineProd() override {}
 
-      std::shared_ptr< L1MuCSCPtLut > newObject( const std::string& objectKey ) override ;
+      std::unique_ptr< L1MuCSCPtLut > newObject( const std::string& objectKey ) override ;
    private:
 };
 

--- a/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFAlignmentOnlineProd.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFAlignmentOnlineProd.cc
@@ -1,6 +1,6 @@
 #include "L1TriggerConfig/CSCTFConfigProducers/interface/CSCTFAlignmentOnlineProd.h"
 
-std::shared_ptr< L1MuCSCTFAlignment >
+std::unique_ptr< L1MuCSCTFAlignment >
 CSCTFAlignmentOnlineProd::newObject( const std::string& objectKey )
 {
    // Execute SQL queries to get data from OMDS (using key) and make C++ object
@@ -35,7 +35,7 @@ CSCTFAlignmentOnlineProd::newObject( const std::string& objectKey )
    if( results.queryFailed() ) // check if query was successful
    {
       edm::LogError( "L1-O2O" ) << "Problem with CSCTF_ALIGN_PARAM query." ;
-      return std::make_shared<L1MuCSCTFAlignment>() ;
+      return std::make_unique<L1MuCSCTFAlignment>() ;
    }
 
 // oracle doesn't support double so some tweaks
@@ -66,7 +66,7 @@ CSCTFAlignmentOnlineProd::newObject( const std::string& objectKey )
 	edm::LogInfo( "algn_par queried" ) << par_align[i] ;
 	par_align_double[i]=par_align[i] ;
    }
-   return std::make_shared<L1MuCSCTFAlignment>(par_align_double) ;
+   return std::make_unique<L1MuCSCTFAlignment>(par_align_double) ;
 }
 
 

--- a/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigOnlineProd.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigOnlineProd.cc
@@ -2,7 +2,7 @@
 #include <cstdio>
 #include <string>
 
-std::shared_ptr< L1MuCSCTFConfiguration >
+std::unique_ptr< L1MuCSCTFConfiguration >
 CSCTFConfigOnlineProd::newObject( const std::string& objectKey )
 {
   
@@ -39,7 +39,7 @@ CSCTFConfigOnlineProd::newObject( const std::string& objectKey )
       {
 	edm::LogError( "L1-O2O" ) << "Problem with L1CSCTFParameters key." ;
 	// return empty configuration
-	return std::make_shared<L1MuCSCTFConfiguration>() ;
+	return std::make_unique<L1MuCSCTFConfiguration>() ;
       }
   
 
@@ -137,7 +137,7 @@ CSCTFConfigOnlineProd::newObject( const std::string& objectKey )
   }  
   
   // return the final object with the configuration for all CSCTF
-  return std::make_shared<L1MuCSCTFConfiguration>(csctfreg) ;    
+  return std::make_unique<L1MuCSCTFConfiguration>(csctfreg) ;    
 
 }
 

--- a/L1TriggerConfig/CSCTFConfigProducers/src/L1MuCSCPtLutConfigOnlineProd.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/L1MuCSCPtLutConfigOnlineProd.cc
@@ -1,6 +1,6 @@
 #include "L1TriggerConfig/CSCTFConfigProducers/interface/L1MuCSCPtLutConfigOnlineProd.h"
 
-std::shared_ptr< L1MuCSCPtLut >
+std::unique_ptr< L1MuCSCPtLut >
 L1MuCSCPtLutConfigOnlineProd::newObject( const std::string& objectKey )
 {
 
@@ -24,7 +24,7 @@ L1MuCSCPtLutConfigOnlineProd::newObject( const std::string& objectKey )
     {
       edm::LogError( "L1-O2O" ) << "Problem with L1MuCSCPtLutParameters key" ;
       // return empty object
-      return std::shared_ptr< L1MuCSCPtLut >() ;
+      return std::unique_ptr< L1MuCSCPtLut >() ;
     }
   
   
@@ -37,7 +37,7 @@ L1MuCSCPtLutConfigOnlineProd::newObject( const std::string& objectKey )
   
   edm::LogInfo( "L1-O2O: L1MuCSCPtLutConfigOnlineProd" ) << "Returning L1MuCSCPtLut";
 
-  std::shared_ptr< L1MuCSCPtLut > CSCTFPtLut = std::make_shared< L1MuCSCPtLut >();
+  auto CSCTFPtLut = std::make_unique< L1MuCSCPtLut >();
   CSCTFPtLut->readFromDBS(ptlut);
 
   return CSCTFPtLut;

--- a/L1TriggerConfig/DTTrackFinder/src/DTEtaPatternLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTEtaPatternLutOnlineProd.cc
@@ -39,8 +39,8 @@ class DTEtaPatternLutOnlineProd :
       DTEtaPatternLutOnlineProd(const edm::ParameterSet&);
       ~DTEtaPatternLutOnlineProd() override;
 
-  std::shared_ptr< L1MuDTEtaPatternLut > newObject(
-    const std::string& objectKey ) override ;
+      std::unique_ptr< L1MuDTEtaPatternLut > newObject(
+         const std::string& objectKey ) override ;
 
    private:
       // ----------member data ---------------------------
@@ -77,13 +77,13 @@ DTEtaPatternLutOnlineProd::~DTEtaPatternLutOnlineProd()
 
 }
 
-std::shared_ptr< L1MuDTEtaPatternLut >
+std::unique_ptr< L1MuDTEtaPatternLut >
 DTEtaPatternLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTEtaPatternLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return std::shared_ptr< L1MuDTEtaPatternLut >() ;
+  return std::unique_ptr< L1MuDTEtaPatternLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTExtLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTExtLutOnlineProd.cc
@@ -39,8 +39,8 @@ class DTExtLutOnlineProd :
       DTExtLutOnlineProd(const edm::ParameterSet&);
       ~DTExtLutOnlineProd() override;
 
-  std::shared_ptr< L1MuDTExtLut > newObject(
-    const std::string& objectKey ) override ;
+      std::unique_ptr< L1MuDTExtLut > newObject(
+         const std::string& objectKey ) override ;
 
    private:
       // ----------member data ---------------------------
@@ -77,13 +77,13 @@ DTExtLutOnlineProd::~DTExtLutOnlineProd()
 
 }
 
-std::shared_ptr< L1MuDTExtLut >
+std::unique_ptr< L1MuDTExtLut >
 DTExtLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTExtLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return std::shared_ptr< L1MuDTExtLut >() ;
+  return std::unique_ptr< L1MuDTExtLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTPhiLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTPhiLutOnlineProd.cc
@@ -39,8 +39,8 @@ class DTPhiLutOnlineProd :
       DTPhiLutOnlineProd(const edm::ParameterSet&);
       ~DTPhiLutOnlineProd() override;
 
-  std::shared_ptr< L1MuDTPhiLut > newObject(
-    const std::string& objectKey ) override ;
+      std::unique_ptr< L1MuDTPhiLut > newObject(
+         const std::string& objectKey ) override ;
 
    private:
       // ----------member data ---------------------------
@@ -77,13 +77,13 @@ DTPhiLutOnlineProd::~DTPhiLutOnlineProd()
 
 }
 
-std::shared_ptr< L1MuDTPhiLut >
+std::unique_ptr< L1MuDTPhiLut >
 DTPhiLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTPhiLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return std::shared_ptr< L1MuDTPhiLut >() ;
+  return std::unique_ptr< L1MuDTPhiLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTPtaLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTPtaLutOnlineProd.cc
@@ -39,8 +39,8 @@ class DTPtaLutOnlineProd :
       DTPtaLutOnlineProd(const edm::ParameterSet&);
       ~DTPtaLutOnlineProd() override;
 
-  std::shared_ptr< L1MuDTPtaLut > newObject(
-    const std::string& objectKey ) override ;
+      std::unique_ptr< L1MuDTPtaLut > newObject(
+         const std::string& objectKey ) override ;
 
    private:
       // ----------member data ---------------------------
@@ -77,13 +77,13 @@ DTPtaLutOnlineProd::~DTPtaLutOnlineProd()
 
 }
 
-std::shared_ptr< L1MuDTPtaLut >
+std::unique_ptr< L1MuDTPtaLut >
 DTPtaLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTPtaLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return std::shared_ptr< L1MuDTPtaLut >() ;
+  return std::unique_ptr< L1MuDTPtaLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTQualPatternLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTQualPatternLutOnlineProd.cc
@@ -39,8 +39,8 @@ class DTQualPatternLutOnlineProd :
       DTQualPatternLutOnlineProd(const edm::ParameterSet&);
       ~DTQualPatternLutOnlineProd() override;
 
-  std::shared_ptr< L1MuDTQualPatternLut > newObject(
-    const std::string& objectKey ) override ;
+      std::unique_ptr< L1MuDTQualPatternLut > newObject(
+         const std::string& objectKey ) override ;
 
    private:
       // ----------member data ---------------------------
@@ -77,13 +77,13 @@ DTQualPatternLutOnlineProd::~DTQualPatternLutOnlineProd()
 
 }
 
-std::shared_ptr< L1MuDTQualPatternLut >
+std::unique_ptr< L1MuDTQualPatternLut >
 DTQualPatternLutOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1MuDTQualPatternLut object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return std::shared_ptr< L1MuDTQualPatternLut >() ;
+  return std::unique_ptr< L1MuDTQualPatternLut >() ;
 }
 
 //

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFMasksOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFMasksOnlineProd.cc
@@ -36,7 +36,7 @@ class DTTFMasksOnlineProd :
       DTTFMasksOnlineProd(const edm::ParameterSet&);
       ~DTTFMasksOnlineProd() override;
 
-      std::shared_ptr< L1MuDTTFMasks > newObject(
+      std::unique_ptr< L1MuDTTFMasks > newObject(
         const std::string& objectKey ) override ;
 
    private:
@@ -66,12 +66,10 @@ DTTFMasksOnlineProd::~DTTFMasksOnlineProd()
 
 }
 
-std::shared_ptr< L1MuDTTFMasks >
+std::unique_ptr< L1MuDTTFMasks >
 DTTFMasksOnlineProd::newObject( const std::string& objectKey )
 {
-     using namespace edm::es;
-
-     auto pDTTFMasks = std::make_shared< L1MuDTTFMasks >() ;
+     auto pDTTFMasks = std::make_unique< L1MuDTTFMasks >() ;
 
      pDTTFMasks->reset() ;
 
@@ -104,7 +102,7 @@ DTTFMasksOnlineProd::newObject( const std::string& objectKey )
        {
 	 edm::LogError( "L1-O2O" )
 	   << "Problem with L1MuDTTFMasks key " << objectKey ;
-	 return std::shared_ptr< L1MuDTTFMasks >() ;
+	 return std::unique_ptr< L1MuDTTFMasks >() ;
        }
 
      // Cache crate masks

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFParametersOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFParametersOnlineProd.cc
@@ -36,7 +36,7 @@ class DTTFParametersOnlineProd :
       DTTFParametersOnlineProd(const edm::ParameterSet&);
       ~DTTFParametersOnlineProd() override;
 
-      std::shared_ptr< L1MuDTTFParameters > newObject(
+      std::unique_ptr< L1MuDTTFParameters > newObject(
         const std::string& objectKey ) override ;
 
    private:
@@ -66,12 +66,10 @@ DTTFParametersOnlineProd::~DTTFParametersOnlineProd()
 
 }
 
-std::shared_ptr< L1MuDTTFParameters >
+std::unique_ptr< L1MuDTTFParameters >
 DTTFParametersOnlineProd::newObject( const std::string& objectKey )
 {
-     using namespace edm::es;
-
-     auto pDTTFParameters = std::make_shared< L1MuDTTFParameters >() ;
+     auto pDTTFParameters = std::make_unique< L1MuDTTFParameters >() ;
 
      pDTTFParameters->reset() ;
 
@@ -98,7 +96,7 @@ DTTFParametersOnlineProd::newObject( const std::string& objectKey )
        {
 	 edm::LogError( "L1-O2O" )
 	   << "Problem with L1MuDTTFParameters key " << objectKey ;
-	 return std::shared_ptr< L1MuDTTFParameters >() ;
+	 return std::unique_ptr< L1MuDTTFParameters >() ;
        }
 
      // print crate keys -- delete when done debugging
@@ -180,7 +178,7 @@ DTTFParametersOnlineProd::newObject( const std::string& objectKey )
 		   {
 		     edm::LogError( "L1-O2O" )
 		       << "Problem with WEDGE_CRATE_CONF key." ;
-		     return std::shared_ptr< L1MuDTTFParameters >() ;
+		     return std::unique_ptr< L1MuDTTFParameters >() ;
 		   }
 		 
 		 std::string dummy ;
@@ -200,7 +198,7 @@ DTTFParametersOnlineProd::newObject( const std::string& objectKey )
 		       {
 			 edm::LogError( "L1-O2O" )
 			   << "Problem with PHTF_CONF key." ;
-			 return std::shared_ptr< L1MuDTTFParameters >() ;
+			 return std::unique_ptr< L1MuDTTFParameters >() ;
 		       }
 		     
 		     long long tmp ;

--- a/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersOnlineProducer.h
+++ b/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersOnlineProducer.h
@@ -33,7 +33,7 @@ public:
   ~L1MuGMTParametersOnlineProducer() override;
   
   /// The method that actually implements the production of the parameter objects
-  std::shared_ptr<L1MuGMTParameters> newObject( const std::string& objectKey ) override;
+  std::unique_ptr<L1MuGMTParameters> newObject( const std::string& objectKey ) override;
  protected:
 
   void checkCMSSWVersion(const coral::AttributeList& configRecord);

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTChannelMaskOnlineProducer.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTChannelMaskOnlineProducer.cc
@@ -8,11 +8,11 @@ class L1MuGMTChannelMaskOnlineProducer : public L1ConfigOnlineProdBase< L1MuGMTC
          : L1ConfigOnlineProdBase< L1MuGMTChannelMaskRcd, L1MuGMTChannelMask >( iConfig ) {}
       ~L1MuGMTChannelMaskOnlineProducer() override {}
 
-      std::shared_ptr< L1MuGMTChannelMask > newObject( const std::string& objectKey ) override ;
+      std::unique_ptr< L1MuGMTChannelMask > newObject( const std::string& objectKey ) override ;
    private:
 };
 
-std::shared_ptr< L1MuGMTChannelMask >
+std::unique_ptr< L1MuGMTChannelMask >
 L1MuGMTChannelMaskOnlineProducer::newObject( const std::string& objectKey )
 {
 
@@ -35,7 +35,7 @@ L1MuGMTChannelMaskOnlineProducer::newObject( const std::string& objectKey )
    if( results.queryFailed() ) // check if query was successful
    {
       edm::LogError( "L1-O2O" ) << "L1MuGMTChannelMaskOnlineProducer: Problem getting " << objectKey << " key from GMT_RUN_SETTING." ;
-      return std::shared_ptr< L1MuGMTChannelMask >() ;
+      return std::unique_ptr< L1MuGMTChannelMask >() ;
    }
 
    unsigned mask = 0;
@@ -49,7 +49,7 @@ L1MuGMTChannelMaskOnlineProducer::newObject( const std::string& objectKey )
    results.fillVariable( "ENABLE_RPCF", maskaux ) ;
    if(!maskaux) mask|=8;
 
-   auto gmtchanmask = std::make_shared< L1MuGMTChannelMask >();
+   auto gmtchanmask = std::make_unique< L1MuGMTChannelMask >();
 
    gmtchanmask->setSubsystemMask(mask);
    

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersOnlineProducer.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersOnlineProducer.cc
@@ -31,10 +31,8 @@ RH_ASSIGN_GROUP(L1MuGMTParameters, TGlobalTriggerGroup)
  *  Query the CMS_GMT.GMT_SOFTWARE_CONFIG table with a key determined by the "master" config table
  *  and return the matching record.
  */
-std::shared_ptr<L1MuGMTParameters> L1MuGMTParametersOnlineProducer::newObject( const std::string& objectKey )
+std::unique_ptr<L1MuGMTParameters> L1MuGMTParametersOnlineProducer::newObject( const std::string& objectKey )
 {
-  using namespace edm::es;
-
   RecordHelper<L1MuGMTParameters> helper;
 
   // Copy data members from L1MuGMTParameters,
@@ -83,7 +81,7 @@ std::shared_ptr<L1MuGMTParameters> L1MuGMTParametersOnlineProducer::newObject( c
   ADD_FIELD(helper, L1MuGMTParameters, VersionSortRankEtaQLUT);
   ADD_FIELD(helper, L1MuGMTParameters, VersionLUTs);
 
-  auto ptrResult = std::make_shared<L1MuGMTParameters>();
+  auto ptrResult = std::make_unique<L1MuGMTParameters>();
 
   std::vector<std::string> resultColumns = helper.getColumnList();
   resultColumns.push_back("CMSSW_VERSION");

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersProducer.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersProducer.cc
@@ -34,7 +34,7 @@ L1MuGMTParametersProducer::~L1MuGMTParametersProducer() {
 std::unique_ptr<L1MuGMTParameters> 
 L1MuGMTParametersProducer::produceL1MuGMTParameters(const L1MuGMTParametersRcd& iRecord)
 {
-  std::unique_ptr<L1MuGMTParameters> gmtparams = std::unique_ptr<L1MuGMTParameters>( new L1MuGMTParameters() );
+  auto gmtparams = std::make_unique<L1MuGMTParameters>();
 
   gmtparams->setEtaWeight_barrel(m_ps->getParameter<double>("EtaWeight_barrel"));
   gmtparams->setPhiWeight_barrel(m_ps->getParameter<double>("PhiWeight_barrel"));
@@ -85,11 +85,10 @@ L1MuGMTParametersProducer::produceL1MuGMTParameters(const L1MuGMTParametersRcd& 
 std::unique_ptr<L1MuGMTChannelMask> 
 L1MuGMTParametersProducer::produceL1MuGMTChannelMask(const L1MuGMTChannelMaskRcd& iRecord)
 {
-  std::unique_ptr<L1MuGMTChannelMask> gmtchanmask = std::unique_ptr<L1MuGMTChannelMask>( new L1MuGMTChannelMask() );
+  auto gmtchanmask = std::make_unique<L1MuGMTChannelMask>();
 
   gmtchanmask->setSubsystemMask(m_ps->getParameter<unsigned>("SubsystemMask"));
 
   return gmtchanmask ;
 }
-
 

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersProducer.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersProducer.cc
@@ -34,8 +34,6 @@ L1MuGMTParametersProducer::~L1MuGMTParametersProducer() {
 std::unique_ptr<L1MuGMTParameters> 
 L1MuGMTParametersProducer::produceL1MuGMTParameters(const L1MuGMTParametersRcd& iRecord)
 {
-  using namespace edm::es;
-
   std::unique_ptr<L1MuGMTParameters> gmtparams = std::unique_ptr<L1MuGMTParameters>( new L1MuGMTParameters() );
 
   gmtparams->setEtaWeight_barrel(m_ps->getParameter<double>("EtaWeight_barrel"));
@@ -87,8 +85,6 @@ L1MuGMTParametersProducer::produceL1MuGMTParameters(const L1MuGMTParametersRcd& 
 std::unique_ptr<L1MuGMTChannelMask> 
 L1MuGMTParametersProducer::produceL1MuGMTChannelMask(const L1MuGMTChannelMaskRcd& iRecord)
 {
-  using namespace edm::es;
-
   std::unique_ptr<L1MuGMTChannelMask> gmtchanmask = std::unique_ptr<L1MuGMTChannelMask>( new L1MuGMTChannelMask() );
 
   gmtchanmask->setSubsystemMask(m_ps->getParameter<unsigned>("SubsystemMask"));

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctChannelMaskOnlineProd.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctChannelMaskOnlineProd.cc
@@ -8,11 +8,11 @@ class L1GctChannelMaskOnlineProd : public L1ConfigOnlineProdBase< L1GctChannelMa
          : L1ConfigOnlineProdBase< L1GctChannelMaskRcd, L1GctChannelMask >( iConfig ) {}
       ~L1GctChannelMaskOnlineProd() override {}
 
-      std::shared_ptr< L1GctChannelMask > newObject( const std::string& objectKey ) override ;
+      std::unique_ptr< L1GctChannelMask > newObject( const std::string& objectKey ) override ;
    private:
 };
 
-std::shared_ptr< L1GctChannelMask >
+std::unique_ptr< L1GctChannelMask >
 L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
 { 
   // get EM mask data
@@ -26,7 +26,7 @@ L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
   
   if( emMaskResults.queryFailed() ) { // check if query was successful
     edm::LogError( "L1-O2O" ) << "Problem with L1GctChannelMask EM mask for key "  << objectKey;
-    return std::shared_ptr< L1GctChannelMask >() ;
+    return std::unique_ptr< L1GctChannelMask >() ;
   }
   
   int emMask = -1;
@@ -43,7 +43,7 @@ L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
   
   if( rgnMaskKeyResults.queryFailed() ) { // check if query was successful
     edm::LogError( "L1-O2O" ) << "Problem with L1GctChannelMask region mask for key "  << objectKey;
-    return std::shared_ptr< L1GctChannelMask >() ;
+    return std::unique_ptr< L1GctChannelMask >() ;
   }
 
   std::string rgnKey;
@@ -89,7 +89,7 @@ L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
   
   if( esumMaskKeyResults.queryFailed() ) { // check if query was successful
     edm::LogError( "L1-O2O" ) << "Problem with L1GctChannelMask energy sum mask for key "  << objectKey;
-    return std::shared_ptr< L1GctChannelMask >() ;
+    return std::unique_ptr< L1GctChannelMask >() ;
   }
 
   std::string esumKey;
@@ -111,7 +111,7 @@ L1GctChannelMaskOnlineProd::newObject( const std::string& objectKey )
 
 
   // create masks object
-  auto masks = std::make_shared< L1GctChannelMask >();
+  auto masks = std::make_unique< L1GctChannelMask >();
   
   // set EM masks
   for (int i=0; i<18; i++) {

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctJetFinderParamsOnlineProd.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctJetFinderParamsOnlineProd.cc
@@ -8,11 +8,11 @@ class L1GctJetFinderParamsOnlineProd : public L1ConfigOnlineProdBase< L1GctJetFi
          : L1ConfigOnlineProdBase< L1GctJetFinderParamsRcd, L1GctJetFinderParams >( iConfig ) {}
       ~L1GctJetFinderParamsOnlineProd() override {}
 
-      std::shared_ptr< L1GctJetFinderParams > newObject( const std::string& objectKey ) override ;
+      std::unique_ptr< L1GctJetFinderParams > newObject( const std::string& objectKey ) override ;
    private:
 };
 
-std::shared_ptr< L1GctJetFinderParams >
+std::unique_ptr< L1GctJetFinderParams >
 L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
 {
    // Execute SQL queries to get data from OMDS (using key) and make C++ object
@@ -42,7 +42,7 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
    if( results.queryFailed() ) // check if query was successful
    {
       edm::LogError( "L1-O2O" ) << "Problem with L1GctJetFinderParams key." ;
-      return std::shared_ptr< L1GctJetFinderParams >() ;
+      return std::unique_ptr< L1GctJetFinderParams >() ;
    }
 
    // fill values
@@ -112,7 +112,7 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
    if( jetCorrResults.queryFailed() ) // check if query was successful
    {
       edm::LogError( "L1-O2O" ) << "Problem getting L1 jet corrections" ;
-      return std::shared_ptr< L1GctJetFinderParams >() ;
+      return std::unique_ptr< L1GctJetFinderParams >() ;
    }
 
    // fill jet corr type
@@ -162,7 +162,7 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
      if( results.queryFailed() ) // check if query was successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem getting L1 jet correction coefficients" ;
-	 return std::shared_ptr< L1GctJetFinderParams >() ;
+	 return std::unique_ptr< L1GctJetFinderParams >() ;
        }
 
      // fill coeffs - TODO
@@ -176,7 +176,7 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
      else if (corrType == 5) nCoeffs=6;  // PF
      else {
        edm::LogError( "L1-O2O" ) << "Unsupported jet correction type : " << corrType ;
-       return std::shared_ptr< L1GctJetFinderParams >() ;
+       return std::unique_ptr< L1GctJetFinderParams >() ;
      }
 
      for (unsigned j=0; j< nCoeffs; ++j) {
@@ -198,7 +198,7 @@ L1GctJetFinderParamsOnlineProd::newObject( const std::string& objectKey )
    
    
 
-   return std::make_shared< L1GctJetFinderParams >( 
+   return std::make_unique< L1GctJetFinderParams >( 
 						   rgnEtLsb,
 						   htLsb,
 						   cJetSeed,

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersConfigOnlineProd.h
@@ -42,7 +42,7 @@ public:
     ~L1GtParametersConfigOnlineProd() override;
 
     /// public methods
-    std::shared_ptr<L1GtParameters> newObject(const std::string& objectKey) override;
+    std::unique_ptr<L1GtParameters> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.h
@@ -42,7 +42,7 @@ public:
     ~L1GtPrescaleFactorsAlgoTrigConfigOnlineProd() override;
 
     /// public methods
-    std::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey) override;
+    std::unique_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigConfigOnlineProd.h
@@ -42,7 +42,7 @@ public:
     ~L1GtPrescaleFactorsTechTrigConfigOnlineProd() override;
 
     /// public methods
-    std::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey) override;
+    std::unique_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupConfigOnlineProd.h
@@ -45,7 +45,7 @@ public:
     ~L1GtPsbSetupConfigOnlineProd() override;
 
     /// public methods
-    std::shared_ptr<L1GtPsbSetup> newObject(const std::string& objectKey) override;
+    std::unique_ptr<L1GtPsbSetup> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigConfigOnlineProd.h
@@ -42,7 +42,7 @@ public:
     ~L1GtTriggerMaskAlgoTrigConfigOnlineProd() override;
 
     /// public methods
-    std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey) override;
+    std::unique_ptr<L1GtTriggerMask> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigConfigOnlineProd.h
@@ -42,7 +42,7 @@ public:
     ~L1GtTriggerMaskTechTrigConfigOnlineProd() override;
 
     /// public methods
-    std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey) override;
+    std::unique_ptr<L1GtTriggerMask> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.h
@@ -42,7 +42,7 @@ public:
     ~L1GtTriggerMaskVetoTechTrigConfigOnlineProd() override;
 
     /// public methods
-    std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey) override;
+    std::unique_ptr<L1GtTriggerMask> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuConfigOnlineProd.h
@@ -58,7 +58,7 @@ public:
     ~L1GtTriggerMenuConfigOnlineProd() override;
 
     /// public methods
-    std::shared_ptr<L1GtTriggerMenu> newObject(const std::string& objectKey) override;
+    std::unique_ptr<L1GtTriggerMenu> newObject(const std::string& objectKey) override;
 
     /// initialize the class (mainly reserve/resize)
     void init(const int numberConditionChips);

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersConfigOnlineProd.cc
@@ -38,11 +38,10 @@ L1GtParametersConfigOnlineProd::~L1GtParametersConfigOnlineProd() {
 
 // public methods
 
-std::shared_ptr<L1GtParameters> L1GtParametersConfigOnlineProd::newObject(
+std::unique_ptr<L1GtParameters> L1GtParametersConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
-    // shared pointer for L1GtParameters
-    auto pL1GtParameters = std::make_shared<L1GtParameters>();
+    auto pL1GtParameters = std::make_unique<L1GtParameters>();
 
     // l1GtParameters: parameters in table GTFE_SETUP_FK
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.cc
@@ -42,14 +42,13 @@ L1GtPrescaleFactorsAlgoTrigConfigOnlineProd::~L1GtPrescaleFactorsAlgoTrigConfigO
 
 // public methods
 
-std::shared_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsAlgoTrigConfigOnlineProd::newObject(
+std::unique_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsAlgoTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // FIXME seems to not work anymore in constructor...
     m_isDebugEnabled = edm::isDebugEnabled();
 
-    // shared pointer for L1GtPrescaleFactors
-    auto pL1GtPrescaleFactors = std::make_shared<L1GtPrescaleFactors>();
+    auto pL1GtPrescaleFactors = std::make_unique<L1GtPrescaleFactors>();
 
     // Procedure:
     // objectKey received as input is GT_RUN_SETTINGS_FK

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsTechTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsTechTrigConfigOnlineProd.cc
@@ -42,14 +42,13 @@ L1GtPrescaleFactorsTechTrigConfigOnlineProd::~L1GtPrescaleFactorsTechTrigConfigO
 
 // public methods
 
-std::shared_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsTechTrigConfigOnlineProd::newObject(
+std::unique_ptr<L1GtPrescaleFactors> L1GtPrescaleFactorsTechTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // FIXME seems to not work anymore in constructor...
     m_isDebugEnabled = edm::isDebugEnabled();
 
-    // shared pointer for L1GtPrescaleFactors
-    auto pL1GtPrescaleFactors = std::make_shared<L1GtPrescaleFactors>();
+    auto pL1GtPrescaleFactors = std::make_unique<L1GtPrescaleFactors>();
 
     // Procedure:
     // objectKey received as input is GT_RUN_SETTINGS_FK

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupConfigOnlineProd.cc
@@ -40,11 +40,10 @@ L1GtPsbSetupConfigOnlineProd::~L1GtPsbSetupConfigOnlineProd() {
 
 // public methods
 
-std::shared_ptr<L1GtPsbSetup> L1GtPsbSetupConfigOnlineProd::newObject(
+std::unique_ptr<L1GtPsbSetup> L1GtPsbSetupConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
-    // shared pointer for L1GtPsbSetup
-    auto pL1GtPsbSetup = std::make_shared<L1GtPsbSetup>();
+    auto pL1GtPsbSetup = std::make_unique<L1GtPsbSetup>();
 
     const std::string gtSchema = "CMS_GT";
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskAlgoTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskAlgoTrigConfigOnlineProd.cc
@@ -42,11 +42,10 @@ L1GtTriggerMaskAlgoTrigConfigOnlineProd::~L1GtTriggerMaskAlgoTrigConfigOnlinePro
 
 // public methods
 
-std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskAlgoTrigConfigOnlineProd::newObject(
+std::unique_ptr<L1GtTriggerMask> L1GtTriggerMaskAlgoTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
-    // shared pointer for L1GtTriggerMask
-    auto pL1GtTriggerMask = std::make_shared<L1GtTriggerMask>();
+    auto pL1GtTriggerMask = std::make_unique<L1GtTriggerMask>();
 
     // l1GtTriggerMaskAlgoTrig: FINOR_ALGO_FK key in GT_PARTITION_FINOR_ALGO
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskTechTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskTechTrigConfigOnlineProd.cc
@@ -41,11 +41,10 @@ L1GtTriggerMaskTechTrigConfigOnlineProd::~L1GtTriggerMaskTechTrigConfigOnlinePro
 
 // public methods
 
-std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskTechTrigConfigOnlineProd::newObject(
+std::unique_ptr<L1GtTriggerMask> L1GtTriggerMaskTechTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
-    // shared pointer for L1GtTriggerMask
-    auto pL1GtTriggerMask = std::make_shared<L1GtTriggerMask>();
+    auto pL1GtTriggerMask = std::make_unique<L1GtTriggerMask>();
 
     // l1GtTriggerMaskTechTrig: FINOR_TT_FK key in GT_PARTITION_FINOR_TT
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.cc
@@ -40,11 +40,10 @@ L1GtTriggerMaskVetoTechTrigConfigOnlineProd::~L1GtTriggerMaskVetoTechTrigConfigO
 
 // public methods
 
-std::shared_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoTechTrigConfigOnlineProd::newObject(
+std::unique_ptr<L1GtTriggerMask> L1GtTriggerMaskVetoTechTrigConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
-    // shared pointer for L1GtTriggerMask
-    auto pL1GtTriggerMask = std::make_shared<L1GtTriggerMask>();
+    auto pL1GtTriggerMask = std::make_unique<L1GtTriggerMask>();
 
     // l1GtTriggerMaskVetoTechTrig: VETO_TT_FK key in GT_PARTITION_VETO_TT
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuConfigOnlineProd.cc
@@ -79,14 +79,13 @@ void L1GtTriggerMenuConfigOnlineProd::init(const int numberConditionChips) {
 
 }
 
-std::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuConfigOnlineProd::newObject(
+std::unique_ptr<L1GtTriggerMenu> L1GtTriggerMenuConfigOnlineProd::newObject(
         const std::string& objectKey) {
 
     // FIXME seems to not work anymore in constructor...
     m_isDebugEnabled = edm::isDebugEnabled();
 
-    // shared pointer for L1GtTriggerMenu - empty menu
-    auto pL1GtTriggerMenuEmpty = std::make_shared<L1GtTriggerMenu>();
+    auto pL1GtTriggerMenuEmpty = std::make_unique<L1GtTriggerMenu>();
 
     // FIXME get it from L1GtStableParameters?
     //       initialize once, from outside
@@ -152,7 +151,7 @@ std::shared_ptr<L1GtTriggerMenu> L1GtTriggerMenuConfigOnlineProd::newObject(
     addConditions();
 
     // fill the record
-    auto pL1GtTriggerMenu = std::make_shared<L1GtTriggerMenu>(
+    auto pL1GtTriggerMenu = std::make_unique<L1GtTriggerMenu>(
                         menuName, numberConditionChips,
                         m_vecMuonTemplate,
                         m_vecCaloTemplate,

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleOnlineProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleOnlineProducer.h
@@ -35,7 +35,7 @@ public:
   L1MuTriggerPtScaleOnlineProducer(const edm::ParameterSet&);
   ~L1MuTriggerPtScaleOnlineProducer() override;
   
-  std::shared_ptr<L1MuTriggerPtScale> newObject(const std::string& objectKey) override;
+  std::unique_ptr<L1MuTriggerPtScale> newObject(const std::string& objectKey) override;
 
 private:
   // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesOnlineProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesOnlineProducer.h
@@ -37,7 +37,7 @@ public:
   L1MuTriggerScalesOnlineProducer(const edm::ParameterSet&);
   ~L1MuTriggerScalesOnlineProducer() override;
 
-  std::shared_ptr<L1MuTriggerScales> newObject(
+  std::unique_ptr<L1MuTriggerScales> newObject(
 	const std::string& objectKey ) override ;
 
 private:

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloEcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloEcalScaleConfigOnlineProd.cc
@@ -78,7 +78,7 @@ L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 {
      std:: cout << "object Key " << objectKey <<std::endl;
 
-     if(objectKey == "NULL" || objectKey == "")  { // return default blank ecal scale
+     if(objectKey == "NULL" || objectKey.empty())  { // return default blank ecal scale
        return std::make_unique<L1CaloEcalScale>(0);
      }
      if(objectKey == "IDENTITY") {  // return identity ecal scale

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -99,7 +99,7 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
   
      edm::LogInfo("L1CaloHcalScaleConfigOnlineProd") << "object Key " << objectKey;
 
-     if(objectKey == "NULL" || objectKey == "") { // return default blank ecal scale
+     if(objectKey == "NULL" || objectKey.empty()) { // return default blank ecal scale
        return std::make_unique<L1CaloHcalScale>(0);
      }
      if(objectKey == "IDENTITY") {  // return identity ecal scale

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesProducer.cc
@@ -75,7 +75,6 @@ L1CaloInputScalesProducer::~L1CaloInputScalesProducer()
 std::unique_ptr<L1CaloEcalScale>
 L1CaloInputScalesProducer::produceEcalScale(const L1CaloEcalScaleRcd& iRecord)
 {
-   using namespace edm::es;
    auto pL1CaloEcalScale = std::make_unique<L1CaloEcalScale>() ;
 
    std::vector< double >::const_iterator posItr =

--- a/L1TriggerConfig/L1ScalesProducers/src/L1EmEtScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1EmEtScaleOnlineProd.cc
@@ -36,8 +36,8 @@ class L1EmEtScaleOnlineProd :
       L1EmEtScaleOnlineProd(const edm::ParameterSet&);
       ~L1EmEtScaleOnlineProd() override;
 
-  std::shared_ptr< L1CaloEtScale > newObject(
-    const std::string& objectKey ) override ;
+      std::unique_ptr< L1CaloEtScale > newObject(
+         const std::string& objectKey ) override ;
 
 
    private:
@@ -74,11 +74,9 @@ L1EmEtScaleOnlineProd::~L1EmEtScaleOnlineProd()
 
 }
 
-std::shared_ptr< L1CaloEtScale >
+std::unique_ptr< L1CaloEtScale >
 L1EmEtScaleOnlineProd::newObject( const std::string& objectKey )
 {
-     using namespace edm::es;
-
      // ~~~~~~~~~ Cut values ~~~~~~~~~
 
 
@@ -170,7 +168,7 @@ L1EmEtScaleOnlineProd::newObject( const std::string& objectKey )
 	 scaleResults.numberRows() != 1 ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1EmEtScale key." ;
-	 return std::shared_ptr< L1CaloEtScale >() ;
+	 return std::unique_ptr< L1CaloEtScale >() ;
        }
      std::vector<double> m_thresholds;
 
@@ -192,7 +190,7 @@ L1EmEtScaleOnlineProd::newObject( const std::string& objectKey )
 	 lsbResults.numberRows() != 1 ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1EmEtScale key." ;
-	 return std::shared_ptr< L1CaloEtScale >() ;
+	 return std::unique_ptr< L1CaloEtScale >() ;
        }
 
      double m_lsb = 0.;
@@ -204,7 +202,7 @@ L1EmEtScaleOnlineProd::newObject( const std::string& objectKey )
 
      // Default objects for Lindsey 
 
-     return std::make_shared<L1CaloEtScale>(m_lsb,m_thresholds);
+     return std::make_unique<L1CaloEtScale>(m_lsb,m_thresholds);
 }
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1HfRingEtScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1HfRingEtScaleOnlineProd.cc
@@ -36,8 +36,8 @@ class L1HfRingEtScaleOnlineProd :
       L1HfRingEtScaleOnlineProd(const edm::ParameterSet&);
       ~L1HfRingEtScaleOnlineProd() override;
 
-  std::shared_ptr< L1CaloEtScale > newObject(
-    const std::string& objectKey ) override ;
+      std::unique_ptr< L1CaloEtScale > newObject(
+         const std::string& objectKey ) override ;
 
 
    private:
@@ -74,11 +74,9 @@ L1HfRingEtScaleOnlineProd::~L1HfRingEtScaleOnlineProd()
 
 }
 
-std::shared_ptr< L1CaloEtScale >
+std::unique_ptr< L1CaloEtScale >
 L1HfRingEtScaleOnlineProd::newObject( const std::string& objectKey )
 {
-     using namespace edm::es;
-
      // get scales keys
      l1t::OMDSReader::QueryResults scalesKeyResults =
        m_omdsReader.basicQuery(
@@ -182,7 +180,7 @@ L1HfRingEtScaleOnlineProd::newObject( const std::string& objectKey )
      }
 
      //~~~~~~~~~ Instantiate new L1HfRingEtScale object. ~~~~~~~~~
-     return std::make_shared<L1CaloEtScale>(0xff, 0x7, rgnEtLsb, thresholds);
+     return std::make_unique<L1CaloEtScale>(0xff, 0x7, rgnEtLsb, thresholds);
 }
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1HtMissScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1HtMissScaleOnlineProd.cc
@@ -36,8 +36,8 @@ class L1HtMissScaleOnlineProd :
       L1HtMissScaleOnlineProd(const edm::ParameterSet&);
       ~L1HtMissScaleOnlineProd() override;
 
-  std::shared_ptr< L1CaloEtScale > newObject(
-    const std::string& objectKey ) override ;
+      std::unique_ptr< L1CaloEtScale > newObject(
+         const std::string& objectKey ) override ;
 
 
    private:
@@ -74,10 +74,9 @@ L1HtMissScaleOnlineProd::~L1HtMissScaleOnlineProd()
 
 }
 
-std::shared_ptr< L1CaloEtScale >
+std::unique_ptr< L1CaloEtScale >
 L1HtMissScaleOnlineProd::newObject( const std::string& objectKey )
 {
-  using namespace edm::es;
      // get scales keys
      l1t::OMDSReader::QueryResults scalesKeyResults =
        m_omdsReader.basicQuery(
@@ -305,7 +304,7 @@ L1HtMissScaleOnlineProd::newObject( const std::string& objectKey )
      }
 
      // return object
-     return std::make_shared<L1CaloEtScale>( 0, 0x7f, rgnEtLsb, thresholds );
+     return std::make_unique<L1CaloEtScale>( 0, 0x7f, rgnEtLsb, thresholds );
 
 }
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1JetEtScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1JetEtScaleOnlineProd.cc
@@ -36,8 +36,8 @@ class L1JetEtScaleOnlineProd :
       L1JetEtScaleOnlineProd(const edm::ParameterSet&);
       ~L1JetEtScaleOnlineProd() override;
 
-  std::shared_ptr< L1CaloEtScale > newObject(
-    const std::string& objectKey ) override ;
+      std::unique_ptr< L1CaloEtScale > newObject(
+         const std::string& objectKey ) override ;
 
 
    private:
@@ -74,11 +74,9 @@ L1JetEtScaleOnlineProd::~L1JetEtScaleOnlineProd()
 
 }
 
-std::shared_ptr< L1CaloEtScale >
+std::unique_ptr< L1CaloEtScale >
 L1JetEtScaleOnlineProd::newObject( const std::string& objectKey )
 {
-     using namespace edm::es;
-
      // get scales keys
      l1t::OMDSReader::QueryResults scalesKeyResults =
        m_omdsReader.basicQuery(
@@ -237,7 +235,7 @@ L1JetEtScaleOnlineProd::newObject( const std::string& objectKey )
      }
 
      // return object
-     return std::make_shared<L1CaloEtScale>( rgnEtLsb, thresholds );
+     return std::make_unique<L1CaloEtScale>( rgnEtLsb, thresholds );
 }
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuGMTScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuGMTScalesProducer.cc
@@ -66,8 +66,6 @@ L1MuGMTScalesProducer::~L1MuGMTScalesProducer() {}
 std::unique_ptr<L1MuGMTScales> 
 L1MuGMTScalesProducer::produceL1MuGMTScales(const L1MuGMTScalesRcd& iRecord)
 {
-   using namespace edm::es;
-
    std::unique_ptr<L1MuGMTScales> l1muscale = std::unique_ptr<L1MuGMTScales>( new L1MuGMTScales( m_scales ) );
 
    return l1muscale ;

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuGMTScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuGMTScalesProducer.cc
@@ -66,8 +66,6 @@ L1MuGMTScalesProducer::~L1MuGMTScalesProducer() {}
 std::unique_ptr<L1MuGMTScales> 
 L1MuGMTScalesProducer::produceL1MuGMTScales(const L1MuGMTScalesRcd& iRecord)
 {
-   std::unique_ptr<L1MuGMTScales> l1muscale = std::unique_ptr<L1MuGMTScales>( new L1MuGMTScales( m_scales ) );
-
-   return l1muscale ;
+  return std::make_unique<L1MuGMTScales>(m_scales);
 }
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleOnlineProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleOnlineProducer.cc
@@ -36,11 +36,9 @@ L1MuTriggerPtScaleOnlineProducer::~L1MuTriggerPtScaleOnlineProducer() {}
 //
 
 // ------------ method called to produce the data  ------------
-std::shared_ptr<L1MuTriggerPtScale> 
+std::unique_ptr<L1MuTriggerPtScale> 
 L1MuTriggerPtScaleOnlineProducer::newObject(const std::string& objectKey )
 {
-   using namespace edm::es;
-
    // find Pt key from main scales key
    l1t::OMDSReader::QueryResults keysRecord = 
          m_omdsReader.basicQuery(
@@ -98,7 +96,7 @@ SQL> describe cms_gt.l1t_scale_muon_pt;
    vector<double> scales;
    h.extractScales(resultRecord, scales);
    
-   auto result = std::make_shared<L1MuTriggerPtScale>(m_nbitsPacking, m_signedPacking, m_nBins, scales);
+   auto result = std::make_unique<L1MuTriggerPtScale>(m_nbitsPacking, m_signedPacking, m_nBins, scales);
    
 #ifdef DEBUG_PT_SCALE
    cout << "PT scale:" << endl << result->getPtScale()->print() << endl;

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleProducer.cc
@@ -31,9 +31,6 @@ L1MuTriggerPtScaleProducer::~L1MuTriggerPtScaleProducer() {}
 std::unique_ptr<L1MuTriggerPtScale> 
 L1MuTriggerPtScaleProducer::produceL1MuTriggerPtScale(const L1MuTriggerPtScaleRcd& iRecord)
 {
-   std::unique_ptr<L1MuTriggerPtScale> l1muscale =
-     std::unique_ptr<L1MuTriggerPtScale>( new L1MuTriggerPtScale( m_scales ) );
-
-   return l1muscale ;
+  return std::make_unique<L1MuTriggerPtScale>(m_scales);
 }
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerPtScaleProducer.cc
@@ -31,8 +31,6 @@ L1MuTriggerPtScaleProducer::~L1MuTriggerPtScaleProducer() {}
 std::unique_ptr<L1MuTriggerPtScale> 
 L1MuTriggerPtScaleProducer::produceL1MuTriggerPtScale(const L1MuTriggerPtScaleRcd& iRecord)
 {
-   using namespace edm::es;
-
    std::unique_ptr<L1MuTriggerPtScale> l1muscale =
      std::unique_ptr<L1MuTriggerPtScale>( new L1MuTriggerPtScale( m_scales ) );
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesOnlineProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesOnlineProducer.cc
@@ -111,10 +111,8 @@ const string PhiScaleHelper::LowMarkColumn = "PHI_DEG_BIN_LOW_0";
 const string PhiScaleHelper::StepColumn = "PHI_DEG_BIN_STEP";
 
 // ------------ method called to produce the data  ------------
-std::shared_ptr<L1MuTriggerScales> L1MuTriggerScalesOnlineProducer::newObject(const std::string& objectKey ) 
+std::unique_ptr<L1MuTriggerScales> L1MuTriggerScalesOnlineProducer::newObject(const std::string& objectKey ) 
 {
-   using namespace edm::es;   
-
    // The key we get from the O2O subsystem is the CMS_GMT.L1T_SCALES key,
    // but the eta/phi scales have their own subtables, so let's find 
    // out.
@@ -198,5 +196,5 @@ std::shared_ptr<L1MuTriggerScales> L1MuTriggerScalesOnlineProducer::newObject(co
 
    m_scales.setPhiScale(*ptrPhiScale);
 
-   return std::make_shared<L1MuTriggerScales>(m_scales);
+   return std::make_unique<L1MuTriggerScales>(m_scales);
 }

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesProducer.cc
@@ -58,8 +58,6 @@ L1MuTriggerScalesProducer::~L1MuTriggerScalesProducer() {}
 std::unique_ptr<L1MuTriggerScales> 
 L1MuTriggerScalesProducer::produceL1MuTriggerScales(const L1MuTriggerScalesRcd& iRecord)
 {
-   using namespace edm::es;
-
    std::unique_ptr<L1MuTriggerScales> l1muscale =
      std::unique_ptr<L1MuTriggerScales>( new L1MuTriggerScales( m_scales ) );
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScalesProducer.cc
@@ -58,9 +58,6 @@ L1MuTriggerScalesProducer::~L1MuTriggerScalesProducer() {}
 std::unique_ptr<L1MuTriggerScales> 
 L1MuTriggerScalesProducer::produceL1MuTriggerScales(const L1MuTriggerScalesRcd& iRecord)
 {
-   std::unique_ptr<L1MuTriggerScales> l1muscale =
-     std::unique_ptr<L1MuTriggerScales>( new L1MuTriggerScales( m_scales ) );
-
-   return l1muscale ;
+  return std::make_unique<L1MuTriggerScales>(m_scales);
 }
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTrivialProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTrivialProducer.cc
@@ -53,8 +53,6 @@ L1ScalesTrivialProducer::~L1ScalesTrivialProducer()
 // ------------ method called to produce the data  ------------
 std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceEmScale(const L1EmEtScaleRcd& iRecord)
 {
-   using namespace edm::es;
-
    std::unique_ptr<L1CaloEtScale> emScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(m_emEtScaleInputLsb, m_emEtThresholds) );
 
    return emScale ;
@@ -62,8 +60,6 @@ std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceEmScale(const L1E
 
 std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceJetScale(const L1JetEtScaleRcd& iRecord)
 {
-   using namespace edm::es;
-
    std::unique_ptr<L1CaloEtScale> jetEtScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(m_jetEtScaleInputLsb, m_jetEtThresholds) );
 
    return jetEtScale ;
@@ -72,8 +68,6 @@ std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceJetScale(const L1
 
 std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceHtMissScale(const L1HtMissScaleRcd& iRecord)
 {
-   using namespace edm::es;
-
    std::unique_ptr<L1CaloEtScale> htMissScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(0, 0x7f, m_jetEtScaleInputLsb, m_htMissThresholds) );
 
    return htMissScale ;
@@ -82,8 +76,6 @@ std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceHtMissScale(const
 
 std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceHfRingScale(const L1HfRingEtScaleRcd& iRecord)
 {
-   using namespace edm::es;
-
    std::unique_ptr<L1CaloEtScale> hfRingEtScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(0xff, 0x7, m_jetEtScaleInputLsb, m_hfRingThresholds) );
 
    return hfRingEtScale ;

--- a/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTrivialProducer.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTrivialProducer.cc
@@ -53,32 +53,21 @@ L1ScalesTrivialProducer::~L1ScalesTrivialProducer()
 // ------------ method called to produce the data  ------------
 std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceEmScale(const L1EmEtScaleRcd& iRecord)
 {
-   std::unique_ptr<L1CaloEtScale> emScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(m_emEtScaleInputLsb, m_emEtThresholds) );
-
-   return emScale ;
+   return std::make_unique<L1CaloEtScale>(m_emEtScaleInputLsb, m_emEtThresholds);
 }
 
 std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceJetScale(const L1JetEtScaleRcd& iRecord)
 {
-   std::unique_ptr<L1CaloEtScale> jetEtScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(m_jetEtScaleInputLsb, m_jetEtThresholds) );
-
-   return jetEtScale ;
+   return std::make_unique<L1CaloEtScale>(m_jetEtScaleInputLsb, m_jetEtThresholds);
 }
-
 
 std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceHtMissScale(const L1HtMissScaleRcd& iRecord)
 {
-   std::unique_ptr<L1CaloEtScale> htMissScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(0, 0x7f, m_jetEtScaleInputLsb, m_htMissThresholds) );
-
-   return htMissScale ;
+   return std::make_unique<L1CaloEtScale>(0, 0x7f, m_jetEtScaleInputLsb, m_htMissThresholds);
 }
-
 
 std::unique_ptr<L1CaloEtScale> L1ScalesTrivialProducer::produceHfRingScale(const L1HfRingEtScaleRcd& iRecord)
 {
-   std::unique_ptr<L1CaloEtScale> hfRingEtScale = std::unique_ptr<L1CaloEtScale>( new L1CaloEtScale(0xff, 0x7, m_jetEtScaleInputLsb, m_hfRingThresholds) );
-
-   return hfRingEtScale ;
+   return std::make_unique<L1CaloEtScale>(0xff, 0x7, m_jetEtScaleInputLsb, m_hfRingThresholds);
 }
-
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -27,7 +27,7 @@ l1t::Mask>& );
     bool readCaloLayer2OnlineSettings(l1t::CaloParamsHelperO2O& paramsHelper, std::map<std::string, l1t::Parameter>& conf, std::map<std::string, 
 l1t::Mask>& );
 public:
-    std::shared_ptr<l1t::CaloParams> newObject(const std::string& objectKey, const L1TCaloParamsO2ORcd& record) override ;
+    std::unique_ptr<const l1t::CaloParams> newObject(const std::string& objectKey, const L1TCaloParamsO2ORcd& record) override ;
 
     L1TCaloParamsOnlineProd(const edm::ParameterSet&);
     ~L1TCaloParamsOnlineProd(void) override{}
@@ -198,8 +198,7 @@ L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfi
     transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
-std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::string& objectKey, const L1TCaloParamsO2ORcd& record) {
-    using namespace edm::es;
+std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::string& objectKey, const L1TCaloParamsO2ORcd& record) {
 
     const L1TCaloParamsRcd& baseRcd = record.template getRecord< L1TCaloParamsRcd >() ;
     edm::ESHandle< l1t::CaloParams > baseSettings ;
@@ -212,7 +211,7 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
             throw std::runtime_error("SummaryForFunctionManager: Calo  | Faulty  | Empty objectKey");
         else {
             edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "returning unmodified prototype of l1t::CaloParams";
-            return std::make_shared< l1t::CaloParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const l1t::CaloParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -294,7 +293,7 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
             throw std::runtime_error(std::string("SummaryForFunctionManager: Calo  | Faulty  | ") + e.what());
         else {
             edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "returning unmodified prototype of l1t::CaloParams";
-            return std::make_shared< l1t::CaloParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const l1t::CaloParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -341,7 +340,7 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
                 throw std::runtime_error(std::string("SummaryForFunctionManager: Calo  | Faulty  | ") + e.what());
             else {
                 edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "returning unmodified prototype of l1t::CaloParams";
-                return std::make_shared< l1t::CaloParams >( *(baseSettings.product()) ) ;
+                return std::make_unique< const l1t::CaloParams >( *(baseSettings.product()) ) ;
             }
         }
     }
@@ -374,12 +373,12 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
                 throw std::runtime_error(std::string("SummaryForFunctionManager: Calo  | Faulty  | ") + e.what());
             else {
                 edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "returning unmodified prototype of l1t::CaloParams";
-                return std::make_shared< l1t::CaloParams >( *(baseSettings.product()) ) ;
+                return std::make_unique< const l1t::CaloParams >( *(baseSettings.product()) ) ;
             }
         }
     }
     
-    std::shared_ptr< l1t::CaloParams > retval = std::make_shared< l1t::CaloParams >( m_params_helper ) ;
+    auto retval = std::make_unique< const l1t::CaloParams >( m_params_helper ) ;
     
     edm::LogInfo( "L1-O2O: L1TCaloParamsOnlineProd" ) << "SummaryForFunctionManager: Calo  | OK      | All looks good";
     return retval;

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
@@ -29,7 +29,7 @@ class L1TGlobalPrescalesVetosOnlineProd : public L1ConfigOnlineProdBaseExt<L1TGl
 private:
     bool transactionSafe;
 public:
-    std::shared_ptr<L1TGlobalPrescalesVetos> newObject(const std::string& objectKey, const L1TGlobalPrescalesVetosO2ORcd& record) override ;
+    std::unique_ptr<const L1TGlobalPrescalesVetos> newObject(const std::string& objectKey, const L1TGlobalPrescalesVetosO2ORcd& record) override ;
 
     L1TGlobalPrescalesVetosOnlineProd(const edm::ParameterSet&);
     ~L1TGlobalPrescalesVetosOnlineProd(void) override{}
@@ -39,8 +39,7 @@ L1TGlobalPrescalesVetosOnlineProd::L1TGlobalPrescalesVetosOnlineProd(const edm::
     transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
-std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newObject(const std::string& objectKey, const L1TGlobalPrescalesVetosO2ORcd& record) {
-    using namespace edm::es;
+std::unique_ptr<const L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newObject(const std::string& objectKey, const L1TGlobalPrescalesVetosO2ORcd& record) {
 
     edm::LogInfo( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "Producing L1TGlobalPrescalesVetos with TSC:RS key = " << objectKey ;
 
@@ -49,7 +48,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
             throw std::runtime_error("SummaryForFunctionManager: uGTrs | Faulty  | Empty objectKey");
         else {
             edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "returning empty L1TGlobalPrescalesVetos object";
-            return std::make_shared< L1TGlobalPrescalesVetos >( ) ;
+            return std::make_unique< const L1TGlobalPrescalesVetos >( ) ;
         }
     }
 
@@ -82,7 +81,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
                 throw std::runtime_error("SummaryForFunctionManager: uGTrs | Faulty  | Broken key");
             else {
                 edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "returning empty L1TGlobalPrescalesVetos object";
-                return std::make_shared< L1TGlobalPrescalesVetos >( ) ;
+                return std::make_unique< const L1TGlobalPrescalesVetos >( ) ;
             }
         }
 
@@ -96,7 +95,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
                 throw std::runtime_error("SummaryForFunctionManager: uGTrs | Faulty  | Empty objectKey");
             else {
                 edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "returning empty L1TGlobalPrescalesVetos object";
-                return std::make_shared< L1TGlobalPrescalesVetos >( ) ;
+                return std::make_unique< const L1TGlobalPrescalesVetos >( ) ;
             }
         }
 
@@ -117,7 +116,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
                 throw std::runtime_error("SummaryForFunctionManager: uGTrs | Faulty  | Broken key");
             else {
                 edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "returning empty L1TGlobalPrescalesVetos object";
-                return std::make_shared< L1TGlobalPrescalesVetos >( ) ;
+                return std::make_unique< const L1TGlobalPrescalesVetos >( ) ;
             }
         }
 
@@ -163,7 +162,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
             throw std::runtime_error(std::string("SummaryForFunctionManager: uGTrs | Faulty  | ") + e.what());
         else {
             edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "returning empty L1TGlobalPrescalesVetos object";
-            return std::make_shared< L1TGlobalPrescalesVetos >( ) ;
+            return std::make_unique< const L1TGlobalPrescalesVetos >( ) ;
         }
     }
 
@@ -234,7 +233,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
             throw std::runtime_error(std::string("SummaryForFunctionManager: uGTrs | Faulty  | ") + e.what());
         else {
             edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "returning empty L1TGlobalPrescalesVetos object";
-            return std::make_shared< L1TGlobalPrescalesVetos >( ) ;
+            return std::make_unique< const L1TGlobalPrescalesVetos >( ) ;
         }
     }
 
@@ -289,7 +288,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
             throw std::runtime_error(std::string("SummaryForFunctionManager: uGTrs | Faulty  | ") + e.what());
         else {
             edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "returning empty L1TGlobalPrescalesVetos object";
-            return std::make_shared< L1TGlobalPrescalesVetos >( ) ;
+            return std::make_unique< const L1TGlobalPrescalesVetos >( ) ;
         }
     }
 
@@ -343,7 +342,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
             throw std::runtime_error(std::string("SummaryForFunctionManager: uGTrs | Faulty  | ") + e.what());
         else {
             edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "returning empty L1TGlobalPrescalesVetos object";
-            return std::make_shared< L1TGlobalPrescalesVetos >( ) ;
+            return std::make_unique< const L1TGlobalPrescalesVetos >( ) ;
         }
     }
 
@@ -376,7 +375,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
             throw std::runtime_error(std::string("SummaryForFunctionManager: uGTrs | Faulty  | ") + e.what());
         else {
             edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "returning empty L1TGlobalPrescalesVetos object";
-            return std::make_shared< L1TGlobalPrescalesVetos >( ) ;
+            return std::make_unique< const L1TGlobalPrescalesVetos >( ) ;
         }
     }
 
@@ -650,8 +649,7 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
   data_.setTriggerMaskVeto     ( triggerVetoMasks          );
   data_.setTriggerAlgoBxMask   ( triggerAlgoBxMaskAlgoTrig );
 
-  using namespace edm::es;
-  std::shared_ptr<L1TGlobalPrescalesVetos> payload( std::make_shared<L1TGlobalPrescalesVetos>(*data_.getWriteInstance()) );
+  auto payload = std::make_unique<const L1TGlobalPrescalesVetos>(*data_.getWriteInstance());
 
   edm::LogInfo( "L1-O2O: L1TCaloParamsOnlineProd" ) << "SummaryForFunctionManager: uGTrs | OK      | All looks good";
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
@@ -17,7 +17,7 @@ class L1TMuonBarrelParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonBa
 private:
     bool transactionSafe;
 public:
-    std::shared_ptr<L1TMuonBarrelParams> newObject(const std::string& objectKey, const L1TMuonBarrelParamsO2ORcd& record) override ;
+    std::unique_ptr<const L1TMuonBarrelParams> newObject(const std::string& objectKey, const L1TMuonBarrelParamsO2ORcd& record) override ;
 
     L1TMuonBarrelParamsOnlineProd(const edm::ParameterSet&);
     ~L1TMuonBarrelParamsOnlineProd(void) override{}
@@ -27,8 +27,7 @@ L1TMuonBarrelParamsOnlineProd::L1TMuonBarrelParamsOnlineProd(const edm::Paramete
     transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
-std::shared_ptr<L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(const std::string& objectKey, const L1TMuonBarrelParamsO2ORcd& record) {
-    using namespace edm::es;
+std::unique_ptr<const L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(const std::string& objectKey, const L1TMuonBarrelParamsO2ORcd& record) {
 
     const L1TMuonBarrelParamsRcd& baseRcd = record.template getRecord< L1TMuonBarrelParamsRcd >() ;
     edm::ESHandle< L1TMuonBarrelParams > baseSettings ;
@@ -40,7 +39,7 @@ std::shared_ptr<L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(co
             throw std::runtime_error("SummaryForFunctionManager: BMTF  | Faulty  | Empty objectKey");
         else {
             edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonBarrelParams";
-            return std::make_shared< L1TMuonBarrelParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonBarrelParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -105,7 +104,7 @@ std::shared_ptr<L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(co
             throw std::runtime_error(std::string("SummaryForFunctionManager: BMTF  | Faulty  | ") + e.what());
         else {
             edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonBarrelParams";
-            return std::make_shared< L1TMuonBarrelParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonBarrelParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -158,7 +157,7 @@ std::shared_ptr<L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(co
             throw std::runtime_error(std::string("SummaryForFunctionManager: BMTF  | Faulty  | ") + e.what());
         else {
             edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonBarrelParams";
-            return std::make_shared< L1TMuonBarrelParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonBarrelParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -171,11 +170,11 @@ std::shared_ptr<L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(co
             throw std::runtime_error(std::string("SummaryForFunctionManager: BMTF  | Faulty  | ") + e.what());
         else {
             edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonBarrelParams";
-            return std::make_shared< L1TMuonBarrelParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonBarrelParams >( *(baseSettings.product()) ) ;
         }
     }
 
-    std::shared_ptr< L1TMuonBarrelParams > retval = std::make_shared< L1TMuonBarrelParams>( m_params_helper );
+    auto retval = std::make_unique< const L1TMuonBarrelParams>( m_params_helper );
 
     edm::LogInfo( "L1-O2O: L1TCaloParamsOnlineProd" ) << "SummaryForFunctionManager: BMTF  | OK      | All looks good"; 
     return retval;

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProd.cc
@@ -11,7 +11,7 @@ class L1TMuonEndCapForestOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonEn
 private:
     bool transactionSafe;
 public:
-    std::shared_ptr<L1TMuonEndCapForest> newObject(const std::string& objectKey, const L1TMuonEndCapForestO2ORcd& record) override ;
+    std::unique_ptr<const L1TMuonEndCapForest> newObject(const std::string& objectKey, const L1TMuonEndCapForestO2ORcd& record) override ;
 
     L1TMuonEndCapForestOnlineProd(const edm::ParameterSet&);
     ~L1TMuonEndCapForestOnlineProd(void) override{}
@@ -21,14 +21,14 @@ L1TMuonEndCapForestOnlineProd::L1TMuonEndCapForestOnlineProd(const edm::Paramete
     transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
-std::shared_ptr<L1TMuonEndCapForest> L1TMuonEndCapForestOnlineProd::newObject(const std::string& objectKey, const L1TMuonEndCapForestO2ORcd& record) {
+std::unique_ptr<const L1TMuonEndCapForest> L1TMuonEndCapForestOnlineProd::newObject(const std::string& objectKey, const L1TMuonEndCapForestO2ORcd& record) {
 
     edm::LogError( "L1-O2O" ) << "L1TMuonEndCapForest object with key " << objectKey << " not in ORCON!" ;
 
     if( transactionSafe )
         throw std::runtime_error("SummaryForFunctionManager: EMTF  | Faulty  | You are never supposed to get Forests online producer running!");
 
-    std::shared_ptr< L1TMuonEndCapForest > retval = std::make_shared< L1TMuonEndCapForest >();
+    auto retval = std::make_unique< const L1TMuonEndCapForest >();
 
     edm::LogError( "L1-O2O: L1TMuonEndCapForestOnlineProd" ) << "SummaryForFunctionManager: EMTF  | Faulty  | You are never supposed to get Forests online producer running; returning empty L1TMuonEndCapForest";
     return retval;

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
@@ -16,7 +16,7 @@ class L1TMuonEndCapParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonEn
 private:
     bool transactionSafe;
 public:
-    std::shared_ptr<L1TMuonEndCapParams> newObject(const std::string& objectKey, const L1TMuonEndCapParamsO2ORcd& record) override ;
+    std::unique_ptr<const L1TMuonEndCapParams> newObject(const std::string& objectKey, const L1TMuonEndCapParamsO2ORcd& record) override ;
 
     L1TMuonEndCapParamsOnlineProd(const edm::ParameterSet&);
     ~L1TMuonEndCapParamsOnlineProd(void) override{}
@@ -26,8 +26,7 @@ L1TMuonEndCapParamsOnlineProd::L1TMuonEndCapParamsOnlineProd(const edm::Paramete
     transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
-std::shared_ptr<L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObject(const std::string& objectKey, const L1TMuonEndCapParamsO2ORcd& record) {
-    using namespace edm::es;
+std::unique_ptr<const L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObject(const std::string& objectKey, const L1TMuonEndCapParamsO2ORcd& record) {
 
     const L1TMuonEndCapParamsRcd& baseRcd = record.template getRecord< L1TMuonEndCapParamsRcd >() ;
     edm::ESHandle< L1TMuonEndCapParams > baseSettings ;
@@ -40,7 +39,7 @@ std::shared_ptr<L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObject(co
             throw std::runtime_error("SummaryForFunctionManager: BMTF  | Faulty  | Empty objectKey");
         else {
             edm::LogError( "L1-O2O: L1TMuonEndCapParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonEndCapParams";
-            return std::make_shared< L1TMuonEndCapParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonEndCapParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -80,7 +79,7 @@ std::shared_ptr<L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObject(co
             throw std::runtime_error("SummaryForFunctionManager: EMTF  | Faulty  | Broken key");
         else {
             edm::LogError( "L1-O2O: L1TMuonEndCapParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonEndCapParams";
-            return std::make_shared< L1TMuonEndCapParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonEndCapParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -113,7 +112,7 @@ std::shared_ptr<L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObject(co
             throw std::runtime_error("SummaryForFunctionManager: EMTF  | Faulty  | Cannot parse XMLs");
         else {
             edm::LogError( "L1-O2O: L1TMuonEndCapParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonEndCapParams";
-            return std::make_shared< L1TMuonEndCapParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonEndCapParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -130,7 +129,7 @@ std::shared_ptr<L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObject(co
 //    strptime(pclut_v.c_str(), "%Y-%m-%d", &brokenTime);
 //    time_t pclut_sinceEpoch = timegm(&brokenTime);
 
-    std::shared_ptr< L1TMuonEndCapParams > retval( new L1TMuonEndCapParams() ); 
+    auto retval = std::make_unique<L1TMuonEndCapParams>();
     
     retval->firmwareVersion_ = fw_sinceEpoch;
     retval->PtAssignVersion_ = conf["pt_lut_version"].getValue<unsigned int>();

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
@@ -16,7 +16,7 @@ class L1TMuonGlobalParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonGl
 private:
     bool transactionSafe;
 public:
-    std::shared_ptr<L1TMuonGlobalParams> newObject(const std::string& objectKey, const L1TMuonGlobalParamsO2ORcd &record) override ;
+    std::unique_ptr<const L1TMuonGlobalParams> newObject(const std::string& objectKey, const L1TMuonGlobalParamsO2ORcd &record) override ;
 
     L1TMuonGlobalParamsOnlineProd(const edm::ParameterSet&);
     ~L1TMuonGlobalParamsOnlineProd(void) override{}
@@ -26,8 +26,7 @@ L1TMuonGlobalParamsOnlineProd::L1TMuonGlobalParamsOnlineProd(const edm::Paramete
     transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
-std::shared_ptr<L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(const std::string& objectKey, const L1TMuonGlobalParamsO2ORcd &record) {
-    using namespace edm::es;
+std::unique_ptr<const L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(const std::string& objectKey, const L1TMuonGlobalParamsO2ORcd &record) {
 
     const L1TMuonGlobalParamsRcd& baseRcd = record.template getRecord< L1TMuonGlobalParamsRcd >() ;
     edm::ESHandle< L1TMuonGlobalParams > baseSettings ;
@@ -39,7 +38,7 @@ std::shared_ptr<L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(co
             throw std::runtime_error("SummaryForFunctionManager: uGMT  | Faulty  | Empty objectKey");
         else {
             edm::LogError( "L1-O2O: L1TMuonGlobalParams" ) << "returning unmodified prototype of L1TMuonGlobalParams";
-            return std::make_shared< L1TMuonGlobalParams>( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonGlobalParams>( *(baseSettings.product()) ) ;
         }
     }
 
@@ -102,7 +101,7 @@ std::shared_ptr<L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(co
             throw std::runtime_error("SummaryForFunctionManager: uGMT  | Faulty  | Broken key");
         else {
             edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonGlobalParams";
-            return std::make_shared< L1TMuonGlobalParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonGlobalParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -148,7 +147,7 @@ std::shared_ptr<L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(co
             throw std::runtime_error("SummaryForFunctionManager: uGMT  | Faulty  | Cannot parse XMLs");
         else {
             edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonGlobalParams";
-            return std::make_shared< L1TMuonGlobalParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonGlobalParams >( *(baseSettings.product()) ) ;
         }
     }
 
@@ -161,11 +160,11 @@ std::shared_ptr<L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(co
             throw std::runtime_error("SummaryForFunctionManager: uGMT  | Faulty  | Cannot run helper");
         else {
             edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "returning unmodified prototype of L1TMuonGlobalParams";
-            return std::make_shared< L1TMuonGlobalParams >( *(baseSettings.product()) ) ;
+            return std::make_unique< const L1TMuonGlobalParams >( *(baseSettings.product()) ) ;
         }
     }
 
-    std::shared_ptr< L1TMuonGlobalParams > retval = std::make_shared< L1TMuonGlobalParams >( cast_to_L1TMuonGlobalParams(m_params_helper) );
+    auto retval = std::make_unique< const L1TMuonGlobalParams >( cast_to_L1TMuonGlobalParams(m_params_helper) );
 
     edm::LogInfo( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "SummaryForFunctionManager: uGMT  | OK      | All looks good";
     return retval ;

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProd.cc
@@ -12,7 +12,7 @@ private:
     bool transactionSafe;
 
 public:
-    std::shared_ptr<L1TMuonOverlapParams> newObject(const std::string& objectKey, const L1TMuonOverlapParamsO2ORcd& record) override ;
+    std::unique_ptr<const L1TMuonOverlapParams> newObject(const std::string& objectKey, const L1TMuonOverlapParamsO2ORcd& record) override ;
 
     L1TMuonOverlapParamsOnlineProd(const edm::ParameterSet&);
     ~L1TMuonOverlapParamsOnlineProd(void) override{}
@@ -22,14 +22,14 @@ L1TMuonOverlapParamsOnlineProd::L1TMuonOverlapParamsOnlineProd(const edm::Parame
     transactionSafe = iConfig.getParameter<bool>("transactionSafe");
 }
 
-std::shared_ptr<L1TMuonOverlapParams> L1TMuonOverlapParamsOnlineProd::newObject(const std::string& objectKey, const L1TMuonOverlapParamsO2ORcd& record) {
+std::unique_ptr<const L1TMuonOverlapParams> L1TMuonOverlapParamsOnlineProd::newObject(const std::string& objectKey, const L1TMuonOverlapParamsO2ORcd& record) {
 
     edm::LogError( "L1-O2O" ) << "L1TMuonOverlapParams object with key " << objectKey << " not in ORCON!" ;
 
     if( transactionSafe )
         throw std::runtime_error("SummaryForFunctionManager: OMTF  | Faulty  | You are never supposed to get OMTF online producer running!");
 
-    std::shared_ptr< L1TMuonOverlapParams > retval = std::make_shared< L1TMuonOverlapParams >();
+    auto retval = std::make_unique< const L1TMuonOverlapParams >();
 
     edm::LogError( "L1-O2O: L1TMuonOverlapParamsOnlineProd" ) << "SummaryForFunctionManager: OMTF  | Faulty  | You are never supposed to get OMTF online producer running; returning empty L1TMuonOverlapParams";
     return retval;

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
@@ -20,7 +20,7 @@
 class L1TUtmTriggerMenuOnlineProd : public L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuO2ORcd,L1TUtmTriggerMenu> {
 private:
 public:
-    std::shared_ptr<L1TUtmTriggerMenu> newObject(const std::string& objectKey, const L1TUtmTriggerMenuO2ORcd& record) override ;
+    std::unique_ptr<const L1TUtmTriggerMenu> newObject(const std::string& objectKey, const L1TUtmTriggerMenuO2ORcd& record) override ;
 
     L1TUtmTriggerMenuOnlineProd(const edm::ParameterSet&);
     ~L1TUtmTriggerMenuOnlineProd(void) override{}
@@ -28,8 +28,7 @@ public:
 
 L1TUtmTriggerMenuOnlineProd::L1TUtmTriggerMenuOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuO2ORcd,L1TUtmTriggerMenu>(iConfig) {}
 
-std::shared_ptr<L1TUtmTriggerMenu> L1TUtmTriggerMenuOnlineProd::newObject(const std::string& objectKey, const L1TUtmTriggerMenuO2ORcd& record) {
-    using namespace edm::es;
+std::unique_ptr<const L1TUtmTriggerMenu> L1TUtmTriggerMenuOnlineProd::newObject(const std::string& objectKey, const L1TUtmTriggerMenuO2ORcd& record) {
 
     std::string stage2Schema = "CMS_TRG_L1_CONF" ;
     edm::LogInfo( "L1-O2O: L1TUtmTriggerMenuOnlineProd" ) << "Producing L1TUtmTriggerMenu with key =" << objectKey ;
@@ -37,7 +36,6 @@ std::shared_ptr<L1TUtmTriggerMenu> L1TUtmTriggerMenuOnlineProd::newObject(const 
     if( objectKey.empty() ){
         edm::LogError( "L1-O2O: L1TUtmTriggerMenuOnlineProd" ) << "Key is empty, returning empty L1TUtmTriggerMenu object";
         throw std::runtime_error("Empty objectKey");
-///        return boost::shared_ptr< L1TUtmTriggerMenu > ( new L1TUtmTriggerMenu() );
     }
 
     std::vector< std::string > queryColumns;
@@ -54,20 +52,15 @@ std::shared_ptr<L1TUtmTriggerMenu> L1TUtmTriggerMenuOnlineProd::newObject(const 
     if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
         edm::LogError( "L1-O2O: L1TUtmTriggerMenuOnlineProd" ) << "Cannot get UGT_L1_MENU.CONF for ID = " << objectKey ;
         throw std::runtime_error("Broken key");
-///        return boost::shared_ptr< L1TUtmTriggerMenu >() ;
     }
 
     std::string l1Menu;
     queryResult.fillVariable( "CONF", l1Menu );
-///
+
     std::istringstream iss(l1Menu);
 
     const L1TUtmTriggerMenu * cmenu = reinterpret_cast<const L1TUtmTriggerMenu *>(tmeventsetup::getTriggerMenu(iss));  
-    L1TUtmTriggerMenu * menu = const_cast<L1TUtmTriggerMenu *>(cmenu);
-
-    using namespace edm::es;
-    std::shared_ptr<L1TUtmTriggerMenu> pMenu(menu);
-    return pMenu;
+    return std::unique_ptr<const L1TUtmTriggerMenu>(cmenu);
 }
 
 //define this as a plug-in

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskOnlineProd.cc
@@ -41,7 +41,7 @@ class L1RCTChannelMaskOnlineProd :
     : L1ConfigOnlineProdBase< L1RCTChannelMaskRcd, L1RCTChannelMask > (iConfig) {}
   ~L1RCTChannelMaskOnlineProd() override {}
   
-  std::shared_ptr< L1RCTChannelMask > newObject(const std::string& objectKey ) override ;
+  std::unique_ptr< L1RCTChannelMask > newObject(const std::string& objectKey ) override ;
 
 
    private:
@@ -60,12 +60,9 @@ class L1RCTChannelMaskOnlineProd :
 // constructors and destructor
 //
 
-std::shared_ptr< L1RCTChannelMask >
+std::unique_ptr< L1RCTChannelMask >
 L1RCTChannelMaskOnlineProd::newObject( const std::string& objectKey )
 {
-     using namespace edm::es;
-
-
       std::cout << " Current key is " << objectKey <<std::endl;
 
      std::string rctSchema = "CMS_RCT" ;
@@ -165,7 +162,7 @@ L1RCTChannelMaskOnlineProd::newObject( const std::string& objectKey )
 	 
 
 	 std::cout << " Returened rows " << dcMaskResults.numberRows() <<std::endl;
-	 return std::shared_ptr< L1RCTChannelMask >() ;
+	 return std::unique_ptr< L1RCTChannelMask >() ;
        }
      
       L1RCTChannelMask* m = new L1RCTChannelMask;
@@ -300,7 +297,7 @@ L1RCTChannelMaskOnlineProd::newObject( const std::string& objectKey )
      //~~~~~~~~~ Instantiate new L1RCTChannelMask object. ~~~~~~~~~
 
 
-     return std::shared_ptr< L1RCTChannelMask >(m);
+     return std::unique_ptr< L1RCTChannelMask >(m);
 } 
 	
 

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersOnlineProd.cc
@@ -38,7 +38,7 @@ class L1RCTParametersOnlineProd :
       L1RCTParametersOnlineProd(const edm::ParameterSet&);
       ~L1RCTParametersOnlineProd() override;
 
-  std::shared_ptr< L1RCTParameters > newObject(
+  std::unique_ptr< L1RCTParameters > newObject(
     const std::string& objectKey ) override ;
 
   void fillScaleFactors(
@@ -84,11 +84,9 @@ L1RCTParametersOnlineProd::~L1RCTParametersOnlineProd()
 
 }
 
-std::shared_ptr< L1RCTParameters >
+std::unique_ptr< L1RCTParameters >
 L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
 {
-     using namespace edm::es;
-
      std::string rctSchema = "CMS_RCT" ;
      const l1t::OMDSReader::QueryResults paremKeyResults =
        m_omdsReader.singleAttribute( objectKey ) ;
@@ -133,7 +131,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
 	 paremResults.numberRows() != 1 ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with L1RCTParameters key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
      double eGammaLSB, jetMETLSB, eMinForFGCut, eMaxForFGCut, hOeCut ;
@@ -206,7 +204,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( egammaEcalResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with EgammaEcal key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "egammaEcal " ;
@@ -236,7 +234,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( egammaHcalResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with EgammaHcal key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "egammaHcal " ;
@@ -266,7 +264,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( jetmetEcalResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with JetmetEcal key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "jetmetEcal " ;
@@ -296,7 +294,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( jetmetHcalResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with JetmetHcal key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "jetmetHcal " ;
@@ -340,7 +338,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
        if( hcalCalibResults.queryFailed() ) {// check query successful
 	 
 	 edm::LogError( "L1-O2O" ) << "Problem with JetmetHcal key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
        
 //      std::cout << "jetmetHcal " ;
@@ -362,7 +360,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( hcalCalibHighResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with hcalHigh key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
 
@@ -384,7 +382,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( ecalCalibResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with ecal calib key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
      
@@ -414,7 +412,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( crossTermResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with crossTerms key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
      fillScaleFactors( crossTermResults, crossTermsScaleFactors,6 ) ;
@@ -434,7 +432,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( hoveresmearhighResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with low h over e smear key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "egammaEcal " ;
@@ -456,7 +454,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
      if( hoveresmearlowResults.queryFailed() ) // check query successful
        {
 	 edm::LogError( "L1-O2O" ) << "Problem with low h over e smear key." ;
-	 return std::shared_ptr< L1RCTParameters >() ;
+	 return std::unique_ptr< L1RCTParameters >() ;
        }
 
 //      std::cout << "egammaEcal " ;
@@ -468,7 +466,7 @@ L1RCTParametersOnlineProd::newObject( const std::string& objectKey )
 
      // Default objects for Lindsey 
 
-     return std::make_shared< L1RCTParameters >(
+     return std::make_unique< L1RCTParameters >(
                              eGammaLSB,
                              jetMETLSB,
                              eMinForFGCut,

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCBxOrConfigOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCBxOrConfigOnlineProd.cc
@@ -31,7 +31,7 @@ class L1RPCBxOrConfigOnlineProd : public L1ConfigOnlineProdBase< L1RPCBxOrConfig
       L1RPCBxOrConfigOnlineProd(const edm::ParameterSet&);
       ~L1RPCBxOrConfigOnlineProd() override;
 
-  std::shared_ptr< L1RPCBxOrConfig > newObject(
+  std::unique_ptr< L1RPCBxOrConfig > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -67,16 +67,15 @@ L1RPCBxOrConfigOnlineProd::~L1RPCBxOrConfigOnlineProd()
 
 }
 
-std::shared_ptr< L1RPCBxOrConfig >
+std::unique_ptr< L1RPCBxOrConfig >
 L1RPCBxOrConfigOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1RPCBxOrConfig object with key "
 			    << objectKey << " not in ORCON!" ;
-  auto pBxOrConfig = std::make_shared< L1RPCBxOrConfig >();
+  auto pBxOrConfig = std::make_unique< L1RPCBxOrConfig >();
   pBxOrConfig->setFirstBX(0);
   pBxOrConfig->setLastBX(0);
   return pBxOrConfig;
-//  return std::shared_ptr< L1RPCBxOrConfig >() ;
 }
 
 //

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionOnlineProd.cc
@@ -38,7 +38,7 @@ class L1RPCConeDefinitionOnlineProd : public L1ConfigOnlineProdBase<
       L1RPCConeDefinitionOnlineProd(const edm::ParameterSet&);
       ~L1RPCConeDefinitionOnlineProd() override;
 
-  std::shared_ptr< L1RPCConeDefinition > newObject(
+  std::unique_ptr< L1RPCConeDefinition > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -75,13 +75,13 @@ L1RPCConeDefinitionOnlineProd::~L1RPCConeDefinitionOnlineProd()
 
 }
 
-std::shared_ptr< L1RPCConeDefinition >
+std::unique_ptr< L1RPCConeDefinition >
 L1RPCConeDefinitionOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1RPCConeDefinition object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return std::shared_ptr< L1RPCConeDefinition >() ;
+  return std::unique_ptr< L1RPCConeDefinition >() ;
 }
 
 //

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCHsbConfigOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCHsbConfigOnlineProd.cc
@@ -31,7 +31,7 @@ class L1RPCHsbConfigOnlineProd : public L1ConfigOnlineProdBase< L1RPCHsbConfigRc
       L1RPCHsbConfigOnlineProd(const edm::ParameterSet&);
       ~L1RPCHsbConfigOnlineProd() override;
 
-  std::shared_ptr< L1RPCHsbConfig > newObject(
+  std::unique_ptr< L1RPCHsbConfig > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -67,12 +67,12 @@ L1RPCHsbConfigOnlineProd::~L1RPCHsbConfigOnlineProd()
 
 }
 
-std::shared_ptr< L1RPCHsbConfig >
+std::unique_ptr< L1RPCHsbConfig >
 L1RPCHsbConfigOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1RPCHsbConfig object with key "
 			    << objectKey << " not in ORCON!" ;
-  auto pHsbConfig = std::make_shared< L1RPCHsbConfig >();
+  auto pHsbConfig = std::make_unique< L1RPCHsbConfig >();
   std::vector<int> hsbconf;
   int mask=3;
   // XX was: i<9, corrected
@@ -80,7 +80,6 @@ L1RPCHsbConfigOnlineProd::newObject( const std::string& objectKey )
   pHsbConfig->setHsbMask(0, hsbconf);
   pHsbConfig->setHsbMask(1, hsbconf);
   return pHsbConfig;
-//  return std::shared_ptr< L1RPCHsbConfig >() ;
 }
 
 //

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCConfigOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCConfigOnlineProd.cc
@@ -38,7 +38,7 @@ class RPCConfigOnlineProd : public L1ConfigOnlineProdBase< L1RPCConfigRcd,
       RPCConfigOnlineProd(const edm::ParameterSet&);
       ~RPCConfigOnlineProd() override;
 
-  std::shared_ptr< L1RPCConfig > newObject(
+  std::unique_ptr< L1RPCConfig > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -74,13 +74,13 @@ RPCConfigOnlineProd::~RPCConfigOnlineProd()
 
 }
 
-std::shared_ptr< L1RPCConfig >
+std::unique_ptr< L1RPCConfig >
 RPCConfigOnlineProd::newObject( const std::string& objectKey )
 {
   edm::LogError( "L1-O2O" ) << "L1RPCConfig object with key "
 			    << objectKey << " not in ORCON!" ;
 
-  return std::shared_ptr< L1RPCConfig >() ;
+  return std::unique_ptr< L1RPCConfig >() ;
 }
 
 //

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerBxOrConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerBxOrConfig.cc
@@ -88,7 +88,6 @@ RPCTriggerBxOrConfig::~RPCTriggerBxOrConfig()
 RPCTriggerBxOrConfig::ReturnType
 RPCTriggerBxOrConfig::produce(const L1RPCBxOrConfigRcd& iRecord)
 {
-   using namespace edm::es;
    auto pRPCTriggerBxOrConfig = std::make_unique<L1RPCBxOrConfig>();
 
    if (m_firstBX > m_lastBX )

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
@@ -104,7 +104,6 @@ RPCTriggerConfig::~RPCTriggerConfig()
 RPCTriggerConfig::ReturnType
 RPCTriggerConfig::produce(const L1RPCConfigRcd& iRecord)
 {
-   using namespace edm::es;
    auto pL1RPCConfig = std::make_unique<L1RPCConfig>();
 
    pL1RPCConfig->setPPT(m_ppt);

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHsbConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHsbConfig.cc
@@ -94,8 +94,6 @@ RPCTriggerHsbConfig::~RPCTriggerHsbConfig()
 RPCTriggerHsbConfig::ReturnType
 RPCTriggerHsbConfig::produce(const L1RPCHsbConfigRcd& iRecord)
 {
-
-   using namespace edm::es;
    auto pRPCTriggerHsbConfig = std::make_unique<L1RPCHsbConfig>();
 
    pRPCTriggerHsbConfig->setHsbMask(0, m_hsb0);

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHwConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHwConfig.cc
@@ -114,7 +114,6 @@ RPCTriggerHwConfig::~RPCTriggerHwConfig()
 RPCTriggerHwConfig::ReturnType
 RPCTriggerHwConfig::produce(const L1RPCHwConfigRcd& iRecord)
 {
-   using namespace edm::es;
    auto pL1RPCHwConfig = std::make_unique<L1RPCHwConfig>();
 
    if (m_disableAll) {


### PR DESCRIPTION
Prepare for concurrent IOVs in files related to L1ConfigOnlineProdBase
and L1ConfigOnlineProdBaseExt. Mostly this is conversion of
shared_ptr to unique_ptr in those base classes and the many ESProducers
that derive from them. In a few modules I needed to remove a data member
to do this.

Note this also required changing the return type of the deserialization
function in CondCore/CondDB/interface/Serialization.h and the fetchPayload
function in CondCore/CondDB/interface/Session.h. Both of these changes
seem to be better design to me. Probably the only reason it was a shared_ptr
was because this code was originally written before unique_ptr existed. I do
not know if it is significant, but this should also improve performance at least
slightly. (One could make more similar changes in CondCore, but I only did
the minimum necessary for my immediate goal).

There is also a bit of cleanup mixed in. "scram code-checks" fixed a few things.
In one of the previous PRs in this ESProducer campaign
someone requested I remove all the unnecessary "using edm::es" namespace
directives, so I removed all those in these packages as well. Plus a little bit of
fixing indentation around the lines I changed.

FYI @Dr15Jones 