### PR TITLE
elide newCombinedSeeds in electron seeding

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -69,7 +69,7 @@ class ElectronSeedGenerator
   void run(
     edm::Event&, const edm::EventSetup& setup,
     const reco::SuperClusterRefVector &, const std::vector<float> & hoe1s, const std::vector<float> & hoe2s,
-    const TrajectorySeedCollection *seeds, reco::ElectronSeedCollection&);
+    const std::vector<const TrajectorySeedCollection *>& seedsV, reco::ElectronSeedCollection&);
 
  private:
 
@@ -111,8 +111,7 @@ class ElectronSeedGenerator
   PixelHitMatcher *myMatchEle;
   PixelHitMatcher *myMatchPos;
 
-  //  edm::Handle<TrajectorySeedCollection> theInitialSeedColl;
-  const TrajectorySeedCollection* theInitialSeedColl;
+  const std::vector<const TrajectorySeedCollection*>* theInitialSeedCollV = nullptr;
 
   edm::ESHandle<MagneticField>                theMagField;
   edm::ESHandle<TrackerGeometry>              theTrackerGeometry;

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -69,13 +69,15 @@ class ElectronSeedGenerator
   void run(
     edm::Event&, const edm::EventSetup& setup,
     const reco::SuperClusterRefVector &, const std::vector<float> & hoe1s, const std::vector<float> & hoe2s,
-    TrajectorySeedCollection *seeds, reco::ElectronSeedCollection&);
+    const TrajectorySeedCollection *seeds, reco::ElectronSeedCollection&);
 
  private:
 
   void seedsFromThisCluster( edm::Ref<reco::SuperClusterCollection> seedCluster, float hoe1, float hoe2, reco::ElectronSeedCollection & out, const TrackerTopology *tTopo ) ;
-  void seedsFromRecHits( std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> > & elePixelHits, PropagationDirection & dir, const GlobalPoint & vertexPos, const reco::ElectronSeed::CaloClusterRef & cluster, reco::ElectronSeedCollection & out, bool positron ) ;
-  void seedsFromTrajectorySeeds( const std::vector<SeedWithInfo> & elePixelSeeds, const reco::ElectronSeed::CaloClusterRef & cluster, float hoe1, float hoe2, reco::ElectronSeedCollection & out, bool positron ) ;
+  void seedsFromRecHits( std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> > & elePixelHits, PropagationDirection & dir, 
+                         const GlobalPoint & vertexPos, const reco::ElectronSeed::CaloClusterRef & cluster, reco::ElectronSeedCollection & out, bool positron ) ;
+  void seedsFromTrajectorySeeds( const std::vector<SeedWithInfo> & elePixelSeeds, const reco::ElectronSeed::CaloClusterRef & cluster, 
+                                 float hoe1, float hoe2, reco::ElectronSeedCollection & out, bool positron ) ;
   void addSeed( reco::ElectronSeed & seed, const SeedWithInfo * info, bool positron, reco::ElectronSeedCollection & out ) ;
   bool prepareElTrackSeed( ConstRecHitPointer outerhit,ConstRecHitPointer innerhit, const GlobalPoint & vertexPos) ;
 
@@ -110,7 +112,7 @@ class ElectronSeedGenerator
   PixelHitMatcher *myMatchPos;
 
   //  edm::Handle<TrajectorySeedCollection> theInitialSeedColl;
-  TrajectorySeedCollection* theInitialSeedColl;
+  const TrajectorySeedCollection* theInitialSeedColl;
 
   edm::ESHandle<MagneticField>                theMagField;
   edm::ESHandle<TrackerGeometry>              theTrackerGeometry;

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
@@ -185,7 +185,7 @@ class PixelHitMatcher
 
     std::vector<SeedWithInfo>
     compatibleSeeds
-      ( TrajectorySeedCollection * seeds, const GlobalPoint & xmeas,
+      ( const TrajectorySeedCollection * seeds, const GlobalPoint & xmeas,
         const GlobalPoint & vprim, float energy, float charge ) ;
 
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
@@ -185,7 +185,7 @@ class PixelHitMatcher
 
     std::vector<SeedWithInfo>
     compatibleSeeds
-      ( const TrajectorySeedCollection * seeds, const GlobalPoint & xmeas,
+      ( const std::vector<const TrajectorySeedCollection *>& seedsV, const GlobalPoint & xmeas,
         const GlobalPoint & vprim, float energy, float charge ) ;
 
 

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -220,7 +220,7 @@ bool equivalent( const TrajectorySeed & s1, const TrajectorySeed & s2 )
 void  ElectronSeedGenerator::run
  ( edm::Event & e, const edm::EventSetup & setup,
    const reco::SuperClusterRefVector & sclRefs, const std::vector<float> & hoe1s, const std::vector<float> & hoe2s,
-   TrajectorySeedCollection * seeds, reco::ElectronSeedCollection & out )
+   const TrajectorySeedCollection * seeds, reco::ElectronSeedCollection & out )
  {
   theInitialSeedColl = seeds ;
 //  bool duplicateTrajectorySeeds =false ;

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -220,9 +220,9 @@ bool equivalent( const TrajectorySeed & s1, const TrajectorySeed & s2 )
 void  ElectronSeedGenerator::run
  ( edm::Event & e, const edm::EventSetup & setup,
    const reco::SuperClusterRefVector & sclRefs, const std::vector<float> & hoe1s, const std::vector<float> & hoe2s,
-   const TrajectorySeedCollection * seeds, reco::ElectronSeedCollection & out )
+   const std::vector<const TrajectorySeedCollection *>& seedsV, reco::ElectronSeedCollection & out )
  {
-  theInitialSeedColl = seeds ;
+   theInitialSeedCollV = &seedsV;
 //  bool duplicateTrajectorySeeds =false ;
 //  unsigned int i,j ;
 //  for (i=0;i<seeds->size();++i)
@@ -259,9 +259,6 @@ void  ElectronSeedGenerator::run
   e.getByToken(theMeasurementTrackerEventTag, data);
   myMatchEle->setEvent(*data);
   myMatchPos->setEvent(*data);
-
-  // get initial TrajectorySeeds if necessary
-  //  if (fromTrackerSeeds_) e.getByToken(initialSeeds_, theInitialSeedColl);
 
   // get the beamspot from the Event:
   //e.getByType(theBeamSpot);
@@ -371,11 +368,11 @@ void ElectronSeedGenerator::seedsFromThisCluster
      {
       // try electron
       std::vector<SeedWithInfo> elePixelSeeds
-       = myMatchEle->compatibleSeeds(theInitialSeedColl,clusterPos,vertexPos,clusterEnergy,-1.) ;
+       = myMatchEle->compatibleSeeds(*theInitialSeedCollV,clusterPos,vertexPos,clusterEnergy,-1.) ;
       seedsFromTrajectorySeeds(elePixelSeeds,caloCluster,hoe1,hoe2,out,false) ;
       // try positron
       std::vector<SeedWithInfo> posPixelSeeds
-       = myMatchPos->compatibleSeeds(theInitialSeedColl,clusterPos,vertexPos,clusterEnergy,1.) ;
+       = myMatchPos->compatibleSeeds(*theInitialSeedCollV,clusterPos,vertexPos,clusterEnergy,1.) ;
       seedsFromTrajectorySeeds(posPixelSeeds,caloCluster,hoe1,hoe2,out,true) ;
      }
 
@@ -425,11 +422,11 @@ void ElectronSeedGenerator::seedsFromThisCluster
        {
         // try electron
         std::vector<SeedWithInfo> elePixelSeeds
-         = myMatchEle->compatibleSeeds(theInitialSeedColl,clusterPos,vertexPos,clusterEnergy,-1.) ;
+         = myMatchEle->compatibleSeeds(*theInitialSeedCollV,clusterPos,vertexPos,clusterEnergy,-1.) ;
         seedsFromTrajectorySeeds(elePixelSeeds,caloCluster,hoe1,hoe2,out,false) ;
         // try positron
         std::vector<SeedWithInfo> posPixelSeeds
-         = myMatchPos->compatibleSeeds(theInitialSeedColl,clusterPos,vertexPos,clusterEnergy,1.) ;
+         = myMatchPos->compatibleSeeds(*theInitialSeedCollV,clusterPos,vertexPos,clusterEnergy,1.) ;
         seedsFromTrajectorySeeds(posPixelSeeds,caloCluster,hoe1,hoe2,out,true) ;
        }
      }

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -97,7 +97,7 @@ float PixelHitMatcher::getVertex()
 
 std::vector<SeedWithInfo>
 PixelHitMatcher::compatibleSeeds
- ( TrajectorySeedCollection * seeds, const GlobalPoint & xmeas,
+ ( const TrajectorySeedCollection * seeds, const GlobalPoint & xmeas,
    const GlobalPoint & vprim, float energy, float fcharge )
  {
    typedef std::unordered_map<const GeomDet *, TrajectoryStateOnSurface> DetTsosAssoc;

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -97,7 +97,7 @@ float PixelHitMatcher::getVertex()
 
 std::vector<SeedWithInfo>
 PixelHitMatcher::compatibleSeeds
- ( const TrajectorySeedCollection * seeds, const GlobalPoint & xmeas,
+( const std::vector<const TrajectorySeedCollection *>& seedsV, const GlobalPoint & xmeas,
    const GlobalPoint & vprim, float energy, float fcharge )
  {
    typedef std::unordered_map<const GeomDet *, TrajectoryStateOnSurface> DetTsosAssoc;
@@ -115,11 +115,11 @@ PixelHitMatcher::compatibleSeeds
   TrajectoryStateOnSurface tsos(fts, *bpb(fts.position(), fts.momentum()));
   
   std::vector<SeedWithInfo> result ;
-  
-  //mapTsos_fast_.clear();  
+  unsigned int allSeedsSize = 0;
+  for (auto const sc : seedsV) allSeedsSize += sc->size();
+
   mapTsos2_fast_.clear();  
-  // mapTsos_fast_.reserve(seeds->size()) ;
-  mapTsos2_fast_.reserve(seeds->size()) ;
+  mapTsos2_fast_.reserve(allSeedsSize) ;
 
   // std::vector<TrajectoryStateOnSurface> vTsos(theTrackerGeometry->dets().size());
   // TrajectoryStateOnSurface vTsos[theTrackerGeometry->dets().size()];
@@ -128,110 +128,111 @@ PixelHitMatcher::compatibleSeeds
 
   int iTsos[ndets];
   for ( auto & i : iTsos) i=-1;
-  std::vector<TrajectoryStateOnSurface> vTsos; vTsos.reserve(seeds->size());
+  std::vector<TrajectoryStateOnSurface> vTsos; vTsos.reserve(allSeedsSize);
 
-  for(const auto& seed : *seeds) {
-    hit_gp_map_.clear();
-    if( seed.nHits() > 9 ) {
-      edm::LogWarning("GsfElectronAlgo|UnexpectedSeed") <<"We cannot deal with seeds having more than 9 hits." ;
-      continue;
-    }
-    
-    const TrajectorySeed::range& hits = seed.recHits();
-    // cache the global points
-   
-    for( auto it = hits.first; it != hits.second; ++it ) {
-      hit_gp_map_.emplace_back(it->globalPosition());      
-    }
-
-    //iterate on the hits 
-    auto he =  hits.second -1;   
-    for( auto it1 = hits.first; it1 < he; ++it1 ) {
-      if( !it1->isValid() ) continue;
-      auto  idx1 = std::distance(hits.first,it1);
-      const DetId id1 = it1->geographicalId();
-      const GeomDet *geomdet1 = it1->det();
-
-      auto ix1 = geomdet1->gdetIndex();
-
-      /*  VI: this generates regression (other cut is just in phi). in my opinion it is safe and makes sense
-      auto away = geomdet1->position().basicVector().dot(xmeas.basicVector()) <0;
-      if (away) continue;
-      */
-
-      const GlobalPoint& hit1Pos = hit_gp_map_[idx1];
-      auto dt = hit1Pos.x()*xmeas.x()+hit1Pos.y()*xmeas.y();
-      if (dt<0) continue;
-      if (dt<phicut*(xmeas_r*hit1Pos.perp())) continue;
-
-      if(iTsos[ix1]<0)   {
-        iTsos[ix1] = vTsos.size();
-        vTsos.push_back(prop1stLayer->propagate(tsos,geomdet1->surface()));
+  for (const auto seeds : seedsV) {
+    for(const auto& seed : *seeds) {
+      hit_gp_map_.clear();
+      if( seed.nHits() > 9 ) {
+        edm::LogWarning("GsfElectronAlgo|UnexpectedSeed") <<"We cannot deal with seeds having more than 9 hits." ;
+        continue;
       }
-      auto tsos1 = &vTsos[iTsos[ix1]];
-
-      if( !tsos1->isValid() ) continue;
-      std::pair<bool, double> est = ( id1.subdetId() % 2 ? 
-				      meas1stBLayer.estimate(vprim, *tsos1, hit1Pos) :
-				      meas1stFLayer.estimate(vprim, *tsos1, hit1Pos)  );
-      if( !est.first ) continue;
-      EleRelPointPair pp1(hit1Pos,tsos1->globalParameters().position(),vprim);
-      const math::XYZPoint relHit1Pos(hit1Pos-vprim), relTSOSPos(tsos1->globalParameters().position() - vprim);
-      const int subDet1 = id1.subdetId();
-      const float dRz1 = ( id1.subdetId()%2 ? pp1.dZ() : pp1.dPerp() );
-      const float dPhi1 = pp1.dPhi();
-      // setup our vertex
-      double zVertex;
-      if (!useRecoVertex_) {
-	// we don't know the z vertex position, get it from linear extrapolation
-	// compute the z vertex from the cluster point and the found pixel hit
-	const double pxHit1z = hit1Pos.z();
-	const double pxHit1x = hit1Pos.x();
-	const double pxHit1y = hit1Pos.y();
-	const double r1diff = std::sqrt( (pxHit1x-vprim.x())*(pxHit1x-vprim.x()) + 
-					 (pxHit1y-vprim.y())*(pxHit1y-vprim.y())   );
-	const double r2diff = std::sqrt( (xmeas.x()-pxHit1x)*(xmeas.x()-pxHit1x) + 
-					 (xmeas.y()-pxHit1y)*(xmeas.y()-pxHit1y)   );
-	zVertex = pxHit1z - r1diff*(xmeas.z()-pxHit1z)/r2diff;
-      } else { 
-	// here use rather the reco vertex z position
-	zVertex = vprim.z(); 
+      
+      const TrajectorySeed::range& hits = seed.recHits();
+      // cache the global points
+      
+      for( auto it = hits.first; it != hits.second; ++it ) {
+        hit_gp_map_.emplace_back(it->globalPosition());      
       }
-      GlobalPoint vertex(vprim.x(),vprim.y(),zVertex);
-      FreeTrajectoryState fts2 = FTSFromVertexToPointFactory::get(*theMagField, hit1Pos, vertex, energy, charge) ;
-      // now find the matching hit
-      for( auto it2 = it1+1; it2 != hits.second; ++it2 ) {
-	if( !it2->isValid() ) continue;
-	auto idx2 = std::distance(hits.first,it2);
-	const DetId id2 = it2->geographicalId();
-	const GeomDet *geomdet2 = it2->det();
-	const std::pair<const GeomDet *,GlobalPoint> det_key(geomdet2,hit1Pos);	
-	const TrajectoryStateOnSurface* tsos2;
-	auto tsos2_itr = mapTsos2_fast_.find(det_key);
-	if( tsos2_itr != mapTsos2_fast_.end() ) {
-	  tsos2 = &(tsos2_itr->second);
-	} else {
-	  auto empl_result =
-	    mapTsos2_fast_.emplace(det_key,prop2ndLayer->propagate(fts2,geomdet2->surface()));
-	  tsos2 = &(empl_result.first->second);
-	}
-	if( !tsos2->isValid() ) continue;
-	const GlobalPoint& hit2Pos = hit_gp_map_[idx2];
-	std::pair<bool,double> est2  = ( id2.subdetId()%2 ? 
-					 meas2ndBLayer.estimate(vertex, *tsos2,hit2Pos) :
-					 meas2ndFLayer.estimate(vertex, *tsos2,hit2Pos)   );
-	if (est2.first) {
-	  EleRelPointPair pp2(hit2Pos,tsos2->globalParameters().position(),vertex) ;
-	  const int subDet2 = id2.subdetId();
-	  const float dRz2 = (subDet2%2==1)?pp2.dZ():pp2.dPerp();
-	  const float dPhi2 = pp2.dPhi();
-	  const unsigned char hitsMask = (1<<idx1)|(1<<idx2);
-	  result.push_back(SeedWithInfo(seed,hitsMask,subDet2,dRz2,dPhi2,subDet1,dRz1,dPhi1)) ;
-	}
-      }// inner loop on hits
-    }// outer loop on hits
-  }// loop on seeds  
-
+      
+      //iterate on the hits 
+      auto he =  hits.second -1;   
+      for( auto it1 = hits.first; it1 < he; ++it1 ) {
+        if( !it1->isValid() ) continue;
+        auto  idx1 = std::distance(hits.first,it1);
+        const DetId id1 = it1->geographicalId();
+        const GeomDet *geomdet1 = it1->det();
+        
+        auto ix1 = geomdet1->gdetIndex();
+        
+        /*  VI: this generates regression (other cut is just in phi). in my opinion it is safe and makes sense
+            auto away = geomdet1->position().basicVector().dot(xmeas.basicVector()) <0;
+            if (away) continue;
+        */
+        
+        const GlobalPoint& hit1Pos = hit_gp_map_[idx1];
+        auto dt = hit1Pos.x()*xmeas.x()+hit1Pos.y()*xmeas.y();
+        if (dt<0) continue;
+        if (dt<phicut*(xmeas_r*hit1Pos.perp())) continue;
+        
+        if(iTsos[ix1]<0)   {
+          iTsos[ix1] = vTsos.size();
+          vTsos.push_back(prop1stLayer->propagate(tsos,geomdet1->surface()));
+        }
+        auto tsos1 = &vTsos[iTsos[ix1]];
+        
+        if( !tsos1->isValid() ) continue;
+        std::pair<bool, double> est = ( id1.subdetId() % 2 ? 
+                                        meas1stBLayer.estimate(vprim, *tsos1, hit1Pos) :
+                                        meas1stFLayer.estimate(vprim, *tsos1, hit1Pos)  );
+        if( !est.first ) continue;
+        EleRelPointPair pp1(hit1Pos,tsos1->globalParameters().position(),vprim);
+        const math::XYZPoint relHit1Pos(hit1Pos-vprim), relTSOSPos(tsos1->globalParameters().position() - vprim);
+        const int subDet1 = id1.subdetId();
+        const float dRz1 = ( id1.subdetId()%2 ? pp1.dZ() : pp1.dPerp() );
+        const float dPhi1 = pp1.dPhi();
+        // setup our vertex
+        double zVertex;
+        if (!useRecoVertex_) {
+          // we don't know the z vertex position, get it from linear extrapolation
+          // compute the z vertex from the cluster point and the found pixel hit
+          const double pxHit1z = hit1Pos.z();
+          const double pxHit1x = hit1Pos.x();
+          const double pxHit1y = hit1Pos.y();
+          const double r1diff = std::sqrt( (pxHit1x-vprim.x())*(pxHit1x-vprim.x()) + 
+                                           (pxHit1y-vprim.y())*(pxHit1y-vprim.y())   );
+          const double r2diff = std::sqrt( (xmeas.x()-pxHit1x)*(xmeas.x()-pxHit1x) + 
+                                           (xmeas.y()-pxHit1y)*(xmeas.y()-pxHit1y)   );
+          zVertex = pxHit1z - r1diff*(xmeas.z()-pxHit1z)/r2diff;
+        } else { 
+          // here use rather the reco vertex z position
+          zVertex = vprim.z(); 
+        }
+        GlobalPoint vertex(vprim.x(),vprim.y(),zVertex);
+        FreeTrajectoryState fts2 = FTSFromVertexToPointFactory::get(*theMagField, hit1Pos, vertex, energy, charge) ;
+        // now find the matching hit
+        for( auto it2 = it1+1; it2 != hits.second; ++it2 ) {
+          if( !it2->isValid() ) continue;
+          auto idx2 = std::distance(hits.first,it2);
+          const DetId id2 = it2->geographicalId();
+          const GeomDet *geomdet2 = it2->det();
+          const std::pair<const GeomDet *,GlobalPoint> det_key(geomdet2,hit1Pos);	
+          const TrajectoryStateOnSurface* tsos2;
+          auto tsos2_itr = mapTsos2_fast_.find(det_key);
+          if( tsos2_itr != mapTsos2_fast_.end() ) {
+            tsos2 = &(tsos2_itr->second);
+          } else {
+            auto empl_result =
+              mapTsos2_fast_.emplace(det_key,prop2ndLayer->propagate(fts2,geomdet2->surface()));
+            tsos2 = &(empl_result.first->second);
+          }
+          if( !tsos2->isValid() ) continue;
+          const GlobalPoint& hit2Pos = hit_gp_map_[idx2];
+          std::pair<bool,double> est2  = ( id2.subdetId()%2 ? 
+                                           meas2ndBLayer.estimate(vertex, *tsos2,hit2Pos) :
+                                           meas2ndFLayer.estimate(vertex, *tsos2,hit2Pos)   );
+          if (est2.first) {
+            EleRelPointPair pp2(hit2Pos,tsos2->globalParameters().position(),vertex) ;
+            const int subDet2 = id2.subdetId();
+            const float dRz2 = (subDet2%2==1)?pp2.dZ():pp2.dPerp();
+            const float dPhi2 = pp2.dPhi();
+            const unsigned char hitsMask = (1<<idx1)|(1<<idx2);
+            result.push_back(SeedWithInfo(seed,hitsMask,subDet2,dRz2,dPhi2,subDet1,dRz1,dPhi1)) ;
+          }
+        }// inner loop on hits
+      }// outer loop on hits
+    }// loop on seeds  
+  }//loop on vector of seeds
   mapTsos2_fast_.clear() ;
  
   return result ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -197,13 +197,21 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
      {
       edm::Handle<TrajectorySeedCollection> hSeeds;
       e.getByToken(initialSeeds_, hSeeds);
-      theInitialSeedColl = const_cast<TrajectorySeedCollection *> (hSeeds.product());
+      theInitialSeedCollConst = hSeeds.product();
+      theInitialSeedColl = nullptr;// not needed in this case
      }
     else
-     { theInitialSeedColl = new TrajectorySeedCollection ; }
+     { 
+       theInitialSeedCollConst = nullptr;//reset later
+       theInitialSeedColl = new TrajectorySeedCollection ; 
+     }
    }
   else
-   { theInitialSeedColl = nullptr ; } // not needed in this case
+   {
+     // not needed in this case
+     theInitialSeedCollConst = nullptr;
+     theInitialSeedColl = nullptr ; 
+   }
 
   ElectronSeedCollection * seeds = new ElectronSeedCollection ;
 
@@ -216,7 +224,7 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
     filterClusters(*theBeamSpot,clusters,/*mhbhe_,*/clusterRefs,hoe1s,hoe2s,e, iSetup);
     if ((fromTrackerSeeds_) && (prefilteredSeeds_))
       { filterSeeds(e,iSetup,clusterRefs) ; }
-    matcher_->run(e,iSetup,clusterRefs,hoe1s,hoe2s,theInitialSeedColl,*seeds);
+    matcher_->run(e,iSetup,clusterRefs,hoe1s,hoe2s,theInitialSeedCollConst,*seeds);
   }
 
   // store the accumulated result
@@ -316,7 +324,8 @@ void ElectronSeedProducer::filterSeeds
   for ( unsigned int i=0 ; i<sclRefs.size() ; ++i )
    {
     seedFilter_->seeds(event,setup,sclRefs[i],theInitialSeedColl) ;
-    LogDebug("ElectronSeedProducer")<<"Number of Seeds: "<<theInitialSeedColl->size() ;
+    theInitialSeedCollConst = theInitialSeedColl;
+    LogDebug("ElectronSeedProducer")<<"Number of Seeds: "<<theInitialSeedCollConst->size() ;
    }
  }
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -48,6 +48,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "FWCore/Utilities/interface/transform.h"
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
@@ -58,67 +59,76 @@
 using namespace reco ;
 
 ElectronSeedProducer::ElectronSeedProducer( const edm::ParameterSet& iConfig )
- : //conf_(iConfig),
-   applyHOverECut_(true), hcalHelper_(nullptr),
+ : applyHOverECut_(true), hcalHelper_(nullptr),
    caloGeom_(nullptr), caloGeomCacheId_(0), caloTopo_(nullptr), caloTopoCacheId_(0)
  {
-  conf_ = iConfig.getParameter<edm::ParameterSet>("SeedConfiguration") ;
+  auto const& conf = iConfig.getParameter<edm::ParameterSet>("SeedConfiguration") ;
 
-  initialSeeds_ = consumes<TrajectorySeedCollection>(conf_.getParameter<edm::InputTag>("initialSeeds")) ;
-  SCEtCut_ = conf_.getParameter<double>("SCEtCut");
-  fromTrackerSeeds_ = conf_.getParameter<bool>("fromTrackerSeeds") ;
-  prefilteredSeeds_ = conf_.getParameter<bool>("preFilteredSeeds") ;
+  auto legacyConfSeeds = conf.getParameter<edm::InputTag>("initialSeeds");
+  if (legacyConfSeeds.label().empty())
+    {//new format
+      initialSeeds_ = edm::vector_transform(conf.getParameter<std::vector<edm::InputTag> >( "initialSeedsVector" ), 
+                                            [this](edm::InputTag const & tag){return consumes<TrajectorySeedCollection >(tag);});
+    } 
+  else
+    {
+      initialSeeds_ = {consumes<TrajectorySeedCollection>(conf.getParameter<edm::InputTag>("initialSeeds"))};
+    }
+
+  SCEtCut_ = conf.getParameter<double>("SCEtCut");
+  fromTrackerSeeds_ = conf.getParameter<bool>("fromTrackerSeeds") ;
+  prefilteredSeeds_ = conf.getParameter<bool>("preFilteredSeeds") ;
 
   auto theconsumes = consumesCollector();
 
   // new beamSpot tag
-  beamSpotTag_ = consumes<reco::BeamSpot>(conf_.getParameter<edm::InputTag>("beamSpot")); 
+  beamSpotTag_ = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpot")); 
 
   // for H/E
-  applyHOverECut_ = conf_.getParameter<bool>("applyHOverECut") ;
+  applyHOverECut_ = conf.getParameter<bool>("applyHOverECut") ;
   if (applyHOverECut_)
    {
      ElectronHcalHelper::Configuration hcalCfg ;
-     hcalCfg.hOverEConeSize = conf_.getParameter<double>("hOverEConeSize") ;
+     hcalCfg.hOverEConeSize = conf.getParameter<double>("hOverEConeSize") ;
      if (hcalCfg.hOverEConeSize>0)
        {
 	 hcalCfg.useTowers = true ;
 	 hcalCfg.hcalTowers = 
-	   consumes<CaloTowerCollection>(conf_.getParameter<edm::InputTag>("hcalTowers")) ;
-	 hcalCfg.hOverEPtMin = conf_.getParameter<double>("hOverEPtMin") ;
+	   consumes<CaloTowerCollection>(conf.getParameter<edm::InputTag>("hcalTowers")) ;
+	 hcalCfg.hOverEPtMin = conf.getParameter<double>("hOverEPtMin") ;
        }
      hcalHelper_ = new ElectronHcalHelper(hcalCfg) ;
      
-     allowHGCal_ = conf_.getParameter<bool>("allowHGCal");
+     allowHGCal_ = conf.getParameter<bool>("allowHGCal");
      if( allowHGCal_ ) {
-       const edm::ParameterSet& hgcCfg = conf_.getParameterSet("HGCalConfig");
+       const edm::ParameterSet& hgcCfg = conf.getParameterSet("HGCalConfig");
        hgcClusterTools_.reset( new hgcal::ClusterTools(hgcCfg, theconsumes) );
      }
      
-     maxHOverEBarrel_=conf_.getParameter<double>("maxHOverEBarrel") ;
-     maxHOverEEndcaps_=conf_.getParameter<double>("maxHOverEEndcaps") ;
-     maxHBarrel_=conf_.getParameter<double>("maxHBarrel") ;
-     maxHEndcaps_=conf_.getParameter<double>("maxHEndcaps") ;
+     maxHOverEBarrel_=conf.getParameter<double>("maxHOverEBarrel") ;
+     maxHOverEEndcaps_=conf.getParameter<double>("maxHOverEEndcaps") ;
+     maxHBarrel_=conf.getParameter<double>("maxHBarrel") ;
+     maxHEndcaps_=conf.getParameter<double>("maxHEndcaps") ;
    }
 
-  applySigmaIEtaIEtaCut_ = conf_.getParameter<bool>("applySigmaIEtaIEtaCut");
+  applySigmaIEtaIEtaCut_ = conf.getParameter<bool>("applySigmaIEtaIEtaCut");
 
   // apply sigma_ieta_ieta cut
   if (applySigmaIEtaIEtaCut_ == true)
     {
-      maxSigmaIEtaIEtaBarrel_ = conf_.getParameter<double>("maxSigmaIEtaIEtaBarrel");
-      maxSigmaIEtaIEtaEndcaps_ = conf_.getParameter<double>("maxSigmaIEtaIEtaEndcaps");
+      maxSigmaIEtaIEtaBarrel_ = conf.getParameter<double>("maxSigmaIEtaIEtaBarrel");
+      maxSigmaIEtaIEtaEndcaps_ = conf.getParameter<double>("maxSigmaIEtaIEtaEndcaps");
     }
 
-  edm::ParameterSet rpset = conf_.getParameter<edm::ParameterSet>("RegionPSet");
+  edm::ParameterSet rpset = conf.getParameter<edm::ParameterSet>("RegionPSet");
   filterVtxTag_ = consumes<std::vector<reco::Vertex> >(rpset.getParameter<edm::InputTag> ("VertexProducer"));
 
   ElectronSeedGenerator::Tokens esg_tokens;
   esg_tokens.token_bs = beamSpotTag_;
-  esg_tokens.token_vtx = mayConsume<reco::VertexCollection>(conf_.getParameter<edm::InputTag>("vertices"));
-  esg_tokens.token_measTrkEvt= consumes<MeasurementTrackerEvent>(conf_.getParameter<edm::InputTag>("measurementTrackerEvent"));
+  esg_tokens.token_vtx = mayConsume<reco::VertexCollection>(conf.getParameter<edm::InputTag>("vertices"));
+  esg_tokens.token_measTrkEvt= consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("measurementTrackerEvent"));
 
-  matcher_ = new ElectronSeedGenerator(conf_,esg_tokens) ;
+  matcher_ = new ElectronSeedGenerator(conf,esg_tokens) ;
 
   //  get collections from config
   if (applySigmaIEtaIEtaCut_ == true) {
@@ -142,7 +152,7 @@ ElectronSeedProducer::ElectronSeedProducer( const edm::ParameterSet& iConfig )
     sf_tokens.token_bs  = beamSpotTag_;
     sf_tokens.token_vtx = filterVtxTag_;
     edm::ConsumesCollector iC = consumesCollector();
-    seedFilter_.reset(new SeedFilter(conf_, sf_tokens, iC));
+    seedFilter_.reset(new SeedFilter(conf, sf_tokens, iC));
   }
 
   //register your products
@@ -195,21 +205,26 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
    {
     if (!prefilteredSeeds_)
      {
-      edm::Handle<TrajectorySeedCollection> hSeeds;
-      e.getByToken(initialSeeds_, hSeeds);
-      theInitialSeedCollConst = hSeeds.product();
-      theInitialSeedColl = nullptr;// not needed in this case
+       theInitialSeedColls.clear();
+       for (auto const& seeds : initialSeeds_)
+         {
+           edm::Handle<TrajectorySeedCollection> hSeeds;
+           e.getByToken(seeds, hSeeds);
+           theInitialSeedColls.push_back(hSeeds.product());
+         }
+       theInitialSeedColl = nullptr;// not needed in this case
+
      }
     else
      { 
-       theInitialSeedCollConst = nullptr;//reset later
+       theInitialSeedColls.clear();//reset later
        theInitialSeedColl = new TrajectorySeedCollection ; 
      }
    }
   else
    {
      // not needed in this case
-     theInitialSeedCollConst = nullptr;
+     theInitialSeedColls.clear();
      theInitialSeedColl = nullptr ; 
    }
 
@@ -224,7 +239,7 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
     filterClusters(*theBeamSpot,clusters,/*mhbhe_,*/clusterRefs,hoe1s,hoe2s,e, iSetup);
     if ((fromTrackerSeeds_) && (prefilteredSeeds_))
       { filterSeeds(e,iSetup,clusterRefs) ; }
-    matcher_->run(e,iSetup,clusterRefs,hoe1s,hoe2s,theInitialSeedCollConst,*seeds);
+    matcher_->run(e,iSetup,clusterRefs,hoe1s,hoe2s,theInitialSeedColls,*seeds);
   }
 
   // store the accumulated result
@@ -324,8 +339,8 @@ void ElectronSeedProducer::filterSeeds
   for ( unsigned int i=0 ; i<sclRefs.size() ; ++i )
    {
     seedFilter_->seeds(event,setup,sclRefs[i],theInitialSeedColl) ;
-    theInitialSeedCollConst = theInitialSeedColl;
-    LogDebug("ElectronSeedProducer")<<"Number of Seeds: "<<theInitialSeedCollConst->size() ;
+    theInitialSeedColls.push_back(theInitialSeedColl);
+    LogDebug("ElectronSeedProducer")<<"Number of Seeds: "<<theInitialSeedColl->size() ;
    }
  }
 
@@ -377,7 +392,8 @@ ElectronSeedProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
     psd0.add<double>("r2MaxF",0.15);
     psd0.add<double>("hOverEConeSize",0.15);
     psd0.add<double>("pPhiMin1",-0.075);
-    psd0.add<edm::InputTag>("initialSeeds",edm::InputTag("newCombinedSeeds"));
+    psd0.add<edm::InputTag>("initialSeeds",edm::InputTag(""));//keep for be compatibility
+    psd0.add<std::vector<edm::InputTag>>("initialSeedsVector",{{"newCombinedSeeds"}});
     psd0.add<double>("deltaZ1WithVertex",25.0);
     psd0.add<double>("SCEtCut",0.0);
     psd0.add<double>("z2MaxB",0.09);

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
@@ -74,6 +74,7 @@ class ElectronSeedProducer : public edm::stream::EDProducer<>
     std::unique_ptr<SeedFilter> seedFilter_;
 
     TrajectorySeedCollection * theInitialSeedColl ;
+    const TrajectorySeedCollection * theInitialSeedCollConst ;
 
     // for the filter
     // H/E

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
@@ -63,18 +63,17 @@ class ElectronSeedProducer : public edm::stream::EDProducer<>
     void filterSeeds(edm::Event& e, const edm::EventSetup& setup, reco::SuperClusterRefVector &sclRefs);
     
     edm::EDGetTokenT<reco::SuperClusterCollection> superClusters_[2] ;
-    edm::EDGetTokenT<TrajectorySeedCollection> initialSeeds_ ;
+    std::vector<edm::EDGetTokenT<TrajectorySeedCollection>> initialSeeds_ ;
     edm::EDGetTokenT<std::vector<reco::Vertex> > filterVtxTag_;
     edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_ ;
     edm::EDGetTokenT<EcalRecHitCollection> ebRecHitCollection_;
     edm::EDGetTokenT<EcalRecHitCollection> eeRecHitCollection_;
 
-    edm::ParameterSet conf_ ;
     ElectronSeedGenerator * matcher_ ;
     std::unique_ptr<SeedFilter> seedFilter_;
 
-    TrajectorySeedCollection * theInitialSeedColl ;
-    const TrajectorySeedCollection * theInitialSeedCollConst ;
+    TrajectorySeedCollection * theInitialSeedColl ;//created on the fly
+    std::vector<const TrajectorySeedCollection *> theInitialSeedColls ;
 
     // for the filter
     // H/E

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
@@ -1,11 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoTracker.IterativeTracking.ElectronSeeds_cff import newCombinedSeeds as _newCombinedSeeds
+
 ecalDrivenElectronSeedsParameters = cms.PSet(
 
     # steering
     fromTrackerSeeds = cms.bool(True),
     initialSeeds = cms.InputTag(""),
-    initialSeedsVector = cms.VInputTag( "newCombinedSeeds" ),
+    initialSeedsVector = _newCombinedSeeds.seedCollections,
     preFilteredSeeds = cms.bool(False),
     useRecoVertex = cms.bool(False),
     vertices = cms.InputTag("offlinePrimaryVerticesWithBS"),

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
@@ -4,7 +4,8 @@ ecalDrivenElectronSeedsParameters = cms.PSet(
 
     # steering
     fromTrackerSeeds = cms.bool(True),
-    initialSeeds = cms.InputTag("newCombinedSeeds"),
+    initialSeeds = cms.InputTag(""),
+    initialSeedsVector = cms.VInputTag( "newCombinedSeeds" ),
     preFilteredSeeds = cms.bool(False),
     useRecoVertex = cms.bool(False),
     vertices = cms.InputTag("offlinePrimaryVerticesWithBS"),

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
@@ -7,6 +7,7 @@ ecalDrivenElectronSeedsParameters = cms.PSet(
     # steering
     fromTrackerSeeds = cms.bool(True),
     initialSeeds = cms.InputTag(""),
+    #skip newCombinedSeeds if it is a trivial seed merger
     initialSeedsVector = _newCombinedSeeds.seedCollections,
     preFilteredSeeds = cms.bool(False),
     useRecoVertex = cms.bool(False),


### PR DESCRIPTION
backport of #25199

instead of making a trivial merge-by-copy done in newCombinedSeeds, pass the inputs directly to the ElectronSeedProducer.
This PR avoids extra work spent in copying and reduces the memory utilization.

see more notes in #25199