### PR TITLE
Tracker DQM HI Quality Test tuning for Offline and Online (backport of #25374)

### DIFF
--- a/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0.xml
+++ b/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0.xml
@@ -54,8 +54,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.001</PARAM>
-<!--        <PARAM name="MaxAbs">40.</PARAM> pp parameter-->
-        <PARAM name="MaxAbs">70.</PARAM> 
+        <PARAM name="MaxAbs">40.</PARAM>
 	<PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">100</PARAM>
@@ -67,8 +66,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.01</PARAM>
-<!--        <PARAM name="MaxAbs">90.</PARAM> pp parameter -->
-        <PARAM name="MaxAbs">180.</PARAM>
+        <PARAM name="MaxAbs">90.</PARAM>
         <PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">200</PARAM>
@@ -83,8 +81,7 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">15.0</PARAM>
-<!--      <PARAM name="xmax">50.0</PARAM> pp parameter -->
-      <PARAM name="xmax">80.0</PARAM>
+      <PARAM name="xmax">50.0</PARAM>
 </QTEST>
 <QTEST name="MeanWithinExpectedRange:StoNTOB" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
@@ -96,8 +93,7 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">15.0</PARAM>
-<!--      <PARAM name="xmax">50.0</PARAM> pp parameter -->
-      <PARAM name="xmax">80.0</PARAM>
+      <PARAM name="xmax">50.0</PARAM>
 </QTEST>
 <QTEST name="MeanWithinExpectedRange:StoNTEC" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
@@ -109,8 +105,7 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">15.0</PARAM>
-<!--      <PARAM name="xmax">50.0</PARAM> pp parameter -->
-      <PARAM name="xmax">80.0</PARAM>
+      <PARAM name="xmax">50.0</PARAM>
 </QTEST>
 <QTEST name="MeanWithinExpectedRange:StoNTID" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
@@ -122,8 +117,7 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">15.0</PARAM>
-<!--      <PARAM name="xmax">50.0</PARAM> pp parameter -->
-      <PARAM name="xmax">80.0</PARAM>
+      <PARAM name="xmax">50.0</PARAM>
 </QTEST>
 <QTEST name="XrangeWithin:0-10.0" activate="false"> 
      <TYPE>ContentsXRange</TYPE> 

--- a/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0_heavyions.xml
+++ b/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0_heavyions.xml
@@ -1,6 +1,7 @@
 <TESTSCONFIGURATION> 
-<QTEST name="MeanWithinExpectedRange:nFEDErrors">
+<QTEST name="MeanWithinExpectedRange:nFEDErrors" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
+      <PARAM name="minEntries">0</PARAM> 
       <PARAM name="error">0.05</PARAM>
       <PARAM name="warning">0.3</PARAM>
       <PARAM name="mean">1.0</PARAM>
@@ -10,8 +11,9 @@
       <PARAM name="xmin">0.0</PARAM>
       <PARAM name="xmax">10.0</PARAM>
 </QTEST>
-<QTEST name="MeanWithinExpectedRange:nBadChannelStatusBits">
+<QTEST name="MeanWithinExpectedRange:nBadChannelStatusBits" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
+      <PARAM name="minEntries">0</PARAM> 
       <PARAM name="error">0.05</PARAM>
       <PARAM name="warning">0.3</PARAM>
       <PARAM name="mean">1.0</PARAM>
@@ -21,8 +23,9 @@
       <PARAM name="xmin">0.0</PARAM>
       <PARAM name="xmax">380.0</PARAM>
 </QTEST>
-<QTEST name="MeanWithinExpectedRange:nBadActiveChannelStatusBits">
+<QTEST name="MeanWithinExpectedRange:nBadActiveChannelStatusBits" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
+      <PARAM name="minEntries">0</PARAM> 
       <PARAM name="error">0.05</PARAM>
       <PARAM name="warning">0.3</PARAM>
       <PARAM name="mean">1.0</PARAM>
@@ -32,7 +35,7 @@
       <PARAM name="xmin">0.0</PARAM>
       <PARAM name="xmax">380.0</PARAM>
 </QTEST>
-<QTEST name="ContentsWithinExpected:TkHistoFedError">
+<QTEST name="ContentsWithinExpected:TkHistoFedError" activate="true">
         <TYPE>ContentsWithinExpected</TYPE>
         <PARAM name="minMean">0.0</PARAM>
         <PARAM name="maxMean">0.2</PARAM>
@@ -46,10 +49,11 @@
 </QTEST>
 <QTEST name="CompareToMedian:TkHistoNumberOfCluster" activate="true">
 	<TYPE>CompareToMedian</TYPE>
+        <PARAM name="minEntries">0</PARAM> 
 	<PARAM name="MinRel">0.1</PARAM>
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
-        <PARAM name="MinAbs">0.</PARAM>
+        <PARAM name="MinAbs">0.001</PARAM>
         <PARAM name="MaxAbs">70.</PARAM> 
 	<PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
@@ -57,16 +61,17 @@
 </QTEST>
 <QTEST name="CompareToMedian:TkHistoNumberOfDigi" activate="true">
         <TYPE>CompareToMedian</TYPE>
+        <PARAM name="minEntries">0</PARAM> 
         <PARAM name="MinRel">0.1</PARAM>
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
-        <PARAM name="MinAbs">0.</PARAM>
+        <PARAM name="MinAbs">0.01</PARAM>
         <PARAM name="MaxAbs">180.</PARAM>
         <PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">200</PARAM>
 </QTEST>
-<QTEST name="MeanWithinExpectedRange:StoNTIB">
+<QTEST name="MeanWithinExpectedRange:StoNTIB" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
       <PARAM name="error">0.05</PARAM>
       <PARAM name="warning">0.3</PARAM>
@@ -76,9 +81,9 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">15.0</PARAM>
-      <PARAM name="xmax">100.0</PARAM>
+      <PARAM name="xmax">80.0</PARAM>
 </QTEST>
-<QTEST name="MeanWithinExpectedRange:StoNTOB">
+<QTEST name="MeanWithinExpectedRange:StoNTOB" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
       <PARAM name="error">0.05</PARAM>
       <PARAM name="warning">0.3</PARAM>
@@ -88,9 +93,9 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">15.0</PARAM>
-      <PARAM name="xmax">100.0</PARAM>
+      <PARAM name="xmax">80.0</PARAM>
 </QTEST>
-<QTEST name="MeanWithinExpectedRange:StoNTEC">
+<QTEST name="MeanWithinExpectedRange:StoNTEC" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
       <PARAM name="error">0.05</PARAM>
       <PARAM name="warning">0.3</PARAM>
@@ -100,9 +105,9 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">15.0</PARAM>
-      <PARAM name="xmax">100.0</PARAM>
+      <PARAM name="xmax">80.0</PARAM>
 </QTEST>
-<QTEST name="MeanWithinExpectedRange:StoNTID">
+<QTEST name="MeanWithinExpectedRange:StoNTID" activate="true">
       <TYPE>MeanWithinExpected</TYPE>
       <PARAM name="error">0.05</PARAM>
       <PARAM name="warning">0.3</PARAM>
@@ -112,42 +117,14 @@
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="xmin">15.0</PARAM>
-      <PARAM name="xmax">100.0</PARAM>
+      <PARAM name="xmax">80.0</PARAM>
 </QTEST>
-<QTEST name="XrangeWithin:0-10.0" activate="true"> 
+<QTEST name="XrangeWithin:0-10.0" activate="false"> 
      <TYPE>ContentsXRange</TYPE> 
      <PARAM name="error">0.2</PARAM> 
      <PARAM name="warning">0.4</PARAM> 
      <PARAM name="xmin">0</PARAM> 
      <PARAM name="xmax">10.0</PARAM> 
-</QTEST>
-<QTEST name="XrangeWithin:NumberOfTracks" activate="true">
-      <TYPE>ContentsXRange</TYPE>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="xmin">0.0</PARAM>
-      <PARAM name="xmax">2000.0</PARAM>
-</QTEST>
-<QTEST name="XrangeWithin:NumberOfRecHitsPerTrk" activate="true"> 
-     <TYPE>ContentsXRange</TYPE> 
-     <PARAM name="error">0.80</PARAM> 
-     <PARAM name="warning">0.90</PARAM> 
-     <PARAM name="xmin">4.0</PARAM> 
-     <PARAM name="xmax">35.0</PARAM> 
-</QTEST>
-<QTEST name="XrangeWithin:Chi2overDoF" activate="true"> 
-     <TYPE>ContentsXRange</TYPE> 
-     <PARAM name="error">0.85</PARAM> 
-     <PARAM name="warning">0.95</PARAM> 
-     <PARAM name="xmin">0</PARAM> 
-     <PARAM name="xmax">10.0</PARAM> 
-</QTEST>
-<QTEST name="XrangeWithin:TrackPt" activate="true"> 
-     <TYPE>ContentsXRange</TYPE> 
-     <PARAM name="error">0.85</PARAM> 
-     <PARAM name="warning">0.95</PARAM> 
-     <PARAM name="xmin">0</PARAM> 
-     <PARAM name="xmax">100.0</PARAM> 
 </QTEST>
 <LINK name="*nFEDErrors">
   <TestName activate="true">MeanWithinExpectedRange:nFEDErrors</TestName>
@@ -185,16 +162,4 @@
 <LINK name="*Summary_ClusterStoNCorr__OnTrack__TID__PLUS__wheel__*">
   <TestName activate="true">MeanWithinExpectedRange:StoNTID</TestName>
 </LINK>
-<LINK name="*TrackParameters/GeneralProperties/NumberOfTracks_HeavyIonTk">
-  <TestName activate="true">XrangeWithin:NumberOfTracks</TestName>
-</LINK>
-<LINK name="*TrackParameters/HitProperties/NumberOfRecHitsPerTrack_HeavyIonTk">
-  <TestName activate="true">XrangeWithin:NumberOfRecHitsPerTrk</TestName>
-</LINK>
-<LINK name="*TrackParameters/GeneralProperties/Chi2oNDF_HeavyIonTk">
-  <TestName activate="true">XrangeWithin:Chi2overDoF</TestName>
-</LINK>
-<LINK name="*TrackParameters/GeneralProperties/TrackPt_ImpactPoint_HeavyIonTk">
-  <TestName activate="true">XrangeWithin:TrackPt</TestName>
-</LINK>
-</TESTCONFIGURATION>
+</TESTSCONFIGURATION>

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
@@ -37,6 +37,11 @@ siStripQTester = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(siStripQTester,
+                       qtList = cms.untracked.FileInPath('DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0_heavyions.xml')
+                       )
+
 from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
 siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
 siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)

--- a/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0.xml
+++ b/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0.xml
@@ -11,8 +11,7 @@
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
       <PARAM name="xmin">0.0</PARAM>
-<!--      <PARAM name="xmax">800.0</PARAM> pp parameter -->
-      <PARAM name="xmax">2000.0</PARAM>
+      <PARAM name="xmax">800.0</PARAM>
 </QTEST>
 <QTEST name="XrangeWithin:NumberOfRecHitsPerTrack" activate="true"> 
      <TYPE>ContentsXRange</TYPE> 

--- a/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0_heavyions.xml
+++ b/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0_heavyions.xml
@@ -1,4 +1,11 @@
 <TESTSCONFIGURATION> 
+<QTEST name="XrangeWithin:0-10.0" activate="false"> 
+     <TYPE>ContentsXRange</TYPE> 
+     <PARAM name="error">0.2</PARAM> 
+     <PARAM name="warning">0.4</PARAM> 
+     <PARAM name="xmin">0</PARAM> 
+     <PARAM name="xmax">10.0</PARAM> 
+</QTEST>
 <QTEST name="XrangeWithin:NumberOfTracks" activate="true">
       <TYPE>ContentsXRange</TYPE>
       <PARAM name="error">0.85</PARAM>
@@ -6,38 +13,130 @@
       <PARAM name="xmin">0.0</PARAM>
       <PARAM name="xmax">2000.0</PARAM>
 </QTEST>
-<QTEST name="XrangeWithin:NumberOfRecHitsPerTrk" activate="true"> 
+<QTEST name="XrangeWithin:NumberOfRecHitsPerTrack" activate="true"> 
      <TYPE>ContentsXRange</TYPE> 
      <PARAM name="error">0.80</PARAM> 
      <PARAM name="warning">0.90</PARAM> 
-     <PARAM name="xmin">4.0</PARAM> 
+     <PARAM name="xmin">3.0</PARAM> 
      <PARAM name="xmax">35.0</PARAM> 
 </QTEST>
-<QTEST name="XrangeWithin:Chi2overDoF" activate="true"> 
-     <TYPE>ContentsXRange</TYPE> 
+<QTEST name="MeanWithinExpected:NumberOfRecHitsPerTrack" activate="true">
+     <TYPE>MeanWithinExpected</TYPE> 
+     <PARAM name="error">0.80</PARAM> 
+     <PARAM name="warning">0.90</PARAM> 
+     <PARAM name="mean">1.0</PARAM>
+     <PARAM name="useRMS">0</PARAM>
+     <PARAM name="useSigma">0</PARAM>
+     <PARAM name="useRange">1</PARAM>
+     <PARAM name="minEntries">0</PARAM>
+     <PARAM name="xmin">8.0</PARAM>
+     <PARAM name="xmax">17.0</PARAM>       
+</QTEST>
+<QTEST name="MeanWithinExpected:Chi2oNDF" activate="true">
+     <TYPE>MeanWithinExpected</TYPE> 
      <PARAM name="error">0.85</PARAM> 
      <PARAM name="warning">0.95</PARAM> 
-     <PARAM name="xmin">0</PARAM> 
-     <PARAM name="xmax">10.0</PARAM> 
+     <PARAM name="mean">1.0</PARAM>
+     <PARAM name="useRMS">0</PARAM>
+     <PARAM name="useSigma">0</PARAM>
+     <PARAM name="useRange">1</PARAM>
+     <PARAM name="minEntries">0</PARAM>
+     <PARAM name="xmin">0.5</PARAM>
+     <PARAM name="xmax">2.5</PARAM> 
 </QTEST>
 <QTEST name="XrangeWithin:TrackPt" activate="true"> 
      <TYPE>ContentsXRange</TYPE> 
      <PARAM name="error">0.85</PARAM> 
      <PARAM name="warning">0.95</PARAM> 
      <PARAM name="xmin">0</PARAM> 
-     <PARAM name="xmax">100.0</PARAM> 
+     <PARAM name="xmax">200.0</PARAM> 
 </QTEST>
-
-<LINK name="*TrackParameters/GeneralProperties/NumberOfTracks_HeavyIonTk">
+<QTEST name="XrangeWithin:FractionOfGoodTracks" activate="true"> 
+     <TYPE>ContentsXRange</TYPE> 
+     <PARAM name="error">0.85</PARAM> 
+     <PARAM name="warning">0.95</PARAM> 
+     <PARAM name="xmin">0.7</PARAM> 
+     <PARAM name="xmax">1.1</PARAM> 
+</QTEST>
+<QTEST name="MeanWithinExpected:TrackSeed" activate="true"> 
+     <TYPE>MeanWithinExpected</TYPE> 
+     <PARAM name="error">0.75</PARAM> 
+     <PARAM name="warning">0.90</PARAM> 
+     <PARAM name="mean">1.0</PARAM>
+     <PARAM name="useRMS">0</PARAM>
+     <PARAM name="useSigma">0</PARAM>
+     <PARAM name="useRange">1</PARAM>
+     <PARAM name="minEntries">0</PARAM>
+     <PARAM name="xmin">0.5</PARAM>
+     <PARAM name="xmax">50000.0</PARAM>
+</QTEST>
+<QTEST name="CheckVariance:BPixLayersPerTrackVsPhi" activate="true">
+     <TYPE>CheckVariance</TYPE>
+     <PARAM name="error">0.05</PARAM>
+     <PARAM name="warning">0.04</PARAM>
+</QTEST>
+<QTEST name="CheckVariance:PixEndcapLayersPerTrackVsPhi" activate="true">
+     <TYPE>CheckVariance</TYPE>
+     <PARAM name="error">0.05</PARAM>
+     <PARAM name="warning">0.04</PARAM>
+</QTEST>
+<QTEST name="CheckVariance:TIBLayersPerTrackVsPhi" activate="true">
+     <TYPE>CheckVariance</TYPE>
+     <PARAM name="error">0.05</PARAM>
+     <PARAM name="warning">0.04</PARAM>
+</QTEST>
+<QTEST name="CheckVariance:TOBLayersPerTrackVsPhi" activate="true">
+     <TYPE>CheckVariance</TYPE>
+     <PARAM name="error">0.05</PARAM>
+     <PARAM name="warning">0.04</PARAM>
+</QTEST>
+<QTEST name="CheckVariance:TIDLayersPerTrackVsPhi" activate="true">
+     <TYPE>CheckVariance</TYPE>
+     <PARAM name="error">0.05</PARAM>
+     <PARAM name="warning">0.04</PARAM>
+</QTEST>
+<QTEST name="CheckVariance:TECLayersPerTrackVsPhi" activate="true">
+     <TYPE>CheckVariance</TYPE>
+     <PARAM name="error">0.05</PARAM>
+     <PARAM name="warning">0.04</PARAM>
+</QTEST>
+<LINK name="*TrackParameters/*/GeneralProperties/NumberOfTracks_GenTk">
   <TestName activate="true">XrangeWithin:NumberOfTracks</TestName>
 </LINK>
-<LINK name="*TrackParameters/HitProperties/NumberOfRecHitsPerTrack_HeavyIonTk">
-  <TestName activate="true">XrangeWithin:NumberOfRecHitsPerTrk</TestName>
+<LINK name="*TrackParameters/*/HitProperties/NumberOfRecHitsPerTrack_GenTk">
+  <TestName activate="true">XrangeWithin:NumberOfRecHitsPerTrack</TestName>
 </LINK>
-<LINK name="*TrackParameters/GeneralProperties/Chi2oNDF_HeavyIonTk">
-  <TestName activate="true">XrangeWithin:Chi2overDoF</TestName>
+<LINK name="*TrackParameters/*/HitProperties/NumberOfRecHitsPerTrack_GenTk">
+  <TestName activate="true">MeanWithinExpected:NumberOfRecHitsPerTrack</TestName>
 </LINK>
-<LINK name="*TrackParameters/GeneralProperties/TrackPt_ImpactPoint_HeavyIonTk">
+<LINK name="*TrackParameters/*/GeneralProperties/Chi2oNDF_GenTk">
+  <TestName activate="true">MeanWithinExpected:Chi2oNDF</TestName>
+</LINK>
+<LINK name="*TrackParameters/*/GeneralProperties/TrackPt_ImpactPoint_GenTk">
   <TestName activate="true">XrangeWithin:TrackPt</TestName>
 </LINK>
-</TESTCONFIGURATION>
+<LINK name="*TrackParameters/*/GeneralProperties/FractionOfGoodTracks_GenTk">
+  <TestName activate="false">XrangeWithin:FractionOfGoodTracks</TestName>
+</LINK>
+<LINK name="*TrackParameters/*/TrackBuilding/NumberOfSeeds_*">
+  <TestName activate="true">MeanWithinExpected:TrackSeed</TestName>
+</LINK>
+<LINK name="*TrackParameters/HitProperties/PixBarrel/NumberOfPixBarrelLayersPerTrackVsPhiProfile_GenTk*">
+  <TestName activate="true">CheckVariance:BPixLayersPerTrackVsPhi</TestName>
+</LINK>
+<LINK name="*TrackParameters/HitProperties/PixEndcap/NumberOfPixEndcapLayersPerTrackVsPhiProfile_GenTk*">
+  <TestName activate="true">CheckVariance:BPixLayersPerTrackVsPhi</TestName>
+</LINK>
+<LINK name="*TrackParameters/HitProperties/TIB/NumberOfTIBLayersPerTrackVsPhiProfile_GenTk*">
+  <TestName activate="true">CheckVariance:BPixLayersPerTrackVsPhi</TestName>
+</LINK>
+<LINK name="*TrackParameters/HitProperties/TOB/NumberOfTOBLayersPerTrackVsPhiProfile_GenTk*">
+  <TestName activate="true">CheckVariance:BPixLayersPerTrackVsPhi</TestName>
+</LINK>
+<LINK name="*TrackParameters/HitProperties/TID/NumberOfTIDLayersPerTrackVsPhiProfile_GenTk*">
+  <TestName activate="true">CheckVariance:BPixLayersPerTrackVsPhi</TestName>
+</LINK>
+<LINK name="*TrackParameters/HitProperties/TEC/NumberOfTECLayersPerTrackVsPhiProfile_GenTk*">
+  <TestName activate="true">CheckVariance:BPixLayersPerTrackVsPhi</TestName>
+</LINK>
+</TESTSCONFIGURATION>

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
@@ -66,6 +66,11 @@ trackingQTester = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(trackingQTester,
+                       qtList = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0_heavyions.xml')
+                       )
+
 from DQM.TrackingMonitorClient.TrackingEffFromHitPatternClientConfig_cff import trackingEffFromHitPattern
 
 from DQM.TrackingMonitorClient.V0MonitoringClient_cff import *


### PR DESCRIPTION
Updates of some DQM Quality Test threshold for both Offline and Online Tracker DQM. Mainly for HI data taking, selection of the correct parameters via Era modifier. Backport of #25374

This PR reverts back some changes done on #25254 since now the correct configuration parameters are selected via Era Modifier
