### PR TITLE
HCAL: HF SIM update for >= Run2

### DIFF
--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -108,8 +108,8 @@ run2_common.toModify( hcalSimParameters,
     ho = dict(
         siPMCode = cms.int32(1)
     ),
-    hf1 = dict( samplingFactor = cms.double(0.67) ),
-    hf2 = dict( samplingFactor = cms.double(0.67) )
+    hf1 = dict( samplingFactor = cms.double(0.335) ),
+    hf2 = dict( samplingFactor = cms.double(0.335) )
 )
 
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -531,6 +531,8 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
 ##
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify( g4SimHits.HFShowerLibrary, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v4.root' )
+run2_common.toModify( g4SimHits.HFShower, ProbMax = 0.5)
+
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( g4SimHits, HCalSD = dict( TestNumberingScheme = True ) )
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing


### PR DESCRIPTION
Follow up on a discussion back in August at HCAL DPG meeting
https://indico.cern.ch/event/745475/contributions/3080994/attachments/1697133/2732028/HF_MC_Update_Aug3_2018_v3.pdf

Some more plots will be presented at HCAL DPG this Friday (Nov.9) 
https://indico.cern.ch/event/768831/
Doesn't change much HF energy scale, while improves low-energy (single p.e. domain) agreement of HF spectrum with data.
