### PR TITLE
DQM: add @none sequence

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -19,6 +19,8 @@ from DQMOffline.Hcal.HcalDQMOfflineSequence_cff import *
 from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
 from DQM.CTPPS.ctppsDQM_cff import *
 
+DQMNone = cms.Sequence()
+
 DQMOfflinePreDPG = cms.Sequence( dqmDcsInfo *
                                  l1TriggerDqmOffline * # L1 emulator is run within this sequence for real data
                                  ecal_dqm_source_offline *

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -73,7 +73,10 @@ autoDQM = { 'common' : ['DQMOfflineCommon+@L1TMon',
                                    'dqmHarvestingFakeHLT'],
             'liteDQMHI': ['liteDQMOfflineHeavyIons',
                           'PostDQMOffline',
-                          'dqmHarvesting']
+                          'dqmHarvesting'],
+            'none': ['DQMNone',
+                     'PostDQMOffline',
+                     'DQMNone'],
             }
 
 _phase2_allowed = ['trackingOnlyDQM','outerTracker','muon','hcal','hcal2','egamma']


### PR DESCRIPTION
Add an empty sequence to be sure that no DQM is running, as discussed with @icali . To be used at T0 *together* with `write_dqm=False`.

Seems to work fine in a data relval, not sure about the implications when used in T0. Combining it with `write_dqm=False` is probably safer than using this as-is.