### PR TITLE
MET EE noise mitigation in 2017 data [remove unnecessary lines]

### DIFF
--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -278,11 +278,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if self._parameters["Puppi"].value and not onMiniAOD:
             self.setParameter('reclusterJets',False)
 
-        #jet collection overloading for automatic jet reclustering or JEC application
-        if reclusterJets:
-            self.setParameter('jetCollectionUnskimmed',cms.InputTag('patJets'))
-
-
         self.apply(process)
 
 


### PR DESCRIPTION
A new PR is related to the PR #24876 in which unnecessary lines have already removed from MET tool. 