### PR TITLE
Removed unused variables and functions in RecoLocalCalo/HGCalRecAlgos

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
@@ -148,7 +148,6 @@ bool ClusterTools::getWidths(const reco::CaloCluster & clus,double & sigmaetaeta
     const DetId & id = (clus.hitsAndFractions())[ih].first;
     if ((clus.hitsAndFractions())[ih].second==0.) continue;
 
-    HGCRecHitCollection::const_iterator theHit;
     if ((id.det() == DetId::HGCalEE) ||
 	(id.det()==DetId::Forward && id.subdetId()==HGCEE)) {
       const HGCRecHit * theHit = &(*eerh_->find(id));

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -18,11 +18,6 @@
 using namespace hgcal;
 
 namespace {
-  constexpr char hgcalee_sens[] = "HGCalEESensitive";
-  constexpr char hgcalfh_sens[] = "HGCalHESiliconSensitive";
-
-  constexpr std::float_t idx_to_thickness = std::float_t(100.0);
-
   template<typename DDD>
   inline void check_ddd(const DDD* ddd) {
     if( nullptr == ddd ) {
@@ -39,14 +34,6 @@ namespace {
     }
   }
 
-  inline const HcalDDDRecConstants* get_ddd(const CaloSubdetectorGeometry* geom,
-					    const HcalDetId& detid) {
-    const HcalGeometry* hc = static_cast<const HcalGeometry*>(geom);
-    const HcalDDDRecConstants* ddd = hc->topology().dddConstants();
-    check_ddd(ddd);
-    return ddd;
-  }
-
   inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom,
 					  const HGCalDetId& detid) {
     const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
@@ -57,14 +44,6 @@ namespace {
 
   inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom,
 					  const HGCSiliconDetId& detid) {
-    const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
-    const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
-    check_ddd(ddd);
-    return ddd;
-  }
-
-  inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom,
-					  const HGCScintillatorDetId& detid) {
     const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
     const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
     check_ddd(ddd);


### PR DESCRIPTION
These were causing clang warnings.