### PR TITLE
Updated precomputed value sort

### DIFF
--- a/Utilities/General/interface/precomputed_value_sort.h
+++ b/Utilities/General/interface/precomputed_value_sort.h
@@ -4,94 +4,46 @@
 /** \file precomputed_value_sort.h
  *  Sort using precomputed values.
  *
- *  precomputed_value_sort behaves like std::sort, but pre-computes the 
+ *  precomputed_value_sort behaves like std::sort, but pre-computes the
  *  values used in the sorting using an Extractor, so that the computation
  *  is performed only once per element.
- *
  */
 
-#include <utility>
 #include <vector>
 #include <algorithm>
+#include <functional>
 
-namespace {
-  template<class T, class Scalar>
-  struct LessPair {
-    typedef std::pair<T,Scalar> SortPair;
-    bool operator()( const SortPair& a, const SortPair& b) {
-      return a.second < b.second;
-    }
-  };
+template<class RandomAccessIterator, class Extractor, class Compare>
+void precomputed_value_sort( RandomAccessIterator begin, RandomAccessIterator end,
+                             const Extractor& extr, const Compare& comp )
+{
+  using Value  = typename std::iterator_traits<RandomAccessIterator>::value_type;
+  using Scalar = decltype(extr(*begin));
 
-  template <class T, class Scalar, class BinaryPredicate>
-  struct ComparePair {
-    ComparePair( const BinaryPredicate& cmp) : cmp_(cmp) {}
-    typedef std::pair<T,Scalar> SortPair;
-    bool operator()( const SortPair& a, const SortPair& b) {
-      return cmp_(a.second, b.second);
-    }
-    BinaryPredicate cmp_;
-  };
+  std::vector<std::pair<RandomAccessIterator,Scalar>> tmpvec;
+  tmpvec.reserve(end-begin);
+
+  // tmpvec holds iterators - does not copy the real objects
+  for (RandomAccessIterator i=begin; i!=end; i++) tmpvec.emplace_back(i,extr(*i));
+
+  std::sort(tmpvec.begin(), tmpvec.end(),[&comp](auto const& a, auto const& b){
+          return comp(a.second, b.second);
+  });
+
+  // overwrite the input range with the sorted values
+  // copy of input container not necessary, but tricky to avoid
+  std::vector<Value> tmpcopy(begin,end);
+  for (unsigned int i=0; i < tmpvec.size(); i++) {
+    *(begin+i) = std::move(tmpcopy[tmpvec[i].first - begin]);
+  }
 }
-
 
 template<class RandomAccessIterator, class Extractor>
-void precomputed_value_sort(RandomAccessIterator begin,
-			    RandomAccessIterator end,
-			    const Extractor& extr) {
-
-  typedef typename Extractor::result_type        Scalar;
-  typedef std::pair<RandomAccessIterator,Scalar> SortPair;
-
-  std::vector<SortPair> tmpvec; 
-  tmpvec.reserve(end-begin);
-
-  // tmpvec holds iterators - does not copy the real objects
-  for (RandomAccessIterator i=begin; i!=end; i++) {
-    tmpvec.push_back(SortPair(i,extr(*i)));
-  }
-  
-  std::sort(tmpvec.begin(), tmpvec.end(),
-	    LessPair<RandomAccessIterator,Scalar>());    
-
-  // overwrite the input range with the sorted values
-  // copy of input container not necessary, but tricky to avoid
-  std::vector<typename std::iterator_traits<RandomAccessIterator>::value_type> tmpcopy(begin,end);
-  for (unsigned int i=0; i<tmpvec.size(); i++) {
-    *(begin+i) = tmpcopy[tmpvec[i].first - begin];
-  }
-}
-
-
-/// Sort using a BinaryPredicate
-
-template<class RandomAccessIterator, class Extractor, class BinaryPredicate>
-void precomputed_value_sort( RandomAccessIterator begin,
-			     RandomAccessIterator end,
-			     const Extractor& extr,
-			     const BinaryPredicate& pred) {
-
-  typedef typename Extractor::result_type        Scalar;
-  typedef std::pair<RandomAccessIterator,Scalar> SortPair;
-
-  std::vector<SortPair> tmpvec; 
-  tmpvec.reserve(end-begin);
-
-  // tmpvec holds iterators - does not copy the real objects
-  for (RandomAccessIterator i=begin; i!=end; i++) {
-    tmpvec.push_back(SortPair(i,extr(*i)));
-  }
-  
-  std::sort(tmpvec.begin(), tmpvec.end(),
-	    ComparePair< RandomAccessIterator,Scalar,BinaryPredicate>(pred));
-
-  // overwrite the input range with the sorted values
-  // copy of input container not necessary, but tricky to avoid
-  std::vector<typename std::iterator_traits<RandomAccessIterator>::value_type> tmpcopy(begin,end);
-  for (unsigned int i=0; i<tmpvec.size(); i++) {
-    *(begin+i) = tmpcopy[tmpvec[i].first - begin];
-  }
-
+void precomputed_value_sort( RandomAccessIterator begin, RandomAccessIterator end,
+                             const Extractor& extr )
+{
+  using Scalar = decltype(extr(*begin));
+  precomputed_value_sort(begin, end, extr, std::less<Scalar>());
 }
 
 #endif

--- a/Utilities/General/test/test_precomputed_value_sort.cpp
+++ b/Utilities/General/test/test_precomputed_value_sort.cpp
@@ -3,7 +3,6 @@
 #include <vector>
 #include <iterator>
 #include <iostream>
-#include <functional>
 #include <cmath>
 
 using namespace std;
@@ -48,33 +47,37 @@ Point::Point(const Point& p): X(p.X), Y(p.Y){
 }
 
 
+// A trivial operation on Point
+float extractR1(const Point& p) {
+    return p.r();
+}
+
+// Same, but on Point*
+float extractR2(const Point* p) {
+    return p->r();
+}
+
+// Extract phi on Point*
+Phi extractPhi2(const Point* p) {
+    return p->phi();
+}
+
+// A trivial (useless!) binary predicate
+bool lessR(const double& a, const double& b) {
+    return a<b;
+}
+
+// A less trivial example: sorts angles 
+// within any range SMALLER THAN PI "counter-clockwise" 
+// even if the angles cross the pi boundary.
+// The result is undefined if the input values cover a range larger than pi!!!
+// note: Phi handles periodicity...
+bool lessDPhi(const Phi& a, const Phi& b) {
+    return b - a > 0.;
+}
 
  
 int main() {
-
-  // A trivial operation on Point
-  std::function<float(const Point&)> extractR1
-        {[](const Point& p){return p.r();}};
-
-  // Same, but on Point*
-  std::function<float(const Point*)> extractR2
-        {[](const Point* p){return p->r();}};
-
-  // Extract phi on Point*
-  std::function<Phi(const Point*)> extractPhi2
-        {[](const Point* p){return p->phi();}};
-
-  // A trivial (useless!) binary predicate
-  std::function<bool(const double& a, const double& b)> lessR
-        {[](const double& a, const double& b){return a<b;}};
-
-  // A less trivial example: sorts angles 
-  // within any range SMALLER THAN PI "counter-clockwise" 
-  // even if the angles cross the pi boundary.
-  // The result is undefined if the input values cover a range larger than pi!!!
-  // note: Phi handles periodicity...
-  std::function<bool(const Phi& a, const Phi& b)> lessDPhi
-        {[](const Phi& a, const Phi& b){return b - a > 0.;}};
 
   // Create a vector with some random Points
   vector<Point> v1;


### PR DESCRIPTION
The current implementation of precomputed_value_sort requires the passed functions to be functors inheriting from the deprecated binary_/unary_function or functions wrapped in a `std::function`.

Here, I propose to improve it in a way that it can be used with any function object (in particular normal functions and lambdas). That will allow us to drop the binary_/unary_functions more easily.