### PR TITLE
Fix two memory leaks in pixel and strip digitizers

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -251,13 +251,12 @@ namespace cms
     std::vector<edm::DetSet<PixelDigi> > theDigiVector;
     std::vector<edm::DetSet<PixelDigiSimLink> > theDigiLinkVector;
  
-    PileupInfo_ = getEventPileupInfo();
     if (firstFinalizeEvent_) {
       const unsigned int bunchspace = PileupInfo_->getMix_bunchSpacing();
       _pixeldigialgo->init_DynIneffDB(iSetup, bunchspace);
       firstFinalizeEvent_ = false;
     }
-    _pixeldigialgo->calculateInstlumiFactor(PileupInfo_);   
+    _pixeldigialgo->calculateInstlumiFactor(PileupInfo_.get());
 
     for( const auto& iu : pDD->detUnits()) {
       

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -62,10 +62,10 @@ namespace cms {
 					 std::vector<int> &bunchCrossingList,
 					 std::vector<float> &TrueInteractionList, 
 					 std::vector<edm::EventID> &eventInfoList, int bunchSpacing) override{
-      PileupInfo_ = new PileupMixingContent(numInteractionList, bunchCrossingList, TrueInteractionList, eventInfoList, bunchSpacing);
+      PileupInfo_ = std::make_unique<PileupMixingContent>(numInteractionList, bunchCrossingList, TrueInteractionList, eventInfoList, bunchSpacing);
     }
 
-    PileupMixingContent* getEventPileupInfo() override { return PileupInfo_; }
+    PileupMixingContent* getEventPileupInfo() override { return PileupInfo_.get(); }
 
   private:
     void accumulatePixelHits(edm::Handle<std::vector<PSimHit> >,
@@ -95,7 +95,7 @@ namespace cms {
     std::map<unsigned int, PixelGeomDetUnit const *> detectorUnits;
     CLHEP::HepRandomEngine* randomEngine_ = nullptr;
 
-    PileupMixingContent* PileupInfo_;
+    std::unique_ptr<PileupMixingContent> PileupInfo_;
     
     const bool pilotBlades; // Default = false
     const int NumberOfEndcapDisks; // Default = 2

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -154,8 +154,7 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
     const TrackerTopology *tTopo=tTopoHand.product();
 
     //Re-compute luminosity for accumulation for HIP effects
-    PileupInfo_ = getEventPileupInfo();
-    theDigiAlgo->calculateInstlumiScale(PileupInfo_);
+    theDigiAlgo->calculateInstlumiScale(PileupInfo_.get());
 
     // Step A: Get Inputs
     for(auto const& trackerContainer : trackerContainers) {

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -56,10 +56,10 @@ public:
 				       std::vector<int> &bunchCrossingList,
 				       std::vector<float> &TrueInteractionList,
 				       std::vector<edm::EventID> &eventInfoList, int bunchSpacing) override{
-    PileupInfo_ = new PileupMixingContent(numInteractionList, bunchCrossingList, TrueInteractionList, eventInfoList, bunchSpacing);
+    PileupInfo_ = std::make_unique<PileupMixingContent>(numInteractionList, bunchCrossingList, TrueInteractionList, eventInfoList, bunchSpacing);
   } 
 
-  PileupMixingContent* getEventPileupInfo() override { return PileupInfo_; } 
+  PileupMixingContent* getEventPileupInfo() override { return PileupInfo_.get(); }
 
   
 private:
@@ -100,7 +100,7 @@ private:
   CLHEP::HepRandomEngine* randomEngine_ = nullptr;
   std::vector<std::pair<int,std::bitset<6>>> theAffectedAPVvector;
 
-  PileupMixingContent* PileupInfo_;
+  std::unique_ptr<PileupMixingContent> PileupInfo_;
 
 };
 


### PR DESCRIPTION
A valgrind log from @Dr15Jones pointed to a memory leak in pixel and strip digitizers. The function `StorePileupInformation()` is called from `MixingModule::doPileup()` once per (signal) event. 

The minimal fix is to use `std::unique_ptr`. 

Tested in 10_4_0_pre2, no changes expected.

@mdhildreth @Dr15Jones 