### PR TITLE
Add an override version option for standard PyReleaseValidation workflows (Backport PR 25245)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1320,6 +1320,17 @@ steps['Upsilon4sBaBarExample_BpBm_Dstarpipi_D0Kpi_nonres_forSTEAM_13TeV_TuneCUET
 steps['LambdaBToLambdaMuMuToPPiMuMu_forSTEAM_13TeV_TuneCUETP8M1']=genvalid('LambdaBToLambdaMuMuToPPiMuMu_forSTEAM_13TeV_TuneCUETP8M1_cfi',step1GenDefaults)
 steps['BsToMuMu_forSTEAM_13TeV_TuneCUETP8M1']=genvalid('BsToMuMu_forSTEAM_13TeV_TuneCUETP8M1_cfi',step1GenDefaults)
 
+# sometimes v1 won't be used - override it here - the dictionary key is gen fragment + '_' + geometry
+overrideFragments={'QQH1352T_13UP18INPUT':'2'}
+
+import re
+for key in overrideFragments:
+    for inI in steps[key]:
+        DSold=steps[key][inI].dataSet
+        DS = re.sub('v[0-9]*/','v'+overrideFragments[key]+'/',DSold.rstrip())
+        del steps[key]
+        steps[key]={'INPUT':InputInfo(dataSet=DS,location='STD')}
+
 
 #PU for FullSim
 PU={'-n':10,'--pileup':'default','--pileup_input':'das:/RelValMinBias/%s/GEN-SIM'%(baseDataSetRelease[0],)}


### PR DESCRIPTION
This PR addresses the problem discussed in #24850, that is causing wf 250204.18 to be broken since more than on month. The version of the input RelVal to be used is not the default one, but the override mechanism added for the upgrade version is not directly applicable to the standard relval workflows because they are added with a different syntax.

Here the dataset stored in the desired element of the dictionary is extracted, modified according to the predefined input dictionary "overrideFragment", and the dictionary element is re-created with the new definition.

Verified to solve the pending issue when running the command runTheMatrix.py -i all -t 4 -l 250204.18. Note: the sample is not present at CERN but existent (FNAL), so it will be copied.

backport #25245 