### PR TITLE
Egamma PhotonMVANtuplizer.cc completion

### DIFF
--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
@@ -129,7 +129,7 @@ namespace {
     {
       // Find the closest status 1 gen photon to the reco photon
       double dR = 999;
-      reco::GenParticle const * closestPhoton;
+      reco::GenParticle const * closestPhoton = &genParticles[0];
       for (auto & particle : genParticles) {
         // Drop everything that is not photon or not status 1
         if( abs(particle.pdgId()) != 22 || particle.status() != 1 ) continue;

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
@@ -48,17 +48,10 @@
 // class declaration
 //
 
-// If the analyzer does not use TFileService, please remove
-// the template argument to the base class so the class inherits
-// from  edm::one::EDAnalyzer<>
-// This will improve performance in multithreaded jobs.
-//
-
 class PhotonMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
 
    public:
       explicit PhotonMVANtuplizer(const edm::ParameterSet&);
-      ~PhotonMVANtuplizer() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -66,17 +59,13 @@ class PhotonMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources
    private:
       void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-      // method called once each job just before starting event loop
-      void beginJob() override {};
-      // method called once each job just after ending the event loop
-      void endJob() override {};
-
-      int matchToTruth(const reco::Photon& ph, const edm::View<reco::GenParticle> &genParticles) const;
-
       // ----------member data ---------------------------
 
       // other
       TTree* tree_;
+
+      // To manage the variables which are parsed from the text file
+      MVAVariableManager<reco::Photon> mvaVarMngr_;
 
       std::vector<float> vars_;
       int nVars_;
@@ -86,7 +75,7 @@ class PhotonMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources
       int genNpu_;
       int vtxN_;
       double pT_, eta_;
-      
+
       // photon genMatch variable
       int matchedToGenPh_;
       int matchedGenIdx_;
@@ -126,25 +115,46 @@ class PhotonMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources
 
 };
 
-//
-// constants, enums and typedefs
-//
-
 enum PhotonMatchType {
   FAKE_PHOTON,
   TRUE_PROMPT_PHOTON,
   TRUE_NON_PROMPT_PHOTON,
-}; 
+};
 
-//
-// static data member definitions
-//
+namespace {
 
-//
-// constructors and destructor
-//
+    int matchToTruth( const reco::Photon& ph,
+                      const edm::View<reco::GenParticle>& genParticles,
+                      double deltaR)
+    {
+      // Find the closest status 1 gen photon to the reco photon
+      double dR = 999;
+      reco::GenParticle const * closestPhoton;
+      for (auto & particle : genParticles) {
+        // Drop everything that is not photon or not status 1
+        if( abs(particle.pdgId()) != 22 || particle.status() != 1 ) continue;
+
+        double dRtmp = ROOT::Math::VectorUtil::DeltaR( ph.p4(), particle.p4() );
+        if( dRtmp < dR ) {
+          dR = dRtmp;
+          closestPhoton = &particle;
+        }
+      }
+      // See if the closest photon (if it exists) is close enough.
+      // If not, no match found.
+      if(dR < deltaR) {
+          if( closestPhoton->isPromptFinalState() ) return TRUE_PROMPT_PHOTON;
+          else return TRUE_NON_PROMPT_PHOTON;
+      }
+      return FAKE_PHOTON;
+    }
+
+};
+
+// constructor
 PhotonMVANtuplizer::PhotonMVANtuplizer(const edm::ParameterSet& iConfig)
- : phoMapTags_            (iConfig.getUntrackedParameter<std::vector<std::string>>("phoMVAs"))
+ : mvaVarMngr_            (iConfig.getParameter<std::string>("variableDefinition"))
+ , phoMapTags_            (iConfig.getUntrackedParameter<std::vector<std::string>>("phoMVAs"))
  , phoMapBranchNames_     (iConfig.getUntrackedParameter<std::vector<std::string>>("phoMVALabels"))
  , nPhoMaps_              (phoMapBranchNames_.size())
  , valMapTags_            (iConfig.getUntrackedParameter<std::vector<std::string>>("phoMVAValMaps"))
@@ -161,79 +171,74 @@ PhotonMVANtuplizer::PhotonMVANtuplizer(const edm::ParameterSet& iConfig)
  , pileup_          (src_, consumesCollector(), iConfig, "pileup"  , "pileupMiniAOD")
  , genParticles_    (src_, consumesCollector(), iConfig, "genParticles", "genParticlesMiniAOD")
 {
-  // phoMaps
-  for (size_t k = 0; k < nPhoMaps_; ++k) {
+    // phoMaps
+    for (size_t k = 0; k < nPhoMaps_; ++k) {
 
-    phoMapTokens_.push_back(consumes<edm::ValueMap<bool> >(edm::InputTag(phoMapTags_[k])));
-    
-    // Initialize vectors for holding ID decisions
-    mvaPasses_.push_back(0);
-  }
-  
-  // valMaps
-  for (size_t k = 0; k < nValMaps_; ++k) {
-    valMapTokens_.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(valMapTags_[k])));
-    
-    // Initialize vectors for holding MVA values
-    mvaValues_.push_back(0.0);
-  }
-  
-  // categories
-  for (size_t k = 0; k < nCats_; ++k) {
-    mvaCatTokens_.push_back(consumes<edm::ValueMap<int> >(edm::InputTag(mvaCatTags_[k])));
-    
-    // Initialize vectors for holding MVA values
-    mvaCats_.push_back(0);
-  }
-  
-  // Book tree
-  usesResource(TFileService::kSharedResource);
-  edm::Service<TFileService> fs ;
-  tree_  = fs->make<TTree>("tree","tree");
-  
-  tree_->Branch("nEvent", &nEvent_);
-  tree_->Branch("nRun", &nRun_);
-  tree_->Branch("nLumi", &nLumi_);
-  if (isMC_) {
-    tree_->Branch("genNpu", &genNpu_);
-    tree_->Branch("matchedToGenPh", &matchedToGenPh_);
-  }
-  tree_->Branch("vtxN", &vtxN_);
-  tree_->Branch("pT", &pT_);
-  tree_->Branch("eta", &eta_);
+        phoMapTokens_.push_back(consumes<edm::ValueMap<bool> >(edm::InputTag(phoMapTags_[k])));
 
-  // Has to be in two different loops
-  for (int i = 0; i < nVars_; ++i) {
-    vars_.push_back(0.0);
-  }
-  
-  // IDs
-  for (size_t k = 0; k < nValMaps_; ++k) {
-    tree_->Branch(valMapBranchNames_[k].c_str() ,  &mvaValues_[k]);
-  }
-  
-  for (size_t k = 0; k < nPhoMaps_; ++k) {
-    tree_->Branch(phoMapBranchNames_[k].c_str() ,  &mvaPasses_[k]);
-  }
-  
-  for (size_t k = 0; k < nCats_; ++k) {
-    tree_->Branch(mvaCatBranchNames_[k].c_str() ,  &mvaCats_[k]);
-  }
+        // Initialize vectors for holding ID decisions
+        mvaPasses_.push_back(0);
+    }
+
+    // valMaps
+    for (size_t k = 0; k < nValMaps_; ++k) {
+        valMapTokens_.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(valMapTags_[k])));
+
+        // Initialize vectors for holding MVA values
+        mvaValues_.push_back(0.0);
+    }
+
+    // categories
+    for (size_t k = 0; k < nCats_; ++k) {
+        mvaCatTokens_.push_back(consumes<edm::ValueMap<int> >(edm::InputTag(mvaCatTags_[k])));
+
+        // Initialize vectors for holding MVA values
+        mvaCats_.push_back(0);
+    }
+
+    // Book tree
+    usesResource(TFileService::kSharedResource);
+    edm::Service<TFileService> fs ;
+    tree_  = fs->make<TTree>("tree","tree");
+
+    nVars_ = mvaVarMngr_.getNVars();
+
+    tree_->Branch("nEvent", &nEvent_);
+    tree_->Branch("nRun", &nRun_);
+    tree_->Branch("nLumi", &nLumi_);
+    if (isMC_) {
+        tree_->Branch("genNpu", &genNpu_);
+        tree_->Branch("matchedToGenPh", &matchedToGenPh_);
+    }
+    tree_->Branch("vtxN", &vtxN_);
+    tree_->Branch("pT", &pT_);
+    tree_->Branch("eta", &eta_);
+
+    // Has to be in two different loops
+    for (int i = 0; i < nVars_; ++i) {
+        vars_.push_back(0.0);
+    }
+    for (int i = 0; i < nVars_; ++i) {
+        tree_->Branch(mvaVarMngr_.getName(i).c_str(), &vars_[i]);
+    }
+
+    // IDs
+    for (size_t k = 0; k < nValMaps_; ++k) {
+        tree_->Branch(valMapBranchNames_[k].c_str() ,  &mvaValues_[k]);
+    }
+
+    for (size_t k = 0; k < nPhoMaps_; ++k) {
+        tree_->Branch(phoMapBranchNames_[k].c_str() ,  &mvaPasses_[k]);
+    }
+
+    for (size_t k = 0; k < nCats_; ++k) {
+        tree_->Branch(mvaCatBranchNames_[k].c_str() ,  &mvaCats_[k]);
+    }
+
+    // All tokens for event content needed by this MVA
+    // Tags from the variable helper
+    mvaVarMngr_.setConsumes(consumesCollector());
 }
-
-
-PhotonMVANtuplizer::~PhotonMVANtuplizer()
-{
-  
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-  
-}
-
-
-//
-// member functions
-//
 
 // ------------ method called for each event  ------------
 void
@@ -264,124 +269,90 @@ PhotonMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
            }
        }
     }
-  
+
     // Get MVA decisions
     edm::Handle<edm::ValueMap<bool> > decisions[nPhoMaps_];
     for (size_t k = 0; k < nPhoMaps_; ++k) {
-      iEvent.getByToken(phoMapTokens_[k],decisions[k]);
+        iEvent.getByToken(phoMapTokens_[k],decisions[k]);
     }
-  
+
     // Get MVA values
     edm::Handle<edm::ValueMap<float> > values[nValMaps_];
     for (size_t k = 0; k < nValMaps_; ++k) {
-      iEvent.getByToken(valMapTokens_[k],values[k]);
+        iEvent.getByToken(valMapTokens_[k],values[k]);
     }
-  
+
     // Get MVA categories
     edm::Handle<edm::ValueMap<int> > mvaCats[nCats_];
     for (size_t k = 0; k < nCats_; ++k) {
-      iEvent.getByToken(mvaCatTokens_[k],mvaCats[k]);
+        iEvent.getByToken(mvaCatTokens_[k],mvaCats[k]);
     }
-    
+
     int nPho = src->size();
-    
-    for(int iPho = 0; iPho < nPho; ++iPho)
-    {
-      
-      const auto pho =  src->ptrAt(iPho);
-      
-      if (pho->pt() < ptThreshold_) {
-        continue;
-      }
-      pT_ = pho->pt();
-      eta_ = pho->eta();
 
-      if (isMC_) {
-        matchedToGenPh_ = matchToTruth( *pho, *genParticles);
-      }
-      
-      //
-      // Look up and save the ID decisions
-      //
-      for (size_t k = 0; k < nPhoMaps_; ++k) {
-        mvaPasses_[k] = (int)(*decisions[k])[pho];
-      }
-      
-      for (size_t k = 0; k < nValMaps_; ++k) {
-        mvaValues_[k] = (*values[k])[pho];
-      }
-      
-      for (size_t k = 0; k < nCats_; ++k) {
-        mvaCats_[k] = (*mvaCats[k])[pho];
-      }
-      
-      tree_->Fill();
-    }
-  
-}
+    for(int iPho = 0; iPho < nPho; ++iPho) {
 
-int PhotonMVANtuplizer::matchToTruth(
-        const reco::Photon& ph,
-        const edm::View<reco::GenParticle>& genParticles) const
-{
-  
-  // Find the closest status 1 gen photon to the reco photon
-  double dR = 999;
-  reco::GenParticle const * closestPhoton;
-  for (auto & particle : genParticles)
-  {
-    // Drop everything that is not photon or not status 1
-    if( abs(particle.pdgId()) != 22 || particle.status() != 1 )
-    {
-      continue;
+        const auto pho =  src->ptrAt(iPho);
+
+        if (pho->pt() < ptThreshold_) {
+            continue;
+        }
+        pT_ = pho->pt();
+        eta_ = pho->eta();
+
+        // variables from the text file
+        for (int iVar = 0; iVar < nVars_; ++iVar) {
+            vars_[iVar] = mvaVarMngr_.getValue(iVar, pho, iEvent);
+        }
+
+        if (isMC_) {
+            matchedToGenPh_ = matchToTruth( *pho, *genParticles, deltaR_);
+        }
+
+        //
+        // Look up and save the ID decisions
+        //
+        for (size_t k = 0; k < nPhoMaps_; ++k) {
+            mvaPasses_[k] = (int)(*decisions[k])[pho];
+        }
+
+        for (size_t k = 0; k < nValMaps_; ++k) {
+            mvaValues_[k] = (*values[k])[pho];
+        }
+
+        for (size_t k = 0; k < nCats_; ++k) {
+          mvaCats_[k] = (*mvaCats[k])[pho];
+        }
+
+        tree_->Fill();
     }
 
-    double dRtmp = ROOT::Math::VectorUtil::DeltaR( ph.p4(), particle.p4() );
-    if( dRtmp < dR )
-    {
-      dR = dRtmp;
-      closestPhoton = &particle;
-    }
-  }
-  // See if the closest photon (if it exists) is close enough.
-  // If not, no match found.
-  if(dR < deltaR_)
-  {
-      if( closestPhoton->isPromptFinalState() )
-      {
-          return TRUE_PROMPT_PHOTON;
-      }
-      else
-      {
-          return TRUE_NON_PROMPT_PHOTON;
-      }
-  }
-  return FAKE_PHOTON;
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void
 PhotonMVANtuplizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  
-  edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src");
-  desc.add<edm::InputTag>("vertices");
-  desc.add<edm::InputTag>("pileup");
-  desc.add<edm::InputTag>("genParticles");
-  desc.add<edm::InputTag>("srcMiniAOD");
-  desc.add<edm::InputTag>("verticesMiniAOD");
-  desc.add<edm::InputTag>("pileupMiniAOD");
-  desc.add<edm::InputTag>("genParticlesMiniAOD");
-  desc.addUntracked<std::vector<std::string>>("phoMVAs");
-  desc.addUntracked<std::vector<std::string>>("phoMVALabels");
-  desc.addUntracked<std::vector<std::string>>("phoMVAValMaps");
-  desc.addUntracked<std::vector<std::string>>("phoMVAValMapLabels");
-  desc.addUntracked<std::vector<std::string>>("phoMVACats");
-  desc.addUntracked<std::vector<std::string>>("phoMVACatLabels");
-  desc.add<bool>("isMC");
-  desc.add<double>("ptThreshold", 5.0);
-  desc.add<double>("deltaR", 0.1);
-  descriptions.addDefault(desc);
+
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("src");
+    desc.add<edm::InputTag>("vertices");
+    desc.add<edm::InputTag>("pileup");
+    desc.add<edm::InputTag>("genParticles");
+    desc.add<edm::InputTag>("srcMiniAOD");
+    desc.add<edm::InputTag>("verticesMiniAOD");
+    desc.add<edm::InputTag>("pileupMiniAOD");
+    desc.add<edm::InputTag>("genParticlesMiniAOD");
+    desc.addUntracked<std::vector<std::string>>("phoMVAs");
+    desc.addUntracked<std::vector<std::string>>("phoMVALabels");
+    desc.addUntracked<std::vector<std::string>>("phoMVAValMaps");
+    desc.addUntracked<std::vector<std::string>>("phoMVAValMapLabels");
+    desc.addUntracked<std::vector<std::string>>("phoMVACats");
+    desc.addUntracked<std::vector<std::string>>("phoMVACatLabels");
+    desc.add<bool>("isMC");
+    desc.add<double>("ptThreshold", 5.0);
+    desc.add<double>("deltaR", 0.1);
+    desc.add<std::string>("variableDefinition");
+    descriptions.addDefault(desc);
 }
 
 //define this as a plug-in

--- a/RecoEgamma/PhotonIdentification/test/testPhotonMVA_cfg.py
+++ b/RecoEgamma/PhotonIdentification/test/testPhotonMVA_cfg.py
@@ -5,19 +5,21 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process = cms.Process("PhotonMVANtuplizer")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+process.GlobalTag.globaltag = '94X_mc2017_realistic_v10'
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 outputFile = "photon_validation_ntuple.root"
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-         '/store/mc/RunIIFall17MiniAOD/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/RECOSIMstep_94X_mc2017_realistic_v10-v1/00000/0293A280-B5F3-E711-8303-3417EBE33927.root'
+#        '/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIIFall17-3_1_0/3_1_0/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/RunIIFall17-3_1_0-3_1_0-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/180606_161119/0000/myMicroAODOutputFile_125.root'
+'/store/mc/RunIIFall17MiniAODv2/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/00000/00AE0E2A-6F42-E811-8EA2-0025905B85AA.root'
     )
 )
 
@@ -49,14 +51,16 @@ process.ntuplizer = cms.EDAnalyzer('PhotonMVANtuplizer',
         src                  = cms.InputTag('gedPhotons'),
         vertices             = cms.InputTag('offlinePrimaryVertices'),
         pileup               = cms.InputTag('addPileupInfo'),
+        genParticles         = cms.InputTag('genParticles'),         
         # miniAOD case
         srcMiniAOD           = cms.InputTag('slimmedPhotons'),
         verticesMiniAOD      = cms.InputTag('offlineSlimmedPrimaryVertices'),
         pileupMiniAOD        = cms.InputTag('slimmedAddPileupInfo'),
+        genParticlesMiniAOD  = cms.InputTag('prunedGenParticles'),
         #
-        phoMVAs             = cms.untracked.vstring(
+        phoMVAs              = cms.untracked.vstring(
                                           ),
-        phoMVALabels        = cms.untracked.vstring(
+        phoMVALabels         = cms.untracked.vstring(
                                           ),
         phoMVAValMaps        = cms.untracked.vstring(
                                            "photonMVAValueMapProducer:PhotonMVAEstimatorRun2Spring16NonTrigV1Values",
@@ -75,6 +79,8 @@ process.ntuplizer = cms.EDAnalyzer('PhotonMVANtuplizer',
                                            "PhoMVACats",
                                            ),
         isMC                 = cms.bool(True),
+        ptThreshold          = cms.double(15.0),
+        deltaR               = cms.double(0.1),
         )
 
 process.TFileService = cms.Service("TFileService",

--- a/RecoEgamma/PhotonIdentification/test/testPhotonMVA_cfg.py
+++ b/RecoEgamma/PhotonIdentification/test/testPhotonMVA_cfg.py
@@ -4,22 +4,22 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 
 process = cms.Process("PhotonMVANtuplizer")
 
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 
-process.GlobalTag.globaltag = '94X_mc2017_realistic_v10'
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
-outputFile = "photon_validation_ntuple.root"
+# File with the ID variables form the text file to include in the Ntuplizer
+mvaVariablesFile = "RecoEgamma/PhotonIdentification/data/PhotonMVAEstimatorRun2VariablesFall17V1p1.txt"
+
+outputFile = "photon_ntuple.root"
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-#        '/store/group/phys_higgs/cmshgg/sethzenz/flashgg/RunIIFall17-3_1_0/3_1_0/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/RunIIFall17-3_1_0-3_1_0-v0-RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/180606_161119/0000/myMicroAODOutputFile_125.root'
-'/store/mc/RunIIFall17MiniAODv2/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/00000/00AE0E2A-6F42-E811-8EA2-0025905B85AA.root'
+        '/store/mc/RunIIFall17MiniAODv2/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/00000/00AE0E2A-6F42-E811-8EA2-0025905B85AA.root'
     )
 )
 
@@ -81,6 +81,7 @@ process.ntuplizer = cms.EDAnalyzer('PhotonMVANtuplizer',
         isMC                 = cms.bool(True),
         ptThreshold          = cms.double(15.0),
         deltaR               = cms.double(0.1),
+        variableDefinition = cms.string(mvaVariablesFile),
         )
 
 process.TFileService = cms.Service("TFileService",


### PR DESCRIPTION
Hi,

maybe you give me a free pass updating the PhotonMVANtuplizer in CMSSW, even if it is not used in production? The equivalent ElectronMVANtuplizer was well received and is now used by quite a few people for little studies. It's a quick and safe way to get a flat electron ntuple with the exact same ID variables and signal/background definition as in the MVAs used in production.

For the photons, I did not dare implementing the same functionality since I'm not so familiar with them. The PhotonMVANtuplizer was so far only able to dump final ID scores to validate them. However, I got many requests to implement the matching and dumping of ID variables also in the PhotonMVANtuplizer, and teamed up with @kmondal to implement the same "gen" matching as in the flashgg framework.

Getting this into release would keep me from maintaining one more private branch which people have to merge.

This might be interesting for @fcouderc and @mhuwiler, and of course @michelif and @swagata87 should somehow approve this first.

Here a little histogram with the pT of the different reco photon populations, as a first quick validation.

![photon_ntuple](https://user-images.githubusercontent.com/6578603/48424068-221df500-e762-11e8-8fc4-3f16dc22595e.png)
