### PR TITLE
restoring ecal pulse shape hard-coded-thresholds when not using DB

### DIFF
--- a/SimCalorimetry/EcalSimAlgos/src/APDShape.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/APDShape.cc
@@ -22,6 +22,7 @@ APDShape::fillShape(float &time_interval, double &m_thresh, EcalShapeBase::DVec&
     }
     else
     {
+	m_thresh = 0.0;
         time_interval = 1.0; 
         aVec.reserve(500);
         const double m_tStart=74.5;

--- a/SimCalorimetry/EcalSimAlgos/src/EBShape.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EBShape.cc
@@ -22,6 +22,7 @@ EBShape::fillShape( float &time_interval, double &m_thresh, EcalShapeBase::DVec&
 
     } else   // use old hardcoded arrays
     {
+        m_thresh = 0.00013;
         time_interval = 1.0; 
         aVec.reserve(500);
      	aVec = {6.94068e-05,

--- a/SimCalorimetry/EcalSimAlgos/src/EEShape.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EEShape.cc
@@ -20,6 +20,7 @@ EEShape::fillShape(float &time_interval, double &m_thresh, EcalShapeBase::DVec& 
 	m_thresh = esps->endcap_thresh;
     } else
     {
+	m_thresh = 0.00025;
         time_interval = 1.0; 
         aVec.reserve(500);
    	aVec = {9.09091e-05,


### PR DESCRIPTION
This PR should not introduce any noticeable change anywhere in MC production or data reconstruction.

Within CMSSW, the pulse shape's thresholds are private members of the EcalShapeBase class and are not directly used anywhere. By default for >= CMSSW_10_3_0_pre5, the pulse shape data are fetched from DB and the hard-coded values are ignored. The restoration of the hard-coded thresholds are to needed in case an expert tries to use the Phase-I compatibility mode of the class, which is not using the DB, and tries to evaluate the shape(time) on its own. The thresholds are not explicitly used by the Digitization/Reconstruction code of CMSSW.
