### PR TITLE
L1T CaloL2: Fix MPUnpacker so that it does not go out of range for old test run

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010010.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010010.cc
@@ -315,6 +315,11 @@ namespace stage2 {
        res4_->push_back(0,tau);
      }
 
+     // check block size to avoid problems with test run 272133
+     // which used wrong fw version and doesn't have aux output
+
+     if(block.header().getSize()>faux){
+
       //      ===== Aux =====
       raw_data = block.payload()[faux];
 
@@ -356,6 +361,7 @@ namespace stage2 {
       default:
         break;
       }
+     }
 
      return true;
    }


### PR DESCRIPTION
There appears to be a run 272133 where the firmware version was updated, but the additional output required by the versioned unpacker is not present in the readout. This was during commissioning of the Stage 2 trigger. I've added a check that makes sure the unpacker doesn't go outside the block length.