### PR TITLE
Modernized RawPCCProducer

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/RawPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/RawPCCProducer.cc
@@ -43,55 +43,33 @@ class RawPCCProducer : public edm::one::EDProducer<edm::EndLuminosityBlockProduc
             void produce                  (edm::Event& iEvent, const edm::EventSetup& iSetup) final;
 
 
-            edm::EDGetTokenT<reco::PixelClusterCounts>  pccToken;
-            std::string   pccSource_;                   //input file EDproducer module label 
-            std::string   prodInst_;                    //input file product instance 
-            std::string   takeAverageValue_;            //Output average values 
+            edm::EDGetTokenT<reco::PixelClusterCounts>  pccToken_;
+            const edm::EDPutTokenT<LumiInfo> putToken_;
+            const std::string   takeAverageValue_;      //Output average values 
 
-            std::vector<int>   modVeto_;                //The list of modules to skip in the lumi calc. 
-            std::string outputProductName_;             //specifies the trigger Rand or ZeroBias 
-            std::vector<int> clustersPerBXInput_;       //Will fill this with content from PCC
-            std::vector<int> modID_;                    //vector with Module IDs 1-1 map to bunch x-ing in clusers
-            std::vector<int> events_;                   //vector with total events at each bxid.
-            std::vector<int> clustersPerBXOutput_;      //new vector containing clusters per bxid 
-            std::vector<float> corrClustersPerBXOutput_;//new vector containing clusters per bxid with afterglow corrections 
-            std::vector<float> errorPerBX_;             //Stat error (or number of events)
-            std::vector<int> goodMods_;                 //The indicies of all the good modules - not vetoed
-            float totalLumi_;                           //The total raw luminosity from the pixel clusters - not scaled
-            float statErrOnLumi_;                       //the statistical error on the lumi - large num ie sqrt(N)
+            const std::vector<int>   modVeto_;          //The list of modules to skip in the lumi calc. 
 
-            std::string csvOutLabel_;
-            bool saveCSVFile_;
+            const std::string csvOutLabel_;
+            const bool saveCSVFile_;
 
-            bool applyCorr_;
-            std::vector<float> correctionScaleFactors_;
+            const bool applyCorr_;
 
-            std::unique_ptr<LumiInfo> outputLumiInfo;
-
-            std::ofstream csvfile;
+            std::ofstream csvfile_;
     };
 
 //--------------------------------------------------------------------------------------------------
-RawPCCProducer::RawPCCProducer(const edm::ParameterSet& iConfig)
+RawPCCProducer::RawPCCProducer(const edm::ParameterSet& iConfig):
+  putToken_{ produces<LumiInfo, edm::Transition::EndLuminosityBlock>(iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<std::string>("outputProductName","alcaLumi"))},
+  takeAverageValue_ {iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<std::string>("OutputValue",std::string("Totals"))},
+  modVeto_{ iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::vector<int>>("modVeto")},
+  csvOutLabel_{ iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<std::string>("label",std::string("rawPCC.csv")) },
+  saveCSVFile_{ iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<bool>("saveCSVFile",false)},
+  applyCorr_{ iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<bool>("ApplyCorrections",false) }
 {
-    pccSource_ = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::string>("inputPccLabel");
-    prodInst_ = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::string>("ProdInst");
-    takeAverageValue_ = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<std::string>("OutputValue",std::string("Totals")); 
-    outputProductName_ = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<std::string>("outputProductName","alcaLumi");
-    modVeto_ = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::vector<int>>("modVeto");
-    applyCorr_ = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<bool>("ApplyCorrections",false);
-    saveCSVFile_ = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<bool>("saveCSVFile",false);
-    csvOutLabel_ = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<std::string>("label",std::string("rawPCC.csv"));
+    auto pccSource = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::string>("inputPccLabel");
+    auto prodInst = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::string>("ProdInst");
 
-    edm::InputTag PCCInputTag_(pccSource_, prodInst_);
-    clustersPerBXOutput_.resize(LumiConstants::numBX,0);//vector containing clusters per bxid 
-    corrClustersPerBXOutput_.resize(LumiConstants::numBX,0);//vector containing clusters per bxid 
-    pccToken=consumes<reco::PixelClusterCounts, edm::InLumi>(PCCInputTag_);
-    produces<LumiInfo, edm::Transition::EndLuminosityBlock>(outputProductName_);
-
-    if(!applyCorr_){
-        correctionScaleFactors_.resize(LumiConstants::numBX,1.0);
-    }
+    pccToken_=consumes<reco::PixelClusterCounts, edm::InLumi>(edm::InputTag(pccSource, prodInst));
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -107,113 +85,122 @@ void RawPCCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
 //--------------------------------------------------------------------------------------------------
 void RawPCCProducer::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup){
 
-    outputLumiInfo = std::make_unique<LumiInfo>(); 
 
     if(saveCSVFile_){
-        csvfile.open(csvOutLabel_, std::ios_base::app);
-        csvfile<<std::to_string(lumiSeg.run())<<",";
-        csvfile<<std::to_string(lumiSeg.luminosityBlock())<<",";
+        csvfile_.open(csvOutLabel_, std::ios_base::app);
+        csvfile_<<std::to_string(lumiSeg.run())<<",";
+        csvfile_<<std::to_string(lumiSeg.luminosityBlock())<<",";
     }
 }
 
 //--------------------------------------------------------------------------------------------------
 void RawPCCProducer::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup){
-    totalLumi_=0.0;
-    statErrOnLumi_=0.0;
+}
 
-    std::fill(clustersPerBXOutput_.begin(),  clustersPerBXOutput_.end(),0);
-    std::fill(corrClustersPerBXOutput_.begin(),     corrClustersPerBXOutput_.end(),   0);
+//--------------------------------------------------------------------------------------------------
+void RawPCCProducer::endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup){
+    float totalLumi=0.0; //The total raw luminosity from the pixel clusters - not scaled
+    float statErrOnLumi=0.0; //the statistical error on the lumi - large num ie sqrt(N)
 
-    goodMods_.clear();
+    //new vector containing clusters per bxid
+    std::vector<int> clustersPerBXOutput(LumiConstants::numBX,0);
+    //new vector containing clusters per bxid with afterglow corrections 
+    std::vector<float> corrClustersPerBXOutput(LumiConstants::numBX,0);
+
+    //The indicies of all the good modules - not vetoed
+    std::vector<int> goodMods;                 
 
     edm::Handle<reco::PixelClusterCounts> pccHandle; 
-    lumiSeg.getByToken(pccToken,pccHandle);
+    lumiSeg.getByToken(pccToken_,pccHandle);
 
     const reco::PixelClusterCounts& inputPcc = *(pccHandle.product()); 
 
-    modID_ = inputPcc.readModID();
-    events_= inputPcc.readEvents();
-    clustersPerBXInput_ = inputPcc.readCounts();
+    //vector with Module IDs 1-1 map to bunch x-ing in clusers
+    auto modID = inputPcc.readModID();
+    //vector with total events at each bxid.
+    auto events= inputPcc.readEvents();
+    auto clustersPerBXInput = inputPcc.readCounts();
 
     //making list of modules to sum over
-    for (unsigned int i=0;i<modID_.size();i++){
-        if (std::find(modVeto_.begin(),modVeto_.end(), modID_.at(i)) == modVeto_.end()){
-            goodMods_.push_back(i);
+    for (unsigned int i=0;i<modID.size();i++){
+        if (std::find(modVeto_.begin(),modVeto_.end(), modID.at(i)) == modVeto_.end()){
+            goodMods.push_back(i);
         }
     }
 
     //summing over good modules only 
     for (int bx=0;bx<int(LumiConstants::numBX);bx++){
-        for (unsigned int i=0;i<goodMods_.size();i++){
-            clustersPerBXOutput_.at(bx)+=clustersPerBXInput_.at(goodMods_.at(i)*int(LumiConstants::numBX)+bx);
+        for (unsigned int i=0;i<goodMods.size();i++){
+            clustersPerBXOutput.at(bx)+=clustersPerBXInput.at(goodMods.at(i)*int(LumiConstants::numBX)+bx);
 
         }
     }
 
+    std::vector<float> correctionScaleFactors;
     if(applyCorr_){
         edm::ESHandle< LumiCorrections > corrHandle;
         iSetup.get<LumiCorrectionsRcd>().get(corrHandle);
         const LumiCorrections *pccCorrections = corrHandle.product();
-        correctionScaleFactors_ = pccCorrections->getCorrectionsBX();
+        correctionScaleFactors = pccCorrections->getCorrectionsBX();
+    } else {
+        correctionScaleFactors.resize(LumiConstants::numBX,1.0);
     }
 
-    for (unsigned int i=0;i<clustersPerBXOutput_.size();i++){
-        if (events_.at(i)!=0){
-            corrClustersPerBXOutput_[i]=clustersPerBXOutput_[i]*correctionScaleFactors_[i];
+    for (unsigned int i=0;i<clustersPerBXOutput.size();i++){
+        if (events.at(i)!=0){
+            corrClustersPerBXOutput[i]=clustersPerBXOutput[i]*correctionScaleFactors[i];
         }else{
-            corrClustersPerBXOutput_[i]=0.0;
+            corrClustersPerBXOutput[i]=0.0;
         }
-        totalLumi_+=corrClustersPerBXOutput_[i];
-        statErrOnLumi_+=float(events_[i]);
+        totalLumi+=corrClustersPerBXOutput[i];
+        statErrOnLumi+=float(events[i]);
     }
 
-    errorPerBX_.clear();
-    errorPerBX_.assign(events_.begin(),events_.end()); 
+    std::vector<float> errorPerBX;             //Stat error (or number of events)
+    errorPerBX.assign(events.begin(),events.end()); 
 
     if(takeAverageValue_=="Average"){
         unsigned int NActiveBX=0;
         for (int bx=0;bx<int(LumiConstants::numBX);bx++){
-            if(events_[bx]>0){
+            if(events[bx]>0){
                 NActiveBX++;  
                 // Counting where events are will only work 
                 // for ZeroBias or AlwaysTrue triggers.
                 // Random triggers will get all BXs.
-                corrClustersPerBXOutput_[bx]/=float(events_[bx]);
-                errorPerBX_[bx]=1/TMath::Sqrt(float(events_[bx]));
+                corrClustersPerBXOutput[bx]/=float(events[bx]);
+                errorPerBX[bx]=1/TMath::Sqrt(float(events[bx]));
             }
         }
-        if (statErrOnLumi_!=0) {
-            totalLumi_=totalLumi_/statErrOnLumi_*float(NActiveBX);
-            statErrOnLumi_=1/TMath::Sqrt(statErrOnLumi_)*totalLumi_;
+        if (statErrOnLumi!=0) {
+            totalLumi=totalLumi/statErrOnLumi*float(NActiveBX);
+            statErrOnLumi=1/TMath::Sqrt(statErrOnLumi)*totalLumi;
         }
     }
 
+    LumiInfo outputLumiInfo;
 
-    outputLumiInfo->setTotalInstLumi(totalLumi_);
-    outputLumiInfo->setTotalInstStatError(statErrOnLumi_);
 
-    outputLumiInfo->setErrorLumiAllBX(errorPerBX_);
-    outputLumiInfo->setInstLumiAllBX(corrClustersPerBXOutput_);
+    outputLumiInfo.setTotalInstLumi(totalLumi);
+    outputLumiInfo.setTotalInstStatError(statErrOnLumi);
+
+    outputLumiInfo.setErrorLumiAllBX(errorPerBX);
+    outputLumiInfo.setInstLumiAllBX(corrClustersPerBXOutput);
 
     if(saveCSVFile_){
-        csvfile<<std::to_string(totalLumi_);
+        csvfile_<<std::to_string(totalLumi);
         
-        if(totalLumi_>0){
+        if(totalLumi>0){
             for(unsigned int bx=0;bx<LumiConstants::numBX;bx++){
-                csvfile<<","<<std::to_string(corrClustersPerBXOutput_[bx]);
+                csvfile_<<","<<std::to_string(corrClustersPerBXOutput[bx]);
             }
-            csvfile<<std::endl;   
-        } else if (totalLumi_<0) {
-            edm::LogInfo("WARNING")<<"WHY IS LUMI NEGATIVE?!?!?!? "<<totalLumi_;
+            csvfile_<<std::endl;   
+        } else if (totalLumi<0) {
+            edm::LogInfo("WARNING")<<"WHY IS LUMI NEGATIVE?!?!?!? "<<totalLumi;
         }
 
-        csvfile.close();
+        csvfile_.close();
     }
-}
-
-//--------------------------------------------------------------------------------------------------
-void RawPCCProducer::endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup){
-    lumiSeg.put(std::move(outputLumiInfo), std::string(outputProductName_)); 
+    lumiSeg.emplace(putToken_, std::move(outputLumiInfo) ); 
 
 }
 


### PR DESCRIPTION
The order in which endLuminosityBlock and endLuminosityBlockProduce
are called by the framework was reversed to match the behavior in
global modules. This required moving the computation from one function
to the other function.

In addition
-many member data were converted to local variables
-member data were marked as 'const' if possible
-switched to using edm::EDPutTokenT
These changes would make it easy to convert this module to a global
module in the future. This was not done now because of the output file.