### PR TITLE
Remove some const-away casts from AlCa

### DIFF
--- a/Alignment/CocoaToDDL/src/CocoaUnitsTable.cc
+++ b/Alignment/CocoaToDDL/src/CocoaUnitsTable.cc
@@ -64,14 +64,14 @@ CocoaUnitDefinition& CocoaUnitDefinition::operator=(const CocoaUnitDefinition& r
  
 ALIint CocoaUnitDefinition::operator==(const CocoaUnitDefinition& right) const
 {
-  return (this == (CocoaUnitDefinition *) &right);
+  return (this == &right);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
  
 ALIint CocoaUnitDefinition::operator!=(const CocoaUnitDefinition &right) const
 {
-  return (this != (CocoaUnitDefinition *) &right);
+  return (this != &right);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
@@ -297,14 +297,14 @@ CocoaUnitsCategory& CocoaUnitsCategory::operator=(const CocoaUnitsCategory& righ
  
 ALIint CocoaUnitsCategory::operator==(const CocoaUnitsCategory& right) const
 {
-  return (this == (CocoaUnitsCategory *) &right);
+  return (this == &right);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
  
 ALIint CocoaUnitsCategory::operator!=(const CocoaUnitsCategory &right) const
 {
-  return (this != (CocoaUnitsCategory *) &right);
+  return (this != &right);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc
@@ -3719,7 +3719,7 @@ void TEcnaGui::DoButtonVmaxD_SCs_ChNb()
 {
 //Registration of Ymax for sigmas of cor(s,s')
 
-  const char *bufferchain = (char*)fVmaxD_SCs_ChNbText->GetBuffer()->GetString();
+  const char *bufferchain = fVmaxD_SCs_ChNbText->GetBuffer()->GetString();
 
   fKeyVmaxD_SCs_ChNb = (Double_t)atof(bufferchain);
 
@@ -3831,7 +3831,7 @@ void TEcnaGui::DoButtonStinA()
 {
 //Registration of the Stin A number (A = X coordinate for cor(c,c') plots)
 
-  const char *bufferchain = (char*)fStinAText->GetBuffer()->GetString();
+  const char *bufferchain = fStinAText->GetBuffer()->GetString();
 
   Int_t xReadStinANumberForCons = atoi(bufferchain);
 
@@ -4012,7 +4012,7 @@ void TEcnaGui::DoButtonRul()
 //Register the name of the file containing the list of run parameters
 
   //........................... get info from the entry field
-  char* listchain = (char*)fRulText->GetBuffer()->GetString();
+  const char* listchain = fRulText->GetBuffer()->GetString();
   if( listchain[0] == '\0' )
     {
       fCnaError++;
@@ -4054,7 +4054,7 @@ void TEcnaGui::DoButtonGent()
 {
 //Register the general title
   //........................... get info from the entry field
-  char* listchain = (char*)fGentText->GetBuffer()->GetString();  
+  const char* listchain = fGentText->GetBuffer()->GetString();
   fKeyGeneralTitle = listchain;
   
   fCnaCommand++;

--- a/CalibTracker/SiStripHitEfficiency/src/TrajectoryAtInvalidHit.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/TrajectoryAtInvalidHit.cc
@@ -52,7 +52,7 @@ TrajectoryAtInvalidHit::TrajectoryAtInvalidHit( const TrajectoryMeasurement& tm,
     unsigned int matched_iidd = iidd-(iidd & 0x3);
     DetId matched_id(matched_iidd);
     
-    GluedGeomDet * gdet=(GluedGeomDet *)tracker->idToDet(matched_id);
+    const GluedGeomDet * gdet=static_cast<const GluedGeomDet *>(tracker->idToDet(matched_id));
     
     // get the sensor det indicated by mono
     if (mono == 1) monodet=gdet->stereoDet();
@@ -92,7 +92,7 @@ TrajectoryAtInvalidHit::TrajectoryAtInvalidHit( const TrajectoryMeasurement& tm,
     //set module id to be mono det
     iidd = monodet->geographicalId().rawId();
   } else {
-    monodet = (GeomDetUnit*)theHit->det();
+    monodet = theHit->det();
     hasValidHit = theHit->isValid();
   }
   


### PR DESCRIPTION
To clean up static analyzer reports.

Tested in CMSSW_10_4_X_2018-10-25-2300, no changes expected.