### PR TITLE
Extend ConfigBuilder.scheduleSequence() to support Tasks

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1207,7 +1207,11 @@ class ConfigBuilder(object):
                     setattr(self.process,prefix,getattr(cms,what)( getattr(self.process, s) ))
                 else:
                     p=getattr(self.process,prefix)
-                    p+=getattr(self.process, s)
+                    tmp = getattr(self.process, s)
+                    if isinstance(tmp, cms.Task):
+                        p.associate(tmp)
+                    else:
+                        p+=tmp
             self.schedule.append(getattr(self.process,prefix))
             return
         else:


### PR DESCRIPTION
This PR will make the `STEP:task1*task2` syntax work for `cms.Task`s (the more usual `STEP:task1+task2` already works automatically).

Tested in 10_4_0_pre1, no changes expected.