### PR TITLE
speedup of some slower modules from miniAOD

### DIFF
--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -20,6 +20,7 @@ public:
     // const std::vector<double> puppiAlpha   () {return fAlpha;}
     const std::vector<double> & puppiAlphasMed() {return fAlphaMed;}
     const std::vector<double> & puppiAlphasRMS() {return fAlphaRMS;}
+    const std::vector<int>& recoToPup() const {return fRecoToPup;}
 
     int puppiNAlgos(){ return fNAlgos; }
     std::vector<PuppiCandidate> const & puppiParticles() const { return fPupParticles;}
@@ -42,6 +43,7 @@ protected:
     std::vector<double>    fRawAlphas;
     std::vector<double>    fAlphaMed;
     std::vector<double>    fAlphaRMS;
+    std::vector<int>       fRecoToPup;
 
     bool   fApplyCHS;
     bool   fInvert;

--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -33,7 +33,7 @@ protected:
     double  var_within_R (int iId, const std::vector<PuppiCandidate> & particles, const PuppiCandidate& centre, const double R);
     
     bool      fPuppiDiagnostics;
-    std::vector<RecoObj>   fRecoParticles;
+    const std::vector<RecoObj>* fRecoParticles;
     std::vector<PuppiCandidate> fPFParticles;
     std::vector<PuppiCandidate> fChargedPV;
     std::vector<PuppiCandidate> fPupParticles;

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -250,15 +250,16 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     }
     LorentzVector pVec;
 
-    // Find the Puppi particle matched to the input collection using the "user_index" of the object. 
-    auto puppiMatched = find_if( lCandidates.begin(), lCandidates.end(), [&val]( PuppiCandidate const & i ){ return i.user_index() == val; } );
-    if ( puppiMatched != lCandidates.end() ) {
-      pVec.SetPxPyPzE(puppiMatched->px(),puppiMatched->py(),puppiMatched->pz(),puppiMatched->E());
+    //get an index to a pup in lCandidates: either fUseExistingWeights with no skips or get from fPuppiContainer
+    int iPuppiMatched = fUseExistingWeights ? val : fPuppiContainer->recoToPup()[val];
+    if ( iPuppiMatched >= 0 ) {
+      auto const& puppiMatched = lCandidates[iPuppiMatched];
+      pVec.SetPxPyPzE(puppiMatched.px(),puppiMatched.py(),puppiMatched.pz(),puppiMatched.E());
       if(fClonePackedCands && (!fUseExistingWeights)) {
         if(fPuppiForLeptons)
-          pCand->setPuppiWeight(pCand->puppiWeight(),lWeights[puppiMatched-lCandidates.begin()]);
+          pCand->setPuppiWeight(pCand->puppiWeight(),lWeights[iPuppiMatched]);
         else
-          pCand->setPuppiWeight(lWeights[puppiMatched-lCandidates.begin()],pCand->puppiWeightNoLep());
+          pCand->setPuppiWeight(lWeights[iPuppiMatched],pCand->puppiWeightNoLep());
       }
     } else {
       pVec.SetPxPyPzE( 0, 0, 0, 0);

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -88,7 +88,8 @@ double PuppiContainer::var_within_R(int iId, const vector<PuppiCandidate> & part
     vector<double > near_pts;      near_pts.reserve(std::min(50UL, particles.size()));
     const double r2 = R*R;
     for (auto const& part : particles){
-      if ( part.squared_distance(centre) < r2 ){
+      //squared_distance is in (y,phi) coords: rap() has faster access -> check it first
+      if ( std::abs(part.rap()-centre.rap()) < R && part.squared_distance(centre) < r2 ){
         near_dR2s.push_back(reco::deltaR2(part, centre));
         near_pts.push_back(part.pt());
       }
@@ -145,8 +146,12 @@ void PuppiContainer::getRMSAvg(int iOpt,std::vector<PuppiCandidate> const &iCons
             pCharged = fPuppiAlgo[i1].isCharged(iOpt);
             pCone    = fPuppiAlgo[i1].coneSize (iOpt);
             double curVal = -1; 
-            if(!pCharged) curVal = goodVar(iConstits[i0],iParticles       ,pAlgo,pCone);
-            if( pCharged) curVal = goodVar(iConstits[i0],iChargedParticles,pAlgo,pCone);
+            if (i1 != pPupId){
+              if(!pCharged) curVal = goodVar(iConstits[i0],iParticles       ,pAlgo,pCone);
+              if( pCharged) curVal = goodVar(iConstits[i0],iChargedParticles,pAlgo,pCone);
+            } else {//no need to repeat the computation
+              curVal = pVal;
+            }
             //std::cout << "i1 = " << i1 << ", curVal = " << curVal << ", eta = " << iConstits[i0].eta() << ", pupID = " << pPupId << std::endl;
             fPuppiAlgo[i1].add(iConstits[i0],curVal,iOpt);
         }

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -39,6 +39,8 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
     fPVFrac = 0.;
     fNPV    = 1.;
     fRecoParticles = &iRecoObjects;
+    fRecoToPup.clear();
+    fRecoToPup.reserve(fRecoParticles->size());
     for (auto const& rParticle : *fRecoParticles){
         PuppiCandidate curPseudoJet;
         // float nom = sqrt((rParticle.m)*(rParticle.m) + (rParticle.pt)*(rParticle.pt)*(cosh(rParticle.eta))*(cosh(rParticle.eta))) + (rParticle.pt)*sinh(rParticle.eta);//hacked
@@ -203,21 +205,26 @@ double PuppiContainer::getChi2FromdZ(double iDZ) {
     return lChi2PU;
 }
 std::vector<double> const & PuppiContainer::puppiWeights() {
-    fPupParticles .resize(0);
-    fWeights      .resize(0);
-    fVals         .resize(0);
+    int lNParticles    = fRecoParticles->size();
+
+    fPupParticles .clear();
+    fPupParticles.reserve(lNParticles);
+    fWeights      .clear();
+    fWeights.reserve(lNParticles);
+    fVals         .clear();
+    fVals.reserve(lNParticles);
     for(int i0 = 0; i0 < fNAlgos; i0++) fPuppiAlgo[i0].reset();
     
     int lNMaxAlgo = 1;
     for(int i0 = 0; i0 < fNAlgos; i0++) lNMaxAlgo = std::max(fPuppiAlgo[i0].numAlgos(),lNMaxAlgo);
     //Run through all compute mean and RMS
-    int lNParticles    = fRecoParticles->size();
     for(int i0 = 0; i0 < lNMaxAlgo; i0++) {
         getRMSAvg(i0,fPFParticles,fPFParticles,fChargedPV);
     }
     if (fPuppiDiagnostics) getRawAlphas(0,fPFParticles,fPFParticles,fChargedPV);
 
     std::vector<double> pVals;
+    pVals.reserve(lNParticles);
     for(int i0 = 0; i0 < lNParticles; i0++) {
         //Refresh
         pVals.clear();
@@ -228,8 +235,11 @@ std::vector<double> const & PuppiContainer::puppiWeights() {
         if(pPupId == -1) {
             fWeights .push_back(pWeight);
             fAlphaMed.push_back(-10);
-            fAlphaRMS.push_back(-10);            
+            fAlphaRMS.push_back(-10);
+            fRecoToPup.push_back(-1);
             continue;
+        } else {
+          fRecoToPup.push_back(fPupParticles.size());//watch out: there should be no skips after this
         }
         // fill the p-values
         double pChi2   = 0;

--- a/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
@@ -47,6 +47,10 @@ class PFCand_AssoMapAlgos : public PF_PU_AssoMapAlgos  {
    //get all needed collections at the beginning
    void GetInputCollections(edm::Event&, const edm::EventSetup&) override;
 
+   //create the pf candidate to vertex association and the inverse map
+   std::pair<std::unique_ptr<PFCandToVertexAssMap>, std::unique_ptr<VertexToPFCandAssMap>>
+     createMappings(edm::Handle<reco::PFCandidateCollection> pfCandH, const edm::EventSetup& iSetup);
+
    //create the pf candidate to vertex association map
    std::unique_ptr<PFCandToVertexAssMap> CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollection>, const edm::EventSetup&);
 

--- a/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
@@ -106,13 +106,13 @@ class PF_PU_AssoMapAlgos{
   //protected functions
 
    //create helping vertex vector to remove associated vertices
-   std::vector<reco::VertexRef>* CreateVertexVector(edm::Handle<reco::VertexCollection>);
+   std::vector<reco::VertexRef> CreateVertexVector(edm::Handle<reco::VertexCollection>);
 
    //erase one vertex from the vertex vector
-   void EraseVertex(std::vector<reco::VertexRef>*, reco::VertexRef);
+   void EraseVertex(std::vector<reco::VertexRef>&, reco::VertexRef);
 
    //find an association for a certain track
-   VertexStepPair FindAssociation(const reco::TrackRef&, std::vector<reco::VertexRef>*,
+   VertexStepPair FindAssociation(const reco::TrackRef&, const std::vector<reco::VertexRef>&,
                                   edm::ESHandle<MagneticField>, const edm::EventSetup&,
 		                  edm::Handle<reco::BeamSpot>, int);
 
@@ -124,10 +124,10 @@ class PF_PU_AssoMapAlgos{
   // private methods for internal usage
 
    //function to find the closest vertex in z for a certain track
-   static reco::VertexRef FindClosestZ(const reco::TrackRef, std::vector<reco::VertexRef>*, double tWeight = 0.);
+   static reco::VertexRef FindClosestZ(const reco::TrackRef, const std::vector<reco::VertexRef>&, double tWeight = 0.);
 
    //function to find the closest vertex in 3D for a certain track
-   static reco::VertexRef FindClosest3D(reco::TransientTrack, std::vector<reco::VertexRef>*, double tWeight = 0.);
+   static reco::VertexRef FindClosest3D(reco::TransientTrack, const std::vector<reco::VertexRef>&, double tWeight = 0.);
 
    //function to calculate the deltaR between a vector and a vector connecting two points
    static double dR(const math::XYZPoint&, const math::XYZVector&, edm::Handle<reco::BeamSpot>);
@@ -141,7 +141,7 @@ class PF_PU_AssoMapAlgos{
 
    static reco::VertexRef FindConversionVertex(const reco::TrackRef, const reco::Conversion&,
                                                edm::ESHandle<MagneticField>, const edm::EventSetup&,
-				               edm::Handle<reco::BeamSpot>, std::vector<reco::VertexRef>*, double);
+				               edm::Handle<reco::BeamSpot>, const std::vector<reco::VertexRef>&, double);
 
    //function to filter the Kshort collection
    static std::unique_ptr<reco::VertexCompositeCandidateCollection> GetCleanedKshort(edm::Handle<reco::VertexCompositeCandidateCollection>, edm::Handle<reco::BeamSpot>, bool);
@@ -155,7 +155,7 @@ class PF_PU_AssoMapAlgos{
 
    static reco::VertexRef FindV0Vertex(const reco::TrackRef, const reco::VertexCompositeCandidate&,
                                        edm::ESHandle<MagneticField>, const edm::EventSetup&,
-				       edm::Handle<reco::BeamSpot>, std::vector<reco::VertexRef>*, double);
+				       edm::Handle<reco::BeamSpot>, const std::vector<reco::VertexRef>&, double);
 
    //function to filter the nuclear interaction collection
    static std::unique_ptr<reco::PFDisplacedVertexCollection> GetCleanedNI(edm::Handle<reco::PFDisplacedVertexCollection>, edm::Handle<reco::BeamSpot>, bool);
@@ -165,10 +165,10 @@ class PF_PU_AssoMapAlgos{
 
    static reco::VertexRef FindNIVertex(const reco::TrackRef, const reco::PFDisplacedVertex&,
                                        edm::ESHandle<MagneticField>, const edm::EventSetup&,
- 	 	                       edm::Handle<reco::BeamSpot>, std::vector<reco::VertexRef>*, double);
+ 	 	                       edm::Handle<reco::BeamSpot>, const std::vector<reco::VertexRef>&, double);
 
    //function to find the vertex with the highest TrackWeight for a certain track
-   template<typename TREF> static reco::VertexRef TrackWeightAssociation(const TREF&, std::vector<reco::VertexRef>*);
+   template<typename TREF> static reco::VertexRef TrackWeightAssociation(const TREF&, const std::vector<reco::VertexRef>&);
 
 
   // ----------member data ---------------------------

--- a/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
@@ -93,6 +93,10 @@ class PF_PU_AssoMapAlgos{
    //get all needed collections at the beginning
    virtual void GetInputCollections(edm::Event&, const edm::EventSetup&);
 
+   //create the track-to-vertex and vertex-to-track maps in one go
+   std::pair<std::unique_ptr<TrackToVertexAssMap>, std::unique_ptr<VertexToTrackAssMap>> 
+     createMappings(edm::Handle<reco::TrackCollection> trkcollH, const edm::EventSetup& iSetup);
+
    //create the track to vertex association map
    std::unique_ptr<TrackToVertexAssMap> CreateTrackToVertexMap(edm::Handle<reco::TrackCollection>, const edm::EventSetup&);
 

--- a/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
@@ -168,7 +168,7 @@ class PF_PU_AssoMapAlgos{
  	 	                       edm::Handle<reco::BeamSpot>, std::vector<reco::VertexRef>*, double);
 
    //function to find the vertex with the highest TrackWeight for a certain track
-   static reco::VertexRef TrackWeightAssociation(const reco::TrackBaseRef&, std::vector<reco::VertexRef>*);
+   template<typename TREF> static reco::VertexRef TrackWeightAssociation(const TREF&, std::vector<reco::VertexRef>*);
 
 
   // ----------member data ---------------------------

--- a/CommonTools/RecoUtils/plugins/PFCand_AssoMap.cc
+++ b/CommonTools/RecoUtils/plugins/PFCand_AssoMap.cc
@@ -86,15 +86,15 @@ PFCand_AssoMap::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 	PFCand_AssoMapAlgos::GetInputCollections(iEvent,iSetup);
 
-	if ( ( asstype == "PFCandsToVertex" ) || ( asstype == "Both" ) ) {
-	  unique_ptr<PFCandToVertexAssMap> PFCand2Vertex = CreatePFCandToVertexMap(pfCandH, iSetup);
-	  iEvent.put( SortPFCandAssociationMap( &(*PFCand2Vertex), &iEvent.productGetter() ) );
-	}
-
-	if ( ( asstype == "VertexToPFCands" ) || ( asstype == "Both" ) ) {
-	  unique_ptr<VertexToPFCandAssMap> Vertex2PFCand = CreateVertexToPFCandMap(pfCandH, iSetup);
-	  iEvent.put(std::move(Vertex2PFCand));
-	}
+        if (asstype == "PFCandsToVertex" || asstype == "VertexToPFCands" || asstype == "Both") {
+          auto mappings = createMappings(pfCandH, iSetup);
+          if (asstype == "PFCandsToVertex" || asstype == "Both") {
+            iEvent.put( SortPFCandAssociationMap( &(*mappings.first), &iEvent.productGetter() ) );
+          }
+          if (asstype == "VertexToPFCands" || asstype == "Both") {
+            iEvent.put( std::move(mappings.second));
+          }          
+        }
 
 }
 

--- a/CommonTools/RecoUtils/plugins/PF_PU_AssoMap.cc
+++ b/CommonTools/RecoUtils/plugins/PF_PU_AssoMap.cc
@@ -85,15 +85,15 @@ PF_PU_AssoMap::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 	PF_PU_AssoMapAlgos::GetInputCollections(iEvent,iSetup);
 
-	if ( ( asstype == "TracksToVertex" ) || ( asstype == "Both" ) ) {
-	  unique_ptr<TrackToVertexAssMap> Track2Vertex = CreateTrackToVertexMap(trkcollH, iSetup);
-  	  iEvent.put( SortAssociationMap( &(*Track2Vertex) , trkcollH ) );
-	}
-
-	if ( ( asstype == "VertexToTracks" ) || ( asstype == "Both" ) ) {
-	  unique_ptr<VertexToTrackAssMap> Vertex2Track = CreateVertexToTrackMap(trkcollH, iSetup);
-	  iEvent.put(std::move(Vertex2Track));
-	}
+        if (asstype == "TracksToVertex" || asstype == "VertexToTracks" || asstype == "Both") {
+          auto mappings = createMappings(trkcollH, iSetup);
+          if (asstype == "TracksToVertex" || asstype == "Both") {
+            iEvent.put( SortAssociationMap( &(*mappings.first), trkcollH ) );
+          }
+          if (asstype == "VertexToTracks" || asstype == "Both") {
+            iEvent.put( std::move(mappings.second));
+          }
+        }
 
 }
 

--- a/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
@@ -14,11 +14,11 @@ using namespace reco;
 PFCand_AssoMapAlgos::PFCand_AssoMapAlgos(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC):PF_PU_AssoMapAlgos(iConfig, iC)
 {
 
-  	input_MaxNumAssociations_ = iConfig.getParameter<int>("MaxNumberOfAssociations");
+        input_MaxNumAssociations_ = iConfig.getParameter<int>("MaxNumberOfAssociations");
 
-  	token_VertexCollection_= iC.consumes<VertexCollection>(iConfig.getParameter<InputTag>("VertexCollection"));
+        token_VertexCollection_= iC.consumes<VertexCollection>(iConfig.getParameter<InputTag>("VertexCollection"));
 
-  	token_BeamSpot_= iC.consumes<BeamSpot>(iConfig.getParameter<InputTag>("BeamSpot"));
+        token_BeamSpot_= iC.consumes<BeamSpot>(iConfig.getParameter<InputTag>("BeamSpot"));
 
 }
 
@@ -30,15 +30,15 @@ void
 PFCand_AssoMapAlgos::GetInputCollections(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-	PF_PU_AssoMapAlgos::GetInputCollections(iEvent, iSetup);
+        PF_PU_AssoMapAlgos::GetInputCollections(iEvent, iSetup);
 
-  	//get the offline beam spot
-  	iEvent.getByToken(token_BeamSpot_, beamspotH);
+        //get the offline beam spot
+        iEvent.getByToken(token_BeamSpot_, beamspotH);
 
-  	//get the input vertex collection
-  	iEvent.getByToken(token_VertexCollection_, vtxcollH);
+        //get the input vertex collection
+        iEvent.getByToken(token_VertexCollection_, vtxcollH);
 
-     	iSetup.get<IdealMagneticFieldRecord>().get(bFieldH);
+        iSetup.get<IdealMagneticFieldRecord>().get(bFieldH);
 
 }
 
@@ -50,35 +50,35 @@ std::pair<std::unique_ptr<PFCandToVertexAssMap>, std::unique_ptr<VertexToPFCandA
         unique_ptr<PFCandToVertexAssMap> pfcand2vertex(new PFCandToVertexAssMap(vtxcollH, pfCandH));
         unique_ptr<VertexToPFCandAssMap> vertex2pfcand(new VertexToPFCandAssMap(pfCandH, vtxcollH));
 
-	int num_vertices = vtxcollH->size();
-	if ( num_vertices < input_MaxNumAssociations_) input_MaxNumAssociations_ = num_vertices;
+        int num_vertices = vtxcollH->size();
+        if ( num_vertices < input_MaxNumAssociations_) input_MaxNumAssociations_ = num_vertices;
         vector<VertexRef> vtxColl_help;
         if (input_MaxNumAssociations_ == 1) vtxColl_help = CreateVertexVector(vtxcollH);
 
-	for( unsigned i=0; i<pfCandH->size(); i++ ) {
+        for( unsigned i=0; i<pfCandH->size(); i++ ) {
 
           PFCandidateRef candref(pfCandH, i);
 
-	  if (input_MaxNumAssociations_ > 1) vtxColl_help = CreateVertexVector(vtxcollH);
+          if (input_MaxNumAssociations_ > 1) vtxColl_help = CreateVertexVector(vtxcollH);
 
           VertexPfcQuality VtxPfcQual;
 
-	  TrackRef PFCtrackref = candref->trackRef();
+          TrackRef PFCtrackref = candref->trackRef();
 
-	  if ( PFCtrackref.isNull() ){
+          if ( PFCtrackref.isNull() ){
 
-	    for ( int assoc_ite = 0; assoc_ite < input_MaxNumAssociations_; ++assoc_ite ) {
+            for ( int assoc_ite = 0; assoc_ite < input_MaxNumAssociations_; ++assoc_ite ) {
 
-	      int quality = -1 - assoc_ite;
+              int quality = -1 - assoc_ite;
 
-    	      // Insert the best vertex and the pair of track and the quality of this association in the map
-    	      pfcand2vertex->insert( vtxColl_help.at(0), make_pair(candref, quality) );
+              // Insert the best vertex and the pair of track and the quality of this association in the map
+              pfcand2vertex->insert( vtxColl_help.at(0), make_pair(candref, quality) );
               vertex2pfcand->insert( candref, make_pair(vtxColl_help.at(0), quality) );
 
               //cleanup only if multiple iterations are made
-	      if (input_MaxNumAssociations_ > 1) PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, vtxColl_help.at(0));
+              if (input_MaxNumAssociations_ > 1) PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, vtxColl_help.at(0));
 
-	    }
+            }
 
           } else {
 
@@ -86,28 +86,28 @@ std::pair<std::unique_ptr<PFCandToVertexAssMap>, std::unique_ptr<VertexToPFCandA
             transtrk.setBeamSpot(*beamspotH);
             transtrk.setES(iSetup);
 
-	    for ( int assoc_ite = 0; assoc_ite < input_MaxNumAssociations_; ++assoc_ite ) {
+            for ( int assoc_ite = 0; assoc_ite < input_MaxNumAssociations_; ++assoc_ite ) {
 
-    	      VertexStepPair assocVtx = FindAssociation(PFCtrackref, vtxColl_help, bFieldH, iSetup, beamspotH, assoc_ite);
-	      int step = assocVtx.second;
-	      double distance = ( IPTools::absoluteImpactParameter3D( transtrk, *(assocVtx.first) ) ).second.value();
+              VertexStepPair assocVtx = FindAssociation(PFCtrackref, vtxColl_help, bFieldH, iSetup, beamspotH, assoc_ite);
+              int step = assocVtx.second;
+              double distance = ( IPTools::absoluteImpactParameter3D( transtrk, *(assocVtx.first) ) ).second.value();
 
-	      int quality = DefineQuality(assoc_ite, step, distance);
+              int quality = DefineQuality(assoc_ite, step, distance);
 
-    	      // Insert the best vertex and the pair of track and the quality of this association in the map
-    	      pfcand2vertex->insert( assocVtx.first, make_pair(candref, quality) );
+              // Insert the best vertex and the pair of track and the quality of this association in the map
+              pfcand2vertex->insert( assocVtx.first, make_pair(candref, quality) );
               vertex2pfcand->insert( candref, make_pair(assocVtx.first, quality) );
 
               //cleanup only if multiple iterations are made
-	      if (input_MaxNumAssociations_ > 2) PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, assocVtx.first);
+              if (input_MaxNumAssociations_ > 2) PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, assocVtx.first);
 
-	    }
+            }
 
-	  }//check PFCtrackref.isNull
+          }//check PFCtrackref.isNull
 
-       	}//i on pfCandH
+        }//i on pfCandH
 
-	return {std::move(pfcand2vertex), std::move(vertex2pfcand)};
+        return {std::move(pfcand2vertex), std::move(vertex2pfcand)};
 }
 
 /*************************************************************************************/
@@ -138,74 +138,74 @@ std::unique_ptr<PFCandToVertexAssMap>
 PFCand_AssoMapAlgos::SortPFCandAssociationMap(PFCandToVertexAssMap* pfcvertexassInput,
                                               edm::EDProductGetter const* getter)
 {
-	//create a new PFCandVertexAssMap for the Output which will be sorted
-	unique_ptr<PFCandToVertexAssMap> pfcvertexassOutput(new PFCandToVertexAssMap(getter) );
+        //create a new PFCandVertexAssMap for the Output which will be sorted
+        unique_ptr<PFCandToVertexAssMap> pfcvertexassOutput(new PFCandToVertexAssMap(getter) );
 
-	//Create and fill a vector of pairs of vertex and the summed (pT)**2 of the pfcandidates associated to the vertex
-	VertexPtsumVector vertexptsumvector;
+        //Create and fill a vector of pairs of vertex and the summed (pT)**2 of the pfcandidates associated to the vertex
+        VertexPtsumVector vertexptsumvector;
 
-	//loop over all vertices in the association map
+        //loop over all vertices in the association map
         for(PFCandToVertexAssMap::const_iterator assomap_ite=pfcvertexassInput->begin(); assomap_ite!=pfcvertexassInput->end(); assomap_ite++){
 
-	  const VertexRef assomap_vertexref = assomap_ite->key;
-  	  const PFCandQualityPairVector pfccoll = assomap_ite->val;
+          const VertexRef assomap_vertexref = assomap_ite->key;
+          const PFCandQualityPairVector pfccoll = assomap_ite->val;
 
-	  float ptsum = 0;
+          float ptsum = 0;
 
-	  PFCandidateRef pfcandref;
+          PFCandidateRef pfcandref;
 
-	  //get the pfcandidates associated to the vertex and calculate the pT**2
-	  for(unsigned int pfccoll_ite=0; pfccoll_ite<pfccoll.size(); pfccoll_ite++){
+          //get the pfcandidates associated to the vertex and calculate the pT**2
+          for(unsigned int pfccoll_ite=0; pfccoll_ite<pfccoll.size(); pfccoll_ite++){
 
-	    pfcandref = pfccoll[pfccoll_ite].first;
-	    int quality = pfccoll[pfccoll_ite].second;
+            pfcandref = pfccoll[pfccoll_ite].first;
+            int quality = pfccoll[pfccoll_ite].second;
 
-	    if ( (quality<=2) && (quality!=-1) ) continue;
+            if ( (quality<=2) && (quality!=-1) ) continue;
 
-	    double man_pT = pfcandref->pt();
-	    if(man_pT>0.) ptsum+=man_pT*man_pT;
+            double man_pT = pfcandref->pt();
+            if(man_pT>0.) ptsum+=man_pT*man_pT;
 
-	  }
+          }
 
-	  vertexptsumvector.push_back(make_pair(assomap_vertexref,ptsum));
+          vertexptsumvector.push_back(make_pair(assomap_vertexref,ptsum));
 
-	}
+        }
 
-	while (!vertexptsumvector.empty()){
+        while (!vertexptsumvector.empty()){
 
-	  VertexRef vertexref_highestpT;
-	  float highestpT = 0.;
-	  int highestpT_index = 0;
+          VertexRef vertexref_highestpT;
+          float highestpT = 0.;
+          int highestpT_index = 0;
 
-	  for(unsigned int vtxptsumvec_ite=0; vtxptsumvec_ite<vertexptsumvector.size(); vtxptsumvec_ite++){
+          for(unsigned int vtxptsumvec_ite=0; vtxptsumvec_ite<vertexptsumvector.size(); vtxptsumvec_ite++){
 
- 	    if(vertexptsumvector[vtxptsumvec_ite].second>highestpT){
+            if(vertexptsumvector[vtxptsumvec_ite].second>highestpT){
 
-	      vertexref_highestpT = vertexptsumvector[vtxptsumvec_ite].first;
-	      highestpT = vertexptsumvector[vtxptsumvec_ite].second;
-	      highestpT_index = vtxptsumvec_ite;
+              vertexref_highestpT = vertexptsumvector[vtxptsumvec_ite].first;
+              highestpT = vertexptsumvector[vtxptsumvec_ite].second;
+              highestpT_index = vtxptsumvec_ite;
 
-	    }
+            }
 
-	  }
+          }
 
-	  //loop over all vertices in the association map
+          //loop over all vertices in the association map
           for(PFCandToVertexAssMap::const_iterator assomap_ite=pfcvertexassInput->begin(); assomap_ite!=pfcvertexassInput->end(); assomap_ite++){
 
-	    const VertexRef assomap_vertexref = assomap_ite->key;
-  	    const PFCandQualityPairVector pfccoll = assomap_ite->val;
+            const VertexRef assomap_vertexref = assomap_ite->key;
+            const PFCandQualityPairVector pfccoll = assomap_ite->val;
 
-	    //if the vertex from the association map the vertex with the highest pT
-	    //insert all associated pfcandidates in the output Association Map
-	    if(assomap_vertexref==vertexref_highestpT)
-	      for(unsigned int pfccoll_ite=0; pfccoll_ite<pfccoll.size(); pfccoll_ite++)
-	        pfcvertexassOutput->insert(assomap_vertexref,pfccoll[pfccoll_ite]);
+            //if the vertex from the association map the vertex with the highest pT
+            //insert all associated pfcandidates in the output Association Map
+            if(assomap_vertexref==vertexref_highestpT)
+              for(unsigned int pfccoll_ite=0; pfccoll_ite<pfccoll.size(); pfccoll_ite++)
+                pfcvertexassOutput->insert(assomap_vertexref,pfccoll[pfccoll_ite]);
 
-	  }
+          }
 
-	  vertexptsumvector.erase(vertexptsumvector.begin()+highestpT_index);
+          vertexptsumvector.erase(vertexptsumvector.begin()+highestpT_index);
 
-	}
+        }
 
-  	return std::move(pfcvertexassOutput);
+        return std::move(pfcvertexassOutput);
 }

--- a/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
@@ -59,7 +59,7 @@ PFCand_AssoMapAlgos::CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollec
 
           PFCandidateRef candref(pfCandH, i);
 
-	  vector<VertexRef>* vtxColl_help = CreateVertexVector(vtxcollH);
+	  vector<VertexRef> vtxColl_help = CreateVertexVector(vtxcollH);
 
           VertexPfcQuality VtxPfcQual;
 
@@ -72,9 +72,9 @@ PFCand_AssoMapAlgos::CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollec
 	      int quality = -1 - assoc_ite;
 
     	      // Insert the best vertex and the pair of track and the quality of this association in the map
-    	      pfcand2vertex->insert( vtxColl_help->at(0), make_pair(candref, quality) );
+    	      pfcand2vertex->insert( vtxColl_help.at(0), make_pair(candref, quality) );
 
-	      PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, vtxColl_help->at(0));
+	      PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, vtxColl_help.at(0));
 
 	    }
 
@@ -101,7 +101,6 @@ PFCand_AssoMapAlgos::CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollec
 
 	  }
 
-	  delete vtxColl_help;
        	}
 
 	return pfcand2vertex;
@@ -125,7 +124,7 @@ PFCand_AssoMapAlgos::CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollec
 
           PFCandidateRef candref(pfCandH, i);
 
-	  vector<VertexRef>* vtxColl_help = CreateVertexVector(vtxcollH);
+	  vector<VertexRef> vtxColl_help = CreateVertexVector(vtxcollH);
 
           VertexPfcQuality VtxPfcQual;
 
@@ -138,9 +137,9 @@ PFCand_AssoMapAlgos::CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollec
 	      int quality = -1 - assoc_ite;
 
     	      // Insert the best vertex and the pair of track and the quality of this association in the map
-    	      vertex2pfcand->insert( candref, make_pair(vtxColl_help->at(0), quality) );
+    	      vertex2pfcand->insert( candref, make_pair(vtxColl_help.at(0), quality) );
 
-	      PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, vtxColl_help->at(0));
+	      PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, vtxColl_help.at(0));
 
 	    }
 
@@ -167,7 +166,6 @@ PFCand_AssoMapAlgos::CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollec
 
 	  }
 
-	  delete vtxColl_help;
        	}
 
 	return std::move(vertex2pfcand);

--- a/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
@@ -207,5 +207,5 @@ PFCand_AssoMapAlgos::SortPFCandAssociationMap(PFCandToVertexAssMap* pfcvertexass
 
         }
 
-        return std::move(pfcvertexassOutput);
+        return pfcvertexassOutput;
 }

--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -124,7 +124,7 @@ PF_PU_AssoMapAlgos::CreateTrackToVertexMap(edm::Handle<reco::TrackCollection> tr
           transtrk.setBeamSpot(*beamspotH);
           transtrk.setES(iSetup);
 
-	  vector<VertexRef>* vtxColl_help = CreateVertexVector(vtxcollH);
+	  vector<VertexRef> vtxColl_help = CreateVertexVector(vtxcollH);
 
 	  for ( int assoc_ite = 0; assoc_ite < input_MaxNumAssociations_; ++assoc_ite ) {
 
@@ -145,8 +145,6 @@ PF_PU_AssoMapAlgos::CreateTrackToVertexMap(edm::Handle<reco::TrackCollection> tr
 	    PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, assocVtx.first);
 
 	  }
-
-	  delete vtxColl_help;
 
   	}
 
@@ -176,7 +174,7 @@ PF_PU_AssoMapAlgos::CreateVertexToTrackMap(edm::Handle<reco::TrackCollection> tr
           transtrk.setBeamSpot(*beamspotH);
           transtrk.setES(iSetup);
 
-	  vector<VertexRef>* vtxColl_help = CreateVertexVector(vtxcollH);
+	  vector<VertexRef> vtxColl_help = CreateVertexVector(vtxcollH);
 
 	  for ( int assoc_ite = 0; assoc_ite < input_MaxNumAssociations_; ++assoc_ite ) {
 
@@ -196,8 +194,6 @@ PF_PU_AssoMapAlgos::CreateVertexToTrackMap(edm::Handle<reco::TrackCollection> tr
 	    PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, assocVtx.first);
 
 	  }
-
-	  delete vtxColl_help;
 
 	}
 
@@ -295,19 +291,14 @@ PF_PU_AssoMapAlgos::SortAssociationMap(TrackToVertexAssMap* trackvertexassInput,
 /* create helping vertex vector to remove associated vertices                        */
 /*************************************************************************************/
 
-std::vector<reco::VertexRef>*
+std::vector<reco::VertexRef>
 PF_PU_AssoMapAlgos::CreateVertexVector(edm::Handle<reco::VertexCollection> vtxcollH)
 {
 
-	vector<VertexRef>* output = new vector<VertexRef>();
-
-  	for(unsigned int index_vtx=0;  index_vtx<vtxcollH->size(); ++index_vtx){
-
-          VertexRef vertexref(vtxcollH,index_vtx);
-
-	  output->push_back(vertexref);
-
-	}
+	vector<VertexRef> output;
+        output.reserve(vtxcollH->size());
+        auto const nVtx = vtxcollH->size();
+        for (unsigned int i = 0; i < nVtx; ++i) output.emplace_back(vtxcollH,i);
 
 	return output;
 
@@ -318,15 +309,15 @@ PF_PU_AssoMapAlgos::CreateVertexVector(edm::Handle<reco::VertexCollection> vtxco
 /****************************************************************************/
 
 void
-PF_PU_AssoMapAlgos::EraseVertex(std::vector<reco::VertexRef>* vtxcollV, reco::VertexRef toErase)
+PF_PU_AssoMapAlgos::EraseVertex(std::vector<reco::VertexRef>& vtxcollV, reco::VertexRef toErase)
 {
 
-  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV->size(); ++index_vtx){
+  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV.size(); ++index_vtx){
 
-          VertexRef vertexref = vtxcollV->at(index_vtx);
+          VertexRef vertexref = vtxcollV.at(index_vtx);
 
 	  if ( vertexref == toErase ){
-            vtxcollV->erase(vtxcollV->begin()+index_vtx);
+            vtxcollV.erase(vtxcollV.begin()+index_vtx);
 	    break;
 	  }
 
@@ -340,19 +331,19 @@ PF_PU_AssoMapAlgos::EraseVertex(std::vector<reco::VertexRef>* vtxcollV, reco::Ve
 /*************************************************************************************/
 
 VertexRef
-PF_PU_AssoMapAlgos::FindClosestZ(const reco::TrackRef trkref, std::vector<reco::VertexRef>* vtxcollV, double tWeight)
+PF_PU_AssoMapAlgos::FindClosestZ(const reco::TrackRef trkref, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
 	double ztrack = trkref->vertex().z();
 
-	VertexRef foundVertexRef = vtxcollV->at(0);
+	VertexRef foundVertexRef = vtxcollV.at(0);
 
 	double dzmin = 1e5;
 
 	//loop over all vertices with a good quality in the vertex collection
-  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV->size(); ++index_vtx){
+  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV.size(); ++index_vtx){
 
-          VertexRef vertexref = vtxcollV->at(index_vtx);
+          VertexRef vertexref = vtxcollV.at(index_vtx);
 
 	  double nTracks = sqrt(vertexref->tracksSize());
 
@@ -376,17 +367,17 @@ PF_PU_AssoMapAlgos::FindClosestZ(const reco::TrackRef trkref, std::vector<reco::
 /*************************************************************************************/
 
 VertexRef
-PF_PU_AssoMapAlgos::FindClosest3D(TransientTrack transtrk, std::vector<reco::VertexRef>* vtxcollV, double tWeight)
+PF_PU_AssoMapAlgos::FindClosest3D(TransientTrack transtrk, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
-	VertexRef foundVertexRef = vtxcollV->at(0);
+	VertexRef foundVertexRef = vtxcollV.at(0);
 
 	double d3min = 1e5;
 
 	//loop over all vertices with a good quality in the vertex collection
-  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV->size(); ++index_vtx){
+  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV.size(); ++index_vtx){
 
-          VertexRef vertexref = vtxcollV->at(index_vtx);
+          VertexRef vertexref = vtxcollV.at(index_vtx);
 
 	  double nTracks = sqrt(vertexref->tracksSize());
 
@@ -494,7 +485,8 @@ PF_PU_AssoMapAlgos::ComesFromConversion(const TrackRef trackref, const Conversio
 /********************************************************************************/
 
 VertexRef
-PF_PU_AssoMapAlgos::FindConversionVertex(const reco::TrackRef trackref, const reco::Conversion& gamma, ESHandle<MagneticField> bfH, const EventSetup& iSetup, edm::Handle<reco::BeamSpot> bsH, std::vector<reco::VertexRef>* vtxcollV, double tWeight)
+PF_PU_AssoMapAlgos::FindConversionVertex(const reco::TrackRef trackref, const reco::Conversion& gamma, ESHandle<MagneticField> bfH, 
+                                         const EventSetup& iSetup, edm::Handle<reco::BeamSpot> bsH, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
 	math::XYZPoint conv_pos = gamma.conversionVertex().position();
@@ -662,7 +654,8 @@ PF_PU_AssoMapAlgos::ComesFromV0Decay(const TrackRef trackref, const VertexCompos
 /*************************************************************************************/
 
 VertexRef
-PF_PU_AssoMapAlgos::FindV0Vertex(const TrackRef trackref, const VertexCompositeCandidate& V0_vtx, ESHandle<MagneticField> bFieldH, const EventSetup& iSetup, Handle<BeamSpot> bsH, std::vector<reco::VertexRef>* vtxcollV, double tWeight)
+PF_PU_AssoMapAlgos::FindV0Vertex(const TrackRef trackref, const VertexCompositeCandidate& V0_vtx, ESHandle<MagneticField> bFieldH, 
+                                 const EventSetup& iSetup, Handle<BeamSpot> bsH, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
 	const math::XYZPoint& dec_pos = V0_vtx.vertex();
@@ -758,7 +751,8 @@ PF_PU_AssoMapAlgos::ComesFromNI(const TrackRef trackref, const PFDisplacedVertex
 /*************************************************************************************/
 
 VertexRef
-PF_PU_AssoMapAlgos::FindNIVertex(const TrackRef trackref, const PFDisplacedVertex& displVtx, ESHandle<MagneticField> bFieldH, const EventSetup& iSetup, Handle<BeamSpot> bsH, std::vector<reco::VertexRef>* vtxcollV, double tWeight)
+PF_PU_AssoMapAlgos::FindNIVertex(const TrackRef trackref, const PFDisplacedVertex& displVtx, ESHandle<MagneticField> bFieldH, 
+                                 const EventSetup& iSetup, Handle<BeamSpot> bsH, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
 	TrackCollection refittedTracks = displVtx.refittedTracks();
@@ -810,14 +804,14 @@ PF_PU_AssoMapAlgos::FindNIVertex(const TrackRef trackref, const PFDisplacedVerte
 /*************************************************************************************/
 template<typename TREF>
 VertexRef
-PF_PU_AssoMapAlgos::TrackWeightAssociation(const TREF& trackRef, std::vector<reco::VertexRef>* vtxcollV)
+PF_PU_AssoMapAlgos::TrackWeightAssociation(const TREF& trackRef, const std::vector<reco::VertexRef>& vtxcollV)
 {
 
-	VertexRef bestvertexref = vtxcollV->at(0);
+	VertexRef bestvertexref = vtxcollV.at(0);
  	float bestweight = 0.;
 
 	//loop over all vertices in the vertex collection
-        for(auto const& vertexref : *vtxcollV){
+        for(auto const& vertexref : vtxcollV){
 
      	  //get the most probable vertex for the track
 	  float weight = vertexref->trackWeight(trackRef);
@@ -837,7 +831,8 @@ PF_PU_AssoMapAlgos::TrackWeightAssociation(const TREF& trackRef, std::vector<rec
 /*************************************************************************************/
 
 VertexStepPair
-PF_PU_AssoMapAlgos::FindAssociation(const reco::TrackRef& trackref, std::vector<reco::VertexRef>* vtxColl, edm::ESHandle<MagneticField> bfH, const edm::EventSetup& iSetup, edm::Handle<reco::BeamSpot> bsH, int assocNum)
+PF_PU_AssoMapAlgos::FindAssociation(const reco::TrackRef& trackref, const std::vector<reco::VertexRef>& vtxColl, 
+                                    edm::ESHandle<MagneticField> bfH, const edm::EventSetup& iSetup, edm::Handle<reco::BeamSpot> bsH, int assocNum)
 {
 
 	VertexRef foundVertex;
@@ -925,7 +920,7 @@ PF_PU_AssoMapAlgos::FindAssociation(const reco::TrackRef& trackref, std::vector<
  	  default:{
 
 	    // allways first vertex
-            foundVertex = vtxColl->at(0);
+            foundVertex = vtxColl.at(0);
 	    break;
 
           }

--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -28,27 +28,27 @@ PF_PU_AssoMapAlgos::PF_PU_AssoMapAlgos(const edm::ParameterSet& iConfig, edm::Co
     numWarnings_(0)
 {
 
-  	input_MaxNumAssociations_ = iConfig.getParameter<int>("MaxNumberOfAssociations");
+        input_MaxNumAssociations_ = iConfig.getParameter<int>("MaxNumberOfAssociations");
 
-  	token_VertexCollection_= iC.consumes<VertexCollection>(iConfig.getParameter<InputTag>("VertexCollection"));
+        token_VertexCollection_= iC.consumes<VertexCollection>(iConfig.getParameter<InputTag>("VertexCollection"));
 
-  	token_BeamSpot_= iC.consumes<BeamSpot>(iConfig.getParameter<InputTag>("BeamSpot"));
+        token_BeamSpot_= iC.consumes<BeamSpot>(iConfig.getParameter<InputTag>("BeamSpot"));
 
-  	input_doReassociation_= iConfig.getParameter<bool>("doReassociation");
-  	cleanedColls_ = iConfig.getParameter<bool>("GetCleanedCollections");
+        input_doReassociation_= iConfig.getParameter<bool>("doReassociation");
+        cleanedColls_ = iConfig.getParameter<bool>("GetCleanedCollections");
 
-  	ConversionsCollectionToken_= iC.consumes<ConversionCollection>(iConfig.getParameter<InputTag>("ConversionsCollection"));
+        ConversionsCollectionToken_= iC.consumes<ConversionCollection>(iConfig.getParameter<InputTag>("ConversionsCollection"));
 
-  	KshortCollectionToken_= iC.consumes<VertexCompositeCandidateCollection>(iConfig.getParameter<InputTag>("V0KshortCollection"));
-  	LambdaCollectionToken_= iC.consumes<VertexCompositeCandidateCollection>(iConfig.getParameter<InputTag>("V0LambdaCollection"));
+        KshortCollectionToken_= iC.consumes<VertexCompositeCandidateCollection>(iConfig.getParameter<InputTag>("V0KshortCollection"));
+        LambdaCollectionToken_= iC.consumes<VertexCompositeCandidateCollection>(iConfig.getParameter<InputTag>("V0LambdaCollection"));
 
-  	NIVertexCollectionToken_= iC.consumes<PFDisplacedVertexCollection>(iConfig.getParameter<InputTag>("NIVertexCollection"));
+        NIVertexCollectionToken_= iC.consumes<PFDisplacedVertexCollection>(iConfig.getParameter<InputTag>("NIVertexCollection"));
 
-  	input_FinalAssociation_= iConfig.getUntrackedParameter<int>("FinalAssociation", 0);
+        input_FinalAssociation_= iConfig.getUntrackedParameter<int>("FinalAssociation", 0);
 
-  	ignoremissingpfcollection_ = iConfig.getParameter<bool>("ignoreMissingCollection");
+        ignoremissingpfcollection_ = iConfig.getParameter<bool>("ignoreMissingCollection");
 
-  	input_nTrack_ = iConfig.getParameter<double>("nTrackWeight");
+        input_nTrack_ = iConfig.getParameter<double>("nTrackWeight");
 
 }
 
@@ -60,46 +60,46 @@ void
 PF_PU_AssoMapAlgos::GetInputCollections(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
-  	//get the offline beam spot
-  	iEvent.getByToken(token_BeamSpot_, beamspotH);
+        //get the offline beam spot
+        iEvent.getByToken(token_BeamSpot_, beamspotH);
 
-  	//get the conversion collection for the gamma conversions
-  	iEvent.getByToken(ConversionsCollectionToken_, convCollH);
-	cleanedConvCollP = PF_PU_AssoMapAlgos::GetCleanedConversions(convCollH,beamspotH,cleanedColls_);
+        //get the conversion collection for the gamma conversions
+        iEvent.getByToken(ConversionsCollectionToken_, convCollH);
+        cleanedConvCollP = PF_PU_AssoMapAlgos::GetCleanedConversions(convCollH,beamspotH,cleanedColls_);
 
-  	//get the vertex composite candidate collection for the Kshort's
-  	iEvent.getByToken(KshortCollectionToken_, vertCompCandCollKshortH);
-	cleanedKshortCollP = PF_PU_AssoMapAlgos::GetCleanedKshort(vertCompCandCollKshortH,beamspotH,cleanedColls_);
+        //get the vertex composite candidate collection for the Kshort's
+        iEvent.getByToken(KshortCollectionToken_, vertCompCandCollKshortH);
+        cleanedKshortCollP = PF_PU_AssoMapAlgos::GetCleanedKshort(vertCompCandCollKshortH,beamspotH,cleanedColls_);
 
-  	//get the vertex composite candidate collection for the Lambda's
-  	iEvent.getByToken(LambdaCollectionToken_, vertCompCandCollLambdaH);
-	cleanedLambdaCollP = PF_PU_AssoMapAlgos::GetCleanedLambda(vertCompCandCollLambdaH,beamspotH,cleanedColls_);
+        //get the vertex composite candidate collection for the Lambda's
+        iEvent.getByToken(LambdaCollectionToken_, vertCompCandCollLambdaH);
+        cleanedLambdaCollP = PF_PU_AssoMapAlgos::GetCleanedLambda(vertCompCandCollLambdaH,beamspotH,cleanedColls_);
 
-  	//get the displaced vertex collection for nuclear interactions
-  	//create a new bool, true if no displaced vertex collection is in the event, mostly for AOD
-  	missingColls = false;
-  	if(!iEvent.getByToken(NIVertexCollectionToken_,displVertexCollH)){
+        //get the displaced vertex collection for nuclear interactions
+        //create a new bool, true if no displaced vertex collection is in the event, mostly for AOD
+        missingColls = false;
+        if(!iEvent.getByToken(NIVertexCollectionToken_,displVertexCollH)){
           if (ignoremissingpfcollection_){
 
-    	    missingColls = true;
+            missingColls = true;
 
             if ( numWarnings_ < maxNumWarnings_ ) {
-	      LogWarning("PF_PU_AssoMapAlgos::GetInputCollections")
-	        << "No Extra objects available in input file --> skipping reconstruction of displaced vertices !!" << endl;
-	      ++numWarnings_;
+              LogWarning("PF_PU_AssoMapAlgos::GetInputCollections")
+                << "No Extra objects available in input file --> skipping reconstruction of displaced vertices !!" << endl;
+              ++numWarnings_;
             }
 
-  	  }
-	} else {
+          }
+        } else {
 
-	    cleanedNICollP = PF_PU_AssoMapAlgos::GetCleanedNI(displVertexCollH,beamspotH,true);
+            cleanedNICollP = PF_PU_AssoMapAlgos::GetCleanedNI(displVertexCollH,beamspotH,true);
 
-	}
+        }
 
-  	//get the input vertex collection
-  	iEvent.getByToken(token_VertexCollection_, vtxcollH);
+        //get the input vertex collection
+        iEvent.getByToken(token_VertexCollection_, vtxcollH);
 
-     	iSetup.get<IdealMagneticFieldRecord>().get(bFieldH);
+        iSetup.get<IdealMagneticFieldRecord>().get(bFieldH);
 
 }
 
@@ -110,50 +110,50 @@ std::pair<std::unique_ptr<TrackToVertexAssMap>, std::unique_ptr<VertexToTrackAss
 PF_PU_AssoMapAlgos::createMappings(edm::Handle<reco::TrackCollection> trkcollH, const edm::EventSetup& iSetup)
 {
 
-	unique_ptr<TrackToVertexAssMap> track2vertex(new TrackToVertexAssMap(vtxcollH, trkcollH));
-	unique_ptr<VertexToTrackAssMap> vertex2track(new VertexToTrackAssMap(trkcollH, vtxcollH));
+        unique_ptr<TrackToVertexAssMap> track2vertex(new TrackToVertexAssMap(vtxcollH, trkcollH));
+        unique_ptr<VertexToTrackAssMap> vertex2track(new VertexToTrackAssMap(trkcollH, vtxcollH));
 
-	int num_vertices = vtxcollH->size();
-	if ( num_vertices < input_MaxNumAssociations_) input_MaxNumAssociations_ = num_vertices;
+        int num_vertices = vtxcollH->size();
+        if ( num_vertices < input_MaxNumAssociations_) input_MaxNumAssociations_ = num_vertices;
         vector<VertexRef> vtxColl_help;
         if (input_MaxNumAssociations_ == 1) vtxColl_help = CreateVertexVector(vtxcollH);
 
-  	//loop over all tracks of the track collection
-  	for ( size_t idxTrack = 0; idxTrack < trkcollH->size(); ++idxTrack ) {
+        //loop over all tracks of the track collection
+        for ( size_t idxTrack = 0; idxTrack < trkcollH->size(); ++idxTrack ) {
 
-    	  TrackRef trackref = TrackRef(trkcollH, idxTrack);
+          TrackRef trackref = TrackRef(trkcollH, idxTrack);
 
           TransientTrack transtrk(trackref, &(*bFieldH) );
           transtrk.setBeamSpot(*beamspotH);
           transtrk.setES(iSetup);
 
-	  if (input_MaxNumAssociations_ > 1) vtxColl_help = CreateVertexVector(vtxcollH);
+          if (input_MaxNumAssociations_ > 1) vtxColl_help = CreateVertexVector(vtxcollH);
 
-	  for ( int assoc_ite = 0; assoc_ite < input_MaxNumAssociations_; ++assoc_ite ) {
+          for ( int assoc_ite = 0; assoc_ite < input_MaxNumAssociations_; ++assoc_ite ) {
 
-    	    VertexStepPair assocVtx = FindAssociation(trackref, vtxColl_help, bFieldH, iSetup, beamspotH, assoc_ite);
-	    int step = assocVtx.second;
-	    double distance = ( IPTools::absoluteImpactParameter3D( transtrk, *(assocVtx.first) ) ).second.value();
+            VertexStepPair assocVtx = FindAssociation(trackref, vtxColl_help, bFieldH, iSetup, beamspotH, assoc_ite);
+            int step = assocVtx.second;
+            double distance = ( IPTools::absoluteImpactParameter3D( transtrk, *(assocVtx.first) ) ).second.value();
 
-	    int quality = DefineQuality(assoc_ite, step, distance);
+            int quality = DefineQuality(assoc_ite, step, distance);
 
-    	    //std::cout << "associating track: Pt = " << trackref->pt() << ","
-    	    //	        << " eta = " << trackref->eta() << ", phi = " << trackref->phi()
-    	    //	        << " to vertex: z = " << associatedVertex.first->position().z() << " with quality q = " << quality << std::endl;
+            //std::cout << "associating track: Pt = " << trackref->pt() << ","
+            //          << " eta = " << trackref->eta() << ", phi = " << trackref->phi()
+            //          << " to vertex: z = " << associatedVertex.first->position().z() << " with quality q = " << quality << std::endl;
 
 
-    	    // Insert the best vertex and the pair of track and the quality of this association in the map
-    	    track2vertex->insert( assocVtx.first, make_pair(trackref, quality) );
+            // Insert the best vertex and the pair of track and the quality of this association in the map
+            track2vertex->insert( assocVtx.first, make_pair(trackref, quality) );
             vertex2track->insert( trackref, make_pair(assocVtx.first, quality) );
 
             //cleanup only if multiple iterations are made
-	    if (input_MaxNumAssociations_ > 1) PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, assocVtx.first);
+            if (input_MaxNumAssociations_ > 1) PF_PU_AssoMapAlgos::EraseVertex(vtxColl_help, assocVtx.first);
 
-	  }
+          }
 
-  	}
+        }
 
-	return {std::move(track2vertex), std::move(vertex2track)};
+        return {std::move(track2vertex), std::move(vertex2track)};
 
 }
 
@@ -184,76 +184,76 @@ PF_PU_AssoMapAlgos::CreateVertexToTrackMap(edm::Handle<reco::TrackCollection> tr
 unique_ptr<TrackToVertexAssMap>
 PF_PU_AssoMapAlgos::SortAssociationMap(TrackToVertexAssMap* trackvertexassInput, edm::Handle<reco::TrackCollection> trkcollH)
 {
-	//create a new TrackVertexAssMap for the Output which will be sorted
-	unique_ptr<TrackToVertexAssMap> trackvertexassOutput(new TrackToVertexAssMap(vtxcollH, trkcollH));
+        //create a new TrackVertexAssMap for the Output which will be sorted
+        unique_ptr<TrackToVertexAssMap> trackvertexassOutput(new TrackToVertexAssMap(vtxcollH, trkcollH));
 
-	//Create and fill a vector of pairs of vertex and the summed (pT-pT_Error)**2 of the tracks associated to the vertex
-	VertexPtsumVector vertexptsumvector;
+        //Create and fill a vector of pairs of vertex and the summed (pT-pT_Error)**2 of the tracks associated to the vertex
+        VertexPtsumVector vertexptsumvector;
 
-	//loop over all vertices in the association map
+        //loop over all vertices in the association map
         for(TrackToVertexAssMap::const_iterator assomap_ite=trackvertexassInput->begin(); assomap_ite!=trackvertexassInput->end(); assomap_ite++){
 
-	  const VertexRef assomap_vertexref = assomap_ite->key;
-  	  const TrackQualityPairVector trckcoll = assomap_ite->val;
+          const VertexRef assomap_vertexref = assomap_ite->key;
+          const TrackQualityPairVector trckcoll = assomap_ite->val;
 
-	  float ptsum = 0;
+          float ptsum = 0;
 
-	  TrackRef trackref;
+          TrackRef trackref;
 
-	  //get the tracks associated to the vertex and calculate the manipulated pT**2
-	  for(unsigned int trckcoll_ite=0; trckcoll_ite<trckcoll.size(); trckcoll_ite++){
+          //get the tracks associated to the vertex and calculate the manipulated pT**2
+          for(unsigned int trckcoll_ite=0; trckcoll_ite<trckcoll.size(); trckcoll_ite++){
 
-	    trackref = trckcoll[trckcoll_ite].first;
-	    int quality = trckcoll[trckcoll_ite].second;
+            trackref = trckcoll[trckcoll_ite].first;
+            int quality = trckcoll[trckcoll_ite].second;
 
-	    if ( quality<=2 ) continue;
+            if ( quality<=2 ) continue;
 
-	    double man_pT = trackref->pt() - trackref->ptError();
-	    if(man_pT>0.) ptsum+=man_pT*man_pT;
+            double man_pT = trackref->pt() - trackref->ptError();
+            if(man_pT>0.) ptsum+=man_pT*man_pT;
 
-	  }
+          }
 
-	  vertexptsumvector.push_back(make_pair(assomap_vertexref,ptsum));
+          vertexptsumvector.push_back(make_pair(assomap_vertexref,ptsum));
 
-	}
+        }
 
-	while (!vertexptsumvector.empty()){
+        while (!vertexptsumvector.empty()){
 
-	  VertexRef vertexref_highestpT;
-	  float highestpT = 0.;
-	  int highestpT_index = 0;
+          VertexRef vertexref_highestpT;
+          float highestpT = 0.;
+          int highestpT_index = 0;
 
-	  for(unsigned int vtxptsumvec_ite=0; vtxptsumvec_ite<vertexptsumvector.size(); vtxptsumvec_ite++){
+          for(unsigned int vtxptsumvec_ite=0; vtxptsumvec_ite<vertexptsumvector.size(); vtxptsumvec_ite++){
 
- 	    if(vertexptsumvector[vtxptsumvec_ite].second>highestpT){
+            if(vertexptsumvector[vtxptsumvec_ite].second>highestpT){
 
-	      vertexref_highestpT = vertexptsumvector[vtxptsumvec_ite].first;
-	      highestpT = vertexptsumvector[vtxptsumvec_ite].second;
-	      highestpT_index = vtxptsumvec_ite;
+              vertexref_highestpT = vertexptsumvector[vtxptsumvec_ite].first;
+              highestpT = vertexptsumvector[vtxptsumvec_ite].second;
+              highestpT_index = vtxptsumvec_ite;
 
-	    }
+            }
 
-	  }
+          }
 
-	  //loop over all vertices in the association map
+          //loop over all vertices in the association map
           for(TrackToVertexAssMap::const_iterator assomap_ite=trackvertexassInput->begin(); assomap_ite!=trackvertexassInput->end(); assomap_ite++){
 
-	    const VertexRef assomap_vertexref = assomap_ite->key;
-  	    const TrackQualityPairVector trckcoll = assomap_ite->val;
+            const VertexRef assomap_vertexref = assomap_ite->key;
+            const TrackQualityPairVector trckcoll = assomap_ite->val;
 
-	    //if the vertex from the association map the vertex with the highest manipulated pT
-	    //insert all associated tracks in the output Association Map
-	    if(assomap_vertexref==vertexref_highestpT)
-	      for(unsigned int trckcoll_ite=0; trckcoll_ite<trckcoll.size(); trckcoll_ite++)
-	        trackvertexassOutput->insert(assomap_vertexref,trckcoll[trckcoll_ite]);
+            //if the vertex from the association map the vertex with the highest manipulated pT
+            //insert all associated tracks in the output Association Map
+            if(assomap_vertexref==vertexref_highestpT)
+              for(unsigned int trckcoll_ite=0; trckcoll_ite<trckcoll.size(); trckcoll_ite++)
+                trackvertexassOutput->insert(assomap_vertexref,trckcoll[trckcoll_ite]);
 
-	  }
+          }
 
-	  vertexptsumvector.erase(vertexptsumvector.begin()+highestpT_index);
+          vertexptsumvector.erase(vertexptsumvector.begin()+highestpT_index);
 
-	}
+        }
 
-  	return trackvertexassOutput;
+        return trackvertexassOutput;
 
 }
 
@@ -271,12 +271,12 @@ std::vector<reco::VertexRef>
 PF_PU_AssoMapAlgos::CreateVertexVector(edm::Handle<reco::VertexCollection> vtxcollH)
 {
 
-	vector<VertexRef> output;
+        vector<VertexRef> output;
         output.reserve(vtxcollH->size());
         auto const nVtx = vtxcollH->size();
         for (unsigned int i = 0; i < nVtx; ++i) output.emplace_back(vtxcollH,i);
 
-	return output;
+        return output;
 
 }
 
@@ -288,16 +288,16 @@ void
 PF_PU_AssoMapAlgos::EraseVertex(std::vector<reco::VertexRef>& vtxcollV, reco::VertexRef toErase)
 {
 
-  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV.size(); ++index_vtx){
+        for(unsigned int index_vtx=0;  index_vtx<vtxcollV.size(); ++index_vtx){
 
           VertexRef vertexref = vtxcollV.at(index_vtx);
 
-	  if ( vertexref == toErase ){
+          if ( vertexref == toErase ){
             vtxcollV.erase(vtxcollV.begin()+index_vtx);
-	    break;
-	  }
+            break;
+          }
 
-	}
+        }
 
 }
 
@@ -310,31 +310,31 @@ VertexRef
 PF_PU_AssoMapAlgos::FindClosestZ(const reco::TrackRef trkref, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
-	double ztrack = trkref->vertex().z();
+        double ztrack = trkref->vertex().z();
 
-	VertexRef foundVertexRef = vtxcollV.at(0);
+        VertexRef foundVertexRef = vtxcollV.at(0);
 
-	double dzmin = 1e5;
+        double dzmin = 1e5;
 
-	//loop over all vertices with a good quality in the vertex collection
-  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV.size(); ++index_vtx){
+        //loop over all vertices with a good quality in the vertex collection
+        for(unsigned int index_vtx=0;  index_vtx<vtxcollV.size(); ++index_vtx){
 
           VertexRef vertexref = vtxcollV.at(index_vtx);
 
-	  double nTracks = sqrt(vertexref->tracksSize());
+          double nTracks = sqrt(vertexref->tracksSize());
 
           double z_distance = fabs(ztrack - vertexref->z());
 
-	  double weightedDistance = z_distance-tWeight*nTracks;
+          double weightedDistance = z_distance-tWeight*nTracks;
 
           if(weightedDistance<dzmin) {
             dzmin = weightedDistance;
             foundVertexRef = vertexref;
           }
 
-	}
+        }
 
-	return foundVertexRef;
+        return foundVertexRef;
 }
 
 
@@ -346,33 +346,33 @@ VertexRef
 PF_PU_AssoMapAlgos::FindClosest3D(TransientTrack transtrk, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
-	VertexRef foundVertexRef = vtxcollV.at(0);
+        VertexRef foundVertexRef = vtxcollV.at(0);
 
-	double d3min = 1e5;
+        double d3min = 1e5;
 
-	//loop over all vertices with a good quality in the vertex collection
-  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV.size(); ++index_vtx){
+        //loop over all vertices with a good quality in the vertex collection
+        for(unsigned int index_vtx=0;  index_vtx<vtxcollV.size(); ++index_vtx){
 
           VertexRef vertexref = vtxcollV.at(index_vtx);
 
-	  double nTracks = sqrt(vertexref->tracksSize());
+          double nTracks = sqrt(vertexref->tracksSize());
 
           double distance = 1e5;
           pair<bool,Measurement1D> IpPair = IPTools::absoluteImpactParameter3D(transtrk, *vertexref);
 
-	  if(IpPair.first)
+          if(IpPair.first)
             distance = IpPair.second.value();
 
-	  double weightedDistance = distance-tWeight*nTracks;
+          double weightedDistance = distance-tWeight*nTracks;
 
           if(weightedDistance<d3min) {
             d3min = weightedDistance;
             foundVertexRef = vertexref;
           }
 
-	}
+        }
 
-	return foundVertexRef;
+        return foundVertexRef;
 }
 
 /****************************************************************************************/
@@ -383,21 +383,21 @@ double
 PF_PU_AssoMapAlgos::dR(const math::XYZPoint& vtx_pos, const math::XYZVector& vtx_mom, edm::Handle<reco::BeamSpot> bsH)
 {
 
-	double bs_x = bsH->x0();
-	double bs_y = bsH->y0();
-	double bs_z = bsH->z0();
+        double bs_x = bsH->x0();
+        double bs_y = bsH->y0();
+        double bs_z = bsH->z0();
 
-     	double connVec_x = vtx_pos.x() - bs_x;
-	double connVec_y = vtx_pos.y() - bs_y;
-	double connVec_z = vtx_pos.z() - bs_z;
+        double connVec_x = vtx_pos.x() - bs_x;
+        double connVec_y = vtx_pos.y() - bs_y;
+        double connVec_z = vtx_pos.z() - bs_z;
 
-     	double connVec_r = sqrt(connVec_x*connVec_x + connVec_y*connVec_y + connVec_z*connVec_z);
-	double connVec_theta = acos(connVec_z*1./connVec_r);
+        double connVec_r = sqrt(connVec_x*connVec_x + connVec_y*connVec_y + connVec_z*connVec_z);
+        double connVec_theta = acos(connVec_z*1./connVec_r);
 
-	double connVec_eta = -1.*log(tan(connVec_theta*1./2.));
-	double connVec_phi = atan2(connVec_y,connVec_x);
+        double connVec_eta = -1.*log(tan(connVec_theta*1./2.));
+        double connVec_phi = atan2(connVec_y,connVec_x);
 
-	return deltaR(vtx_mom.eta(),vtx_mom.phi(),connVec_eta,connVec_phi);
+        return deltaR(vtx_mom.eta(),vtx_mom.phi(),connVec_eta,connVec_phi);
 
 }
 
@@ -408,27 +408,27 @@ PF_PU_AssoMapAlgos::dR(const math::XYZPoint& vtx_pos, const math::XYZVector& vtx
 unique_ptr<ConversionCollection>
 PF_PU_AssoMapAlgos::GetCleanedConversions(edm::Handle<reco::ConversionCollection> convCollH, Handle<BeamSpot> bsH, bool cleanedColl)
 {
-     	unique_ptr<ConversionCollection> cleanedConvColl(new ConversionCollection() );
+        unique_ptr<ConversionCollection> cleanedConvColl(new ConversionCollection() );
 
-	for (unsigned int convcoll_idx=0; convcoll_idx<convCollH->size(); convcoll_idx++){
+        for (unsigned int convcoll_idx=0; convcoll_idx<convCollH->size(); convcoll_idx++){
 
-	  ConversionRef convref(convCollH,convcoll_idx);
+          ConversionRef convref(convCollH,convcoll_idx);
 
- 	  if(!cleanedColl){
+          if(!cleanedColl){
             cleanedConvColl->push_back(*convref);
-	    continue;
+            continue;
           }
 
-	  if( (convref->nTracks()==2) &&
+          if( (convref->nTracks()==2) &&
               (fabs(convref->pairInvariantMass())<=0.1) ){
 
             cleanedConvColl->push_back(*convref);
 
-	  }
+          }
 
-	}
+        }
 
-  	return cleanedConvColl;
+        return cleanedConvColl;
 
 }
 
@@ -441,18 +441,18 @@ bool
 PF_PU_AssoMapAlgos::ComesFromConversion(const TrackRef trackref, const ConversionCollection& cleanedConvColl, Conversion* gamma)
 {
 
-	for(unsigned int convcoll_ite=0; convcoll_ite<cleanedConvColl.size(); convcoll_ite++){
+        for(unsigned int convcoll_ite=0; convcoll_ite<cleanedConvColl.size(); convcoll_ite++){
 
-	  if(ConversionTools::matchesConversion(trackref,cleanedConvColl.at(convcoll_ite))){
+          if(ConversionTools::matchesConversion(trackref,cleanedConvColl.at(convcoll_ite))){
 
-	    *gamma = cleanedConvColl.at(convcoll_ite);
-	    return true;
+            *gamma = cleanedConvColl.at(convcoll_ite);
+            return true;
 
-  	  }
+          }
 
-  	}
+        }
 
-	return false;
+        return false;
 }
 
 
@@ -465,19 +465,19 @@ PF_PU_AssoMapAlgos::FindConversionVertex(const reco::TrackRef trackref, const re
                                          const EventSetup& iSetup, edm::Handle<reco::BeamSpot> bsH, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
-	math::XYZPoint conv_pos = gamma.conversionVertex().position();
+        math::XYZPoint conv_pos = gamma.conversionVertex().position();
 
-	math::XYZVector conv_mom(gamma.refittedPair4Momentum().x(),
-	                         gamma.refittedPair4Momentum().y(),
-	                         gamma.refittedPair4Momentum().z());
+        math::XYZVector conv_mom(gamma.refittedPair4Momentum().x(),
+                                 gamma.refittedPair4Momentum().y(),
+                                 gamma.refittedPair4Momentum().z());
 
-	Track photon(trackref->chi2(), trackref->ndof(), conv_pos, conv_mom, 0, trackref->covariance());
+        Track photon(trackref->chi2(), trackref->ndof(), conv_pos, conv_mom, 0, trackref->covariance());
 
-    	TransientTrack transpho(photon, &(*bfH) );
-    	transpho.setBeamSpot(*bsH);
-    	transpho.setES(iSetup);
+        TransientTrack transpho(photon, &(*bfH) );
+        transpho.setBeamSpot(*bsH);
+        transpho.setES(iSetup);
 
-	return FindClosest3D(transpho, vtxcollV, tWeight);
+        return FindClosest3D(transpho, vtxcollV, tWeight);
 
 }
 
@@ -489,33 +489,33 @@ unique_ptr<VertexCompositeCandidateCollection>
 PF_PU_AssoMapAlgos::GetCleanedKshort(Handle<VertexCompositeCandidateCollection> KshortsH, Handle<BeamSpot> bsH, bool cleanedColl)
 {
 
-     	unique_ptr<VertexCompositeCandidateCollection> cleanedKaonColl(new VertexCompositeCandidateCollection() );
+        unique_ptr<VertexCompositeCandidateCollection> cleanedKaonColl(new VertexCompositeCandidateCollection() );
 
-	for (unsigned int kscoll_idx=0; kscoll_idx<KshortsH->size(); kscoll_idx++){
+        for (unsigned int kscoll_idx=0; kscoll_idx<KshortsH->size(); kscoll_idx++){
 
-	  VertexCompositeCandidateRef ksref(KshortsH,kscoll_idx);
+          VertexCompositeCandidateRef ksref(KshortsH,kscoll_idx);
 
- 	  if(!cleanedColl){
+          if(!cleanedColl){
             cleanedKaonColl->push_back(*ksref);
-	    continue;
-	  }
+            continue;
+          }
 
-  	  VertexDistance3D distanceComputer;
+          VertexDistance3D distanceComputer;
 
           GlobalPoint dec_pos = RecoVertex::convertPos(ksref->vertex());
 
-       	  GlobalError decayVertexError = GlobalError(ksref->vertexCovariance(0,0), ksref->vertexCovariance(0,1), ksref->vertexCovariance(1,1), ksref->vertexCovariance(0,2), ksref->vertexCovariance(1,2), ksref->vertexCovariance(2,2));
+          GlobalError decayVertexError = GlobalError(ksref->vertexCovariance(0,0), ksref->vertexCovariance(0,1), ksref->vertexCovariance(1,1), ksref->vertexCovariance(0,2), ksref->vertexCovariance(1,2), ksref->vertexCovariance(2,2));
 
-      	  math::XYZVector dec_mom(ksref->momentum().x(),
-	                          ksref->momentum().y(),
-	                          ksref->momentum().z());
+          math::XYZVector dec_mom(ksref->momentum().x(),
+                                  ksref->momentum().y(),
+                                  ksref->momentum().z());
 
-      	  GlobalPoint bsPosition = RecoVertex::convertPos(bsH->position());
-      	  GlobalError bsError = RecoVertex::convertError(bsH->covariance3D());
+          GlobalPoint bsPosition = RecoVertex::convertPos(bsH->position());
+          GlobalError bsError = RecoVertex::convertError(bsH->covariance3D());
 
-   	  double kaon_significance = (distanceComputer.distance(VertexState(bsPosition,bsError), VertexState(dec_pos, decayVertexError))).significance();
+          double kaon_significance = (distanceComputer.distance(VertexState(bsPosition,bsError), VertexState(dec_pos, decayVertexError))).significance();
 
-	  if ((ksref->vertex().rho()>=3.) &&
+          if ((ksref->vertex().rho()>=3.) &&
               (ksref->vertexNormalizedChi2()<=3.) &&
               (fabs(ksref->mass() - kMass)<=0.01) &&
               (kaon_significance>15.) &&
@@ -523,11 +523,11 @@ PF_PU_AssoMapAlgos::GetCleanedKshort(Handle<VertexCompositeCandidateCollection> 
 
             cleanedKaonColl->push_back(*ksref);
 
-       	  }
+          }
 
-	}
+        }
 
-	return cleanedKaonColl;
+        return cleanedKaonColl;
 }
 
 /*************************************************************************************/
@@ -538,33 +538,33 @@ unique_ptr<VertexCompositeCandidateCollection>
 PF_PU_AssoMapAlgos::GetCleanedLambda(Handle<VertexCompositeCandidateCollection> LambdasH, Handle<BeamSpot> bsH, bool cleanedColl)
 {
 
-     	unique_ptr<VertexCompositeCandidateCollection> cleanedLambdaColl(new VertexCompositeCandidateCollection() );
+        unique_ptr<VertexCompositeCandidateCollection> cleanedLambdaColl(new VertexCompositeCandidateCollection() );
 
-	for (unsigned int lambdacoll_idx=0; lambdacoll_idx<LambdasH->size(); lambdacoll_idx++){
+        for (unsigned int lambdacoll_idx=0; lambdacoll_idx<LambdasH->size(); lambdacoll_idx++){
 
-	  VertexCompositeCandidateRef lambdaref(LambdasH,lambdacoll_idx);
+          VertexCompositeCandidateRef lambdaref(LambdasH,lambdacoll_idx);
 
- 	  if(!cleanedColl){
+          if(!cleanedColl){
             cleanedLambdaColl->push_back(*lambdaref);
-	    continue;
+            continue;
           }
 
-  	  VertexDistance3D distanceComputer;
+          VertexDistance3D distanceComputer;
 
           GlobalPoint dec_pos = RecoVertex::convertPos(lambdaref->vertex());
 
-       	  GlobalError decayVertexError = GlobalError(lambdaref->vertexCovariance(0,0), lambdaref->vertexCovariance(0,1), lambdaref->vertexCovariance(1,1), lambdaref->vertexCovariance(0,2), lambdaref->vertexCovariance(1,2), lambdaref->vertexCovariance(2,2));
+          GlobalError decayVertexError = GlobalError(lambdaref->vertexCovariance(0,0), lambdaref->vertexCovariance(0,1), lambdaref->vertexCovariance(1,1), lambdaref->vertexCovariance(0,2), lambdaref->vertexCovariance(1,2), lambdaref->vertexCovariance(2,2));
 
-      	  math::XYZVector dec_mom(lambdaref->momentum().x(),
-	                          lambdaref->momentum().y(),
-	                          lambdaref->momentum().z());
+          math::XYZVector dec_mom(lambdaref->momentum().x(),
+                                  lambdaref->momentum().y(),
+                                  lambdaref->momentum().z());
 
-      	  GlobalPoint bsPosition = RecoVertex::convertPos(bsH->position());
-      	  GlobalError bsError = RecoVertex::convertError(bsH->covariance3D());
+          GlobalPoint bsPosition = RecoVertex::convertPos(bsH->position());
+          GlobalError bsError = RecoVertex::convertError(bsH->covariance3D());
 
-   	  double lambda_significance = (distanceComputer.distance(VertexState(bsPosition,bsError), VertexState(dec_pos, decayVertexError))).significance();
+          double lambda_significance = (distanceComputer.distance(VertexState(bsPosition,bsError), VertexState(dec_pos, decayVertexError))).significance();
 
-	  if ((lambdaref->vertex().rho()>=3.) &&
+          if ((lambdaref->vertex().rho()>=3.) &&
               (lambdaref->vertexNormalizedChi2()<=3.) &&
               (fabs(lambdaref->mass() - lamMass)<=0.005) &&
               (lambda_significance>15.) &&
@@ -572,11 +572,11 @@ PF_PU_AssoMapAlgos::GetCleanedLambda(Handle<VertexCompositeCandidateCollection> 
 
             cleanedLambdaColl->push_back(*lambdaref);
 
-	  }
+          }
 
-	}
+        }
 
-	return cleanedLambdaColl;
+        return cleanedLambdaColl;
 }
 
 /*************************************************************************************/
@@ -587,41 +587,41 @@ bool
 PF_PU_AssoMapAlgos::ComesFromV0Decay(const TrackRef trackref, const VertexCompositeCandidateCollection& cleanedKshort, const VertexCompositeCandidateCollection& cleanedLambda, VertexCompositeCandidate* V0)
 {
 
-	//the part for the reassociation of particles from Kshort decays
-	for(VertexCompositeCandidateCollection::const_iterator iKS=cleanedKshort.begin(); iKS!=cleanedKshort.end(); iKS++){
+        //the part for the reassociation of particles from Kshort decays
+        for(VertexCompositeCandidateCollection::const_iterator iKS=cleanedKshort.begin(); iKS!=cleanedKshort.end(); iKS++){
 
-	  const RecoChargedCandidate *dauCand1 = dynamic_cast<const RecoChargedCandidate*>(iKS->daughter(0));
- 	  TrackRef dauTk1 = dauCand1->track();
-	  const RecoChargedCandidate *dauCand2 = dynamic_cast<const RecoChargedCandidate*>(iKS->daughter(1));
- 	  TrackRef dauTk2 = dauCand2->track();
+          const RecoChargedCandidate *dauCand1 = dynamic_cast<const RecoChargedCandidate*>(iKS->daughter(0));
+          TrackRef dauTk1 = dauCand1->track();
+          const RecoChargedCandidate *dauCand2 = dynamic_cast<const RecoChargedCandidate*>(iKS->daughter(1));
+          TrackRef dauTk2 = dauCand2->track();
 
-	  if((trackref==dauTk1) || (trackref==dauTk2)){
+          if((trackref==dauTk1) || (trackref==dauTk2)){
 
-	    *V0 = *iKS;
-	    return true;
+            *V0 = *iKS;
+            return true;
 
-	  }
+          }
 
-	}
+        }
 
-	//the part for the reassociation of particles from Lambda decays
-	for(VertexCompositeCandidateCollection::const_iterator iLambda=cleanedLambda.begin(); iLambda!=cleanedLambda.end(); iLambda++){
+        //the part for the reassociation of particles from Lambda decays
+        for(VertexCompositeCandidateCollection::const_iterator iLambda=cleanedLambda.begin(); iLambda!=cleanedLambda.end(); iLambda++){
 
-	  const RecoChargedCandidate *dauCand1 = dynamic_cast<const RecoChargedCandidate*>(iLambda->daughter(0));
- 	  TrackRef dauTk1 = dauCand1->track();
-	  const RecoChargedCandidate *dauCand2 = dynamic_cast<const RecoChargedCandidate*>(iLambda->daughter(1));
- 	  TrackRef dauTk2 = dauCand2->track();
+          const RecoChargedCandidate *dauCand1 = dynamic_cast<const RecoChargedCandidate*>(iLambda->daughter(0));
+          TrackRef dauTk1 = dauCand1->track();
+          const RecoChargedCandidate *dauCand2 = dynamic_cast<const RecoChargedCandidate*>(iLambda->daughter(1));
+          TrackRef dauTk2 = dauCand2->track();
 
-   	  if((trackref==dauTk1) || (trackref==dauTk2)){
+          if((trackref==dauTk1) || (trackref==dauTk2)){
 
-	    *V0 = *iLambda;
-	    return true;
+            *V0 = *iLambda;
+            return true;
 
-	  }
+          }
 
-	}
+        }
 
-	return false;
+        return false;
 }
 
 
@@ -634,19 +634,19 @@ PF_PU_AssoMapAlgos::FindV0Vertex(const TrackRef trackref, const VertexCompositeC
                                  const EventSetup& iSetup, Handle<BeamSpot> bsH, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
-	const math::XYZPoint& dec_pos = V0_vtx.vertex();
+        const math::XYZPoint& dec_pos = V0_vtx.vertex();
 
-	math::XYZVector dec_mom(V0_vtx.momentum().x(),
-	                        V0_vtx.momentum().y(),
-	                        V0_vtx.momentum().z());
+        math::XYZVector dec_mom(V0_vtx.momentum().x(),
+                                V0_vtx.momentum().y(),
+                                V0_vtx.momentum().z());
 
-	Track V0(trackref->chi2(), trackref->ndof(), dec_pos, dec_mom, 0, trackref->covariance());
+        Track V0(trackref->chi2(), trackref->ndof(), dec_pos, dec_mom, 0, trackref->covariance());
 
-    	TransientTrack transV0(V0, &(*bFieldH) );
-    	transV0.setBeamSpot(*bsH);
-    	transV0.setES(iSetup);
+        TransientTrack transV0(V0, &(*bFieldH) );
+        transV0.setBeamSpot(*bsH);
+        transV0.setES(iSetup);
 
-	return FindClosest3D(transV0, vtxcollV, tWeight);
+        return FindClosest3D(transV0, vtxcollV, tWeight);
 
 }
 
@@ -659,43 +659,43 @@ unique_ptr<PFDisplacedVertexCollection>
 PF_PU_AssoMapAlgos::GetCleanedNI(Handle<PFDisplacedVertexCollection> NuclIntH, Handle<BeamSpot> bsH, bool cleanedColl)
 {
 
-     	unique_ptr<PFDisplacedVertexCollection> cleanedNIColl(new PFDisplacedVertexCollection() );
+        unique_ptr<PFDisplacedVertexCollection> cleanedNIColl(new PFDisplacedVertexCollection() );
 
-	for (PFDisplacedVertexCollection::const_iterator niref=NuclIntH->begin(); niref!=NuclIntH->end(); niref++){
+        for (PFDisplacedVertexCollection::const_iterator niref=NuclIntH->begin(); niref!=NuclIntH->end(); niref++){
 
 
-	  if( (niref->isFake()) || !(niref->isNucl()) ) continue;
+          if( (niref->isFake()) || !(niref->isNucl()) ) continue;
 
-	  if(!cleanedColl){
-	    cleanedNIColl->push_back(*niref);
-	    continue;
+          if(!cleanedColl){
+            cleanedNIColl->push_back(*niref);
+            continue;
           }
 
-  	  VertexDistance3D distanceComputer;
+          VertexDistance3D distanceComputer;
 
-      	  GlobalPoint ni_pos = RecoVertex::convertPos(niref->position());
-      	  GlobalError interactionVertexError = RecoVertex::convertError(niref->error());
+          GlobalPoint ni_pos = RecoVertex::convertPos(niref->position());
+          GlobalError interactionVertexError = RecoVertex::convertError(niref->error());
 
-      	  math::XYZVector ni_mom(niref->primaryMomentum().x(),
-	                         niref->primaryMomentum().y(),
-	                         niref->primaryMomentum().z());
+          math::XYZVector ni_mom(niref->primaryMomentum().x(),
+                                 niref->primaryMomentum().y(),
+                                 niref->primaryMomentum().z());
 
-      	  GlobalPoint bsPosition = RecoVertex::convertPos(bsH->position());
-      	  GlobalError bsError = RecoVertex::convertError(bsH->covariance3D());
+          GlobalPoint bsPosition = RecoVertex::convertPos(bsH->position());
+          GlobalError bsError = RecoVertex::convertError(bsH->covariance3D());
 
-   	  double nuclint_significance = (distanceComputer.distance(VertexState(bsPosition,bsError), VertexState(ni_pos, interactionVertexError))).significance();
+          double nuclint_significance = (distanceComputer.distance(VertexState(bsPosition,bsError), VertexState(ni_pos, interactionVertexError))).significance();
 
-	  if ((niref->position().rho()>=3.) &&
+          if ((niref->position().rho()>=3.) &&
               (nuclint_significance>15.) &&
               (PF_PU_AssoMapAlgos::dR(niref->position(),ni_mom,bsH)<=0.3) ){
 
             cleanedNIColl->push_back(*niref);
 
-	  }
+          }
 
-	}
+        }
 
-	return cleanedNIColl;
+        return cleanedNIColl;
 }
 
 /*************************************************************************************/
@@ -706,19 +706,19 @@ bool
 PF_PU_AssoMapAlgos::ComesFromNI(const TrackRef trackref, const PFDisplacedVertexCollection& cleanedNI, PFDisplacedVertex* displVtx)
 {
 
-	//the part for the reassociation of particles from nuclear interactions
-	for(PFDisplacedVertexCollection::const_iterator iDisplV=cleanedNI.begin(); iDisplV!=cleanedNI.end(); iDisplV++){
+        //the part for the reassociation of particles from nuclear interactions
+        for(PFDisplacedVertexCollection::const_iterator iDisplV=cleanedNI.begin(); iDisplV!=cleanedNI.end(); iDisplV++){
 
-	  if(iDisplV->trackWeight(trackref)>1.e-5){
+          if(iDisplV->trackWeight(trackref)>1.e-5){
 
-	    *displVtx = *iDisplV;
-	    return true;
+            *displVtx = *iDisplV;
+            return true;
 
-	  }
+          }
 
-	}
+        }
 
-	return false;
+        return false;
 }
 
 
@@ -731,47 +731,47 @@ PF_PU_AssoMapAlgos::FindNIVertex(const TrackRef trackref, const PFDisplacedVerte
                                  const EventSetup& iSetup, Handle<BeamSpot> bsH, const std::vector<reco::VertexRef>& vtxcollV, double tWeight)
 {
 
-	TrackCollection refittedTracks = displVtx.refittedTracks();
+        TrackCollection refittedTracks = displVtx.refittedTracks();
 
-	if((displVtx.isTherePrimaryTracks()) || (displVtx.isThereMergedTracks())){
+        if((displVtx.isTherePrimaryTracks()) || (displVtx.isThereMergedTracks())){
 
-	  for(TrackCollection::const_iterator trkcoll_ite=refittedTracks.begin(); trkcoll_ite!=refittedTracks.end(); trkcoll_ite++){
+          for(TrackCollection::const_iterator trkcoll_ite=refittedTracks.begin(); trkcoll_ite!=refittedTracks.end(); trkcoll_ite++){
 
-	    const TrackBaseRef retrackbaseref = displVtx.originalTrack(*trkcoll_ite);
+            const TrackBaseRef retrackbaseref = displVtx.originalTrack(*trkcoll_ite);
 
-	    if(displVtx.isIncomingTrack(retrackbaseref)){
+            if(displVtx.isIncomingTrack(retrackbaseref)){
 
               VertexRef VOAssociation = TrackWeightAssociation(retrackbaseref, vtxcollV);
 
-	      if( VOAssociation->trackWeight(retrackbaseref) >= 1.e-5 ){
-	        return VOAssociation;
-	      }
+              if( VOAssociation->trackWeight(retrackbaseref) >= 1.e-5 ){
+                return VOAssociation;
+              }
 
-    	      TransientTrack transIncom(*retrackbaseref, &(*bFieldH) );
-    	      transIncom.setBeamSpot(*bsH);
-    	      transIncom.setES(iSetup);
+              TransientTrack transIncom(*retrackbaseref, &(*bFieldH) );
+              transIncom.setBeamSpot(*bsH);
+              transIncom.setES(iSetup);
 
-	      return FindClosest3D(transIncom, vtxcollV, tWeight);
+              return FindClosest3D(transIncom, vtxcollV, tWeight);
 
-	    }
+            }
 
-	  }
+          }
 
-	}
+        }
 
-	const math::XYZPoint& ni_pos = displVtx.position();
+        const math::XYZPoint& ni_pos = displVtx.position();
 
-	math::XYZVector ni_mom(displVtx.primaryMomentum().x(),
-	                       displVtx.primaryMomentum().y(),
-	                       displVtx.primaryMomentum().z());
+        math::XYZVector ni_mom(displVtx.primaryMomentum().x(),
+                               displVtx.primaryMomentum().y(),
+                               displVtx.primaryMomentum().z());
 
-	Track incom(trackref->chi2(), trackref->ndof(), ni_pos, ni_mom, 0, trackref->covariance());
+        Track incom(trackref->chi2(), trackref->ndof(), ni_pos, ni_mom, 0, trackref->covariance());
 
-    	TransientTrack transIncom(incom, &(*bFieldH) );
-    	transIncom.setBeamSpot(*bsH);
-    	transIncom.setES(iSetup);
+        TransientTrack transIncom(incom, &(*bFieldH) );
+        transIncom.setBeamSpot(*bsH);
+        transIncom.setES(iSetup);
 
-	return FindClosest3D(transIncom, vtxcollV, tWeight);
+        return FindClosest3D(transIncom, vtxcollV, tWeight);
 
 }
 
@@ -783,22 +783,22 @@ VertexRef
 PF_PU_AssoMapAlgos::TrackWeightAssociation(const TREF& trackRef, const std::vector<reco::VertexRef>& vtxcollV)
 {
 
-	VertexRef bestvertexref = vtxcollV.at(0);
- 	float bestweight = 0.;
+        VertexRef bestvertexref = vtxcollV.at(0);
+        float bestweight = 0.;
 
-	//loop over all vertices in the vertex collection
+        //loop over all vertices in the vertex collection
         for(auto const& vertexref : vtxcollV){
 
-     	  //get the most probable vertex for the track
-	  float weight = vertexref->trackWeight(trackRef);
-	  if(weight>bestweight){
-  	    bestweight = weight;
-	    bestvertexref = vertexref;
- 	  }
+          //get the most probable vertex for the track
+          float weight = vertexref->trackWeight(trackRef);
+          if(weight>bestweight){
+            bestweight = weight;
+            bestvertexref = vertexref;
+          }
 
-	}
+        }
 
-  	return bestvertexref;
+        return bestvertexref;
 
 }
 
@@ -811,99 +811,99 @@ PF_PU_AssoMapAlgos::FindAssociation(const reco::TrackRef& trackref, const std::v
                                     edm::ESHandle<MagneticField> bfH, const edm::EventSetup& iSetup, edm::Handle<reco::BeamSpot> bsH, int assocNum)
 {
 
-	VertexRef foundVertex;
+        VertexRef foundVertex;
 
-	//if it is not the first try of an association jump to the final association
-	//to avoid multiple (secondary) associations and/or unphysical (primary and secondary) associations
-	if ( assocNum>0 ) goto finalStep;
+        //if it is not the first try of an association jump to the final association
+        //to avoid multiple (secondary) associations and/or unphysical (primary and secondary) associations
+        if ( assocNum>0 ) goto finalStep;
 
-	// Step 1: First round of association:
-    	// Find the vertex with the highest track-to-vertex association weight
-    	foundVertex = TrackWeightAssociation(trackref, vtxColl);
+        // Step 1: First round of association:
+        // Find the vertex with the highest track-to-vertex association weight
+        foundVertex = TrackWeightAssociation(trackref, vtxColl);
 
-    	if ( foundVertex->trackWeight(trackref) >= 1.e-5 ){
+        if ( foundVertex->trackWeight(trackref) >= 1.e-5 ){
           return make_pair( foundVertex, 0. );
-	}
+        }
 
-	// Step 2: Reassociation
-    	// Second round of association:
-    	// In case no vertex with track-to-vertex association weight > 1.e-5 is found,
-    	// check the track originates from a neutral hadron decay, photon conversion or nuclear interaction
+        // Step 2: Reassociation
+        // Second round of association:
+        // In case no vertex with track-to-vertex association weight > 1.e-5 is found,
+        // check the track originates from a neutral hadron decay, photon conversion or nuclear interaction
 
-	if ( input_doReassociation_ ) {
+        if ( input_doReassociation_ ) {
 
-      	  // Test if the track comes from a photon conversion:
-      	  // If so, try to find the vertex of the mother particle
-	  Conversion gamma;
+          // Test if the track comes from a photon conversion:
+          // If so, try to find the vertex of the mother particle
+          Conversion gamma;
           if ( ComesFromConversion(trackref, *cleanedConvCollP, &gamma) ){
-  	    foundVertex = FindConversionVertex(trackref, gamma, bfH, iSetup, bsH, vtxColl, input_nTrack_);
+            foundVertex = FindConversionVertex(trackref, gamma, bfH, iSetup, bsH, vtxColl, input_nTrack_);
             return make_pair( foundVertex, 1. );
           }
 
-      	  // Test if the track comes from a Kshort or Lambda decay:
-      	  // If so, reassociate the track to the vertex of the V0
-	  VertexCompositeCandidate V0;
-	  if ( ComesFromV0Decay(trackref, *cleanedKshortCollP, *cleanedLambdaCollP, &V0) ) {
+          // Test if the track comes from a Kshort or Lambda decay:
+          // If so, reassociate the track to the vertex of the V0
+          VertexCompositeCandidate V0;
+          if ( ComesFromV0Decay(trackref, *cleanedKshortCollP, *cleanedLambdaCollP, &V0) ) {
             foundVertex = FindV0Vertex(trackref, V0, bfH, iSetup, bsH, vtxColl, input_nTrack_);
             return make_pair( foundVertex, 1. );
-	  }
+          }
 
-	  if ( !missingColls ) {
+          if ( !missingColls ) {
 
-      	    // Test if the track comes from a nuclear interaction:
-      	    // If so, reassociate the track to the vertex of the incoming particle
-	    PFDisplacedVertex displVtx;
-	    if ( ComesFromNI(trackref, *cleanedNICollP, &displVtx) ){
- 	      foundVertex = FindNIVertex(trackref, displVtx, bfH, iSetup, bsH, vtxColl, input_nTrack_);
+            // Test if the track comes from a nuclear interaction:
+            // If so, reassociate the track to the vertex of the incoming particle
+            PFDisplacedVertex displVtx;
+            if ( ComesFromNI(trackref, *cleanedNICollP, &displVtx) ){
+              foundVertex = FindNIVertex(trackref, displVtx, bfH, iSetup, bsH, vtxColl, input_nTrack_);
               return make_pair( foundVertex, 1. );
-	    }
+            }
 
-	  }
+          }
 
-	}
+        }
 
-	// Step 3: Final association
-      	// If no vertex is found with track-to-vertex association weight > 1.e-5
-      	// and no reassociation was done do the final association
-	// look for the closest vertex in 3D or in z/longitudinal distance
-	// or associate the track always to the first vertex (default)
+        // Step 3: Final association
+        // If no vertex is found with track-to-vertex association weight > 1.e-5
+        // and no reassociation was done do the final association
+        // look for the closest vertex in 3D or in z/longitudinal distance
+        // or associate the track always to the first vertex (default)
 
-	finalStep:
+        finalStep:
 
-	switch (input_FinalAssociation_) {
+        switch (input_FinalAssociation_) {
 
- 	  case 1:{
+          case 1:{
 
-	    // closest in z
-	    foundVertex = FindClosestZ(trackref,vtxColl,input_nTrack_);
-	    break;
+            // closest in z
+            foundVertex = FindClosestZ(trackref,vtxColl,input_nTrack_);
+            break;
 
 
           }
 
- 	  case 2:{
+          case 2:{
 
-	    // closest in 3D
+            // closest in 3D
             TransientTrack transtrk(trackref, &(*bfH) );
             transtrk.setBeamSpot(*bsH);
             transtrk.setES(iSetup);
 
-	    foundVertex = FindClosest3D(transtrk,vtxColl,input_nTrack_);
-	    break;
+            foundVertex = FindClosest3D(transtrk,vtxColl,input_nTrack_);
+            break;
 
           }
 
- 	  default:{
+          default:{
 
-	    // allways first vertex
+            // allways first vertex
             foundVertex = vtxColl.at(0);
-	    break;
+            break;
 
           }
 
-	}
+        }
 
-	return make_pair( foundVertex, 2. );
+        return make_pair( foundVertex, 2. );
 
 }
 
@@ -915,78 +915,78 @@ int
 PF_PU_AssoMapAlgos::DefineQuality(int assoc_ite, int step, double distance)
 {
 
-	int quality = 0;
+        int quality = 0;
 
-	switch (step) {
+        switch (step) {
 
-	  case 0:{
+          case 0:{
 
-	    //TrackWeight association
+            //TrackWeight association
             if ( distance <= tw_90 ) {
               quality = 5;
-	    } else {
-	      if ( distance <= tw_70 ) {
+            } else {
+              if ( distance <= tw_70 ) {
                 quality = 4;
-	      } else {
-	        if ( distance <= tw_50 ) {
+              } else {
+                if ( distance <= tw_50 ) {
                   quality = 3;
-	        } else {
+                } else {
                   quality = 2;
-	        }
-	      }
-	    }
-	    break;
+                }
+              }
+            }
+            break;
 
-	  }
+          }
 
-	  case 1:{
+          case 1:{
 
-      	    //Secondary association
+            //Secondary association
             if ( distance <= sec_70 ) {
               quality = 4;
-	    } else {
-	      if ( distance <= sec_50 ) {
+            } else {
+              if ( distance <= sec_50 ) {
                 quality = 3;
-	      } else {
+              } else {
                 quality = 2;
-	      }
-	    }
-	    break;
+              }
+            }
+            break;
 
-	  }
+          }
 
-	  case 2:{
+          case 2:{
 
-	    //Final association
+            //Final association
             if ( assoc_ite == 1 ) {
               quality = 1;
-	    } else {
+            } else {
               if ( assoc_ite >= 2 ) {
                 quality = 0;
-	      } else {
+              } else {
                 if ( distance <= fin_70 ) {
                   quality = 4;
-	        } else {
-	          if ( distance <= fin_50 ) {
+                } else {
+                  if ( distance <= fin_50 ) {
                     quality = 3;
-	          } else {
+                  } else {
                     quality = 2;
-	          }
-	        }
-	      }
-	    }
-	    break;
+                  }
+                }
+              }
+            }
+            break;
 
-	  }
+          }
 
-	  default:{
+          default:{
 
             quality = -1;
-	    break;
-     	  }
+            break;
+          }
 
-	}
+        }
 
-	return quality;
+        return quality;
 
 }

--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -808,21 +808,19 @@ PF_PU_AssoMapAlgos::FindNIVertex(const TrackRef trackref, const PFDisplacedVerte
 /*************************************************************************************/
 /* function to find the vertex with the highest TrackWeight for a certain track      */
 /*************************************************************************************/
-
+template<typename TREF>
 VertexRef
-PF_PU_AssoMapAlgos::TrackWeightAssociation(const TrackBaseRef& trackbaseRef, std::vector<reco::VertexRef>* vtxcollV)
+PF_PU_AssoMapAlgos::TrackWeightAssociation(const TREF& trackRef, std::vector<reco::VertexRef>* vtxcollV)
 {
 
 	VertexRef bestvertexref = vtxcollV->at(0);
  	float bestweight = 0.;
 
 	//loop over all vertices in the vertex collection
-  	for(unsigned int index_vtx=0;  index_vtx<vtxcollV->size(); ++index_vtx){
-
-          VertexRef vertexref = vtxcollV->at(index_vtx);
+        for(auto const& vertexref : *vtxcollV){
 
      	  //get the most probable vertex for the track
-	  float weight = vertexref->trackWeight(trackbaseRef);
+	  float weight = vertexref->trackWeight(trackRef);
 	  if(weight>bestweight){
   	    bestweight = weight;
 	    bestvertexref = vertexref;
@@ -842,8 +840,6 @@ VertexStepPair
 PF_PU_AssoMapAlgos::FindAssociation(const reco::TrackRef& trackref, std::vector<reco::VertexRef>* vtxColl, edm::ESHandle<MagneticField> bfH, const edm::EventSetup& iSetup, edm::Handle<reco::BeamSpot> bsH, int assocNum)
 {
 
-	const TrackBaseRef& trackbaseRef = TrackBaseRef(trackref);
-
 	VertexRef foundVertex;
 
 	//if it is not the first try of an association jump to the final association
@@ -852,9 +848,9 @@ PF_PU_AssoMapAlgos::FindAssociation(const reco::TrackRef& trackref, std::vector<
 
 	// Step 1: First round of association:
     	// Find the vertex with the highest track-to-vertex association weight
-    	foundVertex = TrackWeightAssociation(trackbaseRef, vtxColl);
+    	foundVertex = TrackWeightAssociation(trackref, vtxColl);
 
-    	if ( foundVertex->trackWeight(trackbaseRef) >= 1.e-5 ){
+    	if ( foundVertex->trackWeight(trackref) >= 1.e-5 ){
           return make_pair( foundVertex, 0. );
 	}
 

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -443,3 +443,4 @@ const reco::Track* PhotonIDValueMapProducer::getTrackPointer(const edm::Ptr<reco
         &(((const edm::Ptr<pat::PackedCandidate>)candidate)->pseudoTrack());
 }
 
+DEFINE_FWK_MODULE(PhotonIDValueMapProducer);

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -17,6 +17,7 @@
 #include "RecoEgamma/EgammaTools/interface/Utils.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
+namespace {
 // This template function finds whether theCandidate is in thefootprint
 // collection. It is templated to be able to handle both reco and pat
 // photons (from AOD and miniAOD, respectively).
@@ -29,6 +30,31 @@ bool isInFootprint(const T& footprint, const U& candidate)
     }
     return false;
 }
+
+  struct CachingPtrCandidate {
+    CachingPtrCandidate(const reco::Candidate* cPtr, bool isAOD) : 
+      candidate(cPtr), 
+      track(isAOD? &*static_cast<const reco::PFCandidate* >(cPtr)->trackRef() : nullptr),
+      packed(isAOD? nullptr : static_cast<const pat::PackedCandidate*>(cPtr))
+    {}
+    
+    const reco::Candidate* candidate;
+    const reco::Track* track;
+    const pat::PackedCandidate* packed;
+  };
+
+  void getImpactParameters(const CachingPtrCandidate& candidate, const reco::Vertex& pv, float& dxy, float& dz)
+  {
+    if (candidate.track != nullptr) {
+      dxy = candidate.track->dxy(pv.position());
+      dz = candidate.track->dz(pv.position());
+    } else {
+      dxy = candidate.packed->dxy(pv.position());
+      dz = candidate.packed->dz(pv.position());
+    }
+  }
+
+};
 
 class PhotonIDValueMapProducer : public edm::stream::EDProducer<> {
 
@@ -57,11 +83,9 @@ private:
 
     // Some helper functions that are needed to access info in
     // AOD vs miniAOD
-    reco::PFCandidate::ParticleType candidatePdgId(const edm::Ptr<reco::Candidate> candidate);
+    reco::PFCandidate::ParticleType candidatePdgId(const reco::Candidate* candidate);
 
     const reco::Track* getTrackPointer(const edm::Ptr<reco::Candidate> candidate);
-    void getImpactParameters(
-        const edm::Ptr<reco::Candidate>& candidate, const reco::Vertex& pv, float& dxy, float& dz);
 
     // check whether a non-null preshower is there
     const bool usesES_;
@@ -253,7 +277,7 @@ void PhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup
             }
 
             // Find candidate type
-            reco::PFCandidate::ParticleType thisCandidateType = candidatePdgId(iCand);
+            reco::PFCandidate::ParticleType thisCandidateType = candidatePdgId(&*iCand);
 
             // Increment the appropriate isolation sum
             if (thisCandidateType == reco::PFCandidate::h) {
@@ -261,7 +285,7 @@ void PhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup
                 // with the PV
                 float dxy = -999;
                 float dz = -999;
-                getImpactParameters(iCand, pv, dxy, dz);
+                getImpactParameters(CachingPtrCandidate(&*iCand, isAOD_), pv, dxy, dz);
 
                 if (fabs(dxy) > dxyMax || fabs(dz) > dzMax)
                     continue;
@@ -341,6 +365,21 @@ float PhotonIDValueMapProducer ::computeWorstPFChargedIsolation(const T& photon,
 
     const float dRveto = photon->isEB() ? dRvetoBarrel : dRvetoEndcap;
 
+    std::vector<CachingPtrCandidate> chargedCands;
+    chargedCands.reserve(pfCands->size());
+    for (auto const& aCand : *pfCands){
+      
+      // require that PFCandidate is a charged hadron
+      reco::PFCandidate::ParticleType thisCandidateType = candidatePdgId(&aCand);
+      if (thisCandidateType != reco::PFCandidate::h)
+        continue;
+      
+      if ((options & PT_MIN_THRESH) && aCand.pt() < ptMin)
+        continue;
+
+      chargedCands.emplace_back(&aCand, isAOD_);
+    }
+
     // Calculate isolation sum separately for each vertex
     for (unsigned int ivtx = 0; ivtx < vertices->size(); ++ivtx) {
 
@@ -351,28 +390,19 @@ float PhotonIDValueMapProducer ::computeWorstPFChargedIsolation(const T& photon,
 
         float sum = 0;
         // Loop over the PFCandidates
-        for (unsigned int i = 0; i < pfCands->size(); i++) {
-
-            const auto& iCand = pfCands->ptrAt(i);
-
-            // require that PFCandidate is a charged hadron
-            reco::PFCandidate::ParticleType thisCandidateType = candidatePdgId(iCand);
-            if (thisCandidateType != reco::PFCandidate::h)
-                continue;
-
-            if ((options & PT_MIN_THRESH) && iCand->pt() < ptMin)
-                continue;
+        for (auto const& aCCand : chargedCands) {
 
             float dxy = -999;
             float dz = -999;
             if (options & PV_CONSTRAINT)
-                getImpactParameters(iCand, pv, dxy, dz);
+                getImpactParameters(aCCand, pv, dxy, dz);
             else
-                getImpactParameters(iCand, *vtx, dxy, dz);
+                getImpactParameters(aCCand, *vtx, dxy, dz);
 
             if (fabs(dxy) > dxyMax || fabs(dz) > dzMax)
                 continue;
 
+            auto iCand = aCCand.candidate;
             float dR2 = deltaR2(phoWrtVtx.Eta(), phoWrtVtx.Phi(), iCand->eta(), iCand->phi());
             if (dR2 > coneSizeDR * coneSizeDR ||
                     (options & DR_VETO && dR2 < dRveto * dRveto))
@@ -388,14 +418,14 @@ float PhotonIDValueMapProducer ::computeWorstPFChargedIsolation(const T& photon,
 }
 
 reco::PFCandidate::ParticleType PhotonIDValueMapProducer::candidatePdgId(
-    const edm::Ptr<reco::Candidate> candidate)
+    const reco::Candidate* candidate)
 {
     if (isAOD_)
-        return ((const edm::Ptr<reco::PFCandidate>)candidate)->particleId();
+      return static_cast<const reco::PFCandidate*>(candidate)->particleId();
 
     // the neutral hadrons and charged hadrons can be of pdgId types
     // only 130 (K0L) and +-211 (pi+-) in packed candidates
-    const int pdgId = ((const edm::Ptr<pat::PackedCandidate>)candidate)->pdgId();
+    const int pdgId = static_cast<const pat::PackedCandidate*>(candidate)->pdgId();
     if (pdgId == 22)
         return reco::PFCandidate::gamma;
     else if (abs(pdgId) == 130) // PDG ID for K0L
@@ -413,18 +443,3 @@ const reco::Track* PhotonIDValueMapProducer::getTrackPointer(const edm::Ptr<reco
         &(((const edm::Ptr<pat::PackedCandidate>)candidate)->pseudoTrack());
 }
 
-void PhotonIDValueMapProducer::getImpactParameters(
-    const edm::Ptr<reco::Candidate>& candidate, const reco::Vertex& pv, float& dxy, float& dz)
-{
-    if (isAOD_) {
-        auto const& theTrack = *static_cast<const edm::Ptr<reco::PFCandidate>>(candidate)->trackRef();
-        dxy = theTrack.dxy(pv.position());
-        dz = theTrack.dz(pv.position());
-    } else {
-        auto const& aCand = *static_cast<const edm::Ptr<pat::PackedCandidate>>(candidate);
-        dxy = aCand.dxy(pv.position());
-        dz = aCand.dz(pv.position());
-    }
-}
-
-DEFINE_FWK_MODULE(PhotonIDValueMapProducer);


### PR DESCRIPTION
The update is supposed to be technical.
Tested on 1K events reminiAOD workflows and shows no differences.

Timing tests on 2018 setup miniAOD MC ttbar with PU50 show about 16% total job time reduction.
- PuppiProducer speedup by a factor 2.2
- PhotonIDValueMapProducer by a factor 9
- PFCand_AssoMap by a factor of 3.4

More details in 
- baseline https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/CMSSW_10_3_0_pre5-miniOpt0_TTbar_13UP18+DIGIPRMX_AVE_50_BX_25ns.step6.200.871f3256d9c.pp/cumulative
- this PR https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/CMSSW_10_3_0_pre5-miniOpt0_TTbar_13UP18+DIGIPRMX_AVE_50_BX_25ns.step6.200.O0-orig.pp/cumulative

About a half of the code line differences are due to untabifying \*AssoMapAlgos.cc