### PR TITLE
Include missing header in ThreadSafeStringCut.h

### DIFF
--- a/RecoEgamma/EgammaTools/interface/ThreadSafeStringCut.h
+++ b/RecoEgamma/EgammaTools/interface/ThreadSafeStringCut.h
@@ -5,6 +5,7 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 #include <mutex>
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 /*
  * This class is a simple wrapper around either a StringObjectFunction or


### PR DESCRIPTION
Not clear why the automatic check did not notice it while merging #25101, but now the following message shows up in the log of the jenkins tests for header consistency:
```
src/RecoEgamma/EgammaTools/interface/ThreadSafeStringCut.h:40:5: error: 'CMS_THREAD_SAFE' does not name a type; did you mean '_SC_THREADS'?
     CMS_THREAD_SAFE mutable std::mutex mutex_;
```

The inclusion of 
```
#include "FWCore/Utilities/interface/thread_safety_macros.h"
```
seems to be missing.

This PR wants to add it