### PR TITLE
RECO Geometry: CTPPS DetGeomDesc Cleanup

### DIFF
--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -36,7 +36,6 @@ class RPAlignmentCorrectionData;
 class DetGeomDesc
 {
  public:
-  using ConstContainer = std::vector< const DetGeomDesc* >;
   using Container = std::vector< DetGeomDesc* >;
   using RotationMatrix = ROOT::Math::Rotation3D;
   using Translation = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
@@ -53,10 +52,10 @@ class DetGeomDesc
   
   /// ID stuff
   void setGeographicalID(DetId id) { m_geographicalID = id; }
-  virtual DetId geographicalID() const { return m_geographicalID; }
+  DetId geographicalID() const { return m_geographicalID; }
   
   /// access to the tree structure
-  virtual Container components() const;
+  Container components() const;
   float planeZPos() const { return m_z; }
   
   /// components (children) management
@@ -68,15 +67,15 @@ class DetGeomDesc
   Translation		translation() const { return m_trans; }
   const std::string&	name() const {return m_name;};
   std::vector<double>	params() const {return m_params;}
-  virtual int		copyno() const {return m_copy;}
+  int                   copyno() const {return m_copy;}
   
   /// alignment
-  void ApplyAlignment(const RPAlignmentCorrectionData&);
+  void applyAlignment( const RPAlignmentCorrectionData& );
   
  private:
   DetGeomDesc() {}
   void deleteComponents(); /// deletes just the first daughters
-  void deepDeleteComponents(); ///traverses the treee and deletes all nodes.
+  void deepDeleteComponents(); /// traverses the treee and deletes all nodes.
   void clearComponents() { m_container.resize(0); }
   
   Container		 m_container;

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -55,7 +55,7 @@ class DetGeomDesc
   
   /// access to the tree structure
   Container components() const;
-  float planeZPos() const { return m_z; }
+  float parentZPosition() const { return m_z; }
   
   /// components (children) management
   void addComponent( DetGeomDesc* );
@@ -64,9 +64,9 @@ class DetGeomDesc
   /// geometry information
   RotationMatrix	rotation() const { return m_rot; }
   Translation		translation() const { return m_trans; }
-  const std::string&	name() const {return m_name;};
-  std::vector<double>	params() const {return m_params;}
-  int                   copyno() const {return m_copy;}
+  const std::string&	name() const { return m_name; }
+  std::vector<double>	params() const { return m_params; }
+  int copyno() const { return m_copy; }
   
   /// alignment
   void applyAlignment( const RPAlignmentCorrectionData& );
@@ -78,13 +78,13 @@ class DetGeomDesc
   void clearComponents() { m_container.resize(0); }
   
   Container		 m_container;
-  Translation            m_trans;
-  RotationMatrix         m_rot;
-  std::string            m_name;
-  std::vector<double>    m_params;
-  DetId 		 m_geographicalID;
-  int    		 m_copy;
-  float                  m_z;
+  Translation m_trans;
+  RotationMatrix m_rot;
+  std::string m_name;
+  std::vector<double> m_params;
+  DetId m_geographicalID;
+  int m_copy;
+  float m_z;
 };
 
 #endif

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -12,10 +12,9 @@
 #include <utility>
 
 #include "DetectorDescription/Core/interface/DDExpandedView.h"
-#include "DetectorDescription/Core/interface/DDRotationMatrix.h"
-#include "DetectorDescription/Core/interface/DDTranslation.h"
 #include "DetectorDescription/Core/interface/DDSolidShapes.h"
 #include "DataFormats/DetId/interface/DetId.h"
+#include <Math/Rotation3D.h>
 
 class DDFilteredView;
 class RPAlignmentCorrectionData;
@@ -36,82 +35,58 @@ class RPAlignmentCorrectionData;
 
 class DetGeomDesc
 {
-	public:
-		typedef std::vector< const DetGeomDesc*>  ConstContainer;
-		typedef std::vector< DetGeomDesc*>  Container;
-		typedef DDExpandedView::nav_type nav_type;
-		
-		/// a type (not used in the moment, left for the future)
-		typedef unsigned int GeometricEnumType;
-		
-		///Constructors to be used when looping over DDD
-		DetGeomDesc(nav_type navtype, GeometricEnumType dd = 0);
-		DetGeomDesc(DDExpandedView* ev, GeometricEnumType dd = 0);
-		DetGeomDesc(DDFilteredView* fv, GeometricEnumType dd = 0);
-		
-		/// copy constructor and assignment operator
-		DetGeomDesc(const DetGeomDesc &);
-		DetGeomDesc& operator= (const DetGeomDesc &);
+ public:
+  using ConstContainer = std::vector< const DetGeomDesc* >;
+  using Container = std::vector< DetGeomDesc* >;
+  using RotationMatrix = ROOT::Math::Rotation3D;
+  using Translation = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
 
-		/// destructor
-		virtual ~DetGeomDesc();
-		
-		/// ID stuff
-		void setGeographicalID(DetId id) { _geographicalID = id; }
-		virtual DetId geographicalID() const { return _geographicalID; }
-
-		/// access to the tree structure
-		virtual ConstContainer components() const;
-		virtual Container components();
-		virtual ConstContainer deepComponents() const;				/// returns all the components below
-		virtual std::vector< DDExpandedNode > parents() const		/// retuns the geometrical history
-			{ return _parents; }
-
-		/// components (children) management
-		void setComponents(Container cont)
-			{ _container = std::move(cont); }
-		void addComponents(Container cont);
-		void addComponent(DetGeomDesc*);
-		void clearComponents()
-			{ _container.resize(0);} 
-		void deleteComponents(); 									/// deletes just the first daughters
-		void deepDeleteComponents();  								///traverses the treee and deletes all nodes.
-		bool isLeaf() const 
-			{ return (_container.empty()); }
-		
-		/// geometry information
-		DDRotationMatrix	rotation() const {return _rot;}
-		DDTranslation		translation() const {return _trans;}
-		DDSolidShape		shape() const  {return _shape;}
-		GeometricEnumType	type() const {return _type;}
-		DDName				name() const {return _name;};
-		nav_type			navType() const {return _ddd;}
-		std::vector<double>	params() const {return _params;}
-		virtual int			copyno() const {return _copy;}
-		virtual double		volume() const {return _volume;}
-		virtual double		density() const {return _density;}
-		virtual double		weight() const {return _weight;}
-		virtual std::string	material() const {return _material;}
-
-		/// alignment
-		void ApplyAlignment(const RPAlignmentCorrectionData&);
-		
-	private:
-		Container						_container;
-		nav_type 						_ddd;	
-		DDTranslation 					_trans;
-		DDRotationMatrix				_rot;
-		DDSolidShape					_shape;
-		std::string 					_name;
-		GeometricEnumType 				_type;
-		std::vector<double>				_params;
-		DetId 							_geographicalID;
-		std::vector< DDExpandedNode >	_parents;
-		double 							_volume;
-		double 							_density;
-		double 							_weight;
-		int    							_copy;
-		std::string 					_material;
+  ///Constructors to be used when looping over DDD
+  DetGeomDesc( DDFilteredView* fv );
+  
+  /// copy constructor and assignment operator
+  DetGeomDesc( const DetGeomDesc & );
+  DetGeomDesc& operator= ( const DetGeomDesc & );
+  
+  /// destructor
+  virtual ~DetGeomDesc();
+  
+  /// ID stuff
+  void setGeographicalID(DetId id) { m_geographicalID = id; }
+  virtual DetId geographicalID() const { return m_geographicalID; }
+  
+  /// access to the tree structure
+  virtual Container components() const;
+  float planeZPos() const { return m_z; }
+  
+  /// components (children) management
+  void addComponent( DetGeomDesc* );
+  bool isLeaf() const { return m_container.empty(); }
+  
+  /// geometry information
+  RotationMatrix	rotation() const { return m_rot; }
+  Translation		translation() const { return m_trans; }
+  const std::string&	name() const {return m_name;};
+  std::vector<double>	params() const {return m_params;}
+  virtual int		copyno() const {return m_copy;}
+  
+  /// alignment
+  void ApplyAlignment(const RPAlignmentCorrectionData&);
+  
+ private:
+  DetGeomDesc() {}
+  void deleteComponents(); /// deletes just the first daughters
+  void deepDeleteComponents(); ///traverses the treee and deletes all nodes.
+  void clearComponents() { m_container.resize(0); }
+  
+  Container		 m_container;
+  Translation            m_trans;
+  RotationMatrix         m_rot;
+  std::string            m_name;
+  std::vector<double>    m_params;
+  DetId 		 m_geographicalID;
+  int    		 m_copy;
+  float                  m_z;
 };
 
 #endif

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -43,7 +43,7 @@ class DetGeomDesc
   DetGeomDesc( DDFilteredView* fv );
   
   /// copy constructor and assignment operator
-  DetGeomDesc( const DetGeomDesc & ) = default;
+  DetGeomDesc( const DetGeomDesc & );
   DetGeomDesc& operator= ( const DetGeomDesc & );
   
   /// destructor

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -43,7 +43,7 @@ class DetGeomDesc
   DetGeomDesc( DDFilteredView* fv );
   
   /// copy constructor and assignment operator
-  DetGeomDesc( const DetGeomDesc & );
+  DetGeomDesc( const DetGeomDesc & ) = default;
   DetGeomDesc& operator= ( const DetGeomDesc & );
   
   /// destructor

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -10,9 +10,8 @@
 #define Geometry_VeryForwardGeometryBuilder_DetGeomDesc
 
 #include <utility>
+#include <vector>
 
-#include "DetectorDescription/Core/interface/DDExpandedView.h"
-#include "DetectorDescription/Core/interface/DDSolidShapes.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include <Math/Rotation3D.h>
 

--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
@@ -117,7 +117,7 @@ CTPPSGeometryESModule::applyAlignments( const edm::ESHandle<DetGeomDesc>& idealG
 
       if ( alignments.isValid() ) {
         const RPAlignmentCorrectionData& ac = alignments->getFullSensorCorrection( plId );
-        pD->ApplyAlignment( ac );
+        pD->applyAlignment( ac );
       }
     }
 
@@ -130,7 +130,7 @@ CTPPSGeometryESModule::applyAlignments( const edm::ESHandle<DetGeomDesc>& idealG
 
       if ( alignments.isValid() ) {
         const RPAlignmentCorrectionData& ac = alignments->getRPCorrection( rpId );
-        pD->ApplyAlignment( ac );
+        pD->applyAlignment( ac );
       }
     }
 

--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
@@ -105,7 +105,7 @@ CTPPSGeometryESModule::applyAlignments( const edm::ESHandle<DetGeomDesc>& idealG
     buffer.pop_front();
     bufferNew.pop_front();
 
-    const std::string name = pD->name().name();
+    const std::string name = pD->name();
 
     // Is it sensor? If yes, apply full sensor alignments
     if ( name == DDD_TOTEM_RP_SENSOR_NAME

--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryInfo.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryInfo.cc
@@ -158,7 +158,7 @@ CTPPSGeometryInfo::printGeometry( const CTPPSGeometry& geometry, const edm::Even
         << "    ce: RP center in global coordinates, in mm\n";
 
     for ( auto it = geometry.beginRP(); it != geometry.endRP(); ++it ) {
-      const DDTranslation &t = it->second->translation();
+      const DetGeomDesc::Translation &t = it->second->translation();
 
       oss << formatDetId( CTPPSDetId( it->first ), false )
         << std::fixed << std::setprecision( 3 ) << std::showpos

--- a/Geometry/VeryForwardGeometryBuilder/src/CTPPSGeometry.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/CTPPSGeometry.cc
@@ -29,18 +29,18 @@ CTPPSGeometry::build( const DetGeomDesc* gD )
     buffer.pop_front();
 
     // check if it is a sensor
-    if ( d->name().name() == DDD_TOTEM_RP_SENSOR_NAME
-      || std::regex_match( d->name().name(), std::regex( DDD_TOTEM_TIMING_SENSOR_TMPL ) )
-      || d->name().name() == DDD_CTPPS_DIAMONDS_SEGMENT_NAME
-      || d->name().name() == DDD_CTPPS_UFSD_SEGMENT_NAME
-      || d->name().name() == DDD_CTPPS_PIXELS_SENSOR_NAME )
+    if ( d->name() == DDD_TOTEM_RP_SENSOR_NAME
+      || std::regex_match( d->name(), std::regex( DDD_TOTEM_TIMING_SENSOR_TMPL ) )
+      || d->name() == DDD_CTPPS_DIAMONDS_SEGMENT_NAME
+      || d->name() == DDD_CTPPS_UFSD_SEGMENT_NAME
+      || d->name() == DDD_CTPPS_PIXELS_SENSOR_NAME )
       addSensor( d->geographicalID(), d );
 
     // check if it is a RP
-    if ( d->name().name() == DDD_TOTEM_RP_RP_NAME
-      || d->name().name() == DDD_TOTEM_TIMING_RP_NAME
-      || d->name().name() == DDD_CTPPS_DIAMONDS_RP_NAME
-      || d->name().name() == DDD_CTPPS_PIXELS_RP_NAME )
+    if ( d->name() == DDD_TOTEM_RP_RP_NAME
+      || d->name() == DDD_TOTEM_TIMING_RP_NAME
+      || d->name() == DDD_CTPPS_DIAMONDS_RP_NAME
+      || d->name() == DDD_CTPPS_PIXELS_RP_NAME )
       addRP( d->geographicalID(), d );
 
     for ( const auto& comp : d->components() )

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -13,7 +13,6 @@
 
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 #include "DetectorDescription/Core/interface/DDSolid.h"
-#include "DetectorDescription/Core/interface/DDMaterial.h"
 
 #include "DataFormats/CTPPSAlignment/interface/RPAlignmentCorrectionData.h"
 
@@ -21,171 +20,82 @@ using namespace std;
 
 //----------------------------------------------------------------------------------------------------
 
-DetGeomDesc::DetGeomDesc(nav_type navtype, GeometricEnumType type) : _ddd(std::move(navtype)), _type(type)
-{ 
-	DDCompactView cpv;
-	DDExpandedView ev(cpv);
-	ev.goTo(_ddd);
-	_params = ((ev.logicalPart()).solid()).parameters();
-	_trans = ev.translation();
-	_rot = ev.rotation();
-	_shape = ((ev.logicalPart()).solid()).shape();
-	_name = ((ev.logicalPart()).ddname()).name();
-	_parents = ev.geoHistory();
-	_volume   = ((ev.logicalPart()).solid()).volume();
-	_density  = ((ev.logicalPart()).material()).density();
-	_weight   = _density * ( _volume / 1000.); // volume mm3->cm3
-	_copy     = ev.copyno();
-	_material = ((ev.logicalPart()).material()).name().fullname();
+DetGeomDesc::DetGeomDesc( DDFilteredView* fv )
+{
+  m_params = ((fv->logicalPart()).solid()).parameters();
+  m_trans = fv->translation();
+  m_rot = fv->rotation();
+  m_name = ((fv->logicalPart()).ddname()).name();
+  m_copy = fv->copyno();
+  m_z = fv->geoHistory().back().absTranslation().z();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-DetGeomDesc::DetGeomDesc(DDExpandedView* fv, GeometricEnumType type) : _type(type)
+DetGeomDesc::DetGeomDesc( const DetGeomDesc &ref )
 {
-	_ddd = fv->navPos();
-	_params = ((fv->logicalPart()).solid()).parameters();  
-	_trans = fv->translation();
-	_rot = fv->rotation();
-	_shape = ((fv->logicalPart()).solid()).shape();
-	_name = ((fv->logicalPart()).ddname()).name();
-	_parents = fv->geoHistory();
-	_volume   = ((fv->logicalPart()).solid()).volume();  
-	_density  = ((fv->logicalPart()).material()).density();
-	_weight   = _density * ( _volume / 1000.); // volume mm3->cm3
-	_copy     = fv->copyno();
-	_material = ((fv->logicalPart()).material()).name().fullname();
+  (*this) = ref;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-DetGeomDesc::DetGeomDesc(DDFilteredView* fv, GeometricEnumType type) : _type(type)
+DetGeomDesc& DetGeomDesc::operator= ( const DetGeomDesc &ref )
 {
-	_ddd = fv->navPos();
-	_params = ((fv->logicalPart()).solid()).parameters();
-	_trans = fv->translation();
-	_rot = fv->rotation();
-	_shape = ((fv->logicalPart()).solid()).shape();
-	_name = ((fv->logicalPart()).ddname()).name();
-	_parents = fv->geoHistory();
-	_volume   = ((fv->logicalPart()).solid()).volume();
-	_density  = ((fv->logicalPart()).material()).density();
-	_weight   = _density * ( _volume / 1000.); // volume mm3->cm3
-	_copy     = fv->copyno();
-	_material = ((fv->logicalPart()).material()).name().fullname();
-}
-
-//----------------------------------------------------------------------------------------------------
-
-DetGeomDesc::DetGeomDesc(const DetGeomDesc &ref)
-{
-	(*this) = ref;
-}
-
-//----------------------------------------------------------------------------------------------------
-
-DetGeomDesc& DetGeomDesc::operator= (const DetGeomDesc &ref)
-{
-	_ddd			= ref._ddd;
-	_params			= ref._params;
-	_trans			= ref._trans;
-	_rot			= ref._rot;
-	_shape			= ref._shape;
-	_name			= ref._name;
-	_parents		= ref._parents;
-	_volume			= ref._volume;
-	_density		= ref._density;
-	_weight			= ref._weight;
-	_copy			= ref._copy;
-	_material		= ref._material;
-	_geographicalID	= ref._geographicalID;
-	_type			= ref._type;
-
-	return (*this);
+  m_params = ref.m_params;
+  m_trans = ref.m_trans;
+  m_rot = ref.m_rot;
+  m_name = ref.m_name;
+  m_copy = ref.m_copy;
+  m_geographicalID = ref.m_geographicalID;
+  m_z = ref.m_z;
+  return (*this);
 }
 
 //----------------------------------------------------------------------------------------------------
 
 DetGeomDesc::~DetGeomDesc()
 {
-	deepDeleteComponents();
+  deepDeleteComponents();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-DetGeomDesc::Container DetGeomDesc::components()
+DetGeomDesc::Container DetGeomDesc::components() const
 {
-	return _container;
+  return m_container;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-DetGeomDesc::ConstContainer DetGeomDesc::components() const
+void DetGeomDesc::addComponent( DetGeomDesc* det )
 {
-	ConstContainer _temp;
-	for (auto it : _container) {
-		_temp.emplace_back(it);
-	}
-	return _temp;
-}
-
-//----------------------------------------------------------------------------------------------------
-
-DetGeomDesc::ConstContainer DetGeomDesc::deepComponents() const
-{
-  ConstContainer _temp;
-  if (isLeaf())
-    _temp.emplace_back(const_cast<DetGeomDesc*>(this));
-  else {
-    for (auto it : _container){
-      ConstContainer _temp2 =  (*it).deepComponents();
-      copy(_temp2.begin(), _temp2.end(), back_inserter(_temp));
-    }
-  }
-  return _temp;
-}
-
-
-//----------------------------------------------------------------------------------------------------
-
-void DetGeomDesc::addComponents(Container cont)
-{
-	for(auto & ig : cont) {
-		_container.emplace_back(ig);
-	}
-}
-
-//----------------------------------------------------------------------------------------------------
-
-void DetGeomDesc::addComponent(DetGeomDesc* det)
-{
-	_container.emplace_back(det);
+  m_container.emplace_back( det );
 }
 
 //----------------------------------------------------------------------------------------------------
 
 void DetGeomDesc::deleteComponents()
 {
-	_container.erase(_container.begin(), _container.end());
+  m_container.erase( m_container.begin(), m_container.end());
 }
 
 //----------------------------------------------------------------------------------------------------
 
 void DetGeomDesc::deepDeleteComponents()
 {
-	for (auto & it : _container) {
-		( const_cast<DetGeomDesc*>(it) )->deepDeleteComponents();
-		delete it;
-	}
-	clearComponents();  
+  for( auto & it : m_container ) {
+    ( const_cast<DetGeomDesc*>(it) )->deepDeleteComponents();
+    delete it;
+  }
+  clearComponents();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void DetGeomDesc::ApplyAlignment(const RPAlignmentCorrectionData &t)
+void DetGeomDesc::ApplyAlignment( const RPAlignmentCorrectionData &t )
 {
-    //cout << " DetGeomDesc::ApplyAlignment > before: " << _trans << ",  " << _rot << endl;
-	_rot = t.getRotationMatrix() * _rot;
-	_trans = t.getTranslation() + _trans;
-    //cout << " DetGeomDesc::ApplyAlignment > after: " << _trans << ",  " << _rot << endl;
+  //cout << " DetGeomDesc::ApplyAlignment > before: " << _trans << ",  " << _rot << endl;
+  m_rot = t.getRotationMatrix() * m_rot;
+  m_trans = t.getTranslation() + m_trans;
+  //cout << " DetGeomDesc::ApplyAlignment > after: " << _trans << ",  " << _rot << endl;
 }

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -92,7 +92,7 @@ void DetGeomDesc::deepDeleteComponents()
 
 //----------------------------------------------------------------------------------------------------
 
-void DetGeomDesc::ApplyAlignment( const RPAlignmentCorrectionData &t )
+void DetGeomDesc::applyAlignment( const RPAlignmentCorrectionData &t )
 {
   //cout << " DetGeomDesc::ApplyAlignment > before: " << _trans << ",  " << _rot << endl;
   m_rot = t.getRotationMatrix() * m_rot;

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -30,6 +30,12 @@ DetGeomDesc::DetGeomDesc( DDFilteredView* fv ) :
 {}
 
 //----------------------------------------------------------------------------------------------------
+DetGeomDesc::DetGeomDesc(const DetGeomDesc &ref)
+{
+	(*this) = ref;
+}
+
+//----------------------------------------------------------------------------------------------------
 
 DetGeomDesc& DetGeomDesc::operator= ( const DetGeomDesc &ref )
 {

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -20,22 +20,14 @@ using namespace std;
 
 //----------------------------------------------------------------------------------------------------
 
-DetGeomDesc::DetGeomDesc( DDFilteredView* fv )
-{
-  m_params = ((fv->logicalPart()).solid()).parameters();
-  m_trans = fv->translation();
-  m_rot = fv->rotation();
-  m_name = ((fv->logicalPart()).ddname()).name();
-  m_copy = fv->copyno();
-  m_z = fv->geoHistory().back().absTranslation().z();
-}
-
-//----------------------------------------------------------------------------------------------------
-
-DetGeomDesc::DetGeomDesc( const DetGeomDesc &ref )
-{
-  (*this) = ref;
-}
+DetGeomDesc::DetGeomDesc( DDFilteredView* fv ) :
+  m_trans( fv->translation()),
+  m_rot( fv->rotation()),
+  m_name((( fv->logicalPart()).ddname()).name()),
+  m_params((( fv->logicalPart()).solid()).parameters()),
+  m_copy( fv->copyno()),
+  m_z( fv->geoHistory().back().absTranslation().z())
+{}
 
 //----------------------------------------------------------------------------------------------------
 
@@ -84,7 +76,7 @@ void DetGeomDesc::deleteComponents()
 void DetGeomDesc::deepDeleteComponents()
 {
   for( auto & it : m_container ) {
-    ( const_cast<DetGeomDesc*>(it) )->deepDeleteComponents();
+    it->deepDeleteComponents();
     delete it;
   }
   clearComponents();
@@ -94,8 +86,6 @@ void DetGeomDesc::deepDeleteComponents()
 
 void DetGeomDesc::applyAlignment( const RPAlignmentCorrectionData &t )
 {
-  //cout << " DetGeomDesc::ApplyAlignment > before: " << _trans << ",  " << _rot << endl;
   m_rot = t.getRotationMatrix() * m_rot;
   m_trans = t.getTranslation() + m_trans;
-  //cout << " DetGeomDesc::ApplyAlignment > after: " << _trans << ",  " << _rot << endl;
 }

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -303,7 +303,7 @@ void RPixPlaneCombinatoryTracking::findTracks(){
         //This avoids to convert the global plane-line intersection in order not to call the the geometry 
         math::Vector<3>::type maxGlobalPointDistance(maximumXLocalDistanceFromTrack_,maximumYLocalDistanceFromTrack_,0.);
         
-        DDRotationMatrix theRotationMatrix = geometry_->getSensor(tmpPlaneId)->rotation();
+	DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(tmpPlaneId)->rotation();
         AlgebraicMatrix33 tmpPlaneRotationMatrixMap;
         theRotationMatrix.GetComponents(tmpPlaneRotationMatrixMap(0, 0), tmpPlaneRotationMatrixMap(0, 1), tmpPlaneRotationMatrixMap(0, 2),
                                         tmpPlaneRotationMatrixMap(1, 0), tmpPlaneRotationMatrixMap(1, 1), tmpPlaneRotationMatrixMap(1, 2),
@@ -470,7 +470,7 @@ bool RPixPlaneCombinatoryTracking::calculatePointOnDetector(CTPPSPixelLocalTrack
   math::Vector<3>::type pointOnPlane(tmpPointOnPlane.x(), tmpPointOnPlane.y(), tmpPointOnPlane.z());
   math::Vector<3>::type planeUnitVector(0.,0.,1.);
 
-  DDRotationMatrix theRotationMatrix = geometry_->getSensor(planeId)->rotation();
+  DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(planeId)->rotation();
   AlgebraicMatrix33 tmpPlaneRotationMatrixMap;
   theRotationMatrix.GetComponents(tmpPlaneRotationMatrixMap(0, 0), tmpPlaneRotationMatrixMap(0, 1), tmpPlaneRotationMatrixMap(0, 2),
                                   tmpPlaneRotationMatrixMap(1, 0), tmpPlaneRotationMatrixMap(1, 1), tmpPlaneRotationMatrixMap(1, 2),

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -26,8 +26,6 @@ RPixPlaneCombinatoryTracking::RPixPlaneCombinatoryTracking(edm::ParameterSet con
                                                          << "tracking is not possible with " 
                                                          << trackMinNumberOfPoints_ << " hits";
   }
- 
-  
 }
 
 //------------------------------------------------------------------------------------------------//
@@ -38,7 +36,7 @@ RPixPlaneCombinatoryTracking::~RPixPlaneCombinatoryTracking() {
 
 //------------------------------------------------------------------------------------------------//
 
-void RPixPlaneCombinatoryTracking::initialize(){
+void RPixPlaneCombinatoryTracking::initialize() {
  
   uint32_t numberOfCombinations = factorial(numberOfPlanesPerPot_)/
                                   (factorial(numberOfPlanesPerPot_-trackMinNumberOfPoints_)
@@ -56,7 +54,6 @@ void RPixPlaneCombinatoryTracking::initialize(){
       edm::LogInfo("RPixPlaneCombinatoryTracking");
     }
   }
-
 }
 
 //------------------------------------------------------------------------------------------------//
@@ -303,7 +300,7 @@ void RPixPlaneCombinatoryTracking::findTracks(){
         //This avoids to convert the global plane-line intersection in order not to call the the geometry 
         math::Vector<3>::type maxGlobalPointDistance(maximumXLocalDistanceFromTrack_,maximumYLocalDistanceFromTrack_,0.);
         
-	DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(tmpPlaneId)->rotation();
+        DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(tmpPlaneId)->rotation();
         AlgebraicMatrix33 tmpPlaneRotationMatrixMap;
         theRotationMatrix.GetComponents(tmpPlaneRotationMatrixMap(0, 0), tmpPlaneRotationMatrixMap(0, 1), tmpPlaneRotationMatrixMap(0, 2),
                                         tmpPlaneRotationMatrixMap(1, 0), tmpPlaneRotationMatrixMap(1, 1), tmpPlaneRotationMatrixMap(1, 2),

--- a/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
@@ -67,7 +67,7 @@ void RPixRoadFinder::findPattern(){
       localError[2][2] =                  0.;
       if(verbosity_>2) edm::LogInfo("RPixRoadFinder")<<"Hits = "<<ds_rh2.data.size();
 
-      DDRotationMatrix theRotationMatrix = geometry_->getSensor(myid)->rotation();
+      DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(myid)->rotation();
       AlgebraicMatrix33 theRotationTMatrix;
       theRotationMatrix.GetComponents(theRotationTMatrix(0, 0), theRotationTMatrix(0, 1), theRotationTMatrix(0, 2),
                                       theRotationTMatrix(1, 0), theRotationTMatrix(1, 1), theRotationTMatrix(1, 2),

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -28,10 +28,7 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
     const float x_pos = det->translation().x(),
                 y_pos = det->translation().y();
     float z_pos = 0.;
-    if ( det->parents().empty() )
-      edm::LogWarning("CTPPSDiamondRecHitProducerAlgorithm") << "The geometry element for " << detid << " has no parents. Check the geometry hierarchy!";
-    else
-      z_pos = det->parents()[det->parents().size()-1].absTranslation().z(); // retrieve the plane position;
+    z_pos = det->planeZPos(); // retrieve the plane position;
 
     const float x_width = 2.0 * det->params().at( 0 ), // parameters stand for half the size
                 y_width = 2.0 * det->params().at( 1 ),

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -28,7 +28,7 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
     const float x_pos = det->translation().x(),
                 y_pos = det->translation().y();
     float z_pos = 0.;
-    z_pos = det->planeZPos(); // retrieve the plane position;
+    z_pos = det->parentZPosition(); // retrieve the plane position;
 
     const float x_width = 2.0 * det->params().at( 0 ), // parameters stand for half the size
                 y_width = 2.0 * det->params().at( 1 ),

--- a/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
@@ -79,7 +79,7 @@ FastLineRecognition::GeomData FastLineRecognition::getGeomData(unsigned int id)
 
   // calculate it
   CLHEP::Hep3Vector d = geometry->localToGlobalDirection(id, CLHEP::Hep3Vector(0., 1., 0.));
-  DDTranslation c = geometry->getSensor(TotemRPDetId(id))->translation();
+  DetGeomDesc::Translation c = geometry->getSensor(TotemRPDetId(id))->translation();
   GeomData gd;
   gd.z = c.z();
   gd.s = d.x()*c.x() + d.y()*c.y();

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -41,9 +41,9 @@ void TotemTimingRecHitProducerAlgorithm::build(
       x_pos = det->translation().x(), y_pos = det->translation().y();
       z_pos = det->planeZPos(); // retrieve the plane position;
 
-      x_width = 2.0 * det->params().at(0), // parameters stand for half the size
-          y_width = 2.0 * det->params().at(1),
-      z_width = 2.0 * det->params().at(2);
+      x_width = 2.0 * det->params()[0], // parameters stand for half the size
+          y_width = 2.0 * det->params()[1],
+      z_width = 2.0 * det->params()[2];
     } else
       edm::LogWarning("TotemTimingRecHitProducerAlgorithm")
           << "Failed to retrieve a sensor for " << detid;
@@ -64,8 +64,8 @@ void TotemTimingRecHitProducerAlgorithm::build(
       // remove baseline
       std::vector<float> dataCorrected(data.size());
       for (unsigned int i = 0; i < data.size(); ++i)
-        dataCorrected.at(i) = data.at(i) -
-                   (baselineRegression.q + baselineRegression.m * time.at(i));
+        dataCorrected[i] = data[i] -
+                   (baselineRegression.q + baselineRegression.m * time[i]);
       auto max_corrected_it =
           std::max_element(dataCorrected.begin(), dataCorrected.end());
 
@@ -113,7 +113,7 @@ TotemTimingRecHitProducerAlgorithm::simplifiedLinearRegression(
 
   float sxy = .0;
   for (unsigned int i = 0; i < realPoints; ++i)
-    sxy += (time.at(i)) * (data.at(i));
+    sxy += (time[i]) * (data[i]);
 
   // y = mx + q
   results.m = (sxy * realPoints - sx * sy) / (sxx * realPoints - sx * sx);
@@ -121,7 +121,7 @@ TotemTimingRecHitProducerAlgorithm::simplifiedLinearRegression(
 
   float correctedSyy = .0;
   for (unsigned int i = 0; i < realPoints; ++i)
-    correctedSyy += pow(data.at(i) - (results.m * time.at(i) + results.q), 2);
+    correctedSyy += pow(data[i] - (results.m * time[i] + results.q), 2);
   results.rms = sqrt(correctedSyy / realPoints);
 
   return results;
@@ -135,7 +135,7 @@ int TotemTimingRecHitProducerAlgorithm::fastDiscriminator(
 
   for (unsigned int i = 0; i < data.size(); ++i) {
     // Look for first edge
-    if (!above && !lockForHysteresis && data.at(i) > threshold) {
+    if (!above && !lockForHysteresis && data[i] > threshold) {
       threholdCrossingIndex = i;
       above = true;
       lockForHysteresis = true;
@@ -144,11 +144,11 @@ int TotemTimingRecHitProducerAlgorithm::fastDiscriminator(
                                     // the previous if
     {
       // Lock until above threshold_+hysteresis
-      if (lockForHysteresis && data.at(i) > threshold + hysteresis_) {
+      if (lockForHysteresis && data[i] > threshold + hysteresis_) {
         lockForHysteresis = false;
       }
       // Ignore noise peaks
-      if (lockForHysteresis && data.at(i) < threshold) {
+      if (lockForHysteresis && data[i] < threshold) {
         above = false;
         lockForHysteresis = false;
         threholdCrossingIndex = -1; // assigned because of noise
@@ -169,7 +169,7 @@ float TotemTimingRecHitProducerAlgorithm::constantFractionDiscriminator(
            j <= +smoothingPoints_ / 2; ++j) {
         if ((i + j) >= 0 && (i + j) < (int)data.size() && j != 0) {
           float x = SINC_COEFFICIENT * lowPassFrequency_ * j;
-          dataProcessed.at(i) += data.at(i + j) * std::sin(x) / x;
+          dataProcessed[i] += data[i + j] * std::sin(x) / x;
         }
       }
     }
@@ -183,12 +183,12 @@ float TotemTimingRecHitProducerAlgorithm::constantFractionDiscriminator(
   float t = TotemTimingRecHit::NO_T_AVAILABLE;
   if (indexOfThresholdCrossing >= baselinePoints_ &&
       indexOfThresholdCrossing < (int)time.size()) {
-    t = (time.at(indexOfThresholdCrossing - 1) -
-         time.at(indexOfThresholdCrossing)) /
-            (dataProcessed.at(indexOfThresholdCrossing - 1) -
-             dataProcessed.at(indexOfThresholdCrossing)) *
-            (threshold - dataProcessed.at(indexOfThresholdCrossing)) +
-        time.at(indexOfThresholdCrossing);
+    t = (time[indexOfThresholdCrossing - 1] -
+         time[indexOfThresholdCrossing]) /
+            (dataProcessed[indexOfThresholdCrossing - 1] -
+             dataProcessed[indexOfThresholdCrossing]) *
+            (threshold - dataProcessed[indexOfThresholdCrossing]) +
+        time[indexOfThresholdCrossing];
   }
 
   return t;

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -8,6 +8,7 @@
  ****************************************************************************/
 
 #include "RecoCTPPS/TotemRPLocal/interface/TotemTimingRecHitProducerAlgorithm.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //----------------------------------------------------------------------------------------------------
 

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -32,8 +32,8 @@ void TotemTimingRecHitProducerAlgorithm::build(
   for (const auto &vec : input) {
     const TotemTimingDetId detid(vec.detId());
 
-    float x_pos = 0, y_pos = 0, z_pos = 0, x_width = 0, y_width = 0,
-          z_width = 0;
+    float x_pos = 0.0f, y_pos = 0.0f, z_pos = 0.0f, x_width = 0.0f, y_width = 0.0f, 
+          z_width = 0.0f;
 
     // retrieve the geometry element associated to this DetID ( if present )
     const DetGeomDesc *det = geom->getSensorNoThrow(detid);
@@ -43,7 +43,7 @@ void TotemTimingRecHitProducerAlgorithm::build(
       z_pos = det->parentZPosition(); // retrieve the plane position;
 
       x_width = 2.0 * det->params()[0], // parameters stand for half the size
-          y_width = 2.0 * det->params()[1],
+      y_width = 2.0 * det->params()[1],
       z_width = 2.0 * det->params()[2];
     } else
       edm::LogWarning("TotemTimingRecHitProducerAlgorithm")
@@ -102,17 +102,17 @@ TotemTimingRecHitProducerAlgorithm::simplifiedLinearRegression(
   auto d_begin = std::next(data.begin(), start_at);
   auto d_end = std::next(data.begin(), stop_at);
 
-  float sx = .0;
+  float sx = .0f;
   std::for_each(t_begin, t_end, [&](float value) { sx += value; });
-  float sxx = .0;
+  float sxx = .0f;
   std::for_each(t_begin, t_end, [&](float value) { sxx += value * value; });
 
-  float sy = .0;
+  float sy = .0f;
   std::for_each(d_begin, d_end, [&](float value) { sy += value; });
-  float syy = .0;
+  float syy = .0f;
   std::for_each(d_begin, d_end, [&](float value) { syy += value * value; });
 
-  float sxy = .0;
+  float sxy = .0f;
   for (unsigned int i = 0; i < realPoints; ++i)
     sxy += (time[i]) * (data[i]);
 
@@ -120,7 +120,7 @@ TotemTimingRecHitProducerAlgorithm::simplifiedLinearRegression(
   results.m = (sxy * realPoints - sx * sy) / (sxx * realPoints - sx * sx);
   results.q = sy / realPoints - results.m * sx / realPoints;
 
-  float correctedSyy = .0;
+  float correctedSyy = .0f;
   for (unsigned int i = 0; i < realPoints; ++i)
     correctedSyy += pow(data[i] - (results.m * time[i] + results.q), 2);
   results.rms = sqrt(correctedSyy / realPoints);

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -40,7 +40,7 @@ void TotemTimingRecHitProducerAlgorithm::build(
 
     if (det) {
       x_pos = det->translation().x(), y_pos = det->translation().y();
-      z_pos = det->planeZPos(); // retrieve the plane position;
+      z_pos = det->parentZPosition(); // retrieve the plane position;
 
       x_width = 2.0 * det->params()[0], // parameters stand for half the size
           y_width = 2.0 * det->params()[1],

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -39,14 +39,7 @@ void TotemTimingRecHitProducerAlgorithm::build(
 
     if (det) {
       x_pos = det->translation().x(), y_pos = det->translation().y();
-      if (det->parents().empty())
-        edm::LogWarning("TotemTimingRecHitProducerAlgorithm")
-            << "The geometry element for " << detid
-            << " has no parents. Check the geometry hierarchy!";
-      else
-        z_pos = det->parents()[det->parents().size() - 1]
-                    .absTranslation()
-                    .z(); // retrieve the plane position;
+      z_pos = det->planeZPos(); // retrieve the plane position;
 
       x_width = 2.0 * det->params().at(0), // parameters stand for half the size
           y_width = 2.0 * det->params().at(1),


### PR DESCRIPTION
* Tidying up DetGeomDesc API
* Remove DDName usage and other DD dependencies

@slava77 - this is a quick cleanup. The tests run, but the CTPPS folks should look into it in details. 
For example, each DetGeomDesc object used to cache a vector of DDExpandedNodes to retrieve a plane Z position later:
```
z_pos = det->parents()[det->parents().size()-1].absTranslation().z(); // retrieve the plane position;
```
Shouldn't it just cache this position (e.g. a float) instead as implemented in this PR? Further code improvement is possible, I think. 