### PR TITLE
Converted CosmicGenFilterHelix into one module

### DIFF
--- a/GeneratorInterface/GenFilters/interface/CosmicGenFilterHelix.h
+++ b/GeneratorInterface/GenFilters/interface/CosmicGenFilterHelix.h
@@ -16,7 +16,7 @@
 ///
 
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 
@@ -37,7 +37,7 @@
 class MagneticField;
 class Propagator;
 
-class CosmicGenFilterHelix : public edm::EDFilter {
+class CosmicGenFilterHelix : public edm::one::EDFilter<edm::one::SharedResources> {
  public:
   explicit CosmicGenFilterHelix(const edm::ParameterSet& config);
   ~CosmicGenFilterHelix() override;

--- a/GeneratorInterface/GenFilters/src/CosmicGenFilterHelix.cc
+++ b/GeneratorInterface/GenFilters/src/CosmicGenFilterHelix.cc
@@ -49,6 +49,8 @@ CosmicGenFilterHelix::CosmicGenFilterHelix(const edm::ParameterSet& cfg)
 {
   theSrcToken = consumes<edm::HepMCProduct>(cfg.getParameter<edm::InputTag>("src"));
 
+  usesResource(TFileService::kSharedResource);
+
   if (theIds.size() != theCharges.size()) {
     throw cms::Exception("BadConfig") << "CosmicGenFilterHelix: "
 				      << "'pdgIds' and 'charges' need same length.";


### PR DESCRIPTION
CosmicGenFilterHelix shows up in the integration build release validation tests. As a legacy module it was causing threading efficiency issues.