### PR TITLE
Module cleanup in DQM/L1TMonitor

### DIFF
--- a/DQM/L1TMonitor/interface/L1TRCT.h
+++ b/DQM/L1TMonitor/interface/L1TRCT.h
@@ -51,8 +51,6 @@ protected:
 // Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
  
 private:
@@ -120,12 +118,8 @@ private:
   MonitorElement* lumisecId_;
 
 
-  int nev_; // Number of events processed
   std::string histFolder_;
-  std::string outputFile_; //file name for ROOT ouput
   bool verbose_;
-  bool monitorDaemon_;
-  std::ofstream logFile_;
   
   edm::EDGetTokenT<L1CaloRegionCollection> rctSource_L1CRCollection_;
   edm::EDGetTokenT<L1CaloEmCollection> rctSource_L1CEMCollection_;

--- a/DQM/L1TMonitor/interface/L1TRPCTF.h
+++ b/DQM/L1TMonitor/interface/L1TRPCTF.h
@@ -56,10 +56,6 @@ protected:
 
 // BeginJob
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
-
- void beginLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c) override;
-
 
 private:
 
@@ -88,11 +84,7 @@ private:
 
   int nev_; // Number of events processed
   int nevRPC_; // Number of events processed where muon was found by rpc trigger
-  std::string outputFile_; //file name for ROOT ouput
   bool verbose_;
-  bool monitorDaemon_;
-  //bool m_rpcDigiFine;
-  //bool m_useRpcDigi;
 
   long long int m_lastUsedBxInBxdiff;
   std::string output_dir_;

--- a/DQM/L1TMonitor/src/L1TRCT.cc
+++ b/DQM/L1TMonitor/src/L1TRCT.cc
@@ -16,22 +16,23 @@
 
 using namespace edm;
 
-const unsigned int PHIBINS = 18;
-const float PHIMIN = -0.5;
-const float PHIMAX = 17.5;
+namespace {
+constexpr unsigned int PHIBINS = 18;
+constexpr float PHIMIN = -0.5;
+constexpr float PHIMAX = 17.5;
 
 // Ranks 6, 10 and 12 bits
-const unsigned int R6BINS = 64;
-const float R6MIN = -0.5;
-const float R6MAX = 63.5;
-const unsigned int R10BINS = 1024;
-const float R10MIN = -0.5;
-const float R10MAX = 1023.5;
+constexpr unsigned int R6BINS = 64;
+constexpr float R6MIN = -0.5;
+constexpr float R6MAX = 63.5;
+constexpr unsigned int R10BINS = 1024;
+constexpr float R10MIN = -0.5;
+constexpr float R10MAX = 1023.5;
 
-const unsigned int ETABINS = 22;
-const float ETAMIN = -0.5;
-const float ETAMAX = 21.5;
-
+constexpr unsigned int ETABINS = 22;
+constexpr float ETAMIN = -0.5;
+constexpr float ETAMAX = 21.5;
+}
 
 
 L1TRCT::L1TRCT(const ParameterSet & ps) :
@@ -47,20 +48,6 @@ L1TRCT::L1TRCT(const ParameterSet & ps) :
 
   if (verbose_)
     std::cout << "L1TRCT: constructor...." << std::endl;
-
-  outputFile_ =
-      ps.getUntrackedParameter < std::string > ("outputFile", "");
-  if (!outputFile_.empty()) {
-    std::
-	cout << "L1T Monitoring histograms will be saved to " <<
-	outputFile_.c_str() << std::endl;
-  }
-
-  bool disable =
-      ps.getUntrackedParameter < bool > ("disableROOToutput", false);
-  if (disable) {
-    outputFile_ = "";
-  }
 }
 
 L1TRCT::~L1TRCT()
@@ -69,21 +56,8 @@ L1TRCT::~L1TRCT()
 
 
 
-void L1TRCT::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c){
-  //runId_->Fill(r.id().run());
-  //
-}
-
-void L1TRCT::beginLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c){
-  //
-  //lumisecId_->Fill(l.id().luminosityBlock());
-}
-
-
 void L1TRCT::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&)
 {
-  nev_ = 0;
-  
   ibooker.setCurrentFolder(histFolder_);
 
   runId_=ibooker.bookInt("iRun");
@@ -134,7 +108,6 @@ void L1TRCT::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::Ev
 
 void L1TRCT::analyze(const Event & e, const EventSetup & c)
 {
-  nev_++;
   if (verbose_) {
     std::cout << "L1TRCT: analyze...." << std::endl;
   }

--- a/DQM/L1TMonitor/src/L1TRPCTF.cc
+++ b/DQM/L1TMonitor/src/L1TRPCTF.cc
@@ -32,15 +32,6 @@ L1TRPCTF::L1TRPCTF(const ParameterSet& ps)
 
   if(verbose_) cout << "L1TRPCTF: constructor...." << endl;
 
-  outputFile_ = ps.getUntrackedParameter<string>("outputFile", "");
-  if ( !outputFile_.empty() ) {
-    cout << "L1T Monitoring histograms will be saved to " << outputFile_.c_str() << endl;
-  }
-
-  bool disable = ps.getUntrackedParameter<bool>("disableROOToutput", false);
-  if(disable){
-    outputFile_="";
-  }
 }
 
 
@@ -344,21 +335,5 @@ void L1TRPCTF::analyze(const Event& e, const EventSetup& c)
 
   if(verbose_) cout << "L1TRPCTF: end job...." << endl;
   LogInfo("EndJob") << "analyzed " << nev_ << " events"; 
-  
-}
-
-void L1TRPCTF::beginLuminosityBlock(const edm::LuminosityBlock& l, 
-                                    const edm::EventSetup& c){
-//    m_rpcDigiWithBX0=0;
-//    m_rpcDigiWithBXnon0=0;
-//    m_bxs.clear();
-//    m_useRpcDigi = true;
-
-                          
-}
-
-
-
-void L1TRPCTF::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c){
   
 }


### PR DESCRIPTION
Made the following modifications in L1TRCT and L1TRPCTF
- removed unused member variables
- put globals into anonymous namespace to avoid poluting the global
  namespace
- remove trivial member functions associated with Run and LuminosityBlock
  transitions.