### PR TITLE
Disable the APV shot cleaner for 2018 HI

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
@@ -10,6 +10,8 @@ siStripClusters = cms.EDProducer("SiStripClusterizer",
     cms.InputTag('siStripZeroSuppression','ProcessedRaw'),
     cms.InputTag('siStripZeroSuppression','ScopeMode')),
                                )
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(siStripClusters, Clusterizer=DefaultClusterizer.clone(RemoveApvShots=False))
 
 # The SiStripClusters are not used anymore in phase2 tracking
 # This part has to be clean up when they will be officially removed from the entire flow


### PR DESCRIPTION
During HI data taking APVs with more than half (>64 out of 128) of the strips hit do occur, so the APV shot cleaner should not try to re-ZS them (with the hybrid setup the zero-suppression happens either in the FED or in software - in practice in the HLT - so we can guarantee it was performed before anyway). The APV shot cleaner additionally subtracts the median digi, which leads to a (usually moderate) loss in charge of the clusters in such (parts of) modules (and a small reduction of the hit efficiency).
From the comparisons done by @CesarBernardes the effect was clearly visible in the tails of the digi and cluster distributions, and the tracking efficiency slightly increases with this fix.

CC: @icali @abaty @CesarBernardes 