### PR TITLE
DD4hep: Add DDMuonAngular Algorithm

### DIFF
--- a/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug>
+    <debug_shapes/>
+    <debug_includes/>
+    <debug_rotations/>
+    <debug_includes/>
+    <debug_volumes/>
+    <debug_constants/>
+    <!-- debug_materials/ -->
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+
+<!-- 
+    <debug_materials/>
+    <debug_visattr/>
+-->
+  </debug>
+  
+  <open_geometry/>
+  <close_geometry/>
+
+  <ConstantsSection label="" eval="true">
+    <Constant name="world_x" value="100*m"/>
+    <Constant name="world_y" value="100*m"/>
+    <Constant name="world_z" value="100*m"/>
+    <Constant name="fm"      value="1e-12*m"/>
+    <Constant name="mum"     value="1.e-3*mm"/>
+    <Constant name="Air"     value="materials:Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials:Vacuum"  type="string"/>
+  </ConstantsSection>
+
+  <IncludeSection>
+    <Include ref='Geometry/CMSCommonData/data/materials.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/rotations.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/extend/cmsextent.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cms.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsMother.xml'/>
+    <!-- Include ref='Geometry/CMSCommonData/data/cmsTracker.xml'/ -->
+    <!-- Include ref='Geometry/CMSCommonData/data/caloBase.xml'/ -->
+    <!-- Include ref='Geometry/CMSCommonData/data/cmsCalo.xml'/ -->
+    <Include ref='Geometry/CMSCommonData/data/muonBase.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsMuon.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/mgnt.xml'/>
+    <!-- Include ref='Geometry/CMSCommonData/data/beampipe/2015/v1/beampipe.xml'/-->
+    <Include ref='Geometry/CMSCommonData/data/cmsBeam.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonMB.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonMagnet.xml'/>
+    <!-- Include ref='Geometry/CMSCommonData/data/cavern.xml'/ -->
+    <Include ref='Geometry/MuonCommonData/data/mbCommon/2015/v2/mbCommon.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mb1/2015/v2/mb1.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mb2/2015/v2/mb2.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mb3/2015/v2/mb3.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mb4/2015/v2/mb4.xml'/>
+    <!-- Include ref='Geometry/MuonCommonData/data/design/muonYoke.xml'/ -->
+    <Include ref='Geometry/MuonCommonData/data/mf/2015/v1/mf.xml'/>
+    <!-- Include ref='Geometry/MuonCommonData/data/rpcf/2015/v1/rpcf.xml'/ -->
+    <!-- Include ref='Geometry/MuonCommonData/data/csc/2015/v1/csc.xml'/-->
+    <!-- Include ref='Geometry/MuonCommonData/data/mfshield/2015/v1/mfshield.xml'/-->
+  </IncludeSection>
+  
+  <PosPartSection label="">
+    <PosPart copyNumber="1">
+      <rParent name="world_volume"/>
+      <rChild name="cms:OCMS"/>
+    </PosPart>
+  </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/plugins/DDMuonAngular.cc
+++ b/DetectorDescription/DDCMS/plugins/DDMuonAngular.cc
@@ -1,0 +1,61 @@
+#include "DD4hep/DetFactoryHelper.h"
+#include "DetectorDescription/DDCMS/interface/DDPlugins.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+using namespace std;
+using namespace dd4hep;
+using namespace cms;
+
+static long algorithm( Detector& /* description */,
+		       cms::DDParsingContext& context,
+		       xml_h element,
+		       SensitiveDetector& /* sens */)
+{
+  cms::DDNamespace ns( context, element, true );
+  DDAlgoArguments  args( context, element );
+
+  int            n           = args.value<int>("n");
+  int            startCopyNo = args.find("startCopyNo") ? args.value<int>("startCopyNo") : 1;
+  int            incrCopyNo  = args.find("incrCopyNo") ? args.value<int>("incrCopyNo") : 1;
+  double         startAngle  = args.value<double>("startAngle");
+  double         stepAngle   = args.value<double>("stepAngle");
+  double         zoffset     = args.value<double>("zoffset");
+  string         rotns       = args.value<string>("RotNameSpace");
+  Volume         mother      = ns.volume(args.parentName());
+  Volume         child       = ns.volume(args.value<string>("ChildName"));
+
+  LogDebug("DDAlgorithm") << "debug: Parameters for positioning:: n "
+			  << n << " Start, Step " 
+			  << ConvertTo( startAngle, deg ) << " " 
+			  << ConvertTo( stepAngle, deg ) << " " 
+			  << ", zoffset " << zoffset << " "
+			  << ", RotNameSpace " << rotns.c_str();
+  LogDebug("DDAlgorithm") << "debug: Parent " << mother.name() 
+			  << "\tChild " << child.name() << " NameSpace "
+			  << ns.name();
+
+  double phi    = startAngle;
+  int    copyNo = startCopyNo;
+
+  for( int i = 0; i < n; ++i ) {
+    double phitmp = phi;
+    if( phitmp >= 2._pi ) phitmp -= 2._pi;
+    Rotation3D rotation = makeRotation3D( 90._deg, phitmp, 90._deg, 90._deg + phitmp, 0., 0.);
+    string rotstr = ns.nsName( child.name()) + std::to_string( phitmp * 10. );
+    auto irot = context.rotations.find( ns.prepend( rotstr ));
+    if( irot != context.rotations.end()) {
+      rotation = ns.rotation( ns.prepend( rotstr ));
+    }
+    Position tran( 0., 0., zoffset );
+    mother.placeVolume( child, copyNo, Transform3D( rotation, tran ));
+    LogDebug("DDAlgorithm") << "test " << child.name() << " number " 
+			    << copyNo << " positioned in " << mother.name() << " at "
+			    << tran  << " with " << rotstr << ": " << rotation;
+    phi    += stepAngle;
+    copyNo += incrCopyNo;
+  }
+  return 1;
+}
+
+// first argument is the type from the xml file
+DECLARE_DDCMS_DETELEMENT( DDCMS_global_DDMuonAngular, algorithm )

--- a/DetectorDescription/DDCMS/plugins/DDMuonAngular.cc
+++ b/DetectorDescription/DDCMS/plugins/DDMuonAngular.cc
@@ -58,4 +58,4 @@ static long algorithm( Detector& /* description */,
 }
 
 // first argument is the type from the xml file
-DECLARE_DDCMS_DETELEMENT( DDCMS_global_DDMuonAngular, algorithm )
+DECLARE_DDCMS_DETELEMENT( DDCMS_muon_DDMuonAngular, algorithm )

--- a/DetectorDescription/DDCMS/test/python/testMuonGeometry.py
+++ b/DetectorDescription/DDCMS/test/python/testMuonGeometry.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DDCMSDetectorTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.test = cms.EDAnalyzer("DDCMSDetector",
+                              geomXMLFiles = cms.vstring('Geometry/CMSCommonData/data/normal/cmsextent.xml', 
+                                                         'Geometry/CMSCommonData/data/cms.xml', 
+                                                         'DetectorDescription/DDCMS/data/cmsMagneticField.xml', 
+                                                         'MagneticField/GeomBuilder/data/MagneticFieldVolumes_160812_1.xml',
+                                                         'MagneticField/GeomBuilder/data/MagneticFieldVolumes_160812_2.xml',
+                                                         'Geometry/CMSCommonData/data/materials.xml'),
+                              confGeomXMLFiles = cms.string('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml')
+                              )
+
+process.testVectors = cms.EDAnalyzer("DDTestVectors")
+process.testDump = cms.EDAnalyzer("DDTestDumpFile")
+
+process.p = cms.Path(process.test+process.testVectors+process.testDump)

--- a/Geometry/MuonCommonData/data/mb1/2015/v2/mb1.xml
+++ b/Geometry/MuonCommonData/data/mb1/2015/v2/mb1.xml
@@ -1,0 +1,1924 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <ConstantsSection label="mb1.xml" eval="true">
+        <!--- #### MB1: Positions -->
+        <!--%% Radial coordinates for algos-->
+        <Constant name="MB1UnitRadius" value="4329.460186*mm"/>
+        <Constant name="MB1PosAngle" value="5.184184778*deg"/>
+        <!--%% Cartesian coordinates for sector 1 -->
+        <Constant name="MB1Pos_x" value="[mbCommon:MBHC_offset]+4285.*mm"/>
+        <Constant name="MB1Pos_y" value="391.2*mm"/>
+        <!--- #### MB1: Constants for DT superlayer Phi -->
+        <Constant name="MB1SLPhiPl_x" value="2121./2*mm"/>
+        <Constant name="MB1SLPhiL48" value="[mbCommon:MBCell_width]*48+[mbCommon:MBIbeamWall]"/>
+        <Constant name="MB1SLPhiL49" value="[mbCommon:MBCell_width]*49+[mbCommon:MBIbeamWall]"/>
+        <Constant name="MB1SLPhiL50" value="[mbCommon:MBCell_width]*50+[mbCommon:MBIbeamWall]"/>
+        <!--- #### MB1: Constants for DT superlayer Z (although they are placed with a rotation that interchanges X and Z, the _x refers to the coordinate X in EDMS, that is the Z in its final position; similar for _z -->
+        <Constant name="MB1SLZWire_length" value="2038./2.*mm"/>
+        <!--%% Wire length from EDMS: THIS NUMBER DEFINE THE SL DIMENSIONS-->
+        <Constant name="MB1SLZBareWire_length" value="[MB1SLZWire_length]-15.5*mm"/>
+        <!--%% Bare Wire _length == wire_lenght - depth in tappini-->
+        <Constant name="MB1SLZLayer_length" value="[MB1SLZBareWire_length]+2*[mbCommon:MBLayerElectronics_width]"/>
+        <!--%% The z length of the Al layer volume-->
+        <Constant name="MB1SLZPlI_z" value="[MB1SLZLayer_length]+6.5*mm"/>
+        <!--%% Distance between tappini and Al Plate edge-->
+        <Constant name="MB1SLZPlO_z" value="[MB1SLZPlI_z]+38.*mm"/>
+        <!--- #### MB1: X dimensions -->
+        <Constant name="MB1_x" value="1090.*mm"/>
+        <Constant name="MB1HC_x" value="2033/2.*mm"/>
+        <!--- #### MB1: Constants for DT positioning: distance from SL center to HC center -->
+        <Constant name="MB1pSLPhi1_HC_dist" value="16.*mm"/>
+        <Constant name="MB1pSLPhi2_HC_dist" value="-5.*mm"/>
+        <Constant name="MB1pSLZ_HC_dist" value="-5*mm"/>
+        <Constant name="MB1nSLPhi1_HC_dist" value="-16.*mm"/>
+        <Constant name="MB1nSLPhi2_HC_dist" value="5.*mm"/>
+        <Constant name="MB1nSLZ_HC_dist" value="5*mm"/>
+        <!--- #### MB1: Constants for RPCs -->
+        <Constant name="MB1RPC_x" value="2080./2*mm"/>
+        <Constant name="MB1RPC_Gas_x" value="[mb1:MB1RPC_x]-10.*mm"/>
+        <Constant name="MB1RPC_I_x_pos" value="15.2*mm"/>
+        <Constant name="MB1RPC_O_x_pos" value="60.2*mm"/>
+        <!--- #### MB1Chim: Constants for DT RPCs -->
+        <Constant name="MB1ChimRPC_GasRight_y_pos" value="[mbCommon:MBRPC_GasRight_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2.-4.*mm"/>
+        <Constant name="MB1ChimRPC_GasLeft_y_pos" value="[mbCommon:MBRPC_GasLeft_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2.-4.*mm"/>
+    </ConstantsSection>
+    <SolidSection label="mb1.xml">
+        <!-- ####  MB1 Unit: fake volume representing one DTBX + 1 or 2 RPC -->
+        <!-- ####  MB1: DTBX chamber -->
+        <!--%% In MB1 the widest superlayer in x is the Z one -->
+        <Box name="MB1_a" dx="[MB1_x]" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With2RPC]"/>
+        <Box name="MB1_OLAP1" dx="17.*mm" dy="[mbCommon:MBSLPhiPlO_z]+13.*mm" dz="15.*mm"/>
+        <Box name="MB1_OLAP2" dx="5.6*mm" dy="[mbCommon:MBSLPhiPlO_z]+13.*mm" dz="6.6*mm"/>
+        <Box name="MB1_OLAP3" dx="5.*mm" dy="[mbCommon:MBSLPhiPlO_z]+13.*mm" dz="10.*mm"/>
+        <Box name="MB1_OLAP4" dx="20.*mm" dy="[mbCommon:MBSLPhiPlO_z]+13.*mm" dz="40.*mm"/>
+        <SubtractionSolid name="MB1N_b">
+            <rSolid name="MB1_a"/>
+            <rSolid name="MB1_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB1_x]-16.8*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+14.8*mm"/>
+        </SubtractionSolid>
+        <UnionSolid name="MB1N">
+            <rSolid name="MB1N_b"/>
+            <rSolid name="MB1_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB1_x]-5.5*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+6.5*mm"/>
+        </UnionSolid>
+        <UnionSolid name="MB1Nw0_c">
+            <rSolid name="MB1N_b"/>
+            <rSolid name="MB1_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB1_x]-5.5*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+6.5*mm"/>
+        </UnionSolid>
+        <SubtractionSolid name="MB1Nw0_d">
+            <rSolid name="MB1Nw0_c"/>
+            <rSolid name="MB1_OLAP3"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB1_x]+4.9*mm" y="0.*fm" z="[mbCommon:MBHeight_With2RPC]-9.9*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB1Nw0">
+            <rSolid name="MB1Nw0_d"/>
+            <rSolid name="MB1_OLAP4"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB1_x]-19.9*mm" y="0.*fm" z="[mbCommon:MBHeight_With2RPC]-39.9*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB1P_b">
+            <rSolid name="MB1_a"/>
+            <rSolid name="MB1_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB1_x]+16.8*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+14.8*mm"/>
+        </SubtractionSolid>
+        <UnionSolid name="MB1P">
+            <rSolid name="MB1P_b"/>
+            <rSolid name="MB1_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB1_x]+5.5*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+6.5*mm"/>
+        </UnionSolid>
+        <UnionSolid name="MB1Pw0_c">
+            <rSolid name="MB1P_b"/>
+            <rSolid name="MB1_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB1_x]+5.5*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+6.5*mm"/>
+        </UnionSolid>
+        <SubtractionSolid name="MB1Pw0_d">
+            <rSolid name="MB1Pw0_c"/>
+            <rSolid name="MB1_OLAP3"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB1_x]-4.9*mm" y="0.*fm" z="[mbCommon:MBHeight_With2RPC]-9.9*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB1Pw0">
+            <rSolid name="MB1Pw0_d"/>
+            <rSolid name="MB1_OLAP4"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB1_x]+19.0*mm" y="0.*fm" z="[mbCommon:MBHeight_With2RPC]-39.9*mm"/>
+        </SubtractionSolid>
+        <!-- ####  MB1: Superlayers Phi -->
+        <!--%% SuperLayer X,Z dimensions cover the outer Al plate + 2 mm for the closing profiles. Y is 5 Al plates + 4 Layer's -->
+        <Box name="MB1SuperLayerPhi" dx="[mb1:MB1SLPhiPl_x]+2.7*mm" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% MB1SLPhiClosingPlateParal is parallel to gas cells, MB1SLPhiClosingPlatePerp is perpendicular -->
+        <!--%% Parallel are 2 mm thick and as long as outer Plates -->
+        <Box name="MB1SLPhiClosingPlateParal" dx="1.*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB1SLPhi_C_PlateParal" dx="7.*mm" dy="[mbCommon:MBSLPhiPlO_z]-14.*mm" dz="1.*mm"/>
+        <!--%% Perpendicular are 12 mm thick and higher by 20 mm per side than the SL; 2.7 mm are added to reach the parallel "Cs" -->
+        <Box name="MB1SLPhiClosingPlatePerp" dx="[mb1:MB1SLPhiPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB1SLPhi_C_PlatePerp" dx="[mb1:MB1SLPhiPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <!--%% MB1SLPhiAlPlateOuter is 0.7 mm wider (perpendicular to the wires) to reach the parallel "Cs"-->
+        <Box name="MB1SLPhiAlPlateOuter" dx="[mb1:MB1SLPhiPl_x]+0.7*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!--%% MB1SLPhiAlPlateOuter does not reach the parallel "Cs"-->
+        <Box name="MB1SLPhiAlPlateInner" dx="[mb1:MB1SLPhiPl_x]" dy="[mbCommon:MBSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!--%% Fake layer volume contains the ibeams plus gas volumes: n+1 Ibeam's and n gas volumes.
+             (Ibeam wall width is ~1.35mm, but 0.1 is mylar, that is very light, so it set to 1.3) 
+             It is first made of aluminium and them it is filled with the n gas volumes. 
+             Z length is the bare wire length plus the electronics (==tappini)-->
+        <Box name="MB1SLPhiLayer_48Cells" dx="[MB1SLPhiL48]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLPhiLayer_49Cells" dx="[MB1SLPhiL49]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLPhiLayer_50Cells" dx="[MB1SLPhiL50]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <!--%% Tappini, Perpendicular to the Ibeams and at the two ends -->
+        <Box name="MB1SLPhiElectronics_48Cells" dx="[mb1:MB1SLPhiL48]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLPhiElectronics_49Cells" dx="[mb1:MB1SLPhiL49]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLPhiElectronics_50Cells" dx="[mb1:MB1SLPhiL50]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLPhiCommonElectronics" dx="[mb1:MB1SLPhiPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!-- ####  MB1: Superlayer Z -->
+        <Box name="MB1SuperLayerZ" dx="[mbCommon:MBSLZPl_x]+2.7*mm" dy="[mb1:MB1SLZPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB1SLZClosingPlateParal" dx="1.*mm" dy="[mb1:MB1SLZPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB1SLZ_C_PlateParal" dx="7.*mm" dy="[mb1:MB1SLZPlO_z]-14.*mm" dz="1.*mm"/>
+        <Box name="MB1SLZClosingPlatePerp" dx="[mbCommon:MBSLZPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB1SLZ_C_PlatePerp" dx="[mbCommon:MBSLZPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <Box name="MB1SLZAlPlateOuter" dx="[mbCommon:MBSLZPl_x]+0.7*mm" dy="[mb1:MB1SLZPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB1SLZAlPlateInner" dx="[mbCommon:MBSLZPl_x]" dy="[mb1:MB1SLZPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB1SLZLayer_56Cells" dx="[mbCommon:MBSLZL56]" dy="[mb1:MB1SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLZLayer_57Cells" dx="[mbCommon:MBSLZL57]" dy="[mb1:MB1SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLZLayer_58Cells" dx="[mbCommon:MBSLZL58]" dy="[mb1:MB1SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLZElectronics_56Cells" dx="[mbCommon:MBSLZL56]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLZElectronics_57Cells" dx="[mbCommon:MBSLZL57]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLZElectronics_58Cells" dx="[mbCommon:MBSLZL58]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1SLZCommonElectronics" dx="[mbCommon:MBSLZPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!--%% Effective gas volume -->
+        <Box name="MB1SLZGas_a" dx="20.35*mm" dy="[MB1SLZBareWire_length]" dz="[mbCommon:MBGas_height]"/>
+        <!--%% Horizontal bars to make the 'I' shape (without them it would be a '|') -->
+        <Box name="MB1SLZIBeamWing" dx="3.175*mm" dy="[MB1SLZBareWire_length]" dz="0.65*mm"/>
+        <SubtractionSolid name="MB1SLZGas_b">
+            <rSolid name="MB1SLZGas_a"/>
+            <rSolid name="MB1SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" y="0.*fm" z="5.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB1SLZGas_c">
+            <rSolid name="MB1SLZGas_b"/>
+            <rSolid name="MB1SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" y="0.*fm" z="-5.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB1SLZGas_d">
+            <rSolid name="MB1SLZGas_c"/>
+            <rSolid name="MB1SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" y="0.*fm" z="5.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB1SLZGas">
+            <rSolid name="MB1SLZGas_d"/>
+            <rSolid name="MB1SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" y="0.*fm" z="-5.1*mm"/>
+        </SubtractionSolid>
+        <!-- ####  MB1: Honeycomb -->
+        <Box name="MB1HoneycombBox" dx="[mb1:MB1HC_x]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHC_height]"/>
+        <Box name="MB1Honeycomb" dx="[mb1:MB1HC_x]-125.*mm" dy="[mbCommon:MBHC_z]-125.*mm" dz="[mbCommon:MBHC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB1HcPlate" dx="[mb1:MB1HC_x]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB1Hc_LateralC" dx="[mbCommon:MBHC_C_dimension]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB1Hc_FrontC" dx="[mb1:MB1HC_x]-125.*mm" dy="[mbCommon:MBHC_C_dimension]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB1Hc_LateralElectronics" dx="[mbCommon:MBHCLatElectronics_width]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHCElectronics_height]"/>
+        <Box name="MB1Hc_FrontElectronics" dx="[mb1:MB1HC_x]-125.*mm" dy="[mbCommon:MBHCFrontElectronics_width]" dz="[mbCommon:MBHCElectronics_height]"/>
+        <Box name="MB1HcTorsionBar" dx="25*mm" dy="678*mm" dz="50.*mm"/>
+        <!-- ####  MB1: RPC chambers -->
+        <Box name="MB1RPC" dx="[mb1:MB1RPC_x]" dy="[mbCommon:MBRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB1RPC_GasLeft" dx="[mb1:MB1RPC_Gas_x]" dy="[mbCommon:MBRPC_GasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB1RPC_GasRight" dx="[mb1:MB1RPC_Gas_x]" dy="[mbCommon:MBRPC_GasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <!-- ####  MB1Chimney Unit -->
+        <!-- ####  MB1Chim: DTBX chamber -->
+        <Box name="MB1Chim_a" dx="[MB1_x]" dy="[mbCommon:MBChimSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With2RPC]"/>
+        <Box name="MB1Chim_OLAP2" dx="5.6*mm" dy="[mbCommon:MBChimSLPhiPlO_z]+13.*mm" dz="6.6*mm"/>
+        <SubtractionSolid name="MB1ChimN_b">
+            <rSolid name="MB1Chim_a"/>
+            <rSolid name="MB1_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB1_x]-16.8*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+14.8*mm"/>
+        </SubtractionSolid>
+        <UnionSolid name="MB1ChimN">
+            <rSolid name="MB1ChimN_b"/>
+            <rSolid name="MB1Chim_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB1_x]-5.5*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+6.5*mm"/>
+        </UnionSolid>
+        <SubtractionSolid name="MB1ChimP_b">
+            <rSolid name="MB1Chim_a"/>
+            <rSolid name="MB1_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB1_x]+16.8*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+14.8*mm"/>
+        </SubtractionSolid>
+        <UnionSolid name="MB1ChimP">
+            <rSolid name="MB1ChimP_b"/>
+            <rSolid name="MB1Chim_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB1_x]+5.5*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+6.5*mm"/>
+        </UnionSolid>
+        <!-- ####  MB1Chim: DT Superlayers Phi -->
+        <Box name="MB1ChimSuperLayerPhi" dx="[mb1:MB1SLPhiPl_x]+2.7*mm" dy="[mbCommon:MBChimSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% Only extra parallel "Cs" are needed -->
+        <Box name="MB1ChimSLPhiClosingPlateParal" dx="1.*mm" dy="[mbCommon:MBChimSLPhiPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB1ChimSLPhi_C_PlateParal" dx="7.*mm" dy="[mbCommon:MBChimSLPhiPlO_z]-14.*mm" dz="1.*mm"/>
+        <Box name="MB1ChimSLPhiAlPlateOuter" dx="[mb1:MB1SLPhiPl_x]+0.7*mm" dy="[mbCommon:MBChimSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB1ChimSLPhiAlPlateInner" dx="[mb1:MB1SLPhiPl_x]" dy="[mbCommon:MBChimSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB1ChimSLPhiLayer_48Cells" dx="[mb1:MB1SLPhiL48]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1ChimSLPhiLayer_49Cells" dx="[mb1:MB1SLPhiL49]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1ChimSLPhiLayer_50Cells" dx="[mb1:MB1SLPhiL50]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <!-- ####  MB1Chim: DT Superlayer Z -->
+        <Box name="MB1ChimSuperLayerZ" dx="[mbCommon:MBChimSLZPl_x]+2.7*mm" dy="[mb1:MB1SLZPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% Only extra perperdicular "Cs" are needed -->
+        <Box name="MB1ChimSLZClosingPlatePerp" dx="[mbCommon:MBChimSLZPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB1ChimSLZ_C_PlatePerp" dx="[mbCommon:MBChimSLZPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <Box name="MB1ChimSLZAlPlateOuter" dx="[mbCommon:MBChimSLZPl_x]+0.7*mm" dy="[mb1:MB1SLZPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB1ChimSLZAlPlateInner" dx="[mbCommon:MBChimSLZPl_x]" dy="[mb1:MB1SLZPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB1ChimSLZLayer_47Cells" dx="[mbCommon:MBChimSLZL47]" dy="[mb1:MB1SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1ChimSLZLayer_48Cells" dx="[mbCommon:MBChimSLZL48]" dy="[mb1:MB1SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1ChimSLZElectronics_47Cells" dx="[mbCommon:MBChimSLZL47]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1ChimSLZElectronics_48Cells" dx="[mbCommon:MBChimSLZL48]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB1ChimSLZCommonElectronics" dx="[mbCommon:MBChimSLZPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!-- ####  MB1Chim: DT Honeycomb -->
+        <Box name="MB1ChimHoneycombBox" dx="[mb1:MB1HC_x]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHC_height]"/>
+        <Box name="MB1ChimHoneycomb" dx="[mb1:MB1HC_x]-125.*mm" dy="[mbCommon:MBChimHC_z]-125.*mm" dz="[mbCommon:MBHC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB1ChimHc_LateralC" dx="[mbCommon:MBHC_C_dimension]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB1ChimHc_LateralElectronics" dx="[mbCommon:MBHCLatElectronics_width]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHCElectronics_height]"/>
+        <Box name="MB1ChimHcPlate" dx="[mb1:MB1HC_x]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!-- ####  MB1Chim: RPC chambers -->
+        <Box name="MB1ChimRPC" dx="[mb1:MB1RPC_x]" dy="[mbCommon:MBChimRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB1ChimRPC_GasLeft" dx="[mb1:MB1RPC_Gas_x]" dy="[mbCommon:MBChimRPC_OGasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB1ChimRPC_GasRight" dx="[mb1:MB1RPC_Gas_x]" dy="[mbCommon:MBChimRPC_OGasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+    </SolidSection>
+    <LogicalPartSection label="mb1.xml">
+        <!-- ####  MB1 Unit -->
+        <!-- ####  MB1: DTBX -->
+        <LogicalPart name="MB1P" category="unspecified">
+            <rSolid name="MB1P"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB1P0" category="unspecified">
+            <rSolid name="MB1Pw0"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB1N" category="unspecified">
+            <rSolid name="MB1N"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <!-- # In wheel_0, all the RPC chambers are Positive, while the DT are half positive, half negative -->
+        <LogicalPart name="MB1N0P" category="unspecified">
+            <rSolid name="MB1Nw0"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <!-- ####  MB1: DT Superlayers Phi -->
+        <LogicalPart name="MB1SuperLayerPhi" category="unspecified">
+            <rSolid name="MB1SuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiClosingPlateParal" category="unspecified">
+            <rSolid name="MB1SLPhiClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhi_C_PlateParal" category="unspecified">
+            <rSolid name="MB1SLPhi_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiClosingPlatePerp" category="unspecified">
+            <rSolid name="MB1SLPhiClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhi_C_PlatePerp" category="unspecified">
+            <rSolid name="MB1SLPhi_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB1SLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB1SLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiLayer_48Cells" category="unspecified">
+            <rSolid name="MB1SLPhiLayer_48Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiLayer_49Cells" category="unspecified">
+            <rSolid name="MB1SLPhiLayer_49Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiLayer_50Cells" category="unspecified">
+            <rSolid name="MB1SLPhiLayer_50Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiElectronics_48Cells" category="unspecified">
+            <rSolid name="MB1SLPhiElectronics_48Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiElectronics_49Cells" category="unspecified">
+            <rSolid name="MB1SLPhiElectronics_49Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiElectronics_50Cells" category="unspecified">
+            <rSolid name="MB1SLPhiElectronics_50Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLPhiCommonElectronics" category="unspecified">
+            <rSolid name="MB1SLPhiCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB1: DT Superlayer Z -->
+        <LogicalPart name="MB1SuperLayerZ" category="unspecified">
+            <rSolid name="MB1SuperLayerZ"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZClosingPlateParal" category="unspecified">
+            <rSolid name="MB1SLZClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZClosingPlatePerp" category="unspecified">
+            <rSolid name="MB1SLZClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZ_C_PlateParal" category="unspecified">
+            <rSolid name="MB1SLZ_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZ_C_PlatePerp" category="unspecified">
+            <rSolid name="MB1SLZ_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZAlPlateOuter" category="unspecified">
+            <rSolid name="MB1SLZAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZAlPlateInner" category="unspecified">
+            <rSolid name="MB1SLZAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZLayer_56Cells" category="unspecified">
+            <rSolid name="MB1SLZLayer_56Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZLayer_57Cells" category="unspecified">
+            <rSolid name="MB1SLZLayer_57Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZLayer_58Cells" category="unspecified">
+            <rSolid name="MB1SLZLayer_58Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZIBeamWing" category="unspecified">
+            <rSolid name="MB1SLZIBeamWing"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZGas" category="unspecified">
+            <rSolid name="MB1SLZGas"/>
+            <rMaterial name="materials:M_DTBX Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZElectronics_56Cells" category="unspecified">
+            <rSolid name="MB1SLZElectronics_56Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZElectronics_57Cells" category="unspecified">
+            <rSolid name="MB1SLZElectronics_57Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZElectronics_58Cells" category="unspecified">
+            <rSolid name="MB1SLZElectronics_58Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1SLZCommonElectronics" category="unspecified">
+            <rSolid name="MB1SLZCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB1: DT Honeycomb -->
+        <LogicalPart name="MB1HoneycombBox" category="unspecified">
+            <rSolid name="MB1HoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB1Honeycomb" category="unspecified">
+            <rSolid name="MB1Honeycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB1HcPlate" category="unspecified">
+            <rSolid name="MB1HcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1Hc_LateralC" category="unspecified">
+            <rSolid name="MB1Hc_LateralC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1Hc_FrontC" category="unspecified">
+            <rSolid name="MB1Hc_FrontC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1Hc_LateralElectronics" category="unspecified">
+            <rSolid name="MB1Hc_LateralElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1Hc_FrontElectronics" category="unspecified">
+            <rSolid name="MB1Hc_FrontElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1HcTorsionBar" category="unspecified">
+            <rSolid name="MB1HcTorsionBar"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- ####  MB1: RPC chambers -->
+        <LogicalPart name="MB1RPC_IP" category="unspecified">
+            <rSolid name="MB1RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB1RPC_IN" category="unspecified">
+            <rSolid name="MB1RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB1RPC_IGasLeft" category="unspecified">
+            <rSolid name="MB1RPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB1RPC_IGasRight" category="unspecified">
+            <rSolid name="MB1RPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB1RPC_OP" category="unspecified">
+            <rSolid name="MB1RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB1RPC_ON" category="unspecified">
+            <rSolid name="MB1RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB1RPC_OGasLeft" category="unspecified">
+            <rSolid name="MB1RPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB1RPC_OGasRight" category="unspecified">
+            <rSolid name="MB1RPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <!-- ####  MB1Chimney Unit -->
+        <!-- ####  MB1Chim: DTBX -->
+        <LogicalPart name="MB1ChimP" category="unspecified">
+            <rSolid name="MB1ChimP"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimN" category="unspecified">
+            <rSolid name="MB1ChimN"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <!-- ####  MB1Chim: DT Superlayers Phi -->
+        <LogicalPart name="MB1ChimSuperLayerPhi" category="unspecified">
+            <rSolid name="MB1ChimSuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLPhiClosingPlateParal" category="unspecified">
+            <rSolid name="MB1ChimSLPhiClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLPhi_C_PlateParal" category="unspecified">
+            <rSolid name="MB1ChimSLPhi_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB1ChimSLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB1ChimSLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLPhiLayer_48Cells" category="unspecified">
+            <rSolid name="MB1ChimSLPhiLayer_48Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLPhiLayer_49Cells" category="unspecified">
+            <rSolid name="MB1ChimSLPhiLayer_49Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLPhiLayer_50Cells" category="unspecified">
+            <rSolid name="MB1ChimSLPhiLayer_50Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- ####  MB1Chim: DT Superlayer Z -->
+        <LogicalPart name="MB1ChimSuperLayerZ" category="unspecified">
+            <rSolid name="MB1ChimSuperLayerZ"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZClosingPlatePerp" category="unspecified">
+            <rSolid name="MB1ChimSLZClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZ_C_PlatePerp" category="unspecified">
+            <rSolid name="MB1ChimSLZ_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZAlPlateOuter" category="unspecified">
+            <rSolid name="MB1ChimSLZAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZAlPlateInner" category="unspecified">
+            <rSolid name="MB1ChimSLZAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZLayer_47Cells" category="unspecified">
+            <rSolid name="MB1ChimSLZLayer_47Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZLayer_47Cells_startCell2" category="unspecified">
+            <rSolid name="MB1ChimSLZLayer_47Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZLayer_48Cells" category="unspecified">
+            <rSolid name="MB1ChimSLZLayer_48Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZElectronics_47Cells" category="unspecified">
+            <rSolid name="MB1ChimSLZElectronics_47Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZElectronics_48Cells" category="unspecified">
+            <rSolid name="MB1ChimSLZElectronics_48Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimSLZCommonElectronics" category="unspecified">
+            <rSolid name="MB1ChimSLZCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB1Chim: DT Honeycomb -->
+        <LogicalPart name="MB1ChimHoneycombBox" category="unspecified">
+            <rSolid name="MB1ChimHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimHoneycomb" category="unspecified">
+            <rSolid name="MB1ChimHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimHcPlate" category="unspecified">
+            <rSolid name="MB1ChimHcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimHc_LateralC" category="unspecified">
+            <rSolid name="MB1ChimHc_LateralC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimHc_LateralElectronics" category="unspecified">
+            <rSolid name="MB1ChimHc_LateralElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB1Chim: RPC chambers -->
+        <LogicalPart name="MB1ChimRPC_IP" category="unspecified">
+            <rSolid name="MB1ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimRPC_IN" category="unspecified">
+            <rSolid name="MB1ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimRPC_IGasLeft" category="unspecified">
+            <rSolid name="MB1ChimRPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimRPC_IGasRight" category="unspecified">
+            <rSolid name="MB1ChimRPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimRPC_OP" category="unspecified">
+            <rSolid name="MB1ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimRPC_ON" category="unspecified">
+            <rSolid name="MB1ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimRPC_OGasLeft" category="unspecified">
+            <rSolid name="MB1ChimRPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB1ChimRPC_OGasRight" category="unspecified">
+            <rSolid name="MB1ChimRPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="mb1.xml">
+        <!-- ####  MB1 Unit -->
+        <!-- ####  MB1: DTBX chamber -->
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb1:MB1N0P"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB1UnitRadius]"/>
+            <Numeric name="StartAngle" value="[MB1PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB1PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb1:MB1P0"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB1UnitRadius]"/>
+            <Numeric name="StartAngle" value="30.*deg+[MB1PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB1PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb1:MB1P0"/>
+            <Numeric name="StartCopyNo" value="3"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB1UnitRadius]"/>
+            <Numeric name="StartAngle" value="60.*deg+[MB1PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB1PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb1:MB1N0P"/>
+            <Numeric name="StartCopyNo" value="4"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB1UnitRadius]"/>
+            <Numeric name="StartAngle" value="90.*deg+[MB1PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB1PosAngle] </Vector>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb1:MB1P"/>
+            <rRotation name="rotations:RM1872"/>
+            <Translation x="[MB1Pos_x]" y="[MB1Pos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb1:MB1P"/>
+            <rRotation name="rotations:RM1882"/>
+            <Translation x="[MB1Pos_x]*0.86602543-[MB1Pos_y]*0.5" y="[MB1Pos_x]*0.5+[MB1Pos_y]*0.86602543" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb1:MB1P"/>
+            <rRotation name="rotations:RM1892"/>
+            <Translation x="[MB1Pos_x]*0.5-[MB1Pos_y]*0.86602543" y="[MB1Pos_x]*0.86602543+[MB1Pos_y]*0.5" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb1:MB1ChimP"/>
+            <rRotation name="rotations:RM1902"/>
+            <Translation x="-[MB1Pos_y]" y="[MB1Pos_x]" z="[mbCommon:MBChimPos_z]"/>
+        </PosPart>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <String name="ChildName" value="mb1:MB1P"/>
+            <Numeric name="StartCopyNo" value="5"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="8"/>
+            <Numeric name="Radius" value="[MB1UnitRadius]"/>
+            <Numeric name="StartAngle" value="120.*deg+[MB1PosAngle]"/>
+            <Numeric name="RangeAngle" value="210.*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB1PosAngle] </Vector>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb1:MB1N"/>
+            <rRotation name="rotations:E127"/>
+            <Translation x="[MB1Pos_x]" y="[MB1Pos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb1:MB1N"/>
+            <rRotation name="rotations:MM200"/>
+            <Translation x="[MB1Pos_x]*0.86602543-[MB1Pos_y]*0.5" y="[MB1Pos_x]*0.5+[MB1Pos_y]*0.86602543" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb1:MB1ChimN"/>
+            <rRotation name="rotations:MM300"/>
+            <Translation x="[MB1Pos_x]*0.5-[MB1Pos_y]*0.86602543" y="[MB1Pos_x]*0.86602543+[MB1Pos_y]*0.5" z="-[mbCommon:MBChimPos_z]"/>
+        </PosPart>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <String name="ChildName" value="mb1:MB1N"/>
+            <Numeric name="StartCopyNo" value="4"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="9"/>
+            <Numeric name="Radius" value="[MB1UnitRadius]"/>
+            <Numeric name="StartAngle" value="90.*deg+[MB1PosAngle]"/>
+            <Numeric name="RangeAngle" value="240.*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB1PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <String name="ChildName" value="mb1:MB1P"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="12"/>
+            <Numeric name="Radius" value="[MB1UnitRadius]"/>
+            <Numeric name="StartAngle" value="[MB1PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB1PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <String name="ChildName" value="mb1:MB1N"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="12"/>
+            <Numeric name="Radius" value="[MB1UnitRadius]"/>
+            <Numeric name="StartAngle" value="[MB1PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB1PosAngle] </Vector>
+        </Algorithm>
+        <!-- #### MB1: DT Superlayers Phi -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1P"/>
+            <rChild name="mb1:MB1SuperLayerPhi"/>
+            <Translation x="[mb1:MB1pSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1P"/>
+            <rChild name="mb1:MB1SuperLayerPhi"/>
+            <Translation x="[mb1:MB1pSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1P0"/>
+            <rChild name="mb1:MB1SuperLayerPhi"/>
+            <Translation x="[mb1:MB1pSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1P0"/>
+            <rChild name="mb1:MB1SuperLayerPhi"/>
+            <Translation x="[mb1:MB1pSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1N0P"/>
+            <rChild name="mb1:MB1SuperLayerPhi"/>
+            <Translation x="[mb1:MB1nSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1N0P"/>
+            <rChild name="mb1:MB1SuperLayerPhi"/>
+            <Translation x="[mb1:MB1nSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1N"/>
+            <rChild name="mb1:MB1SuperLayerPhi"/>
+            <Translation x="[mb1:MB1nSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1N"/>
+            <rChild name="mb1:MB1SuperLayerPhi"/>
+            <Translation x="[mb1:MB1nSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <!-- ## MB1: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiLayer_49Cells"/>
+            <Translation x="0*fm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiLayer_50Cells"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiLayer_49Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiLayer_48Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiClosingPlateParal"/>
+            <Translation x="[mb1:MB1SLPhiPl_x]+1.7*mm" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiClosingPlateParal"/>
+            <Translation x="-([mb1:MB1SLPhiPl_x]+1.7*mm)" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlateParal"/>
+            <Translation x="[mb1:MB1SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlateParal"/>
+            <Translation x="[mb1:MB1SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlateParal"/>
+            <Translation x="-([mb1:MB1SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlateParal"/>
+            <Translation x="-([mb1:MB1SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1SLPhiLayer_48Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="N" value="48"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb1:MB1SLPhiL48]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1SLPhiLayer_49Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="N" value="49"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb1:MB1SLPhiL49]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1SLPhiLayer_50Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="N" value="50"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb1:MB1SLPhiL50]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SLPhiLayer_48Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_48Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SLPhiLayer_48Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_48Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SLPhiLayer_49Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_49Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SLPhiLayer_49Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_49Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SLPhiLayer_50Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_50Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SLPhiLayer_50Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_50Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- #### MB1: DT Superlayer Z -->
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1P"/>
+            <rChild name="mb1:MB1SuperLayerZ"/>
+            <Translation x="[mb1:MB1pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1P0"/>
+            <rChild name="mb1:MB1SuperLayerZ"/>
+            <Translation x="[mb1:MB1pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1N"/>
+            <rChild name="mb1:MB1SuperLayerZ"/>
+            <Translation x="[mb1:MB1nSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1N0P"/>
+            <rChild name="mb1:MB1SuperLayerZ"/>
+            <Translation x="[mb1:MB1nSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <!-- #### MB1: DT Superlayer Z internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="0.*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZLayer_57Cells"/>
+            <Translation x="0*fm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZLayer_58Cells"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZLayer_57Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZLayer_56Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZClosingPlateParal"/>
+            <Translation x="[mbCommon:MBSLZPl_x]+1.7*mm" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZClosingPlateParal"/>
+            <Translation x="-([mbCommon:MBSLZPl_x]+1.7*mm)" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZCommonElectronics"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SuperLayerZ"/>
+            <rChild name="mb1:MB1SLZCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1SLZLayer_56Cells"/>
+            <String name="ChildName" value="mb1:MB1SLZGas"/>
+            <Numeric name="N" value="56"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBSLZL56]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1SLZLayer_57Cells"/>
+            <String name="ChildName" value="mb1:MB1SLZGas"/>
+            <Numeric name="N" value="57"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBSLZL57]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1SLZLayer_58Cells"/>
+            <String name="ChildName" value="mb1:MB1SLZGas"/>
+            <Numeric name="N" value="58"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBSLZL58]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SLZLayer_56Cells"/>
+            <rChild name="mb1:MB1SLZElectronics_56Cells"/>
+            <Translation x="0.*fm" y="[MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SLZLayer_56Cells"/>
+            <rChild name="mb1:MB1SLZElectronics_56Cells"/>
+            <Translation x="0.*fm" y="-([MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SLZLayer_57Cells"/>
+            <rChild name="mb1:MB1SLZElectronics_57Cells"/>
+            <Translation x="0.*fm" y="[MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SLZLayer_57Cells"/>
+            <rChild name="mb1:MB1SLZElectronics_57Cells"/>
+            <Translation x="0.*fm" y="-([MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1SLZLayer_58Cells"/>
+            <rChild name="mb1:MB1SLZElectronics_58Cells"/>
+            <Translation x="0.*fm" y="[MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1SLZLayer_58Cells"/>
+            <rChild name="mb1:MB1SLZElectronics_58Cells"/>
+            <Translation x="0.*fm" y="-([MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ##### MB1: DT honeycomb -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1P"/>
+            <rChild name="mb1:MB1HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1P0"/>
+            <rChild name="mb1:MB1HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1N"/>
+            <rChild name="mb1:MB1HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1N0P"/>
+            <rChild name="mb1:MB1HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Honeycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBHC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([mbCommon:MBHC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_LateralC"/>
+            <Translation x="[mb1:MB1HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_LateralC"/>
+            <Translation x="[mb1:MB1HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_LateralC"/>
+            <Translation x="-([mb1:MB1HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_LateralC"/>
+            <Translation x="-([mb1:MB1HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_LateralElectronics"/>
+            <Translation x="[mb1:MB1HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_LateralElectronics"/>
+            <Translation x="-([mb1:MB1HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1HoneycombBox"/>
+            <rChild name="mb1:MB1HcTorsionBar"/>
+            <Translation x="[mb1:MB1HC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- ##### MB1: RPC chambers -->
+        <!-- ##### MB1: RPC_IP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1P"/>
+            <rChild name="mb1:MB1RPC_IP"/>
+            <Translation x="[mb1:MB1RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1P0"/>
+            <rChild name="mb1:MB1RPC_IP"/>
+            <Translation x="[mb1:MB1RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1RPC_IP"/>
+            <rChild name="mb1:MB1RPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1RPC_IP"/>
+            <rChild name="mb1:MB1RPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB1: RPC_OP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1P"/>
+            <rChild name="mb1:MB1RPC_OP"/>
+            <Translation x="[mb1:MB1RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1P0"/>
+            <rChild name="mb1:MB1RPC_OP"/>
+            <Translation x="[mb1:MB1RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1RPC_OP"/>
+            <rChild name="mb1:MB1RPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1RPC_OP"/>
+            <rChild name="mb1:MB1RPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB1: RPC_IN chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1N"/>
+            <rChild name="mb1:MB1RPC_IN"/>
+            <Translation x="-[mb1:MB1RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1N0P"/>
+            <rChild name="mb1:MB1RPC_IP"/>
+            <Translation x="-[mb1:MB1RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1RPC_IN"/>
+            <rChild name="mb1:MB1RPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1RPC_IN"/>
+            <rChild name="mb1:MB1RPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB1: RPC_ON chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1N"/>
+            <rChild name="mb1:MB1RPC_ON"/>
+            <Translation x="-[mb1:MB1RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1N0P"/>
+            <rChild name="mb1:MB1RPC_OP"/>
+            <Translation x="-[mb1:MB1RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1RPC_ON"/>
+            <rChild name="mb1:MB1RPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1RPC_ON"/>
+            <rChild name="mb1:MB1RPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ####  MB1Chimney Unit -->
+        <!-- ####  MB1Chim: DTBX chamber -->
+        <!-- #### MB1: DT Superlayers Phi -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimP"/>
+            <rChild name="mb1:MB1ChimSuperLayerPhi"/>
+            <Translation x="[mb1:MB1pSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimP"/>
+            <rChild name="mb1:MB1ChimSuperLayerPhi"/>
+            <Translation x="[mb1:MB1pSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimN"/>
+            <rChild name="mb1:MB1ChimSuperLayerPhi"/>
+            <Translation x="[mb1:MB1nSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimN"/>
+            <rChild name="mb1:MB1ChimSuperLayerPhi"/>
+            <Translation x="[mb1:MB1nSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <!-- ## MB1: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiLayer_49Cells"/>
+            <Translation x="0*fm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiLayer_50Cells"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiLayer_49Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiLayer_48Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiClosingPlateParal"/>
+            <Translation x="[mb1:MB1SLPhiPl_x]+1.7*mm" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhiClosingPlateParal"/>
+            <Translation x="-([mb1:MB1SLPhiPl_x]+1.7*mm)" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhi_C_PlateParal"/>
+            <Translation x="[mb1:MB1SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhi_C_PlateParal"/>
+            <Translation x="[mb1:MB1SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhi_C_PlateParal"/>
+            <Translation x="-([mb1:MB1SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1ChimSLPhi_C_PlateParal"/>
+            <Translation x="-([mb1:MB1SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerPhi"/>
+            <rChild name="mb1:MB1SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1ChimSLPhiLayer_48Cells"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="N" value="48"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb1:MB1SLPhiL48]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1ChimSLPhiLayer_49Cells"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="N" value="49"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb1:MB1SLPhiL49]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1ChimSLPhiLayer_50Cells"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="N" value="50"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb1:MB1SLPhiL50]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSLPhiLayer_48Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_48Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSLPhiLayer_48Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_48Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSLPhiLayer_49Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_49Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSLPhiLayer_49Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_49Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSLPhiLayer_50Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_50Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSLPhiLayer_50Cells"/>
+            <rChild name="mb1:MB1SLPhiElectronics_50Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- #### MB1Chim: DT Superlayer Z -->
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimP"/>
+            <rChild name="mb1:MB1ChimSuperLayerZ"/>
+            <Translation x="[mb1:MB1pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimN"/>
+            <rChild name="mb1:MB1ChimSuperLayerZ"/>
+            <Translation x="[mb1:MB1pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <!-- #### MB1Chim: DT Superlayer Z internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZLayer_47Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZLayer_48Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZLayer_48Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZLayer_47Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1SLZClosingPlateParal"/>
+            <Translation x="[mbCommon:MBChimSLZPl_x]+1.7*mm" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1SLZClosingPlateParal"/>
+            <Translation x="-([mbCommon:MBChimSLZPl_x]+1.7*mm)" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZCommonElectronics"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSuperLayerZ"/>
+            <rChild name="mb1:MB1ChimSLZCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1ChimSLZLayer_47Cells"/>
+            <String name="ChildName" value="mb1:MB1SLZGas"/>
+            <Numeric name="N" value="47"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBChimSLZL47]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1ChimSLZLayer_47Cells_startCell2"/>
+            <String name="ChildName" value="mb1:MB1SLZGas"/>
+            <Numeric name="N" value="47"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBChimSLZL47]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb1:MB1ChimSLZLayer_48Cells"/>
+            <String name="ChildName" value="mb1:MB1SLZGas"/>
+            <Numeric name="N" value="48"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBChimSLZL48]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSLZLayer_47Cells"/>
+            <rChild name="mb1:MB1ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSLZLayer_47Cells"/>
+            <rChild name="mb1:MB1ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSLZLayer_47Cells_startCell2"/>
+            <rChild name="mb1:MB1ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSLZLayer_47Cells_startCell2"/>
+            <rChild name="mb1:MB1ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimSLZLayer_48Cells"/>
+            <rChild name="mb1:MB1ChimSLZElectronics_48Cells"/>
+            <Translation x="0.*fm" y="[mb1:MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimSLZLayer_48Cells"/>
+            <rChild name="mb1:MB1ChimSLZElectronics_48Cells"/>
+            <Translation x="0.*fm" y="-([mb1:MB1SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ##### MB1Chim: DT honeycomb -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimP"/>
+            <rChild name="mb1:MB1ChimHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimN"/>
+            <rChild name="mb1:MB1ChimHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1ChimHoneycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1ChimHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBHC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1ChimHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([mbCommon:MBHC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1ChimHc_LateralC"/>
+            <Translation x="[mb1:MB1HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1ChimHc_LateralC"/>
+            <Translation x="[mb1:MB1HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1ChimHc_LateralC"/>
+            <Translation x="-([mb1:MB1HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1ChimHc_LateralC"/>
+            <Translation x="-([mb1:MB1HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension]" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension]" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension])" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension])" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1ChimHc_LateralElectronics"/>
+            <Translation x="[mb1:MB1HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1ChimHc_LateralElectronics"/>
+            <Translation x="-([mb1:MB1HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimHoneycombBox"/>
+            <rChild name="mb1:MB1HcTorsionBar"/>
+            <Translation x="[mb1:MB1HC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- ##### MB1Chim: RPC chambers -->
+        <!-- ##### MB1Chim: RPC_IP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimP"/>
+            <rChild name="mb1:MB1ChimRPC_IP"/>
+            <Translation x="[mb1:MB1RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimRPC_IP"/>
+            <rChild name="mb1:MB1ChimRPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb1:MB1ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimRPC_IP"/>
+            <rChild name="mb1:MB1ChimRPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mb1:MB1ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB1Chim: RPC_OP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimP"/>
+            <rChild name="mb1:MB1ChimRPC_OP"/>
+            <Translation x="[mb1:MB1RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimRPC_OP"/>
+            <rChild name="mb1:MB1ChimRPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mb1:MB1ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimRPC_OP"/>
+            <rChild name="mb1:MB1ChimRPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mb1:MB1ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB1Chim: RPC_IN chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimN"/>
+            <rChild name="mb1:MB1ChimRPC_IN"/>
+            <Translation x="-[mb1:MB1RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimRPC_IN"/>
+            <rChild name="mb1:MB1ChimRPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb1:MB1ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimRPC_IN"/>
+            <rChild name="mb1:MB1ChimRPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mb1:MB1ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB1Chim: RPC_ON chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimN"/>
+            <rChild name="mb1:MB1ChimRPC_ON"/>
+            <Translation x="-[mb1:MB1RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimRPC_ON"/>
+            <rChild name="mb1:MB1ChimRPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mb1:MB1ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb1:MB1ChimRPC_ON"/>
+            <rChild name="mb1:MB1ChimRPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mb1:MB1ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/MuonCommonData/data/mb2/2015/v2/mb2.xml
+++ b/Geometry/MuonCommonData/data/mb2/2015/v2/mb2.xml
@@ -1,0 +1,2084 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <ConstantsSection label="mb2.xml" eval="true">
+        <!--- #### MB2: Positions -->
+        <!--%% Radial coordinates fo algos -->
+        <Constant name="MB2UnitRadius" value="5129.2287 *mm"/>
+        <Constant name="MB2PosAngle" value="-2.3945239*deg"/>
+        <!--%% Cartesian coordinates for sector 1 -->
+        <Constant name="MB2Pos_x" value="5098.*mm+[mbCommon:MBHC_offset]"/>
+        <Constant name="MB2Pos_y" value="-214.3*mm"/>
+        <!--- #### MB2: Constants for DT superlayer Phi -->
+        <Constant name="MB2SLPhiPl_x" value="2562./2*mm"/>
+        <Constant name="MB2SLPhiL59" value="[mbCommon:MBCell_width]*59+[mbCommon:MBIbeamWall]"/>
+        <Constant name="MB2SLPhiL60" value="[mbCommon:MBCell_width]*60+[mbCommon:MBIbeamWall]"/>
+        <!--- #### MB2: Constants for DT superlayer Z (although they are placed with a rotation that interchanges X and Z, the _x refers to the coordinate X in EDMS, that is the Z in its final position; similar for _z -->
+        <Constant name="MB2SLZWire_length" value="2501./2.*mm"/>
+        <!--%% Wire length from EDMS: THIS NUMBER DEFINE THE SL DIMENSIONS-->
+        <Constant name="MB2SLZBareWire_length" value="[MB2SLZWire_length]-15.5*mm"/>
+        <!--%% Bare Wire _length == wire_lenght - depth in tappini-->
+        <Constant name="MB2SLZLayer_length" value="[MB2SLZBareWire_length]+2*[mbCommon:MBLayerElectronics_width]"/>
+        <!--%% The z length of the Al layer volume-->
+        <Constant name="MB2SLZPlI_z" value="[MB2SLZLayer_length]+6.5*mm"/>
+        <!--%% Distance between tappini and Al Plate edge-->
+        <Constant name="MB2SLZPlO_z" value="[MB2SLZPlI_z]+38.*mm"/>
+        <!--- #### MB2: X dimensions -->
+        <Constant name="MB2_x" value="1334.*mm"/>
+        <Constant name="MB2HC_x" value="2488./2*mm"/>
+        <!--- #### MB2: Constants for DT positioning: distance from SL center to HC center -->
+        <Constant name="MB2pSLPhi1_HC_dist" value="-34.*mm"/>
+        <Constant name="MB2pSLPhi2_HC_dist" value="8.*mm"/>
+        <Constant name="MB2pSLZ_HC_dist" value="17.5*mm"/>
+        <Constant name="MB2nSLPhi1_HC_dist" value="34.*mm"/>
+        <Constant name="MB2nSLPhi2_HC_dist" value="-8.*mm"/>
+        <Constant name="MB2nSLZ_HC_dist" value="-17.5*mm"/>
+        <!--- #### MB2: Constants for DT RPCs -->
+        <Constant name="MB2RPC_x" value="2500./2*mm"/>
+        <Constant name="MB2RPC_Gas_x" value="[mb2:MB2RPC_x]-10.*mm"/>
+        <Constant name="MB2RPC_IGasLeft_y_pos" value="829*mm"/>
+        <Constant name="MB2RPC_IGasMiddle_y_pos" value="41.5*mm"/>
+        <Constant name="MB2RPC_IGasRight_y_pos" value="787.5*mm"/>
+        <Constant name="MB2RPC_I_x_pos" value="34.3*mm"/>
+        <Constant name="MB2RPC_O_x_pos" value="27.3*mm"/>
+        <!--- #### MB2Chim: Constants for DT RPCs -->
+        <Constant name="MB2ChimRPC_IGasLeft_y_pos" value="[mb2:MB2RPC_IGasLeft_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2-4.*mm"/>
+        <Constant name="MB2ChimRPC_IGasMiddle_y_pos" value="[mb2:MB2RPC_IGasMiddle_y_pos]"/>
+        <Constant name="MB2ChimRPC_IGasRight_y_pos" value="[mb2:MB2RPC_IGasRight_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2.-4.*mm"/>
+        <Constant name="MB2ChimRPC_OGasRight_y_pos" value="[mbCommon:MBRPC_GasRight_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2-4.*mm"/>
+        <Constant name="MB2ChimRPC_OGasLeft_y_pos" value="[mbCommon:MBRPC_GasLeft_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2.-4.*mm"/>
+    </ConstantsSection>
+    <SolidSection label="mb2.xml">
+        <!-- ####  MB2 Unit: fake volume representing one DTBX + 1 or 2 RPC -->
+        <!-- ####  MB2: DTBX chamber -->
+        <!--%% In MB2 the widest superlayer in x is the Z one -->
+        <Box name="MB2_a" dx="[MB2_x]" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With2RPC]"/>
+        <Box name="MB2_OLAP1" dx="19.5*mm" dy="[mbCommon:MBSLPhiPlO_z]+13.*mm" dz="11.5*mm"/>
+        <Box name="MB2_OLAP2" dx="39.9*mm" dy="[mbCommon:MBSLPhiPlO_z]+13.*mm" dz="69.1*mm"/>
+        <SubtractionSolid name="MB2P_b">
+            <rSolid name="MB2_a"/>
+            <rSolid name="MB2_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB2_x]-19.1*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+11.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB2P">
+            <rSolid name="MB2P_b"/>
+            <rSolid name="MB2_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB2_x]-39.8*mm" y="0.*fm" z="[mbCommon:MBHeight_With2RPC]-68.9*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB2N_b">
+            <rSolid name="MB2_a"/>
+            <rSolid name="MB2_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB2_x]+19.1*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+11.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB2N">
+            <rSolid name="MB2N_b"/>
+            <rSolid name="MB2_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB2_x]+39.8*mm" y="0.*fm" z="[mbCommon:MBHeight_With2RPC]-68.9*mm"/>
+        </SubtractionSolid>
+        <!-- ####  MB2: Superlayers Phi -->
+        <!--%% SuperLayer X,Z dimensions cover the outer Al plate + 2 mm for the closing profiles. Y is 5 Al plates + 4 Layer's -->
+        <Box name="MB2SuperLayerPhi" dx="[mb2:MB2SLPhiPl_x]+2.7*mm" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% MB2SLPhiClosingPlateParal is parallel to gas cells, MB2SLPhiClosingPlatePerp is perpendicular -->
+        <!--%% Parallel are 2 mm thick and as long as outer Plates -->
+        <Box name="MB2SLPhiClosingPlateParal" dx="1.*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB2SLPhi_C_PlateParal" dx="7.*mm" dy="[mbCommon:MBSLPhiPlO_z]-14.*mm" dz="1.*mm"/>
+        <!--%% Perpendicular are 12 mm thick and higher by 20 mm per side than the SL; 2.7 mm are added to reach the parallel "Cs" -->
+        <Box name="MB2SLPhiClosingPlatePerp" dx="[mb2:MB2SLPhiPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB2SLPhi_C_PlatePerp" dx="[mb2:MB2SLPhiPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <!--%% MB2SLPhiAlPlateOuter is 0.7 mm wider (perpendicular to the wires) to reach the parallel "Cs"-->
+        <Box name="MB2SLPhiAlPlateOuter" dx="[mb2:MB2SLPhiPl_x]+0.7*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!--%% MB2SLPhiAlPlateOuter does not reach the parallel "Cs"-->
+        <Box name="MB2SLPhiAlPlateInner" dx="[mb2:MB2SLPhiPl_x]" dy="[mbCommon:MBSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!--%% Fake layer volume contains the ibeams plus gas volumes: n+1 Ibeam's and n gas volumes.
+             (Ibeam wall width is ~1.35mm, but 0.1 is mylar, that is very light, so it set to 1.3) 
+             It is first made of aluminium and them it is filled with the n gas volumes. 
+             Z length is the bare wire length plus the electronics (==tappini)-->
+        <Box name="MB2SLPhiLayer_59Cells" dx="[MB2SLPhiL59]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2SLPhiLayer_60Cells" dx="[MB2SLPhiL60]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <!--%% Tappini, Perpendicular to the Ibeams and at the two ends -->
+        <Box name="MB2SLPhiElectronics_59Cells" dx="[mb2:MB2SLPhiL59]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2SLPhiElectronics_60Cells" dx="[mb2:MB2SLPhiL60]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2SLPhiCommonElectronics" dx="[mb2:MB2SLPhiPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!-- ####  MB2: Superlayer Z -->
+        <Box name="MB2SuperLayerZ" dx="[mbCommon:MBSLZPl_x]+2.7*mm" dy="[mb2:MB2SLZPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB2SLZClosingPlateParal" dx="1.*mm" dy="[mb2:MB2SLZPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB2SLZ_C_PlateParal" dx="7.*mm" dy="[mb2:MB2SLZPlO_z]-14.*mm" dz="1.*mm"/>
+        <Box name="MB2SLZClosingPlatePerp" dx="[mbCommon:MBSLZPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB2SLZ_C_PlatePerp" dx="[mbCommon:MBSLZPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <Box name="MB2SLZAlPlateOuter" dx="[mbCommon:MBSLZPl_x]+0.7*mm" dy="[mb2:MB2SLZPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB2SLZAlPlateInner" dx="[mbCommon:MBSLZPl_x]" dy="[mb2:MB2SLZPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB2SLZLayer_56Cells" dx="[mbCommon:MBSLZL56]" dy="[mb2:MB2SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2SLZLayer_57Cells" dx="[mbCommon:MBSLZL57]" dy="[mb2:MB2SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2SLZLayer_58Cells" dx="[mbCommon:MBSLZL58]" dy="[mb2:MB2SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2SLZElectronics_56Cells" dx="[mbCommon:MBSLZL56]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2SLZElectronics_57Cells" dx="[mbCommon:MBSLZL57]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2SLZElectronics_58Cells" dx="[mbCommon:MBSLZL58]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2SLZCommonElectronics" dx="[mbCommon:MBSLZPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!--%% Effective gas volume -->
+        <Box name="MB2SLZGas_a" dx="20.35*mm" dy="[MB2SLZBareWire_length]" dz="[mbCommon:MBGas_height]"/>
+        <!--%% Horizontal bars to make the 'I' shape (without them it would be a '|') -->
+        <Box name="MB2SLZIBeamWing" dx="3.175*mm" dy="[MB2SLZBareWire_length]" dz="0.65*mm"/>
+        <SubtractionSolid name="MB2SLZGas_b">
+            <rSolid name="MB2SLZGas_a"/>
+            <rSolid name="MB2SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" y="0.*fm" z="5.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB2SLZGas_c">
+            <rSolid name="MB2SLZGas_b"/>
+            <rSolid name="MB2SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" y="0.*fm" z="-5.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB2SLZGas_d">
+            <rSolid name="MB2SLZGas_c"/>
+            <rSolid name="MB2SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" y="0.*fm" z="5.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB2SLZGas">
+            <rSolid name="MB2SLZGas_d"/>
+            <rSolid name="MB2SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" y="0.*fm" z="-5.1*mm"/>
+        </SubtractionSolid>
+        <!-- ####  MB2: Honeycomb -->
+        <Box name="MB2HoneycombBox" dx="[mb2:MB2HC_x]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHC_height]"/>
+        <Box name="MB2Honeycomb" dx="[mb2:MB2HC_x]-125.*mm" dy="[mbCommon:MBHC_z]-125.*mm" dz="[mbCommon:MBHC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB2HcPlate" dx="[mb2:MB2HC_x]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB2Hc_LateralC" dx="[mbCommon:MBHC_C_dimension]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB2Hc_FrontC" dx="[mb2:MB2HC_x]-125.*mm" dy="[mbCommon:MBHC_C_dimension]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB2Hc_LateralElectronics" dx="[mbCommon:MBHCLatElectronics_width]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHCElectronics_height]"/>
+        <Box name="MB2Hc_FrontElectronics" dx="[mb2:MB2HC_x]-125.*mm" dy="[mbCommon:MBHCFrontElectronics_width]" dz="[mbCommon:MBHCElectronics_height]"/>
+        <Box name="MB2HcTorsionBar" dx="25*mm" dy="678*mm" dz="50.*mm"/>
+        <!-- ####  MB2: RPC chambers -->
+        <Box name="MB2RPC" dx="[mb2:MB2RPC_x]" dy="[mbCommon:MBRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB23RPC_IGasLeft" dx="[mb2:MB2RPC_Gas_x]" dy="384.5*mm" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB23RPC_IGasMiddle" dx="[mb2:MB2RPC_Gas_x]" dy="397.*mm" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB23RPC_IGasRight" dx="[mb2:MB2RPC_Gas_x]" dy="426.*mm" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB23RPC_OGasLeft" dx="[mb2:MB2RPC_Gas_x]" dy="384.5*mm" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB23RPC_OGasMiddle" dx="[mb2:MB2RPC_Gas_x]" dy="397.*mm" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB23RPC_OGasRight" dx="[mb2:MB2RPC_Gas_x]" dy="426.*mm" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB22RPC_IGasLeft" dx="[mb2:MB2RPC_Gas_x]" dy="[mbCommon:MBRPC_GasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB22RPC_IGasRight" dx="[mb2:MB2RPC_Gas_x]" dy="[mbCommon:MBRPC_GasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB22RPC_OGasLeft" dx="[mb2:MB2RPC_Gas_x]" dy="[mbCommon:MBRPC_GasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB22RPC_OGasRight" dx="[mb2:MB2RPC_Gas_x]" dy="[mbCommon:MBRPC_GasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <!-- ####  MB2Chimney Unit -->
+        <!-- ####  MB2Chim: DTBX chamber -->
+        <Box name="MB2Chim_a" dx="[MB2_x]" dy="[mbCommon:MBChimSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With2RPC]"/>
+        <SubtractionSolid name="MB2ChimP_b">
+            <rSolid name="MB2Chim_a"/>
+            <rSolid name="MB2_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB2_x]-19.1*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+11.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB2ChimP">
+            <rSolid name="MB2ChimP_b"/>
+            <rSolid name="MB2_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB2_x]-39.8*mm" y="0.*fm" z="[mbCommon:MBHeight_With2RPC]-68.9*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB2ChimN_b">
+            <rSolid name="MB2Chim_a"/>
+            <rSolid name="MB2_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB2_x]+19.1*mm" y="0.*fm" z="-[mbCommon:MBHeight_With2RPC]+11.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB2ChimN">
+            <rSolid name="MB2ChimN_b"/>
+            <rSolid name="MB2_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB2_x]+39.8*mm" y="0.*fm" z="[mbCommon:MBHeight_With2RPC]-68.9*mm"/>
+        </SubtractionSolid>
+        <!-- ####  MB2Chim: DT Superlayers Phi -->
+        <Box name="MB2ChimSuperLayerPhi" dx="[mb2:MB2SLPhiPl_x]+2.7*mm" dy="[mbCommon:MBChimSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% Only extra parallel "Cs" are needed -->
+        <Box name="MB2ChimSLPhiClosingPlateParal" dx="1.*mm" dy="[mbCommon:MBChimSLPhiPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB2ChimSLPhi_C_PlateParal" dx="7.*mm" dy="[mbCommon:MBChimSLPhiPlO_z]-14.*mm" dz="1.*mm"/>
+        <Box name="MB2ChimSLPhiAlPlateOuter" dx="[mb2:MB2SLPhiPl_x]+0.7*mm" dy="[mbCommon:MBChimSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB2ChimSLPhiAlPlateInner" dx="[mb2:MB2SLPhiPl_x]" dy="[mbCommon:MBChimSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB2ChimSLPhiLayer_59Cells" dx="[mb2:MB2SLPhiL59]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2ChimSLPhiLayer_60Cells" dx="[mb2:MB2SLPhiL60]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <!-- ####  MB2Chim: DT Superlayer Z -->
+        <Box name="MB2ChimSuperLayerZ" dx="[mbCommon:MBChimSLZPl_x]+2.7*mm" dy="[mb2:MB2SLZPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% Only extra perperdicular "Cs" are needed -->
+        <Box name="MB2ChimSLZClosingPlatePerp" dx="[mbCommon:MBChimSLZPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB2ChimSLZ_C_PlatePerp" dx="[mbCommon:MBChimSLZPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <Box name="MB2ChimSLZAlPlateOuter" dx="[mbCommon:MBChimSLZPl_x]+0.7*mm" dy="[mb2:MB2SLZPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB2ChimSLZAlPlateInner" dx="[mbCommon:MBChimSLZPl_x]" dy="[mb2:MB2SLZPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB2ChimSLZLayer_47Cells" dx="[mbCommon:MBChimSLZL47]" dy="[mb2:MB2SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2ChimSLZLayer_48Cells" dx="[mbCommon:MBChimSLZL48]" dy="[mb2:MB2SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2ChimSLZElectronics_47Cells" dx="[mbCommon:MBChimSLZL47]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2ChimSLZElectronics_48Cells" dx="[mbCommon:MBChimSLZL48]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB2ChimSLZCommonElectronics" dx="[mbCommon:MBChimSLZPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!-- ####  MB2Chim: DT Honeycomb -->
+        <Box name="MB2ChimHoneycombBox" dx="[mb2:MB2HC_x]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHC_height]"/>
+        <Box name="MB2ChimHoneycomb" dx="[mb2:MB2HC_x]-125.*mm" dy="[mbCommon:MBChimHC_z]-125.*mm" dz="[mbCommon:MBHC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB2ChimHc_LateralC" dx="[mbCommon:MBHC_C_dimension]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB2ChimHc_LateralElectronics" dx="[mbCommon:MBHCLatElectronics_width]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHCElectronics_height]"/>
+        <Box name="MB2ChimHcPlate" dx="[mb2:MB2HC_x]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!-- ####  MB2Chim: RPC chambers -->
+        <Box name="MB2ChimRPC" dx="[mb2:MB2RPC_x]" dy="[mbCommon:MBChimRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB2ChimRPC_IGasLeft" dx="[mb2:MB2RPC_Gas_x]" dy="(379.+195.)/2*mm" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB2ChimRPC_IGasRight" dx="[mb2:MB2RPC_Gas_x]" dy="(852.-195.)/2*mm" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB2ChimRPC_OGasLeft" dx="[mb2:MB2RPC_Gas_x]" dy="[mbCommon:MBChimRPC_OGasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB2ChimRPC_OGasRight" dx="[mb2:MB2RPC_Gas_x]" dy="[mbCommon:MBChimRPC_OGasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+    </SolidSection>
+    <LogicalPartSection label="mb2.xml">
+        <!-- ####  MB2 Unit -->
+        <!-- ####  MB2: DTBX -->
+        <!-- START COMMENT
+             
+             The following two LogicalParts need not be built!  Please tell me if you uncomment these two LP's 
+             Michael Case
+             
+             <LogicalPart name="MB2P" category="unspecified">
+             <rSolid name="MB2P"/>
+             <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+             <LogicalPart name="MB2N" category="unspecified">
+             <rSolid name="MB2N"/>
+             <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+             END COMMENT -->
+        <!-- # There are several combinations of DT and RPC chambers for this station: mixing DT positive and negative and RPC positive with 3 gas volumes inner and 2 outer, positive with 2 gas volumes inner and 2 outer, negative with 3 gas volumes inner and 2 outer, negative with 2 gas volumes inner and 2 outer
+             Wheel_0:  DT pos, RPC pos 3/2  -  MB2P32P
+             Wheel_0:  DT neg, RPC pos 3/2  -  MB2N32P
+             Wheel_1P: DT pos, RPC pos 3/2  -  (also MB2P32P)
+             Wheel_2P: DT pos, RPC pos 2/3  -  MB2P23P
+             Wheel_1N: DT neg, RPC neg 3/2  -  MB2N32N
+             Wheel_2N: DT neg, RPC neg 2/3  -  MB2N23N,
+             
+             plus MB2ChimP (32P) , MB2ChimN (32N)
+             -->
+        <LogicalPart name="MB2P32P" category="unspecified">
+            <rSolid name="MB2P"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2N32P" category="unspecified">
+            <rSolid name="MB2N"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2P23P" category="unspecified">
+            <rSolid name="MB2P"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2N32N" category="unspecified">
+            <rSolid name="MB2N"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2N23N" category="unspecified">
+            <rSolid name="MB2N"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <!-- ####  MB2: DT Superlayers Phi -->
+        <LogicalPart name="MB2SuperLayerPhi" category="unspecified">
+            <rSolid name="MB2SuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiClosingPlateParal" category="unspecified">
+            <rSolid name="MB2SLPhiClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhi_C_PlateParal" category="unspecified">
+            <rSolid name="MB2SLPhi_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiClosingPlatePerp" category="unspecified">
+            <rSolid name="MB2SLPhiClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhi_C_PlatePerp" category="unspecified">
+            <rSolid name="MB2SLPhi_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB2SLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB2SLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiLayer_59Cells" category="unspecified">
+            <rSolid name="MB2SLPhiLayer_59Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiLayer_59Cells_startCell2" category="unspecified">
+            <rSolid name="MB2SLPhiLayer_59Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiLayer_60Cells" category="unspecified">
+            <rSolid name="MB2SLPhiLayer_60Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiElectronics_59Cells" category="unspecified">
+            <rSolid name="MB2SLPhiElectronics_59Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiElectronics_60Cells" category="unspecified">
+            <rSolid name="MB2SLPhiElectronics_60Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLPhiCommonElectronics" category="unspecified">
+            <rSolid name="MB2SLPhiCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB2: DT Superlayer Z -->
+        <LogicalPart name="MB2SuperLayerZ" category="unspecified">
+            <rSolid name="MB2SuperLayerZ"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZClosingPlateParal" category="unspecified">
+            <rSolid name="MB2SLZClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZClosingPlatePerp" category="unspecified">
+            <rSolid name="MB2SLZClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZ_C_PlateParal" category="unspecified">
+            <rSolid name="MB2SLZ_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZ_C_PlatePerp" category="unspecified">
+            <rSolid name="MB2SLZ_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZAlPlateOuter" category="unspecified">
+            <rSolid name="MB2SLZAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZAlPlateInner" category="unspecified">
+            <rSolid name="MB2SLZAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZLayer_56Cells" category="unspecified">
+            <rSolid name="MB2SLZLayer_56Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZLayer_57Cells" category="unspecified">
+            <rSolid name="MB2SLZLayer_57Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZLayer_58Cells" category="unspecified">
+            <rSolid name="MB2SLZLayer_58Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZIBeamWing" category="unspecified">
+            <rSolid name="MB2SLZIBeamWing"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZGas" category="unspecified">
+            <rSolid name="MB2SLZGas"/>
+            <rMaterial name="materials:M_DTBX Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZElectronics_56Cells" category="unspecified">
+            <rSolid name="MB2SLZElectronics_56Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZElectronics_57Cells" category="unspecified">
+            <rSolid name="MB2SLZElectronics_57Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZElectronics_58Cells" category="unspecified">
+            <rSolid name="MB2SLZElectronics_58Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB2SLZCommonElectronics" category="unspecified">
+            <rSolid name="MB2SLZCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB2: DT Honeycomb -->
+        <LogicalPart name="MB2HoneycombBox" category="unspecified">
+            <rSolid name="MB2HoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2Honeycomb" category="unspecified">
+            <rSolid name="MB2Honeycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB2HcPlate" category="unspecified">
+            <rSolid name="MB2HcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2Hc_LateralC" category="unspecified">
+            <rSolid name="MB2Hc_LateralC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2Hc_FrontC" category="unspecified">
+            <rSolid name="MB2Hc_FrontC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2Hc_LateralElectronics" category="unspecified">
+            <rSolid name="MB2Hc_LateralElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB2Hc_FrontElectronics" category="unspecified">
+            <rSolid name="MB2Hc_FrontElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB2HcTorsionBar" category="unspecified">
+            <rSolid name="MB2HcTorsionBar"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- ####  MB2: RPC chambers -->
+        <LogicalPart name="MB22RPC_IP" category="unspecified">
+            <rSolid name="MB2RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB22RPC_IN" category="unspecified">
+            <rSolid name="MB2RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_IP" category="unspecified">
+            <rSolid name="MB2RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_IN" category="unspecified">
+            <rSolid name="MB2RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_IGasLeft" category="unspecified">
+            <rSolid name="MB23RPC_IGasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_IGasMiddle" category="unspecified">
+            <rSolid name="MB23RPC_IGasMiddle"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_IGasRight" category="unspecified">
+            <rSolid name="MB23RPC_IGasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB22RPC_IGasLeft" category="unspecified">
+            <rSolid name="MB22RPC_IGasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB22RPC_IGasRight" category="unspecified">
+            <rSolid name="MB22RPC_IGasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB22RPC_OP" category="unspecified">
+            <rSolid name="MB2RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB22RPC_ON" category="unspecified">
+            <rSolid name="MB2RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_OP" category="unspecified">
+            <rSolid name="MB2RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_ON" category="unspecified">
+            <rSolid name="MB2RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_OGasLeft" category="unspecified">
+            <rSolid name="MB23RPC_OGasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_OGasMiddle" category="unspecified">
+            <rSolid name="MB23RPC_OGasMiddle"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB23RPC_OGasRight" category="unspecified">
+            <rSolid name="MB23RPC_OGasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB22RPC_OGasLeft" category="unspecified">
+            <rSolid name="MB22RPC_OGasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB22RPC_OGasRight" category="unspecified">
+            <rSolid name="MB22RPC_OGasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <!-- ####  MB2Chimney Unit -->
+        <!-- ####  MB2Chim: DTBX -->
+        <LogicalPart name="MB2ChimP" category="unspecified">
+            <rSolid name="MB2ChimP"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimN" category="unspecified">
+            <rSolid name="MB2ChimN"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <!-- ####  MB2Chim: DT Superlayers Phi -->
+        <LogicalPart name="MB2ChimSuperLayerPhi" category="unspecified">
+            <rSolid name="MB2ChimSuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLPhiClosingPlateParal" category="unspecified">
+            <rSolid name="MB2ChimSLPhiClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLPhi_C_PlateParal" category="unspecified">
+            <rSolid name="MB2ChimSLPhi_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB2ChimSLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB2ChimSLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLPhiLayer_59Cells" category="unspecified">
+            <rSolid name="MB2ChimSLPhiLayer_59Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLPhiLayer_59Cells_startCell2" category="unspecified">
+            <rSolid name="MB2ChimSLPhiLayer_59Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLPhiLayer_60Cells" category="unspecified">
+            <rSolid name="MB2ChimSLPhiLayer_60Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- ####  MB2Chim: DT Superlayer Z -->
+        <LogicalPart name="MB2ChimSuperLayerZ" category="unspecified">
+            <rSolid name="MB2ChimSuperLayerZ"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZClosingPlatePerp" category="unspecified">
+            <rSolid name="MB2ChimSLZClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZ_C_PlatePerp" category="unspecified">
+            <rSolid name="MB2ChimSLZ_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZAlPlateOuter" category="unspecified">
+            <rSolid name="MB2ChimSLZAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZAlPlateInner" category="unspecified">
+            <rSolid name="MB2ChimSLZAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZLayer_47Cells" category="unspecified">
+            <rSolid name="MB2ChimSLZLayer_47Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZLayer_47Cells_startCell2" category="unspecified">
+            <rSolid name="MB2ChimSLZLayer_47Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZLayer_48Cells" category="unspecified">
+            <rSolid name="MB2ChimSLZLayer_48Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZElectronics_47Cells" category="unspecified">
+            <rSolid name="MB2ChimSLZElectronics_47Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZElectronics_48Cells" category="unspecified">
+            <rSolid name="MB2ChimSLZElectronics_48Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimSLZCommonElectronics" category="unspecified">
+            <rSolid name="MB2ChimSLZCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB2Chim: DT Honeycomb -->
+        <LogicalPart name="MB2ChimHoneycombBox" category="unspecified">
+            <rSolid name="MB2ChimHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimHoneycomb" category="unspecified">
+            <rSolid name="MB2ChimHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimHcPlate" category="unspecified">
+            <rSolid name="MB2ChimHcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimHc_LateralC" category="unspecified">
+            <rSolid name="MB2ChimHc_LateralC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimHc_LateralElectronics" category="unspecified">
+            <rSolid name="MB2ChimHc_LateralElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB2Chim: RPC chambers -->
+        <LogicalPart name="MB2ChimRPC_IP" category="unspecified">
+            <rSolid name="MB2ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimRPC_IN" category="unspecified">
+            <rSolid name="MB2ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimRPC_IGasLeft" category="unspecified">
+            <rSolid name="MB2ChimRPC_IGasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimRPC_IGasMiddle" category="unspecified">
+            <rSolid name="MB23RPC_IGasMiddle"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimRPC_IGasRight" category="unspecified">
+            <rSolid name="MB2ChimRPC_IGasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimRPC_OP" category="unspecified">
+            <rSolid name="MB2ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimRPC_ON" category="unspecified">
+            <rSolid name="MB2ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimRPC_OGasLeft" category="unspecified">
+            <rSolid name="MB2ChimRPC_OGasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB2ChimRPC_OGasRight" category="unspecified">
+            <rSolid name="MB2ChimRPC_OGasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="mb2.xml">
+        <!-- ####  MB2 Unit -->
+        <!-- ####  MB2: DTBX chamber -->
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb2:MB2N32P"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB2UnitRadius]"/>
+            <Numeric name="StartAngle" value="360.*deg+[MB2PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB2PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb2:MB2P32P"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB2UnitRadius]"/>
+            <Numeric name="StartAngle" value="30.*deg+[MB2PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB2PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb2:MB2P32P"/>
+            <Numeric name="StartCopyNo" value="3"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB2UnitRadius]"/>
+            <Numeric name="StartAngle" value="60.*deg+[MB2PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB2PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb2:MB2N32P"/>
+            <Numeric name="StartCopyNo" value="4"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB2UnitRadius]"/>
+            <Numeric name="StartAngle" value="90.*deg+[MB2PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB2PosAngle] </Vector>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb2:MB2P32P"/>
+            <rRotation name="rotations:RM1872"/>
+            <Translation x="[MB2Pos_x]" y="[MB2Pos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb2:MB2P32P"/>
+            <rRotation name="rotations:RM1882"/>
+            <Translation x="[MB2Pos_x]*0.86602543-[MB2Pos_y]*0.5" y="[MB2Pos_x]*0.5+[MB2Pos_y]*0.86602543" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb2:MB2P32P"/>
+            <rRotation name="rotations:RM1892"/>
+            <Translation x="[MB2Pos_x]*0.5-[MB2Pos_y]*0.86602543" y="[MB2Pos_x]*0.86602543+[MB2Pos_y]*0.5" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb2:MB2ChimP"/>
+            <rRotation name="rotations:RM1902"/>
+            <Translation x="-[MB2Pos_y]" y="[MB2Pos_x]" z="[mbCommon:MBChimPos_z]"/>
+        </PosPart>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <String name="ChildName" value="mb2:MB2P32P"/>
+            <Numeric name="StartCopyNo" value="5"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="8"/>
+            <Numeric name="Radius" value="[MB2UnitRadius]"/>
+            <Numeric name="StartAngle" value="120.*deg+[MB2PosAngle]"/>
+            <Numeric name="RangeAngle" value="210.*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB2PosAngle] </Vector>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb2:MB2N32N"/>
+            <rRotation name="rotations:E127"/>
+            <Translation x="[MB2Pos_x]" y="[MB2Pos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb2:MB2N32N"/>
+            <rRotation name="rotations:MM200"/>
+            <Translation x="[MB2Pos_x]*0.86602543-[MB2Pos_y]*0.5" y="[MB2Pos_x]*0.5+[MB2Pos_y]*0.86602543" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb2:MB2ChimN"/>
+            <rRotation name="rotations:MM300"/>
+            <Translation x="[MB2Pos_x]*0.5-[MB2Pos_y]*0.86602543" y="[MB2Pos_x]*0.86602543+[MB2Pos_y]*0.5" z="-[mbCommon:MBChimPos_z]"/>
+        </PosPart>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <String name="ChildName" value="mb2:MB2N32N"/>
+            <Numeric name="StartCopyNo" value="4"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="9"/>
+            <Numeric name="Radius" value="[MB2UnitRadius]"/>
+            <Numeric name="StartAngle" value="90.*deg+[MB2PosAngle]"/>
+            <Numeric name="RangeAngle" value="240.*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB2PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <String name="ChildName" value="mb2:MB2P23P"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="12"/>
+            <Numeric name="Radius" value="[MB2UnitRadius]"/>
+            <Numeric name="StartAngle" value="360.*deg+[MB2PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB2PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <String name="ChildName" value="mb2:MB2N23N"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="12"/>
+            <Numeric name="Radius" value="[MB2UnitRadius]"/>
+            <Numeric name="StartAngle" value="360.*deg+[MB2PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB2PosAngle] </Vector>
+        </Algorithm>
+        <!-- #### MB2: DT Superlayers Phi -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2P32P"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2pSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2P32P"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2pSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2P23P"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2pSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2P23P"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2pSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N32P"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2nSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2N32P"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2nSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N32N"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2nSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2N32N"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2nSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N23N"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2nSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2N23N"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb2:MB2nSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <!-- ## MB2: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiLayer_59Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiLayer_60Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiLayer_60Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiLayer_59Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiClosingPlateParal"/>
+            <Translation x="[mb2:MB2SLPhiPl_x]+1.7*mm" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiClosingPlateParal"/>
+            <Translation x="-([mb2:MB2SLPhiPl_x]+1.7*mm)" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlateParal"/>
+            <Translation x="[mb2:MB2SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlateParal"/>
+            <Translation x="[mb2:MB2SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlateParal"/>
+            <Translation x="-([mb2:MB2SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlateParal"/>
+            <Translation x="-([mb2:MB2SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2SLPhiLayer_59Cells"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="59"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb2:MB2SLPhiL59]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2SLPhiLayer_59Cells_startCell2"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="59"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb2:MB2SLPhiL59]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2SLPhiLayer_60Cells"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="60"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb2:MB2SLPhiL60]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SLPhiLayer_59Cells"/>
+            <rChild name="mb2:MB2SLPhiElectronics_59Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SLPhiLayer_59Cells"/>
+            <rChild name="mb2:MB2SLPhiElectronics_59Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SLPhiLayer_59Cells_startCell2"/>
+            <rChild name="mb2:MB2SLPhiElectronics_59Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SLPhiLayer_59Cells_startCell2"/>
+            <rChild name="mb2:MB2SLPhiElectronics_59Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SLPhiLayer_60Cells"/>
+            <rChild name="mb2:MB2SLPhiElectronics_60Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SLPhiLayer_60Cells"/>
+            <rChild name="mb2:MB2SLPhiElectronics_60Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- #### MB2: DT Superlayer Z -->
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2P32P"/>
+            <rChild name="mb2:MB2SuperLayerZ"/>
+            <Translation x="[mb2:MB2pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2P23P"/>
+            <rChild name="mb2:MB2SuperLayerZ"/>
+            <Translation x="[mb2:MB2pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2N32P"/>
+            <rChild name="mb2:MB2SuperLayerZ"/>
+            <Translation x="[mb2:MB2nSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2N32N"/>
+            <rChild name="mb2:MB2SuperLayerZ"/>
+            <Translation x="[mb2:MB2nSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2N23N"/>
+            <rChild name="mb2:MB2SuperLayerZ"/>
+            <Translation x="[mb2:MB2nSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <!-- #### MB2: DT Superlayer Z internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="0.*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZLayer_57Cells"/>
+            <Translation x="0*fm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZLayer_58Cells"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZLayer_57Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZLayer_56Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZClosingPlateParal"/>
+            <Translation x="[mbCommon:MBSLZPl_x]+1.7*mm" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZClosingPlateParal"/>
+            <Translation x="-([mbCommon:MBSLZPl_x]+1.7*mm)" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZCommonElectronics"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SuperLayerZ"/>
+            <rChild name="mb2:MB2SLZCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2SLZLayer_56Cells"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="56"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mb2:MB2SLZGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBSLZL56]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2SLZLayer_57Cells"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="57"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mb2:MB2SLZGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBSLZL57]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2SLZLayer_58Cells"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="58"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mb2:MB2SLZGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBSLZL58]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SLZLayer_56Cells"/>
+            <rChild name="mb2:MB2SLZElectronics_56Cells"/>
+            <Translation x="0.*fm" y="[MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SLZLayer_56Cells"/>
+            <rChild name="mb2:MB2SLZElectronics_56Cells"/>
+            <Translation x="0.*fm" y="-([MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SLZLayer_57Cells"/>
+            <rChild name="mb2:MB2SLZElectronics_57Cells"/>
+            <Translation x="0.*fm" y="[MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SLZLayer_57Cells"/>
+            <rChild name="mb2:MB2SLZElectronics_57Cells"/>
+            <Translation x="0.*fm" y="-([MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2SLZLayer_58Cells"/>
+            <rChild name="mb2:MB2SLZElectronics_58Cells"/>
+            <Translation x="0.*fm" y="[MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2SLZLayer_58Cells"/>
+            <rChild name="mb2:MB2SLZElectronics_58Cells"/>
+            <Translation x="0.*fm" y="-([MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ##### MB2: DT honeycomb -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2P32P"/>
+            <rChild name="mb2:MB2HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2P23P"/>
+            <rChild name="mb2:MB2HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N32P"/>
+            <rChild name="mb2:MB2HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N32N"/>
+            <rChild name="mb2:MB2HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N23N"/>
+            <rChild name="mb2:MB2HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Honeycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBHC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([mbCommon:MBHC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_LateralC"/>
+            <Translation x="[mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_LateralC"/>
+            <Translation x="[mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_LateralC"/>
+            <Translation x="-([mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_LateralC"/>
+            <Translation x="-([mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_LateralElectronics"/>
+            <Translation x="[mb2:MB2HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_LateralElectronics"/>
+            <Translation x="-([mb2:MB2HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2HoneycombBox"/>
+            <rChild name="mb2:MB2HcTorsionBar"/>
+            <Translation x="[mb2:MB2HC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- ##### MB2: RPC chambers -->
+        <!-- ##### MB2/3:  RPC_IP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2P32P"/>
+            <rChild name="mb2:MB23RPC_IP"/>
+            <Translation x="-[mb2:MB2RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_IP"/>
+            <rChild name="mb2:MB23RPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb2:MB2RPC_IGasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_IP"/>
+            <rChild name="mb2:MB23RPC_IGasMiddle"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb2:MB2RPC_IGasMiddle_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_IP"/>
+            <rChild name="mb2:MB23RPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mb2:MB2RPC_IGasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2/3:  RPC_OP chamber -->
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2P23P"/>
+            <rChild name="mb2:MB23RPC_OP"/>
+            <Translation x="-[mb2:MB2RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_OP"/>
+            <rChild name="mb2:MB23RPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mb2:MB2RPC_IGasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_OP"/>
+            <rChild name="mb2:MB23RPC_OGasMiddle"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mb2:MB2RPC_IGasMiddle_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_OP"/>
+            <rChild name="mb2:MB23RPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mb2:MB2RPC_IGasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2/3:  RPC_IN chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N32P"/>
+            <rChild name="mb2:MB23RPC_IN"/>
+            <Translation x="[mb2:MB2RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N32N"/>
+            <rChild name="mb2:MB23RPC_IN"/>
+            <Translation x="[mb2:MB2RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_IN"/>
+            <rChild name="mb2:MB23RPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb2:MB2RPC_IGasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_IN"/>
+            <rChild name="mb2:MB23RPC_IGasMiddle"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb2:MB2RPC_IGasMiddle_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_IN"/>
+            <rChild name="mb2:MB23RPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mb2:MB2RPC_IGasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2/2:  RPC_IP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2P23P"/>
+            <rChild name="mb2:MB22RPC_IP"/>
+            <Translation x="-[mb2:MB2RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB22RPC_IP"/>
+            <rChild name="mb2:MB22RPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB22RPC_IP"/>
+            <rChild name="mb2:MB22RPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2/2:  RPC_OP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2P32P"/>
+            <rChild name="mb2:MB22RPC_OP"/>
+            <Translation x="-[mb2:MB2RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB22RPC_OP"/>
+            <rChild name="mb2:MB22RPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB22RPC_OP"/>
+            <rChild name="mb2:MB22RPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2/2:  RPC_IN chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N23N"/>
+            <rChild name="mb2:MB22RPC_IN"/>
+            <Translation x="[mb2:MB2RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB22RPC_IN"/>
+            <rChild name="mb2:MB22RPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB22RPC_IN"/>
+            <rChild name="mb2:MB22RPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2/3:  RPC_ON chamber -->
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2N23N"/>
+            <rChild name="mb2:MB23RPC_ON"/>
+            <Translation x="[mb2:MB2RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_ON"/>
+            <rChild name="mb2:MB23RPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mb2:MB2RPC_IGasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_ON"/>
+            <rChild name="mb2:MB23RPC_OGasMiddle"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mb2:MB2RPC_IGasMiddle_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB23RPC_ON"/>
+            <rChild name="mb2:MB23RPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mb2:MB2RPC_IGasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2/2:  RPC_ON chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N32P"/>
+            <rChild name="mb2:MB22RPC_ON"/>
+            <Translation x="[mb2:MB2RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2N32N"/>
+            <rChild name="mb2:MB22RPC_ON"/>
+            <Translation x="[mb2:MB2RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB22RPC_ON"/>
+            <rChild name="mb2:MB22RPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB22RPC_ON"/>
+            <rChild name="mb2:MB22RPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2: RPC_ON chamber -->
+        <!-- ####  MB2Chimney Unit -->
+        <!-- ####  MB2Chim: DTBX chamber -->
+        <!-- #### MB2: DT Superlayers Phi -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimP"/>
+            <rChild name="mb2:MB2ChimSuperLayerPhi"/>
+            <Translation x="[mb2:MB2pSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimP"/>
+            <rChild name="mb2:MB2ChimSuperLayerPhi"/>
+            <Translation x="[mb2:MB2pSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimN"/>
+            <rChild name="mb2:MB2ChimSuperLayerPhi"/>
+            <Translation x="[mb2:MB2nSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimN"/>
+            <rChild name="mb2:MB2ChimSuperLayerPhi"/>
+            <Translation x="[mb2:MB2nSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]"/>
+        </PosPart>
+        <!-- ## MB2: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiLayer_59Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiLayer_60Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiLayer_60Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiLayer_59Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiClosingPlateParal"/>
+            <Translation x="[mb2:MB2SLPhiPl_x]+1.7*mm" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhiClosingPlateParal"/>
+            <Translation x="-([mb2:MB2SLPhiPl_x]+1.7*mm)" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhi_C_PlateParal"/>
+            <Translation x="[mb2:MB2SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhi_C_PlateParal"/>
+            <Translation x="[mb2:MB2SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhi_C_PlateParal"/>
+            <Translation x="-([mb2:MB2SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2ChimSLPhi_C_PlateParal"/>
+            <Translation x="-([mb2:MB2SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerPhi"/>
+            <rChild name="mb2:MB2SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2ChimSLPhiLayer_59Cells"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="59"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb2:MB2SLPhiL59]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2ChimSLPhiLayer_59Cells_startCell2"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="59"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb2:MB2SLPhiL59]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2ChimSLPhiLayer_60Cells"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="60"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb2:MB2SLPhiL60]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSLPhiLayer_59Cells"/>
+            <rChild name="mb2:MB2SLPhiElectronics_59Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSLPhiLayer_59Cells"/>
+            <rChild name="mb2:MB2SLPhiElectronics_59Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSLPhiLayer_59Cells_startCell2"/>
+            <rChild name="mb2:MB2SLPhiElectronics_59Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSLPhiLayer_59Cells_startCell2"/>
+            <rChild name="mb2:MB2SLPhiElectronics_59Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSLPhiLayer_60Cells"/>
+            <rChild name="mb2:MB2SLPhiElectronics_60Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSLPhiLayer_60Cells"/>
+            <rChild name="mb2:MB2SLPhiElectronics_60Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- #### MB2Chim: DT Superlayer Z -->
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimP"/>
+            <rChild name="mb2:MB2ChimSuperLayerZ"/>
+            <Translation x="[mb2:MB2pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimN"/>
+            <rChild name="mb2:MB2ChimSuperLayerZ"/>
+            <Translation x="[mb2:MB2pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <!-- #### MB2Chim: DT Superlayer Z internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZLayer_47Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZLayer_48Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZLayer_48Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZLayer_47Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2SLZClosingPlateParal"/>
+            <Translation x="[mbCommon:MBChimSLZPl_x]+1.7*mm" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2SLZClosingPlateParal"/>
+            <Translation x="-([mbCommon:MBChimSLZPl_x]+1.7*mm)" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZCommonElectronics"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSuperLayerZ"/>
+            <rChild name="mb2:MB2ChimSLZCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2ChimSLZLayer_47Cells"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="47"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mb2:MB2SLZGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBChimSLZL47]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2ChimSLZLayer_47Cells_startCell2"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="47"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mb2:MB2SLZGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBChimSLZL47]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb2:MB2ChimSLZLayer_48Cells"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="48"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <String name="ChildName" value="mb2:MB2SLZGas"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBChimSLZL48]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSLZLayer_47Cells"/>
+            <rChild name="mb2:MB2ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSLZLayer_47Cells"/>
+            <rChild name="mb2:MB2ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSLZLayer_47Cells_startCell2"/>
+            <rChild name="mb2:MB2ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSLZLayer_47Cells_startCell2"/>
+            <rChild name="mb2:MB2ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimSLZLayer_48Cells"/>
+            <rChild name="mb2:MB2ChimSLZElectronics_48Cells"/>
+            <Translation x="0.*fm" y="[mb2:MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimSLZLayer_48Cells"/>
+            <rChild name="mb2:MB2ChimSLZElectronics_48Cells"/>
+            <Translation x="0.*fm" y="-([mb2:MB2SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ##### MB2Chim: DT honeycomb -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimP"/>
+            <rChild name="mb2:MB2ChimHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimN"/>
+            <rChild name="mb2:MB2ChimHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2ChimHoneycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2ChimHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBHC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2ChimHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([mbCommon:MBHC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2ChimHc_LateralC"/>
+            <Translation x="[mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2ChimHc_LateralC"/>
+            <Translation x="[mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2ChimHc_LateralC"/>
+            <Translation x="-([mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2ChimHc_LateralC"/>
+            <Translation x="-([mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension]" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension]" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension])" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension])" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2ChimHc_LateralElectronics"/>
+            <Translation x="[mb2:MB2HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2ChimHc_LateralElectronics"/>
+            <Translation x="-([mb2:MB2HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimHoneycombBox"/>
+            <rChild name="mb2:MB2HcTorsionBar"/>
+            <Translation x="[mb2:MB2HC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- ##### MB2Chim: RPC chambers -->
+        <!-- ##### MB2Chim: RPC_IP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimP"/>
+            <rChild name="mb2:MB2ChimRPC_IP"/>
+            <Translation x="-[mb2:MB2RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_IP"/>
+            <rChild name="mb2:MB2ChimRPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb2:MB2ChimRPC_IGasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_IP"/>
+            <rChild name="mb2:MB2ChimRPC_IGasMiddle"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb2:MB2ChimRPC_IGasMiddle_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_IP"/>
+            <rChild name="mb2:MB2ChimRPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mb2:MB2ChimRPC_IGasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2Chim: RPC_OP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimP"/>
+            <rChild name="mb2:MB2ChimRPC_OP"/>
+            <Translation x="-[mb2:MB2RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_OP"/>
+            <rChild name="mb2:MB2ChimRPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mb2:MB2ChimRPC_OGasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_OP"/>
+            <rChild name="mb2:MB2ChimRPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mb2:MB2ChimRPC_OGasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2Chim: RPC_IN chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimN"/>
+            <rChild name="mb2:MB2ChimRPC_IN"/>
+            <Translation x="[mb2:MB2RPC_I_x_pos]" y="0*fm" z="[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_IN"/>
+            <rChild name="mb2:MB2ChimRPC_IGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb2:MB2ChimRPC_IGasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_IN"/>
+            <rChild name="mb2:MB2ChimRPC_IGasMiddle"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="-[mb2:MB2ChimRPC_IGasMiddle_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_IN"/>
+            <rChild name="mb2:MB2ChimRPC_IGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*cm" y="[mb2:MB2ChimRPC_IGasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB2Chim: RPC_ON chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimN"/>
+            <rChild name="mb2:MB2ChimRPC_ON"/>
+            <Translation x="[mb2:MB2RPC_O_x_pos]" y="0*fm" z="-[mbCommon:MBRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_ON"/>
+            <rChild name="mb2:MB2ChimRPC_OGasLeft"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="-[mb2:MB2ChimRPC_OGasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb2:MB2ChimRPC_ON"/>
+            <rChild name="mb2:MB2ChimRPC_OGasRight"/>
+            <rRotation name="rotations:RPCD"/>
+            <Translation x="0*cm" y="[mb2:MB2ChimRPC_OGasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/MuonCommonData/data/mb3/2015/v2/mb3.xml
+++ b/Geometry/MuonCommonData/data/mb3/2015/v2/mb3.xml
@@ -1,0 +1,1755 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <ConstantsSection label="mb3.xml" eval="true">
+        <!--- #### MB3: Positions -->
+        <!--%% Radial coordinates fo algos-->
+        <Constant name="MB3UnitRadius" value="6182.6939277*mm"/>
+        <Constant name="MB3PosAngle" value="2.046615755*deg"/>
+        <!--- #### MB3: Constants for DT superlayer Phi -->
+        <Constant name="MB3SLPhiPl_x" value="3066./2*mm"/>
+        <Constant name="MB3SLPhiL71" value="[mbCommon:MBCell_width]*71+[mbCommon:MBIbeamWall]"/>
+        <Constant name="MB3SLPhiL72" value="[mbCommon:MBCell_width]*72+[mbCommon:MBIbeamWall]"/>
+        <!--- #### MB3: Constants for DT superlayer Z (although they are placed with a rotation that interchanges X and Z, the _x refers to the coordinate X in EDMS, that is the Z in its final position; similar for _z -->
+        <Constant name="MB3SLZWire_length" value="3021./2.*mm"/>
+        <!--%% Wire length from EDMS: THIS NUMBER DEFINE THE SL DIMENSIONS-->
+        <Constant name="MB3SLZBareWire_length" value="[MB3SLZWire_length]-15.5*mm"/>
+        <!--%% Bare Wire _length == wire_lenght - depth in tappini-->
+        <Constant name="MB3SLZLayer_length" value="[MB3SLZBareWire_length]+2*[mbCommon:MBLayerElectronics_width]"/>
+        <!--%% The z length of the Al layer volume-->
+        <Constant name="MB3SLZPlI_z" value="[MB3SLZLayer_length]+6.5*mm"/>
+        <!--%% Distance between tappini and Al Plate edge-->
+        <Constant name="MB3SLZPlO_z" value="[MB3SLZPlI_z]+38.*mm"/>
+        <!--- #### MB3: X dimensions -->
+        <Constant name="MB3_x" value="1579.6*mm"/>
+        <Constant name="MB3HC_x" value="3037./2*mm"/>
+        <!--- #### MB3: Constants for DT positioning: distance from SL center to HC center -->
+        <Constant name="MB3pSLPhi1_HC_dist" value="15.*mm"/>
+        <Constant name="MB3pSLPhi2_HC_dist" value="15.*mm"/>
+        <Constant name="MB3pSLZ_HC_dist" value="-3*mm"/>
+        <Constant name="MB3nSLPhi1_HC_dist" value="-15.*mm"/>
+        <Constant name="MB3nSLPhi2_HC_dist" value="-15.*mm"/>
+        <Constant name="MB3nSLZ_HC_dist" value="3*mm"/>
+        <!--- #### MB3: Constants for RPCs -->
+        <Constant name="MB3RPC_EngineerXPos" value="5994.*mm"/>
+        <Constant name="MB3RPC_EngineerYPos" value="184.*mm"/>
+        <Constant name="MB3RPC_x" value="3000./2*mm"/>
+        <Constant name="MB3RPC_Gas_x" value="1480./2*mm"/>
+        <Constant name="MB3RPC_Gas_x_pos" value="75*cm"/>
+        <Constant name="MB3RPC_x_pos" value="[mb3:MB3UnitRadius]*sin([mb3:MB3PosAngle])-[mb3:MB3RPC_EngineerYPos]"/>
+        <!---  36.80 mm -->
+        <Constant name="MB3RPC_z_pos" value="[mb3:MB3UnitRadius]*cos([mb3:MB3PosAngle])-([mb3:MB3RPC_EngineerXPos]+[mbCommon:MBRPC_EngineerChamberWidth])"/>
+        <!--- 157.25*mm -->
+        <Constant name="MB3Height_With1RPC" value="326./2.*mm+0.25*mm"/>
+        <!--- #### MB3Chim: Constants for DT RPCs -->
+        <Constant name="MB3ChimRPC_GasRight_y_pos" value="[mbCommon:MBRPC_GasRight_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2.-4.*mm"/>
+        <Constant name="MB3ChimRPC_GasLeft_y_pos" value="[mbCommon:MBRPC_GasLeft_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2.-4.*mm"/>
+    </ConstantsSection>
+    <SolidSection label="mb3.xml">
+        <!-- ####  MB3 Unit: fake volume representing one DTBX + 1 or 2 RPC -->
+        <!-- ####  MB3: DTBX chamber -->
+        <!--%% In MB3 the widest superlayer in x is the Z one -->
+        <Box name="MB3_a" dx="[MB3_x]" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[MB3Height_With1RPC]+0.25*mm"/>
+        <Box name="MB3_OLAP1" dx="28.*mm" dy="[mbCommon:MBSLPhiPlO_z]+13.*mm" dz="18.75*mm"/>
+        <Box name="MB3_OLAP2" dx="25.75*mm" dy="[mbCommon:MBSLPhiPlO_z]+13.*mm" dz="44.75*mm"/>
+        <SubtractionSolid name="MB3P_b">
+            <rSolid name="MB3_a"/>
+            <rSolid name="MB3_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB3_x]+27.6*mm" y="0.*fm" z="-[MB3Height_With1RPC]+18.*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB3P">
+            <rSolid name="MB3P_b"/>
+            <rSolid name="MB3_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB3_x]+25.26*mm" y="0.*fm" z="[MB3Height_With1RPC]-44.25*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB3N_b">
+            <rSolid name="MB3_a"/>
+            <rSolid name="MB3_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB3_x]-27.6*mm" y="0.*fm" z="-[MB3Height_With1RPC]+18.*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB3N">
+            <rSolid name="MB3N_b"/>
+            <rSolid name="MB3_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB3_x]-25.26*mm" y="0.*fm" z="[MB3Height_With1RPC]-44.25*mm"/>
+        </SubtractionSolid>
+        <!-- ####  MB3: Superlayers Phi -->
+        <!--%% SuperLayer X,Z dimensions cover the outer Al plate + 2 mm for the closing profiles. Y is 5 Al plates + 4 Layer's -->
+        <Box name="MB3SuperLayerPhi" dx="[mb3:MB3SLPhiPl_x]+2.7*mm" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% MB3SLPhiClosingPlateParal is parallel to gas cells, MB3SLPhiClosingPlatePerp is perpendicular -->
+        <!--%% Parallel are 2 mm thick and as long as outer Plates -->
+        <Box name="MB3SLPhiClosingPlateParal" dx="1.*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB3SLPhi_C_PlateParal" dx="7.*mm" dy="[mbCommon:MBSLPhiPlO_z]-14.*mm" dz="1.*mm"/>
+        <!--%% Perpendicular are 12 mm thick and higher by 20 mm per side than the SL; 2.7 mm are added to reach the parallel "Cs" -->
+        <Box name="MB3SLPhiClosingPlatePerp" dx="[mb3:MB3SLPhiPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB3SLPhi_C_PlatePerp" dx="[mb3:MB3SLPhiPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <!--%% MB3SLPhiAlPlateOuter is 0.7 mm wider (perpendicular to the wires) to reach the parallel "Cs"-->
+        <Box name="MB3SLPhiAlPlateOuter" dx="[mb3:MB3SLPhiPl_x]+0.7*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!--%% MB3SLPhiAlPlateOuter does not reach the parallel "Cs"-->
+        <Box name="MB3SLPhiAlPlateInner" dx="[mb3:MB3SLPhiPl_x]" dy="[mbCommon:MBSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!--%% Fake layer volume contains the ibeams plus gas volumes: n+1 Ibeam's and n gas volumes.
+             (Ibeam wall width is ~1.35mm, but 0.1 is mylar, that is very light, so it set to 1.3) 
+             It is first made of aluminium and them it is filled with the n gas volumes. 
+             Z length is the bare wire length plus the electronics (==tappini)-->
+        <Box name="MB3SLPhiLayer_71Cells" dx="[MB3SLPhiL71]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLPhiLayer_71Cells_startCell2" dx="[MB3SLPhiL71]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLPhiLayer_72Cells" dx="[MB3SLPhiL72]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <!--%% Tappini, Perpendicular to the Ibeams and at the two ends -->
+        <Box name="MB3SLPhiElectronics_71Cells" dx="[mb3:MB3SLPhiL71]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLPhiElectronics_72Cells" dx="[mb3:MB3SLPhiL72]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLPhiCommonElectronics" dx="[mb3:MB3SLPhiPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!-- ####  MB3: Superlayer Z -->
+        <Box name="MB3SuperLayerZ" dx="[mbCommon:MBSLZPl_x]+2.7*mm" dy="[mb3:MB3SLZPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB3SLZClosingPlateParal" dx="1.*mm" dy="[mb3:MB3SLZPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB3SLZ_C_PlateParal" dx="7.*mm" dy="[mb3:MB3SLZPlO_z]-14.*mm" dz="1.*mm"/>
+        <Box name="MB3SLZClosingPlatePerp" dx="[mbCommon:MBSLZPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB3SLZ_C_PlatePerp" dx="[mbCommon:MBSLZPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <Box name="MB3SLZAlPlateOuter" dx="[mbCommon:MBSLZPl_x]+0.7*mm" dy="[mb3:MB3SLZPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB3SLZAlPlateInner" dx="[mbCommon:MBSLZPl_x]" dy="[mb3:MB3SLZPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB3SLZLayer_56Cells" dx="[mbCommon:MBSLZL56]" dy="[mb3:MB3SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLZLayer_57Cells" dx="[mbCommon:MBSLZL57]" dy="[mb3:MB3SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLZLayer_58Cells" dx="[mbCommon:MBSLZL58]" dy="[mb3:MB3SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLZElectronics_56Cells" dx="[mbCommon:MBSLZL56]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLZElectronics_57Cells" dx="[mbCommon:MBSLZL57]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLZElectronics_58Cells" dx="[mbCommon:MBSLZL58]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3SLZCommonElectronics" dx="[mbCommon:MBSLZPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!--%% Effective gas volume -->
+        <Box name="MB3SLZGas_a" dx="20.35*mm" dy="[MB3SLZBareWire_length]" dz="[mbCommon:MBGas_height]"/>
+        <!--%% Horizontal bars to make the 'I' shape (without them it would be a '|') -->
+        <Box name="MB3SLZIBeamWing" dx="3.175*mm" dy="[MB3SLZBareWire_length]" dz="0.65*mm"/>
+        <SubtractionSolid name="MB3SLZGas_b">
+            <rSolid name="MB3SLZGas_a"/>
+            <rSolid name="MB3SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" y="0.*fm" z="5.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB3SLZGas_c">
+            <rSolid name="MB3SLZGas_b"/>
+            <rSolid name="MB3SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" y="0.*fm" z="-5.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB3SLZGas_d">
+            <rSolid name="MB3SLZGas_c"/>
+            <rSolid name="MB3SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" y="0.*fm" z="5.1*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB3SLZGas">
+            <rSolid name="MB3SLZGas_d"/>
+            <rSolid name="MB3SLZIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" y="0.*fm" z="-5.1*mm"/>
+        </SubtractionSolid>
+        <!-- ####  MB3: Honeycomb -->
+        <Box name="MB3HoneycombBox" dx="[mb3:MB3HC_x]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHC_height]"/>
+        <Box name="MB3Honeycomb" dx="[mb3:MB3HC_x]-125.*mm" dy="[mbCommon:MBHC_z]-125.*mm" dz="[mbCommon:MBHC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB3HcPlate" dx="[mb3:MB3HC_x]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB3Hc_LateralC" dx="[mbCommon:MBHC_C_dimension]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB3Hc_FrontC" dx="[mb3:MB3HC_x]-125.*mm" dy="[mbCommon:MBHC_C_dimension]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB3Hc_LateralElectronics" dx="[mbCommon:MBHCLatElectronics_width]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHCElectronics_height]"/>
+        <Box name="MB3Hc_FrontElectronics" dx="[mb3:MB3HC_x]-125.*mm" dy="[mbCommon:MBHCFrontElectronics_width]" dz="[mbCommon:MBHCElectronics_height]"/>
+        <Box name="MB3HcTorsionBar" dx="25*mm" dy="678*mm" dz="50.*mm"/>
+        <!-- ####  MB3: RPC chambers -->
+        <Box name="MB3RPC" dx="[mb3:MB3RPC_x]" dy="[mbCommon:MBRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB3RPC_GasLeft" dx="[mb3:MB3RPC_Gas_x]" dy="[mbCommon:MBRPC_GasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB3RPC_GasRight" dx="[mb3:MB3RPC_Gas_x]" dy="[mbCommon:MBRPC_GasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <!-- ####  MB3Chimney Unit -->
+        <!-- ####  MB3Chim: DTBX chamber -->
+        <Box name="MB3Chim_a" dx="[MB3_x]" dy="[mbCommon:MBChimSLPhiPlO_z]+12.*mm" dz="[MB3Height_With1RPC]"/>
+        <SubtractionSolid name="MB3ChimP_b">
+            <rSolid name="MB3Chim_a"/>
+            <rSolid name="MB3_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB3_x]+27.6*mm" y="0.*fm" z="-[MB3Height_With1RPC]+18.*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB3ChimP">
+            <rSolid name="MB3ChimP_b"/>
+            <rSolid name="MB3_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-[MB3_x]+25.26*mm" y="0.*fm" z="[MB3Height_With1RPC]-44.25*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB3ChimN_b">
+            <rSolid name="MB3Chim_a"/>
+            <rSolid name="MB3_OLAP1"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB3_x]-27.6*mm" y="0.*fm" z="-[MB3Height_With1RPC]+18.*mm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MB3ChimN">
+            <rSolid name="MB3ChimN_b"/>
+            <rSolid name="MB3_OLAP2"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="[MB3_x]-25.26*mm" y="0.*fm" z="[MB3Height_With1RPC]-44.25*mm"/>
+        </SubtractionSolid>
+        <!-- ####  MB3Chim: DT Superlayers Phi -->
+        <Box name="MB3ChimSuperLayerPhi" dx="[mb3:MB3SLPhiPl_x]+2.7*mm" dy="[mbCommon:MBChimSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% Only extra parallel "Cs" are needed -->
+        <Box name="MB3ChimSLPhiClosingPlateParal" dx="1.*mm" dy="[mbCommon:MBChimSLPhiPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB3ChimSLPhi_C_PlateParal" dx="7.*mm" dy="[mbCommon:MBChimSLPhiPlO_z]-14.*mm" dz="1.*mm"/>
+        <Box name="MB3ChimSLPhiAlPlateOuter" dx="[mb3:MB3SLPhiPl_x]+0.7*mm" dy="[mbCommon:MBChimSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB3ChimSLPhiAlPlateInner" dx="[mb3:MB3SLPhiPl_x]" dy="[mbCommon:MBChimSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB3ChimSLPhiLayer_71Cells" dx="[mb3:MB3SLPhiL71]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3ChimSLPhiLayer_71Cells_startCell2" dx="[mb3:MB3SLPhiL71]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3ChimSLPhiLayer_72Cells" dx="[mb3:MB3SLPhiL72]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <!-- ####  MB3Chim: DT Superlayer Z -->
+        <Box name="MB3ChimSuperLayerZ" dx="[mbCommon:MBChimSLZPl_x]+2.7*mm" dy="[mb3:MB3SLZPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% Only extra perperdicular "Cs" are needed -->
+        <Box name="MB3ChimSLZClosingPlatePerp" dx="[mbCommon:MBChimSLZPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB3ChimSLZ_C_PlatePerp" dx="[mbCommon:MBChimSLZPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <Box name="MB3ChimSLZAlPlateOuter" dx="[mbCommon:MBChimSLZPl_x]+0.7*mm" dy="[mb3:MB3SLZPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB3ChimSLZAlPlateInner" dx="[mbCommon:MBChimSLZPl_x]" dy="[mb3:MB3SLZPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB3ChimSLZLayer_47Cells" dx="[mbCommon:MBChimSLZL47]" dy="[mb3:MB3SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3ChimSLZLayer_48Cells" dx="[mbCommon:MBChimSLZL48]" dy="[mb3:MB3SLZLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3ChimSLZElectronics_47Cells" dx="[mbCommon:MBChimSLZL47]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3ChimSLZElectronics_48Cells" dx="[mbCommon:MBChimSLZL48]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB3ChimSLZCommonElectronics" dx="[mbCommon:MBChimSLZPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!-- ####  MB3Chim: DT Honeycomb -->
+        <Box name="MB3ChimHoneycombBox" dx="[mb3:MB3HC_x]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHC_height]"/>
+        <Box name="MB3ChimHoneycomb" dx="[mb3:MB3HC_x]-125.*mm" dy="[mbCommon:MBChimHC_z]-125.*mm" dz="[mbCommon:MBHC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB3ChimHc_LateralC" dx="[mbCommon:MBHC_C_dimension]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB3ChimHc_LateralElectronics" dx="[mbCommon:MBHCLatElectronics_width]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHCElectronics_height]"/>
+        <Box name="MB3ChimHcPlate" dx="[mb3:MB3HC_x]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!-- ####  MB3Chim: RPC chambers -->
+        <Box name="MB3ChimRPC" dx="[mb3:MB3RPC_x]" dy="[mbCommon:MBChimRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB3ChimRPC_GasLeft" dx="[mb3:MB3RPC_Gas_x]" dy="[mbCommon:MBChimRPC_OGasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB3ChimRPC_GasRight" dx="[mb3:MB3RPC_Gas_x]" dy="[mbCommon:MBChimRPC_OGasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+    </SolidSection>
+    <LogicalPartSection label="mb3.xml">
+        <!-- ####  MB3 Unit -->
+        <!-- ####  MB3: DTBX -->
+        <LogicalPart name="MB3P" category="unspecified">
+            <rSolid name="MB3P"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB3N" category="unspecified">
+            <rSolid name="MB3N"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <!-- ####  MB3: DT Superlayers Phi -->
+        <LogicalPart name="MB3SuperLayerPhi" category="unspecified">
+            <rSolid name="MB3SuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiClosingPlateParal" category="unspecified">
+            <rSolid name="MB3SLPhiClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhi_C_PlateParal" category="unspecified">
+            <rSolid name="MB3SLPhi_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiClosingPlatePerp" category="unspecified">
+            <rSolid name="MB3SLPhiClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhi_C_PlatePerp" category="unspecified">
+            <rSolid name="MB3SLPhi_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB3SLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB3SLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiLayer_71Cells" category="unspecified">
+            <rSolid name="MB3SLPhiLayer_71Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiLayer_71Cells_startCell2" category="unspecified">
+            <rSolid name="MB3SLPhiLayer_71Cells_startCell2"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiLayer_72Cells" category="unspecified">
+            <rSolid name="MB3SLPhiLayer_72Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiElectronics_71Cells" category="unspecified">
+            <rSolid name="MB3SLPhiElectronics_71Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiElectronics_72Cells" category="unspecified">
+            <rSolid name="MB3SLPhiElectronics_72Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLPhiCommonElectronics" category="unspecified">
+            <rSolid name="MB3SLPhiCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB3: DT Superlayer Z -->
+        <LogicalPart name="MB3SuperLayerZ" category="unspecified">
+            <rSolid name="MB3SuperLayerZ"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZClosingPlateParal" category="unspecified">
+            <rSolid name="MB3SLZClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZClosingPlatePerp" category="unspecified">
+            <rSolid name="MB3SLZClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZ_C_PlateParal" category="unspecified">
+            <rSolid name="MB3SLZ_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZ_C_PlatePerp" category="unspecified">
+            <rSolid name="MB3SLZ_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZAlPlateOuter" category="unspecified">
+            <rSolid name="MB3SLZAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZAlPlateInner" category="unspecified">
+            <rSolid name="MB3SLZAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZLayer_56Cells" category="unspecified">
+            <rSolid name="MB3SLZLayer_56Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZLayer_57Cells" category="unspecified">
+            <rSolid name="MB3SLZLayer_57Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZLayer_58Cells" category="unspecified">
+            <rSolid name="MB3SLZLayer_58Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZIBeamWing" category="unspecified">
+            <rSolid name="MB3SLZIBeamWing"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZGas" category="unspecified">
+            <rSolid name="MB3SLZGas"/>
+            <rMaterial name="materials:M_DTBX Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZElectronics_56Cells" category="unspecified">
+            <rSolid name="MB3SLZElectronics_56Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZElectronics_57Cells" category="unspecified">
+            <rSolid name="MB3SLZElectronics_57Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZElectronics_58Cells" category="unspecified">
+            <rSolid name="MB3SLZElectronics_58Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB3SLZCommonElectronics" category="unspecified">
+            <rSolid name="MB3SLZCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB3: DT Honeycomb -->
+        <LogicalPart name="MB3HoneycombBox" category="unspecified">
+            <rSolid name="MB3HoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB3Honeycomb" category="unspecified">
+            <rSolid name="MB3Honeycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB3HcPlate" category="unspecified">
+            <rSolid name="MB3HcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3Hc_LateralC" category="unspecified">
+            <rSolid name="MB3Hc_LateralC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3Hc_FrontC" category="unspecified">
+            <rSolid name="MB3Hc_FrontC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3Hc_LateralElectronics" category="unspecified">
+            <rSolid name="MB3Hc_LateralElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB3Hc_FrontElectronics" category="unspecified">
+            <rSolid name="MB3Hc_FrontElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB3HcTorsionBar" category="unspecified">
+            <rSolid name="MB3HcTorsionBar"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- ####  MB3: RPC chambers -->
+        <LogicalPart name="MB3RPC_P" category="unspecified">
+            <rSolid name="MB3RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB3RPC_N" category="unspecified">
+            <rSolid name="MB3RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB3RPC_GasLeft" category="unspecified">
+            <rSolid name="MB3RPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB3RPC_GasRight" category="unspecified">
+            <rSolid name="MB3RPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <!-- ####  MB3Chimney Unit -->
+        <!-- ####  MB3Chim: DTBX -->
+        <LogicalPart name="MB3ChimP" category="unspecified">
+            <rSolid name="MB3ChimP"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimN" category="unspecified">
+            <rSolid name="MB3ChimN"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <!-- ####  MB3Chim: DT Superlayers Phi -->
+        <LogicalPart name="MB3ChimSuperLayerPhi" category="unspecified">
+            <rSolid name="MB3ChimSuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLPhiClosingPlateParal" category="unspecified">
+            <rSolid name="MB3ChimSLPhiClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLPhi_C_PlateParal" category="unspecified">
+            <rSolid name="MB3ChimSLPhi_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB3ChimSLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB3ChimSLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLPhiLayer_71Cells" category="unspecified">
+            <rSolid name="MB3ChimSLPhiLayer_71Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLPhiLayer_71Cells_startCell2" category="unspecified">
+            <rSolid name="MB3ChimSLPhiLayer_71Cells_startCell2"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLPhiLayer_72Cells" category="unspecified">
+            <rSolid name="MB3ChimSLPhiLayer_72Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- ####  MB3Chim: DT Superlayer Z -->
+        <LogicalPart name="MB3ChimSuperLayerZ" category="unspecified">
+            <rSolid name="MB3ChimSuperLayerZ"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZClosingPlatePerp" category="unspecified">
+            <rSolid name="MB3ChimSLZClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZ_C_PlatePerp" category="unspecified">
+            <rSolid name="MB3ChimSLZ_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZAlPlateOuter" category="unspecified">
+            <rSolid name="MB3ChimSLZAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZAlPlateInner" category="unspecified">
+            <rSolid name="MB3ChimSLZAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZLayer_47Cells" category="unspecified">
+            <rSolid name="MB3ChimSLZLayer_47Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZLayer_47Cells_startCell2" category="unspecified">
+            <rSolid name="MB3ChimSLZLayer_47Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZLayer_48Cells" category="unspecified">
+            <rSolid name="MB3ChimSLZLayer_48Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZElectronics_47Cells" category="unspecified">
+            <rSolid name="MB3ChimSLZElectronics_47Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZElectronics_48Cells" category="unspecified">
+            <rSolid name="MB3ChimSLZElectronics_48Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimSLZCommonElectronics" category="unspecified">
+            <rSolid name="MB3ChimSLZCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB3Chim: DT Honeycomb -->
+        <LogicalPart name="MB3ChimHoneycombBox" category="unspecified">
+            <rSolid name="MB3ChimHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimHoneycomb" category="unspecified">
+            <rSolid name="MB3ChimHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimHcPlate" category="unspecified">
+            <rSolid name="MB3ChimHcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimHc_LateralC" category="unspecified">
+            <rSolid name="MB3ChimHc_LateralC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimHc_LateralElectronics" category="unspecified">
+            <rSolid name="MB3ChimHc_LateralElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB3Chim: RPC chambers -->
+        <LogicalPart name="MB3ChimRPC_P" category="unspecified">
+            <rSolid name="MB3ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimRPC_N" category="unspecified">
+            <rSolid name="MB3ChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimRPC_GasLeft" category="unspecified">
+            <rSolid name="MB3ChimRPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB3ChimRPC_GasRight" category="unspecified">
+            <rSolid name="MB3ChimRPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="mb3.xml">
+        <!-- ####  MB3 Unit -->
+        <!-- ####  MB3: DTBX chamber -->
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb3:MB3N"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB3UnitRadius]"/>
+            <Numeric name="StartAngle" value="[MB3PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB3PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb3:MB3P"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB3UnitRadius]"/>
+            <Numeric name="StartAngle" value="30.*deg+[MB3PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB3PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb3:MB3P"/>
+            <Numeric name="StartCopyNo" value="3"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB3UnitRadius]"/>
+            <Numeric name="StartAngle" value="60.*deg+[MB3PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB3PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_0"/>
+            <String name="ChildName" value="mb3:MB3N"/>
+            <Numeric name="StartCopyNo" value="4"/>
+            <Numeric name="IncrCopyNo" value="4"/>
+            <Numeric name="N" value="3"/>
+            <Numeric name="Radius" value="[MB3UnitRadius]"/>
+            <Numeric name="StartAngle" value="90.*deg+[MB3PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB3PosAngle] </Vector>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb3:MB3P"/>
+            <rRotation name="rotations:RM1872"/>
+            <Translation x="[MB3UnitRadius]*cos([MB3PosAngle])" y="[MB3UnitRadius]*sin([MB3PosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb3:MB3P"/>
+            <rRotation name="rotations:RM1882"/>
+            <Translation x="[MB3UnitRadius]*cos([MB3PosAngle]+30*deg)" y="[MB3UnitRadius]*sin([MB3PosAngle]+30*deg)" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb3:MB3P"/>
+            <rRotation name="rotations:RM1892"/>
+            <Translation x="[MB3UnitRadius]*cos([MB3PosAngle]+60*deg)" y="[MB3UnitRadius]*sin([MB3PosAngle]+60*deg)" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb3:MB3ChimP"/>
+            <rRotation name="rotations:RM1902"/>
+            <Translation x="[MB3UnitRadius]*cos([MB3PosAngle]+90*deg)" y="[MB3UnitRadius]*sin([MB3PosAngle]+90*deg)" z="[mbCommon:MBChimPos_z]"/>
+        </PosPart>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <String name="ChildName" value="mb3:MB3P"/>
+            <Numeric name="StartCopyNo" value="5"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="8"/>
+            <Numeric name="Radius" value="[MB3UnitRadius]"/>
+            <Numeric name="StartAngle" value="120.*deg+[MB3PosAngle]"/>
+            <Numeric name="RangeAngle" value="210.*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB3PosAngle] </Vector>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb3:MB3N"/>
+            <rRotation name="rotations:E127"/>
+            <Translation x="[MB3UnitRadius]*cos([MB3PosAngle])" y="[MB3UnitRadius]*sin([MB3PosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb3:MB3N"/>
+            <rRotation name="rotations:MM200"/>
+            <Translation x="[MB3UnitRadius]*cos([MB3PosAngle]+30.*deg)" y="[MB3UnitRadius]*sin([MB3PosAngle]+30.*deg)" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb3:MB3ChimN"/>
+            <rRotation name="rotations:MM300"/>
+            <Translation x="[MB3UnitRadius]*cos([MB3PosAngle]+60.*deg)" y="[MB3UnitRadius]*sin([MB3PosAngle]+60.*deg)" z="-[mbCommon:MBChimPos_z]"/>
+        </PosPart>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <String name="ChildName" value="mb3:MB3N"/>
+            <Numeric name="StartCopyNo" value="4"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="9"/>
+            <Numeric name="Radius" value="[MB3UnitRadius]"/>
+            <Numeric name="StartAngle" value="90.*deg+[MB3PosAngle]"/>
+            <Numeric name="RangeAngle" value="240.*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB3PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <String name="ChildName" value="mb3:MB3P"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="12"/>
+            <Numeric name="Radius" value="[MB3UnitRadius]"/>
+            <Numeric name="StartAngle" value="[MB3PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -[mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="6"> 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB3PosAngle] </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <String name="ChildName" value="mb3:MB3N"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="12"/>
+            <Numeric name="Radius" value="[MB3UnitRadius]"/>
+            <Numeric name="StartAngle" value="[MB3PosAngle]"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [mbCommon:MBPos_z] </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="9"> 0.*deg, 0.*deg, 180*deg, 90.*deg, 0.*deg, 90.*deg, 0.*deg, 0.*deg, 270.*deg-[MB3PosAngle] </Vector>
+        </Algorithm>
+        <!-- #### MB3: DT Superlayers Phi -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3P"/>
+            <rChild name="mb3:MB3SuperLayerPhi"/>
+            <Translation x="[mb3:MB3pSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3P"/>
+            <rChild name="mb3:MB3SuperLayerPhi"/>
+            <Translation x="[mb3:MB3pSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3N"/>
+            <rChild name="mb3:MB3SuperLayerPhi"/>
+            <Translation x="[mb3:MB3nSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3N"/>
+            <rChild name="mb3:MB3SuperLayerPhi"/>
+            <Translation x="[mb3:MB3nSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <!-- ## MB3: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiLayer_71Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiLayer_72Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiLayer_72Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiLayer_71Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiClosingPlateParal"/>
+            <Translation x="[mb3:MB3SLPhiPl_x]+1.7*mm" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiClosingPlateParal"/>
+            <Translation x="-([mb3:MB3SLPhiPl_x]+1.7*mm)" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlateParal"/>
+            <Translation x="[mb3:MB3SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlateParal"/>
+            <Translation x="[mb3:MB3SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlateParal"/>
+            <Translation x="-([mb3:MB3SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlateParal"/>
+            <Translation x="-([mb3:MB3SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3SLPhiLayer_71Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="71"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb3:MB3SLPhiL71]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3SLPhiLayer_71Cells_startCell2"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="71"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb3:MB3SLPhiL71]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3SLPhiLayer_72Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="72"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb3:MB3SLPhiL72]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SLPhiLayer_71Cells"/>
+            <rChild name="mb3:MB3SLPhiElectronics_71Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SLPhiLayer_71Cells"/>
+            <rChild name="mb3:MB3SLPhiElectronics_71Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SLPhiLayer_71Cells_startCell2"/>
+            <rChild name="mb3:MB3SLPhiElectronics_71Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SLPhiLayer_71Cells_startCell2"/>
+            <rChild name="mb3:MB3SLPhiElectronics_71Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SLPhiLayer_72Cells"/>
+            <rChild name="mb3:MB3SLPhiElectronics_72Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SLPhiLayer_72Cells"/>
+            <rChild name="mb3:MB3SLPhiElectronics_72Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- #### MB3: DT Superlayer Z -->
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3P"/>
+            <rChild name="mb3:MB3SuperLayerZ"/>
+            <Translation x="[mb3:MB3pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]-[mbCommon:MBSL_posDisp]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3N"/>
+            <rChild name="mb3:MB3SuperLayerZ"/>
+            <Translation x="[mb3:MB3nSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]-[mbCommon:MBSL_posDisp]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <!-- #### MB3: DT Superlayer Z internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="0.*mm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZLayer_57Cells"/>
+            <Translation x="0*fm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZLayer_58Cells"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZLayer_57Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZLayer_56Cells"/>
+            <Translation x="0*fm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZClosingPlateParal"/>
+            <Translation x="[mbCommon:MBSLZPl_x]+1.7*mm" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZClosingPlateParal"/>
+            <Translation x="-([mbCommon:MBSLZPl_x]+1.7*mm)" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZCommonElectronics"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SuperLayerZ"/>
+            <rChild name="mb3:MB3SLZCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3SLZLayer_56Cells"/>
+            <String name="ChildName" value="mb3:MB3SLZGas"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="56"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBSLZL56]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3SLZLayer_57Cells"/>
+            <String name="ChildName" value="mb3:MB3SLZGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="57"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBSLZL57]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3SLZLayer_58Cells"/>
+            <String name="ChildName" value="mb3:MB3SLZGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="58"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBSLZL58]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SLZLayer_56Cells"/>
+            <rChild name="mb3:MB3SLZElectronics_56Cells"/>
+            <Translation x="0.*fm" y="[MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SLZLayer_56Cells"/>
+            <rChild name="mb3:MB3SLZElectronics_56Cells"/>
+            <Translation x="0.*fm" y="-([MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SLZLayer_57Cells"/>
+            <rChild name="mb3:MB3SLZElectronics_57Cells"/>
+            <Translation x="0.*fm" y="[MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SLZLayer_57Cells"/>
+            <rChild name="mb3:MB3SLZElectronics_57Cells"/>
+            <Translation x="0.*fm" y="-([MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3SLZLayer_58Cells"/>
+            <rChild name="mb3:MB3SLZElectronics_58Cells"/>
+            <Translation x="0.*fm" y="[MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3SLZLayer_58Cells"/>
+            <rChild name="mb3:MB3SLZElectronics_58Cells"/>
+            <Translation x="0.*fm" y="-([MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ##### MB3: DT honeycomb -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3P"/>
+            <rChild name="mb3:MB3HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3N"/>
+            <rChild name="mb3:MB3HoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Honeycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBHC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([mbCommon:MBHC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_LateralC"/>
+            <Translation x="[mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_LateralC"/>
+            <Translation x="[mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_LateralC"/>
+            <Translation x="-([mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_LateralC"/>
+            <Translation x="-([mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_LateralElectronics"/>
+            <Translation x="[mb3:MB3HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_LateralElectronics"/>
+            <Translation x="-([mb3:MB3HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3HoneycombBox"/>
+            <rChild name="mb3:MB3HcTorsionBar"/>
+            <Translation x="[mb3:MB3HC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- ##### MB3: RPC chambers -->
+        <!-- ##### MB3: RPC_IP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3P"/>
+            <rChild name="mb3:MB3RPC_P"/>
+            <Translation x="[mb3:MB3RPC_x_pos]" y="0*fm" z="[mb3:MB3RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3RPC_P"/>
+            <rChild name="mb3:MB3RPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3RPC_P"/>
+            <rChild name="mb3:MB3RPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3RPC_P"/>
+            <rChild name="mb3:MB3RPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3RPC_P"/>
+            <rChild name="mb3:MB3RPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB3: RPC_N chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3N"/>
+            <rChild name="mb3:MB3RPC_N"/>
+            <Translation x="-[mb3:MB3RPC_x_pos]" y="0*fm" z="[mb3:MB3RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3RPC_N"/>
+            <rChild name="mb3:MB3RPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3RPC_N"/>
+            <rChild name="mb3:MB3RPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3RPC_N"/>
+            <rChild name="mb3:MB3RPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3RPC_N"/>
+            <rChild name="mb3:MB3RPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="+[mb3:MB3RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ####  MB3Chimney Unit -->
+        <!-- ####  MB3Chim: DTBX chamber -->
+        <!-- #### MB3: DT Superlayers Phi -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimP"/>
+            <rChild name="mb3:MB3ChimSuperLayerPhi"/>
+            <Translation x="[mb3:MB3pSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimP"/>
+            <rChild name="mb3:MB3ChimSuperLayerPhi"/>
+            <Translation x="[mb3:MB3pSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimN"/>
+            <rChild name="mb3:MB3ChimSuperLayerPhi"/>
+            <Translation x="[mb3:MB3nSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimN"/>
+            <rChild name="mb3:MB3ChimSuperLayerPhi"/>
+            <Translation x="[mb3:MB3nSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <!-- ## MB3: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiLayer_71Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiLayer_72Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiLayer_72Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiLayer_71Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiClosingPlateParal"/>
+            <Translation x="[mb3:MB3SLPhiPl_x]+1.7*mm" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhiClosingPlateParal"/>
+            <Translation x="-([mb3:MB3SLPhiPl_x]+1.7*mm)" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhi_C_PlateParal"/>
+            <Translation x="[mb3:MB3SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhi_C_PlateParal"/>
+            <Translation x="[mb3:MB3SLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhi_C_PlateParal"/>
+            <Translation x="-([mb3:MB3SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3ChimSLPhi_C_PlateParal"/>
+            <Translation x="-([mb3:MB3SLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerPhi"/>
+            <rChild name="mb3:MB3SLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3ChimSLPhiLayer_71Cells"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="71"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb3:MB3SLPhiL71]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3ChimSLPhiLayer_71Cells_startCell2"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="71"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb3:MB3SLPhiL71]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3ChimSLPhiLayer_72Cells"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="72"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb3:MB3SLPhiL72]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSLPhiLayer_71Cells"/>
+            <rChild name="mb3:MB3SLPhiElectronics_71Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSLPhiLayer_71Cells"/>
+            <rChild name="mb3:MB3SLPhiElectronics_71Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSLPhiLayer_71Cells_startCell2"/>
+            <rChild name="mb3:MB3SLPhiElectronics_71Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSLPhiLayer_71Cells_startCell2"/>
+            <rChild name="mb3:MB3SLPhiElectronics_71Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSLPhiLayer_72Cells"/>
+            <rChild name="mb3:MB3SLPhiElectronics_72Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSLPhiLayer_72Cells"/>
+            <rChild name="mb3:MB3SLPhiElectronics_72Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- #### MB3Chim: DT Superlayer Z -->
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimP"/>
+            <rChild name="mb3:MB3ChimSuperLayerZ"/>
+            <Translation x="[mb3:MB3pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]-[mbCommon:MBSL_posDisp]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimN"/>
+            <rChild name="mb3:MB3ChimSuperLayerZ"/>
+            <Translation x="[mb3:MB3pSLZ_HC_dist]" y="0.*mm" z="-[mbCommon:MBHC_height]-[mbCommon:MBSL_posDisp]"/>
+            <rRotation name="rotations:R270"/>
+        </PosPart>
+        <!-- #### MB3Chim: DT Superlayer Z internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZLayer_47Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZLayer_48Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZLayer_48Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZLayer_47Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3SLZClosingPlateParal"/>
+            <Translation x="[mbCommon:MBChimSLZPl_x]+1.7*mm" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3SLZClosingPlateParal"/>
+            <Translation x="-([mbCommon:MBChimSLZPl_x]+1.7*mm)" y="0*fm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlateParal"/>
+            <Translation x="[mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3SLZ_C_PlateParal"/>
+            <Translation x="-([mbCommon:MBChimSLZPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZ_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZCommonElectronics"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSuperLayerZ"/>
+            <rChild name="mb3:MB3ChimSLZCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3ChimSLZLayer_47Cells"/>
+            <String name="ChildName" value="mb3:MB3SLZGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="47"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBChimSLZL47]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3ChimSLZLayer_47Cells_startCell2"/>
+            <String name="ChildName" value="mb3:MB3SLZGas"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="47"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBChimSLZL47]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb3:MB3ChimSLZLayer_48Cells"/>
+            <String name="ChildName" value="mb3:MB3SLZGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="48"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mbCommon:MBChimSLZL48]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSLZLayer_47Cells"/>
+            <rChild name="mb3:MB3ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSLZLayer_47Cells"/>
+            <rChild name="mb3:MB3ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSLZLayer_47Cells_startCell2"/>
+            <rChild name="mb3:MB3ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSLZLayer_47Cells_startCell2"/>
+            <rChild name="mb3:MB3ChimSLZElectronics_47Cells"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimSLZLayer_48Cells"/>
+            <rChild name="mb3:MB3ChimSLZElectronics_48Cells"/>
+            <Translation x="0.*fm" y="[mb3:MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimSLZLayer_48Cells"/>
+            <rChild name="mb3:MB3ChimSLZElectronics_48Cells"/>
+            <Translation x="0.*fm" y="-([mb3:MB3SLZLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ##### MB3Chim: DT honeycomb -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimP"/>
+            <rChild name="mb3:MB3ChimHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimN"/>
+            <rChild name="mb3:MB3ChimHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSuperLayer_height]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3ChimHoneycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3ChimHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBHC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3ChimHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([mbCommon:MBHC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3ChimHc_LateralC"/>
+            <Translation x="[mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3ChimHc_LateralC"/>
+            <Translation x="[mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3ChimHc_LateralC"/>
+            <Translation x="-([mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3ChimHc_LateralC"/>
+            <Translation x="-([mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension]" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension]" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension])" z="[mbCommon:MBHC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension])" z="-([mbCommon:MBHC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3ChimHc_LateralElectronics"/>
+            <Translation x="[mb3:MB3HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3ChimHc_LateralElectronics"/>
+            <Translation x="-([mb3:MB3HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3Hc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimHoneycombBox"/>
+            <rChild name="mb3:MB3HcTorsionBar"/>
+            <Translation x="[mb3:MB3HC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- ##### MB3Chim: RPC chambers -->
+        <!-- ##### MB3Chim: RPC_IP chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimP"/>
+            <rChild name="mb3:MB3ChimRPC_P"/>
+            <Translation x="[mb3:MB3RPC_x_pos]" y="0*fm" z="[mb3:MB3RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimRPC_P"/>
+            <rChild name="mb3:MB3ChimRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="-[mb3:MB3ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimRPC_P"/>
+            <rChild name="mb3:MB3ChimRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="-[mb3:MB3ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimRPC_P"/>
+            <rChild name="mb3:MB3ChimRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="[mb3:MB3ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimRPC_P"/>
+            <rChild name="mb3:MB3ChimRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="[mb3:MB3ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB3Chim: RPC_N chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimN"/>
+            <rChild name="mb3:MB3ChimRPC_N"/>
+            <Translation x="-[mb3:MB3RPC_x_pos]" y="0*fm" z="[mb3:MB3RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimRPC_N"/>
+            <rChild name="mb3:MB3ChimRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="-[mb3:MB3ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimRPC_N"/>
+            <rChild name="mb3:MB3ChimRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="-[mb3:MB3ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb3:MB3ChimRPC_N"/>
+            <rChild name="mb3:MB3ChimRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="[mb3:MB3ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb3:MB3ChimRPC_N"/>
+            <rChild name="mb3:MB3ChimRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="[mb3:MB3ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/MuonCommonData/data/mb4/2015/v2/mb4.xml
+++ b/Geometry/MuonCommonData/data/mb4/2015/v2/mb4.xml
@@ -1,0 +1,2994 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <ConstantsSection label="mb4.xml" eval="true">
+        <!--- ### Radius and angle always refer to (eventual) sector 1 -->
+        <!--- ### The center of the HC is at 7220-[mbCommon:MBSL_posDisp] for all the MB4 (but the feet???) -->
+        <!--- ### old  MB4 big center values -->
+        <!--- Constant name="MB4BigUnitRadius" value="7267.02187986935951*mm"/ -->
+        <!--- Constant name="MB4BigPosAngle" value="-7.67032050510571217*deg"/ -->
+        <!--- ### corrected  MB4 big center values (14 Sept 2007)-->
+        <Constant name="MB4BigUnitRadius" value="7264.24876380895967*mm"/>
+        <Constant name="MB4BigPosAngle" value="-7.50616764184939633*deg"/>
+        <Constant name="MB4BigPos_x" value="7220.*mm-[mbCommon:MBSL_posDisp]"/>
+        <Constant name="MB4BigPos_y" value="-948.95*mm"/>
+        <Constant name="MB4SmallUnitRadius" value="7253.75964586641112*mm"/>
+        <Constant name="MB4SmallPosAngle" value="-6.84873371708398970*deg"/>
+        <Constant name="MB4SmallPos_x" value="5804.61495805552568*mm"/>
+        <Constant name="MB4SmallPos_y" value="-4350.11197427354182*mm"/>
+        <Constant name="MB4FeetPos_x" value="3561.43*mm"/>
+        <Constant name="MB4FeetPos_y" value="-6288.24*mm"/>
+        <Constant name="MB4FeetUnitRadius" value="sqrt([mb4:MB4FeetPos_x]*[mb4:MB4FeetPos_x]+[mb4:MB4FeetPos_y]*[mb4:MB4FeetPos_y])"/>
+        <Constant name="MB4FeetPosAngle" value="atan2(-[mb4:MB4FeetPos_y], [mb4:MB4FeetPos_x])*180./3.1415926535*deg"/>
+        <!-- ### Top (MB3) and Bottom (MB4) chamers -->
+        <Constant name="MB4TopPos_x" value="1607.5*mm"/>
+        <Constant name="MB4TopPos_y" value="7220.*mm-[mbCommon:MBSL_posDisp]"/>
+        <Constant name="MB4BottomPos_x" value="1367.7*mm"/>
+        <Constant name="MB4BottomPos_y" value="-7220.*mm+[mbCommon:MBSL_posDisp]"/>
+        <!--- #### MB4: Constants for DT superlayer Phi -->
+        <Constant name="MB4BigSLPhiPl_x" value="4074./2.*mm"/>
+        <Constant name="MB4SLPhiL95" value="[mbCommon:MBCell_width]*95+[mbCommon:MBIbeamWall]"/>
+        <Constant name="MB4SLPhiL96" value="[mbCommon:MBCell_width]*96+[mbCommon:MBIbeamWall]"/>
+        <Constant name="MB4SmallSLPhiPl_x" value="3906./2.*mm"/>
+        <Constant name="MB4SLPhiL91" value="[mbCommon:MBCell_width]*91+[mbCommon:MBIbeamWall]"/>
+        <Constant name="MB4SLPhiL92" value="[mbCommon:MBCell_width]*92+[mbCommon:MBIbeamWall]"/>
+        <Constant name="MB4FeetSLPhiPl_x" value="2058./2.*mm"/>
+        <Constant name="MB4SLPhiL47" value="[mbCommon:MBCell_width]*47+[mbCommon:MBIbeamWall]"/>
+        <Constant name="MB4SLPhiL48" value="[mbCommon:MBCell_width]*48+[mbCommon:MBIbeamWall]"/>
+        <!--- #### MB4: Constants for DT honeycomb -->
+        <Constant name="MB4HC_height" value="[mbCommon:MBSuperLayer_height]+[mbCommon:MBHC_height]"/>
+        <Constant name="MB4BigHC_x" value="3980./2*mm"/>
+        <Constant name="MB4SmallHC_x" value="3812./2*mm"/>
+        <Constant name="MB4FeetHC_x" value="1908./2*mm"/>
+        <Constant name="MB4HCElectronics_height" value="81.*mm"/>
+        <!--- #### MB4: Constants for DT envelops -->
+        <Constant name="MB4Big_x" value="2081.7*mm"/>
+        <Constant name="MB4Small_x" value="2063.32*mm"/>
+        <Constant name="MB4Feet_x" value="1046.*mm"/>
+        <Constant name="MB4Bottom_x" value="1304.7*mm"/>
+        <Constant name="MB4Top_x" value="1558.*mm"/>
+        <!--- #### MB4: Constants for DT positioning: distance from SL center to HC center -->
+        <Constant name="MB4StandardSLPhi1_HC_dist" value="-42.*mm"/>
+        <Constant name="MB4StandardSLPhi2_HC_dist" value="42.*mm"/>
+        <Constant name="MB4BottomSLPhi1_HC_dist" value="21.*mm"/>
+        <Constant name="MB4BottomSLPhi2_HC_dist" value="-21.*mm"/>
+        <!--- #### MB4: Constants for RPC_s -->
+        <Constant name="MB4RPC_EngineerXPos" value="7018.*mm"/>
+        <Constant name="MB4RPC_EngineerYPos" value="-917.*mm"/>
+        <Constant name="MB4SmallRPC_EngineerYPos" value="417.*mm"/>
+        <Constant name="MB4FeetRPC_EngineerXPos" value="7042.5*mm"/>
+        <Constant name="MB4FeetRPC_EngineerYPos" value="60.*mm"/>
+        <Constant name="MB4BottomRPC_EngineerSeparation" value="194.*mm"/>
+        <Constant name="MB4RPC_x" value="4000/2*mm"/>
+        <Constant name="MB4BottomRPC_x" value="2500/2*mm"/>
+        <Constant name="MB4SmallRPC_x" value="3500/2*mm"/>
+        <Constant name="MB4RPC_Gas_x" value="[mb4:MB4RPC_x]/2.-10.*mm"/>
+        <Constant name="MB4RPC_Gas_x_pos" value="[mb4:MB4RPC_x]/2."/>
+        <Constant name="MB4SmallRPC_SmallerGas_x_pos" value="[mb4:MB4SmallRPC_x]-[mb3:MB3RPC_x]/2."/>
+        <Constant name="MB4SmallRPC_BiggerGas_x_pos" value="[mb4:MB4SmallRPC_x]-[mb4:MB4RPC_x]/2."/>
+        <Constant name="MB4BigRPC_x_pos" value="[mb4:MB4RPC_EngineerYPos]-[mb4:MB4BigPos_y]"/>
+        <Constant name="MB4SmallRPC_x_pos" value="-(tan(-[mb4:MB4SmallPosAngle])*[mb4:MB4BigPos_x] - ([mb4:MB4SmallRPC_SmallerGas_x_pos] - [mb4:MB4SmallRPC_BiggerGas_x_pos])-[mb4:MB4SmallRPC_EngineerYPos])"/>
+        <Constant name="MB4BottomRPC_x_pos" value="[mb4:MB4BottomRPC_x]+[mb4:MB4BottomRPC_EngineerSeparation]/2.-[mb4:MB4BottomPos_x]"/>
+        <Constant name="MB4TopRPC_x_pos" value="0*cm"/>
+        <Constant name="MB4RPC_z_pos" value="[mb4:MB4BigPos_x]-([mb4:MB4RPC_EngineerXPos]+[mbCommon:MBRPC_EngineerChamberWidth])"/>
+        <Constant name="MB4FeetRPC_x_pos" value="[mb4:MB4FeetUnitRadius]*sin([mb4:MB4FeetPosAngle]-60.*deg)-[mb4:MB4FeetRPC_EngineerYPos]"/>
+        <Constant name="MB4FeetRPC_z_pos" value="[mb4:MB4FeetUnitRadius]*cos([mb4:MB4FeetPosAngle]-60.*deg)-([mb4:MB4FeetRPC_EngineerXPos]+[mbCommon:MBRPC_EngineerChamberWidth])"/>
+        <!--- #### MB4Chim: Constants for DT RPC_s -->
+        <Constant name="MB4ChimRPC_GasRight_y_pos" value="[mbCommon:MBRPC_GasRight_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2.-4.*mm"/>
+        <Constant name="MB4ChimRPC_GasLeft_y_pos" value="[mbCommon:MBRPC_GasLeft_y_pos]-([mbCommon:MBRPC_z]-[mbCommon:MBChimRPC_z])/2.-4.*mm"/>
+    </ConstantsSection>
+    <SolidSection label="mb4.xml">
+        <!-- ####  MB4 Unit: fake volume representing one DTBX + 1 or 2 RPC -->
+        <!-- ####  MB4: DTBX chamber -->
+        <!--%% In MB4 the widest superlayer in x is the Z one -->
+        <Box name="MB4Big" dx="[mb4:MB4Big_x]" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With1RPC]"/>
+        <Box name="MB4Small" dx="[mb4:MB4Small_x]" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With1RPC]"/>
+        <Box name="MB4Feet" dx="[mb4:MB4Feet_x]" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With1RPC]"/>
+        <Box name="MB4Bottom" dx="[mb4:MB4Bottom_x]" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With1RPC]"/>
+        <Box name="MB4Top" dx="[mb4:MB4Top_x]" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With1RPC]"/>
+        <!-- ####  MB4: Superlayers Phi -->
+        <Box name="MB4BigSuperLayerPhi" dx="[mb4:MB4BigSLPhiPl_x]+2.7*mm" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB4SmallSuperLayerPhi" dx="[mb4:MB4SmallSLPhiPl_x]+2.7*mm" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB4FeetSuperLayerPhi" dx="[mb4:MB4FeetSLPhiPl_x]+2.7*mm" dy="[mbCommon:MBSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% MB4SLPhiClosingPlateParal is parallel to gas cells, MB3SLPhiClosingPlatePerp is perpendicular -->
+        <!--%% Parallel are 2 mm thick and as long as outer Plates -->
+        <Box name="MB4SLPhiClosingPlateParal" dx="1.*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB4SLPhi_C_PlateParal" dx="7.*mm" dy="[mbCommon:MBSLPhiPlO_z]-14.*mm" dz="1.*mm"/>
+        <!--%% Perpendicular are 12 mm thick and higher by 20 mm per side than the SL; 2.7 mm are added to reach the parallel "Cs" -->
+        <Box name="MB4BigSLPhiClosingPlatePerp" dx="[mb4:MB4BigSLPhiPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB4BigSLPhi_C_PlatePerp" dx="[mb4:MB4BigSLPhiPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <Box name="MB4SmallSLPhiClosingPlatePerp" dx="[mb4:MB4SmallSLPhiPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB4SmallSLPhi_C_PlatePerp" dx="[mb4:MB4SmallSLPhiPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <Box name="MB4FeetSLPhiClosingPlatePerp" dx="[mb4:MB4FeetSLPhiPl_x]+2.7*mm" dy="12./2.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB4FeetSLPhi_C_PlatePerp" dx="[mb4:MB4FeetSLPhiPl_x]+0.7*mm" dy="7.*mm" dz="1.*mm"/>
+        <!--%% MB4SLPhiAlPlateOuter is 0.7 mm wider (perpendicular to the wires) to reach the parallel "Cs"-->
+        <Box name="MB4BigSLPhiAlPlateOuter" dx="[mb4:MB4BigSLPhiPl_x]+0.7*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4SmallSLPhiAlPlateOuter" dx="[mb4:MB4SmallSLPhiPl_x]+0.7*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4FeetSLPhiAlPlateOuter" dx="[mb4:MB4FeetSLPhiPl_x]+0.7*mm" dy="[mbCommon:MBSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!--%% MB4SLPhiAlPlateInner does not reach MB4BigSLPhiPlthe parallel "Cs"-->
+        <Box name="MB4BigSLPhiAlPlateInner" dx="[mb4:MB4BigSLPhiPl_x]" dy="[mbCommon:MBSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4SmallSLPhiAlPlateInner" dx="[mb4:MB4SmallSLPhiPl_x]" dy="[mbCommon:MBSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4FeetSLPhiAlPlateInner" dx="[mb4:MB4FeetSLPhiPl_x]" dy="[mbCommon:MBSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4SLPhiLayer_95Cells" dx="[mb4:MB4SLPhiL95]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiLayer_95Cells_startCell2" dx="[mb4:MB4SLPhiL95]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiLayer_96Cells" dx="[mb4:MB4SLPhiL96]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiLayer_91Cells" dx="[mb4:MB4SLPhiL91]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiLayer_91Cells_startCell2" dx="[mb4:MB4SLPhiL91]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiLayer_92Cells" dx="[mb4:MB4SLPhiL92]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiLayer_47Cells" dx="[mb4:MB4SLPhiL47]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiLayer_47Cells_startCell2" dx="[mb4:MB4SLPhiL47]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiLayer_48Cells" dx="[mb4:MB4SLPhiL48]" dy="[mbCommon:MBSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <!--%% Tappini, Perpendicular to the Ibeams and at the two ends -->
+        <Box name="MB4SLPhiElectronics_95Cells" dx="[mb4:MB4SLPhiL95]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiElectronics_96Cells" dx="[mb4:MB4SLPhiL96]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4BigSLPhiCommonElectronics" dx="[mb4:MB4BigSLPhiPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <Box name="MB4SLPhiElectronics_91Cells" dx="[mb4:MB4SLPhiL91]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiElectronics_92Cells" dx="[mb4:MB4SLPhiL92]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SmallSLPhiCommonElectronics" dx="[mb4:MB4SmallSLPhiPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <Box name="MB4SLPhiElectronics_47Cells" dx="[mb4:MB4SLPhiL47]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4SLPhiElectronics_48Cells" dx="[mb4:MB4SLPhiL48]" dy="[mbCommon:MBLayerElectronics_width]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4FeetSLPhiCommonElectronics" dx="[mb4:MB4FeetSLPhiPl_x]" dy="35./2.*mm" dz="[mbCommon:MBSuperLayer_height]-10.*mm"/>
+        <!-- ####  MB4: Honeycomb -->
+        <Box name="MB4Hc_LateralC" dx="[mbCommon:MBHC_C_dimension]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB4Hc_LateralElectronics" dx="[mbCommon:MBHCLatElectronics_width]" dy="[mbCommon:MBHC_z]" dz="[mb4:MB4HCElectronics_height]"/>
+        <Box name="MB4HcTorsionBar" dx="25*mm" dy="678*mm" dz="50.*mm"/>
+        <Box name="MB4BigHoneycombBox" dx="[mb4:MB4BigHC_x]" dy="[mbCommon:MBHC_z]" dz="[mb4:MB4HC_height]"/>
+        <Box name="MB4BigHoneycomb" dx="[mb4:MB4BigHC_x]-125.*mm" dy="[mbCommon:MBHC_z]-125.*mm" dz="[mb4:MB4HC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4BigHcPlate" dx="[mb4:MB4BigHC_x]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4BigHc_FrontC" dx="[mb4:MB4BigHC_x]-125.*mm" dy="[mbCommon:MBHC_C_dimension]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB4BigHc_FrontElectronics" dx="[mb4:MB4BigHC_x]-125.*mm" dy="[mbCommon:MBHCFrontElectronics_width]" dz="[mb4:MB4HCElectronics_height]"/>
+        <Box name="MB4SmallHoneycombBox" dx="[mb4:MB4SmallHC_x]" dy="[mbCommon:MBHC_z]" dz="[mb4:MB4HC_height]"/>
+        <Box name="MB4SmallHoneycomb" dx="[mb4:MB4SmallHC_x]-125.*mm" dy="[mbCommon:MBHC_z]-125.*mm" dz="[mb4:MB4HC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4SmallHcPlate" dx="[mb4:MB4SmallHC_x]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4SmallHc_FrontC" dx="[mb4:MB4SmallHC_x]-125.*mm" dy="[mbCommon:MBHC_C_dimension]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB4SmallHc_FrontElectronics" dx="[mb4:MB4SmallHC_x]-125.*mm" dy="[mbCommon:MBHCFrontElectronics_width]" dz="[mb4:MB4HCElectronics_height]"/>
+        <Box name="MB4FeetHoneycombBox" dx="[mb4:MB4FeetHC_x]" dy="[mbCommon:MBHC_z]" dz="[mb4:MB4HC_height]"/>
+        <Box name="MB4FeetHoneycomb" dx="[mb4:MB4FeetHC_x]-125.*mm" dy="[mbCommon:MBHC_z]-125.*mm" dz="[mb4:MB4HC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4FeetHcPlate" dx="[mb4:MB4FeetHC_x]" dy="[mbCommon:MBHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4FeetHc_FrontC" dx="[mb4:MB4FeetHC_x]-125.*mm" dy="[mbCommon:MBHC_C_dimension]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB4FeetHc_FrontElectronics" dx="[mb4:MB4FeetHC_x]-125.*mm" dy="[mbCommon:MBHCFrontElectronics_width]" dz="[mb4:MB4HCElectronics_height]"/>
+        <Box name="MB4BottomHoneycombBox" dx="[mb2:MB2HC_x]" dy="[mbCommon:MBHC_z]" dz="[mb4:MB4HC_height]"/>
+        <Box name="MB4BottomHoneycomb" dx="[mb2:MB2HC_x]-125.*mm" dy="[mbCommon:MBHC_z]-125.*mm" dz="[mb4:MB4HC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4BottomHc_FrontC" dx="[mb2:MB2HC_x]-125.*mm" dy="[mbCommon:MBHC_C_dimension]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB4BottomHc_FrontElectronics" dx="[mb2:MB2HC_x]-125.*mm" dy="[mbCommon:MBHCFrontElectronics_width]" dz="[mb4:MB4HCElectronics_height]"/>
+        <Box name="MB4TopHoneycombBox" dx="[mb3:MB3HC_x]" dy="[mbCommon:MBHC_z]" dz="[mb4:MB4HC_height]"/>
+        <Box name="MB4TopHoneycomb" dx="[mb3:MB3HC_x]-125.*mm" dy="[mbCommon:MBHC_z]-125.*mm" dz="[mb4:MB4HC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4TopHc_FrontC" dx="[mb3:MB3HC_x]-125.*mm" dy="[mbCommon:MBHC_C_dimension]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB4TopHc_FrontElectronics" dx="[mb3:MB3HC_x]-125.*mm" dy="[mbCommon:MBHCFrontElectronics_width]" dz="[mb4:MB4HCElectronics_height]"/>
+        <!-- ####  MB4: RPC chambers -->
+        <Box name="MB4RPC" dx="[mb4:MB4RPC_x]" dy="[mbCommon:MBRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB4SmallRPC" dx="1750*mm" dy="[mbCommon:MBRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB4TopRPC" dx="1500*mm" dy="[mbCommon:MBRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB4FeetRPC" dx="1000*mm" dy="[mbCommon:MBRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB4BottomRPC" dx="[mb4:MB4BottomRPC_x]" dy="[mbCommon:MBRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB4RPC_GasLeft" dx="[mb4:MB4RPC_Gas_x]" dy="[mbCommon:MBRPC_GasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB4RPC_GasRight" dx="[mb4:MB4RPC_Gas_x]" dy="[mbCommon:MBRPC_GasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <!-- ####  MB4Chimney Unit -->
+        <!-- ####  MB4Chim: DTBX chamber -->
+        <Box name="MB4BigChim" dx="[MB4Big_x]" dy="[mbCommon:MBChimSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With1RPC]"/>
+        <Box name="MB4TopChim" dx="[mb3:MB3_x]" dy="[mbCommon:MBChimSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBHeight_With1RPC]"/>
+        <Box name="MB4BigChimRPC" dx="[mb4:MB4RPC_x]" dy="[mbCommon:MBChimRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <Box name="MB4TopChimRPC" dx="1500*mm" dy="[mbCommon:MBChimRPC_z]" dz="[mbCommon:MBRPC_y]"/>
+        <!-- ####  MB4Chim: DT Superlayers Phi -->
+        <Box name="MB4BigChimSuperLayerPhi" dx="[mb4:MB4BigSLPhiPl_x]+2.7*mm" dy="[mbCommon:MBChimSLPhiPlO_z]+12.*mm" dz="[mbCommon:MBSuperLayer_height]"/>
+        <!--%% Only extra parallel "Cs" are needed -->
+        <Box name="MB4ChimSLPhiClosingPlateParal" dx="1.*mm" dy="[mbCommon:MBChimSLPhiPlO_z]" dz="[mbCommon:MBSuperLayer_height]"/>
+        <Box name="MB4ChimSLPhi_C_PlateParal" dx="7.*mm" dy="[mbCommon:MBChimSLPhiPlO_z]-14.*mm" dz="1.*mm"/>
+        <!-- ## Outer Plates -->
+        <Box name="MB4BigChimSLPhiAlPlateOuter" dx="[mb4:MB4BigSLPhiPl_x]+0.7*mm" dy="[mbCommon:MBChimSLPhiPlO_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <!-- ## Inner Plates -->
+        <Box name="MB4BigChimSLPhiAlPlateInner" dx="[mb4:MB4BigSLPhiPl_x]" dy="[mbCommon:MBChimSLPhiPlI_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4ChimSLPhiLayer_95Cells" dx="[mb4:MB4SLPhiL95]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4ChimSLPhiLayer_95Cells_startCell2" dx="[mb4:MB4SLPhiL95]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <Box name="MB4ChimSLPhiLayer_96Cells" dx="[mb4:MB4SLPhiL96]" dy="[mbCommon:MBChimSLPhiLayer_length]" dz="[mbCommon:MBGas_height]"/>
+        <!-- ####  MB4Chim: DT Honeycomb -->
+        <Box name="MB4ChimHc_LateralC" dx="[mbCommon:MBHC_C_dimension]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBHC_C_width]"/>
+        <Box name="MB4ChimHc_LateralElectronics" dx="[mbCommon:MBHCLatElectronics_width]" dy="[mbCommon:MBChimHC_z]" dz="[mb4:MB4HCElectronics_height]"/>
+        <Box name="MB4BigChimHoneycombBox" dx="[mb4:MB4BigHC_x]" dy="[mbCommon:MBChimHC_z]" dz="[MB4HC_height]"/>
+        <Box name="MB4BigChimHoneycomb" dx="[mb4:MB4BigHC_x]-125.*mm" dy="[mbCommon:MBChimHC_z]-125.*mm" dz="[MB4HC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4BigChimHcPlate" dx="[mb4:MB4BigHC_x]" dy="[mbCommon:MBChimHC_z]" dz="[mbCommon:MBAlPlate_height]"/>
+        <Box name="MB4TopChimHoneycombBox" dx="[mb3:MB3HC_x]" dy="[mbCommon:MBChimHC_z]" dz="[mb4:MB4HC_height]"/>
+        <Box name="MB4TopChimHoneycomb" dx="[mb3:MB3HC_x]-125.*mm" dy="[mbCommon:MBChimHC_z]-125.*mm" dz="[mb4:MB4HC_height]-2*[mbCommon:MBAlPlate_height]"/>
+        <!-- ####  MB4Chim: RPC chambers -->
+        <Box name="MB4BigChimRPC_GasLeft" dx="[mb4:MB4RPC_Gas_x]" dy="[mbCommon:MBChimRPC_OGasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB4BigChimRPC_GasRight" dx="[mb4:MB4RPC_Gas_x]" dy="[mbCommon:MBChimRPC_OGasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB4TopChimRPC_GasLeft" dx="73*cm" dy="[mbCommon:MBChimRPC_OGasLeft_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+        <Box name="MB4TopChimRPC_GasRight" dx="73*cm" dy="[mbCommon:MBChimRPC_OGasRight_z]" dz="[mbCommon:MBRPC_Gas_y]"/>
+    </SolidSection>
+    <LogicalPartSection label="mb4.xml">
+        <!-- ####  MB4 Unit -->
+        <!-- ####  MB4: DTBX -->
+        <!-- #### There are BigLeft, MB4BigRight, MB4SmallLeft, MB4SmallRight, MB4Feet, MB4BottomLeft, MB4BottomRight, MB4Top, plus the two chimney units: Mb4BigChim, MB4TopChim. Plus each of this may have a N or P RPC -->
+        <LogicalPart name="MB4BigLeftP" category="unspecified">
+            <rSolid name="MB4Big"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigRightP" category="unspecified">
+            <rSolid name="MB4Big"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallLeftP" category="unspecified">
+            <rSolid name="MB4Small"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRightP" category="unspecified">
+            <rSolid name="MB4Small"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetP" category="unspecified">
+            <rSolid name="MB4Feet"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomLeftP" category="unspecified">
+            <rSolid name="MB4Bottom"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomRightP" category="unspecified">
+            <rSolid name="MB4Bottom"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopP" category="unspecified">
+            <rSolid name="MB4Top"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopChimP" category="unspecified">
+            <rSolid name="MB4TopChim"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigLeftN" category="unspecified">
+            <rSolid name="MB4Big"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigRightN" category="unspecified">
+            <rSolid name="MB4Big"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallLeftN" category="unspecified">
+            <rSolid name="MB4Small"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRightN" category="unspecified">
+            <rSolid name="MB4Small"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetN" category="unspecified">
+            <rSolid name="MB4Feet"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomLeftN" category="unspecified">
+            <rSolid name="MB4Bottom"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomRightN" category="unspecified">
+            <rSolid name="MB4Bottom"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopN" category="unspecified">
+            <rSolid name="MB4Top"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <!-- ####  MB4: DT Superlayers Phi -->
+        <!-- ## only paralel stuff is common -->
+        <LogicalPart name="MB4SLPhiClosingPlateParal" category="unspecified">
+            <rSolid name="MB4SLPhiClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhi_C_PlateParal" category="unspecified">
+            <rSolid name="MB4SLPhi_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!--- ### MB4 Big -->
+        <LogicalPart name="MB4BigSuperLayerPhi" category="unspecified">
+            <rSolid name="MB4BigSuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigSLPhiClosingPlatePerp" category="unspecified">
+            <rSolid name="MB4BigSLPhiClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigSLPhi_C_PlatePerp" category="unspecified">
+            <rSolid name="MB4BigSLPhi_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigSLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB4BigSLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigSLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB4BigSLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiLayer_95Cells" category="unspecified">
+            <rSolid name="MB4SLPhiLayer_95Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiLayer_95Cells_startCell2" category="unspecified">
+            <rSolid name="MB4SLPhiLayer_95Cells_startCell2"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiLayer_96Cells" category="unspecified">
+            <rSolid name="MB4SLPhiLayer_96Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4ChimSLPhiLayer_95Cells" category="unspecified">
+            <rSolid name="MB4ChimSLPhiLayer_95Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4ChimSLPhiLayer_95Cells_startCell2" category="unspecified">
+            <rSolid name="MB4ChimSLPhiLayer_95Cells_startCell2"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4ChimSLPhiLayer_96Cells" category="unspecified">
+            <rSolid name="MB4ChimSLPhiLayer_96Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiElectronics_95Cells" category="unspecified">
+            <rSolid name="MB4SLPhiElectronics_95Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiElectronics_96Cells" category="unspecified">
+            <rSolid name="MB4SLPhiElectronics_96Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigSLPhiCommonElectronics" category="unspecified">
+            <rSolid name="MB4BigSLPhiCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!--- ### MB4 Small -->
+        <LogicalPart name="MB4SmallSuperLayerPhi" category="unspecified">
+            <rSolid name="MB4SmallSuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallSLPhiClosingPlatePerp" category="unspecified">
+            <rSolid name="MB4SmallSLPhiClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallSLPhi_C_PlatePerp" category="unspecified">
+            <rSolid name="MB4SmallSLPhi_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallSLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB4SmallSLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallSLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB4SmallSLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiLayer_91Cells" category="unspecified">
+            <rSolid name="MB4SLPhiLayer_91Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiLayer_91Cells_startCell2" category="unspecified">
+            <rSolid name="MB4SLPhiLayer_91Cells_startCell2"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiLayer_92Cells" category="unspecified">
+            <rSolid name="MB4SLPhiLayer_92Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiElectronics_91Cells" category="unspecified">
+            <rSolid name="MB4SLPhiElectronics_91Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiElectronics_92Cells" category="unspecified">
+            <rSolid name="MB4SLPhiElectronics_92Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallSLPhiCommonElectronics" category="unspecified">
+            <rSolid name="MB4SmallSLPhiCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!--- ### MB4 Feet -->
+        <LogicalPart name="MB4FeetSuperLayerPhi" category="unspecified">
+            <rSolid name="MB4FeetSuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetSLPhiClosingPlatePerp" category="unspecified">
+            <rSolid name="MB4FeetSLPhiClosingPlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetSLPhi_C_PlatePerp" category="unspecified">
+            <rSolid name="MB4FeetSLPhi_C_PlatePerp"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetSLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB4FeetSLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetSLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB4FeetSLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiLayer_47Cells" category="unspecified">
+            <rSolid name="MB4SLPhiLayer_47Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiLayer_47Cells_startCell2" category="unspecified">
+            <rSolid name="MB4SLPhiLayer_47Cells_startCell2"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiLayer_48Cells" category="unspecified">
+            <rSolid name="MB4SLPhiLayer_48Cells"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiElectronics_47Cells" category="unspecified">
+            <rSolid name="MB4SLPhiElectronics_47Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SLPhiElectronics_48Cells" category="unspecified">
+            <rSolid name="MB4SLPhiElectronics_48Cells"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetSLPhiCommonElectronics" category="unspecified">
+            <rSolid name="MB4FeetSLPhiCommonElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB4: DT Honeycomb -->
+        <LogicalPart name="MB4Hc_LateralC" category="unspecified">
+            <rSolid name="MB4Hc_LateralC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4Hc_LateralElectronics" category="unspecified">
+            <rSolid name="MB4Hc_LateralElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4HcTorsionBar" category="unspecified">
+            <rSolid name="MB4HcTorsionBar"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigHoneycombBox" category="unspecified">
+            <rSolid name="MB4BigHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigHoneycomb" category="unspecified">
+            <rSolid name="MB4BigHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigHcPlate" category="unspecified">
+            <rSolid name="MB4BigHcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigHc_FrontC" category="unspecified">
+            <rSolid name="MB4BigHc_FrontC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigHc_FrontElectronics" category="unspecified">
+            <rSolid name="MB4BigHc_FrontElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallHoneycombBox" category="unspecified">
+            <rSolid name="MB4SmallHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallHoneycomb" category="unspecified">
+            <rSolid name="MB4SmallHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallHcPlate" category="unspecified">
+            <rSolid name="MB4SmallHcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallHc_FrontC" category="unspecified">
+            <rSolid name="MB4SmallHc_FrontC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallHc_FrontElectronics" category="unspecified">
+            <rSolid name="MB4SmallHc_FrontElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetHoneycombBox" category="unspecified">
+            <rSolid name="MB4FeetHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetHoneycomb" category="unspecified">
+            <rSolid name="MB4FeetHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetHcPlate" category="unspecified">
+            <rSolid name="MB4FeetHcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetHc_FrontC" category="unspecified">
+            <rSolid name="MB4FeetHc_FrontC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetHc_FrontElectronics" category="unspecified">
+            <rSolid name="MB4FeetHc_FrontElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomHoneycombBox" category="unspecified">
+            <rSolid name="MB4BottomHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomHoneycomb" category="unspecified">
+            <rSolid name="MB4BottomHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomHc_FrontC" category="unspecified">
+            <rSolid name="MB4BottomHc_FrontC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomHc_FrontElectronics" category="unspecified">
+            <rSolid name="MB4BottomHc_FrontElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopHoneycombBox" category="unspecified">
+            <rSolid name="MB4TopHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopHoneycomb" category="unspecified">
+            <rSolid name="MB4TopHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopHc_FrontC" category="unspecified">
+            <rSolid name="MB4TopHc_FrontC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopHc_FrontElectronics" category="unspecified">
+            <rSolid name="MB4TopHc_FrontElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <!-- ####  MB4: RPC chambers -->
+        <LogicalPart name="MB4RPC_P" category="unspecified">
+            <rSolid name="MB4RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4RPC_N" category="unspecified">
+            <rSolid name="MB4RPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRPC_PS8" category="unspecified">
+            <rSolid name="MB4SmallRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRPC_PS12" category="unspecified">
+            <rSolid name="MB4SmallRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRPC_NS8" category="unspecified">
+            <rSolid name="MB4SmallRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRPC_NS12" category="unspecified">
+            <rSolid name="MB4SmallRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopRPC_P" category="unspecified">
+            <rSolid name="MB4TopRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopRPC_N" category="unspecified">
+            <rSolid name="MB4TopRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetRPC_P" category="unspecified">
+            <rSolid name="MB4FeetRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetRPC_N" category="unspecified">
+            <rSolid name="MB4FeetRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomRPC_P" category="unspecified">
+            <rSolid name="MB4BottomRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomRPC_N" category="unspecified">
+            <rSolid name="MB4BottomRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4RPC_GasLeft" category="unspecified">
+            <rSolid name="MB4RPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4RPC_GasRight" category="unspecified">
+            <rSolid name="MB4RPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRPC_SmallerGasLeft" category="unspecified">
+            <rSolid name="mb3:MB3RPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRPC_SmallerGasRight" category="unspecified">
+            <rSolid name="mb3:MB3RPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRPC_BiggerGasLeft" category="unspecified">
+            <rSolid name="MB4RPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4SmallRPC_BiggerGasRight" category="unspecified">
+            <rSolid name="MB4RPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopRPC_GasLeft" category="unspecified">
+            <rSolid name="mb3:MB3RPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopRPC_GasRight" category="unspecified">
+            <rSolid name="mb3:MB3RPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetRPC_GasLeft" category="unspecified">
+            <rSolid name="mb4:MB4RPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4FeetRPC_GasRight" category="unspecified">
+            <rSolid name="mb4:MB4RPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomRPC_GasLeft" category="unspecified">
+            <rSolid name="mb2:MB22RPC_OGasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BottomRPC_GasRight" category="unspecified">
+            <rSolid name="mb2:MB22RPC_OGasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <!-- ####  MB4Chimney Unit -->
+        <!-- ####  MB4Chim: DTBX -->
+        <LogicalPart name="MB4BigChimN" category="unspecified">
+            <rSolid name="MB4BigChim"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopChim" category="unspecified">
+            <rSolid name="MB4TopChim"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <!-- ####  MB4Chim: DT Superlayers Phi  -->
+        <!-- ## only paralel stuff is common -->
+        <LogicalPart name="MB4ChimSLPhiClosingPlateParal" category="unspecified">
+            <rSolid name="MB4ChimSLPhiClosingPlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4ChimSLPhi_C_PlateParal" category="unspecified">
+            <rSolid name="MB4ChimSLPhi_C_PlateParal"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!--- ### MB4Chim Big -->
+        <LogicalPart name="MB4BigChimSuperLayerPhi" category="unspecified">
+            <rSolid name="MB4BigChimSuperLayerPhi"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigChimSLPhiAlPlateOuter" category="unspecified">
+            <rSolid name="MB4BigChimSLPhiAlPlateOuter"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigChimSLPhiAlPlateInner" category="unspecified">
+            <rSolid name="MB4BigChimSLPhiAlPlateInner"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- ####  MB4Chim: DT Honeycomb -->
+        <LogicalPart name="MB4ChimHc_LateralC" category="unspecified">
+            <rSolid name="MB4ChimHc_LateralC"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4ChimHc_LateralElectronics" category="unspecified">
+            <rSolid name="MB4ChimHc_LateralElectronics"/>
+            <rMaterial name="materials:M_Electronics averag"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigChimHoneycombBox" category="unspecified">
+            <rSolid name="MB4BigChimHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigChimHoneycomb" category="unspecified">
+            <rSolid name="MB4BigChimHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigChimHcPlate" category="unspecified">
+            <rSolid name="MB4BigChimHcPlate"/>
+            <rMaterial name="materials:M_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopChimHoneycombBox" category="unspecified">
+            <rSolid name="MB4TopChimHoneycombBox"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopChimHoneycomb" category="unspecified">
+            <rSolid name="MB4TopChimHoneycomb"/>
+            <rMaterial name="materials:M_honeycomb"/>
+        </LogicalPart>
+        <!-- ####  MB4Chim: RPC chambers -->
+        <LogicalPart name="MB4TopChimRPC_P" category="unspecified">
+            <rSolid name="MB4TopChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigChimRPC_N" category="unspecified">
+            <rSolid name="MB4BigChimRPC"/>
+            <rMaterial name="materials:M_RPC_Bakelite"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigChimRPC_GasLeft" category="unspecified">
+            <rSolid name="MB4BigChimRPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4BigChimRPC_GasRight" category="unspecified">
+            <rSolid name="MB4BigChimRPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopChimRPC_GasLeft" category="unspecified">
+            <rSolid name="MB4TopChimRPC_GasLeft"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MB4TopChimRPC_GasRight" category="unspecified">
+            <rSolid name="MB4TopChimRPC_GasRight"/>
+            <rMaterial name="materials:M_RPC_Gas"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="mb4.xml">
+        <!-- ####  MB4 Unit -->
+        <!-- ####  MB4: DTBX chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4BigLeftN"/>
+            <rRotation name="rotations:MM401"/>
+            <Translation x="[MB4BigPos_x]" y="[MB4BigPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4BigRightP"/>
+            <rRotation name="rotations:RM1882"/>
+            <Translation x="[MB4BigUnitRadius]*cos(30.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(30.*deg+[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4BigRightP"/>
+            <rRotation name="rotations:RM1892"/>
+            <Translation x="[MB4BigUnitRadius]*cos(60.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(60.*deg+[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4TopN"/>
+            <rRotation name="rotations:MM404"/>
+            <Translation x="[MB4TopPos_x]" y="[MB4TopPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="13">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4TopN"/>
+            <rRotation name="rotations:MM404"/>
+            <Translation x="-[MB4TopPos_x]" y="[MB4TopPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4BigRightN"/>
+            <rRotation name="rotations:MM405"/>
+            <Translation x="[MB4BigUnitRadius]*cos(120.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(120.*deg-[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4BigLeftP"/>
+            <rRotation name="rotations:RM1922"/>
+            <Translation x="[MB4BigUnitRadius]*cos(150.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(150.*deg-[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4BigLeftP"/>
+            <rRotation name="rotations:90XD"/>
+            <Translation x="[MB4BigUnitRadius]*cos(180.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(180.*deg-[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4SmallRightN"/>
+            <rRotation name="rotations:MM408"/>
+            <Translation x="-[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4FeetN"/>
+            <rRotation name="rotations:MM409"/>
+            <Translation x="-[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4BottomLeftP"/>
+            <rRotation name="rotations:RM1842"/>
+            <Translation x="-[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="14">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4BottomRightP"/>
+            <rRotation name="rotations:RM1842"/>
+            <Translation x="[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4FeetP"/>
+            <rRotation name="rotations:RM1852"/>
+            <Translation x="[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="muonBase:MBWheel_0"/>
+            <rChild name="mb4:MB4SmallLeftN"/>
+            <rRotation name="rotations:MM412"/>
+            <Translation x="[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4BigRightP"/>
+            <rRotation name="rotations:RM1872"/>
+            <Translation x="[MB4BigPos_x]" y="[MB4BigPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4BigRightP"/>
+            <rRotation name="rotations:RM1882"/>
+            <Translation x="[MB4BigUnitRadius]*cos(30.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(30.*deg+[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4BigRightP"/>
+            <rRotation name="rotations:RM1892"/>
+            <Translation x="[MB4BigUnitRadius]*cos(60.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(60.*deg+[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4TopChimP"/>
+            <rRotation name="rotations:RM1902"/>
+            <Translation x="[MB4TopPos_x]" y="[MB4TopPos_y]" z="[mbCommon:MBChimPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="13">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4TopChimP"/>
+            <rRotation name="rotations:RM1902"/>
+            <Translation x="-[MB4TopPos_x]" y="[MB4TopPos_y]" z="[mbCommon:MBChimPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4BigLeftP"/>
+            <rRotation name="rotations:RM1912"/>
+            <Translation x="[MB4BigUnitRadius]*cos(120.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(120.*deg-[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4BigLeftP"/>
+            <rRotation name="rotations:RM1922"/>
+            <Translation x="[MB4BigUnitRadius]*cos(150.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(150.*deg-[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4BigLeftP"/>
+            <rRotation name="rotations:90XD"/>
+            <Translation x="[MB4BigUnitRadius]*cos(180.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(180.*deg-[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4SmallLeftP"/>
+            <rRotation name="rotations:RM1822"/>
+            <Translation x="-[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4FeetP"/>
+            <rRotation name="rotations:RM1832"/>
+            <Translation x="-[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4BottomLeftP"/>
+            <rRotation name="rotations:RM1842"/>
+            <Translation x="-[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="14">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4BottomRightP"/>
+            <rRotation name="rotations:RM1842"/>
+            <Translation x="[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4FeetP"/>
+            <rRotation name="rotations:RM1852"/>
+            <Translation x="[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mb4:MB4SmallRightP"/>
+            <rRotation name="rotations:RM1862"/>
+            <Translation x="[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4BigRightP"/>
+            <rRotation name="rotations:RM1872"/>
+            <Translation x="[MB4BigPos_x]" y="[MB4BigPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4BigRightP"/>
+            <rRotation name="rotations:RM1882"/>
+            <Translation x="[MB4BigUnitRadius]*cos(30.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(30.*deg+[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4BigRightP"/>
+            <rRotation name="rotations:RM1892"/>
+            <Translation x="[MB4BigUnitRadius]*cos(60.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(60.*deg+[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4TopP"/>
+            <rRotation name="rotations:RM1902"/>
+            <Translation x="[MB4TopPos_x]" y="[MB4TopPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="13">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4TopP"/>
+            <rRotation name="rotations:RM1902"/>
+            <Translation x="-[MB4TopPos_x]" y="[MB4TopPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4BigLeftP"/>
+            <rRotation name="rotations:RM1912"/>
+            <Translation x="[MB4BigUnitRadius]*cos(120.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(120.*deg-[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4BigLeftP"/>
+            <rRotation name="rotations:RM1922"/>
+            <Translation x="[MB4BigUnitRadius]*cos(150.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(150.*deg-[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4BigLeftP"/>
+            <rRotation name="rotations:90XD"/>
+            <Translation x="[MB4BigUnitRadius]*cos(180.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(180.*deg-[MB4BigPosAngle])" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4SmallLeftP"/>
+            <rRotation name="rotations:RM1822"/>
+            <Translation x="-[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4FeetP"/>
+            <rRotation name="rotations:RM1832"/>
+            <Translation x="-[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4BottomLeftP"/>
+            <rRotation name="rotations:RM1842"/>
+            <Translation x="-[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="14">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4BottomRightP"/>
+            <rRotation name="rotations:RM1842"/>
+            <Translation x="[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4FeetP"/>
+            <rRotation name="rotations:RM1852"/>
+            <Translation x="[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <rChild name="mb4:MB4SmallRightP"/>
+            <rRotation name="rotations:RM1862"/>
+            <Translation x="[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="-[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4BigLeftN"/>
+            <rRotation name="rotations:MM401"/>
+            <Translation x="[MB4BigPos_x]" y="[MB4BigPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4BigLeftN"/>
+            <rRotation name="rotations:MM402"/>
+            <Translation x="[MB4BigUnitRadius]*cos(30.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(30.*deg+[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4BigChimN"/>
+            <rRotation name="rotations:MM403"/>
+            <Translation x="[MB4BigUnitRadius]*cos(60.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(60.*deg+[MB4BigPosAngle])" z="-[mbCommon:MBChimPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4TopN"/>
+            <rRotation name="rotations:MM404"/>
+            <Translation x="[MB4TopPos_x]" y="[MB4TopPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="13">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4TopN"/>
+            <rRotation name="rotations:MM404"/>
+            <Translation x="-[MB4TopPos_x]" y="[MB4TopPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4BigRightN"/>
+            <rRotation name="rotations:MM405"/>
+            <Translation x="[MB4BigUnitRadius]*cos(120.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(120.*deg-[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4BigRightN"/>
+            <rRotation name="rotations:MM406"/>
+            <Translation x="[MB4BigUnitRadius]*cos(150.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(150.*deg-[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4BigRightN"/>
+            <rRotation name="rotations:MM407"/>
+            <Translation x="[MB4BigUnitRadius]*cos(180.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(180.*deg-[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4SmallRightN"/>
+            <rRotation name="rotations:MM408"/>
+            <Translation x="-[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4FeetN"/>
+            <rRotation name="rotations:MM409"/>
+            <Translation x="-[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4BottomRightN"/>
+            <rRotation name="rotations:MM410"/>
+            <Translation x="-[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="14">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4BottomLeftN"/>
+            <rRotation name="rotations:MM410"/>
+            <Translation x="[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4FeetN"/>
+            <rRotation name="rotations:MM411"/>
+            <Translation x="[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mb4:MB4SmallLeftN"/>
+            <rRotation name="rotations:MM412"/>
+            <Translation x="[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4BigLeftN"/>
+            <rRotation name="rotations:MM401"/>
+            <Translation x="[MB4BigPos_x]" y="[MB4BigPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4BigLeftN"/>
+            <rRotation name="rotations:MM402"/>
+            <Translation x="[MB4BigUnitRadius]*cos(30.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(30.*deg+[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4BigLeftN"/>
+            <rRotation name="rotations:MM403"/>
+            <Translation x="[MB4BigUnitRadius]*cos(60.*deg+[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(60.*deg+[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4TopN"/>
+            <rRotation name="rotations:MM404"/>
+            <Translation x="[MB4TopPos_x]" y="[MB4TopPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="13">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4TopN"/>
+            <rRotation name="rotations:MM404"/>
+            <Translation x="-[MB4TopPos_x]" y="[MB4TopPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4BigRightN"/>
+            <rRotation name="rotations:MM405"/>
+            <Translation x="[MB4BigUnitRadius]*cos(120.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(120.*deg-[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4BigRightN"/>
+            <rRotation name="rotations:MM406"/>
+            <Translation x="[MB4BigUnitRadius]*cos(150.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(150.*deg-[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4BigRightN"/>
+            <rRotation name="rotations:MM407"/>
+            <Translation x="[MB4BigUnitRadius]*cos(180.*deg-[MB4BigPosAngle])" y="[MB4BigUnitRadius]*sin(180.*deg-[MB4BigPosAngle])" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4SmallRightN"/>
+            <rRotation name="rotations:MM408"/>
+            <Translation x="-[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4FeetN"/>
+            <rRotation name="rotations:MM409"/>
+            <Translation x="-[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4BottomRightN"/>
+            <rRotation name="rotations:MM410"/>
+            <Translation x="-[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="14">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4BottomLeftN"/>
+            <rRotation name="rotations:MM410"/>
+            <Translation x="[MB4BottomPos_x]" y="[MB4BottomPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4FeetN"/>
+            <rRotation name="rotations:MM411"/>
+            <Translation x="[MB4FeetPos_x]" y="[MB4FeetPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <rChild name="mb4:MB4SmallLeftN"/>
+            <rRotation name="rotations:MM412"/>
+            <Translation x="[MB4SmallPos_x]" y="[MB4SmallPos_y]" z="[mbCommon:MBPos_z]"/>
+        </PosPart>
+        <!-- #### MB4: DT Superlayers Phi -->
+        <!-- Staggering to be check -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigRightP"/>
+            <rChild name="mb4:MB4BigSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigRightP"/>
+            <rChild name="mb4:MB4BigSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigRightN"/>
+            <rChild name="mb4:MB4BigSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigRightN"/>
+            <rChild name="mb4:MB4BigSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigLeftP"/>
+            <rChild name="mb4:MB4BigSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi2_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigLeftP"/>
+            <rChild name="mb4:MB4BigSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi1_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigLeftN"/>
+            <rChild name="mb4:MB4BigSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi2_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigLeftN"/>
+            <rChild name="mb4:MB4BigSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi1_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRightN"/>
+            <rChild name="mb4:MB4SmallSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallRightN"/>
+            <rChild name="mb4:MB4SmallSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRightP"/>
+            <rChild name="mb4:MB4SmallSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallRightP"/>
+            <rChild name="mb4:MB4SmallSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallLeftP"/>
+            <rChild name="mb4:MB4SmallSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi2_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallLeftP"/>
+            <rChild name="mb4:MB4SmallSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi1_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallLeftN"/>
+            <rChild name="mb4:MB4SmallSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi2_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallLeftN"/>
+            <rChild name="mb4:MB4SmallSuperLayerPhi"/>
+            <Translation x="[mb4:MB4StandardSLPhi1_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRightP"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb4:MB4BottomSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BottomRightP"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb4:MB4BottomSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRightN"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb4:MB4BottomSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BottomRightN"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb4:MB4BottomSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomLeftP"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb4:MB4BottomSLPhi2_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BottomLeftP"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb4:MB4BottomSLPhi1_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomLeftN"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb4:MB4BottomSLPhi2_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BottomLeftN"/>
+            <rChild name="mb2:MB2SuperLayerPhi"/>
+            <Translation x="[mb4:MB4BottomSLPhi1_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopP"/>
+            <rChild name="mb3:MB3SuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4TopP"/>
+            <rChild name="mb3:MB3SuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopN"/>
+            <rChild name="mb3:MB3SuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4TopN"/>
+            <rChild name="mb3:MB3SuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetP"/>
+            <rChild name="mb4:MB4FeetSuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4FeetP"/>
+            <rChild name="mb4:MB4FeetSuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetN"/>
+            <rChild name="mb4:MB4FeetSuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4FeetN"/>
+            <rChild name="mb4:MB4FeetSuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <!-- ## MB4Big: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_95Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_96Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_96Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_95Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiClosingPlateParal"/>
+            <Translation x="[mb4:MB4BigSLPhiPl_x]+1.7*mm" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiClosingPlateParal"/>
+            <Translation x="-([mb4:MB4BigSLPhiPl_x]+1.7*mm)" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="[mb4:MB4BigSLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="[mb4:MB4BigSLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="-([mb4:MB4BigSLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="-([mb4:MB4BigSLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4SLPhiLayer_95Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="95"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL95]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4SLPhiLayer_95Cells_startCell2"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="95"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL95]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4SLPhiLayer_96Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="96"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL96]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SLPhiLayer_95Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_95Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SLPhiLayer_95Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_95Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SLPhiLayer_95Cells_startCell2"/>
+            <rChild name="mb4:MB4SLPhiElectronics_95Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SLPhiLayer_95Cells_startCell2"/>
+            <rChild name="mb4:MB4SLPhiElectronics_95Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SLPhiLayer_96Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_96Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SLPhiLayer_96Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_96Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ## MB4Small: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_91Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_92Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_92Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_91Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiClosingPlateParal"/>
+            <Translation x="[mb4:MB4SmallSLPhiPl_x]+1.7*mm" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiClosingPlateParal"/>
+            <Translation x="-([mb4:MB4SmallSLPhiPl_x]+1.7*mm)" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="[mb4:MB4SmallSLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="[mb4:MB4SmallSLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="-([mb4:MB4SmallSLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="-([mb4:MB4SmallSLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallSuperLayerPhi"/>
+            <rChild name="mb4:MB4SmallSLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4SLPhiLayer_91Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="91"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL91]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4SLPhiLayer_91Cells_startCell2"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="91"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL91]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4SLPhiLayer_92Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="92"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL92]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SLPhiLayer_91Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_91Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SLPhiLayer_91Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_91Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SLPhiLayer_91Cells_startCell2"/>
+            <rChild name="mb4:MB4SLPhiElectronics_91Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SLPhiLayer_91Cells_startCell2"/>
+            <rChild name="mb4:MB4SLPhiElectronics_91Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SLPhiLayer_92Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_92Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SLPhiLayer_92Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_92Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ## MB4Feet: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_47Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_48Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_48Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiLayer_47Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiClosingPlateParal"/>
+            <Translation x="[mb4:MB4FeetSLPhiPl_x]+1.7*mm" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhiClosingPlateParal"/>
+            <Translation x="-([mb4:MB4FeetSLPhiPl_x]+1.7*mm)" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="[mb4:MB4FeetSLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="[mb4:MB4FeetSLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="-([mb4:MB4FeetSLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4SLPhi_C_PlateParal"/>
+            <Translation x="-([mb4:MB4FeetSLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]+6.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhiClosingPlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]+6.*mm)" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetSuperLayerPhi"/>
+            <rChild name="mb4:MB4FeetSLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4SLPhiLayer_47Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="47"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL47]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4SLPhiLayer_47Cells_startCell2"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="47"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL47]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4SLPhiLayer_48Cells"/>
+            <String name="ChildName" value="mbCommon:MBSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="48"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL48]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SLPhiLayer_47Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_47Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SLPhiLayer_47Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_47Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SLPhiLayer_47Cells_startCell2"/>
+            <rChild name="mb4:MB4SLPhiElectronics_47Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SLPhiLayer_47Cells_startCell2"/>
+            <rChild name="mb4:MB4SLPhiElectronics_47Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SLPhiLayer_48Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_48Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SLPhiLayer_48Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_48Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ##### MB4: DT honeycomb -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigRightP"/>
+            <rChild name="mb4:MB4BigHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigRightN"/>
+            <rChild name="mb4:MB4BigHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigLeftP"/>
+            <rChild name="mb4:MB4BigHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigLeftN"/>
+            <rChild name="mb4:MB4BigHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRightP"/>
+            <rChild name="mb4:MB4SmallHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRightN"/>
+            <rChild name="mb4:MB4SmallHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallLeftP"/>
+            <rChild name="mb4:MB4SmallHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallLeftN"/>
+            <rChild name="mb4:MB4SmallHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopN"/>
+            <rChild name="mb4:MB4TopHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopP"/>
+            <rChild name="mb4:MB4TopHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetP"/>
+            <rChild name="mb4:MB4FeetHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetN"/>
+            <rChild name="mb4:MB4FeetHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRightP"/>
+            <rChild name="mb4:MB4BottomHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRightN"/>
+            <rChild name="mb4:MB4BottomHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomLeftP"/>
+            <rChild name="mb4:MB4BottomHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomLeftN"/>
+            <rChild name="mb4:MB4BottomHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4BigHoneycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4BigHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[MB4HC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4BigHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([MB4HC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb4:MB4BigHC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb4:MB4BigHC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb4:MB4BigHC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb4:MB4BigHC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="[mb4:MB4BigHC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="-([mb4:MB4BigHC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigHoneycombBox"/>
+            <rChild name="mb4:MB4HcTorsionBar"/>
+            <Translation x="[mb4:MB4BigHC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- Small HC -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4SmallHoneycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4SmallHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[MB4HC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4SmallHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([MB4HC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb4:MB4SmallHC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb4:MB4SmallHC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb4:MB4SmallHC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb4:MB4SmallHC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4SmallHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4SmallHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4SmallHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4SmallHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="[mb4:MB4SmallHC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="-([mb4:MB4SmallHC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4SmallHc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4SmallHc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallHoneycombBox"/>
+            <rChild name="mb4:MB4HcTorsionBar"/>
+            <Translation x="[mb4:MB4SmallHC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- Feet HC -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4FeetHoneycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4FeetHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[MB4HC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4FeetHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([MB4HC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb4:MB4FeetHC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb4:MB4FeetHC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb4:MB4FeetHC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb4:MB4FeetHC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4FeetHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4FeetHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4FeetHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4FeetHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="[mb4:MB4FeetHC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="-([mb4:MB4FeetHC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4FeetHc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4FeetHc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetHoneycombBox"/>
+            <rChild name="mb4:MB4HcTorsionBar"/>
+            <Translation x="[mb4:MB4FeetHC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- Bottom HC -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4BottomHoneycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb2:MB2HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[MB4HC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb2:MB2HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([MB4HC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb2:MB2HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4BottomHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4BottomHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4BottomHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4BottomHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="[mb2:MB2HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="-([mb2:MB2HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4BottomHc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4BottomHc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomHoneycombBox"/>
+            <rChild name="mb4:MB4HcTorsionBar"/>
+            <Translation x="[mb2:MB2HC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- Top HC -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4TopHoneycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb3:MB3HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[MB4HC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb3:MB3HcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([MB4HC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="[mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralC"/>
+            <Translation x="-([mb3:MB3HC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4TopHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4TopHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension]" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4TopHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4TopHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-[mbCommon:MBHC_C_dimension])" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="[mb3:MB3HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4Hc_LateralElectronics"/>
+            <Translation x="-([mb3:MB3HC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4TopHc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4TopHc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopHoneycombBox"/>
+            <rChild name="mb4:MB4HcTorsionBar"/>
+            <Translation x="[mb3:MB3HC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- ##### MB4: RPC chambers -->
+        <!-- ##### MB4: RPC_P chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigRightP"/>
+            <rChild name="mb4:MB4RPC_P"/>
+            <Translation x="-[mb4:MB4BigRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigLeftP"/>
+            <rChild name="mb4:MB4RPC_P"/>
+            <Translation x="[mb4:MB4BigRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRightP"/>
+            <rChild name="mb4:MB4SmallRPC_PS12"/>
+            <Translation x="[mb4:MB4SmallRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallLeftP"/>
+            <rChild name="mb4:MB4SmallRPC_PS8"/>
+            <Translation x="-[mb4:MB4SmallRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4RPC_P"/>
+            <rChild name="mb4:MB4RPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4RPC_P"/>
+            <rChild name="mb4:MB4RPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4RPC_P"/>
+            <rChild name="mb4:MB4RPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4RPC_P"/>
+            <rChild name="mb4:MB4RPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallRPC_PS8"/>
+            <rChild name="mb4:MB4SmallRPC_SmallerGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4SmallRPC_SmallerGas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRPC_PS8"/>
+            <rChild name="mb4:MB4SmallRPC_BiggerGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4SmallRPC_BiggerGas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallRPC_PS8"/>
+            <rChild name="mb4:MB4SmallRPC_SmallerGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4SmallRPC_SmallerGas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRPC_PS8"/>
+            <rChild name="mb4:MB4SmallRPC_BiggerGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4SmallRPC_BiggerGas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRPC_PS12"/>
+            <rChild name="mb4:MB4SmallRPC_SmallerGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4SmallRPC_SmallerGas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallRPC_PS12"/>
+            <rChild name="mb4:MB4SmallRPC_BiggerGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4SmallRPC_BiggerGas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRPC_PS12"/>
+            <rChild name="mb4:MB4SmallRPC_SmallerGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4SmallRPC_SmallerGas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallRPC_PS12"/>
+            <rChild name="mb4:MB4SmallRPC_BiggerGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4SmallRPC_BiggerGas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB4: RPC_N chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigRightN"/>
+            <rChild name="mb4:MB4RPC_N"/>
+            <Translation x="-[mb4:MB4BigRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigLeftN"/>
+            <rChild name="mb4:MB4RPC_N"/>
+            <Translation x="[mb4:MB4BigRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRightN"/>
+            <rChild name="mb4:MB4SmallRPC_NS8"/>
+            <Translation x="[mb4:MB4SmallRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallLeftN"/>
+            <rChild name="mb4:MB4SmallRPC_NS12"/>
+            <Translation x="-[mb4:MB4SmallRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4RPC_N"/>
+            <rChild name="mb4:MB4RPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4RPC_N"/>
+            <rChild name="mb4:MB4RPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4RPC_N"/>
+            <rChild name="mb4:MB4RPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4RPC_N"/>
+            <rChild name="mb4:MB4RPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallRPC_NS8"/>
+            <rChild name="mb4:MB4SmallRPC_SmallerGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4SmallRPC_SmallerGas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRPC_NS8"/>
+            <rChild name="mb4:MB4SmallRPC_BiggerGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4SmallRPC_BiggerGas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallRPC_NS8"/>
+            <rChild name="mb4:MB4SmallRPC_SmallerGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4SmallRPC_SmallerGas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRPC_NS8"/>
+            <rChild name="mb4:MB4SmallRPC_BiggerGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4SmallRPC_BiggerGas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRPC_NS12"/>
+            <rChild name="mb4:MB4SmallRPC_SmallerGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4SmallRPC_SmallerGas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallRPC_NS12"/>
+            <rChild name="mb4:MB4SmallRPC_BiggerGasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4SmallRPC_BiggerGas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4SmallRPC_NS12"/>
+            <rChild name="mb4:MB4SmallRPC_SmallerGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4SmallRPC_SmallerGas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4SmallRPC_NS12"/>
+            <rChild name="mb4:MB4SmallRPC_BiggerGasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4SmallRPC_BiggerGas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB4: RPC chambers in MB4Top -->
+        <!-- ##### MB4: RPC_P chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopP"/>
+            <rChild name="mb4:MB4TopRPC_P"/>
+            <Translation x="[mb4:MB4TopRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopRPC_P"/>
+            <rChild name="mb4:MB4TopRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopRPC_P"/>
+            <rChild name="mb4:MB4TopRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopRPC_P"/>
+            <rChild name="mb4:MB4TopRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopRPC_P"/>
+            <rChild name="mb4:MB4TopRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB4: RPC_N chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopN"/>
+            <rChild name="mb4:MB4TopRPC_N"/>
+            <Translation x="[mb4:MB4TopRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopRPC_N"/>
+            <rChild name="mb4:MB4TopRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopRPC_N"/>
+            <rChild name="mb4:MB4TopRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopRPC_N"/>
+            <rChild name="mb4:MB4TopRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopRPC_N"/>
+            <rChild name="mb4:MB4TopRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB4: RPC chambers in MB4Feet -->
+        <!-- ##### MB4: RPC_P chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetP"/>
+            <rChild name="mb4:MB4FeetRPC_P"/>
+            <Translation x="[mb4:MB4FeetRPC_x_pos]" y="0*fm" z="[mb4:MB4FeetRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetRPC_P"/>
+            <rChild name="mb4:MB4FeetRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*fm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetRPC_P"/>
+            <rChild name="mb4:MB4FeetRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*fm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB4: RPC_N chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetN"/>
+            <rChild name="mb4:MB4FeetRPC_N"/>
+            <Translation x="[mb4:MB4FeetRPC_x_pos]" y="0*fm" z="[mb4:MB4FeetRPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetRPC_N"/>
+            <rChild name="mb4:MB4FeetRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*fm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4FeetRPC_N"/>
+            <rChild name="mb4:MB4FeetRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*fm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB4: RPC chambers in MB4Bottom -->
+        <!-- ##### MB4: RPC_P chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRightP"/>
+            <rChild name="mb4:MB4BottomRPC_P"/>
+            <Translation x="-[mb4:MB4BottomRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomLeftP"/>
+            <rChild name="mb4:MB4BottomRPC_P"/>
+            <Translation x="[mb4:MB4BottomRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRPC_P"/>
+            <rChild name="mb4:MB4BottomRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*fm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRPC_P"/>
+            <rChild name="mb4:MB4BottomRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*fm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB4: RPC_N chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRightN"/>
+            <rChild name="mb4:MB4BottomRPC_N"/>
+            <Translation x="-[mb4:MB4BottomRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomLeftN"/>
+            <rChild name="mb4:MB4BottomRPC_N"/>
+            <Translation x="[mb4:MB4BottomRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRPC_N"/>
+            <rChild name="mb4:MB4BottomRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*fm" y="-[mbCommon:MBRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BottomRPC_N"/>
+            <rChild name="mb4:MB4BottomRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="0*fm" y="[mbCommon:MBRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ####  MB4Chimney Unit -->
+        <!-- ####  MB4Chim: DTBX chamber -->
+        <!-- #### MB4BigChim: DT Superlayers Phi -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimN"/>
+            <rChild name="mb4:MB4BigChimSuperLayerPhi"/>
+            <Translation x="-[mb4:MB4StandardSLPhi1_HC_dist]" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigChimN"/>
+            <rChild name="mb4:MB4BigChimSuperLayerPhi"/>
+            <Translation x="-[mb4:MB4StandardSLPhi2_HC_dist]" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopChimP"/>
+            <rChild name="mb3:MB3ChimSuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4TopChimP"/>
+            <rChild name="mb3:MB3ChimSuperLayerPhi"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_pos_z]-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <!-- ## MB4BigChim: DT Superlayers Phi internal -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigChimSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigChimSLPhiAlPlateOuter"/>
+            <Translation x="0*fm" y="0*fm" z="-4*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0.*mm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigChimSLPhiAlPlateInner"/>
+            <Translation x="0*fm" y="0*fm" z="-2*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhiLayer_95Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhiLayer_96Cells"/>
+            <Translation x="-10.5*mm" y="0*fm" z="[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhiLayer_96Cells"/>
+            <Translation x="10.5*mm" y="0*fm" z="-[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhiLayer_95Cells_startCell2"/>
+            <Translation x="10.5*mm" y="0*fm" z="-3*[mbCommon:MBCell_height]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhiClosingPlateParal"/>
+            <Translation x="[mb4:MB4BigSLPhiPl_x]+1.7*mm" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhiClosingPlateParal"/>
+            <Translation x="-([mb4:MB4BigSLPhiPl_x]+1.7*mm)" y="0.*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhi_C_PlateParal"/>
+            <Translation x="[mb4:MB4BigSLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhi_C_PlateParal"/>
+            <Translation x="[mb4:MB4BigSLPhiPl_x]+0.7*mm-7.*mm" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhi_C_PlateParal"/>
+            <Translation x="-([mb4:MB4BigSLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4ChimSLPhi_C_PlateParal"/>
+            <Translation x="-([mb4:MB4BigSLPhiPl_x]+0.7*mm-7.*mm)" y="0.*fm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-7.*mm" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-7.*mm" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-7.*mm)" z="[mbCommon:MBSuperLayer_height]-2.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhi_C_PlatePerp"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-7.*mm)" z="-([mbCommon:MBSuperLayer_height]-2.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiPlO_z]-35./2.*mm" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimSuperLayerPhi"/>
+            <rChild name="mb4:MB4BigSLPhiCommonElectronics"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiPlO_z]-35./2.*mm)" z="0.*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4ChimSLPhiLayer_95Cells"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="95"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL95]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4ChimSLPhiLayer_95Cells_startCell2"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="2"/>
+            <Numeric name="N" value="95"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL95]-3*[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <Algorithm name="global:DDLinear">
+            <rParent name="mb4:MB4ChimSLPhiLayer_96Cells"/>
+            <String name="ChildName" value="mbCommon:MBChimSLPhiGas"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="N" value="96"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="Delta" value="[mbCommon:MBCell_width]*2."/>
+            <Vector name="Base" type="numeric" nEntries="3"> -[mb4:MB4SLPhiL96]-[mbCommon:MBCell_width]+[mbCommon:MBIbeamWall], 0.*mm, 0.*mm </Vector>
+            <Numeric name="Theta" value="90.*deg"/>
+            <Numeric name="Phi" value="0.*deg"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4ChimSLPhiLayer_95Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_95Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4ChimSLPhiLayer_95Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_95Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4ChimSLPhiLayer_95Cells_startCell2"/>
+            <rChild name="mb4:MB4SLPhiElectronics_95Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4ChimSLPhiLayer_95Cells_startCell2"/>
+            <rChild name="mb4:MB4SLPhiElectronics_95Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4ChimSLPhiLayer_96Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_96Cells"/>
+            <Translation x="0.*fm" y="[mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width]" z="0.*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4ChimSLPhiLayer_96Cells"/>
+            <rChild name="mb4:MB4SLPhiElectronics_96Cells"/>
+            <Translation x="0.*fm" y="-([mbCommon:MBChimSLPhiLayer_length]-[mbCommon:MBLayerElectronics_width])" z="0.*fm"/>
+        </PosPart>
+        <!-- ##### MB4Chim: DT honeycomb -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimN"/>
+            <rChild name="mb4:MB4BigChimHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopChimP"/>
+            <rChild name="mb4:MB4TopChimHoneycombBox"/>
+            <Translation x="0*fm" y="0*fm" z="-[mbCommon:MBSL_posDisp]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4BigChimHoneycomb"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4BigChimHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="[MB4HC_height]-0.75*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4BigChimHcPlate"/>
+            <Translation x="0*fm" y="0*fm" z="-([MB4HC_height]-0.75*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4ChimHc_LateralC"/>
+            <Translation x="[mb4:MB4BigHC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4ChimHc_LateralC"/>
+            <Translation x="[mb4:MB4BigHC_x]-[mbCommon:MBHC_C_dimension]" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4ChimHc_LateralC"/>
+            <Translation x="-([mb4:MB4BigHC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4ChimHc_LateralC"/>
+            <Translation x="-([mb4:MB4BigHC_x]-[mbCommon:MBHC_C_dimension])" y="0*fm" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension]" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontC"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension]" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension])" z="[MB4HC_height]-5.5*mm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontC"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-[mbCommon:MBHC_C_dimension])" z="-([MB4HC_height]-5.5*mm)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4ChimHc_LateralElectronics"/>
+            <Translation x="[mb4:MB4BigHC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width]" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4ChimHc_LateralElectronics"/>
+            <Translation x="-([mb4:MB4BigHC_x]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCLatElectronics_width])" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontElectronics"/>
+            <Translation x="0*fm" y="[mbCommon:MBChimHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width]" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4BigHc_FrontElectronics"/>
+            <Translation x="0*fm" y="-([mbCommon:MBChimHC_z]-2*[mbCommon:MBHC_C_dimension]+[mbCommon:MBHCFrontElectronics_width])" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimHoneycombBox"/>
+            <rChild name="mb4:MB4HcTorsionBar"/>
+            <Translation x="[mb4:MB4BigHC_x]-25.*mm" y="0*fm" z="0*fm"/>
+        </PosPart>
+        <!-- ##### MB4Chim: RPC chambers -->
+        <!-- ##### MB4Chim: RPC_P chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopChimP"/>
+            <rChild name="mb4:MB4TopChimRPC_P"/>
+            <Translation x="[mb4:MB4TopRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopChimRPC_P"/>
+            <rChild name="mb4:MB4TopChimRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="-[mb4:MB4ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopChimRPC_P"/>
+            <rChild name="mb4:MB4TopChimRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="-[mb4:MB4ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4TopChimRPC_P"/>
+            <rChild name="mb4:MB4TopChimRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb3:MB3RPC_Gas_x_pos]" y="[mb4:MB4ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4TopChimRPC_P"/>
+            <rChild name="mb4:MB4TopChimRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb3:MB3RPC_Gas_x_pos]" y="[mb4:MB4ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <!-- ##### MB4Chim: RPC_N chamber -->
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimN"/>
+            <rChild name="mb4:MB4BigChimRPC_N"/>
+            <Translation x="[mb4:MB4BigRPC_x_pos]" y="0*fm" z="[mb4:MB4RPC_z_pos]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimRPC_N"/>
+            <rChild name="mb4:MB4BigChimRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4RPC_Gas_x_pos]" y="-[mb4:MB4ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimRPC_N"/>
+            <rChild name="mb4:MB4BigChimRPC_GasLeft"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4RPC_Gas_x_pos]" y="-[mb4:MB4ChimRPC_GasLeft_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mb4:MB4BigChimRPC_N"/>
+            <rChild name="mb4:MB4BigChimRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="-[mb4:MB4RPC_Gas_x_pos]" y="[mb4:MB4ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="mb4:MB4BigChimRPC_N"/>
+            <rChild name="mb4:MB4BigChimRPC_GasRight"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="[mb4:MB4RPC_Gas_x_pos]" y="[mb4:MB4ChimRPC_GasRight_y_pos]" z="0*cm"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/MuonCommonData/data/mbCommon/2015/v2/mbCommon.xml
+++ b/Geometry/MuonCommonData/data/mbCommon/2015/v2/mbCommon.xml
@@ -1,0 +1,443 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- ####### Constants common to all DTBX stations -->
+    <ConstantsSection label="mbCommon.xml" eval="true">
+        <!--- #### Constants for all DT superlayers -->
+        <Constant name="MBHeight_With2RPC" value="362./2.*mm"/>
+        <Constant name="MBHeight_With1RPC" value="326./2.*mm"/>
+        <Constant name="MBSL_posDisp" value="[MBHeight_With2RPC]-[MBHeight_With1RPC]"/>
+        <Constant name="MBSL_pos_z" value="235./2.*mm"/>
+        <Constant name="MBCell_width" value="42./2.*mm"/>
+        <Constant name="MBIbeamWall" value="1.3*mm/2."/>
+        <Constant name="MBLayerElectronics_width" value="25./2.*mm"/>
+        <!--%% tappini -->
+        <Constant name="MBGas_height" value="11.5/2.*mm"/>
+        <Constant name="MBAlPlate_height" value="1.5/2.*mm"/>
+        <Constant name="MBCell_height" value="[MBGas_height]+[MBAlPlate_height]"/>
+        <Constant name="MBSuperLayer_height" value="4*[MBCell_height]+[MBAlPlate_height]"/>
+        <!---%% Honeycomb -->
+        <Constant name="MBHC_offset" value="26.75*mm"/>
+        <Constant name="MBHC_height" value="128./2.*mm"/>
+        <Constant name="MBHC_z" value="2458./2.*mm"/>
+        <Constant name="MBChimHC_z" value="[MBHC_z]-195.*mm"/>
+        <Constant name="MBHCElectronics_height" value="54.5*mm"/>
+        <Constant name="MBHCLatElectronics_width" value="70./2.*mm"/>
+        <Constant name="MBHCFrontElectronics_width" value="64.5/2.*mm"/>
+        <Constant name="MBHC_C_dimension" value="125./2.*mm"/>
+        <Constant name="MBHC_C_width" value="4.*mm"/>
+        <!--- ### Constants for all non-chimney DT superlayers -->
+        <Constant name="MBPos_z" value="8.5*mm"/>
+        <Constant name="MBSLPhiWire_length" value="2379./2.*mm"/>
+        <!--%% Wire length from EDMS: THIS NUMBER DEFINE THE SL DIMENSIONS-->
+        <Constant name="MBSLPhiBareWire_length" value="[MBSLPhiWire_length]-15.5*mm"/>
+        <!--%% Bare Wire _length == wire_lenght - depth in tappini-->
+        <Constant name="MBSLPhiLayer_length" value="[MBSLPhiBareWire_length]+2*[MBLayerElectronics_width]"/>
+        <!--%% The z length of the Al layer volume-->
+        <Constant name="MBSLPhiPlI_z" value="[MBSLPhiLayer_length]+6.5*mm"/>
+        <!--%% 6.5 is the distance between tappini and Al Plate edge-->
+        <Constant name="MBSLPhiPlO_z" value="[MBSLPhiPlI_z]+38.*mm"/>
+        <Constant name="MBSLZPl_x" value="2457./2*mm"/>
+        <Constant name="MBSLZL56" value="[MBCell_width]*56+[MBIbeamWall]"/>
+        <Constant name="MBSLZL57" value="[MBCell_width]*57+[MBIbeamWall]"/>
+        <Constant name="MBSLZL58" value="[MBCell_width]*58+[MBIbeamWall]"/>
+        <!--- #### Constants for all chimney DT superlayers -->
+        <Constant name="MBChimPos_z" value="186.5*mm"/>
+        <Constant name="MBChimSLPhiWire_length" value="1989./2.*mm"/>
+        <!--%% Just change this number -->
+        <Constant name="MBChimSLPhiBareWire_length" value="[MBChimSLPhiWire_length]-15.5*mm"/>
+        <Constant name="MBChimSLPhiLayer_length" value="[MBChimSLPhiBareWire_length]+2*[MBLayerElectronics_width]"/>
+        <Constant name="MBChimSLPhiPlI_z" value="[MBChimSLPhiLayer_length]+6.5*mm"/>
+        <Constant name="MBChimSLPhiPlO_z" value="[MBChimSLPhiPlI_z]+38.*mm"/>
+        <Constant name="MBChimSLZPl_x" value="[MBSLZPl_x]-399./2.*mm"/>
+        <Constant name="MBChimSLZL47" value="[MBCell_width]*47+[MBIbeamWall]"/>
+        <Constant name="MBChimSLZL48" value="[MBCell_width]*48+[MBIbeamWall]"/>
+        <!--- #### Constants for all RPCs -->
+        <Constant name="MBRPC_EngineerChamberWidth" value="55./2*mm"/>
+        <Constant name="MBRPC_y" value="12./2*mm"/>
+        <Constant name="MBRPC_Gas_y" value="4./2.*mm"/>
+        <Constant name="MBRPC_z" value="2455./2.*mm"/>
+        <Constant name="MBChimRPC_OGasLeft_z" value="389.5*mm+195./2.*mm"/>
+        <Constant name="MBChimRPC_OGasRight_z" value="626.*mm-195./2.*mm"/>
+        <Constant name="MBRPC_GasLeft_z" value="584.5*mm"/>
+        <Constant name="MBRPC_GasRight_z" value="626*mm"/>
+        <Constant name="MBRPC_x_pos" value="2*cm"/>
+        <Constant name="MBRPC_z_pos" value="17.5*cm"/>
+        <Constant name="MBRPC_GasLeft_y_pos" value="629*mm"/>
+        <Constant name="MBRPC_GasRight_y_pos" value="587.5*mm"/>
+        <Constant name="MBChimRPC_z" value="2081./2.*mm"/>
+    </ConstantsSection>
+    <SolidSection label="mbCommon.xml">
+        <!-- ####  DTBX Gas cell for non chimney chambers -->
+        <!--%% Effective gas volume: This volume should not include the Ibeam horizontal bars (those that make the 'I' shape; without them it would be a '|') -->
+        <Box name="MBSLPhiGas_a" dx="20.35*mm" dz="[MBGas_height]" dy="[MBSLPhiBareWire_length]"/>
+        <Box name="MBSLPhiIBeamWing" dx="3.175*mm" dz="0.65*mm" dy="[MBSLPhiBareWire_length]"/>
+        <SubtractionSolid name="MBSLPhiGas_b">
+            <rSolid name="MBSLPhiGas_a"/>
+            <rSolid name="MBSLPhiIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" z="5.1*mm" y="0.*fm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MBSLPhiGas_c">
+            <rSolid name="MBSLPhiGas_b"/>
+            <rSolid name="MBSLPhiIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" z="-5.1*mm" y="0.*fm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MBSLPhiGas_d">
+            <rSolid name="MBSLPhiGas_c"/>
+            <rSolid name="MBSLPhiIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" z="5.1*mm" y="0.*fm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MBSLPhiGas">
+            <rSolid name="MBSLPhiGas_d"/>
+            <rSolid name="MBSLPhiIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" z="-5.1*mm" y="0.*fm"/>
+        </SubtractionSolid>
+        <!-- ####  DTBX Gas cell for chimney chambers -->
+        <!--%% Effective gas volume.
+             This volume should not include the Ibeam horizontal bars (those that make the 'I' shape; without them it would be a '|') -->
+        <Box name="MBChimSLPhiGas_a" dx="20.35*mm" dz="[MBGas_height]" dy="[MBChimSLPhiBareWire_length]"/>
+        <Box name="MBChimSLPhiIBeamWing" dx="3.175*mm" dz="0.65*mm" dy="[MBChimSLPhiBareWire_length]"/>
+        <SubtractionSolid name="MBChimSLPhiGas_b">
+            <rSolid name="MBChimSLPhiGas_a"/>
+            <rSolid name="MBChimSLPhiIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" z="5.1*mm" y="0.*fm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MBChimSLPhiGas_c">
+            <rSolid name="MBChimSLPhiGas_b"/>
+            <rSolid name="MBChimSLPhiIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="17.175*mm" z="-5.1*mm" y="0.*fm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MBChimSLPhiGas_d">
+            <rSolid name="MBChimSLPhiGas_c"/>
+            <rSolid name="MBChimSLPhiIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" z="5.1*mm" y="0.*fm"/>
+        </SubtractionSolid>
+        <SubtractionSolid name="MBChimSLPhiGas">
+            <rSolid name="MBChimSLPhiGas_d"/>
+            <rSolid name="MBChimSLPhiIBeamWing"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-17.175*mm" z="-5.1*mm" y="0.*fm"/>
+        </SubtractionSolid>
+        <!--%%%%%%%%%%%  Cables inside wheels -->
+        <Box name="MBCablesBox_Int" dx="50*cm" dy="10*cm" dz="1.268*m"/>
+        <Box name="MBCablesBox_IntChim" dx="50*cm" dy="10*cm" dz="1.073*m"/>
+        <Box name="MBCables_Int" dx="50*cm" dy="2*cm" dz="1.268*m"/>
+        <Box name="MBCables_IntChim" dx="50*cm" dy="2*cm" dz="1.073*m"/>
+        <!--%%%%%%%%%%%  Cables outside wheels -->
+        <Box name="MBCables_Wheels0_1" dx="2.05*m" dy="70*cm" dz="5.4*cm"/>
+        <Box name="MBCables_Wheels1_2" dx="2.05*m" dy="70*cm" dz="3.25*cm"/>
+        <Tubs name="MBCables_Ext" rMin="8.05*m" rMax="8.3*m" dz="30*cm" startPhi="15*deg" deltaPhi="150*deg"/>
+    </SolidSection>
+    <LogicalPartSection label="mbCommon.xml">
+        <!-- ####  DTBX Gas cell for non chimney chambers -->
+        <LogicalPart name="MBSLPhiGas" category="unspecified">
+            <rSolid name="MBSLPhiGas"/>
+            <rMaterial name="materials:M_DTBX Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MBSLPhiIBeamWing" category="unspecified">
+            <rSolid name="MBSLPhiIBeamWing"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!-- ####  DTBX Gas cell for chimney chambers -->
+        <LogicalPart name="MBChimSLPhiGas" category="unspecified">
+            <rSolid name="MBChimSLPhiGas"/>
+            <rMaterial name="materials:M_DTBX Gas"/>
+        </LogicalPart>
+        <LogicalPart name="MBChimSLPhiIBeamWing" category="unspecified">
+            <rSolid name="MBChimSLPhiIBeamWing"/>
+            <rMaterial name="materials:Aluminium"/>
+        </LogicalPart>
+        <!--%%%%%%%%%%%  Cables inside wheels -->
+        <LogicalPart name="MBCablesBox_Int" category="unspecified">
+            <rSolid name="MBCablesBox_Int"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MBCables_Int" category="unspecified">
+            <rSolid name="MBCables_Int"/>
+            <rMaterial name="materials:M_Cables"/>
+        </LogicalPart>
+        <LogicalPart name="MBCablesBox_IntChim" category="unspecified">
+            <rSolid name="MBCablesBox_IntChim"/>
+            <rMaterial name="materials:M_B_Air"/>
+        </LogicalPart>
+        <LogicalPart name="MBCables_IntChim" category="unspecified">
+            <rSolid name="MBCables_IntChim"/>
+            <rMaterial name="materials:M_Cables"/>
+        </LogicalPart>
+        <!--%%%%%%%%%%%  Cables outside wheels -->
+        <LogicalPart name="MBCables_Wheels0_1" category="unspecified">
+            <rSolid name="MBCables_Wheels0_1"/>
+            <rMaterial name="materials:M_Cables"/>
+        </LogicalPart>
+        <LogicalPart name="MBCables_Wheels1_2" category="unspecified">
+            <rSolid name="MBCables_Wheels1_2"/>
+            <rMaterial name="materials:M_Cables"/>
+        </LogicalPart>
+        <LogicalPart name="MBCables_Ext" category="unspecified">
+            <rSolid name="MBCables_Ext"/>
+            <rMaterial name="materials:M_Cables"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="mbCommon.xml">
+        <!--%%%%%%%%%%%  Cables inside wheels -->
+        <PosPart copyNumber="1">
+            <rParent name="mbCommon:MBCablesBox_Int"/>
+            <rChild name="mbCommon:MBCables_Int"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0*fm" y="-8*cm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="mbCommon:MBCablesBox_IntChim"/>
+            <rChild name="mbCommon:MBCables_IntChim"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0*fm" y="-8*cm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R270"/>
+            <Translation x="3.945*m" y="34.5763*cm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R300"/>
+            <Translation x="3.24359*m" y="2.27194*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R330"/>
+            <Translation x="1.67306*m" y="3.58935*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_IntChim"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-34.5763*cm" y="3.945*m" z="19.5/2*cm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R030"/>
+            <Translation x="-2.27194*m" y="3.24359*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R060"/>
+            <Translation x="-3.58935*m" y="1.67306*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R090"/>
+            <Translation x="-3.945*m" y="-34.5764*cm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R120"/>
+            <Translation x="-3.24359*m" y="-2.27194*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R150"/>
+            <Translation x="-1.67306*m" y="-3.58935*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="34.5764*cm" y="-3.945*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R210"/>
+            <Translation x="2.27194*m" y="-3.24359*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="muonBase:MBWheel_1P"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R240"/>
+            <Translation x="3.58935*m" y="-1.67306*m" z="0*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_2P"/>
+            <String name="ChildName" value="mbCommon:MBCablesBox_Int"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="12"/>
+            <Numeric name="Radius" value="3.96012*m"/>
+            <Numeric name="StartAngle" value="5.0089*deg"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 264.9911*deg </Vector>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R270"/>
+            <Translation x="3.945*m" y="34.5763*cm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R300"/>
+            <Translation x="3.24359*m" y="2.27194*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_IntChim"/>
+            <rRotation name="rotations:R330"/>
+            <Translation x="1.67306*m" y="3.58935*m" z="-19.5/2.*cm"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="-34.5763*cm" y="3.945*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R030"/>
+            <Translation x="-2.27194*m" y="3.24359*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R060"/>
+            <Translation x="-3.58935*m" y="1.67306*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R090"/>
+            <Translation x="-3.945*m" y="-34.5764*cm" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R120"/>
+            <Translation x="-3.24359*m" y="-2.27194*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R150"/>
+            <Translation x="-1.67306*m" y="-3.58935*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R180"/>
+            <Translation x="34.5764*cm" y="-3.945*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R210"/>
+            <Translation x="2.27194*m" y="-3.24359*m" z="0*fm"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="muonBase:MBWheel_1N"/>
+            <rChild name="mbCommon:MBCablesBox_Int"/>
+            <rRotation name="rotations:R240"/>
+            <Translation x="3.58935*m" y="-1.67306*m" z="0*fm"/>
+        </PosPart>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MBWheel_2N"/>
+            <String name="ChildName" value="mbCommon:MBCablesBox_Int"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="12"/>
+            <Numeric name="Radius" value="3.96012*m"/>
+            <Numeric name="StartAngle" value="5.0089*deg"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+            <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 264.9911*deg </Vector>
+        </Algorithm>
+        <!--%%%%%%%%%%%  Cables outside wheels -->
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MB"/>
+            <String name="ChildName" value="mbCommon:MBCables_Wheels0_1"/>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+            <Numeric name="N" value="6"/>
+            <Numeric name="Radius" value="5.85*m"/>
+            <Numeric name="StartAngle" value="0.*deg"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 0.00*deg </Vector>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -1.322*m </Vector>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MB"/>
+            <String name="ChildName" value="mbCommon:MBCables_Wheels0_1"/>
+            <Numeric name="N" value="6"/>
+            <Numeric name="Radius" value="5.85*m"/>
+            <Numeric name="StartAngle" value="30.*deg"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 0.00*deg </Vector>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 1.322*m </Vector>
+            <Numeric name="StartCopyNo" value="7"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MB"/>
+            <String name="ChildName" value="mbCommon:MBCables_Wheels1_2"/>
+            <Numeric name="N" value="6"/>
+            <Numeric name="Radius" value="5.85*m"/>
+            <Numeric name="StartAngle" value="0.*deg"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 0.00*deg </Vector>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, -3.9865*m </Vector>
+            <Numeric name="StartCopyNo" value="1"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+        </Algorithm>
+        <Algorithm name="global:DDAngular">
+            <rParent name="muonBase:MB"/>
+            <String name="ChildName" value="mbCommon:MBCables_Wheels1_2"/>
+            <Numeric name="N" value="6"/>
+            <Numeric name="Radius" value="5.85*m"/>
+            <Numeric name="StartAngle" value="30.*deg"/>
+            <Numeric name="RangeAngle" value="360*deg"/>
+            <Vector name="RotateSolid" type="numeric" nEntries="3"> 0.*deg, 0.*deg, 0.00*deg </Vector>
+            <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 3.9865*m </Vector>
+            <Numeric name="StartCopyNo" value="7"/>
+            <Numeric name="IncrCopyNo" value="1"/>
+        </Algorithm>
+        <PosPart copyNumber="1">
+            <rParent name="muonBase:MB"/>
+            <rChild name="mbCommon:MBCables_Ext"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0*fm" y="0*fm" z="1.368*m"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="muonBase:MB"/>
+            <rChild name="mbCommon:MBCables_Ext"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0*fm" y="0*fm" z="-1.368*m"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="muonBase:MB"/>
+            <rChild name="mbCommon:MBCables_Ext"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0*fm" y="0*fm" z="4.064*m"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="muonBase:MB"/>
+            <rChild name="mbCommon:MBCables_Ext"/>
+            <rRotation name="rotations:000D"/>
+            <Translation x="0*fm" y="0*fm" z="-4.064*m"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>


### PR DESCRIPTION
* Port DDMuonAngular algorithm to DD4hep
* Fix units used in XML files describing Muon barrel

Note: CMS DD uses mm == 1. as a default. Missing or excessive use of *mm would be incorrect. For example, before this PR DD vs DD4hep:
![screenshot 2018-11-09 12 11 15](https://user-images.githubusercontent.com/1390682/48343785-9037be80-e673-11e8-932e-e1ba2cfdca8c.png)

Here is the DD4hep result after this PR is applied:
![screenshot 2018-11-12 10 38 15](https://user-images.githubusercontent.com/1390682/48343813-a80f4280-e673-11e8-8e9a-233a7c7a0c14.png)
