### PR TITLE
Remove "using namespace l1t" from L1T DQM header files

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
@@ -26,8 +26,6 @@
 
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
-using namespace l1t;
-
 class L1TdeStage2CaloLayer1 : public DQMEDAnalyzer {
   public:
     L1TdeStage2CaloLayer1(const edm::ParameterSet& ps);
@@ -44,9 +42,9 @@ class L1TdeStage2CaloLayer1 : public DQMEDAnalyzer {
     void updateMismatch(const edm::Event& e, int mismatchType);
     // Input and config info 
     edm::InputTag dataLabel_;
-    edm::EDGetTokenT<CaloTowerBxCollection> dataSource_;
+    edm::EDGetTokenT<l1t::CaloTowerBxCollection> dataSource_;
     edm::InputTag emulLabel_;
-    edm::EDGetTokenT<CaloTowerBxCollection> emulSource_;
+    edm::EDGetTokenT<l1t::CaloTowerBxCollection> emulSource_;
     edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalTowers_;
     edm::EDGetTokenT<FEDRawDataCollection> fedRawData_;
     std::string histFolder_;

--- a/DQM/L1TMonitor/interface/L1TdeStage2uGT.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2uGT.h
@@ -33,8 +33,6 @@
 
 #include "FWCore/Utilities/interface/RegexMatch.h"
 
-using namespace l1t;
-
 class L1TdeStage2uGT : public DQMEDAnalyzer {
   public:
     L1TdeStage2uGT(const edm::ParameterSet& ps);
@@ -54,7 +52,7 @@ class L1TdeStage2uGT : public DQMEDAnalyzer {
     std::vector<std::string>  triggerBlackList_;
     int numBx_;
     std::string histFolder_;
-    L1TGlobalUtil* gtUtil_;
+    l1t::L1TGlobalUtil* gtUtil_;
     int numLS_;
     uint m_currentLumi;
 

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -15,6 +15,7 @@
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 #include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
 
+using namespace l1t;
 
 L1TdeStage2CaloLayer1::L1TdeStage2CaloLayer1(const edm::ParameterSet & ps) :
   dataLabel_(ps.getParameter<edm::InputTag>("dataSource")),


### PR DESCRIPTION
This PR addresses the CMSSW code rules violation reported in the test of #25132 :

Rule1 : https://raw.githubusercontent.com/cms-sw/cmssw/master/Utilities/ReleaseScripts/python/cmsCodeRules/config.py
Search for "using namespace" or "using std::" in header files

/DQM/L1TMonitor/interface/L1TdeStage2uGT.h
[36]
/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
[29]