### PR TITLE
Make sure that Davix file is only closed once

### DIFF
--- a/Utilities/DavixAdaptor/src/DavixFile.cc
+++ b/Utilities/DavixAdaptor/src/DavixFile.cc
@@ -36,6 +36,7 @@ void DavixFile::close(void) {
     auto davixPosix = std::move(m_davixPosix);
     DavixError *err = nullptr;
     davixPosix->close(m_fd, &err);
+    m_fd = nullptr;
     if (err) {
       std::unique_ptr<DavixError> davixErrManaged(err);
       cms::Exception ex("FileCloseError");

--- a/Utilities/DavixAdaptor/src/DavixFile.cc
+++ b/Utilities/DavixAdaptor/src/DavixFile.cc
@@ -33,8 +33,9 @@ DavixFile::~DavixFile(void) {
 
 void DavixFile::close(void) {
   if (m_davixPosix && m_fd) {
+    auto davixPosix = std::move(m_davixPosix);
     DavixError *err = nullptr;
-    m_davixPosix->close(m_fd, &err);
+    davixPosix->close(m_fd, &err);
     if (err) {
       std::unique_ptr<DavixError> davixErrManaged(err);
       cms::Exception ex("FileCloseError");


### PR DESCRIPTION
Telling davix to close the same file multiple times is causing a seg fault. By releasing the underlying file after closing, we avoid that problem.