### PR TITLE
Fix double delete in IsolatedTracksNxN

### DIFF
--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
@@ -514,11 +514,8 @@ IsolatedTracksNxN::~IsolatedTracksNxN() {
   delete t_trackHitInMissTEC;
   delete t_trackHitInMissTIB;
   delete t_trackHitInMissTID;
-  delete t_trackHitOutMissTOB;
-  delete t_trackHitOutMissTEC;
-  delete t_trackHitOutMissTIB;
-  delete t_trackHitOutMissTID;
   delete t_trackHitInMissTIBTID;
+  delete t_trackHitOutMissTOB;
   delete t_trackHitOutMissTEC;
   delete t_trackHitOutMissTIB;
   delete t_trackHitOutMissTID;


### PR DESCRIPTION
The problem was discovered by the static analyzer.