### PR TITLE
Added 2018 PbPb collision vertex smearing parameters

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -58,7 +58,7 @@ VtxSmeared = {
     'Realistic100ns13TeVCollisionBetaStar90mLowBunches' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90mLowBunches_cfi',
     'Realistic25ns13TeVEarly2017Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2017Collision_cfi',
     'Realistic25ns13TeVEarly2018Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2018Collision_cfi',
-    'RealisticPbPbCollision2018' : 'IOMC.EventVertexGenerators.VtxSmearedRealisticPbPbCollision2018_cfi.py',
+    'RealisticPbPbCollision2018' : 'IOMC.EventVertexGenerators.VtxSmearedRealisticPbPbCollision2018_cfi',
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='RealisticHICollision2015'

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -58,7 +58,7 @@ VtxSmeared = {
     'Realistic100ns13TeVCollisionBetaStar90mLowBunches' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90mLowBunches_cfi',
     'Realistic25ns13TeVEarly2017Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2017Collision_cfi',
     'Realistic25ns13TeVEarly2018Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2018Collision_cfi',
-
+    'RealisticPbPbCollision2018' : 'IOMC.EventVertexGenerators.VtxSmearedRealisticPbPbCollision2018_cfi.py',
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='RealisticHICollision2015'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -713,6 +713,19 @@ RealisticXeXeCollision2017VtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.645)
 )
 
+# From fit to 5 TeV PbPb data
+RealisticPbPbCollision2018VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(50),
+    Emittance = cms.double(3.36e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(4.97),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.010),
+    Y0 = cms.double(0.047),
+    Z0 = cms.double(0.903)
+)
+
 # Estimate for 2015 pp collisions at 5.02 TeV, based on feedback from accelerator:  beta* ~ 400cm, normalized emittance = 2.5 um, SigmaZ similar to RunIIWinter15GS
 Nominal5TeVpp2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -714,6 +714,21 @@ RealisticXeXeCollision2017VtxSmearingParameters = cms.PSet(
 )
 
 # From fit to 5 TeV PbPb data
+# From 2018 PbPb  data
+# BS parameters extracted from run 327211, Fill 7471 (from StreamExpressAlignment, HP, BS):
+# X0         =  0.09443  [cm]
+# Y0         = -0.06377  [cm]
+# Z0         =  0.58067  [cm]
+# sigmaZ0    =  4.969    [cm]
+# BeamWidthX 0.0014392
+# BeamWidthY 0.0011545
+#
+# Emittance is 3.36e-8 cm. Calculated by  ((BeamWidthX + BeamWidth)/2)^2/BetaStar
+#
+# BPIX absolute position (from https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod):
+# X =  0.084335 cm
+# Y = -0.110381 cm
+# Z = -0.321904 cm
 RealisticPbPbCollision2018VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),
     BetaStar = cms.double(50),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealisticPbPbCollision2018_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealisticPbPbCollision2018_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import RealisticPbPbCollision2018VtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    RealisticPbPbCollision2018VtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
Added in vertex smearing parameters from the 2018 PbPb collision. More detailed presentation can be seen at:

https://cernbox.cern.ch/index.php/s/J3Emh3kw0Y3EGmf