### PR TITLE
Fix to make Herwig use the CMSSW seed

### DIFF
--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -91,6 +91,7 @@ class Herwig7Interface {
 	// File name containing Herwig input config 
 	std::string				dumpConfig_;
 	const unsigned int			skipEvents_;
+    CLHEP::HepRandomEngine* randomEngine;
 };
 
 

--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -43,7 +43,7 @@ namespace CLHEP {
 class Herwig7Interface {
     public:
 	Herwig7Interface(const edm::ParameterSet &params);
-	~Herwig7Interface();
+	~Herwig7Interface() noexcept;
 
         void setPEGRandomEngine(CLHEP::HepRandomEngine*);
 

--- a/GeneratorInterface/Herwig7Interface/interface/HerwigUIProvider.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HerwigUIProvider.h
@@ -26,6 +26,8 @@ public:
 
   /// Requested Herwig run mode
   RunMode::Mode runMode() const { return runMode_; }
+  void setSeed(long seed){ seed_=seed; }
+
 
   /// Try to resume execution from an earlier interrupted run.
   bool resume() const { return resume_; }

--- a/GeneratorInterface/Herwig7Interface/interface/HerwigUIProvider.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HerwigUIProvider.h
@@ -22,58 +22,58 @@ public:
   HerwigUIProvider(const edm::ParameterSet &pset, std::string inputFileName, RunMode::Mode);
 
   /// Destructor to leave a clean ThePEG::Repository behind
-  ~HerwigUIProvider();
+  ~HerwigUIProvider() override;
 
   /// Requested Herwig run mode
-  RunMode::Mode runMode() const { return runMode_; }
+  RunMode::Mode runMode() const override { return runMode_; }
   void setSeed(long seed){ seed_=seed; }
 
 
   /// Try to resume execution from an earlier interrupted run.
-  bool resume() const { return resume_; }
+  bool resume() const override { return resume_; }
 
   /// Require verbose progress markers
-  bool tics() const { return tics_; }
+  bool tics() const override { return tics_; }
 
   /// A user-defined tag to append to the run name.
-  std::string tag() const { return tag_; }
+  std::string tag() const override { return tag_; }
 
   /// Name of the file to be read
-  std::string inputfile() const { return inputfile_; }
+  std::string inputfile() const override { return inputfile_; }
 
   /// Repository name to operate on
-  std::string repository() const { return repository_; }
+  std::string repository() const override { return repository_; }
 
   /// Name of the setup file to be read, to modify the repository
-  std::string setupfile() const { return setupfile_; }
+  std::string setupfile() const override { return setupfile_; }
  
-  std::string integrationList() const { return integrationList_; }
+  std::string integrationList() const override { return integrationList_; }
 
 
   const std::vector<std::string> & 
-  prependReadDirectories() const { return prependReadDirectories_; }
+  prependReadDirectories() const override { return prependReadDirectories_; }
 
   const std::vector<std::string> & 
-  appendReadDirectories() const { return appendReadDirectories_; }
+  appendReadDirectories() const override { return appendReadDirectories_; }
 
-  long N() const { return  nEvents_; }
-  int seed() const { return seed_; }
-  int jobs() const { return jobs_; }
-  unsigned int jobSize() const { return jobsize_; }
-  unsigned int maxJobs() const { return maxjobs_; }  
+  long N() const override { return  nEvents_; }
+  int seed() const override { return seed_; }
+  int jobs() const override { return jobs_; }
+  unsigned int jobSize() const override { return jobsize_; }
+  unsigned int maxJobs() const override { return maxjobs_; }  
 
-  void quitWithHelp() const;
+  void quitWithHelp() const override;
 
-  void quit() const;
+  void quit() const override;
 
    /// Return the standard out stream to be used
-  virtual std::ostream& outStream() const { return std::cout; }
+  std::ostream& outStream() const override { return std::cout; }
 
    /// Return the standard err stream to be used
-  virtual std::ostream& errStream() const { return std::cerr; }
+  std::ostream& errStream() const override { return std::cerr; }
 
   /// Return the standard in stream to be used
-  virtual std::istream& inStream() const { return std::cin; }
+  std::istream& inStream() const override { return std::cin; }
 
   /**
   *  Change run mode of Herwig

--- a/GeneratorInterface/Herwig7Interface/interface/RandomEngineGlue.h
+++ b/GeneratorInterface/Herwig7Interface/interface/RandomEngineGlue.h
@@ -13,6 +13,7 @@
 #include <ThePEG/Repository/StandardRandom.h>
 
 #include "GeneratorInterface/Herwig7Interface/interface/Proxy.h"
+#include "CLHEP/Random/RandomEngine.h"
 
 namespace CLHEP {
 	class HepRandomEngine;	// forward declaration
@@ -26,7 +27,7 @@ class RandomEngineGlue : public RandomGenerator {
 	~RandomEngineGlue() override;
 
 	void setRandomEngine(CLHEP::HepRandomEngine* v) { randomEngine = v; }
-
+    CLHEP::HepRandomEngine* getRandomEngine() const { return randomEngine; }
 	void flush();
 
 	static void Init();

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
@@ -46,6 +46,8 @@
 #include "GeneratorInterface/Herwig7Interface/interface/RandomEngineGlue.h"
 #include "GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h"
 
+#include "CLHEP/Random/RandomEngine.h"
+
 using namespace std;
 using namespace gen;
 
@@ -76,10 +78,12 @@ Herwig7Interface::~Herwig7Interface () noexcept
 }
 
 void Herwig7Interface::setPEGRandomEngine(CLHEP::HepRandomEngine* v) {
+    
         randomEngineGlueProxy_->setRandomEngine(v);
+        randomEngine = v;
         ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
         if(rnd) {
-          rnd->setRandomEngine(v);
+            rnd->setRandomEngine(v);
         }
 }
 
@@ -167,7 +171,9 @@ void Herwig7Interface::callHerwigGenerator()
     case Herwig::RunMode::BUILD:       Herwig::API::build(*HwUI_);      break;
     case Herwig::RunMode::INTEGRATE:   Herwig::API::integrate(*HwUI_);  break;
     case Herwig::RunMode::MERGEGRIDS:  Herwig::API::mergegrids(*HwUI_); break;
-    case Herwig::RunMode::RUN:         eg_ =  Herwig::API::prepareRun(*HwUI_); break;
+    case Herwig::RunMode::RUN:         {    
+                                            HwUI_->setSeed(randomEngine->getSeed());
+                                            eg_ =  Herwig::API::prepareRun(*HwUI_); break;}
     case Herwig::RunMode::ERROR:       
       edm::LogError("Herwig7Interface") << "Error during read in of command line parameters.\n"
                 << "Program execution will stop now."; 

--- a/GeneratorInterface/Herwig7Interface/src/HerwigUIProvider.cc
+++ b/GeneratorInterface/Herwig7Interface/src/HerwigUIProvider.cc
@@ -183,7 +183,6 @@ void HerwigUIProvider::setRunMode(RunMode::Mode runMode, const edm::ParameterSet
 		ThePEG::SamplerBase::setIntegrationJobs(maxjobs_);
 	}
 }
-
 // End Herwig namespace
 }
 

--- a/GeneratorInterface/Herwig7Interface/src/HerwigUIProvider.cc
+++ b/GeneratorInterface/Herwig7Interface/src/HerwigUIProvider.cc
@@ -70,7 +70,7 @@ HerwigUIProvider::HerwigUIProvider(const edm::ParameterSet &pset, std::string in
 
 
   // run name tag (default given in ggo file)
-  if ( pset.getUntrackedParameter<std::string>("runTag", "") != "")
+  if ( !pset.getUntrackedParameter<std::string>("runTag", "").empty())
     tag_ = pset.getUntrackedParameter<std::string>("runTag", "Tag1");
 
   // Debugging level
@@ -97,7 +97,7 @@ HerwigUIProvider::HerwigUIProvider(const edm::ParameterSet &pset, std::string in
     seed_ = pset.getUntrackedParameter<int>("seed", 0);
 
   // run modification file
-  if ( pset.getUntrackedParameter<std::string>("setupFile", "") != "" )
+  if ( !pset.getUntrackedParameter<std::string>("setupFile", "").empty() )
     setupfile_ = pset.getUntrackedParameter<std::string>("setupFile", "");
 
   // parallel jobs
@@ -121,7 +121,7 @@ HerwigUIProvider::HerwigUIProvider(const edm::ParameterSet &pset, std::string in
  
 
   // integration list
-  if ( pset.getUntrackedParameter<std::string>("integrationList", "") != "" ) {
+  if ( !pset.getUntrackedParameter<std::string>("integrationList", "").empty() ) {
     integrationList_ = "integrationJob" + pset.getUntrackedParameter<std::string>("integrationList", "1");
   }
 


### PR DESCRIPTION
Dear all,

this is a quick, dirty fix to make Herwig 7 use the random number that is provided by CLHEP RandomNumberGenerator.

I need to have a deeper look into how to make this more elegant, but for now this works.

Kind regards,

Andrej