### PR TITLE
Removed trivial functions from DQMHcalIsolatedBunchAlCaReco

### DIFF
--- a/DQMOffline/CalibCalo/src/DQMHcalIsolatedBunchAlCaReco.h
+++ b/DQMOffline/CalibCalo/src/DQMHcalIsolatedBunchAlCaReco.h
@@ -35,14 +35,6 @@ protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event& e, const edm::EventSetup& c) override ;
 
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                            const edm::EventSetup& context) override { }
-
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                          const edm::EventSetup& c) override { }
-
-  void endRun(const edm::Run& r, const edm::EventSetup& c) override { }
-
 private:
       
   //                        


### PR DESCRIPTION
Removed the empty functions for LuminosityBlock and Run transitions.
This will aid future code changes.