### PR TITLE
edm::one modules may use Run and Lumi caches

### DIFF
--- a/FWCore/Framework/interface/one/EDAnalyzer.h
+++ b/FWCore/Framework/interface/one/EDAnalyzer.h
@@ -30,6 +30,13 @@ namespace edm {
     class EDAnalyzer : public virtual EDAnalyzerBase,
                        public analyzer::AbilityToImplementor<T>::Type... { 
     public:
+      static_assert(not (CheckAbility<module::Abilities::kRunCache,T...>::kHasIt and
+                        CheckAbility<module::Abilities::kOneWatchRuns,T...>::kHasIt),
+                   "Cannot use both WatchRuns and RunCache");
+      static_assert(not (CheckAbility<module::Abilities::kLuminosityBlockCache,T...>::kHasIt and
+                        CheckAbility<module::Abilities::kOneWatchLuminosityBlocks,T...>::kHasIt),
+                   "Cannot use both WatchLuminosityBlocks and LuminosityBLockCache");
+
       EDAnalyzer() = default;
 #ifdef __INTEL_COMPILER
       virtual ~EDAnalyzer() = default;
@@ -54,8 +61,8 @@ namespace edm {
       const EDAnalyzer& operator=(const EDAnalyzer&) = delete;
       
       // ---------- member data --------------------------------
-      impl::OptionalSerialTaskQueueHolder<WantsGlobalRunTransitions<T...>::value> globalRunsQueue_;
-      impl::OptionalSerialTaskQueueHolder<WantsGlobalLuminosityBlockTransitions<T...>::value> globalLuminosityBlocksQueue_;
+      impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalRunTransitions<T...>::value> globalRunsQueue_;
+      impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalLuminosityBlockTransitions<T...>::value> globalLuminosityBlocksQueue_;
 
     };
     

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -79,7 +79,8 @@ namespace edm {
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
 
-      void doPreallocate(PreallocationConfiguration const&) {}
+      void doPreallocate(PreallocationConfiguration const&);
+      virtual void preallocLumis(unsigned int);
       void doBeginJob();
       void doEndJob();
       

--- a/FWCore/Framework/interface/one/EDFilter.h
+++ b/FWCore/Framework/interface/one/EDFilter.h
@@ -31,6 +31,12 @@ namespace edm {
                        public virtual EDFilterBase {
       
     public:
+      static_assert(not (CheckAbility<module::Abilities::kRunCache,T...>::kHasIt and
+                      CheckAbility<module::Abilities::kOneWatchRuns,T...>::kHasIt),
+                 "Cannot use both WatchRuns and RunCache");
+      static_assert(not (CheckAbility<module::Abilities::kLuminosityBlockCache,T...>::kHasIt and
+                      CheckAbility<module::Abilities::kOneWatchLuminosityBlocks,T...>::kHasIt),
+                 "Cannot use both WatchLuminosityBlocks and LuminosityBLockCache");
       EDFilter() = default;
       //virtual ~EDFilter();
       
@@ -61,8 +67,8 @@ namespace edm {
       const EDFilter& operator=(const EDFilter&) = delete;
       
       // ---------- member data --------------------------------
-      impl::OptionalSerialTaskQueueHolder<WantsGlobalRunTransitions<T...>::value> globalRunsQueue_;
-      impl::OptionalSerialTaskQueueHolder<WantsGlobalLuminosityBlockTransitions<T...>::value> globalLuminosityBlocksQueue_;
+      impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalRunTransitions<T...>::value> globalRunsQueue_;
+      impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalLuminosityBlockTransitions<T...>::value> globalLuminosityBlocksQueue_;
 
     };
     

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -79,6 +79,7 @@ namespace edm {
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
 
       void doPreallocate(PreallocationConfiguration const&);
+      virtual void preallocLumis(unsigned int);
       void doBeginJob();
       void doEndJob();
       

--- a/FWCore/Framework/interface/one/EDProducer.h
+++ b/FWCore/Framework/interface/one/EDProducer.h
@@ -30,6 +30,13 @@ namespace edm {
     class EDProducer : public virtual EDProducerBase,
                        public producer::AbilityToImplementor<T>::Type... { 
     public:
+      static_assert(not (CheckAbility<module::Abilities::kRunCache,T...>::kHasIt and
+                      CheckAbility<module::Abilities::kOneWatchRuns,T...>::kHasIt),
+                 "Cannot use both WatchRuns and RunCache");
+      static_assert(not (CheckAbility<module::Abilities::kLuminosityBlockCache,T...>::kHasIt and
+                      CheckAbility<module::Abilities::kOneWatchLuminosityBlocks,T...>::kHasIt),
+                 "Cannot use both WatchLuminosityBlocks and LuminosityBLockCache");
+
       EDProducer() = default;
 #ifdef __INTEL_COMPILER
       virtual ~EDProducer() = default;
@@ -64,8 +71,8 @@ namespace edm {
       const EDProducer& operator=(const EDProducer&) = delete;
       
       // ---------- member data --------------------------------
-      impl::OptionalSerialTaskQueueHolder<WantsGlobalRunTransitions<T...>::value> globalRunsQueue_;
-      impl::OptionalSerialTaskQueueHolder<WantsGlobalLuminosityBlockTransitions<T...>::value> globalLuminosityBlocksQueue_;
+      impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalRunTransitions<T...>::value> globalRunsQueue_;
+      impl::OptionalSerialTaskQueueHolder<WantsSerialGlobalLuminosityBlockTransitions<T...>::value> globalLuminosityBlocksQueue_;
     };
     
   }

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -79,6 +79,7 @@ namespace edm {
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
 
       void doPreallocate(PreallocationConfiguration const&);
+      virtual void preallocLumis(unsigned int);
       void doBeginJob();
       void doEndJob();
 

--- a/FWCore/Framework/interface/one/analyzerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/analyzerAbilityToImplementor.h
@@ -47,6 +47,16 @@ namespace edm {
       struct AbilityToImplementor<edm::one::WatchLuminosityBlocks> {
         typedef edm::one::impl::LuminosityBlockWatcher<edm::one::EDAnalyzerBase> Type;
       };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::one::impl::RunCacheHolder<edm::one::EDAnalyzerBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::one::impl::LuminosityBlockCacheHolder<edm::one::EDAnalyzerBase,C> Type;
+      };
     }
   }
 }

--- a/FWCore/Framework/interface/one/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/filterAbilityToImplementor.h
@@ -67,6 +67,17 @@ namespace edm {
       struct AbilityToImplementor<edm::EndLuminosityBlockProducer> {
         typedef edm::one::impl::EndLuminosityBlockProducer<edm::one::EDFilterBase> Type;
       };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::one::impl::RunCacheHolder<edm::one::EDFilterBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::one::impl::LuminosityBlockCacheHolder<edm::one::EDFilterBase,C> Type;
+      };
+
     }
   }
 }

--- a/FWCore/Framework/interface/one/moduleAbilities.h
+++ b/FWCore/Framework/interface/one/moduleAbilities.h
@@ -44,18 +44,33 @@ namespace edm {
     
     template<typename... VArgs>
     struct WantsGlobalRunTransitions {
-      static constexpr bool value = CheckAbility<module::Abilities::kOneWatchRuns,VArgs...>::kHasIt or
+      static constexpr bool value = CheckAbility<module::Abilities::kRunCache,VArgs...>::kHasIt or
+      CheckAbility<module::Abilities::kOneWatchRuns,VArgs...>::kHasIt or
       CheckAbility<module::Abilities::kBeginRunProducer,VArgs...>::kHasIt or
       CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
     };
     
     template<typename... VArgs>
     struct WantsGlobalLuminosityBlockTransitions {
-      static constexpr bool value = CheckAbility<module::Abilities::kOneWatchLuminosityBlocks,VArgs...>::kHasIt or
+      static constexpr bool value = CheckAbility<module::Abilities::kLuminosityBlockCache,VArgs...>::kHasIt or
+      CheckAbility<module::Abilities::kOneWatchLuminosityBlocks,VArgs...>::kHasIt or
       CheckAbility<module::Abilities::kBeginLuminosityBlockProducer,VArgs...>::kHasIt or
       CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
     };
 
+    //RunCache and LuminosityBlockCache do not require serializing their
+    // respective transitions
+    template<typename... VArgs>
+    struct WantsSerialGlobalRunTransitions {
+      static constexpr bool value =
+      WantsGlobalRunTransitions<VArgs...>::value and not CheckAbility<module::Abilities::kRunCache,VArgs...>::kHasIt;
+    };
+
+    template<typename... VArgs>
+    struct WantsSerialGlobalLuminosityBlockTransitions {
+      static constexpr bool value =
+      WantsGlobalLuminosityBlockTransitions<VArgs...>::value and not CheckAbility<module::Abilities::kLuminosityBlockCache,VArgs...>::kHasIt;
+    };
   }
 }
 

--- a/FWCore/Framework/interface/one/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/producerAbilityToImplementor.h
@@ -68,6 +68,16 @@ namespace edm {
         typedef edm::one::impl::EndLuminosityBlockProducer<edm::one::EDProducerBase> Type;
       };
 
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::one::impl::RunCacheHolder<edm::one::EDProducerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::one::impl::LuminosityBlockCacheHolder<edm::one::EDProducerBase,C> Type;
+      };
+
       template<>
       struct AbilityToImplementor<edm::Accumulator> {
         typedef edm::one::impl::Accumulator<edm::one::EDProducerBase> Type;

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -83,6 +84,12 @@ namespace edm {
       this->endJob();
     }
     
+    void
+    EDAnalyzerBase::doPreallocate(PreallocationConfiguration const&iPrealloc) {
+      preallocLumis(iPrealloc.numberOfLuminosityBlocks());
+    }
+    void EDAnalyzerBase::preallocLumis(unsigned int) {};
+
     void
     EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                                ModuleCallingContext const* mcc) {

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -88,7 +88,9 @@ namespace edm {
     EDFilterBase::doPreallocate(PreallocationConfiguration const&iPrealloc) {
       auto const nThreads = iPrealloc.numberOfThreads();
       preallocThreads(nThreads);
+      preallocLumis(iPrealloc.numberOfLuminosityBlocks());
     }
+    void EDFilterBase::preallocLumis(unsigned int) {};
 
     void
     EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -86,7 +86,11 @@ namespace edm {
     EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       auto const nThreads = iPrealloc.numberOfThreads();
       preallocThreads(nThreads);
+      preallocLumis(iPrealloc.numberOfLuminosityBlocks());
     }
+    
+    void EDProducerBase::preallocLumis(unsigned int) {};
+
    
     void
     EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,

--- a/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
@@ -14,6 +14,8 @@ for testing purposes only.
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/src/WorkerT.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
@@ -148,6 +150,105 @@ namespace one {
     }
   };
   
+  namespace an {
+    struct Cache { bool begin = true; bool end = false; };
+  }
+  class RunCacheAnalyzer: public edm::one::EDAnalyzer<edm::RunCache<an::Cache>> {
+  public:
+    explicit RunCacheAnalyzer(edm::ParameterSet const& p) :
+    trans_(p.getParameter<int>("transitions")) {
+    }
+    const unsigned int trans_;
+    mutable unsigned int m_count = 0;
+    
+    void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {
+      ++m_count;
+      auto c = runCache(iEvent.getRun().index());
+      if( nullptr == c) {
+        throw cms::Exception("Missing cache") <<" no cache in analyze";
+      }
+      
+      if ( !c->begin  || c->end ) {
+        throw cms::Exception("out of sequence")
+        << " produce before beginRun or after endRun";
+      }
+    }
+    
+    std::shared_ptr<an::Cache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const final {
+      ++m_count;
+      return std::make_shared<an::Cache>();
+    }
+    
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) final {
+      ++m_count;
+      auto c = runCache(iRun.index());
+      if( nullptr == c) {
+        throw cms::Exception("Missing cache") <<" no cache in globalEndRun";
+      }
+      if ( !c->begin ) {
+        throw cms::Exception("out of sequence")
+        << " endRun before beginRun";
+      }
+      c->begin = false;
+      c->end = true;
+    }
+    
+    ~RunCacheAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+        << "WatchRunsAnalyzer transitions "
+        << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  
+  class LumiBlockCacheAnalyzer: public edm::one::EDAnalyzer< edm::LuminosityBlockCache<an::Cache>> {
+  public:
+    explicit LumiBlockCacheAnalyzer(edm::ParameterSet const& p) :
+    trans_(p.getParameter<int>("transitions")) {
+    }
+    const unsigned int trans_;
+    mutable unsigned int m_count = 0;
+    
+    void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {
+      ++m_count;
+      
+      auto c = luminosityBlockCache(iEvent.getLuminosityBlock().index());
+      if( nullptr == c) {
+        throw cms::Exception("Missing cache") <<" no cache in analyze";
+      }
+
+      if ( !c->begin  || c->end ) {
+        throw cms::Exception("out of sequence")
+        << " produce before beginLumiBlock or after endLumiBlock";
+      }
+    }
+    
+    std::shared_ptr<an::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final {
+      ++m_count;
+      return std::make_shared<an::Cache>();
+    }
+    
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) override {
+      ++m_count;
+      auto c = luminosityBlockCache(iLumi.index());
+      if ( !c->begin ) {
+        throw cms::Exception("out of sequence")
+        << " endLumiBlock before beginLumiBlock";
+      }
+      c->begin = false;
+      c->end = true;
+    }
+    
+    ~LumiBlockCacheAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+        << "WatchLumiBlocksAnalyzer transitions "
+        << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
 
 
 }
@@ -156,4 +257,6 @@ namespace one {
 DEFINE_FWK_MODULE(edmtest::one::SharedResourcesAnalyzer);
 DEFINE_FWK_MODULE(edmtest::one::WatchRunsAnalyzer);
 DEFINE_FWK_MODULE(edmtest::one::WatchLumiBlocksAnalyzer);
+DEFINE_FWK_MODULE(edmtest::one::RunCacheAnalyzer);
+DEFINE_FWK_MODULE(edmtest::one::LumiBlockCacheAnalyzer);
 

--- a/FWCore/Framework/test/test_one_modules_cfg.py
+++ b/FWCore/Framework/test/test_one_modules_cfg.py
@@ -40,6 +40,14 @@ process.WatchLumiBlockProd = cms.EDProducer("edmtest::one::WatchLumiBlocksProduc
     transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
 )
 
+process.RunCacheProd = cms.EDProducer("edmtest::one::RunCacheProducer",
+                                    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+                                    )
+
+process.LumiBlockCacheProd = cms.EDProducer("edmtest::one::LumiBlockCacheProducer",
+                                          transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+                                          )
+
 process.BeginRunProd = cms.EDProducer("edmtest::one::TestBeginRunProducer",
     transitions = cms.int32(nEvt+(nEvt/nEvtRun))
 )
@@ -69,6 +77,14 @@ process.WatchLumiBlockAn = cms.EDAnalyzer("edmtest::one::WatchLumiBlocksAnalyzer
     transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
 )
 
+process.RunCacheAn = cms.EDAnalyzer("edmtest::one::RunCacheAnalyzer",
+                                    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+                                    )
+
+process.LumiBlockCacheAn = cms.EDAnalyzer("edmtest::one::LumiBlockCacheAnalyzer",
+                                          transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+                                          )
+
 process.SharedResFil = cms.EDFilter("edmtest::one::SharedResourcesFilter",
     transitions = cms.int32(nEvt)
 )
@@ -80,6 +96,13 @@ process.WatchRunFil = cms.EDFilter("edmtest::one::WatchRunsFilter",
 process.WatchLumiBlockFil = cms.EDFilter("edmtest::one::WatchLumiBlocksFilter",
     transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
 )
+process.RunCacheFil = cms.EDFilter("edmtest::one::RunCacheFilter",
+                                    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+                                    )
+
+process.LumiBlockCacheFil = cms.EDFilter("edmtest::one::LumiBlockCacheFilter",
+                                          transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+                                          )
 
 process.BeginRunFil = cms.EDFilter("edmtest::one::BeginRunFilter",
     transitions = cms.int32(nEvt+(nEvt/nEvtRun))
@@ -113,6 +136,6 @@ process.testFilterModule = cms.EDFilter("TestFilterModule",
 process.task = cms.Task(process.TestAccumulator1)
 
 
-process.p = cms.Path(process.SharedResProd+process.WatchRunProd+process.WatchLumiBlockProd+process.BeginRunProd+process.BeginLumiBlockProd+process.EndRunProd+process.EndLumiBlockProd+process.SharedResAn+process.WatchRunAn+process.WatchLumiBlockAn+process.SharedResFil+process.WatchRunFil+process.WatchLumiBlockFil+process.BeginRunFil+process.BeginLumiBlockFil+process.EndRunFil+process.EndLumiBlockFil+process.testFilterModule+process.TestAccumulator2, process.task)
+process.p = cms.Path(process.SharedResProd+process.WatchRunProd+process.WatchLumiBlockProd+process.RunCacheProd+process.LumiBlockCacheProd+process.BeginRunProd+process.BeginLumiBlockProd+process.EndRunProd+process.EndLumiBlockProd+process.SharedResAn+process.WatchRunAn+process.WatchLumiBlockAn+process.RunCacheAn+process.LumiBlockCacheAn+process.SharedResFil+process.WatchRunFil+process.WatchLumiBlockFil+process.RunCacheFil+process.LumiBlockCacheFil+process.BeginRunFil+process.BeginLumiBlockFil+process.EndRunFil+process.EndLumiBlockFil+process.testFilterModule+process.TestAccumulator2, process.task)
 
 


### PR DESCRIPTION
Using a Run and/or LuminosityBlock cache avoids the need to synchronize on the transition boundaries.
The module is still only called by one thread at a time, but now events from different Runs/LuminosityBlocks can be interleaved.