### PR TITLE
Restore PA skims, update HI 2018 data test workflows 

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1675,7 +1675,7 @@ steps['RECOHID15']=merge([{ '--runUnscheduled':'',
                            
 steps['RECOHID18']=merge([{ '--scenario':'pp',
                             '--conditions':'103X_dataRun2_Prompt_v2',
-                            '-s':'RAW2DIGI,L1Reco,RECO,EI,DQM:@common+@standardDQM+@ExtraHLT',
+                            '-s':'RAW2DIGI,L1Reco,RECO,ALCA:SiStripCalZeroBias+SiPixelCalZeroBias,SKIM:PbPbEMu+PbPbZEE+PbPbZMM,EI,DQM:@common+@standardDQM+@ExtraHLT',
                             '--datatier':'AOD,DQMIO',
                             '--eventcontent':'AOD,DQM',
                             '--era':'Run2_2018_pp_on_AA'

--- a/Configuration/Skimming/python/PA_MinBiasSkim_cff.py
+++ b/Configuration/Skimming/python/PA_MinBiasSkim_cff.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+# HLT dimuon trigger
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+hltMinBiasPA = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+hltMinBiasPA.HLTPaths = ["HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_ForSkim_v*"]
+hltMinBiasPA.throw = False
+hltMinBiasPA.andOr = True
+
+# selection of valid vertex
+primaryVertexFilterForMinBiasPA = cms.EDFilter("VertexSelector",
+    src = cms.InputTag("offlinePrimaryVertices"),
+    cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
+    filter = cms.bool(True),   # otherwise it won't filter the events
+    )
+
+# MinBias skim sequence
+minBiasPASkimSequence = cms.Sequence(
+    hltMinBiasPA *
+    primaryVertexFilterForMinBiasPA
+)

--- a/Configuration/Skimming/python/PA_ZEESkim_cff.py
+++ b/Configuration/Skimming/python/PA_ZEESkim_cff.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+
+# HLT dimuon trigger
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+hltZEEPA = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+hltZEEPA.HLTPaths = ["HLT_PADoublePhoton15_Eta3p1_Mass50_1000_v*"]
+hltZEEPA.throw = False
+hltZEEPA.andOr = True
+
+# selection of valid vertex
+primaryVertexFilterForZEEPA = cms.EDFilter("VertexSelector",
+                                         src = cms.InputTag("offlinePrimaryVertices"),
+                                         cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
+                                         filter = cms.bool(True),   # otherwise it won't filter the events
+                                         )
+
+# single lepton selector
+goodElectronsForZEEPA = cms.EDFilter("GsfElectronRefSelector",
+                                   src = cms.InputTag("gedGsfElectrons"),
+                                   cut = cms.string("pt > 25 && abs(eta)<1.44")
+                                   )
+
+## dilepton selectors
+diElectronsForZEEPA = cms.EDProducer("CandViewShallowCloneCombiner",
+                                   decay       = cms.string("goodElectronsForZEEPA goodElectronsForZEEPA"),
+                                   checkCharge = cms.bool(False),
+                                   cut         = cms.string("mass > 80 && mass < 110")
+                                   )
+
+# dilepton counter
+diElectronsFilterForZEEPA = cms.EDFilter("CandViewCountFilter",
+                                       src = cms.InputTag("diElectronsForZEEPA"),
+                                       minNumber = cms.uint32(1)
+                                       )
+
+# Z->ee skim sequence
+zEEPASkimSequence = cms.Sequence(
+    hltZEEPA *
+    primaryVertexFilterForZEEPA *
+    goodElectronsForZEEPA * 
+    diElectronsForZEEPA * 
+    diElectronsFilterForZEEPA
+)

--- a/Configuration/Skimming/python/PA_ZMMSkim_cff.py
+++ b/Configuration/Skimming/python/PA_ZMMSkim_cff.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+# HLT dimuon trigger
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+hltZMMPA = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+hltZMMPA.HLTPaths = ["HLT_PAL3Mu15_v*"]
+hltZMMPA.throw = False
+hltZMMPA.andOr = True
+
+# selection of valid vertex
+primaryVertexFilterForZMMPA = cms.EDFilter("VertexSelector",
+    src = cms.InputTag("offlinePrimaryVertices"),
+    cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
+    filter = cms.bool(True),   # otherwise it won't filter the events
+    )
+
+# selection of dimuons with mass in Z range
+muonSelectorForZMMPA = cms.EDFilter("MuonSelector",
+    src = cms.InputTag("muons"),
+    cut = cms.string("(isTrackerMuon && isGlobalMuon) && pt > 25."),
+    filter = cms.bool(True)
+    )
+
+muonFilterForZMMPA = cms.EDFilter("MuonCountFilter",
+    src = cms.InputTag("muonSelectorForZMMPA"),
+    minNumber = cms.uint32(2)
+    )
+
+dimuonMassCutForZMMPA = cms.EDProducer("CandViewShallowCloneCombiner",
+    checkCharge = cms.bool(True),
+    cut = cms.string(' 80 < mass < 110'),
+    decay = cms.string("muonSelectorForZMMPA@+ muonSelectorForZMMPA@-")
+    )
+
+dimuonMassCutFilterForZMMPA = cms.EDFilter("CandViewCountFilter",
+    src = cms.InputTag("dimuonMassCutForZMMPA"),
+    minNumber = cms.uint32(1)
+    )
+
+# Z->mumu skim sequence
+zMMPASkimSequence = cms.Sequence(
+    hltZMMPA *
+    primaryVertexFilterForZMMPA *
+    muonSelectorForZMMPA *
+    muonFilterForZMMPA *
+    dimuonMassCutForZMMPA *
+    dimuonMassCutFilterForZMMPA
+    )

--- a/Configuration/Skimming/python/Skims_PA_cff.py
+++ b/Configuration/Skimming/python/Skims_PA_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.EventContent.EventContent_cff import FEVTEventContent
+
+skimFEVTContent = FEVTEventContent.clone()
+skimFEVTContent.outputCommands.append("drop *_MEtoEDMConverter_*_*")
+skimFEVTContent.outputCommands.append("drop *_*_*_SKIM")
+
+
+#####################
+
+
+from Configuration.Skimming.PA_MinBiasSkim_cff import *
+minBiasPASkimPath = cms.Path( minBiasPASkimSequence )
+SKIMStreamPAMinBias = cms.FilteredStream(
+    responsible = 'HI PAG',
+    name = 'PAMinBias',
+    paths = (minBiasPASkimPath),
+    content = skimFEVTContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+    )
+
+#####################      
+
+
+from Configuration.Skimming.PA_ZEESkim_cff import *
+zEEPASkimPath = cms.Path( zEEPASkimSequence )
+SKIMStreamPAZEE = cms.FilteredStream(
+    responsible = 'HI PAG',
+    name = 'PAZEE',
+    paths = (zEEPASkimPath),
+    content = skimFEVTContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+    )
+
+#####################      
+
+
+from Configuration.Skimming.PA_ZMMSkim_cff import *
+zMMPASkimPath = cms.Path( zMMPASkimSequence )
+SKIMStreamPAZMM = cms.FilteredStream(
+    responsible = 'HI PAG',
+    name = 'PAZMM',
+    paths = (zMMPASkimPath),
+    content = skimFEVTContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+    )
+
+#####################      

--- a/Configuration/StandardSequences/python/Skims_cff.py
+++ b/Configuration/StandardSequences/python/Skims_cff.py
@@ -48,4 +48,5 @@ from DPGAnalysis.Skims.Skims_DPG_cff import *
 
 ### Central Skims ###
 from Configuration.Skimming.Skims_PDWG_cff import *
+from Configuration.Skimming.Skims_PA_cff import *
 from Configuration.Skimming.Skims_PbPb_cff import *


### PR DESCRIPTION
Following the merge of #24927 the test workflow 140.54 is failing because it is using the PA skims, that were removed. This was unfortunately missed during the scrutiny of the PR. Although the test is technical, and most likely these skims will not be reused in any close future, this PR restores them so as to minimize changes to tests and keep PA skims around for memory.

In order to avoid interferences with the new PbPb skims, the names of modules and paths are all updated adding the PA label. With this update wf 140.54 runs again.

With the occasion, the new skims are added to the 2018 HI data test workflows 140.56 and 140.57, as well as the ALCA step (as in the PPRECO tests on MC).