### PR TITLE
Allow one::DQMEDAnalyzer to use LuminosityBlockCache

### DIFF
--- a/DQMServices/Core/interface/oneDQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/oneDQMEDAnalyzer.h
@@ -104,6 +104,7 @@ template <typename... T> class DQMBaseClass;
 template<> class DQMBaseClass<> : public DQMRunEDProducer<> {};
 template<> class DQMBaseClass<DQMLuminosityBlockElements> : public DQMLumisEDProducer {};
 template<> class DQMBaseClass<edm::one::WatchLuminosityBlocks> : public DQMRunEDProducer<edm::one::WatchLuminosityBlocks> {};
+template<typename T> class DQMBaseClass<edm::LuminosityBlockCache<T>> : public DQMRunEDProducer<edm::LuminosityBlockCache<T>>{};
 }
 
 template <typename... T>


### PR DESCRIPTION
This extends one::DQMEDAnalyzer to use the new ability of an edm::one module to use a LuminosityBlockCache.

This facility will allow the framework to efficiently processes concurrent LuminosityBlocks.