### PR TITLE
Fix return type of DependentRecordImplementation::tryToGetRecord()

### DIFF
--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -62,7 +62,7 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
       }
 
       template<class DepRecordT>
-      const DepRecordT* tryToGetRecord() const {
+      std::optional<DepRecordT> tryToGetRecord() const {
         //Make sure that DepRecordT is a type in ListT
         typedef typename boost::mpl::end< ListT >::type EndItrT;
         typedef typename boost::mpl::find< ListT, DepRecordT>::type FoundItrT;

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -633,6 +633,9 @@ void testdependentrecord::getTest()
       const DepRecord& depRecord = eventSetup.get<DepRecord>();
 
       depRecord.getRecord<DummyRecord>();
+
+      auto dr = depRecord.tryToGetRecord<DummyRecord>();
+      CPPUNIT_ASSERT(dr.has_value());
    }
    {
       const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4)));


### PR DESCRIPTION
The return type of `DependentRecordImplementation::tryToGetRecord()` was accidentally not migrated to use `std::optional` (and in fact there are no calls to the function). This PR fixes the return type and adds a minimal unit test.

Tested in 10_4_0_pre1, no changes expected.