### PR TITLE
Remove std::move from return statements in CommonTools/CandUtils

### DIFF
--- a/CommonTools/CandUtils/interface/makeCompositeCandidate.h
+++ b/CommonTools/CandUtils/interface/makeCompositeCandidate.h
@@ -23,7 +23,7 @@ namespace helpers {
     std::unique_ptr<reco::Candidate> release() {
       std::unique_ptr<reco::Candidate> ret( std::move(cmp_.get()) );
       cmp_.release();
-      return std::move(ret);
+      return ret;
     }
   };
 

--- a/CommonTools/CandUtils/src/NamedCandCombinerBase.cc
+++ b/CommonTools/CandUtils/src/NamedCandCombinerBase.cc
@@ -103,7 +103,7 @@ NamedCandCombinerBase::combine(const vector<CandidatePtrVector> & src,
     combine(0, stack, qStack, names, src.begin(), src.end(), comps);
   }
 
-  return std::move(comps);
+  return comps;
 }
 
 unique_ptr<NamedCompositeCandidateCollection> 
@@ -132,7 +132,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src, string_coll const
     } 
   }
 
-  return std::move(comps);
+  return comps;
 }
 
 unique_ptr<NamedCompositeCandidateCollection> 
@@ -140,7 +140,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidateP
   vector<CandidatePtrVector> src;
   src.push_back(src1);
   src.push_back(src2);
-  return std::move(combine(src, names));
+  return combine(src, names);
 }
 
 unique_ptr<NamedCompositeCandidateCollection> 
@@ -150,7 +150,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidateP
   src.push_back(src1);
   src.push_back(src2);
   src.push_back(src3);
-  return std::move(combine(src, names));
+  return combine(src, names);
 }
 
 unique_ptr<NamedCompositeCandidateCollection> 
@@ -162,7 +162,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidateP
   src.push_back(src2);
   src.push_back(src3);
   src.push_back(src4);
-  return std::move(combine(src, names));
+  return combine(src, names);
 }
 
 void NamedCandCombinerBase::combine(size_t collectionIndex, CandStack & stack, ChargeStack & qStack, 

--- a/CommonTools/CandUtils/src/cloneDecayTree.cc
+++ b/CommonTools/CandUtils/src/cloneDecayTree.cc
@@ -8,9 +8,8 @@ unique_ptr<Candidate> cloneDecayTree(const Candidate & c) {
   if (n == 1) return unique_ptr<Candidate>(c.clone());
   // pass a particle, not a candidate, to avoid cloning daughters 
   const Candidate &p = c;
-  CompositeCandidate * cmp(new CompositeCandidate(p));
-  unique_ptr<Candidate> cmpPtr(cmp);
+  auto cmp = std::make_unique<CompositeCandidate>(p);
   for(size_t i = 0; i < n; ++ i)
     cmp->addDaughter(cloneDecayTree(* c.daughter(i)));
-  return std::move(cmpPtr);
+  return cmp;
 }


### PR DESCRIPTION
Doing a std::move stops the compiler from doing copy elision.
This was found by the clang compiler.