### PR TITLE
Make AsciiOutputModule to print out alias branches, and extend EventContentAnalyzer to optionally print provenance information

### DIFF
--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -32,6 +32,7 @@
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/TypeToGet.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
 
 // system include files
 #include <algorithm>
@@ -281,6 +282,7 @@ namespace edm {
      int         evno_;
      std::map<std::string, int> cumulates_;
      bool        listContent_;
+     bool        listProvenance_;
   };
 
   //
@@ -294,7 +296,8 @@ namespace edm {
     getModuleLabels_(iConfig.getUntrackedParameter("getDataForModuleLabels", std::vector<std::string>())),
     getData_(iConfig.getUntrackedParameter("getData", false) || !getModuleLabels_.empty()),
     evno_(1),
-    listContent_(iConfig.getUntrackedParameter("listContent", true))
+    listContent_(iConfig.getUntrackedParameter("listContent", true)),
+    listProvenance_(iConfig.getUntrackedParameter("listProvenance", false))
   {
      //now do what ever initialization is needed
      sort_all(moduleLabels_);
@@ -378,8 +381,42 @@ namespace edm {
                                        << processName << "\""
                                        << " (productId = " << provenance->productID() << ")"
                                        << std::endl;
-         }
 
+           if(listProvenance_) {
+             auto const& prov = iEvent.getProvenance(provenance->branchID());
+             auto const *productProvenance = prov.productProvenance();
+             if(productProvenance) {
+               const bool isAlias = productProvenance->branchID() != provenance->branchID();
+               std::string aliasForModLabel;
+               LogAbsolute("EventContent") << prov;
+               if(isAlias) {
+                 aliasForModLabel = iEvent.getProvenance(productProvenance->branchID()).moduleLabel();
+                 LogAbsolute("EventContent") << "Is an alias for " << aliasForModLabel;
+               }
+               ProcessHistory const *processHistory = prov.processHistoryPtr();
+               if(processHistory) {
+                 for(ProcessConfiguration const& pc: *processHistory) {
+                   if(pc.processName() == prov.processName()) {
+                     ParameterSetID const& psetID = pc.parameterSetID();
+                     pset::Registry const* psetRegistry = pset::Registry::instance();
+                     ParameterSet const* processPset = psetRegistry->getMapped(psetID);
+                     if (processPset) {
+                       if(processPset->existsAs<ParameterSet>(modLabel)) {
+                         if(isAlias) {
+                           LogAbsolute("EventContent") << "Alias PSet";
+                         }
+                         LogAbsolute("EventContent") << processPset->getParameterSet(modLabel);
+                       }
+                       if(isAlias and processPset->existsAs<ParameterSet>(aliasForModLabel)) {
+                         LogAbsolute("EventContent") << processPset->getParameterSet(aliasForModLabel);
+                       }
+                     }
+                   }
+                 }
+               }
+             }
+           }
+         }
          std::string key = friendlyName
            + std::string(" + \"") + modLabel
            + std::string("\" + \"") + instanceName + "\" \"" + processName + "\"";
@@ -472,6 +509,8 @@ namespace edm {
      np = desc.addOptionalUntracked<bool>("listContent", true);
      np->setComment("If true then print a list of all the event content.");
 
+     np = desc.addOptionalUntracked<bool>("listProvenance", false);
+     np->setComment("If true, and if listContent or verbose is true, print provenance information for each product");
 
      descriptions.add("printContent", desc);
   }


### PR DESCRIPTION
This PR includes two related changes for investigating in detail the provenance information of EDAlias products:

### AsciiOutputModule

`Event::getAllProvenance()` ignores alias branches, so `AsciiOutputModule` ignores alias branches as well. In order to print those, I 
* changed the approach to get the list of branches from `ConstProductRegistry` instead
* added a printout whether the branch is an alias for some other branch
* optionally (`verbosity > 2`) print out the PSet of the module producing the branch (and in case of alias, of the module alias is for)

### EventContentAnalyzer

I added an option (`listProvenance`) to print out (event by event) provenance information for the branches.

Tested in CMSSW_10_4_0_pre2, no changes expected.

@Dr15Jones 