### PR TITLE
Removed trivial LuminosityBlock calls in L1TMuonDQMOffline

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
@@ -72,8 +72,6 @@ class L1TMuonDQMOffline : public DQMEDAnalyzer {
         ~L1TMuonDQMOffline() override;
 
     protected:
-        void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
-        virtual void dqmEndLuminosityBlock  (edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
         void dqmBeginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
         virtual void bookControlHistos(DQMStore::IBooker &);
         virtual void bookEfficiencyHistos(DQMStore::IBooker &ibooker);

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -176,16 +176,6 @@ void L1TMuonDQMOffline::bookHistograms(DQMStore::IBooker &ibooker, const edm::Ru
 }
 
 //_____________________________________________________________________
-void L1TMuonDQMOffline::beginLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c) {
-    if(m_verbose) cout << "[L1TMuonDQMOffline:] Called beginLuminosityBlock at LS=" << lumiBlock.id().luminosityBlock() << endl;
-}
-
-//_____________________________________________________________________
-void L1TMuonDQMOffline::dqmEndLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c) {
-    if(m_verbose) cout << "[L1TMuonDQMOffline:] Called endLuminosityBlock at LS=" << lumiBlock.id().luminosityBlock() << endl;
-}
-
-//_____________________________________________________________________
 void L1TMuonDQMOffline::analyze(const Event & iEvent, const EventSetup & eventSetup){
 
     Handle<reco::MuonCollection> muons;


### PR DESCRIPTION
The begin/end LuminosityBlock calls were only being used to print a message. Removing them makes future code migration easier.