### PR TITLE
Added possibility to disable eta/p cut for Geant4 primary

### DIFF
--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -46,6 +46,7 @@ private:
   bool   fPtransCut;
   bool   fEtaCuts;
   bool   fPhiCuts;
+  bool   fFiductialCuts;
   double theMinPhiCut;
   double theMaxPhiCut;
   double theMinEtaCut;


### PR DESCRIPTION
This PR allows to use particle gun in any point in space if eta, phi and momentum cuts are disable in interface between generator and OscarProducer.

Should not affect any mainstream result.

To disable these cuts following lines should be customised:
process.g4SimHits.Generator.ApplyPCuts = cms.bool(False)
process.g4SimHits.Generator.ApplyEtaCuts = cms.bool(False)