### PR TITLE
Added missing cmath header to GBRForest

### DIFF
--- a/CondFormats/EgammaObjects/interface/GBRForest.h
+++ b/CondFormats/EgammaObjects/interface/GBRForest.h
@@ -20,6 +20,7 @@
 #include "CondFormats/EgammaObjects/interface/GBRTree.h"
 
 #include <vector>
+#include <cmath>
 
   class GBRForest {
 


### PR DESCRIPTION
Needed cmath for exp function.

NOTE: this fixes the compiler errors seen in the DEVEL build.