### PR TITLE
Strip packer: protect against invalid header types

### DIFF
--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -158,9 +158,7 @@ namespace sistrip {
             }
 
             if ( fedbuffer->headerType() == sistrip::HEADER_TYPE_INVALID ) {
-              edm::LogWarning("DigiToRaw")
-                << "[sistrip::DigiToRaw::createFedBuffers_]"
-                << " Invalid header type for FED " << *ifed << ", skipping";
+              warnings_.add("Invalid header type for FED, skipping", (boost::format("id %1%") % *ifed).str());
               continue;
             }
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -157,6 +157,13 @@ namespace sistrip {
                         << std::endl;
             }
 
+            if ( fedbuffer->headerType() == sistrip::HEADER_TYPE_INVALID ) {
+              edm::LogWarning("DigiToRaw")
+                << "[sistrip::DigiToRaw::createFedBuffers_]"
+                << " Invalid header type for FED " << *ifed << ", skipping";
+              continue;
+            }
+
             if ( edm::isDebugEnabled() ) {
               edm::LogWarning("DigiToRaw")
                 << "[sistrip::DigiToRaw::createFedBuffers_]"


### PR DESCRIPTION
Fix for a crash in the HLT repacking of HI events where a FED gives an raw data packet with only zeros between the DAQ header and trailer, e.g. (the second warning printout was only for debugging, it's not in the commits of this PR)
```
%MSG-w SiStripRawToDigi:  SiStripRawToDigiModule:siStripDigis  23-Nov-2018 21:39:49 CET Run: 327078 Event: 121269290
Exception caught when creating FEDBuffer object for FED: id 101: An exception of category 'FEDBuffer' occurred.
Exception Message:
Buffer format not recognized. Tracker special header: 00 00 00 00 00 00 00 00

Note: further warnings of this type will be suppressed (this can be changed by enabling debugging printout)
%MSG
%MSG-w SiStripRawToDigi:  SiStripRawToDigiModule:siStripDigis  23-Nov-2018 21:39:49 CET Run: 327078 Event: 121269290
[sistrip::RawToDigiUnpacker::dumpRawData] Dump of buffer for FED id 101
 Buffer contains 96 bytes (NB: payload is byte-swapped)
  Byte |  <---- Byte order ----<  | Byte
  cntr |  7  6  5  4  3  2  1  0  | cntr
     7 : 5f aa 2c 1f 86 20 65 00 :     0
    15 : 00 00 00 00 00 00 00 00 :     8
    23 : 00 00 00 00 00 00 00 00 :    16
    31 : 00 00 00 00 00 00 00 00 :    24
    39 : 00 00 00 00 00 00 00 00 :    32
    47 : 00 00 00 00 00 00 00 00 :    40
    55 : 00 00 00 00 00 00 00 00 :    48
    63 : 00 00 00 00 00 00 00 00 :    56
    71 : 00 00 00 00 00 00 00 00 :    64
    79 : 00 00 00 00 00 00 00 00 :    72
    87 : 00 00 00 00 00 00 00 00 :    80
    95 : a0 00 00 0c cf 8a 00 40 :    88
[sistrip::RawToDigiUnpacker::dumpRawData] End of FED buffer
```

CC: @icali @stahlleiton @CesarBernardes @erikbutz @mmusich 