### PR TITLE
Remove --harvesting AtJobEnd option in GEN Relval workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2317,7 +2317,6 @@ steps['RECOHIMIX']=merge([steps['RECOHI2018PPRECO'],{'--pileup':'HiMix','--pileu
 
 steps['ALCANZS']=merge([{'-s':'ALCA:HcalCalMinBias','--mc':''},step4Defaults])
 steps['HARVESTGEN']={'-s':'HARVESTING:genHarvesting',
-                     '--harvesting':'AtJobEnd',
                      '--conditions':'auto:run2_mc_FULL',
                      '--mc':'',
                      '--era' :'Run2_2016',


### PR DESCRIPTION
In recent 10_4_0_pre2 release validation campaign, DQMIO files of ALL GEN Relval samples were not uploaded to DQM server due to the wrong run number (999999). This was caused by PR #24920 , the dummy run number parameter of all GEN workflows was affected by the change introduced in [DQMSaverAtJobEnd_cff.py](https://github.com/cms-sw/cmssw/pull/24920/files#diff-de4766ca44b88f9363530b795048ba09) because all GEN Relval workflows were using '--harvesting AtJobEnd' option. Since there is no point of using '--harvesting AtJobEnd' option (there is only single harvesting job like any other Relval workflows), simply removing this option can fix the issue.

Fix the issue #25272 . See [JIRA ticket 4020](https://its.cern.ch/jira/browse/CMSCOMPPR-4020) for detailed discussions.