### PR TITLE
Cleanup DQM/CSCMonitorModule

### DIFF
--- a/DQM/CSCMonitorModule/plugins/BuildFile.xml
+++ b/DQM/CSCMonitorModule/plugins/BuildFile.xml
@@ -2,7 +2,6 @@
   <flags   CPPDEFINES="DQMGLOBAL"/>
   <flags   EDM_PLUGIN="1"/>
   <use   name="DQMServices/ClientConfig"/>
-  <use   name="DQMServices/Components"/>
   <use   name="DQMServices/Core"/>
   <use   name="EventFilter/CSCRawToDigi"/>
   <use   name="FWCore/Framework"/>

--- a/DQM/CSCMonitorModule/plugins/CSCMonitorModule.h
+++ b/DQM/CSCMonitorModule/plugins/CSCMonitorModule.h
@@ -127,13 +127,7 @@ class CSCMonitorModule: public DQMEDAnalyzer, public cscdqm::MonitorObjectProvid
 
   protected:
 
-    void beginJob() { }
-    // void beginRun(const edm::Run& r, const edm::EventSetup& c);
-    void setup() { }
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-    void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) override  { }
-    void endRun(const edm::Run& r, const edm::EventSetup& c) override { }
-    void endJob() { }
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 };


### PR DESCRIPTION
-Removed an unnecessary build dependency
-Removed unneeded function declarations in CSCMonitorModule. This will help future code migration.