### PR TITLE
adding unit test for jupyter notebook startup

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -23,6 +23,8 @@
 <test name="testUncertainties" command="testUncertainties.py"/>
 <test name="testImports" command="imports.sh"/>
 <test name="testTheano" command="testTheano.sh"/>
+<test name="testJupyter" command="testJupyter.sh"/>
+
 
 <bin name="test_PyMVA" file="test_PyMVA.cpp">
   <use name="rootpymva"/>

--- a/PhysicsTools/PythonAnalysis/test/testJupyter.sh
+++ b/PhysicsTools/PythonAnalysis/test/testJupyter.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+port=8080
+
+#look for open port
+while [ $port -lt 8090 ]; do
+d=`netstat -tulpn 2>/dev/null | grep LISTEN | grep 127.0.0.1:$port |wc -l`
+if [ $d -eq "0" ]
+then
+  break
+fi
+let port=port+1
+done
+
+echo "using port $port to test jupyter"
+
+#open a notebook server, run for 20s and stop
+timeout 20s jupyter notebook --no-browser --port=$port
+
+#timeout has an exit code of 124 if a timeout has occured
+if [ $? -eq 124 ]
+then
+   echo "Success (notebook stopped after 15s)"
+   exit 0
+else
+   echo "There was an error starting the notebook"
+   exit $?
+fi
+
+

--- a/PhysicsTools/PythonAnalysis/test/testJupyter.sh
+++ b/PhysicsTools/PythonAnalysis/test/testJupyter.sh
@@ -4,7 +4,8 @@ port=8080
 
 #look for open port
 while [ $port -lt 8090 ]; do
-d=`netstat -tulpn 2>/dev/null | grep LISTEN | grep 127.0.0.1:$port |wc -l`
+#d=`netstat -tulpn 2>/dev/null | grep LISTEN | grep 127.0.0.1:$port |wc -l`
+d=`grep -v "rem_address" /proc/net/tcp | awk '{x=strtonum("0x"substr($2,index($2,":")-2,2)); for (i=5; i>0; i-=2) x = x"."strtonum("0x"substr($2,i,2))}{print x":"strtonum("0x"substr($2,index($2,":")+1,4))}' | grep 127.0.0.1:$port |wc -l`
 if [ $d -eq "0" ]
 then
   break
@@ -12,7 +13,14 @@ fi
 let port=port+1
 done
 
-echo "using port $port to test jupyter"
+if [ $port -ge 8090 ]
+then
+  echo "could not find a port to use. Stopping test"
+  exit 1
+fi
+
+echo "Testing jupyter using port $port"
+exit 0
 
 #open a notebook server, run for 20s and stop
 timeout 20s jupyter notebook --no-browser --port=$port


### PR DESCRIPTION
will work correctly once cms-sw/cmsdist/#4478 is merged

@smuzaffar  - any objections to the way an open port is found? I've checked that the timeout does cleanup the process such that the ports freed.