### PR TITLE
Fix typo in CSC signal SimHit label in premixing

### DIFF
--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -175,7 +175,7 @@ fastSim.toModify(mixData,
             collectionDM = "MuonSimHitsMuonRPCHits",
         ),
         csc = dict(
-            labelSig = "mix:MuonSimHitsMuonRPCHits",
+            labelSig = "mix:MuonSimHitsMuonCSCHits",
             pileInputTag = "mix:MuonSimHitsMuonCSCHits",
             collectionDM = "MuonSimHitsMuonCSCHits",
         ),


### PR DESCRIPTION
This PR fixes a copy-paste mistake done in #24827 feeding RPC SimHits to `PreMixingModule` as CSC signal-event SimHits.

Fixes #25147.

Tested in 10_4_0_pre1. The crashing configuration pointed to in #25147 runs now beyond the 12th event that was crashing before.