### PR TITLE
const access to ActivityRegistry in EventSetup

### DIFF
--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -43,8 +43,8 @@ namespace edm {
          // ---------- const member functions ---------------------
          bool cacheIsValid() const { return cacheIsValid_.load(std::memory_order_acquire); }
 
-         void doGet(EventSetupRecordImpl const& iRecord, DataKey const& iKey, bool iTransiently, ActivityRegistry*) const;
-         void const* get(EventSetupRecordImpl const&, DataKey const& iKey, bool iTransiently, ActivityRegistry*) const;
+         void doGet(EventSetupRecordImpl const& iRecord, DataKey const& iKey, bool iTransiently, ActivityRegistry const*) const;
+         void const* get(EventSetupRecordImpl const&, DataKey const& iKey, bool iTransiently, ActivityRegistry const*) const;
 
          ///returns the description of the DataProxyProvider which owns this Proxy
          ComponentDescription const* providerDescription() const {

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -145,9 +145,9 @@ namespace edm {
       void clear();
 
     private:
-      EventSetup(ActivityRegistry*);
+      EventSetup(ActivityRegistry const*);
 
-      ActivityRegistry* activityRegistry() const { return activityRegistry_; }
+      ActivityRegistry const* activityRegistry() const { return activityRegistry_; }
       eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
 
       void insert(const eventsetup::EventSetupRecordKey&,
@@ -158,7 +158,7 @@ namespace edm {
       //NOTE: the records are not owned
       std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const *> recordMap_;
       eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
-      ActivityRegistry* activityRegistry_;
+      ActivityRegistry const* activityRegistry_;
   };
 
   // Free functions to retrieve an object from the EventSetup.

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -103,7 +103,7 @@ namespace  {
       ESSignalSentry(const EventSetupRecordImpl& iRecord,
                      const DataKey& iKey,
                      ComponentDescription const* componentDescription,
-                     ActivityRegistry* activityRegistry) :
+                     ActivityRegistry const* activityRegistry) :
          eventSetupRecord_(iRecord),
          dataKey_(iKey),
          componentDescription_(componentDescription),
@@ -127,12 +127,12 @@ namespace  {
       DataKey const& dataKey_;
       ComponentDescription const* componentDescription_;
       bool calledPostLock_;
-      ActivityRegistry* activityRegistry_;
+      ActivityRegistry const* activityRegistry_;
    };
 }
 
 const void* 
-DataProxy::get(const EventSetupRecordImpl& iRecord, const DataKey& iKey, bool iTransiently, ActivityRegistry* activityRegistry) const
+DataProxy::get(const EventSetupRecordImpl& iRecord, const DataKey& iKey, bool iTransiently, ActivityRegistry const* activityRegistry) const
 {
    if(!cacheIsValid()) {
       ESSignalSentry signalSentry(iRecord, iKey, providerDescription(), activityRegistry);
@@ -156,7 +156,7 @@ DataProxy::get(const EventSetupRecordImpl& iRecord, const DataKey& iKey, bool iT
    return cache_;
 }
 
-void DataProxy::doGet(const EventSetupRecordImpl& iRecord, const DataKey& iKey, bool iTransiently, ActivityRegistry* activityRegistry) const {
+void DataProxy::doGet(const EventSetupRecordImpl& iRecord, const DataKey& iKey, bool iTransiently, ActivityRegistry const* activityRegistry) const {
    get(iRecord, iKey, iTransiently, activityRegistry);
 }
       

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -31,7 +31,7 @@ namespace edm {
 //
 // constructors and destructor
 //
-EventSetup::EventSetup(ActivityRegistry* activityRegistry) :
+EventSetup::EventSetup(ActivityRegistry const* activityRegistry) :
    recordMap_(),
    activityRegistry_(activityRegistry)
 


### PR DESCRIPTION
The EventSetup only needs const access to the ActivityRegistry.
This was spotted by the static analyzer.