### PR TITLE
update fragment for MadGraph Workflow at SL7

### DIFF
--- a/Configuration/Generator/python/BulkG_M1200_narrow_2L2Q_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/BulkG_M1200_narrow_2L2Q_LHE_13TeV_cff.py
@@ -5,7 +5,8 @@ import FWCore.ParameterSet.Config as cms
 
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/madgraph/V5_2.4.2/exo_diboson/Spin_2/BulkGraviton_ZZ_inclu_narrow_M1200_slc6_amd64_gcc481_CMSSW_7_1_30_tarball.tar.xz'),
+#    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/madgraph/V5_2.4.2/exo_diboson/Spin_2/BulkGraviton_ZZ_inclu_narrow_M1200_slc6_amd64_gcc481_CMSSW_7_1_30_tarball.tar.xz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/madgraph/V5_2.4.2/exo_diboson/Spin_2/BkGraviton_ZZ_inclu_narrow_M1200_slc6_amd64_gcc481_CMSSW_7_1_30_gcc700-10-3-0-Syscalc_tarball.tar.xz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/BulkG_M1200_narrow_2L2Q_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/BulkG_M1200_narrow_2L2Q_LHE_13TeV_cff.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 #    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/madgraph/V5_2.4.2/exo_diboson/Spin_2/BulkGraviton_ZZ_inclu_narrow_M1200_slc6_amd64_gcc481_CMSSW_7_1_30_tarball.tar.xz'),
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/madgraph/V5_2.4.2/exo_diboson/Spin_2/BkGraviton_ZZ_inclu_narrow_M1200_slc6_amd64_gcc481_CMSSW_7_1_30_gcc700-10-3-0-Syscalc_tarball.tar.xz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/madgraph/V5_2.4.2/exo_diboson/Spin_2/BkGraviton_ZZ_inclu_narrow_M1200_slc6_amd64_gcc481_CMSSW_7_1_30_gcc630-9-3-0-Syscalc_tarball.tar.xz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
@@ -5,6 +5,6 @@ externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
                                      numberOfParameters = cms.uint32(4), 
                                      args = cms.vstring(#'slc6_amd64_gcc472/13TeV/madgraph/V5_2.2.1/dyellell01234j_5f_LO_MLM/v1/',
                                                         #'dyellell01234j_5f_LO_MLM_tarball.tar.gz'
-                                                        '/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.4.2/dyellell01234j_5f_LO_MLM/v1/dyellell01234j_5f_LO_MLM_tarball.tar.xz','false','slc6_amd64_gcc481','CMSSW_7_1_28'),
+                                                        '/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.4.2/dyellell01234j_5f_LO_MLM/v1/dyellell01234j_5f_LO_MLM_tarball.tar.xz','false','slc6_amd64_gcc530','CMSSW_8_4_0'),
                                      nEvents = cms.untracked.uint32(10)
                                      ) 

--- a/Configuration/Generator/python/WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.4.2/lv_bwcutoff_WJetsToLNu_HT-incl/v1/lv_bwcutoff_WJetsToLNu_HT-incl_tarball.tar.xz','false','slc6_amd64_gcc481','CMSSW_7_1_28'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.4.2/lv_bwcutoff_WJetsToLNu_HT-incl/v1/lv_bwcutoff_WJetsToLNu_HT-incl_tarball.tar.xz','false','slc6_amd64_gcc530','CMSSW_8_4_0'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(4),
     outputFile = cms.string('cmsgrid_final.lhe'),


### PR DESCRIPTION
Set SCRAM_ARCH and Release to 'slc6_amd64_gcc530','CMSSW_8_4_0' for several MG workflows (512, 513)

For 562.0 (BulkG_ZZ_2L2Q_M1200_narrow_13TeV_pythia8),  it is  a bit more complicated, as the original gridpack was made with 7_1_30 and lhapdf 6.2.1.    While at 8_X,  lhapdf is 6.1.6 which doesn't contain several 4f PDF.   Thus I recompile the SysCalc inside the gridpack and repack it, with the details as following, which I think can also be used for other old gridpacks to make them work under SL7:

set an SL6 environment  (930 and amd64_gcc630) to recompile SysCalc 
LHAPDFCONFIG=`echo "$LHAPDF_DATA_PATH/../../bin/lhapdf-config"`
PATH=`${LHAPDFCONFIG} --prefix`/bin:${PATH} make

untar gridpack
replace
mgbasedir/SysCalc/sys_calc

Option:  UPDATE  cmssw_version and scram_arch_version in runcmsgrid.sh  to CMSSW_9_3_0 and slc6_amd64_gcc630

XZ_OPT="--lzma2=preset=9,dict=512MiB" tar -cJpsf YOURS.tar.xz mgbasedir process runcmsgrid.sh gridpack_generation.log InputCards
