### PR TITLE
Backport of #25189 (raising cluster checker threshold for HI events) for 10_3_X

### DIFF
--- a/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
@@ -23,5 +23,6 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify(trackerClusterCheck,
                doClusterCheck=True, 
                cut = "strip < 1000000 && pixel < 150000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/2.)",
-               MaxNumberOfPixelClusters = 150000
+               MaxNumberOfPixelClusters = 150000,
+               MaxNumberOfCosmicClusters = 500000
                )


### PR DESCRIPTION
We would like this PR for the current HI data-taking in 10_3_X.

More documentation and some events for testing can be found in the description for #25189.

@mandrenguyen 