### PR TITLE
Updated trackerStablePhiSort and mtdStablePhiSort

### DIFF
--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDDiscBuilder.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDDiscBuilder.cc
@@ -3,7 +3,7 @@
 #include "Geometry/MTDNumberingBuilder/interface/GeometricTimingDet.h"
 #include "Geometry/MTDNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/MTDNumberingBuilder/plugins/CmsMTDETLRingBuilder.h"
-#include "Geometry/MTDNumberingBuilder/plugins/MTDStablePhiSort.h"
+#include "Geometry/MTDNumberingBuilder/plugins/mtdStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDDiscBuilder.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDDiscBuilder.cc
@@ -3,7 +3,6 @@
 #include "Geometry/MTDNumberingBuilder/interface/GeometricTimingDet.h"
 #include "Geometry/MTDNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/MTDNumberingBuilder/plugins/CmsMTDETLRingBuilder.h"
-#include "Geometry/MTDNumberingBuilder/plugins/mtdStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDETLRingBuilder.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDETLRingBuilder.cc
@@ -8,7 +8,6 @@
 #include "Geometry/MTDNumberingBuilder/plugins/MTDStablePhiSort.h"
 
 #include <vector>
-#include <functional>
 
 void CmsMTDETLRingBuilder::buildComponent(DDFilteredView& fv, GeometricTimingDet* g, std::string s){
 
@@ -24,6 +23,6 @@ void CmsMTDETLRingBuilder::sortNS(DDFilteredView& fv, GeometricTimingDet* det){
   GeometricTimingDet::ConstGeometricTimingDetContainer & comp = det->components();
 
   //increasing phi taking into account the sub-modules
-  MTDStablePhiSort(comp.begin(), comp.end(), std::function<double(const GeometricTimingDet*)>(getPhiGluedModule));
+  mtdStablePhiSort(comp.begin(), comp.end(), getPhiGluedModule);
   
 }

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDETLRingBuilder.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDETLRingBuilder.cc
@@ -5,7 +5,7 @@
 #include "Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "Geometry/MTDNumberingBuilder/plugins/MTDStablePhiSort.h"
+#include "Geometry/MTDNumberingBuilder/plugins/mtdStablePhiSort.h"
 
 #include <vector>
 

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDTrayBuilder.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDTrayBuilder.cc
@@ -7,7 +7,6 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <functional>
 #include <vector>
 #include <bitset>
 
@@ -47,7 +46,7 @@ void CmsMTDTrayBuilder::sortNS(DDFilteredView& fv, GeometricTimingDet* det){
   
   // rods 
   if(!rods.empty()){
-    MTDStablePhiSort(rods.begin(), rods.end(), std::function<double(const GeometricTimingDet*)>(getPhi));
+    mtdStablePhiSort(rods.begin(), rods.end(), getPhi);
     uint32_t  totalrods = rods.size();
   
     LogTrace("DetConstruction") << " Rods ordered by phi: ";

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDTrayBuilder.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDTrayBuilder.cc
@@ -3,7 +3,7 @@
 #include "Geometry/MTDNumberingBuilder/interface/GeometricTimingDet.h"
 #include "Geometry/MTDNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/MTDNumberingBuilder/plugins/CmsMTDModuleBuilder.h"
-#include "Geometry/MTDNumberingBuilder/plugins/MTDStablePhiSort.h"
+#include "Geometry/MTDNumberingBuilder/plugins/mtdStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/Geometry/MTDNumberingBuilder/plugins/MTDStablePhiSort.h
+++ b/Geometry/MTDNumberingBuilder/plugins/MTDStablePhiSort.h
@@ -1,119 +1,13 @@
 #ifndef MTDStablePhiSort_H
 #define MTDStablePhiSort_H
-// #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include<iostream>
+#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
 
-#include <utility>
-#include <vector>
-#include <algorithm>
-
-#include <cmath>
-
-#include<boost/bind.hpp>
-
-namespace details {
-  template<typename Object, typename Scalar> 
-  struct PhiSortElement {
-    typedef PhiSortElement<Object,Scalar> self;
-    
-    template<typename Extractor>
-    static self 
-    build(Object & o, Extractor const & extr) { 
-      return self(&o, extr(o));
-    }
-    
-    PhiSortElement()
-      : pointer(nullptr) {}
-    PhiSortElement(Object * p, Scalar v):
-      pointer(p),
-      value(v) {}
-    
-    Object * pointer;
-    Scalar value;
-    
-    bool operator<(self const & rh) const {
-      return value<rh.value;
-    }
-    Object const &
-    obj() const { return *pointer;}
-  };
-  
-  
+template<class RandomAccessIterator, class Extractor>
+void mtdStablePhiSort(RandomAccessIterator begin, RandomAccessIterator end, const Extractor& extr)
+{
+    trackerStablePhiSort(begin, end, extr);
 }
 
-template<typename RandomAccessIterator, typename Extractor>
-void MTDStablePhiSort(RandomAccessIterator begin,
-			  RandomAccessIterator end,
-			  const Extractor& extr) {
-  
-  typedef typename Extractor::result_type        Scalar;
-  typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
-  
-  typedef details::PhiSortElement<value_type, Scalar> Element;
-  
-  
-  
-  std::vector<Element> tmpvec(end-begin);
-  std::transform(begin,end,tmpvec.begin(),
-		 boost::bind(Element::template build<Extractor>,_1, boost::cref(extr))
-		 );
-  
-  std::vector<Element> tmpcop(end-begin);
-  
-  std::sort(tmpvec.begin(), tmpvec.end());
-  
-  const unsigned int vecSize = tmpvec.size();
-  
-  
-  
-  // special tratment of the TEC modules of rings in petals near phi=0
-  // there are at most 5 modules, no other structure has less than ~10 elements to order in phi
-  // hence the special case in phi~0 if the size of the elements to order is <=5
-  const unsigned int nMaxModulesPerRing = 5;
-  bool phiZeroCase = true;
-  //
-  const double phiMin = M_PI_4;
-  const double phiMax = 2*M_PI-phiMin;
-  //
-  if( vecSize > nMaxModulesPerRing ) {
-    //stability check
-    // check if the last element is too near to zero --> probably it is zero
-    double tolerance = 0.000001;
-    if( std::abs(tmpvec.back().value - 0) < tolerance       // near 0
-	||
-	std::abs(tmpvec.back().value - 2*M_PI) < tolerance ) { // near 2pi
-      // move it to front 
-      tmpvec.insert(tmpvec.begin(),tmpvec.back());
-      tmpvec.pop_back();
-    }
-  }
-  else {
-    // check if all the elements have phi<phiMin or phi>phiMax to be sure we are near phi~0 (angles are in [0,2pi) range)
-    // if a phi goes out from [0,phiMin]U[phiMax,2pi) it is not the case
-    // sorted. if first > phiMax all other will also...
-    typename std::vector<Element>::iterator p = 
-      std::find_if(tmpvec.begin(),tmpvec.end(), boost::bind(&Element::value,_1) > phiMin);
-    phiZeroCase = !(p!=tmpvec.end() && (*p).value<phiMax);
-    
-    // go on if this is the petal phi~0 case, restricted to the case where all the |phi| are in range [0,phiMin]
-    if(phiZeroCase) {
-      // in this case the ordering must be: ('negative' values, >) and then ('positive' values, >) in (-pi,pi] mapping
-      // already sorted, just swap ranges
-      if(p!=tmpvec.end()) {
-	tmpvec.insert(tmpvec.begin(),p,tmpvec.end());
-	tmpvec.resize(vecSize);
-      }
-    }
-  }
-  
-  // overwrite the input range with the sorted values
-  // copy of input container not necessary, but tricky to avoid
-  std::vector<value_type> tmpvecy(vecSize);
-  std::transform(tmpvec.begin(),tmpvec.end(),tmpvecy.begin(),boost::bind(&Element::obj,_1));
-  std::copy(tmpvecy.begin(),tmpvecy.end(),begin);
-  
-}
 
 #endif
-

--- a/Geometry/MTDNumberingBuilder/plugins/mtdStablePhiSort.h
+++ b/Geometry/MTDNumberingBuilder/plugins/mtdStablePhiSort.h
@@ -1,7 +1,7 @@
 #ifndef MTDStablePhiSort_H
 #define MTDStablePhiSort_H
 
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 
 template<class RandomAccessIterator, class Extractor>
 void mtdStablePhiSort(RandomAccessIterator begin, RandomAccessIterator end, const Extractor& extr)

--- a/Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h
+++ b/Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h
@@ -1,5 +1,5 @@
-#ifndef TrackerStablePhiSort_H
-#define TrackerStablePhiSort_H
+#ifndef Geometry_TrackerNumberingBuilder_trackerStablePhiSort_H
+#define Geometry_TrackerNumberingBuilder_trackerStablePhiSort_H
 
 #include <vector>
 #include <algorithm>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.cc
@@ -8,7 +8,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <vector>
-#include <functional>
 #include <algorithm>
 
 using namespace std;
@@ -40,7 +39,7 @@ CmsTrackerDiskBuilder::sortNS( DDFilteredView& fv, GeometricDet* det )
   switch( det->components().front()->type())
   {
   case GeometricDet::panel:
-    TrackerStablePhiSort( comp.begin(), comp.end(), std::function<double(const GeometricDet*)>(getPhi));
+    trackerStablePhiSort( comp.begin(), comp.end(), getPhi);
     break;
   default:
     edm::LogError( "CmsTrackerDiskBuilder" ) << "ERROR - wrong SubDet to sort..... " << det->components().front()->type();

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.cc
@@ -3,7 +3,7 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPanelBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLayerBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLayerBuilder.cc
@@ -5,7 +5,7 @@
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerStringBuilder.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRodBuilder.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLadderBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLayerBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLayerBuilder.cc
@@ -11,7 +11,6 @@
 
 #include <vector>
 #include <bitset>
-#include <functional>
 
 void CmsTrackerLayerBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g, const std::string s){
 
@@ -39,8 +38,6 @@ void CmsTrackerLayerBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g,
 }
 
 void CmsTrackerLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
-
-  const std::function<double(const GeometricDet*)> getPhiFunc{getPhi};
 
   GeometricDet::ConstGeometricDetContainer& comp = det->components();
 
@@ -92,10 +89,10 @@ void CmsTrackerLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
       }
     }
 
-    TrackerStablePhiSort(extneg.begin(), extneg.end(), getPhiFunc);
-    TrackerStablePhiSort(extpos.begin(), extpos.end(), getPhiFunc);
-    TrackerStablePhiSort(intneg.begin(), intneg.end(), getPhiFunc);
-    TrackerStablePhiSort(intpos.begin(), intpos.end(), getPhiFunc);
+    trackerStablePhiSort(extneg.begin(), extneg.end(), getPhi);
+    trackerStablePhiSort(extpos.begin(), extpos.end(), getPhi);
+    trackerStablePhiSort(intneg.begin(), intneg.end(), getPhi);
+    trackerStablePhiSort(intpos.begin(), intpos.end(), getPhi);
 
     for(uint32_t i=0;i<intneg.size();i++){
       uint32_t temp=i+1;
@@ -147,8 +144,8 @@ void CmsTrackerLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
       }
     }
 
-    TrackerStablePhiSort(neg.begin(), neg.end(), getPhiFunc);
-    TrackerStablePhiSort(pos.begin(), pos.end(), getPhiFunc);
+    trackerStablePhiSort(neg.begin(), neg.end(), getPhi);
+    trackerStablePhiSort(pos.begin(), pos.end(), getPhi);
     
     for(uint32_t i=0; i<neg.size();i++){      
       uint32_t temp = i+1;
@@ -168,8 +165,8 @@ void CmsTrackerLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
     
   }else if(det->components().front()->type()== GeometricDet::ladder){
 
-    TrackerStablePhiSort(comp.begin(), comp.end(), getPhiFunc);
-	
+    trackerStablePhiSort(comp.begin(), comp.end(), getPhi);
+
     for(uint32_t i=0; i<comp.size();i++){
       det->component(i)->setGeographicalID(DetId(i+1));
     }    

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTDiscBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTDiscBuilder.cc
@@ -3,7 +3,7 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTRingBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTDiscBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTDiscBuilder.cc
@@ -3,7 +3,6 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTRingBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTLayerBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTLayerBuilder.cc
@@ -4,7 +4,7 @@
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTRingBuilder.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLadderBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTLayerBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTLayerBuilder.cc
@@ -8,7 +8,6 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <functional>
 #include <vector>
 #include <bitset>
 
@@ -76,7 +75,7 @@ void CmsTrackerOTLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
 
   // rods 
   if(!rods.empty()){
-    TrackerStablePhiSort(rods.begin(), rods.end(), std::function<double(const GeometricDet*)>(getPhi));
+    trackerStablePhiSort(rods.begin(), rods.end(), getPhi);
     uint32_t  totalrods = rods.size();
   
     LogTrace("DetConstruction") << " Rods ordered by phi: ";
@@ -109,4 +108,3 @@ void CmsTrackerOTLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
   det->addComponents(ringsPos);
 
 }
-

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTRingBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTRingBuilder.cc
@@ -8,7 +8,6 @@
 #include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
 
 #include <vector>
-#include <functional>
 
 void CmsTrackerOTRingBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g, std::string s){
 
@@ -22,7 +21,7 @@ void CmsTrackerOTRingBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
   GeometricDet::ConstGeometricDetContainer & comp = det->components();
 
   //increasing phi taking into account the sub-modules
-  TrackerStablePhiSort(comp.begin(), comp.end(), std::function<double(const GeometricDet*)>(getPhiGluedModule));
+  trackerStablePhiSort(comp.begin(), comp.end(), getPhiGluedModule);
 
   for(uint32_t i=0; i<comp.size();i++){
     det->component(i)->setGeographicalID(i+1);

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTRingBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTRingBuilder.cc
@@ -5,7 +5,7 @@
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsDetConstruction.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 
 #include <vector>
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase1DiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase1DiskBuilder.cc
@@ -3,7 +3,6 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPanelBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase1DiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase1DiskBuilder.cc
@@ -3,7 +3,7 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPanelBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase2TPDiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase2TPDiskBuilder.cc
@@ -3,7 +3,6 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPanelBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase2TPDiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase2TPDiskBuilder.cc
@@ -3,7 +3,7 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPanelBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2DiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2DiskBuilder.cc
@@ -3,7 +3,7 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2RingBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2DiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2DiskBuilder.cc
@@ -3,7 +3,6 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2RingBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2RingBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2RingBuilder.cc
@@ -7,7 +7,6 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
 
-#include <functional>
 #include <vector>
 
 void CmsTrackerPixelPhase2RingBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g, std::string s){
@@ -22,7 +21,7 @@ void CmsTrackerPixelPhase2RingBuilder::sortNS(DDFilteredView& fv, GeometricDet* 
 
    //increasing phi taking into account the sub-modules
 
-  TrackerStablePhiSort(comp.begin(), comp.end(), std::function<double(const GeometricDet*)>(getPhi));
+  trackerStablePhiSort(comp.begin(), comp.end(), getPhi);
 
 
   for(uint32_t i=0; i<comp.size();i++){

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2RingBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2RingBuilder.cc
@@ -5,7 +5,7 @@
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsDetConstruction.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 
 #include <vector>
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRingBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRingBuilder.cc
@@ -4,7 +4,7 @@
 #include "Geometry/TrackerNumberingBuilder/plugins/ExtractStringFromDDD.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsDetConstruction.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRingBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRingBuilder.cc
@@ -6,8 +6,8 @@
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsDetConstruction.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <vector>
 
+#include <vector>
 #include <bitset>
 
 void CmsTrackerRingBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g, std::string s){
@@ -25,10 +25,10 @@ void CmsTrackerRingBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
   switch(comp.front()->type()) {
   
   case GeometricDet::mergedDet: 
-    TrackerStablePhiSort(comp.begin(), comp.end(), std::function<double(const GeometricDet*)>(getPhiGluedModule));
+    trackerStablePhiSort(comp.begin(), comp.end(), getPhiGluedModule);
     break;
   case GeometricDet::DetUnit: 
-    TrackerStablePhiSort(comp.begin(), comp.end(), std::function<double(const GeometricDet*)>(getPhi));
+    trackerStablePhiSort(comp.begin(), comp.end(), getPhi);
     break;
   default:
     edm::LogError("CmsTrackerRingBuilder")<<"ERROR - wrong SubDet to sort..... "<<det->components().front()->type(); 
@@ -46,11 +46,11 @@ void CmsTrackerRingBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
     
     // TEC- 
     if( det->translation().z() < 0 && pname == TECDet) {
-      TrackerStablePhiSort(comp.begin(), comp.end(), std::function<double(const GeometricDet*)>(getPhiMirror));
+      trackerStablePhiSort(comp.begin(), comp.end(), getPhiMirror);
     }
     
     if( det->translation().z() < 0 && pname == TECGluedDet) {
-      TrackerStablePhiSort(comp.begin(), comp.end(), std::function<double(const GeometricDet*)>(getPhiGluedModuleMirror));
+      trackerStablePhiSort(comp.begin(), comp.end(), getPhiGluedModuleMirror);
     }
 
     for(uint32_t i=0; i<comp.size();i++)

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerWheelBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerWheelBuilder.cc
@@ -5,7 +5,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRingBuilder.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPetalBuilder.h"
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <vector>

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerWheelBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerWheelBuilder.cc
@@ -7,8 +7,8 @@
 #include "Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPetalBuilder.h"
 #include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include<vector>
 
+#include <vector>
 #include <bitset>
 
 void CmsTrackerWheelBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g, std::string s){
@@ -46,8 +46,8 @@ void CmsTrackerWheelBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
 	}
       }    
       
-      TrackerStablePhiSort(compfw.begin(), compfw.end(), std::function<double(const GeometricDet*)>(getPhiModule));
-      TrackerStablePhiSort(compbw.begin(), compbw.end(), std::function<double(const GeometricDet*)>(getPhiModule));
+      trackerStablePhiSort(compfw.begin(), compfw.end(), getPhiModule);
+      trackerStablePhiSort(compbw.begin(), compbw.end(), getPhiModule);
       
       //
       // TEC

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h
@@ -21,11 +21,12 @@ void trackerStablePhiSort(RandomAccessIterator begin, RandomAccessIterator end, 
   // are at most 5 modules, no other structure has less than ~10 elements to
   // order in phi hence the special case in phi~0 if the size of the elements
   // to order is <=5
-  const unsigned int nMaxModulesPerRing = 5;
-  const double       phiMin             = M_PI_4;
-  const double       phiMax             = 2 * M_PI - phiMin;
-  const double       tolerance          = 0.000001;
-  const unsigned int n                  = tmpvec.size();
+  constexpr unsigned int nMaxModulesPerRing = 5;
+  constexpr double       phiMin             = M_PI_4;
+  constexpr double       phiMax             = 2 * M_PI - phiMin;
+  constexpr double       tolerance          = 0.000001;
+
+  const unsigned int n = tmpvec.size();
 
   if( n > nMaxModulesPerRing ) {
     // stability check

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h
@@ -1,119 +1,67 @@
 #ifndef TrackerStablePhiSort_H
 #define TrackerStablePhiSort_H
-// #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include<iostream>
-
-#include <utility>
 #include <vector>
 #include <algorithm>
-
 #include <cmath>
 
-#include<boost/bind.hpp>
+template<class RandomAccessIterator, class Extractor>
+void trackerStablePhiSort(RandomAccessIterator begin, RandomAccessIterator end, const Extractor& extr)
+{
+  using Scalar  = decltype(extr(*begin));
+  using Value   = typename std::iterator_traits<RandomAccessIterator>::value_type;
+  using Element = std::pair<Scalar, Value*>;
 
-namespace details {
-  template<typename Object, typename Scalar> 
-  struct PhiSortElement {
-    typedef PhiSortElement<Object,Scalar> self;
-    
-    template<typename Extractor>
-    static self 
-    build(Object & o, Extractor const & extr) { 
-      return self(&o, extr(o));
-    }
-    
-    PhiSortElement()
-      : pointer(nullptr) {}
-    PhiSortElement(Object * p, Scalar v):
-      pointer(p),
-      value(v) {}
-    
-    Object * pointer;
-    Scalar value;
-    
-    bool operator<(self const & rh) const {
-      return value<rh.value;
-    }
-    Object const &
-    obj() const { return *pointer;}
-  };
-  
-  
-}
-
-template<typename RandomAccessIterator, typename Extractor>
-void TrackerStablePhiSort(RandomAccessIterator begin,
-			  RandomAccessIterator end,
-			  const Extractor& extr) {
-  
-  typedef typename Extractor::result_type        Scalar;
-  typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
-  
-  typedef details::PhiSortElement<value_type, Scalar> Element;
-  
-  
-  
   std::vector<Element> tmpvec(end-begin);
-  std::transform(begin,end,tmpvec.begin(),
-		 std::bind(Element::template build<Extractor>,std::placeholders::_1, boost::cref(extr))
-		 );
-  
-  std::vector<Element> tmpcop(end-begin);
+  std::transform(begin,end,tmpvec.begin(), [&extr](Value& it){ return Element(extr(it), &it); });
   
   std::sort(tmpvec.begin(), tmpvec.end());
   
-  const unsigned int vecSize = tmpvec.size();
-  
-  
-  
-  // special tratment of the TEC modules of rings in petals near phi=0
-  // there are at most 5 modules, no other structure has less than ~10 elements to order in phi
-  // hence the special case in phi~0 if the size of the elements to order is <=5
+  // special tratment of the TEC modules of rings in petals near phi=0 there
+  // are at most 5 modules, no other structure has less than ~10 elements to
+  // order in phi hence the special case in phi~0 if the size of the elements
+  // to order is <=5
   const unsigned int nMaxModulesPerRing = 5;
-  bool phiZeroCase = true;
-  //
-  const double phiMin = M_PI_4;
-  const double phiMax = 2*M_PI-phiMin;
-  //
-  if( vecSize > nMaxModulesPerRing ) {
-    //stability check
+  const double       phiMin             = M_PI_4;
+  const double       phiMax             = 2 * M_PI - phiMin;
+  const double       tolerance          = 0.000001;
+  const unsigned int n                  = tmpvec.size();
+
+  if( n > nMaxModulesPerRing ) {
+    // stability check
     // check if the last element is too near to zero --> probably it is zero
-    double tolerance = 0.000001;
-    if( std::abs(tmpvec.back().value - 0) < tolerance       // near 0
-	||
-	std::abs(tmpvec.back().value - 2*M_PI) < tolerance ) { // near 2pi
+    if(    std::abs(tmpvec.back().first - 0)      < tolerance   // near 0
+        || std::abs(tmpvec.back().first - 2*M_PI) < tolerance ) // near 2pi
+    {
       // move it to front 
       tmpvec.insert(tmpvec.begin(),tmpvec.back());
       tmpvec.pop_back();
     }
-  }
-  else {
-    // check if all the elements have phi<phiMin or phi>phiMax to be sure we are near phi~0 (angles are in [0,2pi) range)
-    // if a phi goes out from [0,phiMin]U[phiMax,2pi) it is not the case
-    // sorted. if first > phiMax all other will also...
-    typename std::vector<Element>::iterator p = 
-      std::find_if(tmpvec.begin(),tmpvec.end(), boost::bind(&Element::value,_1) > phiMin);
-    phiZeroCase = !(p!=tmpvec.end() && (*p).value<phiMax);
+  } else {
+    // check if all the elements have phi<phiMin or phi>phiMax to be sure we
+    // are near phi~0 (angles are in [0,2pi) range) if a phi goes out from
+    // [0,phiMin]U[phiMax,2pi) it is not the case sorted. if first > phiMax all
+    // other will also...
+    auto p = std::find_if(tmpvec.begin(),tmpvec.end(), [&phiMin](auto const& x){ return x.first > phiMin; });
     
-    // go on if this is the petal phi~0 case, restricted to the case where all the |phi| are in range [0,phiMin]
-    if(phiZeroCase) {
-      // in this case the ordering must be: ('negative' values, >) and then ('positive' values, >) in (-pi,pi] mapping
-      // already sorted, just swap ranges
+    // go on if this is the petal phi~0 case, restricted to the case where all
+    // the |phi| are in range [0,phiMin]
+    if(p == tmpvec.end() || p->first >= phiMax) {
+      // in this case the ordering must be: ('negative' values, >) and then
+      // ('positive' values, >) in (-pi,pi] mapping already sorted, just swap
+      // ranges
       if(p!=tmpvec.end()) {
-	tmpvec.insert(tmpvec.begin(),p,tmpvec.end());
-	tmpvec.resize(vecSize);
+        tmpvec.insert(tmpvec.begin(),p,tmpvec.end());
+        tmpvec.resize(n);
       }
     }
   }
   
   // overwrite the input range with the sorted values
   // copy of input container not necessary, but tricky to avoid
-  std::vector<value_type> tmpvecy(vecSize);
-  std::transform(tmpvec.begin(),tmpvec.end(),tmpvecy.begin(),boost::bind(&Element::obj,_1));
+  std::vector<Value> tmpvecy(n);
+  std::transform(tmpvec.begin(),tmpvec.end(),tmpvecy.begin(), [](auto& x){ return *x.second; });
   std::copy(tmpvecy.begin(),tmpvecy.end(),begin);
-  
 }
 
 #endif
-

--- a/Geometry/TrackerNumberingBuilder/test/testTrackerPhiSort.cpp
+++ b/Geometry/TrackerNumberingBuilder/test/testTrackerPhiSort.cpp
@@ -1,36 +1,15 @@
-// io ho un link a boost
-// Boost1331 -> /afs/cern.ch/cms/external/lcg/external/Boost/1.33.1/slc4_ia32_gcc34/include/boost-1_33_1/
-// 
-// g++ -IBoost1331/ testTrackerPhiSort.cpp
-//  -g -O2 -fPIC -pthread
-// or
-// g++4 -O3 -pthread -IBoost1331/ testTrackerPhiSort.cpp
-// 
-// to compile use this command:
-// g++4 -O3 -pthread -I/afs/cern.ch/cms/external/lcg/external/Boost/1.33.1/slc4_ia32_gcc34/include/boost-1_33_1/ testTrackerPhiSort.cpp
-//
-
-
-#include "../interface/TrackerStablePhiSort.h"
-
+#include "../plugins/TrackerStablePhiSort.h"
 #include "FakeCPP.h"
 
-#include<cmath>
-#include<ctime>
+#include <cmath>
+#include <ctime>
+#include <vector>
+#include <algorithm>
+#include <random>
+#include <iostream>
 
-
-#include<vector>
-#include<algorithm>
-#include<iterator>
-#include <boost/function.hpp>
-#include <boost/bind.hpp>
-#include <boost/assign/std/vector.hpp>
-// for operator =+
-using namespace boost::assign;
-
-// stubs
 namespace {
-  
+
   struct XY {
     XY(double ix=0,double iy=0):x(ix),y(iy){}
     double x;
@@ -40,120 +19,87 @@ namespace {
     return a.x==b.x&&a.y==b.y;
   }
 
-  struct GetPhi {
-    typedef double result_type;
-    double operator()(XY const & xy) const {
-      static const double pi2 = 2.*M_PI;
-      return xy.y >= 0 ?  
-	std::atan2(xy.y,xy.x) :
-	pi2-std::atan2(-xy.y,xy.x);
-	//double phi = std::atan2(xy.y,xy.x);
-	//return phi<0 ? phi+pi2 : phi;
-    }
-  };
-
-
-  XY fromRP(double r, double phi) {
-    XY xy(r*std::cos(phi), r*std::sin(phi));
-    return xy;
+  double getPhi(XY const & xy) {
+    static const double pi2 = 2.*M_PI;
+    return xy.y >= 0 ? std::atan2(xy.y,xy.x) : pi2-std::atan2(-xy.y,xy.x);
   }
+
+  template<typename V>
+  void printPhi(V const & v ) {
+    for(auto const& x : v) std::cout << getPhi(x) << " ";
+    std::cout << std::endl;
+  }
+
 }
 
-
-template<typename T>
-inline void crap(T t1, T t2) {
-  std::random_shuffle(t1,t2);
-}
-
-template<typename V>
-void printPhi(V const & v ) {
-  std::transform(v.begin(),
-		 v.end(),
-		 std::ostream_iterator<double>(std::cout," "), 
-		 boost::bind(GetPhi(),_1)
-		 );
-		
-  std::cout << std::endl;
-}
-
-int main() {
+int main()
+{
   cppUnit::Dump a;
 
-  typedef std::vector<XY> Vector;
+  typedef std::vector<XY>     Vector;
+  typedef std::vector<Vector> Collection;
 
- typedef std::vector<Vector> Collection;
+  Collection original;
+  Collection shuffled;
+  Collection sorted;
 
-  Collection original, shuffled, sorted;
+  auto fromRP = [](double phi){ return XY(2*std::cos(phi), 2*std::sin(phi)); };
 
   // test1
   {
-    // ordered....
-    std::vector<double> phis; phis += 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3., 3.1, 4.2, 5.2, 6.25;
-    // add an almost 0 (but not quite)
-    phis += GetPhi()(XY(1.E5,-1.));
-    original += Vector(phis.size());
-    std::transform(phis.begin(),phis.end(),original.back().begin(),boost::bind(fromRP,2.,_1));
+    // ordered.... last element is almost 0 (but not quite)
+    std::vector<double> phis {0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3., 3.1, 4.2, 5.2, 6.25, getPhi(XY(1.E5,-1.))};
+    original.push_back(Vector(phis.size()));
+    std::transform(phis.begin(),phis.end(),original.back().begin(),fromRP);
   }  // test1
   {
-    // ordered....
-    std::vector<double> phis; phis += 0.000001, 0.5, 1.0, 1.5, 2.0, 2.5, 3., 3.1, 4.2, 5.2, 6.25;
-    // add an almost 0 (is zero for the algo)
-    phis.insert(phis.begin(),(GetPhi()(XY(1.E10,-1.))));
-    original += Vector(phis.size());
-    std::transform(phis.begin(),phis.end(),original.back().begin(),boost::bind(fromRP,2.,_1));
-  }		 
+    // ordered.... first element is almost 0 (is zero for the algo)
+    std::vector<double> phis {getPhi(XY(1.E10,-1.)), 0.000001, 0.5, 1.0, 1.5, 2.0, 2.5, 3., 3.1, 4.2, 5.2, 6.25, };
+    original.push_back(Vector(phis.size()));
+    std::transform(phis.begin(),phis.end(),original.back().begin(),fromRP);
+  }
   // TEC tests???
   {
     // ordered....
-    std::vector<double> phis; phis += 0.0, 0.5, 3., 5.2, 6.25;
-    original += Vector(phis.size());
-    std::transform(phis.begin(),phis.end(),original.back().begin(),boost::bind(fromRP,2.,_1));
-  }		 
-		 
+    std::vector<double> phis {0.0, 0.5, 3., 5.2, 6.25};
+    original.push_back(Vector(phis.size()));
+    std::transform(phis.begin(),phis.end(),original.back().begin(),fromRP);
+  }
   {
     // ordered....
-    std::vector<double> phis; phis += -0.1683, -0.0561, +0.0000, +0.0561 +0.1683;
-    original += Vector(phis.size());
-    std::transform(phis.begin(),phis.end(),original.back().begin(),boost::bind(fromRP,2.,_1));
-  }		 
+    std::vector<double> phis {-0.1683, -0.0561, +0.0000, +0.0561, +0.1683};
+    original.push_back(Vector(phis.size()));
+    std::transform(phis.begin(),phis.end(),original.back().begin(),fromRP);
+  }
 
 
-  std::for_each(original.begin(),original.end(),printPhi<Vector>);
+  for(auto const& v : original) printPhi<Vector>(v);
 
   // do the test
   shuffled.resize(original.size());
   sorted.resize(original.size());
   std::copy(original.begin(),original.end(),shuffled.begin());
-  // boost::function<void(Vector::iterator,Vector::iterator)> f = &std::random_shuffle<Vector::iterator>;
-  std::for_each(shuffled.begin(),shuffled.end(),
-		//		boost::bind(f,
-		//boost::bind(std::random_shuffle<Vector::iterator>,  no idea why does not compile....
-	       		    boost::bind(crap<Vector::iterator>,
-			    boost::bind<Vector::iterator>(&Vector::begin,_1),
-			    boost::bind<Vector::iterator>(&Vector::end,_1)
-			    )
-		);
- 
-  
+  auto rng = std::default_random_engine {};
+  for(auto& v : shuffled) {
+      std::shuffle(v.begin(), v.end(), rng);
+  }
+
   std::copy(shuffled.begin(),shuffled.end(),sorted.begin());
 
   CPPUNIT_ASSERT(original!=sorted);
 
   double before = std::clock();
-  std::for_each(sorted.begin(),sorted.end(),
-		boost::bind(TrackerStablePhiSort<Vector::iterator,GetPhi>,
-			    boost::bind<Vector::iterator>(&Vector::begin,_1),
-			    boost::bind<Vector::iterator>(&Vector::end,_1),GetPhi()
-			    )
-		);
+  for(auto& v : sorted) {
+      trackerStablePhiSort(v.begin(), v.end(), getPhi);
+  }
 
   double after = std::clock();
   std::cout << "elapsed " << (after-before)*0.01 << std::endl;
 
   CPPUNIT_ASSERT(original==sorted);
 
-  std::for_each(sorted.begin(),sorted.end(),printPhi<Vector>);
-
+  for(auto const& v : sorted) printPhi<Vector>(v);
   std::cout << std::endl;
+
   return 0;
 }

--- a/Geometry/TrackerNumberingBuilder/test/testTrackerPhiSort.cpp
+++ b/Geometry/TrackerNumberingBuilder/test/testTrackerPhiSort.cpp
@@ -1,4 +1,4 @@
-#include "../plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
 #include "FakeCPP.h"
 
 #include <cmath>
@@ -80,18 +80,14 @@ int main()
   sorted.resize(original.size());
   std::copy(original.begin(),original.end(),shuffled.begin());
   auto rng = std::default_random_engine {};
-  for(auto& v : shuffled) {
-      std::shuffle(v.begin(), v.end(), rng);
-  }
+  for(auto& v : shuffled) std::shuffle(v.begin(), v.end(), rng);
 
   std::copy(shuffled.begin(),shuffled.end(),sorted.begin());
 
   CPPUNIT_ASSERT(original!=sorted);
 
   double before = std::clock();
-  for(auto& v : sorted) {
-      trackerStablePhiSort(v.begin(), v.end(), getPhi);
-  }
+  for(auto& v : sorted) trackerStablePhiSort(v.begin(), v.end(), getPhi);
 
   double after = std::clock();
   std::cout << "elapsed " << (after-before)*0.01 << std::endl;

--- a/Geometry/TrackerNumberingBuilder/test/testTrackerPhiSort.cpp
+++ b/Geometry/TrackerNumberingBuilder/test/testTrackerPhiSort.cpp
@@ -1,4 +1,4 @@
-#include "Geometry/TrackerNumberingBuilder/plugins/TrackerStablePhiSort.h"
+#include "Geometry/TrackerNumberingBuilder/interface/trackerStablePhiSort.h"
 #include "FakeCPP.h"
 
 #include <cmath>
@@ -11,7 +11,7 @@
 namespace {
 
   struct XY {
-    XY(double ix=0,double iy=0):x(ix),y(iy){}
+    XY(double ix=0.,double iy=0.):x(ix),y(iy){}
     double x;
     double y;
   };
@@ -36,44 +36,43 @@ int main()
 {
   cppUnit::Dump a;
 
-  typedef std::vector<XY>     Vector;
-  typedef std::vector<Vector> Collection;
+  using Collection =  std::vector<std::vector<XY>>;
 
   Collection original;
   Collection shuffled;
   Collection sorted;
 
-  auto fromRP = [](double phi){ return XY(2*std::cos(phi), 2*std::sin(phi)); };
+  auto fromRP = [](double phi){ return XY(2.*std::cos(phi), 2.*std::sin(phi)); };
 
   // test1
   {
     // ordered.... last element is almost 0 (but not quite)
     std::vector<double> phis {0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3., 3.1, 4.2, 5.2, 6.25, getPhi(XY(1.E5,-1.))};
-    original.push_back(Vector(phis.size()));
+    original.emplace_back(phis.size());
     std::transform(phis.begin(),phis.end(),original.back().begin(),fromRP);
   }  // test1
   {
     // ordered.... first element is almost 0 (is zero for the algo)
     std::vector<double> phis {getPhi(XY(1.E10,-1.)), 0.000001, 0.5, 1.0, 1.5, 2.0, 2.5, 3., 3.1, 4.2, 5.2, 6.25, };
-    original.push_back(Vector(phis.size()));
+    original.emplace_back(phis.size());
     std::transform(phis.begin(),phis.end(),original.back().begin(),fromRP);
   }
   // TEC tests???
   {
     // ordered....
     std::vector<double> phis {0.0, 0.5, 3., 5.2, 6.25};
-    original.push_back(Vector(phis.size()));
+    original.emplace_back(phis.size());
     std::transform(phis.begin(),phis.end(),original.back().begin(),fromRP);
   }
   {
     // ordered....
     std::vector<double> phis {-0.1683, -0.0561, +0.0000, +0.0561, +0.1683};
-    original.push_back(Vector(phis.size()));
+    original.emplace_back(phis.size());
     std::transform(phis.begin(),phis.end(),original.back().begin(),fromRP);
   }
 
 
-  for(auto const& v : original) printPhi<Vector>(v);
+  for(auto const& v : original) printPhi(v);
 
   // do the test
   shuffled.resize(original.size());
@@ -94,7 +93,7 @@ int main()
 
   CPPUNIT_ASSERT(original==sorted);
 
-  for(auto const& v : sorted) printPhi<Vector>(v);
+  for(auto const& v : sorted) printPhi(v);
   std::cout << std::endl;
 
   return 0;


### PR DESCRIPTION
Hi, this is a follow up on https://github.com/cms-sw/cmssw/pull/24549, where I had to wrap some functions which did not inherit anymore from the `unary_function` into `std::functions` such that they could be used with the trackerStablePhiSort and mtdStablePhiSort. I knew that was not the most elegant solution, but since https://github.com/cms-sw/cmssw/pull/24549 was already a huge PR I accepted it for now. 

Here I propose a better solution with is to rewrite trackerStablePhiSort and mtdStablePhiSort in a way that they can take arbitrary function objects, including normal functions and lambdas. Basically the same as I did here https://github.com/cms-sw/cmssw/pull/25080 for the precomputed_value_sort.