### PR TITLE
MEtoEDMConverter does not need synchronizing on Run and Lumi boundaries

### DIFF
--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -98,11 +98,13 @@ MEtoEDMConverter::beginJob()
 void
 MEtoEDMConverter::endJob() {}
 
-void
-MEtoEDMConverter::beginRun(edm::Run const& iRun, const edm::EventSetup& iSetup) {}
+std::shared_ptr<meedm::Void>
+MEtoEDMConverter::globalBeginRun(edm::Run const& iRun, const edm::EventSetup& iSetup) const {
+  return std::shared_ptr<meedm::Void>();
+}
 
 void
-MEtoEDMConverter::endRun(edm::Run const& iRun, const edm::EventSetup& iSetup) {}
+MEtoEDMConverter::globalEndRun(edm::Run const& iRun, const edm::EventSetup& iSetup) {}
 
 void
 MEtoEDMConverter::endRunProduce(edm::Run& iRun, const edm::EventSetup& iSetup)
@@ -112,6 +114,11 @@ MEtoEDMConverter::endRunProduce(edm::Run& iRun, const edm::EventSetup& iSetup)
     store->scaleElements();
     putData(g, iRun, false, iRun.run(), 0);
   });
+}
+
+std::shared_ptr<meedm::Void>  
+MEtoEDMConverter::globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const {
+  return std::shared_ptr<meedm::Void>();
 }
 
 void

--- a/DQMServices/Components/plugins/MEtoEDMConverter.h
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.h
@@ -50,8 +50,15 @@
 #include "TProfile2D.h"
 #include "TObjString.h"
 
-class MEtoEDMConverter : public edm::one::EDProducer<edm::one::WatchRuns,
-                                                     edm::one::WatchLuminosityBlocks,
+namespace meedm {
+  struct Void {};
+}
+
+//Using RunCache and LuminosityBlockCache tells the framework the module is able to 
+// allow multiple concurrent Runs and LuminosityBlocks.
+
+class MEtoEDMConverter : public edm::one::EDProducer<edm::RunCache<meedm::Void>,
+                                                     edm::LuminosityBlockCache<meedm::Void>,
                                                      edm::EndLuminosityBlockProducer,
                                                      edm::EndRunProducer,
                                                      edm::one::SharedResources>
@@ -62,12 +69,12 @@ public:
   void beginJob() override;
   void endJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void beginRun(edm::Run const&, const edm::EventSetup&) override;
-  void endRun(edm::Run const&, const edm::EventSetup&) override;
+  std::shared_ptr<meedm::Void> globalBeginRun(edm::Run const&, const edm::EventSetup&) const override;
+  void globalEndRun(edm::Run const&, const edm::EventSetup&) override;
   void endRunProduce(edm::Run&, const edm::EventSetup&) override;
   void endLuminosityBlockProduce(edm::LuminosityBlock&, const edm::EventSetup&) override;
-  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
-  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
+  std::shared_ptr<meedm::Void>  globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override;
 
   template <class T>
   void putData(DQMStore::IGetter &g, T& iPutTo, bool iLumiOnly, uint32_t run, uint32_t lumi);


### PR DESCRIPTION
Using a RunCache and LuminosityBlockCache signals to the framework
the module will not require synchronization on those boundaries.