### PR TITLE
Fix incorrect delete of an array in RawFile

### DIFF
--- a/IORawData/DTCommissioning/plugins/RawFile.cc
+++ b/IORawData/DTCommissioning/plugins/RawFile.cc
@@ -6,6 +6,7 @@
 #include <IORawData/DTCommissioning/plugins/RawFile.h>
 #include <cstring>
 #include <cstdio>
+#include <memory>
 
 #include <XrdPosix/XrdPosixExtern.hh> 
 
@@ -21,11 +22,10 @@ RawFile* RawFile::open(const char* path) {
 
   //cout << " Full path: " << path << endl;
 
-  char* chaux = new char[strlen(path)+1];
-  strcpy(chaux,path);
-  char* prefix = strtok(chaux,":");
+  std::unique_ptr<char[]> chaux{ new char[strlen(path)+1] };
+  strcpy(chaux.get(),path);
+  char* prefix = strtok(chaux.get(),":");
   //cout << " Prefix: " << prefix << endl;
-  delete chaux;
 
   char* filename = prefix;
   if (strlen(prefix)<strlen(path)) filename = strtok(nullptr,":");


### PR DESCRIPTION
The wrong delete was being called on an array. In addition, the memory in that array was being accessed after the array was deleted (strtok uses the same memory as is passed to it).
The problem was caught by the static analyzer.