### PR TITLE
Implementation of the option preexistingprimaryvertex

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
@@ -4,6 +4,7 @@ from geometryComparison import GeometryComparison
 from helperFunctions import boolfromstring, getCommandOutput2, parsecolor, parsestyle
 from monteCarloValidation import MonteCarloValidation
 from offlineValidation import OfflineValidation
+from primaryVertexValidation import PrimaryVertexValidation
 from plottingOptions import PlottingOptions
 from TkAlExceptions import AllInOneError
 from trackSplittingValidation import TrackSplittingValidation
@@ -95,6 +96,18 @@ class PreexistingOfflineValidation(PreexistingValidation, OfflineValidation):
 
     def getRepMap(self):
         result = super(PreexistingOfflineValidation, self).getRepMap()
+        result.update({
+                       "filetoplot": self.general["file"],
+                     })
+        return result
+
+    def appendToMerge(self, *args, **kwargs):
+        raise AllInOneError("Shouldn't be here...")
+
+class PreexistingPrimaryVertexValidation(PreexistingValidation, PrimaryVertexValidation):
+    removemandatories = {"isda","ismc","runboundary","vertexcollection","lumilist","ptCut","etaCut","runControl","numberOfBins"}
+    def getRepMap(self):
+        result = super(PreexistingPrimaryVertexValidation, self).getRepMap()
         result.update({
                        "filetoplot": self.general["file"],
                      })

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
@@ -75,6 +75,7 @@ class PrimaryVertexValidation(GenericValidationData_CTSR, ValidationWithPlots):
             #"eosdir": os.path.join(self.general["eosdir"], "%s/%s/%s" % (self.outputBaseName, self.name, alignment.name)),
             "workingdir": ".oO[datadir]Oo./%s/%s/%s" % (self.outputBaseName, self.name, alignment.name),
             "plotsdir": ".oO[datadir]Oo./%s/%s/%s/plots" % (self.outputBaseName, self.name, alignment.name),
+            "filetoplot": "root://eoscms//eos/cms.oO[finalResultFile]Oo.",
             })
 
         return repMap
@@ -93,8 +94,8 @@ class PrimaryVertexValidation(GenericValidationData_CTSR, ValidationWithPlots):
 
     def appendToPlots(self):
         repMap = self.getRepMap()
-        return (' loadFileList("root://eoscms//eos/cms%(finalResultFile)s",'
-                '"PVValidation","%(title)s", %(color)s, %(style)s);\n')%repMap
+        return (' loadFileList("%(filetoplot)s",'
+                '"PVValidation", "%(title)s", %(color)s, %(style)s);\n')%repMap
 
     @classmethod
     def runPlots(cls, validations):

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -175,6 +175,8 @@ class ValidationJob:
         elif valType == "primaryvertex":
             validation = PrimaryVertexValidation( name, 
                 Alignment( alignments.strip(), self.__config ), self.__config )
+        elif valType == "preexistingprimaryvertex":
+            validation = PreexistingPrimaryVertexValidation(name, self.__config)
         else:
             raise AllInOneError("Unknown validation mode '%s'"%valType)
 


### PR DESCRIPTION
Backport of #24761

Making this PR for @henriettepetersen, who originally did #24761 in master = 10_3_X and a backport #24762 in 10_2_X.  But then before it was merged, master became 10_4_X, and as a result 10_3_X got skipped.

> I implemented the option preexistingprimaryvertex in the same style as the existing option preexistingoffline in the TkAlAllInOneTool for alignment @hroskes, @connorpa.