### PR TITLE
Remove std::move call from function return statement for L1TRawToDigi/Block

### DIFF
--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -74,13 +74,13 @@ namespace l1t {
    {
       if (end_ - data_ < getHeaderSize()) {
          LogDebug("L1T") << "Reached end of payload";
-         return std::move(std::unique_ptr<Block>());
+         return std::unique_ptr<Block>();
       }
 
       if (data_[0] == 0xffffffff) {
          LogDebug("L1T") << "Skipping padding word";
          ++data_;
-         return std::move(getBlock());
+         return getBlock();
       }
 
       auto header = getHeader();
@@ -89,14 +89,14 @@ namespace l1t {
          edm::LogError("L1T")
             << "Expecting a block size of " << header.getSize()
             << " but only " << (end_ - data_) << " words remaining";
-         return std::move(std::unique_ptr<Block>());
+         return std::unique_ptr<Block>();
       }
 
       LogTrace("L1T") << "Creating block with size " << header.getSize();
 
-      auto res = std::unique_ptr<Block>(new Block(header, data_, data_ + header.getSize()));
+      auto res = std::make_unique<Block>(header, data_, data_ + header.getSize());
       data_ += header.getSize();
-      return std::move(res);
+      return res;
    }
 
    MP7Payload::MP7Payload(const uint32_t * data, const uint32_t * end, bool legacy_mc) : Payload(data, end)
@@ -192,7 +192,7 @@ namespace l1t {
   MTF7Payload::getBlock()
   {
     if (end_ - data_ < 2)
-      return std::move(std::unique_ptr<Block>(nullptr));
+      return std::unique_ptr<Block>();
     
     const uint16_t * data16 = reinterpret_cast<const uint16_t*>(data_);
     const uint16_t * end16 = reinterpret_cast<const uint16_t*>(end_);
@@ -215,11 +215,11 @@ namespace l1t {
     
     if (not valid(pattern)) {
       edm::LogWarning("L1T") << "MTF7 block with unrecognized id 0x" << std::hex << pattern;
-      return std::move(std::unique_ptr<Block>(nullptr));
+      return std::unique_ptr<Block>();
     }
     
     data_ += (i + 1) * 2;
-    return std::move(std::unique_ptr<Block>(new Block(pattern, payload, 0, MTF7)));
+    return std::make_unique<Block>(pattern, payload, 0, MTF7);
   }
   
    CTP7Payload::CTP7Payload(const uint32_t * data, const uint32_t * end, amc::Header amcHeader) : Payload(data, end), amcHeader_(amcHeader)
@@ -257,7 +257,7 @@ namespace l1t {
    {
       if (end_ - data_ < getHeaderSize()) {
          LogDebug("L1T") << "Reached end of payload";
-         return std::move(std::unique_ptr<Block>());
+         return std::unique_ptr<Block>();
       }
       if ( capId_ > bx_per_l1a_ ) {
         edm::LogWarning("L1T") << "CTP7 with more bunch crossings than expected";
@@ -269,14 +269,14 @@ namespace l1t {
          edm::LogError("L1T")
             << "Expecting a block size of " << header.getSize()
             << " but only " << (end_ - data_) << " words remaining";
-         return std::move(std::unique_ptr<Block>());
+         return std::unique_ptr<Block>();
       }
 
       LogTrace("L1T") << "Creating block with size " << header.getSize();
 
-      auto res = std::unique_ptr<Block>(new Block(header, data_, data_ + header.getSize()));
+      auto res = std::make_unique<Block>(header, data_, data_ + header.getSize());
       data_ += header.getSize();
       capId_++;
-      return std::move(res);
+      return res;
    }
 }


### PR DESCRIPTION
The use of move stops the compiler from being able to use copy elision. This was caught by clang.
Also changed to using make_unique.