### PR TITLE
Removed unnecessary overrides in DQM/GEM modules

### DIFF
--- a/DQM/GEM/plugins/GEMDQMSource.cc
+++ b/DQM/GEM/plugins/GEMDQMSource.cc
@@ -33,8 +33,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override {};
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override {};
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override {};
 
 private:

--- a/DQM/GEM/plugins/GEMDQMSourceDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMSourceDigi.cc
@@ -31,8 +31,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override {};
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override {};
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override {};
 
 private:

--- a/DQM/GEM/plugins/GEMDQMStatusDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMStatusDigi.cc
@@ -30,8 +30,6 @@ public:
 protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override {};
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override {};
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override {};
 
 private:


### PR DESCRIPTION
The modules declared LuminosityBlock based functions, but had trivial implementations. Removing them avoids future migration problems.