### PR TITLE
Made EcalDataFrame::MAXSAMPLES constexpr

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalDataFrame.h
+++ b/DataFormats/EcalDigi/interface/EcalDataFrame.h
@@ -45,7 +45,7 @@ class EcalDataFrame {
   bool hasSwitchToGain6() const; 
   bool hasSwitchToGain1() const; 
   
-  static const int MAXSAMPLES = 10;
+  static constexpr int MAXSAMPLES = 10;
 
   edm::DataFrame const & frame() const { return m_data;}
   edm::DataFrame & frame() { return m_data;}


### PR DESCRIPTION
The clang compiler was having a link error because the static class variable EcalDataFrame::MAXSAMPLES did not have an address defined. Changing it to constexpr solves the problem.