### PR TITLE
avoid divide by zero in HCAL status word DQM histograms

### DIFF
--- a/DQMOffline/Hcal/src/HcalRecHitsDQMClient.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsDQMClient.cc
@@ -54,6 +54,10 @@ void HcalRecHitsDQMClient::beginRun(const edm::Run& run, const edm::EventSetup& 
   nChannels_[3] = hoCells.size(); 
   nChannels_[4] = hfCells.size();
   nChannels_[0] = nChannels_[1] + nChannels_[2] + nChannels_[3] + nChannels_[4];
+  //avoid divide by zero
+  for(unsigned i = 0; i < 5; ++i){
+    if(nChannels_[i]==0) nChannels_[i] = 1;
+  }
  
   //std::cout << "Channels HB:" << nChannels_[1] << " HE:" << nChannels_[2] << " HO:" << nChannels_[3] << " HF:" << nChannels_[4] << std::endl;
  


### PR DESCRIPTION
In the new 2023D35 workflow, there are no valid HE cells (replaced by HGCal). This caused a divide by zero problem in the HCAL status word DQM histograms, which showed up as a spurious failure in the comparison tests. It is fixed in this PR.

attn: @abdoulline, @DryRun 