### PR TITLE
fix TrackTimeValueProducer inputs for premixing

### DIFF
--- a/SimTracker/TrackAssociation/python/trackTimeValueMapProducer_cfi.py
+++ b/SimTracker/TrackAssociation/python/trackTimeValueMapProducer_cfi.py
@@ -16,3 +16,9 @@ trackTimeValueMapProducer = cms.EDProducer(
     pMin = cms.double(0.7),
     etaMaxForPtThreshold = cms.double(1.5),
     )
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(trackTimeValueMapProducer,
+    trackingParticleSrc = cms.InputTag("mixData:MergedTrackTruth"),
+    trackingVertexSrc = cms.InputTag("mixData:MergedTrackTruth"),
+)

--- a/SimTracker/TrackAssociation/python/trackTimeValueMapProducer_cfi.py
+++ b/SimTracker/TrackAssociation/python/trackTimeValueMapProducer_cfi.py
@@ -19,6 +19,6 @@ trackTimeValueMapProducer = cms.EDProducer(
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(trackTimeValueMapProducer,
-    trackingParticleSrc = cms.InputTag("mixData:MergedTrackTruth"),
-    trackingVertexSrc = cms.InputTag("mixData:MergedTrackTruth"),
+    trackingParticleSrc = "mixData:MergedTrackTruth",
+    trackingVertexSrc = "mixData:MergedTrackTruth",
 )


### PR DESCRIPTION
@jingyucms found a crash in WF 27634.99 step4:
```
----- Begin Fatal Exception 29-Nov-2018 11:33:58 CST-----------------------
An exception of category 'InvalidReference' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 0
   [1] Running path 'validation_step6'
   [2] Prefetching for module CaloParticleValidation/'caloparticlevalidation'
   [3] Prefetching for module SimPFProducer/'simPFProducer'
   [4] Calling method for module TrackTimeValueMapProducer/'trackTimeValueMapProducer'
Exception Message:
ClusterTPAssociation has TrackingParticles with ProductID 2:158, but got TrackingParticleRef/Handle/ProductID with ID 2:157. This is typically caused by a configuration error.
----- End Fatal Exception -------------------------------------------------
```

This PR fixes the problem. attn: @makortel 