### PR TITLE
Remove some const-away casts from DB

### DIFF
--- a/OnlineDB/EcalCondDB/interface/IODConfig.h
+++ b/OnlineDB/EcalCondDB/interface/IODConfig.h
@@ -88,7 +88,7 @@ void populateClob (Clob &clob, std::string fname, unsigned int bufsize) noexcept
       std::cout << "Populating the Clob using writeBuffer(Stream) method" << std::endl;
       std::cout<<"we are here0"<<std::endl; 
 
-      char *file = (char *)fname.c_str();
+      const char *file = fname.c_str();
       std::cout<<"we are here0.5 file is:"<<fname<<std::endl; 
 
       std::ifstream inFile;
@@ -99,7 +99,7 @@ void populateClob (Clob &clob, std::string fname, unsigned int bufsize) noexcept
 	  inFile.close();
 
 	  std::string fname2="/nfshome0/ecaldev/francesca/null_file.txt";
-	  inFile.open((char*)fname2.c_str(),std::ios::in);
+	  inFile.open(fname2.c_str(),std::ios::in);
 	  
 
           

--- a/OnlineDB/EcalCondDB/src/LMFColor.cc
+++ b/OnlineDB/EcalCondDB/src/LMFColor.cc
@@ -104,7 +104,7 @@ bool LMFColor::isValid() {
   boost::ptr_list<LMFUnique>::const_iterator e = listOfValidColors.end();
   bool ret = false;
   while (i != e) {
-    LMFColor *c = (LMFColor*)&(*i);
+    const LMFColor *c = static_cast<const LMFColor*>(&(*i));
     if (c->getShortName() == getShortName()) {
       ret = true;
       i = e;

--- a/OnlineDB/EcalCondDB/src/LMFDefFabric.cc
+++ b/OnlineDB/EcalCondDB/src/LMFDefFabric.cc
@@ -182,7 +182,7 @@ void LMFDefFabric::initialize()
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      LMFColor *c = (LMFColor*)&(*i);
+      const LMFColor *c = static_cast<const LMFColor*>(&(*i));
       _lmfColors.push_back(*c);
       i++;
     }
@@ -191,7 +191,7 @@ void LMFDefFabric::initialize()
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      LMFTrigType *c = (LMFTrigType*)&(*i);
+      const LMFTrigType *c = static_cast<const LMFTrigType*>(&(*i));
       _lmfTrigTypes.push_back(*c);
       i++;
     }
@@ -200,7 +200,7 @@ void LMFDefFabric::initialize()
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      LMFRunTag *c = (LMFRunTag*)&(*i);
+      const LMFRunTag *c = static_cast<const LMFRunTag*>(&(*i));
       _lmfRunTags.push_back(*c);
       i++;
     }
@@ -209,7 +209,7 @@ void LMFDefFabric::initialize()
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      LMFPrimVers *c = (LMFPrimVers*)&(*i);
+      const LMFPrimVers *c = static_cast<const LMFPrimVers*>(&(*i));
       _lmfPrimVersions.push_back(*c);
       i++;
     }
@@ -218,7 +218,7 @@ void LMFDefFabric::initialize()
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      LMFCorrVers *c = (LMFCorrVers*)&(*i);
+      const LMFCorrVers *c = static_cast<const LMFCorrVers*>(&(*i));
       _lmfCorrVersions.push_back(*c);
       i++;
     }
@@ -227,7 +227,7 @@ void LMFDefFabric::initialize()
     i = listOfObjects.begin();
     e = listOfObjects.end();
     while (i != e) {
-      LMFSeqVers *c = (LMFSeqVers*)&(*i);
+      const LMFSeqVers *c = static_cast<const LMFSeqVers*>(&(*i));
       _lmfSeqVersions.push_back(*c);
       i++;
     }

--- a/OnlineDB/EcalCondDB/src/MODCCSHFDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODCCSHFDat.cc
@@ -264,18 +264,17 @@ void MODCCSHFDat::populateClob (Clob &clob, std::string fname, unsigned int clob
       cout << "Populating the Clob using writeBuffer(Stream) method" << endl;
       std::cout<<"we are here0"<<std::endl; 
 
-      char *file = (char *)fname.c_str();
       std::cout<<"we are here0.5 file is:"<<fname<<std::endl; 
 
       ifstream inFile;
-      inFile.open(file,ios::in);
+      inFile.open(fname.c_str(),ios::in);
       if (!inFile)
 	{
           cout << fname<<" file not found\n";
 	  inFile.close();
 
 	  std::string fname2="/u1/fra/null_file.txt";
-	  inFile.open((char*)fname2.c_str(),ios::in);
+	  inFile.open(fname2.c_str(),ios::in);
 	  
 
           


### PR DESCRIPTION
To clean up static analyzer reports.

Tested in CMSSW_10_4_X_2018-10-25-2300, no changes expected.