### PR TITLE
Warn if modules require LuminosityBlock synchronization

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -281,6 +281,8 @@ namespace edm {
     std::shared_ptr<ThinnedAssociationsHelper>& thinnedAssociationsHelper() {return get_underlying_safe(thinnedAssociationsHelper_);}
     std::shared_ptr<EDLooperBase const> looper() const {return get_underlying_safe(looper_);}
     std::shared_ptr<EDLooperBase>& looper() {return get_underlying_safe(looper_);}
+    
+    void warnAboutModulesRequiringLuminosityBLockSynchronization() const;
     //------------------------------------------------------------------
     //
     // Data members below.

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -541,6 +541,9 @@ namespace edm {
     checkForModuleDependencyCorrectness(pathsAndConsumesOfModules_, printDependencies_);
     actReg_->preBeginJobSignal_(pathsAndConsumesOfModules_, processContext_);
 
+    if(preallocations_.numberOfLuminosityBlocks() > 1) {
+      warnAboutModulesRequiringLuminosityBLockSynchronization();
+    }
     //NOTE:  This implementation assumes 'Job' means one call
     // the EventProcessor::run
     // If it really means once per 'application' then this code will
@@ -1728,5 +1731,18 @@ namespace edm {
       return true;
     }
     return false;
+  }
+  
+  void EventProcessor::warnAboutModulesRequiringLuminosityBLockSynchronization() const {
+    std::unique_ptr<LogSystem> s;
+    for( auto worker: schedule_->allWorkers()) {
+      if( worker->globalLuminosityBlocksQueue()) {
+        if(not s) {
+          s = std::make_unique<LogSystem>("ModulesSynchingOnLumis");
+          (*s) <<"The following modules require synchronizing on LuminosityBlock boundaries:";
+        }
+        (*s)<<"\n  "<<worker->description().moduleName()<<" "<<worker->description().moduleLabel();
+      }
+    }
   }
 }


### PR DESCRIPTION
If multiple concurrent LuminosityBlocks are requested, warn about all modules which are in the job that require synchronization on LuminosityBlock boundaries.