### PR TITLE
Discard Beamspot fit results when d0-phi fit status is unknown

### DIFF
--- a/RecoVertex/BeamSpotProducer/src/BSFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BSFitter.cc
@@ -589,6 +589,7 @@ reco::BeamSpot BSFitter::Fit_d0phi() {
 	if (status){
 	  //edm::LogError("NoBeamSpotFit")<<"gaussian fit failed. no BS d0 fit";
 
+	  goodfit = false;
 	  return reco::BeamSpot();
 	}
 	double fpar[2] = {fgaus.GetParameter(1), fgaus.GetParameter(2) };

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -530,7 +530,7 @@ bool BeamFitter::runFitterNoTxt() {
     h1z = (TH1F*) myalgo->GetVzHisto();
 
     delete myalgo;
-    if ( fbeamspot.type() != 0 ) {// save all results except for Fake (all 0.)
+    if ( fbeamspot.type() > 0 ) {// save all results except for Fake and Unknown (all 0.)
       fit_ok = true;
       if (saveBeamFit_){
 	fx = fbeamspot.x0();


### PR DESCRIPTION
1. Invalidating d0-phi results when an empty reco::Beamspot object is returned due to the failing of the 1D gaussian fit to the track z0 distribution
2. When combining the d0-phi results with the PV fit results, only consider d0-phi fits with status > 0 as good.