### PR TITLE
Migrate RawToDigi to Tasks

### DIFF
--- a/Configuration/StandardSequences/python/RawToDigi_DataMapper_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_DataMapper_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.RawToDigi_Data_cff import *
 from EventFilter.RawDataCollector.rawDataMapperByLabel_cfi import rawDataMapperByLabel
 
-RawToDigi.insert(0, rawDataMapperByLabel)
-RawToDigi_noTk.insert(0, rawDataMapperByLabel)
-RawToDigi_pixelOnly.insert(0, rawDataMapperByLabel)
+RawToDigiTask.add(rawDataMapperByLabel)
+RawToDigiTask_noTk.add(rawDataMapperByLabel)
+RawToDigiTask_pixelOnly.add(rawDataMapperByLabel)
 

--- a/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
@@ -19,10 +19,12 @@ muonDTDigis.inputLabel = 'rawDataRepacker'
 muonRPCDigis.InputLabel = 'rawDataRepacker'
 castorDigis.InputLabel = 'rawDataRepacker'
 
-RawToDigi = cms.Sequence(csctfDigis+dttfDigis+gctDigis+gtDigis+gtEvmDigis+siPixelDigis+siStripDigis+ecalDigis+ecalPreshowerDigis+hcalDigis+muonCSCDigis+muonDTDigis+muonRPCDigis+castorDigis+scalersRawToDigi)
+RawToDigiTask = cms.Task(csctfDigis,dttfDigis,gctDigis,gtDigis,gtEvmDigis,siPixelDigis,siStripDigis,ecalDigis,ecalPreshowerDigis,hcalDigis,muonCSCDigis,muonDTDigis,muonRPCDigis,castorDigis,scalersRawToDigi)
+RawToDigi = cms.Sequence(RawToDigiTask)
 
-RawToDigi_woGCT = cms.Sequence(csctfDigis+dttfDigis+gtDigis+gtEvmDigis+siPixelDigis+siStripDigis+ecalDigis+ecalPreshowerDigis+hcalDigis+muonCSCDigis+muonDTDigis+muonRPCDigis+castorDigis+scalersRawToDigi)
-
+RawToDigiTask_woGCT = RawToDigiTask.copyAndExclude([gctDigis])
+RawToDigi_woGCT = cms.Sequence(RawToDigiTask_woGCT)
 
 siStripVRDigis = siStripDigis.clone(ProductLabel = 'virginRawDataRepacker')
-RawToDigi_withVR = cms.Sequence(RawToDigi + siStripVRDigis)
+RawToDigiTask_withVR = cms.Task(RawToDigiTask, siStripVRDigis)
+RawToDigi_withVR = cms.Sequence(RawToDigiTask_withVR)

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -48,35 +48,27 @@ from L1Trigger.Configuration.L1TRawToDigi_cff import *
 
 from EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff import *
 
-RawToDigi = cms.Sequence(L1TRawToDigi
-                         +siPixelDigis
-                         +siStripDigis
-                         +ecalDigis
-                         +ecalPreshowerDigis
-                         +hcalDigis
-                         +muonCSCDigis
-                         +muonDTDigis
-                         +muonRPCDigis
-                         +castorDigis
-                         +scalersRawToDigi
-                         +tcdsDigis
-                         +onlineMetaDataDigis
+RawToDigiTask = cms.Task(L1TRawToDigiTask,
+                         siPixelDigis,
+                         siStripDigis,
+                         ecalDigis,
+                         ecalPreshowerDigis,
+                         hcalDigis,
+                         muonCSCDigis,
+                         muonDTDigis,
+                         muonRPCDigis,
+                         castorDigis,
+                         scalersRawToDigi,
+                         tcdsDigis,
+                         onlineMetaDataDigis,
                          )
+RawToDigi = cms.Sequence(RawToDigiTask)
 
-RawToDigi_noTk = cms.Sequence(L1TRawToDigi
-                              +ecalDigis
-                              +ecalPreshowerDigis
-                              +hcalDigis
-                              +muonCSCDigis
-                              +muonDTDigis
-                              +muonRPCDigis
-                              +castorDigis
-                              +scalersRawToDigi
-                              +tcdsDigis
-                              +onlineMetaDataDigis
-                              )
+RawToDigiTask_noTk = RawToDigiTask.copyAndExclude([siPixelDigis, siStripDigis])
+RawToDigi_noTk = cms.Sequence(RawToDigiTask_noTk)
 
-RawToDigi_pixelOnly = cms.Sequence(siPixelDigis)
+RawToDigiTask_pixelOnly = cms.Task(siPixelDigis)
+RawToDigi_pixelOnly = cms.Sequence(RawToDigiTask_pixelOnly)
 
 scalersRawToDigi.scalersInputTag = 'rawDataCollector'
 siPixelDigis.InputLabel = 'rawDataCollector'
@@ -90,56 +82,56 @@ muonRPCDigis.InputLabel = 'rawDataCollector'
 castorDigis.InputLabel = 'rawDataCollector'
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([castorDigis]))
+run3_common.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([castorDigis]))
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 # Remove siPixelDigis until we have phase1 pixel digis
-phase2_tracker.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([siPixelDigis])) # FIXME
+phase2_tracker.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([siPixelDigis])) # FIXME
 
 
 # add CTPPS 2016 raw-to-digi modules
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 
-_ctpps_2016_RawToDigi = RawToDigi.copy()
-_ctpps_2016_RawToDigi += ctppsRawToDigi
-ctpps_2016.toReplaceWith(RawToDigi, _ctpps_2016_RawToDigi)
+_ctpps_2016_RawToDigiTask = RawToDigiTask.copy()
+_ctpps_2016_RawToDigiTask.add(ctppsRawToDigiTask)
+ctpps_2016.toReplaceWith(RawToDigiTask, _ctpps_2016_RawToDigiTask)
 
-_ctpps_2016_RawToDigi_noTk = RawToDigi_noTk.copy()
-_ctpps_2016_RawToDigi_noTk += ctppsRawToDigi
-ctpps_2016.toReplaceWith(RawToDigi_noTk, _ctpps_2016_RawToDigi_noTk)
+_ctpps_2016_RawToDigiTask_noTk = RawToDigiTask_noTk.copy()
+_ctpps_2016_RawToDigiTask_noTk.add(ctppsRawToDigiTask)
+ctpps_2016.toReplaceWith(RawToDigiTask_noTk, _ctpps_2016_RawToDigiTask_noTk)
 
 # GEM settings
-_gem_RawToDigi = RawToDigi.copy()
-_gem_RawToDigi.insert(-1,muonGEMDigis)
+_gem_RawToDigiTask = RawToDigiTask.copy()
+_gem_RawToDigiTask.add(muonGEMDigis)
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
-run2_GEM_2017.toReplaceWith(RawToDigi, _gem_RawToDigi)
+run2_GEM_2017.toReplaceWith(RawToDigiTask, _gem_RawToDigiTask)
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toReplaceWith(RawToDigi, _gem_RawToDigi)
+run3_GEM.toReplaceWith(RawToDigiTask, _gem_RawToDigiTask)
 
 from EventFilter.HGCalRawToDigi.HGCalRawToDigi_cfi import *
-_hgcal_RawToDigi = RawToDigi.copy()
-_hgcal_RawToDigi += hgcalDigis
+_hgcal_RawToDigiTask = RawToDigiTask.copy()
+_hgcal_RawToDigiTask.add(hgcalDigis)
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toReplaceWith(RawToDigi,_hgcal_RawToDigi)
+phase2_hgcal.toReplaceWith(RawToDigiTask,_hgcal_RawToDigiTask)
 
 # RPC New Readout Validation
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-_rpc_NewReadoutVal_RawToDigi = RawToDigi.copy()
-_rpc_NewReadoutVal_RawToDigi_noTk = RawToDigi_noTk.copy()
-_rpc_NewReadoutVal_RawToDigi += muonRPCNewDigis
-_rpc_NewReadoutVal_RawToDigi_noTk += muonRPCNewDigis
-stage2L1Trigger_2017.toReplaceWith(RawToDigi, _rpc_NewReadoutVal_RawToDigi)
-stage2L1Trigger_2017.toReplaceWith(RawToDigi_noTk, _rpc_NewReadoutVal_RawToDigi)
+_rpc_NewReadoutVal_RawToDigiTask = RawToDigiTask.copy()
+_rpc_NewReadoutVal_RawToDigiTask_noTk = RawToDigiTask_noTk.copy()
+_rpc_NewReadoutVal_RawToDigiTask.add(muonRPCNewDigis)
+_rpc_NewReadoutVal_RawToDigiTask_noTk.add(muonRPCNewDigis)
+stage2L1Trigger_2017.toReplaceWith(RawToDigiTask, _rpc_NewReadoutVal_RawToDigiTask)
+stage2L1Trigger_2017.toReplaceWith(RawToDigiTask_noTk, _rpc_NewReadoutVal_RawToDigiTask)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith(RawToDigi, RawToDigi.copyAndExclude([muonRPCNewDigis]))
-fastSim.toReplaceWith(RawToDigi_noTk, RawToDigi_noTk.copyAndExclude([muonRPCNewDigis]))
+fastSim.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([muonRPCNewDigis]))
+fastSim.toReplaceWith(RawToDigiTask_noTk, RawToDigiTask_noTk.copyAndExclude([muonRPCNewDigis]))
 
-_hfnose_RawToDigi = RawToDigi.copy()
-_hfnose_RawToDigi += hfnoseDigis
+_hfnose_RawToDigiTask = RawToDigiTask.copy()
+_hfnose_RawToDigiTask.add(hfnoseDigis)
 
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
-phase2_hfnose.toReplaceWith(RawToDigi,_hfnose_RawToDigi)
+phase2_hfnose.toReplaceWith(RawToDigiTask,_hfnose_RawToDigiTask)
 

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -113,11 +113,12 @@ totemTimingRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 from EventFilter.CTPPSRawToDigi.ctppsPixelDigis_cfi import ctppsPixelDigis
 ctppsPixelDigis.inputLabel = cms.InputTag("rawDataCollector")
 
-# raw-to-digi sequence
-ctppsRawToDigi = cms.Sequence(
-  totemTriggerRawToDigi *
-  totemRPRawToDigi *
-  ctppsDiamondRawToDigi*
-  totemTimingRawToDigi*
+# raw-to-digi task and sequence
+ctppsRawToDigiTask = cms.Task(
+  totemTriggerRawToDigi,
+  totemRPRawToDigi,
+  ctppsDiamondRawToDigi,
+  totemTimingRawToDigi,
   ctppsPixelDigis
 )
+ctppsRawToDigi = cms.Sequence(ctppsRawToDigiTask)

--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -29,7 +29,7 @@ def unpack_legacy():
     gctDigis.inputLabel = 'rawDataCollector'
     gtDigis.DaqGtInputTag = 'rawDataCollector'
     gtEvmDigis.EvmGtInputTag = 'rawDataCollector'
-    L1TRawToDigi_Legacy = cms.Sequence(csctfDigis+dttfDigis+gctDigis+gtDigis+gtEvmDigis)
+    L1TRawToDigi_Legacy = cms.Task(csctfDigis,dttfDigis,gctDigis,gtDigis,gtEvmDigis)
     
 
 def unpack_stage1():
@@ -53,7 +53,7 @@ def unpack_stage1():
     import EventFilter.GctRawToDigi.l1GctHwDigis_cfi
     gctDigis = EventFilter.GctRawToDigi.l1GctHwDigis_cfi.l1GctHwDigis.clone()
     gctDigis.inputLabel = 'rawDataCollector'
-    L1TRawToDigi_Stage1 = cms.Sequence(csctfDigis+dttfDigis+gtDigis+caloStage1Digis+caloStage1FinalDigis+caloStage1LegacyFormatDigis+gctDigis)    
+    L1TRawToDigi_Stage1 = cms.Task(csctfDigis,dttfDigis,gtDigis,caloStage1Digis,caloStage1FinalDigis,caloStage1LegacyFormatDigis,gctDigis)    
 
 def unpack_stage2():
     global L1TRawToDigi_Stage2
@@ -68,7 +68,7 @@ def unpack_stage2():
     from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import gmtStage2Digis
     from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
     from EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi import twinMuxStage2Digis
-    L1TRawToDigi_Stage2 = cms.Sequence(rpcTwinMuxRawToDigi + twinMuxStage2Digis * bmtfDigis + omtfStage2Digis + rpcCPPFRawToDigi + emtfStage2Digis + caloLayer1Digis + caloStage2Digis + gmtStage2Digis + gtStage2Digis)
+    L1TRawToDigi_Stage2 = cms.Task(rpcTwinMuxRawToDigi, twinMuxStage2Digis, bmtfDigis, omtfStage2Digis, rpcCPPFRawToDigi, emtfStage2Digis, caloLayer1Digis, caloStage2Digis, gmtStage2Digis, gtStage2Digis)
     
 #
 # Legacy Trigger:
@@ -77,14 +77,14 @@ from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
     unpack_legacy()
-    L1TRawToDigi = cms.Sequence(L1TRawToDigi_Legacy);
+    L1TRawToDigiTask = cms.Task(L1TRawToDigi_Legacy);
 
 #
 # Stage-1 Trigger
 #
 if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
     unpack_stage1()
-    L1TRawToDigi = cms.Sequence(L1TRawToDigi_Stage1)
+    L1TRawToDigiTask = cms.Task(L1TRawToDigi_Stage1)
 
 #
 # Stage-2 Trigger:  fow now, unpack Stage 1 and Stage 2 (in case both available)
@@ -92,9 +92,11 @@ if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
 if stage2L1Trigger.isChosen():
     unpack_stage1()
     unpack_stage2()
-    L1TRawToDigi = cms.Sequence(L1TRawToDigi_Stage1+L1TRawToDigi_Stage2)
+    L1TRawToDigiTask = cms.Task(L1TRawToDigi_Stage1,L1TRawToDigi_Stage2)
     # we only warn if it is stage-2 era and it is an essential, always present, stage-2 payload:
     caloStage2Digis.MinFeds = cms.uint32(1)
     gmtStage2Digis.MinFeds = cms.uint32(1)
     gtStage2Digis.MinFeds = cms.uint32(1)
     
+
+L1TRawToDigi = cms.Sequence(L1TRawToDigiTask)

--- a/SimMuon/CSCDigitizer/python/cscChamberMasker_cff.py
+++ b/SimMuon/CSCDigitizer/python/cscChamberMasker_cff.py
@@ -19,8 +19,7 @@ def appendCSCChamberMaskerAtUnpacking(process):
         process.muonCSCDigis.alctDigiTag = cms.InputTag("preCSCDigis", "MuonCSCALCTDigi") 
         process.muonCSCDigis.clctDigiTag = cms.InputTag("preCSCDigis", "MuonCSCCLCTDigi") 
 
-        process.filteredCscDigiSequence = cms.Sequence(process.preCSCDigis + process.muonCSCDigis)
-        process.RawToDigi.replace(process.muonCSCDigis, process.filteredCscDigiSequence)
+        process.RawToDigiTask.add(process.preCSCDigis)
 
         if hasattr(process,"RandomNumberGeneratorService") :
             process.RandomNumberGeneratorService.muonCSCDigis = cms.PSet(

--- a/SimMuon/DTDigitizer/python/dtChamberMasker_cff.py
+++ b/SimMuon/DTDigitizer/python/dtChamberMasker_cff.py
@@ -15,8 +15,7 @@ def appendDTChamberMaskerAtUnpacking(process):
 
         process.muonDTDigis.digiTag = cms.InputTag('preDtDigis') 
 
-        process.filteredDtDigiSequence = cms.Sequence(process.preDtDigis + process.muonDTDigis)
-        process.RawToDigi.replace(process.muonDTDigis, process.filteredDtDigiSequence)
+        process.RawToDigiTask.add(process.preDtDigis)
 
         if hasattr(process,"dtTriggerEfficiencyMonitor") :
             process.dtTriggerEfficiencyMonitor.inputTagDDU = 'preDtDigis'

--- a/SimMuon/RPCDigitizer/python/rpcChamberMasker_cff.py
+++ b/SimMuon/RPCDigitizer/python/rpcChamberMasker_cff.py
@@ -69,9 +69,6 @@ def appendRPCChamberMaskerAtUnpacking(process):
                 muonRPCDigis = cms.PSet(initialSeed = cms.untracked.uint32(789342))
                 )
 
-        process.filteredRPCDigiSequence = cms.Sequence(process.preRPCDigis \
-                                                       + process.muonRPCDigis)
-        process.RawToDigi.replace(process.muonRPCDigis, \
-                                  process.filteredRPCDigiSequence)
+        process.RawToDigiTask.add(process.preRPCDigis)
 
     return process


### PR DESCRIPTION
Title says it all. Supersedes #25110 by including a "Task" somewhere in the added task names, and keeping the sequences for "backwards" compatibility (to avoid a massive migration as in #25110). I did migrate three customize functions that replaced a module with a `Sequence` (because one can't add a `Sequence` to a `Task`).

Tested in CMSSW_10_4_X_2018-11-01-2300, no changes expected.