### PR TITLE
Remove some const-away casts from analysis

### DIFF
--- a/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
+++ b/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
@@ -77,7 +77,7 @@ void TrackInfoProducerAlgorithm::run(const edm::Ref<std::vector<Trajectory> > tr
       LocalPoint pmonoup, pstereoup;
       if(matchedhit){
 	type=Matched;
-	GluedGeomDet * gdet=(GluedGeomDet *)tracker->idToDet(matchedhit->geographicalId());
+	const GluedGeomDet * gdet=static_cast<const GluedGeomDet *>(tracker->idToDet(matchedhit->geographicalId()));
 	
 	GlobalVector gtrkdirfwd=gdet->toGlobal(fwdptsod.parameters().momentum());
 	GlobalVector gtrkdirbwd=gdet->toGlobal(bwdptsod.parameters().momentum());
@@ -115,7 +115,7 @@ void TrackInfoProducerAlgorithm::run(const edm::Ref<std::vector<Trajectory> > tr
       }
       else if(phit){
 	type=Projected;
-	GluedGeomDet * gdet=(GluedGeomDet *)tracker->idToDet(phit->geographicalId());
+	const GluedGeomDet * gdet=static_cast<const GluedGeomDet *>(tracker->idToDet(phit->geographicalId()));
 	
 	GlobalVector gtrkdirfwd=gdet->toGlobal(fwdptsod.parameters().momentum());
 	GlobalVector gtrkdirbwd=gdet->toGlobal(bwdptsod.parameters().momentum());

--- a/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
+++ b/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
@@ -147,10 +147,10 @@ void TrackInfoProducerAlgorithm::run(const edm::Ref<std::vector<Trajectory> > tr
 	}
       }
       TrackingRecHitInfo::TrackingStates states;
-      if(forwardPredictedStateTag_!="") states.insert(std::make_pair(FwPredicted, TrackingStateInfo(std::make_pair(monofwd,stereofwd), std::make_pair(pmonofwd,pstereofwd), fwdptsod)));
-      if(backwardPredictedStateTag_!="")states.insert(std::make_pair(BwPredicted, TrackingStateInfo(std::make_pair(monobwd,stereobwd), std::make_pair(pmonobwd,pstereobwd), bwdptsod)));
-      if(updatedStateTag_!="")states.insert(std::make_pair(Updated, TrackingStateInfo(std::make_pair(monoup,stereoup), std::make_pair(pmonoup,pstereoup), updatedptsod)));
-      if(combinedStateTag_!="")states.insert(std::make_pair(Combined, TrackingStateInfo(std::make_pair(monoco,stereoco), std::make_pair(pmonoco,pstereoco), combinedptsod)));
+      if(!forwardPredictedStateTag_.empty()) states.insert(std::make_pair(FwPredicted, TrackingStateInfo(std::make_pair(monofwd,stereofwd), std::make_pair(pmonofwd,pstereofwd), fwdptsod)));
+      if(!backwardPredictedStateTag_.empty())states.insert(std::make_pair(BwPredicted, TrackingStateInfo(std::make_pair(monobwd,stereobwd), std::make_pair(pmonobwd,pstereobwd), bwdptsod)));
+      if(!updatedStateTag_.empty())states.insert(std::make_pair(Updated, TrackingStateInfo(std::make_pair(monoup,stereoup), std::make_pair(pmonoup,pstereoup), updatedptsod)));
+      if(!combinedStateTag_.empty())states.insert(std::make_pair(Combined, TrackingStateInfo(std::make_pair(monoco,stereoco), std::make_pair(pmonoco,pstereoco), combinedptsod)));
      
       TrackingRecHitInfo  tkRecHitInfo(type, states);
       

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.cc
@@ -9,15 +9,15 @@ const unsigned int MuScleFitMuonSelector::motherPdgIdArray[] = {23, 100553, 1005
 const reco::Candidate* 
 MuScleFitMuonSelector::getStatus1Muon(const reco::Candidate* status3Muon){
   const reco::Candidate* tempMuon = status3Muon;
-  //  bool lastCopy = ((reco::GenParticle*)tempMuon)->isLastCopy();                      //  isLastCopy() likely not enough robust
-  bool isPromptFinalState = ((reco::GenParticle*)tempMuon)->isPromptFinalState();        //  pre-CMSSW_74X code: int status = tempStatus1Muon->status();
+  //  bool lastCopy = (static_cast<const reco::GenParticle*>(tempMuon))->isLastCopy();                      //  isLastCopy() likely not enough robust
+  bool isPromptFinalState = static_cast<const reco::GenParticle*>(tempMuon)->isPromptFinalState();        //  pre-CMSSW_74X code: int status = tempStatus1Muon->status();
   while(tempMuon == nullptr || tempMuon->numberOfDaughters()!=0){
     if ( isPromptFinalState ) break;                                                     //  pre-CMSSW_74X code: if (status == 1) break;
     //std::vector<const reco::Candidate*> daughters;
     for (unsigned int i=0; i<tempMuon->numberOfDaughters(); ++i){
       if ( tempMuon->daughter(i)->pdgId()==tempMuon->pdgId() ){
 	tempMuon = tempMuon->daughter(i);
-	isPromptFinalState = ((reco::GenParticle*)tempMuon)->isPromptFinalState(); 	 //  pre-CMSSW_74X code: status = tempStatus1Muon->status();
+	isPromptFinalState = static_cast<const reco::GenParticle*>(tempMuon)->isPromptFinalState(); 	 //  pre-CMSSW_74X code: status = tempStatus1Muon->status();
 	break;
       }else continue;
     }//for loop
@@ -29,14 +29,14 @@ MuScleFitMuonSelector::getStatus1Muon(const reco::Candidate* status3Muon){
 const reco::Candidate* 
 MuScleFitMuonSelector::getStatus3Muon(const reco::Candidate* status3Muon){
   const reco::Candidate* tempMuon = status3Muon;
-  bool lastCopy = ((reco::GenParticle*)tempMuon)->isLastCopyBeforeFSR();        //  pre-CMSSW_74X code: int status = tempStatus1Muon->status();
+  bool lastCopy = static_cast<const reco::GenParticle*>(tempMuon)->isLastCopyBeforeFSR();        //  pre-CMSSW_74X code: int status = tempStatus1Muon->status();
   while(tempMuon == nullptr || tempMuon->numberOfDaughters()!=0){
     if ( lastCopy ) break;                                                      //  pre-CMSSW_74X code: if (status == 3) break;
     //std::vector<const reco::Candidate*> daughters;
     for (unsigned int i=0; i<tempMuon->numberOfDaughters(); ++i){
       if ( tempMuon->daughter(i)->pdgId()==tempMuon->pdgId() ){
 	tempMuon = tempMuon->daughter(i);
-	lastCopy = ((reco::GenParticle*)tempMuon)->isLastCopyBeforeFSR(); 	//  pre-CMSSW_74X code: status = tempStatus1Muon->status();
+	lastCopy = static_cast<const reco::GenParticle*>(tempMuon)->isLastCopyBeforeFSR(); 	//  pre-CMSSW_74X code: status = tempStatus1Muon->status();
 	break;
       }else continue;
     }//for loop

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.cc
@@ -93,8 +93,10 @@ void MuScleFitMuonSelector::selectMuons(const edm::Event & event, std::vector<Mu
   MuScleFitPlotter * plotter)
 {
   edm::Handle<pat::CompositeCandidateCollection > collAll;
-  try { event.getByLabel("onia2MuMuPatTrkTrk", collAll); }
-  catch (...) { std::cout << "J/psi not present in event!" << std::endl; }
+  event.getByLabel("onia2MuMuPatTrkTrk", collAll);
+  if(!collAll.isValid()) {
+    edm::LogWarning("MuScleFitUtils") << "J/psi not present in event!";
+  }
   std::vector<const pat::Muon*> collMuSel;
 
   //================onia cuts===========================/

--- a/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
@@ -172,7 +172,7 @@ const reco::GenParticle* TopDecaySubset::findPrimalW(
 			break;
 		}
 	}
-	return (reco::GenParticle*)top->daughter(w_index);
+	return static_cast<const reco::GenParticle*>(top->daughter(w_index));
 }
 
 /// find W bosons that come from top quark decays and decay themselves (end of the MC chain)
@@ -208,7 +208,7 @@ const reco::GenParticle* TopDecaySubset::findLastParticleInChain(
       if(p->status() == 3)
         return p;
     }
-    return findLastParticleInChain((reco::GenParticle*)p->daughter(d_idx));
+    return findLastParticleInChain(static_cast<const reco::GenParticle*>(p->daughter(d_idx)));
   }
 
 
@@ -489,7 +489,7 @@ void TopDecaySubset::fillListing(
 					// for radation to be added we first need to
 					// pick the last quark in the MC chain
 					const reco::GenParticle* last_q = findLastParticleInChain(
-							(reco::GenParticle*) &*td);
+							static_cast<const reco::GenParticle*>(&*td));
 					addRadiation(motherPartIdx_, last_q, target);
 				}
 			} else if (std::abs(td->pdgId()) == TopDecayID::WID) {
@@ -508,7 +508,7 @@ void TopDecaySubset::fillListing(
         // for Pythia 6 this is wrong as the last W has no daughters at all!
         // instead the status 3 W has 3 daughters: q qbar' and W (WTF??!)
 				const reco::GenParticle* decaying_W = findLastParticleInChain(
-						(reco::GenParticle*) &*td);
+						static_cast<const reco::GenParticle*>(&*td));
 				for (reco::GenParticle::const_iterator wd = decaying_W->begin();
 						wd != decaying_W->end(); ++wd) {
 					if (!(std::abs(wd->pdgId()) == TopDecayID::WID)) {
@@ -522,7 +522,7 @@ void TopDecaySubset::fillListing(
 						// increment & push index of the top daughter
 						wDaughters.push_back(++motherPartIdx_);
 						const reco::GenParticle* last_q = findLastParticleInChain(
-													(reco::GenParticle*) &*wd);
+													static_cast<const reco::GenParticle*>(&*wd));
 						addRadiation(motherPartIdx_, last_q, target);
 						if (std::abs(wd->pdgId()) == TopDecayID::tauID) {
 							// add tau daughters

--- a/TopQuarkAnalysis/TopHitFit/src/PatJetHitFitTranslator.cc
+++ b/TopQuarkAnalysis/TopHitFit/src/PatJetHitFitTranslator.cc
@@ -120,7 +120,7 @@ JetTranslatorBase<pat::Jet>::operator()(const pat::Jet& jet,
     double            jet_eta        = jet.eta();
 
     if (jet.isCaloJet()) {
-        jet_eta = ((reco::CaloJet*) jet.originalObject())->detectorP4().eta();
+        jet_eta = static_cast<const reco::CaloJet*>(jet.originalObject())->detectorP4().eta();
     }
     if (jet.isPFJet()) {
         // do nothing at the moment!
@@ -174,7 +174,7 @@ JetTranslatorBase<pat::Jet>::CheckEta(const pat::Jet& jet) const
     double            jet_eta        = jet.eta();
 
     if (jet.isCaloJet()) {
-        jet_eta = ((reco::CaloJet*) jet.originalObject())->detectorP4().eta();
+        jet_eta = static_cast<const reco::CaloJet*>(jet.originalObject())->detectorP4().eta();
     }
     if (jet.isPFJet()) {
         // do nothing at the moment!


### PR DESCRIPTION
To clean up static analyzer reports.

Tested in CMSSW_10_4_X_2018-10-25-2300, no changes expected.