### PR TITLE
Fix clang warnings in RecoTracker/MeasurementDet

### DIFF
--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
@@ -94,11 +94,11 @@ MeasurementTrackerEventProducer::produce(edm::Event &iEvent, const edm::EventSet
 
     // put into MTE
     // put into event
-    iEvent.put(std::move(
+    iEvent.put(
       std::make_unique<MeasurementTrackerEvent>(*measurementTracker, 
                                                 stripData.release(), pixelData.release(), phase2OTData.release(),
 	                                        stripClustersToSkip, pixelClustersToSkip, phase2ClustersToSkip)
-    ));
+    );
 }
 
 void 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
@@ -36,15 +36,15 @@ MeasurementTrackerEventProducer::MeasurementTrackerEventProducer(const edm::Para
     LogDebug("MeasurementTracker")<<"skipping clusters: "<<selfUpdateSkipClusters_;
     isPhase2 = false;
 
-    if (iConfig.getParameter<std::string>("stripClusterProducer") != "") {
+    if (!iConfig.getParameter<std::string>("stripClusterProducer").empty()) {
         theStripClusterLabel = consumes<edmNew::DetSetVector<SiStripCluster> >(edm::InputTag(iConfig.getParameter<std::string>("stripClusterProducer")));
         if (selfUpdateSkipClusters_) theStripClusterMask = consumes<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>>(iConfig.getParameter<edm::InputTag>("skipClusters"));
     }
-    if (iConfig.getParameter<std::string>("pixelClusterProducer") != "") {
+    if (!iConfig.getParameter<std::string>("pixelClusterProducer").empty()) {
         thePixelClusterLabel = consumes<edmNew::DetSetVector<SiPixelCluster> >(edm::InputTag(iConfig.getParameter<std::string>("pixelClusterProducer")));
         if (selfUpdateSkipClusters_) thePixelClusterMask = consumes<edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>>(iConfig.getParameter<edm::InputTag>("skipClusters"));
     }
-    if (iConfig.getParameter<std::string>("Phase2TrackerCluster1DProducer") != "") {
+    if (!iConfig.getParameter<std::string>("Phase2TrackerCluster1DProducer").empty()) {
         thePh2OTClusterLabel = consumes<edmNew::DetSetVector<Phase2TrackerCluster1D> >(edm::InputTag(iConfig.getParameter<std::string>("Phase2TrackerCluster1DProducer")));
         isPhase2 = true;
     }

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -52,15 +52,6 @@ namespace {
 
     return std::make_pair(projectedHitPos, rotatedError);
   }
-
-
-  inline
-  std::pair<LocalPoint,LocalError> projectedPos(const TrackingRecHit& hit,
-                           const GeomDet& det,
-                           const TrajectoryStateOnSurface& ts, const StripClusterParameterEstimator* cpe) {
-      GlobalVector gdir = ts.globalParameters().momentum();
-      return projectedPos(hit, det, gdir, cpe);
-  }
 }
 
 // #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -525,7 +525,7 @@ TkGluedMeasurementDet::HitCollectorForFastMeasurements::add(SiStripMatchedRecHit
 
   std::pair<bool,double> diffEst = est_.estimate( stateOnThisDet_, hit2d);
   if (diffEst.first)
-    target_.add(std::move(hit2d.cloneSH()),diffEst.second);
+    target_.add(hit2d.cloneSH(),diffEst.second);
 }
 
 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -183,7 +183,7 @@ public:
     std::pair<bool,double> diffEst = est.estimate(ltp, recHit);
     LogDebug("TkStripMeasurementDet")<<" chi2=" << diffEst.second;
     if ( diffEst.first ) {
-      result.push_back(std::move(std::make_shared<SiStripRecHit2D>(recHit)));
+      result.push_back(std::make_shared<SiStripRecHit2D>(recHit));
       diffs.push_back(diffEst.second);
     }
     return diffEst.first;


### PR DESCRIPTION
Removed use of std::move with temporaries which was stopping copy elision.
Removed unused file local function.