### PR TITLE
Fix MTV validation of initialStepPreSplitting tracks

### DIFF
--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -35,6 +35,7 @@
 #include "DataFormats/Provenance/interface/ESRecordAuxiliary.h"
 #include "DataFormats/Provenance/interface/ViewTypeChecker.h"
 #include "FWCore/Utilities/interface/typedefs.h"
+#include "FWCore/Utilities/interface/VecArray.h"
 #include <map>
 #include <set>
 #include <vector>

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -61,6 +61,7 @@
  <class name="std::pair<edm::BranchID, std::set<edm::BranchID> >"/>
  <class name="std::vector<edm::BranchID>"/>
  <class name="std::vector<edm::ProductID>"/>
+ <class name="edm::VecArray<edm::ProductID, 2>"/>
  <class name="std::pair<edm::ProductID, unsigned int>" />
  <class name="std::vector<std::pair<edm::ProductID, unsigned int> >" />
  <class name="std::vector<edm::EventID>"/>

--- a/SimTracker/TrackerHitAssociation/BuildFile.xml
+++ b/SimTracker/TrackerHitAssociation/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
+<use   name="FWCore/Utilities"/>
 <use   name="DataFormats/Common"/>
 <use   name="SimDataFormats/CrossingFrame"/>
 <use   name="SimDataFormats/TrackingHit"/>

--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
@@ -4,6 +4,7 @@
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Common/interface/HandleBase.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
+#include "FWCore/Utilities/interface/VecArray.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 
@@ -32,6 +33,10 @@ public:
 
   void emplace_back(const OmniClusterRef& cluster, const TrackingParticleRef& tp) {
     checkMappedProductID(tp);
+    auto foundKeyID = std::find(std::begin(keyProductIDs_), std::end(keyProductIDs_), cluster.id());
+    if(foundKeyID == std::end(keyProductIDs_)) {
+      keyProductIDs_.emplace_back(cluster.id());
+    }
     map_.emplace_back(cluster, tp);
   }
   void sortAndUnique() {
@@ -54,10 +59,14 @@ public:
   const_iterator cend()   const { return map_.end(); }
 
   range equal_range(const OmniClusterRef& key) const {
+    checkKeyProductID(key);
     return std::equal_range(map_.begin(), map_.end(), value_type(key, TrackingParticleRef()), compare);
   }
   
   const map_type& map() const { return map_; }
+
+  void checkKeyProductID(const OmniClusterRef& key) const { checkKeyProductID(key.id()); }
+  void checkKeyProductID(const edm::ProductID& id) const;
 
   void checkMappedProductID(const edm::HandleBase& mappedHandle) const { checkMappedProductID(mappedHandle.id()); }
   void checkMappedProductID(const TrackingParticleRef& tp) const { checkMappedProductID(tp.id()); }
@@ -75,6 +84,7 @@ private:
   }
 
   map_type map_;
+  edm::VecArray<edm::ProductID, 2> keyProductIDs_;
   edm::ProductID mappedProductId_;
 };
 

--- a/SimTracker/TrackerHitAssociation/src/ClusterTPAssociation.cc
+++ b/SimTracker/TrackerHitAssociation/src/ClusterTPAssociation.cc
@@ -1,6 +1,21 @@
 #include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+void ClusterTPAssociation::checkKeyProductID(const edm::ProductID& id) const {
+  if(std::find(std::begin(keyProductIDs_), std::end(keyProductIDs_), id) == std::end(keyProductIDs_)) {
+    auto e = cms::Exception("InvalidReference");
+    e << "ClusterTPAssociation has OmniClusterRefs with ProductIDs ";
+    for(size_t i=0; i<keyProductIDs_.size(); ++i) {
+      e << keyProductIDs_[i];
+      if(i < keyProductIDs_.size()-1) {
+	e << ",";
+      }
+    }
+    e << " but got OmniClusterRef/ProductID with ID " << id << ". This is typically caused by a configuration error.";
+    throw e;
+  }
+}
+
 void ClusterTPAssociation::checkMappedProductID(const edm::ProductID& id) const {
   if(id != mappedProductId_) {
     throw cms::Exception("InvalidReference") << "ClusterTPAssociation has TrackingParticles with ProductID " << mappedProductId_ << ", but got TrackingParticleRef/Handle/ProductID with ID " << id << ". This is typically caused by a configuration error.";

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -68,6 +68,11 @@ MultiTrackValidator::MultiTrackValidator(const edm::ParameterSet& pset):
   doMVAPlots_(pset.getUntrackedParameter<bool>("doMVAPlots")),
   simPVMaxZ_(pset.getUntrackedParameter<double>("simPVMaxZ"))
 {
+  if(label.empty()) {
+    // Disable prefetching of everything if there are no track collections
+    return;
+  }
+
   const edm::InputTag& label_tp_effic_tag = pset.getParameter< edm::InputTag >("label_tp_effic");
   const edm::InputTag& label_tp_fake_tag = pset.getParameter< edm::InputTag >("label_tp_fake");
 
@@ -211,6 +216,10 @@ MultiTrackValidator::~MultiTrackValidator() {}
 
 
 void MultiTrackValidator::bookHistograms(DQMStore::ConcurrentBooker& ibook, edm::Run const&, edm::EventSetup const& setup, Histograms& histograms) const {
+  if(label.empty()) {
+    // Disable histogram booking if there are no track collections
+    return;
+  }
 
   const auto minColl = -0.5;
   const auto maxColl = label.size()-0.5;
@@ -481,6 +490,11 @@ void MultiTrackValidator::trackDR(const edm::View<reco::Track>& trackCollection,
 
 
 void MultiTrackValidator::dqmAnalyze(const edm::Event& event, const edm::EventSetup& setup, const Histograms& histograms) const {
+  if(label.empty()) {
+    // Disable if there are no track collections
+    return;
+  }
+
   using namespace reco;
 
   LogDebug("TrackValidator") << "\n====================================================" << "\n"

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -572,6 +572,8 @@ def _trackingSubFoldersFallbackFromPV(subfolder):
     return subfolder.replace("trackingParticleRecoAsssociation", "trackingParticleRecoAsssociationSignal")
 def _trackingSubFoldersFallbackConversion(subfolder):
     return subfolder.replace("quickAssociatorByHits", "quickAssociatorByHitsConversion")
+def _trackingSubFoldersFallbackPreSplitting(subfolder):
+    return subfolder.replace("quickAssociatorByHits", "quickAssociatorByHitsPreSplitting")
 
 # Additional "quality" flags than highPurity. In a separate list to
 # allow customization.
@@ -1294,7 +1296,8 @@ def _appendTrackingPlots(lastDirName, name, algoPlots, onlyForPileup=False, only
     ], **limiters)
     common = dict(fallbackDqmSubFolders=[
         _trackingSubFoldersFallbackSLHC_Phase1PU140,
-        _trackingSubFoldersFallbackFromPV, _trackingSubFoldersFallbackConversion])
+        _trackingSubFoldersFallbackFromPV, _trackingSubFoldersFallbackConversion,
+        _trackingSubFoldersFallbackPreSplitting])
     plotter.append(name, folders, TrackingPlotFolder(*algoPlots, **commonForTPF), **common)
     extendedPlots = []
     if building:

--- a/Validation/RecoVertex/python/VertexValidation_cff.py
+++ b/Validation/RecoVertex/python/VertexValidation_cff.py
@@ -10,17 +10,17 @@ vertexValidation = cms.Sequence(v0Validator
 
 from Validation.RecoTrack.TrackValidation_cff import tracksValidationTruth, tracksValidationTruthPixelTrackingOnly
 vertexValidationStandalone = cms.Sequence(
+    vertexValidation,
     tracksValidationTruth
-    * vertexValidation
 )
 
 vertexValidationTrackingOnly = cms.Sequence(
+    v0Validator
+    + vertexAnalysisSequenceTrackingOnly,
     tracksValidationTruth
-    + v0Validator
-    + vertexAnalysisSequenceTrackingOnly
 )
 
 vertexValidationPixelTrackingOnly = cms.Sequence(
+    vertexAnalysisSequencePixelTrackingOnly,
     tracksValidationTruthPixelTrackingOnly
-    + vertexAnalysisSequencePixelTrackingOnly
 )


### PR DESCRIPTION
There is a subtle bug in the current tracking validation setup in "built tracks" MultiTrackValidator variant for initialStepPreSplitting tracks. Because of the cluster splitting done in the initialStepPreSplitting iteration, it uses different pixel clusters (`siPixelClustersPreSplitting`) than the rest of the iterations (`siPixelClusters`). However, for the validation only a single the cluster->TrackingParticle mapping (`tpClusters` product) is created with the `siPixelClusters` as an input. When this mapping is queried in QuickTrackAssociatorByHits, there is no check for the `ProductID` of the (pixel) `OmniClusterRef`. In other words, for an `OmniClusterRef` from `siPixelClustersPreSplitting`, take the index of the `Ref` and check if an `OmniClusterRef` from `siPixelClusters` with the same index is matched to a TrackingParticle.

This PR fixes the problem in the following way
* Store the key `ProductID`s in `ClusterTPAssociation`, and check it when querying for matching TrackingParticles
   * This required adding dictionary for `edm::VecArray<ProductID, 2>`
* Add a second instance of the cluster->TP mapping (`tpClustersPreSplitting`) for the PreSplitting clusters, and add an additional MTV instance only for the initialStepPreSplitting tracks.
   * This means that the `initialStepPreSplitting` gets removed from the summary plots for seeds and built tracks
   * I also moved all the producers to Tasks to make sure that they're always run unscheduled

 Tested in CMSSW_10_4_0_pre2, expecting changes in MTV seeding and built tracks summary and initialStepPreSplitting plots.

@VinInn @mtosi @JanFSchulte @hajohajo