### PR TITLE
Removed trivial functions from Phase2TrackerMonitorDigi

### DIFF
--- a/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.cc
+++ b/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.cc
@@ -64,12 +64,7 @@ Phase2TrackerMonitorDigi::~Phase2TrackerMonitorDigi() {
   // (e.g. close files, deallocate resources etc.)
   edm::LogInfo("Phase2TrackerMonitorDigi")<< ">>> Destroy Phase2TrackerMonitorDigi ";
 }
-//
-// -- DQM Begin Run 
-//
-void Phase2TrackerMonitorDigi::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-   edm::LogInfo("Phase2TrackerMonitorDigi")<< "Initialize Phase2TrackerMonitorDigi ";
-}
+
 // -- Analyze
 //
 void Phase2TrackerMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -527,8 +522,6 @@ void Phase2TrackerMonitorDigi::bookLayerHistos(DQMStore::IBooker & ibooker, unsi
 
     layerMEs.insert(std::make_pair(layer, local_mes)); 
   }  
-}
-void Phase2TrackerMonitorDigi::endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& eSetup){
 }
 //define this as a plug-in
 DEFINE_FWK_MODULE(Phase2TrackerMonitorDigi);

--- a/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.h
+++ b/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.h
@@ -24,9 +24,7 @@ public:
   void bookHistograms(DQMStore::IBooker & ibooker,
 		      edm::Run const &  iRun ,
 		      edm::EventSetup const &  iSetup ) override;
-  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override; 
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& iSetup) override;
   
   
   struct DigiMEs{


### PR DESCRIPTION
Removed trivial functions for LuminosityBlock and Run transitions.
This will aid future code changes.