### PR TITLE
Fixed unusable comparison in muonMatches

### DIFF
--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -109,11 +109,7 @@ int Muon::numberOfMatches( unsigned int type ) const
 	     matches++;
 	     break;
 	   }
-         if(type > 1<<7)
-            if(segmentMatch->isMask(type)) {
-               matches++;
-               break;
-            }
+         
       }
    }
 


### PR DESCRIPTION
Fixed the issue* removing the last comparison check. 
(*) https://github.com/cms-sw/cmssw/issues/23057
