### PR TITLE
Remove some const-away casts from simulation

### DIFF
--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -205,7 +205,7 @@ void MuonSensitiveDetector::createHit(const G4Step * aStep){
 
   // convert momentum direction it to local frame
   const G4ThreeVector& gmd  = preStepPoint->GetMomentumDirection();
-  G4ThreeVector lmd = ((G4TouchableHistory *)(preStepPoint->GetTouchable()))->GetHistory()
+  G4ThreeVector lmd = static_cast<const G4TouchableHistory *>(preStepPoint->GetTouchable())->GetHistory()
       ->GetTopTransform().TransformAxis(gmd);
   Local3DPoint lnmd = ConvertToLocal3DPoint(lmd);
   lnmd = theRotation->transformPoint(lnmd, aStep);

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
@@ -114,8 +114,7 @@ void FiberSD::update(const BeginOfJob * job) {
   edm::ESHandle<HcalDDDSimConstants>    hdc;
   es->get<HcalSimNumberingRecord>().get(hdc);
   if (hdc.isValid()) {
-    HcalDDDSimConstants *hcalConstants = (HcalDDDSimConstants*)(&(*hdc));
-    theShower->initRun(hcalConstants);
+    theShower->initRun(hdc.product());
   } else {
     edm::LogError("HcalSim") << "HCalSD : Cannot find HcalDDDSimConstant";
     throw cms::Exception("Unknown", "HCalSD") << "Cannot find HcalDDDSimConstant" << "\n";

--- a/SimG4Core/Application/src/GFlashEMShowerModel.cc
+++ b/SimG4Core/Application/src/GFlashEMShowerModel.cc
@@ -63,12 +63,12 @@ G4bool GFlashEMShowerModel::ModelTrigger(const G4FastTrack & fastTrack )
 
   // This will be changed accordingly when the way 
   // dealing with CaloRegion changes later.
-  G4TouchableHistory* touch = 
-    (G4TouchableHistory*)(fastTrack.GetPrimaryTrack()->GetTouchable());
-  G4VPhysicalVolume* pCurrentVolume = touch->GetVolume();
+  const G4TouchableHistory* touch =
+    static_cast<const G4TouchableHistory*>(fastTrack.GetPrimaryTrack()->GetTouchable());
+  const G4VPhysicalVolume* pCurrentVolume = touch->GetVolume();
   if( pCurrentVolume == nullptr) { return false; }
 
-  G4LogicalVolume* lv = pCurrentVolume->GetLogicalVolume();
+  const G4LogicalVolume* lv = pCurrentVolume->GetLogicalVolume();
   if(lv->GetRegion() != theRegion) { return false; }
   //std::cout << "GFlashEMShowerModel::ModelTrigger: LV " 
   //	    << lv->GetRegion()->GetName() << std::endl;

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -63,7 +63,7 @@ Local3DPoint SensitiveDetector::InitialStepPosition(const G4Step * step, coordin
   const G4StepPoint * preStepPoint = step->GetPreStepPoint();
   const G4ThreeVector& globalCoordinates = preStepPoint->GetPosition();
   if (cd == WorldCoordinates) { return ConvertToLocal3DPoint(globalCoordinates); }
-  G4TouchableHistory * theTouchable=(G4TouchableHistory *)(preStepPoint->GetTouchable());
+  const G4TouchableHistory * theTouchable=static_cast<const G4TouchableHistory *>(preStepPoint->GetTouchable());
   const G4ThreeVector localCoordinates = theTouchable->GetHistory()
                   ->GetTopTransform().TransformPoint(globalCoordinates);
   return ConvertToLocal3DPoint(localCoordinates); 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -159,7 +159,7 @@ bool TrackingMaterialProducer::isSelectedFast(const G4TouchableHistory* touchabl
 //-------------------------------------------------------------------------
 void TrackingMaterialProducer::update(const G4Step* step)
 {
-  const G4TouchableHistory* touchable = (G4TouchableHistory*)(step->GetTrack()->GetTouchable());
+  const G4TouchableHistory* touchable = static_cast<const G4TouchableHistory*>(step->GetTrack()->GetTouchable());
   if (not isSelectedFast( touchable )) {
     LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer:\t[...] skipping "
                                          << touchable->GetVolume()->GetName() << std::endl;


### PR DESCRIPTION
To clean up static analyzer reports.

Tested in CMSSW_10_4_X_2018-10-25-2300, no changes expected.