### PR TITLE
run cx_oracle only if tool if available e.g. only amd64

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -39,4 +39,7 @@
 <iftool name="py2-numpy">
   <test name="testNumPy" command="python -c 'import numpy'"/>
 </iftool>
+<iftool name="py2-cx-oracle">
+  <test name="testCxOracle" command="python -c 'import cx_Oracle'"/>
+</iftool>
 <test name="testPYDablooms" command="python -c 'import pydablooms'"/>

--- a/PhysicsTools/PythonAnalysis/test/imports.sh
+++ b/PhysicsTools/PythonAnalysis/test/imports.sh
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/bash -ex
 
-set -x
-set -e
-
+ERR=0
 echo ">>> Create temporary directory for cache"
 TEST_TMPDIR=$(mktemp -d /tmp/cmssw_theano.XXXXXXX)
 
@@ -10,25 +8,25 @@ echo ">>> Change default behaviour for Theano"
 export THEANO_FLAGS="device=cpu,force_device=True,base_compiledir=$TEST_TMPDIR"
 
 echo ">>> Theano configuration for testing:"
-python -c 'import theano; print(theano.config)'
+python -c 'import theano; print(theano.config)' || ERR=1
 
 echo ">>> Cleaning compile cache"
-theano-cache clear
+theano-cache clear || ERR=1
 
 for i in $(cat ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/imports.txt)
 do
    echo "importing $i"
-   python -c "import $i"
+   python -c "import $i" || ERR=1
 done
 
 echo ">>> Cleaning compile cache"
-theano-cache clear
+theano-cache clear || ERR=1
 
 for i in $(cat ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/commands.txt)
 do
    echo "testing $i"
-   $i -h
+   $i -h || ERR=1
 done
 
-
 rm -rf "$TEST_TMPDIR"
+exit $ERR

--- a/PhysicsTools/PythonAnalysis/test/imports.txt
+++ b/PhysicsTools/PythonAnalysis/test/imports.txt
@@ -117,7 +117,6 @@ webencodings
 werkzeug
 widgetsnbextension
 xgboost
-cx_Oracle
 h5py_cache
 google
 lxml


### PR DESCRIPTION
We do not have oracle client and cx_oracle python module for aarch64. This PR make sure that we run unit test for py2-cx_oracle only if it is available.