### PR TITLE
Fix bug in sign of cot(alpha) in qbin() methods, needed for CPEGeneric errors

### DIFF
--- a/CondFormats/SiPixelTransient/src/SiPixelGenError.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelGenError.cc
@@ -698,7 +698,7 @@ int SiPixelGenError::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
    auto xxratio = 0.f;
    
    {
-      auto j = std::lower_bound(templ.cotalphaX,templ.cotalphaX+Nxx,cotalpha);
+      auto j = std::lower_bound(templ.cotalphaX,templ.cotalphaX+Nxx,cota);
       if (j==templ.cotalphaX+Nxx) { --j;  xxratio = 1.f; }
       else if (j==templ.cotalphaX) { ++j; xxratio = 0.f;}
       else { xxratio = (cota - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -2578,7 +2578,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
    auto xxratio = 0.f;
    
    {
-      auto j = std::lower_bound(templ.cotalphaX,templ.cotalphaX+Nxx,cotalpha);
+      auto j = std::lower_bound(templ.cotalphaX,templ.cotalphaX+Nxx,cota);
       if (j==templ.cotalphaX+Nxx) { --j;  xxratio = 1.f; }
       else if (j==templ.cotalphaX) { ++j; xxratio = 0.f;}
       else { xxratio = (cota - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }


### PR DESCRIPTION
This PR fixes a longstanding software bug that was introduced when we implemented the Phase I FPix.  The FPix template entries for IP related tracks are folded into one quadrant of positive (cotalpha, cotbeta) space and sign flips are used fix signed quantities.  The subtlety is that one can get negative values (cotalpha, cotbeta) from cosmic rays that must also be included.  Therefore the flipping is governed by flags that depend on the local magnetic fields.  The different cases are handled by the signs of cota/cotb and the flags flip_x/flip_y.  This is done correctly in the interpolation code for the template reco, but in the qbin method (used for generic reco) in the template and generror code, the reference to cotalpha was not changed to cota [sign corrected] in a consistent way.  This causes the interpolation fraction xxratio to be outside the 0-1 range and sometimes produces crazy results.  Because of the way that everything is signed, FPix R1P1, R1P2, and R2P1 are affected.  The effect is on the RecHit errors in this panels.

This has been tested by @VinInn .