### PR TITLE
[103X] Change GT. Offline GT Fix ECAL Tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '103X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '103X_dataRun2_v4',
+    'run1_data'         :   '103X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '103X_dataRun2_v4',
+    'run2_data'         :   '103X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '103X_dataRun2_relval_v9',
+    'run2_data_relval'  :   '103X_dataRun2_relval_v10',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '103X_dataRun2_PromptLike_HEfail_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
Using fixed Tags [1] in the Offline GT (the one before did not contain the correct history).

Cheers,
Luca

[1]
EcalTimeCalibConstants_Run1_Run2_v02_offline
EcalPedestals_Run1_Run2_Time_v1
EcalIntercalibConstants_Run1_Run2_V06_offline
EcalPulseShapes_Run1_Run2_V01_offline
