### PR TITLE
PFEGammaAlgo removing unused function arguments

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
@@ -137,10 +137,8 @@ class PFEGammaAlgo {
   }
 
   void RunPFEG(const pfEGHelpers::HeavyObjectCache* hoc,
-               const reco::PFBlockRef&  blockRef,
-               std::vector< bool >& active
-               );
-               
+               const reco::PFBlockRef&  blockRef);
+  
   //get PFCandidate collection
   reco::PFCandidateCollection& getCandidates() {return outcands_;}
 

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -211,10 +211,7 @@ PFEGammaProducer::produce(edm::Event& iEvent,
     // make a copy of the link data, which will be edited.
     //PFBlock::LinkData linkData =  block.linkData();
     
-    // keep track of the elements which are still active.
-    std::vector<bool> active( elements.size(), true );      
-    
-    pfeg_->RunPFEG(globalCache(),blockref,active);
+    pfeg_->RunPFEG(globalCache(),blockref);
 
     if( !pfeg_->getCandidates().empty() ) {
       LOGDRESSED("PFEGammaProducer")


### PR DESCRIPTION
I propose to remove some unused function variables and template parameters (when actually only one template instance is used) from PFEGammaAlgo.