### PR TITLE
HCALDQM: Move channel quality lookup to dqmBeginLuminosityBlock (+increase pedestal RMS axis)

### DIFF
--- a/DQM/HcalCommon/interface/DQClient.h
+++ b/DQM/HcalCommon/interface/DQClient.h
@@ -30,6 +30,9 @@ namespace hcaldqm
 			~DQClient() override {}
 
 			virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+			virtual void beginLuminosityBlock(DQMStore::IBooker&,
+				DQMStore::IGetter&, edm::LuminosityBlock const& lb,
+				edm::EventSetup const&);
 			virtual void endLuminosityBlock(DQMStore::IBooker&,
 				DQMStore::IGetter&,
 				edm::LuminosityBlock const&, edm::EventSetup const&);

--- a/DQM/HcalCommon/interface/DQHarvester.h
+++ b/DQM/HcalCommon/interface/DQHarvester.h
@@ -22,6 +22,9 @@ namespace hcaldqm
 			~DQHarvester() override {}
 
 			void beginRun(edm::Run const&, edm::EventSetup const&) override;
+			void dqmBeginLuminosityBlock(
+				DQMStore::IBooker& ib, DQMStore::IGetter& ig,
+				edm::LuminosityBlock const& lb, edm::EventSetup const& es);
 			void dqmEndLuminosityBlock(
 				DQMStore::IBooker&, DQMStore::IGetter&, 
 				edm::LuminosityBlock const&, edm::EventSetup const&) override;

--- a/DQM/HcalCommon/src/DQClient.cc
+++ b/DQM/HcalCommon/src/DQClient.cc
@@ -87,8 +87,16 @@ namespace hcaldqm
 			}
 		}
 
-		//	get the Channel Quality masks
+		// Initialize channel quality masks, but do not load (changed for 10_4_X, moving to LS granularity)
 		_xQuality.initialize(hashfunctions::fDChannel);
+	}
+	
+	/* virtual */ void DQClient::beginLuminosityBlock(DQMStore::IBooker&,
+		DQMStore::IGetter&, edm::LuminosityBlock const& lb,
+		edm::EventSetup const& es)
+	{
+		//	get the Channel Quality masks
+		_xQuality.reset();
 		edm::ESHandle<HcalChannelQuality> hcq;
 		es.get<HcalChannelQualityRcd>().get("withTopo", hcq);
 		const HcalChannelQuality *cq = hcq.product();

--- a/DQM/HcalCommon/src/DQClient.cc
+++ b/DQM/HcalCommon/src/DQClient.cc
@@ -13,7 +13,7 @@ namespace hcaldqm
 		_name = name;
 	}
 
-	/* virtual */ void DQClient::beginRun(edm::Run const& r,
+	void DQClient::beginRun(edm::Run const& r,
 		edm::EventSetup const& es)
 	{
 		//	TEMPORARY
@@ -91,7 +91,7 @@ namespace hcaldqm
 		_xQuality.initialize(hashfunctions::fDChannel);
 	}
 	
-	/* virtual */ void DQClient::beginLuminosityBlock(DQMStore::IBooker&,
+	void DQClient::beginLuminosityBlock(DQMStore::IBooker&,
 		DQMStore::IGetter&, edm::LuminosityBlock const& lb,
 		edm::EventSetup const& es)
 	{
@@ -118,7 +118,7 @@ namespace hcaldqm
 		}
 	}
 
-	/* virtual */ void DQClient::endLuminosityBlock(DQMStore::IBooker&,
+	void DQClient::endLuminosityBlock(DQMStore::IBooker&,
 		DQMStore::IGetter&, edm::LuminosityBlock const& lb,
 		edm::EventSetup const&)
 	{
@@ -128,7 +128,7 @@ namespace hcaldqm
 			_maxProcessedLS=_currentLS;
 	}
 
-	/* virtual */ std::vector<flag::Flag> DQClient::endJob(DQMStore::IBooker&,
+	std::vector<flag::Flag> DQClient::endJob(DQMStore::IBooker&,
 		DQMStore::IGetter&)
 	{
 		return std::vector<flag::Flag>();

--- a/DQM/HcalCommon/src/DQHarvester.cc
+++ b/DQM/HcalCommon/src/DQHarvester.cc
@@ -90,8 +90,15 @@ namespace hcaldqm
 			}
 		}
 
-		//	get the Hcal Channels Quality for channels that are not 0
+		// Initialize channel quality masks, but do not load (changed for 10_4_X, moving to LS granularity)
 		_xQuality.initialize(hashfunctions::fDChannel);
+	}
+
+	/* virtual */ void DQHarvester::dqmBeginLuminosityBlock(
+		DQMStore::IBooker& ib, DQMStore::IGetter& ig,
+		edm::LuminosityBlock const& lb, edm::EventSetup const& es)
+	{
+		//	get the Hcal Channels Quality for channels that are not 0
 		edm::ESHandle<HcalChannelQuality> hcq;
 		es.get<HcalChannelQualityRcd>().get("withTopo", hcq);
 		const HcalChannelQuality *cq = hcq.product();

--- a/DQM/HcalCommon/src/DQHarvester.cc
+++ b/DQM/HcalCommon/src/DQHarvester.cc
@@ -9,7 +9,7 @@ namespace hcaldqm
 		DQModule(ps)
 	{}
 
-	/* virtual */ void DQHarvester::beginRun(edm::Run const& r,
+	void DQHarvester::beginRun(edm::Run const& r,
 		edm::EventSetup const& es)
 	{
 		if (_ptype==fLocal)
@@ -94,7 +94,7 @@ namespace hcaldqm
 		_xQuality.initialize(hashfunctions::fDChannel);
 	}
 
-	/* virtual */ void DQHarvester::dqmBeginLuminosityBlock(
+	void DQHarvester::dqmBeginLuminosityBlock(
 		DQMStore::IBooker& ib, DQMStore::IGetter& ig,
 		edm::LuminosityBlock const& lb, edm::EventSetup const& es)
 	{
@@ -120,7 +120,7 @@ namespace hcaldqm
 		}
 	}
 
-	/* virtual */ void DQHarvester::dqmEndLuminosityBlock(
+	void DQHarvester::dqmEndLuminosityBlock(
 		DQMStore::IBooker& ib, DQMStore::IGetter& ig,
 		edm::LuminosityBlock const& lb, edm::EventSetup const& es)
 	{
@@ -129,7 +129,7 @@ namespace hcaldqm
 		_totalLS++;
 		_dqmEndLuminosityBlock(ib, ig, lb, es);
 	}
-	/* virtual */ void DQHarvester::dqmEndJob(DQMStore::IBooker& ib, 
+	void DQHarvester::dqmEndJob(DQMStore::IBooker& ib, 
 		DQMStore::IGetter& ig)
 	{
 		_dqmEndJob(ib, ig);

--- a/DQM/HcalCommon/src/DQTask.cc
+++ b/DQM/HcalCommon/src/DQTask.cc
@@ -22,7 +22,7 @@ namespace hcaldqm
 	 *	By design, all the sources will ahve this function inherited and will
 	 *	never override. 
 	 */
-	/* virtual */ void DQTask::analyze(edm::Event const& e,
+	void DQTask::analyze(edm::Event const& e,
 		edm::EventSetup const& es)
 	{
 		this->_resetMonitors(fEvent);
@@ -35,7 +35,7 @@ namespace hcaldqm
 		this->_process(e, es);
 	}
 
-	/* virtual */ void DQTask::bookHistograms(DQMStore::IBooker &ib,
+	void DQTask::bookHistograms(DQMStore::IBooker &ib,
 		edm::Run const& r,
 		edm::EventSetup const& es)
 	{
@@ -86,7 +86,7 @@ namespace hcaldqm
 		_emap = _dbService->getHcalMapping();
 	}
 
-	/* virtual */ void DQTask::dqmBeginRun(edm::Run const& r,
+	void DQTask::dqmBeginRun(edm::Run const& r,
 		edm::EventSetup const& es)
 	{
 		this->_resetMonitors(fEvent);
@@ -96,7 +96,7 @@ namespace hcaldqm
 		this->_resetMonitors(f100LS);
 	}
 
-	/* virtual */ void DQTask::beginLuminosityBlock(
+	void DQTask::beginLuminosityBlock(
 		edm::LuminosityBlock const& lb,
 		edm::EventSetup const& es)
 	{
@@ -136,14 +136,14 @@ namespace hcaldqm
 		}
 	}
 
-	/* virtual */ void DQTask::endLuminosityBlock(
+	void DQTask::endLuminosityBlock(
 		edm::LuminosityBlock const& lb,
 		edm::EventSetup const& es)
 	{
 		_procLSs++;
 	}
 
-	/* virtual */ void DQTask::_resetMonitors(UpdateFreq uf)
+	void DQTask::_resetMonitors(UpdateFreq uf)
 	{
 		//	reset per event
 		switch (uf)
@@ -164,7 +164,7 @@ namespace hcaldqm
 		}
 	}
 
-	/* virtual */ int DQTask::_getCalibType(edm::Event const&e)
+	int DQTask::_getCalibType(edm::Event const&e)
 	{
 		int calibType = 0;
 

--- a/DQM/HcalCommon/src/DQTask.cc
+++ b/DQM/HcalCommon/src/DQTask.cc
@@ -69,30 +69,6 @@ namespace hcaldqm
 			}
 		}
 
-		//	get the Channel Quality Status for all the channels
-		edm::ESHandle<HcalChannelQuality> hcq;
-		es.get<HcalChannelQualityRcd>().get("withTopo", hcq);
-		const HcalChannelQuality *cq = hcq.product();
-		std::vector<DetId> detids = cq->getAllChannels();
-		for (std::vector<DetId>::const_iterator it=detids.begin();
-			it!=detids.end(); ++it)
-		{
-			//	if unknown skip
-			if (HcalGenericDetId(*it).genericSubdet()==
-				HcalGenericDetId::HcalGenUnknown)
-				continue;
-
-			if (HcalGenericDetId(*it).isHcalDetId())
-			{
-				HcalDetId did(*it);
-				uint32_t mask = (cq->getValues(did))->getValue();
-				if (mask!=0)
-				{
-					_xQuality.push(did, mask);
-				}
-			}
-		}
-
 		//	book some base guys
 		_cEvsTotal.book(ib, _subsystem);
 		_cEvsPerLS.book(ib, _subsystem);
@@ -133,7 +109,31 @@ namespace hcaldqm
 			this->_resetMonitors(f50LS);
 		if (_procLSs%100==0)
 			this->_resetMonitors(f100LS);
-			
+	
+		//	get the Channel Quality Status for all the channels
+		_xQuality.reset();
+		edm::ESHandle<HcalChannelQuality> hcq;
+		es.get<HcalChannelQualityRcd>().get("withTopo", hcq);
+		const HcalChannelQuality *cq = hcq.product();
+		std::vector<DetId> detids = cq->getAllChannels();
+		for (std::vector<DetId>::const_iterator it=detids.begin();
+			it!=detids.end(); ++it)
+		{
+			//	if unknown skip
+			if (HcalGenericDetId(*it).genericSubdet()==
+				HcalGenericDetId::HcalGenUnknown)
+				continue;
+
+			if (HcalGenericDetId(*it).isHcalDetId())
+			{
+				HcalDetId did(*it);
+				uint32_t mask = (cq->getValues(did))->getValue();
+				if (mask!=0)
+				{
+					_xQuality.push(did, mask);
+				}
+			}
+		}
 	}
 
 	/* virtual */ void DQTask::endLuminosityBlock(

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -122,7 +122,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	_cRMSTotal_Subdet.initialize(_name, "RMS", hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	_cMeanTotal_depth.initialize(_name, "Mean", hcaldqm::hashfunctions::fdepth, 
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
@@ -131,7 +131,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps):
 	_cRMSTotal_depth.initialize(_name, "RMS", hcaldqm::hashfunctions::fdepth, 
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),0);
 
 	_cMeanDBRef1LS_Subdet.initialize(_name, "MeanDBRef1LS", hcaldqm::hashfunctions::fSubdet,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),


### PR DESCRIPTION
This PR accompanies https://github.com/cms-sw/cmssw/pull/25351, which implements LS-level granularity in HcalChannelQuality conditions. For HCAL DQM, this means that the HcalChannelQuality retrieval should happen in dqmBeginLuminosityBlock, rather than beginRun. 

I also include a small fix for the ADC axis on pedestal RMS plots, which was too small by the end of the year. 