### PR TITLE
Update Castor gain in MC for HI 2018

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,7 +54,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' : '103X_upgrade2018_realistic_HI_v7',
+    'phase1_2018_realistic_hi' : '103X_upgrade2018_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail'    : '103X_upgrade2018_realistic_HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode


### PR DESCRIPTION
Hello all,

the PR is to update the Castor gain in MC for heavy Ion 2018.
Th gain in the MC GT is based on study in 2016.

The GT update can be seen at
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2018_realistic_HI_v8/103X_upgrade2018_realistic_HI_v7