### PR TITLE
Forgot matrix injector splitting when adding cosmic 2016 WF

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -247,6 +247,8 @@ class MatrixInjector(object):
             wmsplit['RECOUP17']=1
             wmsplit['DIGIUP17_PU25']=1
             wmsplit['RECOUP17_PU25']=1
+            wmsplit['DIGICOS_UP16']=1
+            wmsplit['RECOCOS_UP16']=1
             wmsplit['DIGICOS_UP17']=1
             wmsplit['RECOCOS_UP17']=1
             wmsplit['DIGICOS_UP18']=1


### PR DESCRIPTION
This is only used at relval submission (job splitting) 
I forgot those parameters  when I reintroduced the 2016 cosmic WF (transparent to tests) 