### PR TITLE
[103X] Change GT. Update offline GTs. Add 2018 Peak Cosmic Queue. Updated 2018 MC GTs.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '103X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '103X_dataRun2_relval_v8',
+    'run2_data_relval'  :   '103X_dataRun2_relval_v9',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '103X_dataRun2_PromptLike_HEfail_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '103X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '103X_dataRun2_v3',
+    'run1_data'         :   '103X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '103X_dataRun2_v3',
+    'run2_data'         :   '103X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '103X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '103X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '103X_dataRun2_PromptLike_HEfail_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
@@ -52,13 +52,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '103X_upgrade2018_design_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v7',
+    'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' : '103X_upgrade2018_realistic_HI_v7',
+    'phase1_2018_realistic_hi' : '103X_upgrade2018_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail'    : '103X_upgrade2018_realistic_HEfail_v3',
+    'phase1_2018_realistic_HEfail'    : '103X_upgrade2018_realistic_HEfail_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v7',
+    # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
+    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '103X_postLS2_design_v4', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,7 +54,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    : '103X_upgrade2018_realistic_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' : '103X_upgrade2018_realistic_HI_v8',
+    'phase1_2018_realistic_hi' : '103X_upgrade2018_realistic_HI_v9',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail'    : '103X_upgrade2018_realistic_HEfail_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '103X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '103X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '103X_dataRun2_relval_v8',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '103X_dataRun2_PromptLike_HEfail_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -62,7 +62,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics'      :   '103X_upgrade2018cosmics_realistic_peak_v1',
+    'phase1_2018_cosmics_peak' :   '103X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '103X_postLS2_design_v4', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,13 +32,15 @@ autoCond = {
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '103X_dataRun2_PromptLike_HEfail_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '103X_dataRun2_PromptLike_v6',
+    'run2_data_promptlike'    : '103X_dataRun2_PromptLike_v6',
+    'run2_data_promptlike_hi' : '103X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '103X_dataRun2_HLT_relval_v4',
+    'run2_hlt_relval'      :   '103X_dataRun2_HLT_relval_v4',
+    'run2_hlt_relval_hi'   :   '103X_dataRun2_HLT_relval_HI_v1',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)


### PR DESCRIPTION
# Offline Data
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_v3/103X_dataRun2_v4

# Offline Data Relval
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_relval_v6/103X_dataRun2_relval_v7

# 2018 MC realistic (updated ECAL conditions)
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2018_realistic_v7/103X_upgrade2018_realistic_v8
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2018_realistic_HEfail_v3/103X_upgrade2018_realistic_HEfail_v4

# 2018 MC HI realistic conditions (added CastorGains_PbPb_v1.0_mc)
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2018_realistic_HI_v7/103X_upgrade2018_realistic_HI_v8

# Updated DECO 2018 Cosmic Queue (updated ECAL conditions)
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2018cosmics_realistic_deco_v6/103X_upgrade2018cosmics_realistic_deco_v7

# Added PEAK 2018 Cosmic Queue
. https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_upgrade2018cosmics_realistic_deco_v7/103X_upgrade2018cosmics_realistic_peak_v1