### PR TITLE
Update deserialize function to return unique_ptr 

### DIFF
--- a/CondCore/CSCPlugins/src/plugin.cc
+++ b/CondCore/CSCPlugins/src/plugin.cc
@@ -62,17 +62,17 @@
 
 
 namespace cond {
-  template <> std::shared_ptr<CSCReadoutMapping> deserialize<CSCReadoutMapping>( const std::string& payloadType,
-										   const Binary& payloadData,
-										   const Binary& streamerInfoData ){
+  template <> std::unique_ptr<CSCReadoutMapping> deserialize<CSCReadoutMapping>( const std::string& payloadType,
+                                                                                 const Binary& payloadData,
+                                                                                 const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( CSCReadoutMapping ); abstract
     DESERIALIZE_POLIMORPHIC_CASE( CSCReadoutMapping, CSCReadoutMappingFromFile );
     // here we come if none of the deserializations above match the payload type:
     throwException(std::string("Type mismatch, target object is type \"")+payloadType+"\"", "deserialize<>" );
   }
-  template <> std::shared_ptr<CSCReadoutMappingForSliceTest> deserialize<CSCReadoutMappingForSliceTest>( const std::string& payloadType,
-													   const Binary& payloadData,
-													   const Binary& streamerInfoData ){
+  template <> std::unique_ptr<CSCReadoutMappingForSliceTest> deserialize<CSCReadoutMappingForSliceTest>( const std::string& payloadType,
+                                                                                                         const Binary& payloadData,
+                                                                                                         const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( CSCReadoutMappingForSliceTest ); abstract
     DESERIALIZE_POLIMORPHIC_CASE( CSCReadoutMappingForSliceTest, CSCReadoutMappingFromFile );
     // here we come if none of the deserializations above match the payload type:

--- a/CondCore/CalibPlugins/src/plugin.cc
+++ b/CondCore/CalibPlugins/src/plugin.cc
@@ -22,9 +22,9 @@
 
 
 namespace cond {
-  template <> std::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
-                                                                                     const Binary& payloadData,
-                                                                                     const Binary& streamerInfoData ){
+  template <> std::unique_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
+                                                                                   const Binary& payloadData,
+                                                                                   const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( condex::Efficiency ); abstract 
     DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInPt );
     DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInEta );
@@ -36,9 +36,9 @@ namespace cond {
 
 
 namespace cond {
-  template <> std::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
-								   const Binary& payloadData,
-								   const Binary& streamerInfoData ){
+  template <> std::unique_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
+                                                                 const Binary& payloadData,
+                                                                 const Binary& streamerInfoData ){
     DESERIALIZE_BASE_CASE( BaseKeyed );
     DESERIALIZE_POLIMORPHIC_CASE( BaseKeyed, condex::ConfI );
     DESERIALIZE_POLIMORPHIC_CASE( BaseKeyed, condex::ConfI );

--- a/CondCore/CondDB/interface/Serialization.h
+++ b/CondCore/CondDB/interface/Serialization.h
@@ -78,10 +78,10 @@ namespace cond {
   }
 
   // generates an instance of T from the binary serialized data. 
-  template <typename T> std::shared_ptr<T> default_deserialize( const std::string& payloadType, 
-								  const Binary& payloadData, 
-								  const Binary& streamerInfoData ){
-    std::shared_ptr<T> payload;
+  template <typename T> std::unique_ptr<T> default_deserialize( const std::string& payloadType,
+                                                                const Binary& payloadData,
+                                                                const Binary& streamerInfoData ){
+    std::unique_ptr<T> payload;
     std::stringbuf sstreamerInfoBuf;
     sstreamerInfoBuf.pubsetbuf( static_cast<char*>(const_cast<void*>(streamerInfoData.data())), streamerInfoData.size() );
     std::string streamerInfo = sstreamerInfoBuf.str();
@@ -110,9 +110,9 @@ namespace cond {
   }
 
   // default specialization
-  template <typename T> std::shared_ptr<T> deserialize( const std::string& payloadType, 
-							  const Binary& payloadData, 
-							  const Binary& streamerInfoData ){
+  template <typename T> std::unique_ptr<T> deserialize( const std::string& payloadType,
+                                                        const Binary& payloadData,
+                                                        const Binary& streamerInfoData ) {
     return default_deserialize<T>( payloadType, payloadData, streamerInfoData );
  }
 
@@ -125,7 +125,7 @@ namespace cond {
 
 #define DESERIALIZE_POLIMORPHIC_CASE( BASETYPENAME, DERIVEDTYPENAME )	\
   if( payloadType == #DERIVEDTYPENAME ){ \
-    return std::dynamic_pointer_cast<BASETYPENAME>( default_deserialize<DERIVEDTYPENAME>( payloadType, payloadData, streamerInfoData ) ); \
+    return default_deserialize<DERIVEDTYPENAME>( payloadType, payloadData, streamerInfoData ); \
   }
  
 #endif

--- a/CondCore/DTPlugins/src/plugin.cc
+++ b/CondCore/DTPlugins/src/plugin.cc
@@ -52,9 +52,9 @@
 #include <memory>
 
 namespace cond {
-  template <> std::shared_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
-						 const Binary& payloadData,
-						 const Binary& streamerInfoData ){
+  template <> std::unique_ptr<BaseKeyed> deserialize<BaseKeyed>( const std::string& payloadType,
+                                                                 const Binary& payloadData,
+                                                                 const Binary& streamerInfoData ){
     DESERIALIZE_BASE_CASE( BaseKeyed );                                                                                                                                                                                                             
     DESERIALIZE_POLIMORPHIC_CASE( BaseKeyed, DTKeyedConfig );
 

--- a/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
+++ b/CondCore/PhysicsToolsPlugins/src/PerformanceRecordPlugin.cc
@@ -14,9 +14,9 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 
 namespace cond {
-  template <> std::shared_ptr<PerformancePayload> deserialize<PerformancePayload>( const std::string& payloadType, 
-										     const Binary& payloadData, 
-										     const Binary& streamerInfoData ){
+  template <> std::unique_ptr<PerformancePayload> deserialize<PerformancePayload>( const std::string& payloadType,
+                                                                                   const Binary& payloadData,
+                                                                                   const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( PerformancePayload );  abstract 
     DESERIALIZE_POLIMORPHIC_CASE( PerformancePayload, PerformancePayloadFromTFormula ); 
     DESERIALIZE_POLIMORPHIC_CASE( PerformancePayload, PerformancePayloadFromBinnedTFormula ); 

--- a/CondCore/PopCon/test/stubs/EffSourceHandler.cc
+++ b/CondCore/PopCon/test/stubs/EffSourceHandler.cc
@@ -56,7 +56,7 @@ void popcon::ExEffSource::getNewObjects() {
   if (tagInfo().size>0) {
     Ref payload = lastPayload();
     edm::LogInfo   ("ExEffsSource")<<" type of last payload  "<< 
-      typeid(*payload).name()<<std::endl;
+      typeid(value_type).name()<<std::endl;
   }
 
 

--- a/CondCore/PopCon/test/stubs/EffSourceHandler.cc
+++ b/CondCore/PopCon/test/stubs/EffSourceHandler.cc
@@ -14,9 +14,9 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 
 namespace cond {
-  template <> std::shared_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
-                                                                                     const Binary& payloadData,
-                                                                                     const Binary& streamerInfoData ){
+  template <> std::unique_ptr<condex::Efficiency> deserialize<condex::Efficiency>( const std::string& payloadType,
+                                                                                   const Binary& payloadData,
+                                                                                   const Binary& streamerInfoData ){
     // DESERIALIZE_BASE_CASE( condex::Efficiency );  abstract
     DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInPt );
     DESERIALIZE_POLIMORPHIC_CASE( condex::Efficiency, condex::ParametricEfficiencyInEta );

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -2,8 +2,7 @@
 
 #define FETCH_PAYLOAD_CASE( TYPENAME ) \
   if( payloadTypeName == #TYPENAME ){ \
-    auto payload = deserialize<TYPENAME>( payloadTypeName, data, streamerInfo ); \
-    payloadPtr = payload; \
+    payloadPtr = deserialize<TYPENAME>( payloadTypeName, data, streamerInfo ); \
     match = true; \
   }
 
@@ -305,18 +304,15 @@ namespace cond {
 
       //   
       if( payloadTypeName == "PhysicsTools::Calibration::Histogram3D<double,double,double,double>" ){    
-	auto payload = deserialize<PhysicsTools::Calibration::Histogram3D<double,double,double,double> >(payloadTypeName, data, streamerInfo );
-	payloadPtr = payload;
+	payloadPtr = deserialize<PhysicsTools::Calibration::Histogram3D<double,double,double,double> >(payloadTypeName, data, streamerInfo );
 	match = true;
       }
       if( payloadTypeName == "PhysicsTools::Calibration::Histogram2D<double,double,double>" ){    
-	auto payload = deserialize<PhysicsTools::Calibration::Histogram2D<double,double,double> >(payloadTypeName, data, streamerInfo );
-	payloadPtr = payload;
+	payloadPtr = deserialize<PhysicsTools::Calibration::Histogram2D<double,double,double> >(payloadTypeName, data, streamerInfo );
 	match = true;
       }
       if( payloadTypeName == "std::vector<unsignedlonglong,std::allocator<unsignedlonglong>>" ){
-	auto payload = deserialize<std::vector<unsigned long long> >( payloadTypeName, data, streamerInfo );
-	payloadPtr = payload;
+	payloadPtr = deserialize<std::vector<unsigned long long> >( payloadTypeName, data, streamerInfo );
 	match = true;
       }
   


### PR DESCRIPTION
The effects of this pull request on code outside the file Serialization.h are small. Any code that fully specializes the deserialization function template needs to have its return type changed to unique_ptr. In addition, there is one file in CMSSW containing code like "auto x = deserialize ...", where on a subsequent line x is assigned to a shared_ptr. In this particular case, the variable could just be removed. It wasn't needed. An alternative in this case and other similar cases, would be the addition of std::move at the assignment. These problems are easy to find because they cause compilation to fail. All such cases in the CMSSW repository are fixed in this PR. There are not many. Calling deserialize directly is not common in user code, so I suspect there are not many problematic calls to deserialize outside the repository. In most cases I saw, code that uses deserialize will continue to work without any modification or performance problem.

Internally, the deserialize function does not save a copy of the shared_ptr. It does not actually manage the memory of the object. It is hard to imagine modifying the deserialize function in the future to manage this memory. That would imply the internals of deserialize would know when to delete the memory and also hold on to a copy of the shared_ptr.

Externally, we are making deserialize more flexible. Previously, the interface forced the client to use a shared_ptr or make an expensive deep copy. By returning a unique_ptr, the client has a choice. It can use a unique_ptr to manage the memory. But just as easily, it can convert to a shared_ptr. And because it is a move there is no performance penalty. (The inverse, converting from shared_ptr to unique_ptr does not work!)

In general, a unique_ptr performs better than a shared_ptr. With a shared_ptr there are two counters, we use CPU to increment/decrement them, and they use memory. If you do not use make_shared, there is an extra memory allocation. Also, the counters are thread safe and at run time must be synchronized across threads, which can be significant. I do not know if in this case the performance difference is significant.

Unique_ptr's are also easier to understand and think about for both developers and maintainers. See https://herbsutter.com/2013/05/29/gotw-89-solution-smart-pointers/ for some discussion related to this in general.

The immediate motivation that started the core group looking at this relates to our goal of running multiple IOVs concurrently. Let's says an EDProducer processes two events and is using objects from the EventSetup from different IOVs. Assume that the values stored in the object for these different IOVs are different. When we ran one IOV at a time, one could have both objects actually be the same object at the same memory location. This allowed the ESProducer to implement some optimizations such as not having to reallocate the object at an IOV boundary or maybe only parts of the object would change at an IOV boundary. This worked fine when only one IOV is processed at a time. But when both IOVs are running simultaneously, this does not work. Unless you implement a very complex thread safe design for the object, it cannot hold two sets of values at the same time. The same object in the same memory cannot be used simultaneously with two different sets of values. In the past, the EventSetup implemented this reuse of objects by allowing the produce function to return a shared_ptr. The shared_ptr allows the ESProducer module to save a copy of the shared_ptr and reuse the object on the next call to produce. We now need to be careful that all ESProducers are operating in a thread safe manner. And it is important that we be able to verify this quickly. If we allocate new objects on each call to produce and return a unique_ptr, then we can verify this by simply looking at the return type of the produce function. But if a shared_ptr is returned we have to look inside the ESProducer at the details of how that ESProducer is using the shared memory internally and it gets complicated.

ESProducers can still return shared_ptr in some special cases and still work with concurrent IOVs, but in most cases it involves use of the new ReusableObjectHolder class which manages multiple copies of the object, one copy for each IOV. And even this will not work well if handed a shared_ptr that lower level code created.

If you look down the call stack from the produce function of many ESProducers you will find the deserialize function down near the bottom. There is no way to return a unique_ptr from these produce functions without changing the return type of the deserialize function (unless you do an expensive deep copy of the object or implement some horrible hack somewhere in between).

If this PR is approved, additional PRs will follow that modify the code higher in the stack above deserialize. However, this PR is not dependent on those changes. It could be approved alone. Even if none of the other changes are ever made, it would still be an improvement.

There is also another change included in this PR. There is a single one line change that resolves a clang warning. It is in a separate commit and unrelated.

