### PR TITLE
Raising clusterChecker threshhold slightly for Heavy Ion collisions

### DIFF
--- a/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
@@ -23,5 +23,6 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify(trackerClusterCheck,
                doClusterCheck=True, 
                cut = "strip < 1000000 && pixel < 150000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/2.)",
-               MaxNumberOfPixelClusters = 150000
+               MaxNumberOfPixelClusters = 150000,
+               MaxNumberOfCosmicClusters = 500000
                )


### PR DESCRIPTION
We have found that the default parameter 'maxNumberOfCosmicClusters' is causing a few very central heavy ion collisions to bail on the tracking, although these events appear to be good physics events.  We would like to raise this threshhold from 400k to 500k to prevent any bias to physics.  More information on the investigation of these very large events that the tracking is bailing on is given here:

https://www.dropbox.com/s/pgfp21e2329ly69/MonsterEventInvestigation_Nov10.pdf?dl=0

Two of these events, which normally have the tracking not run, as well as a RECO config for testing can be found here:

/afs/cern.ch/user/a/abaty/public/forClusterCheckPR

A backport PR for 10_3_1 will follow shortly.

@mandrenguyen @icali @echapon @mverwe 