### PR TITLE
Backport std::bitset<6> dictionaries

### DIFF
--- a/DataFormats/StdDictionaries/src/classes_def_others.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_others.xml
@@ -5,6 +5,7 @@
  <class name="std::allocator<short>"/>
  <class name="std::basic_string<char>"/>
  <class name="std::bidirectional_iterator_tag"/>
+ <class name="std::bitset<6>"/>
  <class name="std::bitset<7>"/>
  <class name="std::bitset<15>"/>
  <class name="std::deque<int>"/>

--- a/DataFormats/StdDictionaries/src/classes_def_vector.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_vector.xml
@@ -43,4 +43,6 @@
  <class name="std::vector<unsigned long long>"/>
  <class name="std::vector<unsigned short>"/>
  <class name="std::vector<const void*>" />
+ <class name="std::vector<std::pair<int,std::bitset<6> > >" />
+ <class name="std::pair<int,std::bitset<6>>"/>
 </lcgdict>

--- a/DataFormats/WrappedStdDictionaries/src/classes.h
+++ b/DataFormats/WrappedStdDictionaries/src/classes.h
@@ -6,6 +6,7 @@
 #include <deque>
 #include <set>
 #include <string>
+#include <bitset>
 
 namespace DataFormats_WrappedStdDictionaries {
   struct dictionary {

--- a/DataFormats/WrappedStdDictionaries/src/classes_def.xml
+++ b/DataFormats/WrappedStdDictionaries/src/classes_def.xml
@@ -52,4 +52,5 @@
  <class name="edm::Wrapper<unsigned long>"/>
  <class name="edm::Wrapper<unsigned long long>"/>
  <class name="edm::Wrapper<unsigned short>"/>
+ <class name="edm::Wrapper<std::vector<std::pair<int,std::bitset<6> > > >" />
 </lcgdict>


### PR DESCRIPTION
Later releases use bitset<6> classes in a data product. Adding the dictionary allows CMSSW_8_0 to be more forward compatible.
This is useful for the ultra legacy processing.