### PR TITLE
Remove some const-away casts from DQM and validation

### DIFF
--- a/DQM/EcalMonitorTasks/src/RawDataTask.cc
+++ b/DQM/EcalMonitorTasks/src/RawDataTask.cc
@@ -61,7 +61,7 @@ namespace ecaldqm {
     // Get GT L1 info
     const FEDRawData &gtFED(_fedRaw.FEDData(812));
     if(gtFED.size() > sizeof(uint64_t)){ // FED header is one 64 bit word
-      uint32_t *halfHeader((uint32_t *)gtFED.data());
+      const uint32_t *halfHeader = reinterpret_cast<const uint32_t *>(gtFED.data());
       l1A_ = *(halfHeader + 1) & 0xffffff;
     }
 

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTLA.cc
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTLA.cc
@@ -61,7 +61,7 @@ std::vector<std::pair< std::pair<DetId, LocalPoint> ,float> > SiStripFineDelayTL
     const SiStripRecHit2D* hit=dynamic_cast<const SiStripRecHit2D*>((*thit).hit());
     LocalVector trackdirection=tsos.localDirection();
     if(matchedhit){//if matched hit...
-	GluedGeomDet * gdet=(GluedGeomDet *)tracker->idToDet(matchedhit->geographicalId());
+	const GluedGeomDet * gdet=static_cast<const GluedGeomDet *>(tracker->idToDet(matchedhit->geographicalId()));
 	GlobalVector gtrkdir=gdet->toGlobal(trackdirection);
 	// trackdirection on mono det
 	// this the pointer to the mono hit of a matched hit 
@@ -70,7 +70,7 @@ std::vector<std::pair< std::pair<DetId, LocalPoint> ,float> > SiStripFineDelayTL
 	LocalVector monotkdir=monodet->toLocal(gtrkdir);
 	if(monotkdir.z()!=0){
 	  // the local angle (mono)
-          float localpitch = ((StripTopology*)(&monodet->topology()))->localPitch(tsos.localPosition());
+          float localpitch = static_cast<const StripTopology&>(monodet->topology()).localPitch(tsos.localPosition());
           float thickness = ((((((monohit.geographicalId())>>25)&0x7f)==0xd)||
 	                     ((((monohit.geographicalId())>>25)&0x7f)==0xe))&&
 			           ((((monohit.geographicalId())>>5)&0x7)>4)) ? 0.0500 : 0.0320;
@@ -83,7 +83,7 @@ std::vector<std::pair< std::pair<DetId, LocalPoint> ,float> > SiStripFineDelayTL
 	  LocalVector stereotkdir=stereodet->toLocal(gtrkdir);
 	  if(stereotkdir.z()!=0){
 	    // the local angle (stereo)
-            float localpitch = ((StripTopology*)(&stereodet->topology()))->localPitch(tsos.localPosition());
+            float localpitch = static_cast<const StripTopology&>(stereodet->topology()).localPitch(tsos.localPosition());
             float thickness = ((((((stereohit.geographicalId())>>25)&0x7f)==0xd)||
 	                       ((((stereohit.geographicalId())>>25)&0x7f)==0xe))&&
 			             ((((stereohit.geographicalId())>>5)&0x7)>4)) ? 0.0500 : 0.0320;
@@ -93,11 +93,11 @@ std::vector<std::pair< std::pair<DetId, LocalPoint> ,float> > SiStripFineDelayTL
 	}
     }
     else if(hit){
-        GeomDetUnit * det=(GeomDetUnit *)tracker->idToDet(hit->geographicalId());
+	const GeomDetUnit * det=tracker->idToDet(hit->geographicalId());
 	//  hit= pointer to the rechit
 	if(trackdirection.z()!=0){
           // the local angle (single hit)
-          float localpitch = ((StripTopology*)(&det->topology()))->localPitch(tsos.localPosition());
+          float localpitch = static_cast<const StripTopology&>(det->topology()).localPitch(tsos.localPosition());
           float thickness = ((((((hit->geographicalId())>>25)&0x7f)==0xd)||
 	                     ((((hit->geographicalId())>>25)&0x7f)==0xe))&&
 			           ((((hit->geographicalId())>>5)&0x7)>4)) ? 0.0500 : 0.0320;

--- a/DQM/SiStripCommissioningSources/src/FineDelayTask.cc
+++ b/DQM/SiStripCommissioningSources/src/FineDelayTask.cc
@@ -79,9 +79,9 @@ void FineDelayTask::fill( const SiStripEventSummary& summary,
 			  const edm::DetSet<SiStripRawDigi>& digis ) {
   LogDebug("Commissioning") << "[FineDelayTask::fill]";
   // retrieve the delay from the EventSummary
-  float delay = const_cast<SiStripEventSummary&>(summary).ttcrx();
-  uint32_t latencyCode = (const_cast<SiStripEventSummary&>(summary).layerScanned()>>24)&0xff;
-  LogDebug("Commissioning") << "[FineDelayTask::fill]: layerScanned() is " << const_cast<SiStripEventSummary&>(summary).layerScanned();
+  float delay = summary.ttcrx();
+  uint32_t latencyCode = (summary.layerScanned()>>24)&0xff;
+  LogDebug("Commissioning") << "[FineDelayTask::fill]: layerScanned() is " << summary.layerScanned();
   int latencyShift = latencyCode & 0x3f;             // number of bunch crossings between current value and start of scan... must be positive
   if(latencyShift>32) latencyShift -=64;             // allow negative values: we cover [-32,32].. should not be needed.
   if((latencyCode>>6)==2) latencyShift -= 3;         // layer in deconv, rest in peak

--- a/DQM/SiStripCommissioningSources/src/LatencyTask.cc
+++ b/DQM/SiStripCommissioningSources/src/LatencyTask.cc
@@ -130,7 +130,7 @@ void LatencyTask::fill( const SiStripEventSummary& summary,
 			const edm::DetSet<SiStripRawDigi>& digis ) {
   LogDebug("Commissioning") << "[LatencyTask::fill]";
   // retrieve the delay from the EventSummary
-  int32_t delay = static_cast<int32_t>( const_cast<SiStripEventSummary&>(summary).latency() );
+  int32_t delay = static_cast<int32_t>( summary.latency() );
   if(firstReading_==-1) firstReading_ = delay;
   float correctedDelay = 0.;
   LogDebug("Commissioning") << "[LatencyTask::fill]; the delay is " << delay;

--- a/DQM/SiStripCommissioningSources/src/VpspScanTask.cc
+++ b/DQM/SiStripCommissioningSources/src/VpspScanTask.cc
@@ -63,8 +63,8 @@ void VpspScanTask::fill( const SiStripEventSummary& summary,
 			 const edm::DetSet<SiStripRawDigi>& digis ) {
 
   // Retrieve VPSP setting and CCU channel
-  uint32_t vpsp = const_cast<SiStripEventSummary&>(summary).vpsp();
-  uint32_t ccu_chan = const_cast<SiStripEventSummary&>(summary).vpspCcuChan();
+  uint32_t vpsp = summary.vpsp();
+  uint32_t ccu_chan = summary.vpspCcuChan();
 
   // Check CCU channel from EventSummary is consistent with this module
   if ( SiStripFecKey( fecKey() ).ccuChan() != ccu_chan ) { return; }

--- a/DQMOffline/Trigger/plugins/JetMETHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/JetMETHLTOfflineSource.cc
@@ -852,8 +852,7 @@ JetMETHLTOfflineSource::fillMEforEffAllTrigger(const Event & iEvent, const edm::
 	if(!isdigit(tpath[trig])) break;
 	jetTrigVal+=tpath[trig];
       }
-      auto *cjetTrigVal = (char*)jetTrigVal.c_str();
-      jetVal=atof(cjetTrigVal);
+      jetVal=atof(jetTrigVal.c_str());
       //
       if(jetVal>0.){
 	if(jetVal<50.){

--- a/Validation/HGCalValidation/plugins/SimG4HGCalValidation.cc
+++ b/Validation/HGCalValidation/plugins/SimG4HGCalValidation.cc
@@ -193,8 +193,7 @@ void SimG4HGCalValidation::update(const BeginOfJob * job) {
       edm::ESHandle<HcalDDDSimConstants>    hdc;
       es->get<HcalSimNumberingRecord>().get(hdc);
       if (hdc.isValid()) {
-	HcalDDDSimConstants* hcalConstants = (HcalDDDSimConstants*)(&(*hdc));
-	numberingFromDDD_ = new HcalNumberingFromDDD(hcalConstants);
+	numberingFromDDD_ = new HcalNumberingFromDDD(hdc.product());
 	layers = 18;
       } else {
 	edm::LogError("ValidHGCal") << "Cannot find HcalDDDSimConstant";
@@ -263,7 +262,7 @@ void SimG4HGCalValidation::update(const G4Step * aStep) {
       // Right type of SD
       if (type >= 0) {
 	//Get the 32-bit index of the hit cell
-	G4TouchableHistory* touchable = (G4TouchableHistory*)aStep->GetPreStepPoint()->GetTouchable();
+	const G4TouchableHistory* touchable = static_cast<const G4TouchableHistory*>(aStep->GetPreStepPoint()->GetTouchable());
 	unsigned int index(0);
 	int          layer(0);
 	G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -222,8 +222,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
     if(iLayerME != LayerMEsMap.end()){
       for(auto const& rechit : theDetSet){	
         const GeomDetUnit *  det = tracker.idToDetUnit(detid);
-        const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)(det);
-        const StripTopology &topol=(StripTopology&)stripdet->topology();
+        const StripTopology &topol=static_cast<const StripGeomDetUnit*>(det)->specificTopology();
         //analyze RecHits 
         rechitanalysis(rechit,topol,associate);
         // fill the result in a histogram
@@ -262,8 +261,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
     if(iStereoAndMatchedME != StereoAndMatchedMEsMap.end()){
       for (auto const& rechit : theDetSet) {
         const GeomDetUnit *  det = tracker.idToDetUnit(detid);
-        const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)(det);
-        const StripTopology &topol=(StripTopology&)stripdet->topology();
+        const StripTopology &topol=static_cast<const StripGeomDetUnit*>(det)->specificTopology();
         //analyze RecHits
         rechitanalysis(rechit,topol,associate);
         // fill the result in a histogram
@@ -301,7 +299,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
     //loop over rechits-matched in the same subdetector
     if(iStereoAndMatchedME != StereoAndMatchedMEsMap.end()){
       for (auto const& rechit : theDetSet) {
-        const GluedGeomDet* gluedDet = (const GluedGeomDet*)tracker.idToDet(rechit.geographicalId());
+        const GluedGeomDet* gluedDet = static_cast<const GluedGeomDet*>(tracker.idToDet(rechit.geographicalId()));
         //analyze RecHits 
         rechitanalysis_matched(rechit, gluedDet, associate);
         // fill the result in a histogram
@@ -462,7 +460,7 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
     PSimHit const * closest = nullptr;
     std::pair<LocalPoint,LocalVector> closestPair;
 
-    const StripGeomDetUnit* partnerstripdet =(StripGeomDetUnit*) gluedDet->stereoDet();
+    const StripGeomDetUnit* partnerstripdet = static_cast<const StripGeomDetUnit*>(gluedDet->stereoDet());
     std::pair<LocalPoint,LocalVector> hitPair;
 
     for(auto const &m : matched){


### PR DESCRIPTION
To clean up static analyzer reports.

Tested in CMSSW_10_4_X_2018-10-25-2300, no changes expected.