### PR TITLE
Modernize RPCTechnicalTrigger

### DIFF
--- a/L1Trigger/RPCTechnicalTrigger/interface/LogicFactory.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/LogicFactory.h
@@ -5,7 +5,7 @@
 #include <cstdlib>
 #include <string>
 #include <map>
-
+#include <memory>
 /** @class LogicFactory LogicFactory.h
  *  
  *
@@ -27,21 +27,15 @@ public:
   
   bool Unregister( const Identifier & id )
   {
-    typename std::map<Identifier, LogicCreator>::const_iterator itr;
-    itr = m_associations.find(id);
-    if( itr != m_associations.end() ) {
-      delete ( itr->second )() ;
-    }
     return m_associations.erase(id) == 1;
   }
   
-  Ilogic* CreateObject( const Identifier & id )
+  std::unique_ptr<Ilogic> CreateObject( const Identifier & id ) const
   {
-    typename std::map<Identifier, LogicCreator>::const_iterator itr;
-    itr = m_associations.find( id );
+    auto itr = m_associations.find( id );
     
     if ( itr != m_associations.end() )  {
-      return ( itr->second )();
+      return std::unique_ptr<Ilogic>{( itr->second )()};
     } else return nullptr; // handle error
   }
   

--- a/L1Trigger/RPCTechnicalTrigger/interface/LogicTool.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/LogicTool.h
@@ -21,105 +21,70 @@ template <class GenLogic>
 class LogicTool {
 public: 
   /// Standard constructor
-  LogicTool( ) { }; 
+  LogicTool( ) {
+  }
   
-  virtual ~LogicTool( ) { 
-    m_logkeys.clear();
-  }; ///< Destructor
-
   ///...
 
-  typedef LogicFactory< GenLogic, std::string> RBCLogicType;
-  
-  GenLogic * (*createlogic) ();
-    
-  RBCLogicType m_rbclogic;
-  
-  bool initialise() 
+  std::unique_ptr<GenLogic> retrieve( const std::string & _logic_name ) 
   {
-    bool status(true);
-
-    //...
-    std::string key = std::string("ChamberORLogic");
-    createlogic = (GenLogic * (*)()) &createChamberORLogic;
-    status = m_rbclogic.Register( key , createlogic );
-    
-    m_logkeys.push_back( key );
-        
-    key = std::string("TestLogic");
-    createlogic = (GenLogic * (*)()) &createTestLogic;
-    status = m_rbclogic.Register( key , createlogic );
-    
-    m_logkeys.push_back( key );
-
-    key = std::string("PatternLogic");
-    createlogic = (GenLogic * (*)()) &createPatternLogic;
-    status = m_rbclogic.Register( key , createlogic );
-    //...
-    
-    m_logkeys.push_back( key );
-
-    key = std::string("TrackingAlg");
-    createlogic = (GenLogic * (*)()) &createTrackingAlg;
-    status = m_rbclogic.Register( key , createlogic );
-
-    m_logkeys.push_back( key );
-    
-    key = std::string("SectorORLogic");
-    createlogic = (GenLogic * (*)()) &createSectorORLogic;
-    status = m_rbclogic.Register( key , createlogic );
-    
-    m_logkeys.push_back( key );
-
-    key = std::string("TwoORLogic");
-    createlogic = (GenLogic * (*)()) &createTwoORLogic;
-    status = m_rbclogic.Register( key , createlogic );
-
-    m_logkeys.push_back( key );
-
-    key = std::string("WedgeORLogic");
-    createlogic = (GenLogic * (*)()) &createWedgeORLogic;
-    status = m_rbclogic.Register( key , createlogic );
-    
-    m_logkeys.push_back( key );
-
-    key = std::string("PointingLogic");
-    createlogic = (GenLogic * (*)()) &createPointingLogic;
-    status = m_rbclogic.Register( key , createlogic );
-    
-    m_logkeys.push_back( key );
-    
-    return status;
-    
+    return  rbclogic().CreateObject( _logic_name );
   };
-  
-  
-  GenLogic * retrieve( const std::string & _logic_name ) 
-  {
-    GenLogic * _obj;
-    _obj = m_rbclogic.CreateObject( _logic_name );
-    return _obj;
-  };
-  
-  bool endjob()
-  {
-    bool status(true);
-    typename std::vector<std::string>::iterator itr = m_logkeys.begin();
-    while ( itr != m_logkeys.end() ) 
-    {
-      status = status && ( m_rbclogic.Unregister( (*itr) ) );
-      ++itr;
-    }
-    return status;
-    
-  };
-  
   
 protected:
   
 private:
+  using RBCLogicType =  LogicFactory< GenLogic, std::string>;
   
-  typename std::vector<std::string> m_logkeys;
+  static RBCLogicType initialise() 
+  {
+    GenLogic * (*createlogic) ();
+    bool status(true);
+
+    RBCLogicType rbclogic;
+    //...
+    std::string key = std::string("ChamberORLogic");
+    createlogic = (GenLogic * (*)()) &createChamberORLogic;
+    status = rbclogic.Register( key , createlogic );
+    
+    key = std::string("TestLogic");
+    createlogic = (GenLogic * (*)()) &createTestLogic;
+    status = rbclogic.Register( key , createlogic );
+    
+    key = std::string("PatternLogic");
+    createlogic = (GenLogic * (*)()) &createPatternLogic;
+    status = rbclogic.Register( key , createlogic );
+    //...
+    
+    key = std::string("TrackingAlg");
+    createlogic = (GenLogic * (*)()) &createTrackingAlg;
+    status = rbclogic.Register( key , createlogic );
+
+    key = std::string("SectorORLogic");
+    createlogic = (GenLogic * (*)()) &createSectorORLogic;
+    status = rbclogic.Register( key , createlogic );
+    
+    key = std::string("TwoORLogic");
+    createlogic = (GenLogic * (*)()) &createTwoORLogic;
+    status = rbclogic.Register( key , createlogic );
+
+    key = std::string("WedgeORLogic");
+    createlogic = (GenLogic * (*)()) &createWedgeORLogic;
+    status = rbclogic.Register( key , createlogic );
+    
+    key = std::string("PointingLogic");
+    createlogic = (GenLogic * (*)()) &createPointingLogic;
+    status = rbclogic.Register( key , createlogic );
+
+    assert(status);
+    return rbclogic;
+    
+  };
+  
+  static RBCLogicType const& rbclogic() {
+    static const RBCLogicType s_rbclogic = initialise();
+    return s_rbclogic;
+  }
   
 };
 #endif // LOGICTOOL_H

--- a/L1Trigger/RPCTechnicalTrigger/interface/ProcessTestSignal.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/ProcessTestSignal.h
@@ -14,7 +14,7 @@
 #include <ios>
 #include <cmath>
 #include <vector>
-
+#include <memory>
 
 /** @class ProcessTestSignal ProcessTestSignal.h
  *  
@@ -27,10 +27,7 @@
  */
 class ProcessTestSignal : public ProcessInputSignal {
 public: 
-  /// Standard constructor
-  ProcessTestSignal( ) { }; 
-  
-  ProcessTestSignal( const char * );
+  explicit ProcessTestSignal( const char * );
   
   ~ProcessTestSignal( ) override; ///< Destructor
   
@@ -43,7 +40,7 @@ public:
   void reset();
   
   RPCInputSignal * retrievedata() override {
-    return  m_lbin;
+    return  m_lbin.get();
   };
   
   void mask() {};
@@ -55,15 +52,11 @@ private:
   
   void builddata();
   
-  std::ifstream * m_in;
+  std::ifstream  m_in;
   
-  RPCData  * m_block;
+  std::unique_ptr<RPCInputSignal> m_lbin;
   
-  RBCInput * m_rbcinput;
-  
-  RPCInputSignal * m_lbin;
-  
-  std::vector<RPCData*> m_vecdata;
+  std::vector<std::unique_ptr<RPCData>> m_vecdata;
   
   std::map<int,RBCInput*> m_data;
   

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCBasicConfig.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCBasicConfig.h
@@ -14,13 +14,11 @@
 class RBCBasicConfig : public RBCConfiguration {
 public: 
   /// Standard constructor
-  RBCBasicConfig( ) {}; 
+  RBCBasicConfig( ):m_debug{false} {}; 
   
   RBCBasicConfig( const char *); 
 
   RBCBasicConfig( const RBCBoardSpecs * , RBCId * );
-  
-  ~RBCBasicConfig( ) override; ///< Destructor
   
   bool initialise() override;
 
@@ -30,8 +28,6 @@ protected:
   
 private:
   
-  RBCId * m_rbcinfo;
-
   std::vector<int> m_vecmask;
   std::vector<int> m_vecforce;
 

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCChamberORLogic.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCChamberORLogic.h
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <vector>
 #include <map>
-
+#include <array>
 
 /** @class RBCChamberORLogic RBCChamberORLogic.h
  *  
@@ -29,8 +29,6 @@ public:
   /// Standard constructor
   RBCChamberORLogic( ); 
   
-  ~RBCChamberORLogic( ) override; ///< Destructor
-      
   void process ( const RBCInput & , std::bitset<2> & ) override;
   
   void setBoardSpecs( const RBCBoardSpecs::RBCBoardConfig & ) override;
@@ -50,7 +48,7 @@ public:
   
   void setmaxlevel( int _mx ) { m_maxlevel = _mx;};
   
-  std::bitset<6> * m_layersignal;
+  std::array<std::bitset<6>,2> m_layersignal;
   
 protected:
   

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCConfiguration.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCConfiguration.h
@@ -19,18 +19,26 @@
 
 class RBCConfiguration {
 public: 
-  virtual ~RBCConfiguration() {}
+  RBCConfiguration():m_rbcboardspecs(nullptr) {}
+  RBCConfiguration(const RBCBoardSpecs * rbcspecs);
+  RBCConfiguration(const char * _logic);
+
+  RBCConfiguration(RBCConfiguration&&) = default;
+  RBCConfiguration& operator=(RBCConfiguration&&) = default;
+
+  virtual ~RBCConfiguration() = default;
   virtual bool initialise()=0;
 
   virtual void preprocess(RBCInput &)=0;
-    
-  RBCLogicUnit  * m_rbclogic;
   
-  const RBCBoardSpecs * m_rbcboardspecs;
-  
-  RBCBoardSpecs::RBCBoardConfig * m_rbcconf;
+  RBCLogicUnit* rbclogic() { return m_rbclogic.get();}
   
 protected:
+  const RBCBoardSpecs * m_rbcboardspecs;
+  std::unique_ptr<RBCLogicUnit>  m_rbclogic;
+  
+  //RBCBoardSpecs::RBCBoardConfig * m_rbcconf;
+  
   
 private:
 

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCEmulator.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCEmulator.h
@@ -11,6 +11,7 @@
 
 #include "CondFormats/RPCObjects/interface/RBCBoardSpecs.h"
 
+#include <memory>
 /** @class RBCEmulator RBCEmulator.h
  *  
  *
@@ -32,8 +33,6 @@ public:
   
   RBCEmulator( const char * , const char * , int, int *); 
   
-  virtual ~RBCEmulator( ); ///< Destructor
-
   void setSpecifications( const RBCBoardSpecs * );
     
   bool initialise();
@@ -48,34 +47,32 @@ public:
   
   std::bitset<6> * getlayersignal( int idx ) { return m_layersignal[idx];};
 
-  bool getdecision( int idx ) { return m_decision[idx];};
+  bool getdecision( int idx ) const { return m_decision[idx];};
     
-  void printinfo();
+  void printinfo() const;
   
-  void printlayerinfo();
+  void printlayerinfo() const;
   
-  RBCId          * m_rbcinfo;
+  const RBCId& rbcinfo() const { return m_rbcinfo;}
   
 protected:
   
 private:
+  RBCId           m_rbcinfo;
   
-  ProcessInputSignal * m_signal;
+  std::unique_ptr<ProcessInputSignal> m_signal;
   
-  RBCConfiguration   * m_rbcconf;
+  std::unique_ptr<RBCConfiguration>   m_rbcconf;
   
-  RBCInput           * m_input;
+  RBCInput           m_input;
   
   std::bitset<6> * m_layersignal[2];
   
   std::bitset<2> m_decision;
   
-  std::vector< std::bitset<6> *> m_layersignalVec;
+  std::array<std::bitset<6>,2> m_layersignalVec;
   
   //...
-  
-  int m_bx;
-  
   std::string m_logtype;
 
   bool m_debug;

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCId.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCId.h
@@ -20,9 +20,10 @@ public:
 
   RBCId(int , int * );
   
-  RBCId(const RBCId &);
-  
-  virtual ~RBCId( ); ///< Destructor
+  RBCId(const RBCId &) = default;
+  RBCId(RBCId &&) = default;
+  RBCId& operator=(RBCId const&) = default;
+  RBCId& operator=(RBCId&&) = default;
   
   int wheel() const { return m_wheel;};
   
@@ -36,7 +37,7 @@ public:
     m_sector[1] = _sec[1];
   };
   
-  void printinfo();
+  void printinfo() const;
     
 protected:
   

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCInput.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCInput.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <bitset>
 #include <vector>
+#include <array>
 
 /** @class RBCInput RBCInput.h interface/RBCInput.h
  *  
@@ -22,48 +23,24 @@ class RBCInput {
 public: 
   /// Standard constructor
   RBCInput( ) { 
-    input_sec = new std::bitset<15>[2];
     needmapping = false; 
     m_debug = false; 
     hasData = false;
   }; 
   
-  virtual ~RBCInput( ) {
-    if ( input_sec ) delete[] input_sec;
-  }; ///< Destructor
-  
-  RBCInput( const RBCInput & in )
-  {
-    for(int i=0; i < 30; ++i) input[i] = in.input[i];
-    for(int i=0; i <  2; ++i) input_sec[i] = in.input_sec[i];
-    needmapping = in.needmapping;
-    m_debug = in.m_debug;
-    hasData = in.hasData;
-    m_wheelId = in.m_wheelId;
-  };
-  
-  RBCInput & operator=(const RBCInput & rhs) 
-  {
-    if (this == &rhs) {
-      std::cout << "RBCInput:(this=rhs)" << '\n'; return (*this);
-    };
-    for(int i=0; i < 30; ++i) (*this).input[i]     = rhs.input[i];
-    for(int i=0; i <  2; ++i) (*this).input_sec[i] = rhs.input_sec[i];
-    (*this).needmapping = rhs.needmapping;
-    (*this).m_debug = rhs.m_debug;
-    (*this).hasData = rhs.hasData;
-    (*this).m_wheelId = rhs.m_wheelId;
-    return (*this);
-  };
+  RBCInput( const RBCInput &) = default;  
+  RBCInput( RBCInput &&) = default;  
+  RBCInput & operator=(const RBCInput & ) = default;
+  RBCInput & operator=(RBCInput && ) = default;
   
   // io functions
-  friend std::istream& operator>>(std::istream &istr, RBCInput &);
-  friend std::ostream& operator<<(std::ostream &ostr, RBCInput &);
+  friend std::istream& operator>>(std::istream &istr, RBCInput&);
+  friend std::ostream& operator<<(std::ostream &ostr, RBCInput const &);
   
   bool input[30];
-  std::bitset<15>  * input_sec;
+  std::array<std::bitset<15>,2> input_sec;
   
-  void printinfo() {
+  void printinfo() const {
     std::cout << "RBCInput: " << (*this);
   };
   

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCLinkBoardSignal.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCLinkBoardSignal.h
@@ -13,16 +13,11 @@
  */
 class RBCLinkBoardSignal : public RPCInputSignal {
 public: 
-  /// Standard constructor
-  RBCLinkBoardSignal( ) {}; 
-
   RBCLinkBoardSignal( RBCInput * ); 
-  
-  ~RBCLinkBoardSignal( ) override; ///< Destructor
   
   void clear() override { };
 
-  RBCInput * m_linkboardin;
+  RBCInput   m_linkboardin;
   
 protected:
 

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCLogicUnit.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCLogicUnit.h
@@ -47,9 +47,8 @@ private:
   
   std::bitset<6> * m_layersignal[2];
 
-  RBCLogic            * m_logic;
+  std::unique_ptr<RBCLogic> m_logic;
   
-  LogicTool<RBCLogic> * m_logtool;
 
   bool m_debug;
     

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCProcessRPCDigis.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCProcessRPCDigis.h
@@ -39,8 +39,6 @@
 class RBCProcessRPCDigis : public ProcessInputSignal {
 public: 
   /// Standard constructor
-  RBCProcessRPCDigis( ) {};
-  
   RBCProcessRPCDigis( const edm::ESHandle<RPCGeometry> &, 
                       const edm::Handle<RPCDigiCollection> & );
   
@@ -52,14 +50,13 @@ public:
   
   void configure();
     
-  void initialize( std::vector<RPCData*> & );
   
   void builddata();
   
   void print_output();
   
   RPCInputSignal * retrievedata() override {
-    return  m_lbin;
+    return  m_lbin.get();
   };
   
   void rewind() {};
@@ -68,37 +65,27 @@ public:
 protected:
   
 private:
+  void initialize( std::vector<RPCData> & ) const;
   
   int getBarrelLayer(const int &, const int &);
   
-  void setDigiAt( int , int  );
+  void setDigiAt( int , int , RPCData& );
   
   void setInputBit( std::bitset<15> & , int );
   
   const edm::ESHandle<RPCGeometry>     * m_ptr_rpcGeom;
   const edm::Handle<RPCDigiCollection> * m_ptr_digiColl;
   
-  RPCDigiCollection::const_iterator m_digiItr;
-  RPCDigiCollection::DigiRangeIterator m_detUnitItr;
-  
-  RPCData  * m_block;
-  
-  RPCInputSignal * m_lbin;
-  
-  std::map<int, int> m_layermap;
+  std::unique_ptr<RPCInputSignal> m_lbin;
   
   std::map<int, RBCInput*> m_data;
   
-  std::map<int, std::vector<RPCData*> > m_vecDataperBx;
+  std::map<int, std::vector<RPCData> > m_vecDataperBx;
   
-  bool m_debug;
-  int m_maxBxWindow;
-  
-  std::vector<int> m_wheelid;
-  std::vector<int> m_sec1id;
-  std::vector<int> m_sec2id;
-  
-  std::map<int, l1trigger::Counters*> m_digiCounters;
+
+  std::map<int, l1trigger::Counters> m_digiCounters;
+  const int m_maxBxWindow;
+  const bool m_debug;
       
 };
 #endif // RBCPROCESSRPCDIGIS_H

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCProcessRPCSimDigis.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCProcessRPCSimDigis.h
@@ -28,6 +28,7 @@
 #include <cmath>
 #include <map>
 #include <vector>
+#include <memory>
 
 /** @class RBCProcessRPCSimDigis RBCProcessRPCSimDigis.h interface/RBCProcessRPCSimDigis.h
  *  
@@ -48,16 +49,12 @@ public:
   
   void reset();
   
-  void configure();
-  
-  void initialize( std::vector<RPCData*> & );
-  
   void builddata();
   
   void print_output();
   
   RPCInputSignal * retrievedata() override {
-    return  m_lbin;
+    return  m_lbin.get();
   };
   
   void rewind() {};
@@ -71,9 +68,11 @@ private:
   
   int getBarrelLayer(const int &, const int &);
   
-  void setDigiAt( int , int  );
+  void setDigiAt( int , int , RPCData& );
   
   void setInputBit( std::bitset<15> & , int );
+  
+  void initialize( std::vector<RPCData> & );
   
   const edm::ESHandle<RPCGeometry> * m_ptr_rpcGeom;
   const edm::Handle<edm::DetSetVector<RPCDigiSimLink> > * m_ptr_digiSimLink;
@@ -81,23 +80,15 @@ private:
   edm::DetSetVector<RPCDigiSimLink>::const_iterator m_linkItr;
   edm::DetSet<RPCDigiSimLink>::const_iterator m_digiItr;
     
-  RPCData  * m_block;
-  
-  RPCInputSignal * m_lbin;
-  
-  std::map<int, int> m_layermap;
+  std::unique_ptr<RPCInputSignal> m_lbin;
   
   std::map<int, RBCInput*> m_data;
   
-  std::map<int, std::vector<RPCData*> > m_vecDataperBx;
+  std::map<int, std::vector<RPCData> > m_vecDataperBx;
   
   bool m_debug;
   int m_maxBxWindow;
   
-  std::vector<int> m_wheelid;
-  std::vector<int> m_sec1id;
-  std::vector<int> m_sec2id;
-
   
 };
 #endif // INTERFACE_RBCPROCESSRPCSIMDIGIS_H

--- a/L1Trigger/RPCTechnicalTrigger/interface/RBCProcessTestSignal.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RBCProcessTestSignal.h
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <ios>
 #include <cmath>
+#include <memory>
 
 /** @class RBCProcessTestSignal RBCProcessTestSignal.h
  *  
@@ -24,10 +25,7 @@
  */
 class RBCProcessTestSignal : public ProcessInputSignal {
 public: 
-  /// Standard constructor
-  RBCProcessTestSignal( ) {}; 
-  
-  RBCProcessTestSignal( const char * ); 
+  explicit RBCProcessTestSignal( const char * ); 
   
   ~RBCProcessTestSignal( ) override; ///< Destructor
   
@@ -38,18 +36,18 @@ public:
   void showfirst();
   
   RPCInputSignal * retrievedata() override { 
-    return  m_lbin; 
+    return  m_lbin.get(); 
   };
   
 protected:
   
 private:
   
-  std::ifstream * m_in;
+  std::ifstream m_in;
   
-  RBCInput * m_input;
+  RBCInput m_input;
 
-  RPCInputSignal * m_lbin;
+  std::unique_ptr<RPCInputSignal> m_lbin;
   
   
 };

--- a/L1Trigger/RPCTechnicalTrigger/interface/RPCData.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RPCData.h
@@ -24,14 +24,11 @@ namespace l1trigger {
   class Counters {
   public:
   
-    Counters() {};
-    Counters( int );
-  
-    virtual ~Counters();
+    explicit Counters( int );
   
     void incrementSector( int );
   
-    void printSummary();
+    void printSummary() const;
   
     void evalCounters();
   
@@ -46,18 +43,18 @@ namespace l1trigger {
 class RPCData {
 public: 
   /// Standard constructor
-  RPCData( ); 
-  virtual ~RPCData( ); ///< Destructor
+  RPCData( );
+  ~RPCData( ) = default; ///< Destructor
 
   int         m_wheel;
-  int      *  m_sec1;
-  int      *  m_sec2;
-  RBCInput *  m_orsignals;
+  std::array<int,6>  m_sec1;
+  std::array<int ,6> m_sec2;
+  std::array<RBCInput,6>  m_orsignals;
 
   friend std::istream& operator>>(std::istream &, RPCData &);
-  friend std::ostream& operator<<(std::ostream &, RPCData &);
+  friend std::ostream& operator<<(std::ostream &, RPCData const &);
   
-  int wheelIdx() //wheel index starts from 0
+  int wheelIdx() const //wheel index starts from 0
   {
     return (m_wheel + 2);
   }

--- a/L1Trigger/RPCTechnicalTrigger/interface/RPCTechnicalTrigger.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RPCTechnicalTrigger.h
@@ -33,7 +33,7 @@ Implementation:
 // Include files From CMSSW
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -66,7 +66,7 @@ Implementation:
 
 //...........................................................................
 
-class RPCTechnicalTrigger : public edm::EDProducer {
+class RPCTechnicalTrigger : public edm::stream::EDProducer<> {
 public:
 
   explicit RPCTechnicalTrigger(const edm::ParameterSet&);

--- a/L1Trigger/RPCTechnicalTrigger/interface/RPCTechnicalTrigger.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RPCTechnicalTrigger.h
@@ -28,6 +28,7 @@ Implementation:
 // system include files
 #include <memory>
 #include <bitset>
+#include <array>
 
 // Include files From CMSSW
 
@@ -76,51 +77,39 @@ private:
   //virtual void beginJob() ;
   void beginRun(edm::Run const&, const edm::EventSetup&) final;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   //...........................................................................
   
-  void printinfo();
+  void printinfo() const;
 
-  bool Reset();
+  static constexpr int kMaxTtuBoards = 3;
+  std::array<TTUEmulator,kMaxTtuBoards> m_ttu;
+
+  std::array<TTUEmulator,kMaxTtuBoards> m_ttuRbcLine;
     
-  TTUEmulator * m_ttu[3];
-
-  TTUEmulator * m_ttuRbcLine[3];
-  
-  RPCInputSignal * m_input;
-  
-  ProcessInputSignal * m_signal;
-  
-  std::bitset<5> m_triggerbits;
-  
-  edm::ESHandle<RPCGeometry> m_rpcGeometry;
-  
-  int m_verbosity;
-  int m_useEventSetup;
+  const int m_verbosity;
+  const int m_useEventSetup;
   std::string m_configFile;
-  std::vector<unsigned> m_ttBits;
-  std::vector<std::string> m_ttNames;
-  edm::InputTag m_rpcDigiLabel;
-  edm::InputTag m_rpcSimLinkInstance;
+  const std::vector<unsigned> m_ttBits;
+  const std::vector<std::string> m_ttNames;
+  const edm::InputTag m_rpcDigiLabel;
+  const edm::EDGetTokenT<RPCDigiCollection> m_rpcDigiToken;
   
-  int m_useRPCSimLink;
+  const int m_useRPCSimLink;
   
-  TTUConfigurator     * m_readConfig;
+  std::unique_ptr<TTUConfigurator> m_readConfig;
   const TTUBoardSpecs * m_ttuspecs;
   const RBCBoardSpecs * m_rbcspecs;
   
-  int m_ievt;
-  int m_cand;
-  int m_boardIndex[3];
-  int m_nWheels[3];
-  int m_maxTtuBoards;
-  int m_maxBits;
   bool m_hasConfig;
   
   class TTUResults {
   public:
-    TTUResults() {;}
+    TTUResults() = default;
+    TTUResults(const TTUResults&) = default;
+    TTUResults(TTUResults&&) = default;
+    TTUResults& operator=(TTUResults const&) = default;
+    TTUResults& operator=(TTUResults&&) = default;
     
     TTUResults( int idx, int bx, int wh1, int wh2 ):
       m_ttuidx(idx),
@@ -135,22 +124,13 @@ private:
       m_trigWheel2(wh2),
       m_wedge(wdg) {;}
     
-    ~TTUResults() 
-    {
-      m_ttuidx=0;
-      m_bx=0;
-      m_trigWheel1=0;
-      m_trigWheel2=0;
-      m_wedge=0;
-    }
-    
     int m_ttuidx;
     int m_bx;
     int m_trigWheel1;
     int m_trigWheel2;
     int m_wedge;
   
-    int getTriggerForWheel( int wheel ) 
+    int getTriggerForWheel( int wheel ) const
     {
       if( abs(wheel) > 1 ) return m_trigWheel2;
       else return m_trigWheel1;
@@ -159,29 +139,10 @@ private:
   
   };
   
-  struct sortByBx {
-    bool operator()( const TTUResults * a, const TTUResults * b )
-    {
-      return (*a).m_bx < (*b).m_bx;
-    }
-  };
-  
-  std::vector<TTUResults*> m_serializedInfoLine1;
-  std::vector<TTUResults*> m_serializedInfoLine2;
 
-  int convertToMap( const std::vector<TTUResults*> & );
+  std::map<int,TTUResults*> convertToMap( const std::vector<std::unique_ptr<TTUResults>> & ) const;
   
-  bool searchCoincidence( int , int );
-  
-  std::map<int,int> m_WheelTtu;
-  
-  std::map<int,TTUResults*> m_ttuResultsByQuadrant;
-
-  std::vector<int> m_quadrants;
-  
-  std::vector<int>::iterator m_firstSector;
-  
-    
+  bool searchCoincidence( int , int, std::map<int, TTUResults*> const& ttuResultsByQuandrant ) const;
 };
 
 #endif // RPCTECHNICALTRIGGER_H

--- a/L1Trigger/RPCTechnicalTrigger/interface/RPCWheel.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RPCWheel.h
@@ -24,8 +24,8 @@ class RPCWheel {
 public: 
   /// Standard constructor
   RPCWheel( );
-
-  virtual ~RPCWheel( ); ///< Destructor
+  RPCWheel(RPCWheel&&) = default;
+  RPCWheel& operator=(RPCWheel&&) = default;
   
   void setProperties( int );
   
@@ -47,30 +47,27 @@ public:
   
   void retrieveWheelMap( TTUInput & );
   
-  int  getid() { return m_id; };
+  int  getid() const { return m_id; };
   
-  void printinfo();
+  void printinfo() const;
 
-  void print_wheel(const TTUInput & );
+  void print_wheel(const TTUInput & ) const;
   
-  std::vector<RBCEmulator*> m_RBCE;
   
 protected:
   
 private:
+  std::vector<std::unique_ptr<RBCEmulator>> m_RBCE;
   
   int m_id;
-  int m_maxrbc;
-  int m_maxlayers;
-  int m_maxsectors;
-  
-  std::vector<int> m_sec1id;
-  std::vector<int> m_sec2id;
+  static constexpr int m_maxrbc = 6;
+  static constexpr int m_maxlayers = 6;
+  static constexpr int m_maxsectors = 12;
   
   //...
 
   std::bitset<12>  m_rbcDecision;
-  std::bitset<6> * m_wheelmap;
+  std::array<std::bitset<6>,12> m_wheelmap;
 
   bool m_debug;
     

--- a/L1Trigger/RPCTechnicalTrigger/interface/RPCWheelMap.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/RPCWheelMap.h
@@ -12,36 +12,33 @@
  *  @date   2008-11-24
  */
 class RPCWheelMap {
-public: 
-  /// Standard constructor
-  RPCWheelMap( ) {};
-
-  RPCWheelMap( int );
+private:
+  static constexpr int m_maxBx = 7;
+  static constexpr int m_maxSectors = 12;
+  static constexpr int m_maxBxWindow = 3; //... considering that we have a bxing in the range [-3,+3]
   
-  virtual ~RPCWheelMap( ); ///< Destructor
+public: 
+ 
+  RPCWheelMap( int );
   
   void addHit( int , int , int );
   
   void prepareData();
   
-  int wheelid() { return m_wheelid; };
+  int wheelid() const { return m_wheelid; };
   
-  int wheelIdx() { return (m_wheelid+2); };
+  int wheelIdx() const { return (m_wheelid+2); };
   
-  TTUInput * m_ttuinVec;
+  std::array<TTUInput,m_maxBx> m_ttuinVec;
   
 protected:
   
 private:
-  
   int m_bx;
   int m_wheelid;
-  int m_maxBx;
-  int m_maxSectors;
-  int m_maxBxWindow;
   
-  std::bitset<6> * m_wheelMap;
-  std::bitset<6> * m_wheelMapBx;
+  std::array<std::bitset<6>,m_maxSectors>  m_wheelMap;
+  std::array<std::bitset<6>,m_maxSectors * m_maxBx> m_wheelMapBx;
   
   bool m_debug;
   

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUBasicConfig.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUBasicConfig.h
@@ -13,10 +13,7 @@
  *  @date   2008-10-29
  */
 class TTUBasicConfig : public TTUConfiguration {
-public: 
-  /// Standard constructor
-  TTUBasicConfig( ) { };
-
+public:
   TTUBasicConfig( const char * );
   
   TTUBasicConfig( const TTUBoardSpecs * );

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUConfiguration.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUConfiguration.h
@@ -16,23 +16,25 @@
  *  @author Andres Osorio
  *  @date   2008-10-29
  */
+#include <memory>
 
 class TTUConfiguration {
 public: 
-  virtual ~TTUConfiguration() {}
+  TTUConfiguration( const char*);
+  TTUConfiguration( const TTUBoardSpecs*);
+  virtual ~TTUConfiguration() = default;
   virtual bool initialise( int , int )=0;
   
   virtual void preprocess(TTUInput &)=0;
-  
-  TTULogicUnit  * m_ttulogic;
+
+  TTULogicUnit* ttulogic() { return &m_ttulogic; }
 
   const TTUBoardSpecs * m_ttuboardspecs;
-  
-  TTUBoardSpecs::TTUBoardConfig * m_ttuconf;
   
 protected:
   
 private:
+  TTULogicUnit  m_ttulogic;
   
 };
 #endif // INTERFACE_TTUCONFIGURATION_H

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUConfigurator.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUConfigurator.h
@@ -29,16 +29,13 @@
 
 class TTUConfigurator {
 public: 
-  /// Standard constructor
-  TTUConfigurator( ) { };
-  
   TTUConfigurator( const std::string& );
   
-  virtual ~TTUConfigurator( ); ///< Destructor
+  ~TTUConfigurator( ); ///< Destructor
   
-  RBCBoardSpecs * getRbcSpecs(){ return m_rbcspecs; };
+  RBCBoardSpecs * getRbcSpecs(){ return &m_rbcspecs; };
   
-  TTUBoardSpecs * getTtuSpecs(){ return m_ttuspecs; };
+  TTUBoardSpecs * getTtuSpecs(){ return &m_ttuspecs; };
   
   void process();
   
@@ -48,13 +45,13 @@ protected:
   
 private:
   
-  std::ifstream * m_in;
+  std::ifstream  m_in;
   
-  void addData( RBCBoardSpecs *  );
-  void addData( TTUBoardSpecs *  );
+  void addData( RBCBoardSpecs&  );
+  void addData( TTUBoardSpecs&  );
   
-  RBCBoardSpecs * m_rbcspecs;
-  TTUBoardSpecs * m_ttuspecs;
+  RBCBoardSpecs  m_rbcspecs;
+  TTUBoardSpecs  m_ttuspecs;
   
 };
 #endif // TTUCONFIGURATOR_H

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUEmulator.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUEmulator.h
@@ -11,6 +11,8 @@
 
 #include <map>
 #include <bitset>
+#include <array>
+#include <memory>
 
 /** @class TTUEmulator TTUEmulator.h
  *  
@@ -45,8 +47,6 @@ public:
   
   TTUEmulator( int, const char *, const char * , const char *, int );
   
-  virtual ~TTUEmulator( ); ///< Destructor
-  
   bool initialise();
   
   void emulate();
@@ -55,13 +55,13 @@ public:
   
   void processTtu( RPCInputSignal * , int );
   
-  void printinfo();
+  void printinfo() const;
   
   void setSpecifications( const TTUBoardSpecs *, const RBCBoardSpecs *);
   
   void clearTriggerResponse();
   
-  int mode() {
+  int mode() const {
     return m_mode;
   };
   
@@ -69,7 +69,7 @@ public:
     m_mode = mode;
   };
   
-  int line() {
+  int line() const {
     return m_line;
   };
   
@@ -79,7 +79,7 @@ public:
   
   int m_maxWheels;
   
-  RPCWheel * m_Wheels;
+  std::array<RPCWheel,2> m_Wheels;
   std::bitset<2> m_trigger;
   std::map<int, std::bitset<2> > m_triggerBx;
 
@@ -109,7 +109,7 @@ public:
     
   };
   
-  std::vector<TriggerResponse*> m_triggerBxVec;
+  std::vector<TriggerResponse> m_triggerBxVec;
   
 protected:
   
@@ -120,13 +120,13 @@ private:
   int m_mode;
   int m_line;
   
-  int * m_wheelIds;
+  std::array<int,6>  m_wheelIds;
   
   std::string m_logtype;
   
-  TTUInput         * m_ttuin;
+  std::array<TTUInput,2>  m_ttuin;
   
-  TTUConfiguration * m_ttuconf;
+  std::unique_ptr<TTUConfiguration> m_ttuconf;
   
   bool m_debug;
 

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUInput.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUInput.h
@@ -4,6 +4,7 @@
 // Include files
 #include <bitset>
 #include <vector>
+#include <array>
 
 /** @class TTUInput TTUInput.h interface/TTUInput.h
  *  
@@ -20,32 +21,10 @@ public:
   /// Standard constructor
   TTUInput( );
   
-  ///< Destructor
-  virtual ~TTUInput( );
-  
-  TTUInput( const TTUInput & in )
-  {
-    m_bx = in.m_bx;
-    m_wheelId = in.m_wheelId;
-    m_hasHits = in.m_hasHits;
-    m_rbcDecision = in.m_rbcDecision;
-    input_sec = new std::bitset<6>[12];
-    for(int i=0; i < 12; ++i) 
-      input_sec[i] = in.input_sec[i];
-  };
-  
-  TTUInput & operator=( const TTUInput & rhs )
-  {
-    if (this == &rhs) return (*this);
-    (*this).m_bx = rhs.m_bx;
-    (*this).m_wheelId = rhs.m_wheelId;
-    (*this).m_hasHits = rhs.m_hasHits;
-    (*this).input_sec = new std::bitset<6>[12];
-    (*this).m_rbcDecision = rhs.m_rbcDecision;
-    for(int i=0; i < 12; ++i)
-      (*this).input_sec[i] = rhs.input_sec[i];
-    return (*this);
-  };
+  TTUInput( const TTUInput & in ) = default;
+  TTUInput( TTUInput && in ) = default;
+  TTUInput & operator=( const TTUInput & rhs ) = default;
+  TTUInput & operator=( TTUInput && rhs ) = default;
   
   void reset();
   
@@ -55,7 +34,7 @@ public:
   
   bool m_hasHits;
   
-  std::bitset<6>  * input_sec;
+  std::array<std::bitset<6>, 12> input_sec;
   std::bitset<12> m_rbcDecision;
   
   void mask ( const std::vector<int> & );

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTULogicUnit.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTULogicUnit.h
@@ -25,8 +25,6 @@ public:
   
   TTULogicUnit( const char * );
   
-  ~TTULogicUnit( ) override; ///< Destructor
-
   bool initialise();
   
   void setlogic( const char * );
@@ -47,10 +45,8 @@ private:
   
   std::string m_logtype;
   
-  TTULogic             * m_logic;
+  std::unique_ptr<TTULogic> m_logic;
   
-  LogicTool<TTULogic>  * m_logtool;
-
   bool m_debug;
     
 };

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUTwoORLogic.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUTwoORLogic.h
@@ -24,8 +24,6 @@ public:
   /// Standard constructor
   TTUTwoORLogic( ); 
 
-  ~TTUTwoORLogic( ) override; ///< Destructor
-
   //... from TTULogic interface:
   
   bool process( const TTUInput & ) override;
@@ -38,11 +36,12 @@ protected:
 
 private:
 
-  bool m_debug;
 
-  TTUTrackingAlg * m_ttuLogic;
+  TTUTrackingAlg m_ttuLogic;
   
-  TTUSectorORLogic * m_rbcLogic;
+  TTUSectorORLogic m_rbcLogic;
+
+  bool m_debug;
   
 
 };

--- a/L1Trigger/RPCTechnicalTrigger/src/GeometryConstants.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/GeometryConstants.cc
@@ -1,0 +1,42 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger/RPCTechnicalTrigger
+// Class  :     GeometryConstants
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 16 Nov 2018 20:00:03 GMT
+//
+
+// system include files
+
+// user include files
+#include "GeometryConstants.h"
+
+namespace rpctechnicaltrigger {
+    const std::map<int, int> s_layermap = { {113,   0},  //RB1InFw
+                                          {123,   1},  //RB1OutFw
+  
+                                          {20213, 2},  //RB22Fw
+                                          {20223, 2},  //RB22Fw
+                                          {30223, 3},  //RB23Fw
+                                          {30213, 3},  //RB23Fw
+                                          {30212, 4},  //RB23M
+                                          {30222, 4},  //RB23M
+  
+                                          {313,   5},  //RB3Fw
+                                          {413,   6},  //RB4Fw
+                                          {111,   7},  //RB1InBk
+                                          {121,   8},  //RB1OutBk
+  
+                                          {20211, 9},  //RB22Bw
+                                          {20221, 9},  //RB22Bw
+                                          {30211,10}, //RB23Bw
+                                          {30221,10}, //RB23Bw
+  
+                                          {311,  11}, //RB3Bk
+                                          {411,  12} //RB4Bk
+    };
+}

--- a/L1Trigger/RPCTechnicalTrigger/src/GeometryConstants.h
+++ b/L1Trigger/RPCTechnicalTrigger/src/GeometryConstants.h
@@ -1,0 +1,36 @@
+#ifndef L1Trigger_RPCTechnicalTrigger_GeometryConstants_h
+#define L1Trigger_RPCTechnicalTrigger_GeometryConstants_h
+// -*- C++ -*-
+//
+// Package:     L1Trigger/RPCTechnicalTrigger
+// Class  :     GeometryConstants
+// 
+/**\class GeometryConstants GeometryConstants.h "GeometryConstants.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 16 Nov 2018 19:59:59 GMT
+//
+
+// system include files
+#include <array>
+#include <map>
+// user include files
+
+// forward declarations
+namespace rpctechnicaltrigger {
+  constexpr std::array<int,5> s_wheelid = { {-2, -1, 0, 1, 2} };
+  constexpr std::array<int,6> s_sec1id = { {12, 2, 4, 6, 8, 10} };
+  constexpr std::array<int,6> s_sec2id = { {1, 3, 5, 7, 9, 11} };
+
+  extern const std::map<int, int> s_layermap;
+}
+
+
+#endif

--- a/L1Trigger/RPCTechnicalTrigger/src/ProcessTestSignal.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/ProcessTestSignal.cc
@@ -61,7 +61,6 @@ int ProcessTestSignal::next()
 void ProcessTestSignal::showfirst() 
 {
   rewind();
-  std::vector<RPCData*>::iterator itr;
   for(auto& d: m_vecdata)
     std::cout << (*d);
   rewind();

--- a/L1Trigger/RPCTechnicalTrigger/src/ProcessTestSignal.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/ProcessTestSignal.cc
@@ -15,18 +15,18 @@
 // Standard constructor, initializes variables
 //=============================================================================
 ProcessTestSignal::ProcessTestSignal( const char * f_name ) 
+  :m_in{}
 {
   
-  m_in = new std::ifstream();
-  m_in->open(f_name);
+  m_in.open(f_name);
   
-  if(!m_in->is_open()) {
+  if(!m_in.is_open()) {
     std::cout << "ProcessTestSignal> cannot open file" << std::endl;
   } else { 
     std::cout << "ProcessTestSignal> file is now open" << std::endl;
   }
   
-  m_lbin = dynamic_cast<RPCInputSignal*>( new RBCLinkBoardGLSignal( &m_data ) );
+  m_lbin = std::make_unique<RBCLinkBoardGLSignal>( &m_data );
   
 }
 //=============================================================================
@@ -34,13 +34,7 @@ ProcessTestSignal::ProcessTestSignal( const char * f_name )
 //=============================================================================
 ProcessTestSignal::~ProcessTestSignal() {
 
-  if ( m_lbin ) delete m_lbin;
-  
-  if( m_in ) {
-    m_in->close();
-    delete m_in;
-  }
-
+  m_in.close();
 } 
 
 //=============================================================================
@@ -49,18 +43,17 @@ int ProcessTestSignal::next()
   
   reset();
   
-  if ( m_in->fail() ) return 0;
+  if ( m_in.fail() ) return 0;
   
   for(int j=0; j < 5; ++j) {
     
-    m_block = new RPCData();
-    (*m_in) >> (*m_block);
-    m_vecdata.push_back( m_block );
+    auto& block = m_vecdata.emplace_back();
+    (m_in) >> (*block);
   }
   
   builddata();
   
-  if ( m_in->eof() ) return 0;
+  if ( m_in.eof() ) return 0;
   return 1;
   
 }
@@ -69,25 +62,22 @@ void ProcessTestSignal::showfirst()
 {
   rewind();
   std::vector<RPCData*>::iterator itr;
-  for(itr=m_vecdata.begin();itr!=m_vecdata.end();++itr)
-    std::cout << (*(*itr));
+  for(auto& d: m_vecdata)
+    std::cout << (*d);
   rewind();
   
 }
 
 void ProcessTestSignal::rewind() 
 { 
-  m_in->clear();
-  m_in->seekg(0,std::ios::beg); 
+  m_in.clear();
+  m_in.seekg(0,std::ios::beg); 
 }
 
 void ProcessTestSignal::reset()
 {
   
-  std::vector<RPCData*>::iterator itr;
-  for(itr=m_vecdata.begin();itr!=m_vecdata.end();++itr)
-    delete *itr;
-  m_vecdata.clear();
+   m_vecdata.clear();
   
 }
 
@@ -95,16 +85,14 @@ void ProcessTestSignal::builddata()
 {
   
   int _code(0);
-  std::vector<RPCData*>::iterator itr;
-  
-  for(itr = m_vecdata.begin(); itr != m_vecdata.end(); ++itr)
+  for(auto& d : m_vecdata)
   {
     for(int k=0; k < 6; ++k) {
       
-      _code = 10000*(*itr)->m_wheel
-        + 100*(*itr)->m_sec1[k]
-        + 1*(*itr)->m_sec2[k];
-      RBCInput * _signal = & (*itr)->m_orsignals[k];
+      _code = 10000*(d->m_wheel)
+        + 100*d->m_sec1[k]
+        + 1*d->m_sec2[k];
+      RBCInput * _signal = & (d->m_orsignals[k]);
       _signal->needmapping = true;
       m_data.insert( std::make_pair( _code , _signal) );
       

--- a/L1Trigger/RPCTechnicalTrigger/src/RBCBasicConfig.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RBCBasicConfig.cc
@@ -14,33 +14,15 @@
 //=============================================================================
 // Standard constructor, initializes variables
 //=============================================================================
-RBCBasicConfig::RBCBasicConfig( const RBCBoardSpecs * rbcspecs , RBCId * info )
+RBCBasicConfig::RBCBasicConfig( const RBCBoardSpecs * rbcspecs , RBCId * info ) :
+  RBCConfiguration(rbcspecs),
+  m_debug{false}
 {
-  
-  m_rbcboardspecs  = rbcspecs;
-  m_rbclogic       = new RBCLogicUnit();
-  m_rbcinfo        = new RBCId( *info );
+}  
 
-  m_debug = false;
-    
-}
 
-RBCBasicConfig::RBCBasicConfig( const char * _logic ) {
-  
-  m_rbclogic  = new RBCLogicUnit( _logic );
-  
-}
-//=============================================================================
-// Destructor
-//=============================================================================
-RBCBasicConfig::~RBCBasicConfig() {
-  
-  if ( m_rbcinfo  ) delete m_rbcinfo;
-  if ( m_rbclogic ) delete m_rbclogic;
-
-  m_vecmask.clear();
-  m_vecforce.clear();
-  
+RBCBasicConfig::RBCBasicConfig( const char * _logic ):
+  RBCConfiguration(_logic) {
 }
 
 //=============================================================================

--- a/L1Trigger/RPCTechnicalTrigger/src/RBCChamberORLogic.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RBCChamberORLogic.cc
@@ -14,20 +14,20 @@
 // Standard constructor, initializes variables
 //=============================================================================
 RBCChamberORLogic::RBCChamberORLogic(  ) {
-  
-  m_rbname.push_back(std::string("RB1InFw"));
-  m_rbname.push_back(std::string("RB1OutFw"));
-  m_rbname.push_back(std::string("RB22Fw"));
-  m_rbname.push_back(std::string("RB23Fw"));
-  m_rbname.push_back(std::string("RB23M"));
-  m_rbname.push_back(std::string("RB3Fw"));
-  m_rbname.push_back(std::string("RB4Fw"));
-  m_rbname.push_back(std::string("RB1InBk"));
-  m_rbname.push_back(std::string("RB1OutBk"));
-  m_rbname.push_back(std::string("RB22Bk"));
-  m_rbname.push_back(std::string("RB23Bk"));
-  m_rbname.push_back(std::string("RB3Bk"));
-  m_rbname.push_back(std::string("RB4Bk"));
+  m_rbname.reserve(13);
+  m_rbname.emplace_back("RB1InFw");
+  m_rbname.emplace_back("RB1OutFw");
+  m_rbname.emplace_back("RB22Fw");
+  m_rbname.emplace_back("RB23Fw");
+  m_rbname.emplace_back("RB23M");
+  m_rbname.emplace_back("RB3Fw");
+  m_rbname.emplace_back("RB4Fw");
+  m_rbname.emplace_back("RB1InBk");
+  m_rbname.emplace_back("RB1OutBk");
+  m_rbname.emplace_back("RB22Bk");
+  m_rbname.emplace_back("RB23Bk");
+  m_rbname.emplace_back("RB3Bk");
+  m_rbname.emplace_back("RB4Bk");
   
   itr2names itr = m_rbname.begin();
   
@@ -40,20 +40,7 @@ RBCChamberORLogic::RBCChamberORLogic(  ) {
   m_maxcb    = 13;
   m_maxlevel = 3; // 1 <= m <= 6
 
-  m_layersignal = new std::bitset<6>[2];
-  m_layersignal[0].reset();
-  m_layersignal[1].reset();
-  
 }
-
-//=============================================================================
-// Destructor
-//=============================================================================
-RBCChamberORLogic::~RBCChamberORLogic() {
-  
-  if ( m_layersignal ) delete[] m_layersignal;
-  
-} 
 
 //=============================================================================
 

--- a/L1Trigger/RPCTechnicalTrigger/src/RBCConfiguration.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RBCConfiguration.cc
@@ -1,0 +1,40 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger/RPCTechnicalTrigger
+// Class  :     RBCConfiguration
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 15 Nov 2018 21:02:24 GMT
+//
+
+// system include files
+
+// user include files
+#include "L1Trigger/RPCTechnicalTrigger/interface/RBCConfiguration.h"
+
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+RBCConfiguration::RBCConfiguration(const RBCBoardSpecs * rbcspecs):
+  m_rbcboardspecs{rbcspecs},
+  m_rbclogic{std::make_unique<RBCLogicUnit>()}
+{
+}
+
+RBCConfiguration::RBCConfiguration(const char * _logic):
+  m_rbcboardspecs{nullptr},
+  m_rbclogic{std::make_unique<RBCLogicUnit>( _logic )}
+{}
+

--- a/L1Trigger/RPCTechnicalTrigger/src/RBCId.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RBCId.cc
@@ -25,20 +25,8 @@ RBCId::RBCId( int _w, int * _s )
   m_sector[1] = _s[1];
 }
 
-RBCId::RBCId( const RBCId & id ) 
-{
-  m_wheel     = id.wheel();
-  m_sector[0] = id.sector(0);
-  m_sector[1] = id.sector(1);
-}
-
 //=============================================================================
-// Destructor
-//=============================================================================
-RBCId::~RBCId() {} 
-
-//=============================================================================
-void RBCId::printinfo()
+void RBCId::printinfo() const
 {
   
   std::cout << " ---->whe " << m_wheel << '\n';

--- a/L1Trigger/RPCTechnicalTrigger/src/RBCInput.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RBCInput.cc
@@ -23,7 +23,7 @@ std::istream& operator>>(std::istream &istr , RBCInput & rhs) {
 
 }
 
-std::ostream& operator<<(std::ostream &ostr , RBCInput & rhs) {
+std::ostream& operator<<(std::ostream &ostr , RBCInput const & rhs) {
   
   for(int i=0; i < 15; ++i) ostr << rhs.input_sec[0][i];
   ostr << '\t';

--- a/L1Trigger/RPCTechnicalTrigger/src/RBCLinkBoardSignal.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RBCLinkBoardSignal.cc
@@ -14,19 +14,9 @@
 //=============================================================================
 // Standard constructor, initializes variables
 //=============================================================================
-RBCLinkBoardSignal::RBCLinkBoardSignal( RBCInput * in ) {
-
-  RBCInput * m_linkboardin = new RBCInput();
-  (*m_linkboardin) = (*in);
-  
+RBCLinkBoardSignal::RBCLinkBoardSignal( RBCInput * in ) :
+  m_linkboardin{*in}
+{
 }
-//=============================================================================
-// Destructor
-//=============================================================================
-RBCLinkBoardSignal::~RBCLinkBoardSignal() {
-  
-  if ( m_linkboardin ) delete m_linkboardin;
-
-} 
 
 //=============================================================================

--- a/L1Trigger/RPCTechnicalTrigger/src/RBCLogicUnit.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RBCLogicUnit.cc
@@ -14,44 +14,29 @@
 //=============================================================================
 // Standard constructor, initializes variables
 //=============================================================================
-RBCLogicUnit::RBCLogicUnit( ) : RPCLogicUnit() {
-  
-  m_logtool = new LogicTool<RBCLogic>();
-  m_debug = false;
-  
+RBCLogicUnit::RBCLogicUnit( ) : RPCLogicUnit(),
+                                m_debug{false}
+{
 }
 
-RBCLogicUnit::RBCLogicUnit( const char * logic_type ) : RPCLogicUnit() {
-  
-  m_logtool = new LogicTool<RBCLogic>();
-  m_logtype = std::string( logic_type );
-  m_debug = false;
-
+RBCLogicUnit::RBCLogicUnit( const char * logic_type ) : RPCLogicUnit(),
+  m_logtype{ logic_type },
+  m_debug{ false }
+{
 }
 //=============================================================================
 // Destructor
 //=============================================================================
 RBCLogicUnit::~RBCLogicUnit() {
-  
-  if (m_logtool) {
-    if ( m_logtool->endjob() )
-      delete m_logtool;
-  }
-  
 } 
 
 //=============================================================================
 bool RBCLogicUnit::initialise() 
 {
   
-  bool status(false);
-  
-  status = m_logtool->initialise();
-  if ( !status ) { 
-    if( m_debug ) std::cout << "RBCLogicUnit> Problem initialising LogicTool \n"; 
-    return false; };
-  
-  m_logic  = dynamic_cast<RBCLogic*> ( m_logtool->retrieve(m_logtype) );
+  LogicTool<RBCLogic> logtool;
+
+  m_logic  = logtool.retrieve(m_logtype);
   
   if ( ! m_logic ) { 
     if( m_debug ) std::cout << "RBCLogicUnit> No logic found \n"; 
@@ -79,5 +64,4 @@ void RBCLogicUnit::run( const RBCInput & _input , std::bitset<2> & _decision )
   m_logic->process( _input , _decision );
   m_layersignal[0] = m_logic->getlayersignal( 0 );
   m_layersignal[1] = m_logic->getlayersignal( 1 );
-  
 }

--- a/L1Trigger/RPCTechnicalTrigger/src/RBCProcessRPCSimDigis.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RBCProcessRPCSimDigis.cc
@@ -4,12 +4,15 @@
 #include "L1Trigger/RPCTechnicalTrigger/interface/RBCProcessRPCSimDigis.h"
 #include "L1Trigger/RPCTechnicalTrigger/interface/RBCLinkBoardGLSignal.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "GeometryConstants.h"
 
 //-----------------------------------------------------------------------------
 // Implementation file for class : RBCProcessRPCSimDigis
 //
 // 2009-09-20 : Andres Felipe Osorio Oliveros
 //-----------------------------------------------------------------------------
+using namespace rpctechnicaltrigger;
+
 
 RBCProcessRPCSimDigis::RBCProcessRPCSimDigis( const edm::ESHandle<RPCGeometry> & rpcGeom, 
                                               const edm::Handle<edm::DetSetVector<RPCDigiSimLink> > & digiSimLink)
@@ -18,59 +21,9 @@ RBCProcessRPCSimDigis::RBCProcessRPCSimDigis( const edm::ESHandle<RPCGeometry> &
   m_ptr_rpcGeom  = & rpcGeom;
   m_ptr_digiSimLink = & digiSimLink;
   
-  m_lbin = dynamic_cast<RPCInputSignal*>( new RBCLinkBoardGLSignal( &m_data ) );
+  m_lbin = std::make_unique<RBCLinkBoardGLSignal>( &m_data ) ;
   
   m_debug = false;
-  
-  configure();
-  
-}
-
-void RBCProcessRPCSimDigis::configure() 
-{
-  
-  m_wheelid.push_back(-2); //-2
-  m_wheelid.push_back(-1); //-1
-  m_wheelid.push_back(0);  // 0
-  m_wheelid.push_back( 1); //+1
-  m_wheelid.push_back( 2); //+2
-  
-  m_sec1id.push_back(12);
-  m_sec2id.push_back(1);
-  m_sec1id.push_back(2);
-  m_sec2id.push_back(3);
-  m_sec1id.push_back(4);
-  m_sec2id.push_back(5);
-  m_sec1id.push_back(6);
-  m_sec2id.push_back(7);
-  m_sec1id.push_back(8);
-  m_sec2id.push_back(9);
-  m_sec1id.push_back(10);
-  m_sec2id.push_back(11);
-  
-  m_layermap[113]     = 0;  //RB1InFw
-  m_layermap[123]     = 1;  //RB1OutFw
-  
-  m_layermap[20213]   = 2;  //RB22Fw
-  m_layermap[20223]   = 2;  //RB22Fw
-  m_layermap[30223]   = 3;  //RB23Fw
-  m_layermap[30213]   = 3;  //RB23Fw
-  m_layermap[30212]   = 4;  //RB23M
-  m_layermap[30222]   = 4;  //RB23M
-  
-  m_layermap[313]     = 5;  //RB3Fw
-  m_layermap[413]     = 6;  //RB4Fw
-  m_layermap[111]     = 7;  //RB1InBk
-  m_layermap[121]     = 8;  //RB1OutBk
-  
-  m_layermap[20211]   = 9;  //RB22Bw
-  m_layermap[20221]   = 9;  //RB22Bw
-  m_layermap[30211]   = 10; //RB23Bw
-  m_layermap[30221]   = 10; //RB23Bw
-  
-  m_layermap[311]     = 11; //RB3Bk
-  m_layermap[411]     = 12; //RB4Bk
-  
   m_maxBxWindow = 3;
   
 }
@@ -79,16 +32,7 @@ void RBCProcessRPCSimDigis::configure()
 // Destructor
 //=============================================================================
 RBCProcessRPCSimDigis::~RBCProcessRPCSimDigis() {
-  
-  if ( m_lbin ) delete m_lbin;
-
-  m_sec1id.clear();
-  m_sec2id.clear();
-  m_wheelid.clear();
-  m_layermap.clear();
-
   reset();
-  
 } 
 
 //=============================================================================
@@ -156,20 +100,18 @@ int RBCProcessRPCSimDigis::next() {
                                << "Digi at: " << digipos << '\n';
       
       //... Construct the RBCinput objects
-      std::map<int,std::vector<RPCData*> >::iterator itr;
-      itr = m_vecDataperBx.find( bx );
+      auto itr = m_vecDataperBx.find( bx );
       
       if ( itr == m_vecDataperBx.end() ) {
         if ( m_debug ) std::cout << "Found a new Bx: " << bx << std::endl;
-        std::vector<RPCData*> wheelData;
+        auto& wheelData = m_vecDataperBx[bx];
         initialize(wheelData);
-        m_vecDataperBx[bx] = wheelData; 
-        this->m_block = wheelData[ (wheel + 2) ];
-        setDigiAt( sector, digipos );
+        auto& block = wheelData[ (wheel + 2) ];
+        setDigiAt( sector, digipos, block );
       }
       else{
-        this->m_block = (*itr).second[ (wheel + 2) ];
-        setDigiAt( sector, digipos );
+        auto& block = (*itr).second[ (wheel + 2) ];
+        setDigiAt( sector, digipos, block );
       }
       
       if ( m_debug ) std::cout << "looping over digis 2 ..." << std::endl;
@@ -201,43 +143,34 @@ int RBCProcessRPCSimDigis::next() {
 void RBCProcessRPCSimDigis::reset()
 {
   
-  std::map<int,std::vector<RPCData*> >::iterator itr1;
-  for( itr1 = m_vecDataperBx.begin(); itr1 != m_vecDataperBx.end(); ++itr1) {
-    std::vector<RPCData*>::iterator itr2;
-    for(itr2 = (*itr1).second.begin(); itr2 != (*itr1).second.end();++itr2 )
-      if ( (*itr2) ) delete *itr2;
-    (*itr1).second.clear();
-  }
   m_vecDataperBx.clear();
   
 }
 
 
-void RBCProcessRPCSimDigis::initialize( std::vector<RPCData*> & dataVec ) 
+void RBCProcessRPCSimDigis::initialize( std::vector<RPCData> & dataVec ) 
 {
   
   if ( m_debug ) std::cout << "initialize" << std::endl;
   
-  int maxWheels = 5;
-  int maxRbcBrds = 6;
+  constexpr int maxWheels = 5;
+  constexpr int maxRbcBrds = 6;
   
+  dataVec.reserve(maxWheels);
   for(int i=0; i < maxWheels; ++i) {
     
-    m_block = new RPCData();
+    auto& block = dataVec.emplace_back();
     
-    m_block->m_wheel = m_wheelid[i];
+    block.m_wheel = s_wheelid[i];
     
     for(int j=0; j < maxRbcBrds; ++j) {
-      m_block->m_sec1[j] = m_sec1id[j];
-      m_block->m_sec2[j] = m_sec2id[j];
-      m_block->m_orsignals[j].input_sec[0].reset();
-      m_block->m_orsignals[j].input_sec[1].reset();
-      m_block->m_orsignals[j].needmapping = false;
-      m_block->m_orsignals[j].hasData = false;
+      block.m_sec1[j] = s_sec1id[j];
+      block.m_sec2[j] = s_sec2id[j];
+      block.m_orsignals[j].input_sec[0].reset();
+      block.m_orsignals[j].input_sec[1].reset();
+      block.m_orsignals[j].needmapping = false;
+      block.m_orsignals[j].hasData = false;
     }
-
-    dataVec.push_back( m_block );
-    
   }
   
   if ( m_debug ) std::cout << "initialize: completed" << std::endl;
@@ -247,33 +180,27 @@ void RBCProcessRPCSimDigis::initialize( std::vector<RPCData*> & dataVec )
 void RBCProcessRPCSimDigis::builddata() 
 {
   
-  int bx(0);
   int code(0);
-  int bxsign(1);
-  std::vector<RPCData*>::iterator itr;
-  std::map<int, std::vector<RPCData*> >::iterator itr2;
   
-  itr2 = m_vecDataperBx.begin();
-  if( itr2 == ( m_vecDataperBx.end() ) ) return;
-  
-  while ( itr2 != m_vecDataperBx.end() ) {
+  for(auto& dataPerBx: m_vecDataperBx) {
     
-    bx = (*itr2).first;
+    int bx = dataPerBx.first;
     
+    int bxsign;
     if ( bx != 0 ) bxsign = ( bx / abs(bx) );
     else bxsign = 1;
     
-    for(itr = (*itr2).second.begin(); itr != (*itr2).second.end(); ++itr) {
+    for(auto& item : dataPerBx.second) {
       
       for(int k=0; k < 6; ++k) {
         
         code = bxsign * ( 1000000*abs(bx)
-                          + 10000*(*itr)->wheelIdx()
-                          + 100  *(*itr)->m_sec1[k]
-                          + 1    *(*itr)->m_sec2[k] );
+                          + 10000*item.wheelIdx()
+                          + 100  *item.m_sec1[k]
+                          + 1    *item.m_sec2[k] );
 
         
-        RBCInput * signal = & (*itr)->m_orsignals[k];
+        RBCInput * signal = & item.m_orsignals[k];
         signal->needmapping = false;
         
         if ( signal->hasData )
@@ -281,12 +208,9 @@ void RBCProcessRPCSimDigis::builddata()
         
       }
     }
-    
-    ++itr2;
-    
   }
   
-  if ( m_debug ) std::cout << "builddata: completed. size of data: " << m_data.size() << std::endl;
+  if ( m_debug and not m_vecDataperBx.empty()) std::cout << "builddata: completed. size of data: " << m_data.size() << std::endl;
   
 }
 
@@ -308,7 +232,7 @@ int RBCProcessRPCSimDigis::getBarrelLayer( const int & _layer, const int & _stat
 }
 
 
-void RBCProcessRPCSimDigis::setDigiAt( int sector, int digipos )
+void RBCProcessRPCSimDigis::setDigiAt( int sector, int digipos, RPCData& block )
 {
   
   int pos   = 0;
@@ -316,26 +240,25 @@ void RBCProcessRPCSimDigis::setDigiAt( int sector, int digipos )
 
   if ( m_debug ) std::cout << "setDigiAt" << std::endl;
   
-  std::vector<int>::const_iterator itr;
-  itr = std::find( m_sec1id.begin(), m_sec1id.end(), sector );
+  auto itr = std::find( s_sec1id.begin(), s_sec1id.end(), sector );
   
-  if ( itr == m_sec1id.end()) {
-    itr = std::find( m_sec2id.begin(), m_sec2id.end(), sector );
+  if ( itr == s_sec1id.end()) {
+    itr = std::find( s_sec2id.begin(), s_sec2id.end(), sector );
     isAoB = 1;
   } 
   
   for ( pos = 0; pos < 6; ++pos ) {
-    if (this->m_block->m_sec1[pos] == sector || this->m_block->m_sec2[pos] == sector )
+    if (block.m_sec1[pos] == sector || block.m_sec2[pos] == sector )
       break;
   }
   
-  if ( m_debug ) std::cout << this->m_block->m_orsignals[pos];
+  if ( m_debug ) std::cout << block.m_orsignals[pos];
   
-  setInputBit( this->m_block->m_orsignals[pos].input_sec[ isAoB ] , digipos );
+  setInputBit( block.m_orsignals[pos].input_sec[ isAoB ] , digipos );
   
-  this->m_block->m_orsignals[pos].hasData = true;
+  block.m_orsignals[pos].hasData = true;
   
-  if ( m_debug ) std::cout << this->m_block->m_orsignals[pos];
+  if ( m_debug ) std::cout << block.m_orsignals[pos];
   
   if ( m_debug ) std::cout << "setDigiAt completed" << std::endl;
   
@@ -344,7 +267,7 @@ void RBCProcessRPCSimDigis::setDigiAt( int sector, int digipos )
 void RBCProcessRPCSimDigis::setInputBit( std::bitset<15> & signals , int digipos ) 
 {
   
-  int bitpos = m_layermap[digipos];
+  int bitpos = s_layermap.at(digipos);
   if( m_debug ) std::cout << "Bitpos: " << bitpos << std::endl;
   signals.set( bitpos , true );
   

--- a/L1Trigger/RPCTechnicalTrigger/src/RBCProcessTestSignal.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RBCProcessTestSignal.cc
@@ -13,20 +13,18 @@
 //=============================================================================
 // Standard constructor, initializes variables
 //=============================================================================
-RBCProcessTestSignal::RBCProcessTestSignal( const char * f_name )
+RBCProcessTestSignal::RBCProcessTestSignal( const char * f_name ):
+  m_in{},
+  m_input{},
+  m_lbin{std::make_unique<RBCLinkBoardSignal>( &m_input ) }
 {
+  m_in.open(f_name);
   
-  m_in = new std::ifstream();
-  m_in->open(f_name);
-  
-  if(!m_in->is_open()) {
+  if(!m_in.is_open()) {
     std::cout << "RBCProcessTestSignal> cannot open file" << std::endl;
   } else { 
     std::cout << "RBCProcessTestSignal> file is now open" << std::endl;
   }
-  
-  m_input = new RBCInput();
-  m_lbin  = dynamic_cast<RPCInputSignal*>( new RBCLinkBoardSignal( m_input ) );
   
   showfirst();
 
@@ -36,13 +34,7 @@ RBCProcessTestSignal::RBCProcessTestSignal( const char * f_name )
 //=============================================================================
 RBCProcessTestSignal::~RBCProcessTestSignal() 
 {
-  m_in->close();
-  delete m_in;
-
-  if ( m_lbin  ) delete m_lbin;
-  
-  if ( m_input ) delete m_input;
-  
+  m_in.close();
 } 
 
 //=============================================================================
@@ -50,9 +42,9 @@ RBCProcessTestSignal::~RBCProcessTestSignal()
 int RBCProcessTestSignal::next()
 {
   
-  if ( m_in->fail()) return 0;
-  (*m_in) >> (*m_input);
-  if ( m_in->eof() ) return 0;
+  if ( m_in.fail()) return 0;
+  m_in >> m_input;
+  if ( m_in.eof() ) return 0;
   return 1;
   
 }
@@ -60,15 +52,15 @@ int RBCProcessTestSignal::next()
 void RBCProcessTestSignal::showfirst() 
 {
   rewind();
-  (*m_in) >> (*m_input);
-  std::cout << (*m_input);
+  m_in >> m_input;
+  std::cout << m_input;
   rewind();
   
 }
 
 void RBCProcessTestSignal::rewind() 
 { 
-  m_in->clear();
-  m_in->seekg(0,std::ios::beg); 
+  m_in.clear();
+  m_in.seekg(0,std::ios::beg); 
 }
 

--- a/L1Trigger/RPCTechnicalTrigger/src/RPCData.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RPCData.cc
@@ -30,11 +30,6 @@ namespace l1trigger {
   
   }
 
-  Counters::~Counters()
-  {
-    m_sector.clear();
-  }
-
   void Counters::evalCounters()
   {
   
@@ -75,13 +70,13 @@ namespace l1trigger {
 
   }
 
-  void Counters::printSummary()
+  void Counters::printSummary() const
   {
 
     std::cout << m_wheelid << std::endl;
     std::map<int,int>::iterator itr;
-    for(itr = m_sector.begin(); itr != m_sector.end(); ++itr)
-      std::cout << (*itr).first << ": " << (*itr).second << '\t';
+    for(auto const& s :m_sector)
+      std::cout << s.first << ": " << s.second << '\t';
     std::cout << '\n';
   
     std::cout << "total wheel: " 
@@ -95,23 +90,8 @@ namespace l1trigger {
 }
 
 RPCData::RPCData() {
-  
   m_wheel     = 10;
-  m_sec1      = new int[6];
-  m_sec2      = new int[6];
-  m_orsignals = new RBCInput[6];
-
 }
-//=============================================================================
-// Destructor
-//=============================================================================
-RPCData::~RPCData() {
-  
-  delete [] m_sec1;
-  delete [] m_sec2;
-  delete [] m_orsignals;
-  
-} 
 
 //=============================================================================
 
@@ -129,7 +109,7 @@ std::istream& operator>>(std::istream &istr , RPCData & rhs)
     
 }
 
-std::ostream& operator<<(std::ostream& ostr , RPCData & rhs) 
+std::ostream& operator<<(std::ostream& ostr , RPCData const & rhs) 
 {
   
   ostr << rhs.m_wheel << '\t';

--- a/L1Trigger/RPCTechnicalTrigger/src/RPCTechnicalTrigger.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RPCTechnicalTrigger.cc
@@ -25,18 +25,30 @@
 // Standard constructor, initializes variables
 //=============================================================================
 
-RPCTechnicalTrigger::RPCTechnicalTrigger(const edm::ParameterSet& iConfig) {
+namespace {
+  //...........................................................................
+  //For the pointing Logic: declare here the first sector of each quadrant
+  //
+  constexpr std::array<int,10> s_quadrants = { {2,3,4,5,6,7,8,9,10,11} };
+
+  //The wheelTtu is addressed using -2, -1, 0, 1, 2
+  constexpr unsigned int kWheelOffset = 2;
+  constexpr std::array<int, 5> wheelTtu = { {3,3,2,1,1} };
+}
+
+RPCTechnicalTrigger::RPCTechnicalTrigger(const edm::ParameterSet& iConfig):
+  m_verbosity{ iConfig.getUntrackedParameter<int>("Verbosity", 0)},
+  m_useEventSetup{iConfig.getUntrackedParameter<int>("UseEventSetup", 0)},
+  m_ttBits{iConfig.getParameter< std::vector<unsigned> >("BitNumbers")},
+  m_ttNames{iConfig.getParameter< std::vector<std::string> >("BitNames")},
+  m_rpcDigiLabel{iConfig.getParameter<edm::InputTag>("RPCDigiLabel")},
+  m_rpcDigiToken{consumes<RPCDigiCollection>(m_rpcDigiLabel)},
+  m_useRPCSimLink{iConfig.getUntrackedParameter<int>("UseRPCSimLink", 0)}
+{
   
   //...........................................................................
   
   std::string configFile  = iConfig.getParameter<std::string>("ConfigFile");
-  m_verbosity             = iConfig.getUntrackedParameter<int>("Verbosity", 0);
-  m_rpcDigiLabel          = iConfig.getParameter<edm::InputTag>("RPCDigiLabel");
-  m_ttBits                = iConfig.getParameter< std::vector<unsigned> >("BitNumbers");
-  m_ttNames               = iConfig.getParameter< std::vector<std::string> >("BitNames");
-  m_useEventSetup         = iConfig.getUntrackedParameter<int>("UseEventSetup", 0);
-  m_useRPCSimLink         = iConfig.getUntrackedParameter<int>("UseRPCSimLink", 0);
-  m_rpcSimLinkInstance    = iConfig.getParameter<edm::InputTag>("RPCSimLinkInstance");
 
   edm::FileInPath f1("L1Trigger/RPCTechnicalTrigger/data/" + configFile);
   m_configFile = f1.fullPath();
@@ -55,81 +67,28 @@ RPCTechnicalTrigger::RPCTechnicalTrigger(const edm::ParameterSet& iConfig) {
   //... There are three Technical Trigger Units Boards: 1 can handle 2 Wheels
   //... n_Wheels sets the number of wheels attached to board with index boardIndex
   
-  m_boardIndex[0] = 1;
-  m_boardIndex[1] = 2;
-  m_boardIndex[2] = 3;
-  
-  m_nWheels[0]    = 2;
-  m_nWheels[1]    = 1;
-  m_nWheels[2]    = 2;
-  
-  m_ttu[0] = new TTUEmulator( m_boardIndex[0] , m_nWheels[0] );
-  m_ttu[1] = new TTUEmulator( m_boardIndex[1] , m_nWheels[1] );
-  m_ttu[2] = new TTUEmulator( m_boardIndex[2] , m_nWheels[2] );
+  constexpr std::array<int,3> boardIndex={{1,2,3}};
+  constexpr std::array<int,3> nWheels = { {2,1,2} };
+
+  m_ttu[0] = TTUEmulator( boardIndex[0] , nWheels[0] );
+  m_ttu[1] = TTUEmulator( boardIndex[1] , nWheels[1] );
+  m_ttu[2] = TTUEmulator( boardIndex[2] , nWheels[2] );
 
   //... This is second line that delivers in parallel a second trigger
-  m_ttuRbcLine[0] = new TTUEmulator( m_boardIndex[0] , m_nWheels[0] );
-  m_ttuRbcLine[1] = new TTUEmulator( m_boardIndex[1] , m_nWheels[1] );
-  m_ttuRbcLine[2] = new TTUEmulator( m_boardIndex[2] , m_nWheels[2] );
-  
-  m_WheelTtu[-2] = 3;
-  m_WheelTtu[-1] = 3;
-  m_WheelTtu[0 ] = 2;
-  m_WheelTtu[1 ] = 1;
-  m_WheelTtu[2 ] = 1;
+  m_ttuRbcLine[0] = TTUEmulator( boardIndex[0] , nWheels[0] );
+  m_ttuRbcLine[1] = TTUEmulator( boardIndex[1] , nWheels[1] );
+  m_ttuRbcLine[2] = TTUEmulator( boardIndex[2] , nWheels[2] );
   
   //...........................................................................
-  //For the pointing Logic: declare here the first sector of each quadrant
-  //
-  m_quadrants.push_back(2);
-  m_quadrants.push_back(3);
-  m_quadrants.push_back(4);
-  m_quadrants.push_back(5);
-  m_quadrants.push_back(6);
-  m_quadrants.push_back(7);
-  m_quadrants.push_back(8);
-  m_quadrants.push_back(9);
-  m_quadrants.push_back(10);
-  m_quadrants.push_back(11);
-
-  //...........................................................................
   
-  m_ievt = 0;
-  m_cand = 0;
-  m_maxTtuBoards = 3;
-  m_maxBits = 5;
   m_hasConfig = false;
-  m_readConfig = nullptr;
   produces<L1GtTechnicalTriggerRecord>();
-  consumes<RPCDigiCollection>(m_rpcDigiLabel);
   consumes<edm::DetSetVector<RPCDigiSimLink> >(edm::InputTag("simMuonRPCDigis", "RPCDigiSimLink",""));
 }
 
 
 RPCTechnicalTrigger::~RPCTechnicalTrigger()
-{
-  
-  LogDebug("RPCTechnicalTrigger") << "RPCTechnicalTrigger: object starts deletion" << std::endl;
-
-  if ( m_hasConfig ) {
-    
-    delete m_ttu[0];
-    delete m_ttu[1];
-    delete m_ttu[2];
-    
-    delete m_ttuRbcLine[0];
-    delete m_ttuRbcLine[1];
-    delete m_ttuRbcLine[2];
-    
-    if ( m_readConfig )
-      delete m_readConfig;
-    
-  }
-  
-  m_WheelTtu.clear();
-    
-  LogDebug("RPCTechnicalTrigger") << "RPCTechnicalTrigger: object deleted" << '\n';
-  
+{  
 }
 
 //=============================================================================
@@ -144,15 +103,21 @@ void RPCTechnicalTrigger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   
   std::unique_ptr<L1GtTechnicalTriggerRecord> output(new L1GtTechnicalTriggerRecord());
   
+  //.   Set up RPC geometry
+  edm::ESHandle<RPCGeometry> rpcGeometry;
+  iSetup.get<MuonGeometryRecord>().get( rpcGeometry );
+
+  std::unique_ptr<ProcessInputSignal> signal;
   if ( m_useRPCSimLink == 0 ) {
-    iEvent.getByLabel(m_rpcDigiLabel, pIn);
+    iEvent.getByToken(m_rpcDigiToken, pIn);
     if ( ! pIn.isValid() ) {
       edm::LogError("RPCTechnicalTrigger") << "can't find RPCDigiCollection with label: " 
                                            << m_rpcDigiLabel << '\n';
       iEvent.put(std::move(output));
       return;
     }
-    m_signal  = dynamic_cast<ProcessInputSignal*>(new RBCProcessRPCDigis( m_rpcGeometry, pIn ));
+  
+    signal  = std::make_unique<RBCProcessRPCDigis>( rpcGeometry, pIn );
     
   } else {
     
@@ -164,7 +129,7 @@ void RPCTechnicalTrigger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       iEvent.put(std::move(output));
       return;
     }
-    m_signal  = dynamic_cast<ProcessInputSignal*>(new RBCProcessRPCSimDigis( m_rpcGeometry, simIn ));
+    signal  = std::make_unique<RBCProcessRPCSimDigis>( rpcGeometry, simIn );
   }
   
   LogDebug("RPCTechnicalTrigger") << "signal object created" << '\n';
@@ -175,46 +140,47 @@ void RPCTechnicalTrigger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     return;
   }
   
-  status = m_signal->next();
+  status = signal->next();
   
   if ( !status)  { 
-    delete m_signal;
     iEvent.put(std::move(output));
     return;
   }
   
-  m_input = m_signal->retrievedata();
+  auto* input = signal->retrievedata();
   
   std::vector<L1GtTechnicalTrigger> ttVec( m_ttBits.size() );
   
   //. distribute data to different TTU emulator instances and process it
-  
-  m_triggerbits.reset();
+  std::bitset<5> triggerbits;
   
   std::vector<TTUEmulator::TriggerResponse*>::const_iterator outItr;
-  
-  for(int k=0; k < m_maxTtuBoards; ++k) {
+
+  std::vector<std::unique_ptr<TTUResults>> serializedInfoLine1;
+  std::vector<std::unique_ptr<TTUResults>> serializedInfoLine2;
+
+  for(int k=0; k < kMaxTtuBoards; ++k) {
     
-    m_ttu[k]->processTtu( m_input );
+    m_ttu[k].processTtu( input );
     
     //work out Pointing Logic to Tracker
-    for( m_firstSector = m_quadrants.begin(); m_firstSector != m_quadrants.end(); ++m_firstSector)
-      m_ttuRbcLine[k]->processTtu( m_input , (*m_firstSector) );
+    for( auto  firstSector : s_quadrants)
+      m_ttuRbcLine[k].processTtu( input , firstSector );
     
     //...for trigger 1
-    for( outItr  = m_ttu[k]->m_triggerBxVec.begin(); outItr != m_ttu[k]->m_triggerBxVec.end(); ++outItr )
-      m_serializedInfoLine1.push_back( new TTUResults( k, (*outItr)->m_bx, (*outItr)->m_trigger[0], (*outItr)->m_trigger[1] ) );
-    m_ttu[k]->clearTriggerResponse();
+    for( auto const& out : m_ttu[k].m_triggerBxVec)
+      serializedInfoLine1.emplace_back( std::make_unique<TTUResults>( k, out.m_bx, out.m_trigger[0], out.m_trigger[1] ) );
+    m_ttu[k].clearTriggerResponse();
     
     //...for trigger 2
-    for( outItr  = m_ttuRbcLine[k]->m_triggerBxVec.begin(); outItr != m_ttuRbcLine[k]->m_triggerBxVec.end(); ++outItr )
-      m_serializedInfoLine2.push_back( new TTUResults( k, 
-                                                       (*outItr)->m_bx, 
-                                                       (*outItr)->m_trigger[0], 
-                                                       (*outItr)->m_trigger[1], 
-                                                       (*outItr)->m_wedge ) );
+    for( auto const& out : m_ttuRbcLine[k].m_triggerBxVec)
+      serializedInfoLine2.push_back( std::make_unique<TTUResults>( k, 
+                                                                   out.m_bx, 
+                                                                   out.m_trigger[0], 
+                                                                   out.m_trigger[1], 
+                                                                   out.m_wedge ) );
     
-    m_ttuRbcLine[k]->clearTriggerResponse();
+    m_ttuRbcLine[k].clearTriggerResponse();
     
   }
   
@@ -222,45 +188,48 @@ void RPCTechnicalTrigger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   int bx(0);
   int infoSize(0);
   
-  infoSize = m_serializedInfoLine1.size();
+  infoSize = serializedInfoLine1.size();
 
-  std::vector<RPCTechnicalTrigger::TTUResults*>::const_iterator ttuItr;
+  auto sortByBx = [](auto& iLHS, auto& iRHS) {
+      return iLHS->m_bx < iRHS->m_bx;
+  };
+  std::sort( serializedInfoLine1.begin(), serializedInfoLine1.end(), sortByBx );
   
-  std::sort( m_serializedInfoLine1.begin(), m_serializedInfoLine1.end(), sortByBx() );
-  
-  for( ttuItr = m_serializedInfoLine1.begin(); ttuItr != m_serializedInfoLine1.end(); ++ttuItr ) {
-    if ( m_verbosity && abs( (*ttuItr)->m_bx ) <= 1 ) 
-      std::cout << "RPCTechnicalTrigger> " 
-                << (*ttuItr)->m_ttuidx << '\t'
-                << (*ttuItr)->m_bx << '\t'
-                << (*ttuItr)->m_trigWheel1 << '\t'
-                << (*ttuItr)->m_trigWheel2 << '\n';
+  if( m_verbosity ) {
+    for( auto& ttu : serializedInfoLine1) {
+      if ( abs( ttu->m_bx ) <= 1 ) 
+        std::cout << "RPCTechnicalTrigger> " 
+                  << ttu->m_ttuidx << '\t'
+                  << ttu->m_bx << '\t'
+                  << ttu->m_trigWheel1 << '\t'
+                  << ttu->m_trigWheel2 << '\n';
+    }
   }
   
   bool has_bx0 = false;
   
-  for(int k = 0; k < infoSize; k+=m_maxTtuBoards) {
+  for(int k = 0; k < infoSize; k+=kMaxTtuBoards) {
     
-    bx = m_serializedInfoLine1[k]->m_bx;
+    bx = serializedInfoLine1[k]->m_bx;
     
     if ( bx == 0 ) {
       
-      m_triggerbits.set(0, m_serializedInfoLine1[k]->m_trigWheel2);
-      m_triggerbits.set(1, m_serializedInfoLine1[k]->m_trigWheel1);
-      m_triggerbits.set(2, m_serializedInfoLine1[k+1]->m_trigWheel1);
-      m_triggerbits.set(3, m_serializedInfoLine1[k+2]->m_trigWheel1);
-      m_triggerbits.set(4, m_serializedInfoLine1[k+2]->m_trigWheel2);
+      triggerbits.set(0, serializedInfoLine1[k]->m_trigWheel2);
+      triggerbits.set(1, serializedInfoLine1[k]->m_trigWheel1);
+      triggerbits.set(2, serializedInfoLine1[k+1]->m_trigWheel1);
+      triggerbits.set(3, serializedInfoLine1[k+2]->m_trigWheel1);
+      triggerbits.set(4, serializedInfoLine1[k+2]->m_trigWheel2);
       
-      bool five_wheels_OR = m_triggerbits.any();
+      bool five_wheels_OR = triggerbits.any();
       
       ttVec.at(0)=L1GtTechnicalTrigger(m_ttNames.at(0), m_ttBits.at(0), bx, five_wheels_OR ) ;   // bit 24 = Or 5 wheels in TTU mode
-      ttVec.at(2)=L1GtTechnicalTrigger(m_ttNames.at(2), m_ttBits.at(2), bx, m_triggerbits[0] ) ; // bit 26 
-      ttVec.at(3)=L1GtTechnicalTrigger(m_ttNames.at(3), m_ttBits.at(3), bx, m_triggerbits[1] ) ; // bit 27 
-      ttVec.at(4)=L1GtTechnicalTrigger(m_ttNames.at(4), m_ttBits.at(4), bx, m_triggerbits[2] ) ; // bit 28 
-      ttVec.at(5)=L1GtTechnicalTrigger(m_ttNames.at(5), m_ttBits.at(5), bx, m_triggerbits[3] ) ; // bit 29
-      ttVec.at(6)=L1GtTechnicalTrigger(m_ttNames.at(6), m_ttBits.at(6), bx, m_triggerbits[4] ) ; // bit 30
+      ttVec.at(2)=L1GtTechnicalTrigger(m_ttNames.at(2), m_ttBits.at(2), bx, triggerbits[0] ) ; // bit 26 
+      ttVec.at(3)=L1GtTechnicalTrigger(m_ttNames.at(3), m_ttBits.at(3), bx, triggerbits[1] ) ; // bit 27 
+      ttVec.at(4)=L1GtTechnicalTrigger(m_ttNames.at(4), m_ttBits.at(4), bx, triggerbits[2] ) ; // bit 28 
+      ttVec.at(5)=L1GtTechnicalTrigger(m_ttNames.at(5), m_ttBits.at(5), bx, triggerbits[3] ) ; // bit 29
+      ttVec.at(6)=L1GtTechnicalTrigger(m_ttNames.at(6), m_ttBits.at(6), bx, triggerbits[4] ) ; // bit 30
       
-      m_triggerbits.reset();
+      triggerbits.reset();
       
       has_bx0 = true;
       
@@ -270,55 +239,57 @@ void RPCTechnicalTrigger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     
   }
   
-  infoSize = m_serializedInfoLine2.size();
+  infoSize = serializedInfoLine2.size();
   
-  std::sort( m_serializedInfoLine2.begin(), m_serializedInfoLine2.end(), sortByBx() );
+  std::sort( serializedInfoLine2.begin(), serializedInfoLine2.end(), sortByBx );
   
-  for( ttuItr = m_serializedInfoLine2.begin(); ttuItr != m_serializedInfoLine2.end(); ++ttuItr ) {
-    if ( m_verbosity && abs ( (*ttuItr)->m_bx ) <= 1 )
-      std::cout << "RPCTechnicalTrigger> " 
-                << (*ttuItr)->m_ttuidx << '\t'
-                << (*ttuItr)->m_bx << '\t'
-                << (*ttuItr)->m_trigWheel1 << '\t'
-                << (*ttuItr)->m_trigWheel2 << '\t'
-                << (*ttuItr)->m_wedge << '\n';
+  if(m_verbosity) {
+    for( auto& ttu : serializedInfoLine2) {
+      if (abs ( ttu->m_bx ) <= 1 )
+        std::cout << "RPCTechnicalTrigger> " 
+                  << ttu->m_ttuidx << '\t'
+                  << ttu->m_bx << '\t'
+                  << ttu->m_trigWheel1 << '\t'
+                  << ttu->m_trigWheel2 << '\t'
+                  << ttu->m_wedge << '\n';
+    }
   }
   
-  infoSize = convertToMap( m_serializedInfoLine2 );
+  auto ttuResultsByQuadrant  = convertToMap( serializedInfoLine2 );
   
   std::bitset<8> triggerCoincidence;
   triggerCoincidence.reset();
   
   // searchCoincidence( W-2 , W0 )
-  bool result = searchCoincidence( -2, 0 );
+  bool result = searchCoincidence( -2, 0, ttuResultsByQuadrant );
   triggerCoincidence.set(0, result );
   
   // searchCoincidence( W-2 , W+1 )
-  result = searchCoincidence( -2, 1 );
+  result = searchCoincidence( -2, 1, ttuResultsByQuadrant  );
   triggerCoincidence.set(1, result );
   
   // searchCoincidence( W-1 , W0  )
-  result = searchCoincidence( -1, 0 );
+  result = searchCoincidence( -1, 0, ttuResultsByQuadrant  );
   triggerCoincidence.set(2, result );
   
   // searchCoincidence( W-1 , W+1 )
-  result = searchCoincidence( -1, 1 );
+  result = searchCoincidence( -1, 1, ttuResultsByQuadrant  );
   triggerCoincidence.set(3, result );
   
   // searchCoincidence( W-1 , W+2 )
-  result = searchCoincidence( -1, 2 );
+  result = searchCoincidence( -1, 2, ttuResultsByQuadrant  );
   triggerCoincidence.set(4, result );
   
   // searchCoincidence( W0  , W0  )
-  result = searchCoincidence( 0 , 0 );
+  result = searchCoincidence( 0 , 0, ttuResultsByQuadrant  );
   triggerCoincidence.set(5, result );
   
   // searchCoincidence( W+1 , W0  )
-  result = searchCoincidence( 1, 0 );
+  result = searchCoincidence( 1, 0, ttuResultsByQuadrant  );
   triggerCoincidence.set(6, result );
   
   // searchCoincidence( W+2 , W0  ) 
-  result = searchCoincidence( 2, 0 );
+  result = searchCoincidence( 2, 0, ttuResultsByQuadrant  );
   triggerCoincidence.set(7, result );
   
   bool five_wheels_OR = triggerCoincidence.any();
@@ -333,8 +304,6 @@ void RPCTechnicalTrigger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   
   if ( ! has_bx0 ) {
     iEvent.put(std::move(output));
-    status = Reset();
-    ++m_ievt;
     LogDebug("RPCTechnicalTrigger") << "RPCTechnicalTrigger> end of event loop" << std::endl;
     return;
     
@@ -345,43 +314,13 @@ void RPCTechnicalTrigger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   
   //.... all done
   
-  status = Reset();
-  ++m_ievt;
   LogDebug("RPCTechnicalTrigger") << "RPCTechnicalTrigger> end of event loop" << std::endl;
   
 }
-
-bool RPCTechnicalTrigger::Reset()
-{
-  
-  m_input->clear();
-  m_triggerbits.reset();
-  std::vector<TTUResults*>::iterator itrRes;
-  
-  for( itrRes=m_serializedInfoLine1.begin(); itrRes!=m_serializedInfoLine1.end(); ++itrRes)
-    delete (*itrRes);
-  
-  for( itrRes=m_serializedInfoLine2.begin(); itrRes!=m_serializedInfoLine2.end(); ++itrRes)
-    delete (*itrRes);
-  
-  m_serializedInfoLine1.clear();
-  m_serializedInfoLine2.clear();
-  m_ttuResultsByQuadrant.clear();
-  
-  delete m_signal; 
-  
-  return true;
-  
-}
-
 // ------------ method called once each job just before starting event loop  ------------
 void RPCTechnicalTrigger::beginRun(edm::Run const& iRun, const edm::EventSetup& evtSetup)
 {
   LogDebug("RPCTechnicalTrigger") << "RPCTechnicalTrigger::beginRun> starts" << std::endl;
-  
-  //.   Set up RPC geometry
-  
-  evtSetup.get<MuonGeometryRecord>().get( m_rpcGeometry );
   
   //..  Get Board Specifications (hardware configuration)
   
@@ -406,7 +345,7 @@ void RPCTechnicalTrigger::beginRun(edm::Run const& iRun, const edm::EventSetup& 
   } else {
     
     // read hardware configuration from file
-    m_readConfig = new TTUConfigurator( m_configFile );
+    m_readConfig = std::make_unique<TTUConfigurator>( m_configFile );
     
     if ( m_readConfig->m_hasConfig ) {
       m_readConfig->process();
@@ -423,16 +362,16 @@ void RPCTechnicalTrigger::beginRun(edm::Run const& iRun, const edm::EventSetup& 
     
     //... Initialize all
     
-    for (int k=0; k < m_maxTtuBoards; ++k ) {
+    for (int k=0; k < kMaxTtuBoards; ++k ) {
 
-      m_ttu[k]->SetLineId ( 1 );
-      m_ttuRbcLine[k]->SetLineId( 2 );
+      m_ttu[k].SetLineId ( 1 );
+      m_ttuRbcLine[k].SetLineId( 2 );
       
-      m_ttu[k]->setSpecifications( m_ttuspecs, m_rbcspecs );
-      m_ttuRbcLine[k]->setSpecifications( m_ttuspecs, m_rbcspecs );
+      m_ttu[k].setSpecifications( m_ttuspecs, m_rbcspecs );
+      m_ttuRbcLine[k].setSpecifications( m_ttuspecs, m_rbcspecs );
       
-      m_ttu[k]->initialise();
-      m_ttuRbcLine[k]->initialise();
+      m_ttu[k].initialise();
+      m_ttuRbcLine[k].initialise();
     }
   
   }
@@ -440,10 +379,11 @@ void RPCTechnicalTrigger::beginRun(edm::Run const& iRun, const edm::EventSetup& 
 }
 
 //
-int RPCTechnicalTrigger::convertToMap( const std::vector<TTUResults*> & ttuResults )
+std::map<int,RPCTechnicalTrigger::TTUResults*>
+RPCTechnicalTrigger::convertToMap( const std::vector<std::unique_ptr<TTUResults>> & ttuResults ) const
 {
-  
-  std::vector<TTUResults*>::const_iterator itr = ttuResults.begin();
+  std::map<int,TTUResults*> returnValue;
+  auto itr = ttuResults.begin();
   
   while ( itr != ttuResults.end() ) {
     
@@ -454,25 +394,24 @@ int RPCTechnicalTrigger::convertToMap( const std::vector<TTUResults*> & ttuResul
     
     int key(0);
     key = 1000 * ( (*itr)->m_ttuidx + 1 ) + 1*(*itr)->m_wedge;
-    m_ttuResultsByQuadrant[ key ] = (*itr);
+    returnValue[ key ] = itr->get();
     ++itr;
-    
   }
   
-  return m_ttuResultsByQuadrant.size();
+  return returnValue;
     
 }
 
 //...RBC pointing logic to tracker bit 25: hardwired
-bool RPCTechnicalTrigger::searchCoincidence( int wheel1, int wheel2 )
+bool RPCTechnicalTrigger::searchCoincidence( int wheel1, int wheel2,  std::map<int, TTUResults*> const& ttuResultsByQuadrant) const
 {
   
-  std::map<int, TTUResults*>::iterator itr;
+  std::map<int, TTUResults*>::const_iterator itr;
   bool topRight(false);
   bool botLeft(false);
   
-  int indxW1 = m_WheelTtu[wheel1];
-  int indxW2 = m_WheelTtu[wheel2];
+  int indxW1 = wheelTtu[wheel1+kWheelOffset];
+  int indxW2 = wheelTtu[wheel2+kWheelOffset];
   
   int k(0);
   int key(0);
@@ -481,24 +420,24 @@ bool RPCTechnicalTrigger::searchCoincidence( int wheel1, int wheel2 )
   
   //work out Pointing Logic to Tracker
   
-  for( m_firstSector = m_quadrants.begin(); m_firstSector != m_quadrants.end(); ++m_firstSector) {
+  for( auto firstSector : s_quadrants) {
     
-    key = 1000 * ( indxW1 ) + (*m_firstSector);
+    key = 1000 * ( indxW1 ) + firstSector;
     
-    itr = m_ttuResultsByQuadrant.find( key );
-    if ( itr != m_ttuResultsByQuadrant.end() )
+    itr = ttuResultsByQuadrant.find( key );
+    if ( itr != ttuResultsByQuadrant.end() )
       topRight  =  (*itr).second->getTriggerForWheel(wheel1);
 
-    //std::cout << "W1: " << wheel1 << " " << "sec: " << (*m_firstSector) << " dec: " << topRight << '\n';
+    //std::cout << "W1: " << wheel1 << " " << "sec: " << firstSector << " dec: " << topRight << '\n';
     
-    key = 1000 * ( indxW2 ) + (*m_firstSector) + 5;
+    key = 1000 * ( indxW2 ) + firstSector + 5;
     
-    itr = m_ttuResultsByQuadrant.find( key );
+    itr = ttuResultsByQuadrant.find( key );
     
-    if ( itr != m_ttuResultsByQuadrant.end() )
+    if ( itr != ttuResultsByQuadrant.end() )
       botLeft   = (*itr).second->getTriggerForWheel(wheel2);
     
-    //std::cout << "W2: " << wheel2 << " " << "sec: " << (*m_firstSector) + 5 << " dec: " << botLeft << '\n';
+    //std::cout << "W2: " << wheel2 << " " << "sec: " << firstSector + 5 << " dec: " << botLeft << '\n';
     
     finalTrigger |= ( topRight && botLeft );
     
@@ -513,24 +452,24 @@ bool RPCTechnicalTrigger::searchCoincidence( int wheel1, int wheel2 )
 
   k=0;
   
-  for( m_firstSector = m_quadrants.begin(); m_firstSector != m_quadrants.end(); ++m_firstSector) {
+  for( auto firstSector : s_quadrants) {
     
-    key = 1000 * ( indxW2 ) + (*m_firstSector);
+    key = 1000 * ( indxW2 ) + firstSector;
     
-    itr = m_ttuResultsByQuadrant.find( key );
-    if ( itr != m_ttuResultsByQuadrant.end() )
+    itr = ttuResultsByQuadrant.find( key );
+    if ( itr != ttuResultsByQuadrant.end() )
       topRight  =  (*itr).second->getTriggerForWheel(wheel1);
 
-    //std::cout << "W1: " << wheel1 << " " << "sec: " << (*m_firstSector) << " dec: " << topRight << '\n';
+    //std::cout << "W1: " << wheel1 << " " << "sec: " << firstSector << " dec: " << topRight << '\n';
     
-    key = 1000 * ( indxW1 ) + (*m_firstSector) + 5;
+    key = 1000 * ( indxW1 ) + firstSector + 5;
     
-    itr = m_ttuResultsByQuadrant.find( key );
+    itr = ttuResultsByQuadrant.find( key );
     
-    if ( itr != m_ttuResultsByQuadrant.end() )
+    if ( itr != ttuResultsByQuadrant.end() )
       botLeft   = (*itr).second->getTriggerForWheel(wheel2);
     
-    //std::cout << "W2: " << wheel2 << " " << "sec: " << (*m_firstSector) + 5 << " dec: " << botLeft << '\n';
+    //std::cout << "W2: " << wheel2 << " " << "sec: " << firstSector + 5 << " dec: " << botLeft << '\n';
     
     finalTrigger |= ( topRight && botLeft );
     
@@ -547,21 +486,14 @@ bool RPCTechnicalTrigger::searchCoincidence( int wheel1, int wheel2 )
 
 // ------------ method called once each job just after ending the event loop  ------------
 
-void RPCTechnicalTrigger::endJob() 
-{
-  
-  LogDebug("RPCTechnicalTrigger") << "RPCTechnicalTrigger::endJob>" << std::endl;
-  
-}
-
-void RPCTechnicalTrigger::printinfo()
+void RPCTechnicalTrigger::printinfo() const
 {
   
   LogDebug("RPCTechnicalTrigger") << "RPCTechnicalTrigger::Printing TTU emulators info>" << std::endl;
   
-  for (int k=0; k < m_maxTtuBoards; ++k ) {
-    m_ttu[k]->printinfo();
-    m_ttuRbcLine[k]->printinfo();
+  for (int k=0; k < kMaxTtuBoards; ++k ) {
+    m_ttu[k].printinfo();
+    m_ttuRbcLine[k].printinfo();
   }
   
     

--- a/L1Trigger/RPCTechnicalTrigger/src/RPCTechnicalTrigger.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RPCTechnicalTrigger.cc
@@ -154,8 +154,6 @@ void RPCTechnicalTrigger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   //. distribute data to different TTU emulator instances and process it
   std::bitset<5> triggerbits;
   
-  std::vector<TTUEmulator::TriggerResponse*>::const_iterator outItr;
-
   std::vector<std::unique_ptr<TTUResults>> serializedInfoLine1;
   std::vector<std::unique_ptr<TTUResults>> serializedInfoLine2;
 

--- a/L1Trigger/RPCTechnicalTrigger/src/RPCWheel.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RPCWheel.cc
@@ -1,44 +1,25 @@
 // Include files
-
+#include <array>
 
 
 // local
 #include "L1Trigger/RPCTechnicalTrigger/interface/RPCWheel.h"
-
+#include "GeometryConstants.h"
 //-----------------------------------------------------------------------------
 // Implementation file for class : RPCWheel
 //
 // 2008-10-15 : Andres Osorio
 //-----------------------------------------------------------------------------
+using namespace rpctechnicaltrigger;
+
 
 //=============================================================================
 // Standard constructor, initializes variables
 //=============================================================================
-RPCWheel::RPCWheel() {
-  
-  m_id = 0; 
-  
-  m_maxrbc     = 6;
-  m_maxlayers  = 6;
-  m_maxsectors = 12;
-  
-  m_debug = false;
-
-  m_sec1id.push_back(12);
-  m_sec2id.push_back(1);
-  m_sec1id.push_back(2);
-  m_sec2id.push_back(3);
-  m_sec1id.push_back(4);
-  m_sec2id.push_back(5);
-  m_sec1id.push_back(6);
-  m_sec2id.push_back(7);
-  m_sec1id.push_back(8);
-  m_sec2id.push_back(9);
-  m_sec1id.push_back(10);
-  m_sec2id.push_back(11);
-
-  m_wheelmap = new std::bitset<6>[12];
-    
+RPCWheel::RPCWheel():
+  m_id{0},
+  m_debug{false}
+{
 }
 
 void RPCWheel::setProperties( int wid ) {
@@ -47,11 +28,12 @@ void RPCWheel::setProperties( int wid ) {
   
   int bisector[2];
   
+  m_RBCE.reserve(m_maxrbc);
   for( int k=0; k < m_maxrbc; ++k )
   {
-    bisector[0]= m_sec1id[k];
-    bisector[1]= m_sec2id[k];
-    m_RBCE.push_back( new RBCEmulator( ) ); 
+    bisector[0]= s_sec1id[k];
+    bisector[1]= s_sec2id[k];
+    m_RBCE.emplace_back(std::make_unique<RBCEmulator>());
     m_RBCE[k]->setid( wid, bisector );
   }
 
@@ -66,12 +48,12 @@ void RPCWheel::setProperties( int wid, const char * logic_type) {
   m_id = wid;
   
   int bisector[2];
-  
+  m_RBCE.reserve(m_maxrbc);
   for( int k=0; k < m_maxrbc; ++k )
   {
-    bisector[0]= m_sec1id[k];
-    bisector[1]= m_sec2id[k];
-    m_RBCE.push_back( new RBCEmulator( logic_type ) ); 
+    bisector[0]= s_sec1id[k];
+    bisector[1]= s_sec2id[k];
+    m_RBCE.push_back( std::make_unique<RBCEmulator>( logic_type ) ); 
     m_RBCE[k]->setid( wid, bisector );
   }
 
@@ -86,11 +68,12 @@ void RPCWheel::setProperties( int wid, const char * f_name, const char * logic_t
   
   int bisector[2];
   
+  m_RBCE.reserve(m_maxrbc);
   for( int k=0; k < m_maxrbc; ++k )
   {
     bisector[0]= (k*2)+1;
     bisector[1]= (k*2)+2;
-    m_RBCE.push_back( new RBCEmulator( f_name, logic_type ) ); 
+    m_RBCE.push_back(std::make_unique<RBCEmulator>( f_name, logic_type ) ); 
     m_RBCE[k]->setid( wid, bisector );
   }
   
@@ -99,23 +82,6 @@ void RPCWheel::setProperties( int wid, const char * f_name, const char * logic_t
   
 }
 
-//=============================================================================
-// Destructor
-//=============================================================================
-RPCWheel::~RPCWheel() {
-  
-  //destroy all rbc objects associated
-  std::vector<RBCEmulator*>::iterator itr;
-  for( itr = m_RBCE.begin(); itr != m_RBCE.end(); ++itr)
-    if ( (*itr) ) delete (*itr);
-  
-  m_RBCE.clear();
-  m_sec1id.clear();
-  m_sec2id.clear();
-
-  if ( m_wheelmap ) delete[] m_wheelmap;
-    
-} 
 
 //=============================================================================
 void RPCWheel::setSpecifications( const RBCBoardSpecs * rbcspecs )
@@ -162,9 +128,9 @@ bool RPCWheel::process( int bx, const std::map<int,RBCInput*> & data )
     m_RBCE[k]->reset();
     
     int key = bxsign*( 1000000 * abs(bx)
-                       + m_RBCE[k]->m_rbcinfo->wheelIdx()*10000 
-                       + m_RBCE[k]->m_rbcinfo->sector(0)*100
-                       + m_RBCE[k]->m_rbcinfo->sector(1) );
+                       + m_RBCE[k]->rbcinfo().wheelIdx()*10000 
+                       + m_RBCE[k]->rbcinfo().sector(0)*100
+                       + m_RBCE[k]->rbcinfo().sector(1) );
     
     itr = data.find( key );
     
@@ -288,7 +254,7 @@ void RPCWheel::retrieveWheelMap( TTUInput & output )
 //=============================================================================
 
 
-void RPCWheel::printinfo() 
+void RPCWheel::printinfo() const
 {
   
   std::cout << "Wheel -> " << m_id << '\n';
@@ -297,7 +263,7 @@ void RPCWheel::printinfo()
   
 }
 
-void RPCWheel::print_wheel(const TTUInput & wmap )
+void RPCWheel::print_wheel(const TTUInput & wmap ) const
 {
 
   std::cout << "RPCWheel::print_wheel> " << wmap.m_wheelId << '\t' << wmap.m_bx << std::endl;

--- a/L1Trigger/RPCTechnicalTrigger/src/RPCWheelMap.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/RPCWheelMap.cc
@@ -17,36 +17,10 @@
 //=============================================================================
 RPCWheelMap::RPCWheelMap( int wheelid ) {
   
-  m_maxBx = 7;
-  m_maxBxWindow = 3; //... considering that we have a bxing in the range [-3,+3]
-  m_maxSectors = 12;
-  
-  int maxMaps = m_maxBx * m_maxSectors;
-  
   m_wheelid    = wheelid;
-  m_wheelMap   = new std::bitset<6>[m_maxSectors];
-  m_wheelMapBx = new std::bitset<6>[m_maxSectors * m_maxBx];
-  m_ttuinVec   = new TTUInput[m_maxBx];
-    
-  for(int i=0; i < m_maxSectors; ++i)
-    m_wheelMap[i].reset();
-  
-  for(int i=0; i < maxMaps; ++i)
-    m_wheelMapBx[i].reset();
-  
   m_debug = false;
   
 }
-//=============================================================================
-// Destructor
-//=============================================================================
-RPCWheelMap::~RPCWheelMap() {
-  
-  if ( m_wheelMap )   delete[] m_wheelMap;
-  if ( m_wheelMapBx ) delete[] m_wheelMapBx;
-  if ( m_ttuinVec )   delete[] m_ttuinVec;
-  
-} 
 
 //=============================================================================
 void RPCWheelMap::addHit( int bx, int sec, int layer)

--- a/L1Trigger/RPCTechnicalTrigger/src/TTUBasicConfig.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/TTUBasicConfig.cc
@@ -14,34 +14,22 @@
 //=============================================================================
 // Standard constructor, initializes variables
 //=============================================================================
-TTUBasicConfig::TTUBasicConfig( const TTUBoardSpecs * ttuspecs ) {
-
-  m_ttuboardspecs = ttuspecs;
-
-  m_ttulogic      = new TTULogicUnit();
-  
-  m_debug = false;
-  
+TTUBasicConfig::TTUBasicConfig( const TTUBoardSpecs * ttuspecs ):
+  TTUConfiguration(ttuspecs) ,
+  m_debug{false}
+{
 }
 
-TTUBasicConfig::TTUBasicConfig( const char * logic  ) {
-  
-  m_ttulogic = new TTULogicUnit( logic );
-
-  m_debug = false;
-    
+TTUBasicConfig::TTUBasicConfig( const char * logic  ):
+  TTUConfiguration(logic),
+  m_debug{false}
+{
 }
 
 //=============================================================================
 // Destructor
 //=============================================================================
 TTUBasicConfig::~TTUBasicConfig() {
-
-  if (m_ttulogic) delete m_ttulogic;
-
-  m_vecmask.clear();
-  m_vecforce.clear();
-
 } 
 
 //=============================================================================
@@ -69,16 +57,16 @@ bool TTUBasicConfig::initialise( int line , int ttuid )
   // initialise logic unit
   
   if ( line == 2 ) {
-    m_ttulogic->setlogic( "WedgeORLogic" );
+    ttulogic()->setlogic( "WedgeORLogic" );
   } else {
-    m_ttulogic->setlogic( (*itr).m_LogicType.c_str() );
+    ttulogic()->setlogic( (*itr).m_LogicType.c_str() );
   }
   
-  status = m_ttulogic->initialise();
+  status = ttulogic()->initialise();
   
   //itr = m_ttuboardspecs->m_boardspecs.begin();
   
-  m_ttulogic->setBoardSpecs( m_ttuboardspecs->m_boardspecs[pos] );
+  ttulogic()->setBoardSpecs( m_ttuboardspecs->m_boardspecs[pos] );
   
   // get mask and force vectors
   

--- a/L1Trigger/RPCTechnicalTrigger/src/TTUConfiguration.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/TTUConfiguration.cc
@@ -1,0 +1,39 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger/RPCTechnicalTrigger
+// Class  :     TTUConfiguration
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 16 Nov 2018 19:02:33 GMT
+//
+
+// system include files
+
+// user include files
+#include "L1Trigger/RPCTechnicalTrigger/interface/TTUConfiguration.h"
+
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+TTUConfiguration::TTUConfiguration(const char* logic):
+  m_ttuboardspecs{nullptr},
+  m_ttulogic{ logic }
+{
+}
+
+TTUConfiguration::TTUConfiguration( const TTUBoardSpecs* ttuspecs):
+  m_ttuboardspecs{ttuspecs},
+  m_ttulogic{}
+{}

--- a/L1Trigger/RPCTechnicalTrigger/src/TTUConfigurator.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/TTUConfigurator.cc
@@ -15,35 +15,26 @@
 //=============================================================================
 // Standard constructor, initializes variables
 //=============================================================================
-TTUConfigurator::TTUConfigurator( const std::string& infile ) {
+TTUConfigurator::TTUConfigurator( const std::string& infile ):
+  m_in{},
+  m_rbcspecs{},
+  m_ttuspecs{}
+{
   
-  m_in = new std::ifstream();
-  m_in->open( infile.c_str() );
+  m_in.open( infile.c_str() );
   
-  if(!m_in->is_open()) {
+  if(!m_in.is_open()) {
     edm::LogError("TTUConfigurator") << "TTUConfigurator cannot open file";
     m_hasConfig = false;
   } else {
     m_hasConfig = true;
   }
-  
-  m_rbcspecs = new RBCBoardSpecs();
-  m_ttuspecs = new TTUBoardSpecs();
-  
 }
 //=============================================================================
 // Destructor
 //=============================================================================
 TTUConfigurator::~TTUConfigurator() {
-  
-  if ( m_in ) {
-    m_in->close();
-    delete m_in;
-  }
-  
-  if ( m_rbcspecs ) delete m_rbcspecs;
-  if ( m_ttuspecs ) delete m_ttuspecs;
-  
+  m_in.close();  
 } 
 
 //=============================================================================
@@ -56,36 +47,22 @@ void TTUConfigurator::process()
   
 }
 
-void TTUConfigurator::addData( RBCBoardSpecs * specs )
+void TTUConfigurator::addData( RBCBoardSpecs& specs )
 {
-  
-  RBCBoardSpecs::RBCBoardConfig * board;
-  
+  specs.v_boardspecs.reserve(30);
   for( int i=0; i < 30; i++) {
-    
-    board = new RBCBoardSpecs::RBCBoardConfig();
-    
-    (*m_in) >> (*board);
-    
-    specs->v_boardspecs.push_back( *board );
-    
+    auto& board = specs.v_boardspecs.emplace_back();
+    m_in >> board;
   }
   
 }
 
-void TTUConfigurator::addData( TTUBoardSpecs * specs )
+void TTUConfigurator::addData( TTUBoardSpecs& specs )
 {
-  
-  TTUBoardSpecs::TTUBoardConfig * board;
-  
+  specs.m_boardspecs.reserve(3);
   for(int i=0; i < 3; i++){
+    auto& board = specs.m_boardspecs.emplace_back();
     
-    board= new TTUBoardSpecs::TTUBoardConfig();
-    
-    (*m_in) >> (*board);
-    
-    specs->m_boardspecs.push_back( *board );
-    
+    m_in >> board;
   }
-  
 }

--- a/L1Trigger/RPCTechnicalTrigger/src/TTUInput.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/TTUInput.cc
@@ -20,24 +20,11 @@ TTUInput::TTUInput(  ) {
   m_bx = 0;
   m_wheelId = 0;
   m_hasHits = false;
-  input_sec = new std::bitset<6>[12];
   m_rbcDecision.reset();
-  
-  for(int i=0; i < 12; ++i)
-    input_sec[i].reset();
   
   m_debug = false;
 
 }
-//=============================================================================
-// Destructor
-//=============================================================================
-TTUInput::~TTUInput() {
-
-  m_hasHits = false;
-  if ( input_sec ) delete[] input_sec;
-
-} 
 //=============================================================================
 
 void TTUInput::reset() 

--- a/L1Trigger/RPCTechnicalTrigger/src/TTULogicUnit.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/TTULogicUnit.cc
@@ -16,42 +16,23 @@
 //=============================================================================
 TTULogicUnit::TTULogicUnit( ) : RPCLogicUnit () {
   
-  m_logtool = new LogicTool<TTULogic>();
   m_debug = false;
   
 }
 
 TTULogicUnit::TTULogicUnit( const char * logic_type ) : RPCLogicUnit () {
 
-  m_logtool = new LogicTool<TTULogic>();
   m_logtype = std::string( logic_type );
   m_debug = false;
   
 }
-//=============================================================================
-// Destructor
-//=============================================================================
-TTULogicUnit::~TTULogicUnit() {
-  
-  if (m_logtool) {
-    if ( m_logtool->endjob() )
-      delete m_logtool;
-  }
-
-} 
 
 //=============================================================================
 bool TTULogicUnit::initialise() 
 {
   
-  bool status(true);
-  
-  status = m_logtool->initialise();
-  if ( !status ) { 
-    if( m_debug ) std::cout << "TTULogicUnit> Problem initialising LogicTool \n"; 
-    return false; };
-
-  m_logic  = dynamic_cast<TTULogic*> ( m_logtool->retrieve(m_logtype) );
+  LogicTool<TTULogic> logtool;
+  m_logic  = logtool.retrieve(m_logtype);
   
   if ( ! m_logic ) { 
     if( m_debug ) std::cout << "TTULogicUnit> No logic found \n"; 

--- a/L1Trigger/RPCTechnicalTrigger/src/TTUTwoORLogic.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/TTUTwoORLogic.cc
@@ -17,36 +17,24 @@
 //=============================================================================
 // Standard constructor, initializes variables
 //=============================================================================
-TTUTwoORLogic::TTUTwoORLogic(  ) {
+TTUTwoORLogic::TTUTwoORLogic(  ):
+  m_ttuLogic{},
+  m_rbcLogic{},
+  m_debug{false}
+ {
 
   m_triggersignal = false;
  
-  m_debug = false;
-
-  m_ttuLogic = new TTUTrackingAlg();
-  
-  m_rbcLogic = new TTUSectorORLogic();
-  
 }
-//=============================================================================
-// Destructor
-//=============================================================================
-TTUTwoORLogic::~TTUTwoORLogic() {
-
-  if ( m_ttuLogic ) delete m_ttuLogic;
-
-  if ( m_rbcLogic ) delete m_rbcLogic;
-  
-} 
 
 //=============================================================================
 
 void TTUTwoORLogic::setBoardSpecs( const TTUBoardSpecs::TTUBoardConfig & boardspecs ) 
 {
   
-  m_ttuLogic->setBoardSpecs( boardspecs );
+  m_ttuLogic.setBoardSpecs( boardspecs );
   
-  m_rbcLogic->setBoardSpecs( boardspecs );
+  m_rbcLogic.setBoardSpecs( boardspecs );
   
 }
 
@@ -58,12 +46,12 @@ bool TTUTwoORLogic::process( const TTUInput & inmap )
   m_triggersignal = false;
   
   
-  m_ttuLogic->process( inmap );
-  m_rbcLogic->process( inmap );
+  m_ttuLogic.process( inmap );
+  m_rbcLogic.process( inmap );
   
-  bool triggerFromTTU = m_ttuLogic->m_triggersignal;
+  bool triggerFromTTU = m_ttuLogic.m_triggersignal;
   
-  bool triggerFromRBC = m_rbcLogic->m_triggersignal;
+  bool triggerFromRBC = m_rbcLogic.m_triggersignal;
     
   m_triggersignal = triggerFromTTU || triggerFromRBC;
   


### PR DESCRIPTION
- Improved memory management via std::unique_ptr or holding objects by value. This fixed several memory leaks. There are no remaining bare new or delete in this code.
- Removed unnecessary member data.
- Improved const correctness.
- Removed unnecessary virtual destructors.
- Changed to range based for loops.
- Used more efficient patterns for containers.
- Converted RPCTechnicalTrigger to a stream module.