### PR TITLE
[102X] Change GT. Update offline GTs. Add 2018 Peak Cosmic Queue.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -52,9 +52,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '102X_upgrade2018_design_v9',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v14',
+    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v15',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail'    : '102X_upgrade2018_realistic_v12HEfail_v2',
+    'phase1_2018_realistic_HEfail'    : '102X_upgrade2018_realistic_v12HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v13',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '102X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '102X_dataRun2_relval_v8',
+    'run2_data_relval'  :   '102X_dataRun2_relval_v9',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '102X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '102X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '102X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '102X_dataRun2_relval_v8',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '102X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '102X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '102X_dataRun2_v4',
+    'run1_data'         :   '102X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '102X_dataRun2_v4',
+    'run2_data'         :   '102X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '102X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '102X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '102X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
@@ -56,7 +56,9 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail'    : '102X_upgrade2018_realistic_v12HEfail_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v12',
+    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v13',
+    # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
+    'phase1_2018_cosmics_peak' :   '102X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '102X_postLS2_design_v7', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# Offline Data
102X_dataRun2_v6 is identical to the validated GT for the 2018 ReReco
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_v4/102X_dataRun2_v6

# Offline Data Relval
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_dataRun2_relval_v6/102X_dataRun2_relval_v7

# Updated DECO 2018 Cosmic Queue
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018cosmics_realistic_deco_v12/102X_upgrade2018cosmics_realistic_deco_v13

# Added PEAK 2018 Cosmic Queue
. https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018cosmics_realistic_deco_v13/102X_upgrade2018cosmics_realistic_peak_v1