### PR TITLE
Save repacked raw data in FVT, for express wfs

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -412,7 +412,8 @@ REPACKRAWEventContent = cms.PSet(
       'drop *',
       'drop FEDRawDataCollection_*_*_*',
       'keep FEDRawDataCollection_rawDataRepacker_*_*',
-      'keep FEDRawDataCollection_virginRawDataRepacker_*_*'),
+      'keep FEDRawDataCollection_virginRawDataRepacker_*_*',
+      'keep FEDRawDataCollection_rawDataReducedFormat_*_*'),
     splitLevel = cms.untracked.int32(0),
     )
 REPACKRAWSIMEventContent = cms.PSet(
@@ -728,6 +729,8 @@ REPACKRAWSIMEventContent.outputCommands.extend(['drop FEDRawDataCollection_sourc
 REPACKRAWEventContent.outputCommands.extend(['drop FEDRawDataCollection_source_*_*',
                                                 'drop FEDRawDataCollection_rawDataCollector_*_*'])
 
+
+
 #from modules in Configuration.StandardSequence.Generator_cff fixGenInfo
 REGENEventContent = cms.PSet(
     inputCommands=cms.untracked.vstring(
@@ -880,11 +883,12 @@ for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
     run2_GEM_2017.toModify(_entry, outputCommands = _entry.outputCommands + ['keep *_muonGEMDigis_*_*'])
     run3_GEM.toModify(_entry, outputCommands = _entry.outputCommands + ['keep *_muonGEMDigis_*_*'])
     phase2_muon.toModify(_entry, outputCommands = _entry.outputCommands + ['keep *_muonGEMDigis_*_*'])
-
+    pp_on_AA_2018.toModify(_entry, outputCommands = _entry.outputCommands + ['keep FEDRawDataCollection_rawDataRepacker_*_*'])
 
 from RecoLocalFastTime.Configuration.RecoLocalFastTime_EventContent_cff import RecoLocalFastTimeFEVT, RecoLocalFastTimeRECO, RecoLocalFastTimeAOD
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer


### PR DESCRIPTION
The RAW data with label rawDataRepacker is missing from express reco, which should store FVT content. 
This adds it.  Was tested by re-running express on streamers.