### PR TITLE
update HGCal dEdX weights consistently

### DIFF
--- a/RecoEgamma/EgammaTools/python/hgcalElectronIDValueMap_cff.py
+++ b/RecoEgamma/EgammaTools/python/hgcalElectronIDValueMap_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_weights
+from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX
 
 # cfi from HGCalElectronIDValueMapProducer::fillDescriptions()
 from RecoEgamma.EgammaTools.hgcalElectronIDValueMap_cfi import *
-hgcalElectronIDValueMap.dEdXWeights = dEdX_weights
+hgcalElectronIDValueMap.dEdXWeights = dEdX.weights

--- a/RecoEgamma/EgammaTools/python/hgcalPhotonIDValueMap_cff.py
+++ b/RecoEgamma/EgammaTools/python/hgcalPhotonIDValueMap_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_weights
+from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX
 
 # cfi from HGCalPhotonIDValueMapProducer::fillDescriptions()
 from RecoEgamma.EgammaTools.hgcalPhotonIDValueMap_cfi import *
-hgcalPhotonIDValueMap.dEdXWeights = dEdX_weights
+hgcalPhotonIDValueMap.dEdXWeights = dEdX.weights

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import *
 from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi import *
 
-dEdX_weights = cms.vdouble(0.0,   # there is no layer zero
+dEdX = cms.PSet(
+weights = cms.vdouble(0.0,   # there is no layer zero
                            8.603, # Mev
                            8.0675,
                            8.0675,
@@ -55,6 +56,7 @@ dEdX_weights = cms.vdouble(0.0,   # there is no layer zero
                            92.196,
                            92.196,
                            46.098)
+)
 
 dEdX_weights_v9 = cms.vdouble(0.0,      # there is no layer zero
                               8.366557, # Mev
@@ -136,7 +138,7 @@ HGCalRecHit = cms.EDProducer(
 
 
     # EM Scale calibrations
-    layerWeights = dEdX_weights,
+    layerWeights = dEdX.weights,
 
     thicknessCorrection = cms.vdouble(1.132,1.092,1.084), # 100, 200, 300 um
     HGCEE_noise_fC = hgceeDigitizer.digiCfg.noise_fC,
@@ -150,5 +152,5 @@ HGCalRecHit = cms.EDProducer(
     )
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
-phase2_hgcalV9.toModify( HGCalRecHit , layerWeights = dEdX_weights_v9 ) 
+phase2_hgcalV9.toModify( dEdX, weights = dEdX_weights_v9 ) 
 phase2_hgcalV9.toModify( HGCalRecHit , thicknessCorrection = cms.vdouble(0.759,0.760,0.773) ) #120um, 200um, 300um

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cfi import hgcalLayerClusters as hgcalLayerClusters_
 
-from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_weights, HGCalRecHit
+from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX, HGCalRecHit
 
 from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi import HGCalUncalibRecHit
 
@@ -10,7 +10,7 @@ from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import fC_per_ele, hgce
 
 hgcalLayerClusters = hgcalLayerClusters_.clone()
 
-hgcalLayerClusters.dEdXweights = cms.vdouble(dEdX_weights)
+hgcalLayerClusters.dEdXweights = cms.vdouble(dEdX.weights)
 hgcalLayerClusters.fcPerMip = cms.vdouble(HGCalUncalibRecHit.HGCEEConfig.fCPerMIP)
 hgcalLayerClusters.thicknessCorrection = cms.vdouble(HGCalRecHit.thicknessCorrection)
 hgcalLayerClusters.fcPerEle = cms.double(fC_per_ele)


### PR DESCRIPTION
The dEdX weight vector for HGCal calibrated RecHits is wrapped in a PSet so it can be modified by modifiers and imported consistently into configurations for other modules.

attn: @rovere @nsmith- 