### PR TITLE
Return unique_ptr from fetchPayload

### DIFF
--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -138,7 +138,7 @@ namespace cond {
       template <typename T> cond::Hash storePayload( const T& payload, 
 						     const boost::posix_time::ptime& creationTime = boost::posix_time::microsec_clock::universal_time() );
 
-      template <typename T> std::shared_ptr<T> fetchPayload( const cond::Hash& payloadHash );
+      template <typename T> std::unique_ptr<T> fetchPayload( const cond::Hash& payloadHash );
       
       cond::Hash storePayloadData( const std::string& payloadObjectType,
                                    const std::pair<Binary,Binary>& payloadAndStreamerInfoData,
@@ -212,14 +212,14 @@ namespace cond {
       return ret;
     }
     
-    template <typename T> inline std::shared_ptr<T> Session::fetchPayload( const cond::Hash& payloadHash ){
+    template <typename T> inline std::unique_ptr<T> Session::fetchPayload( const cond::Hash& payloadHash ){
       cond::Binary payloadData;
       cond::Binary streamerInfoData;
       std::string payloadType;
       if(! fetchPayloadData( payloadHash, payloadType, payloadData, streamerInfoData ) ) 
 	throwException( "Payload with id "+payloadHash+" has not been found in the database.",
 			"Session::fetchPayload" );
-      std::shared_ptr<T> ret;
+      std::unique_ptr<T> ret;
       try{ 
 	ret = deserialize<T>(  payloadType, payloadData, streamerInfoData );
       } catch ( const cond::persistency::Exception& e ){


### PR DESCRIPTION
These changes logically follow the changes in PR #25126 and are one level higher in the stack. Please see the comments to that PR which apply to this PR also except that the function modified is fetchPayload instead of deserialize. There will be one more pull request after this one that changes many of the ESProducers that depend on the fetchPayload function.
