### PR TITLE
Run2-alca145 Update the calibration code using isolated  tracks

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/CalibCorr.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibCorr.C
@@ -188,20 +188,22 @@ private:
 
 class CalibCorr {
 public :
-  CalibCorr(const char* infile, bool useDepth, bool debug);
+  CalibCorr(const char* infile, int flag, bool debug);
   ~CalibCorr() {}
 
   float getCorr(int run, unsigned int id);
 private:
-  void                     readCorr(const char* infile);
+  void                     readCorrRun(const char* infile);
   void                     readCorrDepth(const char* infile);
+  void                     readCorrResp(const char* infile);
   unsigned int getDetIdHE(int ieta, int iphi, int depth);
   unsigned int getDetId(int subdet, int ieta, int iphi, int depth);
   unsigned int correctDetId(const unsigned int& detId);
 
   static const     unsigned int nmax_=10;
-  bool                          ifDepth_, debug_;
-  std::map<unsigned int,float>  corrFac_[nmax_], corrFacN_;
+  int                           flag_;
+  bool                          debug_;
+  std::map<unsigned int,float>  corrFac_[nmax_], corrFacDepth_, corrFacResp_;
   std::vector<int>              runlow_;
 };
 
@@ -224,11 +226,18 @@ CalibCorrFactor::CalibCorrFactor(const char* infile, int useScale, double scale,
   useScale_(useScale), scale_(scale), etaMax_(etamax), debug_(debug), 
   etamp_(0), etamn_(0), cfacmp_(1), cfacmn_(1) {
 
-  corrE_ = readCorrFactor(infile);
-  std::cout << "Reads " << cfactors_.size() << " correction factors from " 
-	    << infile << " with flag " << corrE_ << std::endl 
-	    << " Flag for scale " << useScale_ << " with scale " << scale_ 
-	    << " and flag for etaMax " << etaMax_ << std::endl;
+  if (std::string(infile) != "") {
+    corrE_ = readCorrFactor(infile);
+    std::cout << "Reads " << cfactors_.size() << " correction factors from " 
+	      << infile << " with flag " << corrE_ << std::endl 
+	      << "Flag for scale " << useScale_ << " with scale " << scale_ 
+	      << " and flag for etaMax " << etaMax_ << std::endl;
+  } else {
+    corrE_ = false;
+    std::cout << "No correction factors provided; Flag for scale " 
+	      << useScale_ << " with scale " << scale_ 
+	      << " and flag for etaMax " << etaMax_ << std::endl;
+  }
 }
 
 double CalibCorrFactor::getCorr(unsigned int id) {
@@ -303,19 +312,24 @@ double CalibCorrFactor::getFactor(const int& ieta) {
   return scale;
 }
 
-
-CalibCorr::CalibCorr(const char* infile, bool ifDepth, bool debug) : 
-  ifDepth_(ifDepth), debug_(debug) {
-  if (ifDepth_) readCorrDepth(infile);
-  else          readCorr(infile);
+CalibCorr::CalibCorr(const char* infile, int flag, bool debug) : 
+  flag_(flag), debug_(debug) {
+  std::cout << "CalibCorr is created with flag " << flag << ":" << flag_ 
+	    << " for i/p file " << infile << std::endl;
+  if      (flag == 1) readCorrDepth(infile);
+  else if (flag == 2) readCorrResp(infile);
+  else                readCorrRun(infile);
 }
 
 float CalibCorr::getCorr(int run, unsigned int id) {
   float cfac(1.0);
   unsigned idx = correctDetId(id);
-  if (ifDepth_) {
-    std::map<unsigned int,float>::iterator itr = corrFacN_.find(idx);
-    if (itr != corrFacN_.end()) cfac = itr->second;
+  if (flag_ == 1) {
+    std::map<unsigned int,float>::iterator itr = corrFacDepth_.find(idx);
+    if (itr != corrFacDepth_.end()) cfac = itr->second;
+  } else if (flag_ == 2) {
+    std::map<unsigned int,float>::iterator itr = corrFacResp_.find(idx);
+    if (itr != corrFacResp_.end()) cfac = itr->second;
   } else {
     int ip(-1);
     for (unsigned int k=0; k<runlow_.size(); ++k) {
@@ -342,54 +356,9 @@ float CalibCorr::getCorr(int run, unsigned int id) {
   return cfac;
 }
 
-void CalibCorr::readCorrDepth(const char* infile) {
+void CalibCorr::readCorrRun(const char* infile) {
 
-  std::ifstream fInput(infile);
-  if (!fInput.good()) {
-    std::cout << "Cannot open file " << infile << std::endl;
-  } else {
-    char buffer [1024];
-    unsigned int all(0), good(0);
-    while (fInput.getline(buffer, 1024)) {
-      ++all;
-      std::string bufferString(buffer);
-      if (bufferString.substr(0,5) == "depth") {
-	continue; //ignore other comments
-      } else {
-	std::vector<std::string> items = splitString(bufferString);
-	if (items.size () != 3) {
-	  std::cout << "Ignore  line: " << buffer << " Size " << items.size();
-	  for (unsigned int k=0; k<items.size(); ++k)
-	    std::cout << " [" << k << "] : " << items[k];
-	  std::cout << std::endl;
-	} else {
-	  ++good;
-	  int   ieta  = std::atoi (items[1].c_str());
-	  int   depth = std::atoi (items[0].c_str());
-	  float corrf = std::atof (items[2].c_str());
-	  int   nphi  = (std::abs(ieta) > 20) ? 36 : 72;
-	  for (int i=1; i<=nphi; ++i) {
-	    int        iphi = (nphi > 36) ? i : (2*i-1);
-	    unsigned int id = getDetIdHE(ieta,iphi,depth);
-	    corrFacN_[id]   = corrf;
-	    if (debug_) {
-	      std::cout << "ID " << std::hex << id << std::dec << ":" << id
-			<< " (eta " << ieta << " phi " << iphi << " depth " 
-			<< depth << ") " << corrFacN_[id] << std::endl;
-	    }
-	  }
-	}
-      }
-    }
-    fInput.close();
-    std::cout << "Reads total of " << all << " and " << good 
-	      << " good records of depth dependent factors from " << infile 
-	      << std::endl;
-  }
-}
-
-void CalibCorr::readCorr(const char* infile) {
-
+  std::cout << "Enters readCorrRun for " << infile << std::endl;
   std::ifstream fInput(infile);
   unsigned int ncorr(0);
   if (!fInput.good()) {
@@ -442,6 +411,101 @@ void CalibCorr::readCorr(const char* infile) {
     fInput.close();
     std::cout << "Reads total of " << all << " and " << good 
 	      << " good records of run dependent corrections from "
+	      << infile << std::endl;
+  }
+}
+
+void CalibCorr::readCorrDepth(const char* infile) {
+
+  std::cout << "Enters readCorrDepth for " << infile << std::endl;
+  std::ifstream fInput(infile);
+  if (!fInput.good()) {
+    std::cout << "Cannot open file " << infile << std::endl;
+  } else {
+    char buffer [1024];
+    unsigned int all(0), good(0);
+    while (fInput.getline(buffer, 1024)) {
+      ++all;
+      std::string bufferString(buffer);
+      if (bufferString.substr(0,5) == "depth") {
+	continue; //ignore other comments
+      } else {
+	std::vector<std::string> items = splitString(bufferString);
+	if (items.size () != 3) {
+	  std::cout << "Ignore  line: " << buffer << " Size " << items.size();
+	  for (unsigned int k=0; k<items.size(); ++k)
+	    std::cout << " [" << k << "] : " << items[k];
+	  std::cout << std::endl;
+	} else {
+	  ++good;
+	  int   ieta  = std::atoi (items[1].c_str());
+	  int   depth = std::atoi (items[0].c_str());
+	  float corrf = std::atof (items[2].c_str());
+	  int   nphi  = (std::abs(ieta) > 20) ? 36 : 72;
+	  for (int i=1; i<=nphi; ++i) {
+	    int        iphi = (nphi > 36) ? i : (2*i-1);
+	    unsigned int id = getDetIdHE(ieta,iphi,depth);
+	    corrFacDepth_[id]   = corrf;
+	    if (debug_) {
+	      std::cout << "ID " << std::hex << id << std::dec << ":" << id
+			<< " (eta " << ieta << " phi " << iphi << " depth " 
+			<< depth << ") " << corrFacDepth_[id] << std::endl;
+	    }
+	  }
+	}
+      }
+    }
+    fInput.close();
+    std::cout << "Reads total of " << all << " and " << good 
+	      << " good records of depth dependent factors from " << infile 
+	      << std::endl;
+  }
+}
+
+void CalibCorr::readCorrResp(const char* infile) {
+
+  std::cout << "Enters readCorrResp for " << infile << std::endl;
+  std::ifstream fInput(infile);
+  if (!fInput.good()) {
+    std::cout << "Cannot open file " << infile << std::endl;
+  } else {
+    char buffer [1024];
+    unsigned int all(0), good(0), other(0);
+    while (fInput.getline(buffer, 1024)) {
+      ++all;
+      std::string bufferString(buffer);
+      if (bufferString.substr(0,1) == "#") {
+	continue; //ignore other comments
+      } else {
+	std::vector<std::string> items = splitString(bufferString);
+	if (items.size () < 5) {
+	  std::cout << "Ignore  line: " << buffer << " Size " << items.size();
+	  for (unsigned int k=0; k<items.size(); ++k)
+	    std::cout << " [" << k << "] : " << items[k];
+	  std::cout << std::endl;
+	} else if (items[3] == "HB" || items[3] == "HE") {
+	  ++good;
+	  int   ieta  = std::atoi (items[0].c_str());
+	  int   iphi  = std::atoi (items[1].c_str());
+	  int   depth = std::atoi (items[2].c_str());
+	  int   subdet= (items[3] == "HE") ? 2 : 1;
+	  float corrf = std::atof (items[4].c_str());
+	  unsigned int id = getDetId(subdet,ieta,iphi,depth);
+	  corrFacResp_[id] = corrf;
+	  if (debug_) {
+	    std::cout << "ID " << std::hex << id << std::dec << ":" << id
+		      << " (subdet " << items[3] << ":" << subdet << " eta " 
+		      << ieta << " phi " << iphi << " depth " << depth 
+		      << ") " << corrFacResp_[id] << std::endl;
+	  }
+	} else {
+	  ++other;
+	}
+      }
+    }
+    fInput.close();
+    std::cout << "Reads total of " << all << " and " << good << " good and "
+	      << other << " detector records of depth dependent factors from "
 	      << infile << std::endl;
   }
 }
@@ -547,4 +611,18 @@ bool CalibSelectRBX::isItRBX(const int ieta, const int iphi) {
 	      << std::endl;
   }
   return ok;
+}
+
+void CalibCorrTest(const char* infile, int flag) {
+
+  CalibCorr* c1 = new CalibCorr(infile, flag, true);
+  for (int ieta = 1; ieta < 29; ++ieta) {
+    int subdet = (ieta > 16) ? 2 : 1;
+    int depth  = (ieta > 16) ? 2 : 1;
+    unsigned int id1 = ((4<<28)|((subdet&0x7)<<25));
+    id1 |= ((0x1000000) | ((depth&0xF)<<20) | (ieta<<10) | 1);
+    c1->getCorr(0, id1);
+    id1 |= (0x80000);
+    c1->getCorr(0, id1);
+  }
 }

--- a/Calibration/HcalCalibAlgos/macros/CalibTree.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibTree.C
@@ -3,9 +3,9 @@
 // .L CalibTree.C+g
 //  Run(inFileName, dirName, treeName, outFileName, corrFileName, dupFileName,
 //      rcorFileName, useweight, useMean, nMin, inverse, ratMin, ratMax, 
-//      ietaMax, sysmode, puCorr, applyL1Cut, l1Cut, truncateFlag, maxIter, 
-//      useDepth, useGen, runlo, runhi, phimin, phimax, zside, nvxlo, nvxhi,
-//      rbx, exclude, higheta, fraction, writeDebugHisto, debug);
+//      ietaMax, ietaTrack, sysmode, puCorr, applyL1Cut, l1Cut, truncateFlag,
+//      maxIter, corForm, useGen, runlo, runhi, phimin, phimax, zside, nvxlo,
+//      nvxhi, rbx, exclude, higheta, fraction, writeDebugHisto, debug);
 //
 //  where:
 //
@@ -36,6 +36,8 @@
 //  ratMax          (double)  = Higher cut on E/p to select a track (3.0)
 //  ietaMax         (int)     = Maximum ieta value for which correcttion
 //                              factor is to be determined (23)
+//  ietaTrack       (int)     = Maximum track ieta (at HCAL) to be considered
+//                              for these; -1 means no check on track ieta (-1)
 //  sysmode         (int)     = systematic error study (-1 if default)
 //                              -1 loose, -2 flexible, > 0 for systematic
 //  puCorr          (int)     = PU correction to be applied or not: 0 no
@@ -53,9 +55,9 @@
 //                              in HB and HE with values > 1 as depth 2 (5)
 //                              (Default 0)
 //  maxIter         (int)     = number of iterations (30)
-//  useDepth        (bool)    = type of rcorFileName: true for depth dependent
-//                              corrections; false for Raddam correcttions
-//                              (false)
+//  rcorForm        (int)     = type of rcorFileName: (0) for Raddam correction,
+//                              (1) for depth dependent corrections; (2) for
+//                              RespCorr corrections; (0)
 //  useGen          (bool)    = use generator level momentum information (False)
 //  runlo           (int)     = lower value of run number to be included (+ve)
 //                              or excluded (-ve) (default 0)
@@ -112,20 +114,51 @@ void Run(const char *inFileName="Silver.root",
 	 const char *dupFileName="events_DXS2.txt", 
 	 const char *rcorFileName="",
 	 bool useweight=true, bool useMean=false, int nMin=0, bool inverse=true,
-	 double ratMin=0.25, double ratMax=3., int ietaMax=23, 
+	 double ratMin=0.25, double ratMax=3., int ietaMax=23, int ietaTrack=-1,
 	 int sysmode=-1, int puCorr=-2, int applyL1Cut=1, double l1Cut=0.5, 
-	 int truncateFlag=0, int maxIter=30, bool useDepth=false, 
-	 bool useGen=false, int runlo=0, int runhi=99999999, int phimin=1, 
-	 int phimax=72, int zside=0, int nvxlo=0, int nvxhi=1000, int rbx=0,
+	 int truncateFlag=0, int maxIter=30, int rcorForm=0, bool useGen=false,
+	 int runlo=0, int runhi=99999999, int phimin=1, int phimax=72, 
+	 int zside=0, int nvxlo=0, int nvxhi=1000, int rbx=0,
 	 bool exclude=true, int higheta=1, double fraction=1.0, 
 	 bool writeDebugHisto=false, bool debug=false);
 
 // Fixed size dimensions of array or collections stored in the TTree if any.
 
 class CalibTree {
+
 public :
+
+  CalibTree(const char *dupFileName, const char* rcorFileName, int truncateFlag,
+	    bool useMean, int runlo, int runhi, int phimin, int phimax,
+	    int zside, int nvxlo, int nvxhi, int sysmode, int rbx, int puCorr,
+	    int rcorForm, bool useGen, bool exclude, int higheta, 
+	    TChain *tree);
+  virtual ~CalibTree();
+  virtual Int_t    Cut(Long64_t entry);
+  virtual Int_t    GetEntry(Long64_t entry);
+  virtual Long64_t LoadTree(Long64_t entry);
+  virtual void     Init(TChain *tree, const char *dupFileName);
+  virtual Double_t Loop(int k, TFile *fout, bool useweight, int nMin, 
+			bool inverse, double rMin, double rMax, int ietaMax,
+			int ietaTrack, int applyL1Cut, double l1Cut, bool last, 
+			double fraction, bool writeHisto, bool debug);
+  virtual Bool_t   Notify();
+  virtual void     Show(Long64_t entry = -1);
+  bool             goodTrack();
+  void             writeCorrFactor(const char *corrFileName, int ietaMax);
+  bool             selectPhi(unsigned int detId);
+  std::pair<double,double> fitMean(TH1D*, int);
+  void             makeplots(double rmin, double rmax, int ietaMax,
+			     bool useWeight, double fraction, bool debug);
+  void             fitPol0(TH1D* hist, bool debug);
+  void             highEtaFactors(int ietaMax, bool debug);
+
   TChain                    *fChain;  //!pointer to the analyzed TTree or TChain
   Int_t                      fCurrent;//!current Tree number in a TChain
+  TH1D                      *h_pbyE, *h_cvg;
+  TProfile                  *h_Ebyp_bfr, *h_Ebyp_aftr;
+
+private:
 
   // Declaration of leaf types
   Int_t                      t_Run;
@@ -207,8 +240,6 @@ public :
   TBranch                   *b_t_HitEnergies1;  //!
   TBranch                   *b_t_HitEnergies3;  //!
 
-  TH1D                                             *h_pbyE, *h_cvg;
-  TProfile                                         *h_Ebyp_bfr, *h_Ebyp_aftr;
   CalibCorr                                        *cFactor_;
   CalibSelectRBX                                   *cSelect_;
   const int                                         truncateFlag_;
@@ -217,7 +248,8 @@ public :
   const int                                         phimin_, phimax_;
   const int                                         zside_, nvxlo_, nvxhi_;
   const int                                         sysmode_, rbx_, puCorr_;
-  const bool                                        useDepth_, useGen_,exclude_;
+  const int                                         rcorForm_;
+  const bool                                        useGen_,exclude_;
   const int                                         higheta_;
   bool                                              includeRun_;
   double                                            log2by18_, eHcalDelta_;
@@ -233,30 +265,6 @@ public :
     double fact0, fact1, fact2;
   };
 
-  CalibTree(const char *dupFileName, const char* rcorFileName, int truncateFlag,
-	    bool useMean, int runlo, int runhi, int phimin, int phimax,
-	    int zside, int nvxlo, int nvxhi, int sysmode, int rbx, int puCorr,
-	    bool useDepth, bool useGen, bool exclude, int higheta, 
-	    TChain *tree);
-  virtual ~CalibTree();
-  virtual Int_t    Cut(Long64_t entry);
-  virtual Int_t    GetEntry(Long64_t entry);
-  virtual Long64_t LoadTree(Long64_t entry);
-  virtual void     Init(TChain *tree, const char *dupFileName);
-  virtual Double_t Loop(int k, TFile *fout, bool useweight, int nMin, 
-			bool inverse, double rMin, double rMax, int ietaMax,
-			int applyL1Cut, double l1Cut, bool last, 
-			double fraction, bool writeHisto, bool debug);
-  virtual Bool_t   Notify();
-  virtual void     Show(Long64_t entry = -1);
-  bool             goodTrack();
-  void             writeCorrFactor(const char *corrFileName, int ietaMax);
-  bool             selectPhi(unsigned int detId);
-  std::pair<double,double> fitMean(TH1D*, int);
-  void             makeplots(double rmin, double rmax, int ietaMax,
-			     bool useWeight, double fraction, bool debug);
-  void             fitPol0(TH1D* hist, bool debug);
-  void             highEtaFactors(int ietaMax, bool debug);
 };
 
 
@@ -269,7 +277,7 @@ void doIt(const char* infile, const char* dup) {
     double lumi = (k==0) ? -1 : lumt;
     lumt *= fac;
     Run(infile,"HcalIsoTrkAnalyzer","CalibTree",outf1,outf2,dup,"",true,false,0,
-	true,0.25,3.0,23,-1,true,1,0.5,0,30,false,false,-1,99999999,1,72,0,0,
+	true,0.25,3.0,25,-1,-1,true,1,0.5,0,30,false,false,-1,99999999,1,72,0,0,
 	true,1,lumi,false,false);
   }
 }
@@ -278,11 +286,11 @@ void Run(const char *inFileName, const char *dirName, const char *treeName,
 	 const char *outFileName, const char *corrFileName,
 	 const char *dupFileName, const char* rcorFileName, 
 	 bool useweight, bool useMean, int nMin, bool inverse, double ratMin, 
-	 double ratMax, int ietaMax, int sysmode, int puCorr, int applyL1Cut,
-	 double l1Cut, int truncateFlag, int maxIter, bool useDepth, 
-	 bool useGen, int runlo, int runhi, int phimin, int phimax, int zside,
-	 int nvxlo, int nvxhi, int rbx, bool exclude, int higheta, 
-	 double fraction, bool writeHisto, bool debug) {
+	 double ratMax, int ietaMax, int ietaTrack, int sysmode, int puCorr, 
+	 int applyL1Cut, double l1Cut, int truncateFlag, int maxIter, 
+	 int rcorForm, bool useGen, int runlo, int runhi, int phimin, 
+	 int phimax, int zside, int nvxlo, int nvxhi, int rbx, bool exclude,
+	 int higheta, double fraction, bool writeHisto, bool debug) {
  
   char    name[500];
   sprintf (name, "%s/%s", dirName, treeName);
@@ -303,7 +311,7 @@ void Run(const char *inFileName, const char *dirName, const char *treeName,
     unsigned int k(0), kmax(maxIter);
     CalibTree t(dupFileName, rcorFileName, truncateFlag, useMean, runlo, runhi, 
 		phimin, phimax, zside, nvxlo, nvxhi, sysmode, rbx, puCorr, 
-		useDepth, useGen, exclude, higheta, chain); 
+		rcorForm, useGen, exclude, higheta, chain); 
     t.h_pbyE      = new TH1D("pbyE", "pbyE", 100, -1.0, 9.0);
     t.h_Ebyp_bfr  = new TProfile("Ebyp_bfr","Ebyp_bfr",60,-30,30,0,10);
     t.h_Ebyp_aftr = new TProfile("Ebyp_aftr","Ebyp_aftr",60,-30,30,0,10);
@@ -320,8 +328,8 @@ void Run(const char *inFileName, const char *dirName, const char *treeName,
     for (; k<=kmax; ++k) {
       std::cout << "Calling Loop() "  << k << "th time" << std::endl; 
       double cvg = t.Loop(k, fout, useweight, nMin, inverse, ratMin, ratMax, 
-			  ietaMax, applyL1Cut, l1Cut, k==kmax, fraction, 
-			  writeHisto, debug);
+			  ietaMax, ietaTrack, applyL1Cut, l1Cut, k==kmax, 
+			  fraction, writeHisto, debug);
       itrs[k] = k;
       cvgs[k] = cvg;
       if (cvg < 0.00001) break;
@@ -345,7 +353,7 @@ void Run(const char *inFileName, const char *dirName, const char *treeName,
 CalibTree::CalibTree(const char *dupFileName, const char* rcorFileName,
 		     int flag, bool useMean, int runlo, int runhi, int phimin,
 		     int phimax, int zside, int nvxlo, int nvxhi, int mode,
-		     int rbx, int pu, bool used, bool gen, bool excl, int heta,
+		     int rbx, int pu, int rForm, bool gen, bool excl, int heta,
 		     TChain *tree) : fChain(nullptr), cFactor_(nullptr),
 				     cSelect_(nullptr), truncateFlag_(flag),
 				     useMean_(useMean), runlo_(runlo), 
@@ -353,7 +361,7 @@ CalibTree::CalibTree(const char *dupFileName, const char* rcorFileName,
 				     phimax_(phimax), zside_(zside), 
 				     nvxlo_(nvxlo), nvxhi_(nvxhi), 
 				     sysmode_(mode), rbx_(rbx), puCorr_(pu),
-				     useDepth_(used), useGen_(gen), 
+				     rcorForm_(rForm), useGen_(gen), 
 				     exclude_(excl), higheta_(heta),
 				     includeRun_(true) {
   
@@ -368,8 +376,8 @@ CalibTree::CalibTree(const char *dupFileName, const char* rcorFileName,
 	    << " UseMean " << useMean_ << " Run Range " << runlo_ << ":"
 	    << runhi_ << " Phi Range " << phimin_ << ":" << phimax_ << ":" 
 	    << zside_ << " Vertex Range " << nvxlo_ << ":" << nvxhi_ 
-	    << " Mode " << sysmode_ << " PU " << puCorr_ << " UseDepth "
-	    << useDepth_ << " Gen " << useGen_ << " High Eta " << higheta_ 
+	    << " Mode " << sysmode_ << " PU " << puCorr_ << " rcorFormat "
+	    << rcorForm_ << " Gen " << useGen_ << " High Eta " << higheta_ 
 	    << std::endl;
   std::cout << "Duplicate events read from " << dupFileName 
 	    << " RadDam Corrections read from " << rcorFileName
@@ -377,7 +385,7 @@ CalibTree::CalibTree(const char *dupFileName, const char* rcorFileName,
 	    << std::endl;
   Init(tree, dupFileName);
   if (std::string(rcorFileName) != "") 
-    cFactor_ = new CalibCorr(rcorFileName,useDepth_,false);
+    cFactor_ = new CalibCorr(rcorFileName,rcorForm_,false);
   if (rbx != 0) cSelect_ = new CalibSelectRBX(rbx);
 }
 
@@ -469,19 +477,23 @@ void CalibTree::Init(TChain *tree, const char *dupFileName) {
   fChain->SetBranchAddress("t_HitEnergies3", &t_HitEnergies3, &b_t_HitEnergies3);
   Notify();
 
-  ifstream infil1(dupFileName);
-  if (!infil1.is_open()) {
-    std::cout << "Cannot open " << dupFileName << std::endl;
-  } else {
-    while (1) {
-      Long64_t jentry;
-      infil1 >> jentry;
-      if (!infil1.good()) break;
-      entries.push_back(jentry);
+  if (std::string(dupFileName) != "") {
+    ifstream infil1(dupFileName);
+    if (!infil1.is_open()) {
+      std::cout << "Cannot open " << dupFileName << std::endl;
+    } else {
+      while (1) {
+	Long64_t jentry;
+	infil1 >> jentry;
+	if (!infil1.good()) break;
+	entries.push_back(jentry);
+      }
+      infil1.close();
+      std::cout << "Reads a list of " << entries.size() << " events from " 
+		<< dupFileName << std::endl;
     }
-    infil1.close();
-    std::cout << "Reads a list of " << entries.size() << " events from " 
-	      << dupFileName << std::endl;
+  } else {
+    std::cout << "No duplicate events in the input file" << std::endl;
   }
 }
 
@@ -511,7 +523,7 @@ Int_t CalibTree::Cut(Long64_t ) {
 
 Double_t CalibTree::Loop(int loop, TFile *fout, bool useweight, int nMin,
 			 bool inverse, double rmin, double rmax, int ietaMax,
-			 int applyL1Cut, double l1Cut, bool last, 
+			 int ietaTrack, int applyL1Cut, double l1Cut, bool last,
 			 double fraction, bool writeHisto, bool debug) {
 
   if (fChain == 0) return 0;
@@ -530,7 +542,8 @@ Double_t CalibTree::Loop(int loop, TFile *fout, bool useweight, int nMin,
       // Find DetIds contributing to the track
       bool selRun = (includeRun_ ? ((t_Run >= runlo_) && (t_Run <= runhi_)) :
 		     ((t_Run < runlo_) || (t_Run > runhi_)));
-      if (selRun && (t_nVtx >= nvxlo_) && (t_nVtx <= nvxhi_)) {
+      bool selTrack = ((ietaTrack <= 0) || (abs(t_ieta) <= ietaTrack));
+      if (selRun && (t_nVtx >= nvxlo_) && (t_nVtx <= nvxhi_) && selTrack) {
 	bool isItRBX = (cSelect_ && exclude_ && cSelect_->isItRBX(t_DetIds));
 	++kprint;
 	if (!isItRBX) {
@@ -631,6 +644,8 @@ Double_t CalibTree::Loop(int loop, TFile *fout, bool useweight, int nMin,
 	if (!(cSelect_->isItRBX(t_ieta,t_iphi)))  continue;
       }
     }
+    bool selTrack = ((ietaTrack <= 0) || (abs(t_ieta) <= ietaTrack));
+    if (!selTrack)                                continue;
 
     if (debug) {
       std::cout << "***Entry (Track) Number : " << ientry << std::endl;

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
@@ -190,7 +190,7 @@ private:
   int                        t_Run, t_Event, t_DataType, t_ieta, t_iphi; 
   int                        t_goodPV, t_nVtx, t_nTrk;
   double                     t_EventWeight, t_p, t_pt, t_phi;
-  double                     t_mapP,t_mapPt,t_mapEta,t_mapPhi;
+  std::vector<double>       *t_mapP,*t_mapPt,*t_mapEta,*t_mapPhi;
   double                     t_l1pt, t_l1eta, t_l1phi;
   double                     t_l3pt, t_l3eta, t_l3phi;
   double                     t_mindR1, t_mindR2;
@@ -731,10 +731,15 @@ void HcalIsoTrackStudy::beginJob() {
   tree->Branch("t_p",           &t_p,           "t_p/D");
   tree->Branch("t_pt",          &t_pt,          "t_pt/D");
   tree->Branch("t_phi",         &t_phi,         "t_phi/D");
-  tree->Branch("t_mapP",        &t_mapP,        "t_mapP/D");
-  tree->Branch("t_mapPt",       &t_mapPt,       "t_mapPt/D");
-  tree->Branch("t_mapEta",      &t_mapEta,      "t_mapEta/D");
-  tree->Branch("t_mapPhi",      &t_mapPhi,      "t_mapPhi/D");
+
+  t_mapP         = new std::vector<double>();
+  t_mapPt        = new std::vector<double>();
+  t_mapEta       = new std::vector<double>();
+  t_mapPhi       = new std::vector<double>();
+  tree->Branch("t_mapP",      "std::vector<double>", &t_mapP);
+  tree->Branch("t_mapPt",     "std::vector<double>", &t_mapPt);
+  tree->Branch("t_mapEta",    "std::vector<double>", &t_mapEta);
+  tree->Branch("t_mapPhi",    "std::vector<double>", &t_mapPhi);
 
   tree->Branch("t_mindR1",      &t_mindR1,      "t_mindR1/D");
   tree->Branch("t_mindR2",      &t_mindR2,      "t_mindR2/D");
@@ -1067,6 +1072,7 @@ std::array<int,3> HcalIsoTrackStudy::fillTree(std::vector< math::XYZTLorentzVect
 	t_DetIds3->clear(); t_HitEnergies3->clear();
 	t_DetIdEC->clear(); t_HitEnergyEC->clear(); t_HitDistEC->clear();
 	t_DetIdHC->clear(); t_HitEnergyHC->clear(); t_HitDistHC->clear();
+	t_mapP->clear();t_mapPt->clear();t_mapEta->clear();t_mapPhi->clear();
 
 	int nRecHits(-999), nRecHits1(-999), nRecHits3(-999);
 	std::vector<DetId>  ids, ids1, ids3;
@@ -1419,10 +1425,10 @@ void HcalIsoTrackStudy::TrackMap(unsigned int trkIndex,
 	  const reco::Track* pTrack = &(*(trkDirs[indx].trkItr));
 	  TVector3 point(trkDirs[indx].pointHCAL.x(),trkDirs[indx].pointHCAL.y(),trkDirs[indx].pointHCAL.z());
 
-	  t_mapP = pTrack->p();
-	  t_mapPt = pTrack->pt();
-	  t_mapEta = point.Eta();
-	  t_mapPhi = point.Phi();
+	  t_mapP  ->emplace_back(pTrack->p());
+	  t_mapPt ->emplace_back(pTrack->pt());
+	  t_mapEta->emplace_back(point.Eta());
+	  t_mapPhi->emplace_back(point.Phi());
 	}
       }
     }


### PR DESCRIPTION
1. Selection of events in calibration now uses limits on ieta of the track at the calorimeter surface.
2. Instead of storing one track in IsoTrackStudy one now stores all tracks in an event which satisfy the isolation condition  