### PR TITLE
Adding rawDataRepacker collection to HLTRaw event content

### DIFF
--- a/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
@@ -13,6 +13,7 @@ HLTriggerRAW  = cms.PSet(
     outputCommands = cms.vstring( *(
         'drop *_hlt*_*_*',
         'keep FEDRawDataCollection_rawDataCollector_*_*',
+        'keep FEDRawDataCollection_rawDataRepacker_*_*',
         'keep FEDRawDataCollection_source_*_*',
         'keep GlobalObjectMapRecord_hltGtStage2ObjectMap_*_*',
         'keep edmTriggerResults_*_*_*',


### PR DESCRIPTION
For the heavy ion run, it was noticed that the rawDataRepacker (our raw data collection) is not in the Express stream because it was not added to the event content.  This PR attempts to fix the issue.

A similar PR for the master branch will follow shortly.

@icali @mandrenguyen 