### PR TITLE
Update of the Zmumu validation tool, pull request to master branch

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
@@ -168,6 +168,9 @@ class PlottingOptionsZMuMu(BasePlottingOptions):
                 "rebinetadiff": "2",
                 "rebineta": "2",
                 "rebinpt": "8",
+                "AutoSetRange": "false",                
+                "CustomMinY": "90.85",
+                "CustomMaxY": "91.5",
                }
     needpackages = {"MuonAnalysis/MomentumScaleCalibration"}
     validationclass = ZMuMuValidation

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
@@ -307,6 +307,6 @@ void TkAlMergeZmumuPlots(){
   TkAlStyle::legendheader = ".oO[legendheader]Oo.";
   TkAlStyle::set(.oO[publicationstatus]Oo., .oO[era]Oo., ".oO[customtitle]Oo.", ".oO[customrighttitle]Oo.");
 
-  MultiHistoOverlapAll_.oO[resonance]Oo.(separatebycommas(filenames), separatebycommas(titles), separatebycommas(colors), separatebycommas(linestyles_new), separatebycommas(markerstyles_new), ".oO[datadir]Oo./.oO[PlotsDirName]Oo.", .oO[switchONfit]Oo.);
+  MultiHistoOverlapAll_.oO[resonance]Oo.(separatebycommas(filenames), separatebycommas(titles), separatebycommas(colors), separatebycommas(linestyles_new), separatebycommas(markerstyles_new), ".oO[datadir]Oo./.oO[PlotsDirName]Oo.", .oO[switchONfit]Oo., .oO[AutoSetRange]Oo., .oO[CustomMinY]Oo., .oO[CustomMaxY]Oo.);
 }
 """

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlapAll_Y1S.C
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlapAll_Y1S.C
@@ -1,5 +1,5 @@
 #include "MultiHistoOverlapAll_Base.C"
 
-void MultiHistoOverlapAll_Y1S(string files, string labels, string colors = "", string linestyles = "", string markerstyles = "", TString directory = ".", bool switchONfit = false){
-  MultiHistoOverlapAll_Base(files, labels, colors, linestyles, markerstyles, directory, "Y1S", switchONfit);
+void MultiHistoOverlapAll_Y1S(string files, string labels, string colors = "", string linestyles = "", string markerstyles = "", TString directory = ".", bool switchONfit = false, bool AutoSetRange=false, float CustomMinY=9.3, float CustomMaxY=9.6){//DEFAULT RANGE TO BE FIXED
+  MultiHistoOverlapAll_Base(files, labels, colors, linestyles, markerstyles, directory, "Y1S", switchONfit, AutoSetRange, CustomMinY, CustomMaxY);
 }

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlapAll_Z.C
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlapAll_Z.C
@@ -1,5 +1,5 @@
 #include "MultiHistoOverlapAll_Base.C"
 
-void MultiHistoOverlapAll_Z(string files, string labels, string colors = "", string linestyles = "", string markerstyles = "", TString directory = ".", bool switchONfit = false){
-  MultiHistoOverlapAll_Base(files, labels, colors, linestyles, markerstyles, directory, "Z", switchONfit);
+void MultiHistoOverlapAll_Z(string files, string labels, string colors = "", string linestyles = "", string markerstyles = "", TString directory = ".", bool switchONfit = false, bool AutoSetRange=false, float CustomMinY=90.85, float CustomMaxY=91.4){
+  MultiHistoOverlapAll_Base(files, labels, colors, linestyles, markerstyles, directory, "Z", switchONfit, AutoSetRange, CustomMinY, CustomMaxY);
 }


### PR DESCRIPTION
This pull request was originally made to a wrong branch by mistake (https://github.com/cms-sw/cmssw/pull/25159). The current version takes into account the comments and suggestions received in the discussion regarding the previous pull request.

Description:
@connorpa @adewit 
Implemented features:
2D plots Mass vs EtaPhi of muon (plus or minus)
Plotting options regarding the Y axis range in 1D histograms

Features presented in:
https://indico.cern.ch/event/768246/#72-latest-developments-of-vali
https://indico.cern.ch/event/688851/#sc-28-2-improvement-of-z-valid
