### PR TITLE
used constexpr to avoid link time errors with clang

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalDataFrame.h
+++ b/DataFormats/EcalDigi/interface/EcalDataFrame.h
@@ -45,7 +45,7 @@ class EcalDataFrame {
   bool hasSwitchToGain6() const; 
   bool hasSwitchToGain1() const; 
   
-  static const int MAXSAMPLES = 10;
+  static constexpr int MAXSAMPLES = 10;
 
   edm::DataFrame const & frame() const { return m_data;}
   edm::DataFrame & frame() { return m_data;}


### PR DESCRIPTION
In clang IBs we see errors like [a]. This PR should avoid this link error. 

[a]
tmp/slc6_amd64_gcc700/src/CondFormats/EcalObjects/src/CondFormatsEcalObjects/EcalSampleMask.cc.o: In function `EcalSampleMask::setEcalSampleMaskRecordEB(std::vector<unsigned int, std::allocator<unsigned int> > const&)':
  EcalSampleMask.cc:(.text+0x52f): undefined reference to `EcalDataFrame::MAXSAMPLES'
 tmp/slc6_amd64_gcc700/src/CondFormats/EcalObjects/src/CondFormatsEcalObjects/EcalSampleMask.cc.o: In function `EcalSampleMask::setEcalSampleMaskRecordEE(std::vector<unsigned int, std::allocator<unsigned int> > const&)':
  EcalSampleMask.cc:(.text+0xc1f): undefined reference to `EcalDataFrame::MAXSAMPLES'
