### PR TITLE
Fix leak from HepPDT::HeavyIonUnknownID

### DIFF
--- a/SimGeneral/HepPDTESSource/BuildFile.xml
+++ b/SimGeneral/HepPDTESSource/BuildFile.xml
@@ -1,3 +1,4 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="SimGeneral/HepPDTRecord"/>
+<use   name="tbb"/>
 <flags   EDM_PLUGIN="1"/>


### PR DESCRIPTION
HepPDT::HeavyIonUnknownID creates a new particle in the case the HepPDT does not know of that particle by default. However, nothing deletes that particle. This code wraps HeavyIonUnknownID and does a thread safe cache of the particle in order to delete it later.