### PR TITLE
Add explicit raw collection label for L1TRawToDigi

### DIFF
--- a/EventFilter/L1TRawToDigi/python/caloStage1Digis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/caloStage1Digis_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 caloStage1Digis = cms.EDProducer(
     "L1TRawToDigi",
+    InputLabel = cms.InputTag("rawDataCollector"),
     Setup = cms.string("stage1::CaloSetup"),
     FedIds = cms.vint32(1352),
     # Uncomment the following for 74x legacy MC

--- a/EventFilter/L1TRawToDigi/python/caloStage2Digis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/caloStage2Digis_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 caloStage2Digis = cms.EDProducer(
     "L1TRawToDigi",
+    InputLabel = cms.InputTag("rawDataCollector"),
     Setup           = cms.string("stage2::CaloSetup"),
     FedIds          = cms.vint32( 1360, 1366 ),
     FWId            = cms.uint32(0),

--- a/EventFilter/L1TRawToDigi/python/gmtStage2Digis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gmtStage2Digis_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 gmtStage2Digis = cms.EDProducer(
     "L1TRawToDigi",
+    InputLabel = cms.InputTag("rawDataCollector"),
     Setup = cms.string("stage2::GMTSetup"),
     FedIds = cms.vint32(1402),
 )

--- a/EventFilter/L1TRawToDigi/python/gtStage2Digis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gtStage2Digis_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 gtStage2Digis = cms.EDProducer(
     "L1TRawToDigi",
+    InputLabel = cms.InputTag("rawDataCollector"),
     Setup           = cms.string("stage2::GTSetup"),
     FedIds          = cms.vint32( 1404 ),
 )


### PR DESCRIPTION
The --repacked command tells the driver to grab raw data with the remapped label.
It does this by invoking the following:
from Configuration.Applications.ConfigBuilder import MassReplaceInputTag
MassReplaceInputTag(process, new="rawDataMapperByLabel", old="rawDataCollector")

The problem is that this doesn't seem to get picked up when this is set in the fillDescriptions, as in EventFilter/L1TRawToDigi/plugins/L1TRawToDigi.cc

This PR makes the InputTag explicit, such that it's picked up by MassReplaceInputTag