### PR TITLE
Migrate tracker local reconstruction and pixel tracking to Tasks

### DIFF
--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_cff.py
@@ -13,22 +13,18 @@ from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerPreSplitting_cfi impo
 from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import *
 from RecoLocalTracker.SubCollectionProducers.clustersummaryproducer_cfi import *
 
-pixeltrackerlocalreco = cms.Sequence(siPixelClustersPreSplitting*siPixelRecHitsPreSplitting)
-striptrackerlocalreco = cms.Sequence(siStripZeroSuppression*siStripClusters*siStripMatchedRecHits)
-trackerlocalreco = cms.Sequence(pixeltrackerlocalreco*striptrackerlocalreco*clusterSummaryProducer)
+pixeltrackerlocalrecoTask = cms.Task(siPixelClustersPreSplitting,siPixelRecHitsPreSplitting)
+striptrackerlocalrecoTask = cms.Task(siStripZeroSuppression,siStripClusters,siStripMatchedRecHits)
+trackerlocalrecoTask = cms.Task(pixeltrackerlocalrecoTask,striptrackerlocalrecoTask,clusterSummaryProducer)
+
+pixeltrackerlocalreco = cms.Sequence(pixeltrackerlocalrecoTask)
+striptrackerlocalreco = cms.Sequence(striptrackerlocalrecoTask)
+trackerlocalreco = cms.Sequence(trackerlocalrecoTask)
 
 from RecoLocalTracker.SiPhase2Clusterizer.phase2TrackerClusterizer_cfi import *
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEGeometricESProducer_cfi import *
 
-phase2_tracker.toReplaceWith(pixeltrackerlocalreco,
-  cms.Sequence(
-          siPhase2Clusters +
-          siPixelClustersPreSplitting +
-          siPixelRecHitsPreSplitting
-  )
-)
-phase2_tracker.toReplaceWith(trackerlocalreco,
-  cms.Sequence(
-          pixeltrackerlocalreco*clusterSummaryProducer
-  )
-)
+_pixeltrackerlocalrecoTask_phase2 = pixeltrackerlocalrecoTask.copy()
+_pixeltrackerlocalrecoTask_phase2.add(siPhase2Clusters)
+phase2_tracker.toReplaceWith(pixeltrackerlocalrecoTask, _pixeltrackerlocalrecoTask_phase2)
+phase2_tracker.toReplaceWith(trackerlocalrecoTask, trackerlocalrecoTask.copyAndExclude([striptrackerlocalrecoTask]))

--- a/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
+++ b/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
@@ -6,4 +6,5 @@ from RecoPixelVertexing.PixelTrackFitting.PixelTracks_cff import *
 #
 #from RecoPixelVertexing.PixelVertexFinding.PixelVertexes_cff import *
 from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
-recopixelvertexing = cms.Sequence(pixelTracksSequence*pixelVertices)
+recopixelvertexingTask = cms.Task(pixelTracksTask,pixelVertices)
+recopixelvertexing = cms.Sequence(recopixelvertexingTask)

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
@@ -64,15 +64,17 @@ pixelTracks = _pixelTracks.clone(
 )
 trackingLowPU.toModify(pixelTracks, SeedingHitSets = "pixelTracksHitTriplets")
 
-pixelTracksSequence = cms.Sequence(
-    pixelTracksTrackingRegions +
-    pixelFitterByHelixProjections +
-    pixelTrackFilterByKinematics +
-    pixelTracksSeedLayers +
-    pixelTracksHitDoublets +
-    pixelTracksHitQuadruplets +
+pixelTracksTask = cms.Task(
+    pixelTracksTrackingRegions,
+    pixelFitterByHelixProjections,
+    pixelTrackFilterByKinematics,
+    pixelTracksSeedLayers,
+    pixelTracksHitDoublets,
+    pixelTracksHitQuadruplets,
     pixelTracks
 )
-_pixelTracksSequence_lowPU = pixelTracksSequence.copy()
-_pixelTracksSequence_lowPU.replace(pixelTracksHitQuadruplets, pixelTracksHitTriplets)
-trackingLowPU.toReplaceWith(pixelTracksSequence, _pixelTracksSequence_lowPU)
+_pixelTracksTask_lowPU = pixelTracksTask.copy()
+_pixelTracksTask_lowPU.replace(pixelTracksHitQuadruplets, pixelTracksHitTriplets)
+trackingLowPU.toReplaceWith(pixelTracksTask, _pixelTracksTask_lowPU)
+
+pixelTracksSequence = cms.Sequence(pixelTracksTask)


### PR DESCRIPTION
Title says it all. This PR supersedes #25122  by including a "Task" somewhere in the added task names, and keeping the sequences for "backwards" compatibility (to avoid a massive migration as in #25110). I also included migration of pixel tracking configuration (I wanted to do that anyway, it is somewhat related, and doesn't add much changes).

Tested in CMSSW_10_4_X_2018-11-05-1100, no changes expected.
