### PR TITLE
Fixed memory leak in HcalDigitizer

### DIFF
--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -2,6 +2,8 @@
 #define HcalSimProducers_HcalDigitizer_h
 
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalDigitizerTraits.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalSimParameterMap.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalQIE1011Traits.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalHitFilter.h"
@@ -22,7 +24,7 @@
 #include <vector>
 
 class CaloHitResponse;
-class HcalSimParameterMap;
+class HcalSiPMHitResponse;
 class HcalAmplifier;
 class HPDIonFeedbackSim;
 class HcalCoderFactory;
@@ -91,35 +93,35 @@ private:
   typedef CaloTDigitizer<HcalQIE10DigitizerTraits,CaloTDigitizerQIE1011Run> QIE10Digitizer;
   typedef CaloTDigitizer<HcalQIE11DigitizerTraits,CaloTDigitizerQIE1011Run> QIE11Digitizer;
 
-  HcalSimParameterMap * theParameterMap;
-  HcalShapes * theShapes;
+  HcalSimParameterMap  theParameterMap;
+  HcalShapes theShapes;
 
-  CaloHitResponse * theHBHEResponse;
-  CaloHitResponse * theHBHESiPMResponse;
-  CaloHitResponse * theHOResponse;
-  CaloHitResponse * theHOSiPMResponse;
-  CaloHitResponse * theHFResponse;
-  CaloHitResponse * theHFQIE10Response;
-  CaloHitResponse * theZDCResponse;
+  std::unique_ptr<CaloHitResponse> theHBHEResponse;
+  std::unique_ptr<HcalSiPMHitResponse> theHBHESiPMResponse;
+  std::unique_ptr<CaloHitResponse> theHOResponse;
+  std::unique_ptr<HcalSiPMHitResponse> theHOSiPMResponse;
+  std::unique_ptr<CaloHitResponse> theHFResponse;
+  std::unique_ptr<CaloHitResponse> theHFQIE10Response;
+  std::unique_ptr<CaloHitResponse> theZDCResponse;
 
   // we need separate amplifiers (and electronicssims)
   // because they might have separate noise generators
-  HcalAmplifier * theHBHEAmplifier;
-  HcalAmplifier * theHFAmplifier;
-  HcalAmplifier * theHOAmplifier;
-  HcalAmplifier * theZDCAmplifier;
-  HcalAmplifier * theHFQIE10Amplifier;
-  HcalAmplifier * theHBHEQIE11Amplifier;
+  std::unique_ptr<HcalAmplifier> theHBHEAmplifier;
+  std::unique_ptr<HcalAmplifier> theHFAmplifier;
+  std::unique_ptr<HcalAmplifier> theHOAmplifier;
+  std::unique_ptr<HcalAmplifier> theZDCAmplifier;
+  std::unique_ptr<HcalAmplifier> theHFQIE10Amplifier;
+  std::unique_ptr<HcalAmplifier> theHBHEQIE11Amplifier;
 
-  HPDIonFeedbackSim * theIonFeedback;
-  HcalCoderFactory * theCoderFactory;
+  std::unique_ptr<HPDIonFeedbackSim> theIonFeedback;
+  std::unique_ptr<HcalCoderFactory> theCoderFactory;
 
-  HcalElectronicsSim * theHBHEElectronicsSim;
-  HcalElectronicsSim * theHFElectronicsSim;
-  HcalElectronicsSim * theHOElectronicsSim;
-  HcalElectronicsSim * theZDCElectronicsSim;
-  HcalElectronicsSim * theHFQIE10ElectronicsSim;
-  HcalElectronicsSim * theHBHEQIE11ElectronicsSim;
+  std::unique_ptr<HcalElectronicsSim> theHBHEElectronicsSim;
+  std::unique_ptr<HcalElectronicsSim> theHFElectronicsSim;
+  std::unique_ptr<HcalElectronicsSim> theHOElectronicsSim;
+  std::unique_ptr<HcalElectronicsSim> theZDCElectronicsSim;
+  std::unique_ptr<HcalElectronicsSim> theHFQIE10ElectronicsSim;
+  std::unique_ptr<HcalElectronicsSim> theHBHEQIE11ElectronicsSim;
 
   HBHEHitFilter theHBHEHitFilter;
   HBHEHitFilter theHBHEQIE11HitFilter;
@@ -129,16 +131,16 @@ private:
   HOHitFilter theHOSiPMHitFilter;
   ZDCHitFilter  theZDCHitFilter;
 
-  HcalTimeSlewSim * theTimeSlewSim;
+  std::unique_ptr<HcalTimeSlewSim> theTimeSlewSim;
 
-  HBHEDigitizer * theHBHEDigitizer;
-  HODigitizer* theHODigitizer;
-  HODigitizer* theHOSiPMDigitizer;
-  HFDigitizer* theHFDigitizer;
-  ZDCDigitizer* theZDCDigitizer;
-  QIE10Digitizer * theHFQIE10Digitizer;
-  QIE11Digitizer * theHBHEQIE11Digitizer;
-  HcalHitRelabeller* theRelabeller;
+  std::unique_ptr<HBHEDigitizer> theHBHEDigitizer;
+  std::unique_ptr<HODigitizer> theHODigitizer;
+  std::unique_ptr<HODigitizer> theHOSiPMDigitizer;
+  std::unique_ptr<HFDigitizer> theHFDigitizer;
+  std::unique_ptr<ZDCDigitizer> theZDCDigitizer;
+  std::unique_ptr<QIE10Digitizer> theHFQIE10Digitizer;
+  std::unique_ptr<QIE11Digitizer> theHBHEQIE11Digitizer;
+  std::unique_ptr<HcalHitRelabeller> theRelabeller;
 
   // need to cache some DetIds for the digitizers,
   // if they don't come straight from the geometry


### PR DESCRIPTION
valgrind had found a memory leak in HcalDigitizer. Changing the member data to be held by value or via std::unique_ptr solved the problem.