### PR TITLE
Fix pileup mixing with multiple pileup files for HGCal

### DIFF
--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -266,11 +266,16 @@ from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( theMixObjects,
     mixCH = dict(
         input = theMixObjects.mixCH.input + [ cms.InputTag("g4SimHits",hgceeDigitizer.hitCollection.value()),
-                                              cms.InputTag("g4SimHits",hgchebackDigitizer.hitCollection.value()),
                                               cms.InputTag("g4SimHits",hgchefrontDigitizer.hitCollection.value()) ],
         subdets = theMixObjects.mixCH.subdets + [ hgceeDigitizer.hitCollection.value(),
-                                                  hgchebackDigitizer.hitCollection.value(),
                                                   hgchefrontDigitizer.hitCollection.value() ],
+    )
+)
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify( theMixObjects,
+    mixCH = dict(
+        input = theMixObjects.mixCH.input + [ cms.InputTag("g4SimHits",hgchebackDigitizer.hitCollection.value()) ],
+        subdets = theMixObjects.mixCH.subdets + [ hgchebackDigitizer.hitCollection.value() ],
     )
 )
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -221,7 +221,7 @@ mixPCFHepMCProducts = cms.PSet(
     type = cms.string('HepMCProductPCrossingFrame')
 )
 
-from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchefrontDigitizer, hfnoseDigitizer
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigitizer
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toModify( theMixObjects,
@@ -266,8 +266,10 @@ from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( theMixObjects,
     mixCH = dict(
         input = theMixObjects.mixCH.input + [ cms.InputTag("g4SimHits",hgceeDigitizer.hitCollection.value()),
+                                              cms.InputTag("g4SimHits",hgchebackDigitizer.hitCollection.value()),
                                               cms.InputTag("g4SimHits",hgchefrontDigitizer.hitCollection.value()) ],
         subdets = theMixObjects.mixCH.subdets + [ hgceeDigitizer.hitCollection.value(),
+                                                  hgchebackDigitizer.hitCollection.value(),
                                                   hgchefrontDigitizer.hitCollection.value() ],
     )
 )


### PR DESCRIPTION
@kpedro88 Reported that MTD RelVals are failing mysteriously with "missing" `g4SimHits:HGCHitsHEback` collection in the pileup files. The product, however, exists in the files and is present in all events. The problem is not visible if the DIGI job is given only one pileup file.

I noticed that there is also another case where the problem is not visible. The mixing system opens a random pileup file once before the event loop to check the event content. Then, in the event loop, the mixing system opens a random pileup file to start processing the pileup events. In case these two files are the same (by chance), the job works fine.

The problem lies in `MixingModule` constructing a list of allowed branches from the specified "mixed objects" (SimTracks, RecoTracks, SimVertices, HepMCProduct, PCaloHits, and PSimHits), and it turns out that the `HGCHitsHEBack` is missing from the list of PCaloHits and thus gets dropped. This PR adds the `HGCHitsHEBack` back to the list.

Digging from the history, the `hgchebackDigitizer` was removed from here in #14667. After that, it was added back to `digitizers_cfi.py` and removed from there a few times such that #16022 left it there. I suppose that PR should have also restored `hgchebackDigitizer` here as well.

Tested in 10_4_0_pre2, no other changes expected.
