### PR TITLE
Add another PbPb central skim for the muon POG

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1678,7 +1678,7 @@ steps['RECOHID15']=merge([{ '--runUnscheduled':'',
                            
 steps['RECOHID18']=merge([{ '--scenario':'pp',
                             '--conditions':'103X_dataRun2_Prompt_v2',
-                            '-s':'RAW2DIGI,L1Reco,RECO,ALCA:SiStripCalZeroBias+SiPixelCalZeroBias,SKIM:PbPbEMu+PbPbZEE+PbPbZMM,EI,DQM:@common+@standardDQM+@ExtraHLT',
+                            '-s':'RAW2DIGI,L1Reco,RECO,ALCA:SiStripCalZeroBias+SiPixelCalZeroBias,SKIM:PbPbEMu+PbPbZEE+PbPbZMM+PbPbZMu,EI,DQM:@common+@standardDQM+@ExtraHLT',
                             '--datatier':'AOD,DQMIO',
                             '--eventcontent':'AOD,DQM',
                             '--era':'Run2_2018_pp_on_AA'

--- a/Configuration/Skimming/python/PbPb_ZMuSkimMuonDPG_cff.py
+++ b/Configuration/Skimming/python/PbPb_ZMuSkimMuonDPG_cff.py
@@ -30,7 +30,7 @@ ConcretelooseMuonsForZMuSkim = cms.EDProducer("ConcreteChargedCandidateProducer"
 
 
 ###create iso deposits
-tkIsoDepositTk = cms.EDProducer("CandIsoDepositProducer",
+tkIsoDepositTkForZMuSkim = cms.EDProducer("CandIsoDepositProducer",
                                 src = cms.InputTag("ConcretelooseMuonsForZMuSkim"),
                                 MultipleDepositsFlag = cms.bool(False),
                                 trackType = cms.string('track'),
@@ -53,19 +53,19 @@ tkIsoDepositTk = cms.EDProducer("CandIsoDepositProducer",
                                 )
 
 ###adding isodeposits to candidate collection
-allPatTracks = patGenericParticles.clone(
+allPatTracksForZMuSkim = patGenericParticles.clone(
     src = cms.InputTag("ConcretelooseMuonsForZMuSkim"),
     # isolation configurables
     userIsolation = cms.PSet(
       tracker = cms.PSet(
         veto = cms.double(0.015),
-        src = cms.InputTag("tkIsoDepositTk"),
+        src = cms.InputTag("tkIsoDepositTkForZMuSkim"),
         deltaR = cms.double(0.3),
         #threshold = cms.double(1.5)
       ),
       ),
     isoDeposits = cms.PSet(
-        tracker = cms.InputTag("tkIsoDepositTk"),
+        tracker = cms.InputTag("tkIsoDepositTkForZMuSkim"),
         ),
     )
 
@@ -74,7 +74,7 @@ allPatTracks = patGenericParticles.clone(
 
 ###create the "probe collection" of isolated tracks 
 looseIsoMuonsForZMuSkim = cms.EDFilter("PATGenericParticleSelector",  
-                             src = cms.InputTag("allPatTracks"), 
+                             src = cms.InputTag("allPatTracksForZMuSkim"), 
                              cut = cms.string("(userIsolation('pat::TrackIso')/pt)<0.4"),
                              filter = cms.bool(True)
                              )
@@ -113,8 +113,8 @@ diMuonSelSeq = cms.Sequence(
                             ZMuHLTFilter *
                             looseMuonsForZMuSkim *
                             ConcretelooseMuonsForZMuSkim *
-                            tkIsoDepositTk *
-                            allPatTracks *
+                            tkIsoDepositTkForZMuSkim *
+                            allPatTracksForZMuSkim *
                             looseIsoMuonsForZMuSkim * 
                             tightMuonsForZMuSkim *
                             dimuonsZMuSkim *

--- a/Configuration/Skimming/python/PbPb_ZMuSkimMuonDPG_cff.py
+++ b/Configuration/Skimming/python/PbPb_ZMuSkimMuonDPG_cff.py
@@ -1,0 +1,128 @@
+import FWCore.ParameterSet.Config as cms
+### HLT filter
+import copy
+from HLTrigger.HLTfilters.hltHighLevel_cfi import *
+from PhysicsTools.PatAlgos.producersLayer1.genericParticleProducer_cfi import patGenericParticles
+
+
+ZMuHLTFilter = copy.deepcopy(hltHighLevel)
+ZMuHLTFilter.throw = cms.bool(False)
+ZMuHLTFilter.HLTPaths = ["HLT_HIL3Mu*"]
+
+### Z -> MuMu candidates
+# Get muons of needed quality for Zs
+
+###create a track collection with generic kinematic cuts
+looseMuonsForZMuSkim = cms.EDFilter("TrackSelector",
+                             src = cms.InputTag("generalTracks"),
+                             cut = cms.string('pt > 10 &&  abs(eta)<2.4 &&  (charge!=0)'),
+                             filter = cms.bool(True)                                
+                             )
+
+
+
+###cloning the previous collection into a collection of candidates
+ConcretelooseMuonsForZMuSkim = cms.EDProducer("ConcreteChargedCandidateProducer",
+                                              src = cms.InputTag("looseMuonsForZMuSkim"),
+                                              particleType = cms.string("mu+")
+                                              )
+
+
+
+###create iso deposits
+tkIsoDepositTk = cms.EDProducer("CandIsoDepositProducer",
+                                src = cms.InputTag("ConcretelooseMuonsForZMuSkim"),
+                                MultipleDepositsFlag = cms.bool(False),
+                                trackType = cms.string('track'),
+                                ExtractorPSet = cms.PSet(
+        #MIsoTrackExtractorBlock
+        Diff_z = cms.double(0.2),
+        inputTrackCollection = cms.InputTag("generalTracks"),
+        BeamSpotLabel = cms.InputTag("offlineBeamSpot"),
+        ComponentName = cms.string('TrackExtractor'),
+        DR_Max = cms.double(0.5),
+        Diff_r = cms.double(0.1),
+        Chi2Prob_Min = cms.double(-1.0),
+        DR_Veto = cms.double(0.01),
+        NHits_Min = cms.uint32(0),
+        Chi2Ndof_Max = cms.double(1e+64),
+        Pt_Min = cms.double(-1.0),
+        DepositLabel = cms.untracked.string('tracker'),
+        BeamlineOption = cms.string('BeamSpotFromEvent')
+        )
+                                )
+
+###adding isodeposits to candidate collection
+allPatTracks = patGenericParticles.clone(
+    src = cms.InputTag("ConcretelooseMuonsForZMuSkim"),
+    # isolation configurables
+    userIsolation = cms.PSet(
+      tracker = cms.PSet(
+        veto = cms.double(0.015),
+        src = cms.InputTag("tkIsoDepositTk"),
+        deltaR = cms.double(0.3),
+        #threshold = cms.double(1.5)
+      ),
+      ),
+    isoDeposits = cms.PSet(
+        tracker = cms.InputTag("tkIsoDepositTk"),
+        ),
+    )
+
+
+
+
+###create the "probe collection" of isolated tracks 
+looseIsoMuonsForZMuSkim = cms.EDFilter("PATGenericParticleSelector",  
+                             src = cms.InputTag("allPatTracks"), 
+                             cut = cms.string("(userIsolation('pat::TrackIso')/pt)<0.4"),
+                             filter = cms.bool(True)
+                             )
+
+
+
+###create the "tag collection" of muon candidate, no dB cut applied 
+
+
+tightMuonsForZMuSkim = cms.EDFilter("MuonSelector",
+    src = cms.InputTag("muons"),
+    cut = cms.string("(isGlobalMuon) && pt > 25. &&  (abs(eta)<2.4) &&  (isPFMuon>0) && (globalTrack().normalizedChi2() < 10) && (globalTrack().hitPattern().numberOfValidMuonHits()>0)&& (numberOfMatchedStations() > 1)&& (innerTrack().hitPattern().numberOfValidPixelHits() > 0)&& (innerTrack().hitPattern().trackerLayersWithMeasurement() > 5) && ((isolationR03().sumPt/pt)<0.1)"),
+    filter = cms.bool(True)
+    )
+
+
+
+
+# build Z-> MuMu candidates
+dimuonsZMuSkim = cms.EDProducer("CandViewShallowCloneCombiner",
+                         checkCharge = cms.bool(False),
+                         cut = cms.string('(mass > 60) &&  (charge=0)'),       
+                         decay = cms.string("tightMuonsForZMuSkim looseIsoMuonsForZMuSkim")
+                         )                                    
+
+
+# Z filter
+dimuonsFilterZMuSkim = cms.EDFilter("CandViewCountFilter",
+                             src = cms.InputTag("dimuonsZMuSkim"),
+                             minNumber = cms.uint32(1)
+                             )
+
+
+
+diMuonSelSeq = cms.Sequence(
+                            ZMuHLTFilter *
+                            looseMuonsForZMuSkim *
+                            ConcretelooseMuonsForZMuSkim *
+                            tkIsoDepositTk *
+                            allPatTracks *
+                            looseIsoMuonsForZMuSkim * 
+                            tightMuonsForZMuSkim *
+                            dimuonsZMuSkim *
+                            dimuonsFilterZMuSkim 
+)
+
+
+
+
+
+

--- a/Configuration/Skimming/python/Skims_PbPb_cff.py
+++ b/Configuration/Skimming/python/Skims_PbPb_cff.py
@@ -52,11 +52,11 @@ SKIMStreamPbPbZMM = cms.FilteredStream(
 #####################      
 
 from Configuration.Skimming.PbPb_ZMuSkimMuonDPG_cff import *
-ZMuSkimPath = cms.Path( diMuonSelSeq )
+ZMuSkimPathPbPb = cms.Path( diMuonSelSeqForPbPbZMuSkim )
 SKIMStreamPbPbZMu = cms.FilteredStream(
     responsible = 'HI PAG',
     name = 'PbPbZMu',
-    paths = (ZMuSkimPath),
+    paths = (ZMuSkimPathPbPb),
     content = skimFEVTContent.outputCommands,
     selectEvents = cms.untracked.PSet(),
     dataTier = cms.untracked.string('RAW-RECO')

--- a/Configuration/Skimming/python/Skims_PbPb_cff.py
+++ b/Configuration/Skimming/python/Skims_PbPb_cff.py
@@ -50,3 +50,16 @@ SKIMStreamPbPbZMM = cms.FilteredStream(
     )
 
 #####################      
+
+from Configuration.Skimming.PbPb_ZMuSkimMuonDPG_cff import *
+ZMuSkimPath = cms.Path( diMuonSelSeq )
+SKIMStreamZMu = cms.FilteredStream(
+    responsible = 'HI PAG',
+    name = 'ZMu',
+    paths = (ZMuSkimPath),
+    content = skimFEVTContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+    )
+
+#####################      

--- a/Configuration/Skimming/python/Skims_PbPb_cff.py
+++ b/Configuration/Skimming/python/Skims_PbPb_cff.py
@@ -53,7 +53,7 @@ SKIMStreamPbPbZMM = cms.FilteredStream(
 
 from Configuration.Skimming.PbPb_ZMuSkimMuonDPG_cff import *
 ZMuSkimPath = cms.Path( diMuonSelSeq )
-SKIMStreamZMu = cms.FilteredStream(
+SKIMStreamPbPbZMu = cms.FilteredStream(
     responsible = 'HI PAG',
     name = 'PbPbZMu',
     paths = (ZMuSkimPath),

--- a/Configuration/Skimming/python/Skims_PbPb_cff.py
+++ b/Configuration/Skimming/python/Skims_PbPb_cff.py
@@ -55,7 +55,7 @@ from Configuration.Skimming.PbPb_ZMuSkimMuonDPG_cff import *
 ZMuSkimPath = cms.Path( diMuonSelSeq )
 SKIMStreamZMu = cms.FilteredStream(
     responsible = 'HI PAG',
-    name = 'ZMu',
+    name = 'PbPbZMu',
     paths = (ZMuSkimPath),
     content = skimFEVTContent.outputCommands,
     selectEvents = cms.untracked.PSet(),


### PR DESCRIPTION
The muon POG requires a central skim for PbPb collisions with a single muon trigger for monitoring the CSCs.  