### PR TITLE
Remove some const-away casts from FastSim

### DIFF
--- a/FastSimulation/CaloHitMakers/src/CaloHitMaker.cc
+++ b/FastSimulation/CaloHitMakers/src/CaloHitMaker.cc
@@ -2,6 +2,8 @@
 #include "FastSimulation/CaloGeometryTools/interface/CaloGeometryHelper.h"
 #include "FastSimulation/CalorimeterProperties/interface/CalorimeterProperties.h"
 #include "FastSimulation/CalorimeterProperties/interface/PreshowerProperties.h"
+#include "FastSimulation/CalorimeterProperties/interface/PreshowerLayer1Properties.h"
+#include "FastSimulation/CalorimeterProperties/interface/ECALProperties.h"
 #include "FastSimulation/CalorimeterProperties/interface/HCALProperties.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
@@ -15,10 +17,10 @@ CaloHitMaker::CaloHitMaker(const CaloGeometryHelper * theCalo,DetId::Detector ba
   HADSHOWER=(sht==1);
   MIP=(sht==2);
   if(base_==DetId::Ecal&&(subdetn_==EcalBarrel||subdetn==EcalEndcap)&&onCal_)
-    theCaloProperties = (CalorimeterProperties*)myCalorimeter->ecalProperties(onCal_);
+    theCaloProperties = myCalorimeter->ecalProperties(onCal_);
   // is it really necessary to cast here ? 
   if(base_==DetId::Ecal&&subdetn_==EcalPreshower&&onCal_)
-    theCaloProperties = (PreshowerProperties*)myCalorimeter->layer1Properties(onCal_);
+    theCaloProperties = myCalorimeter->layer1Properties(onCal_);
   if(base_==DetId::Hcal&&cal) theCaloProperties = myCalorimeter->hcalProperties(onCal_);
 
   if(theCaloProperties)

--- a/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
+++ b/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
@@ -60,7 +60,7 @@ private:
   const edm::ParameterSet fast;
   std::unique_ptr<HFShowerLibrary> hfshower;
   std::unique_ptr<HcalNumberingFromDDD> numberingFromDDD;
-  HcalDDDSimConstants* hcalConstants;
+  const HcalDDDSimConstants* hcalConstants;
   HcalNumberingScheme numberingScheme;
   
   std::map<CaloHitID,float> hitMap;

--- a/FastSimulation/ShowerDevelopment/src/FastHFShowerLibrary.cc
+++ b/FastSimulation/ShowerDevelopment/src/FastHFShowerLibrary.cc
@@ -55,7 +55,7 @@ void const FastHFShowerLibrary::initHFShowerLibrary(const edm::EventSetup& iSetu
 
   edm::ESHandle<HcalDDDSimConstants>    hdc;
   iSetup.get<HcalSimNumberingRecord>().get(hdc);
-  hcalConstants = (HcalDDDSimConstants*)(&(*hdc));
+  hcalConstants = hdc.product();
 
   std::string name = "HcalHits";
   numberingFromDDD.reset(new HcalNumberingFromDDD(hcalConstants));  


### PR DESCRIPTION
To clean up static analyzer reports.

Tested in CMSSW_10_4_X_2018-10-25-2300, no changes expected.

