### PR TITLE
improved position measurement for 2D clusters in HGCAL silicon sensors

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
@@ -91,7 +91,7 @@ enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 }
 
 HGCalImagingAlgo(const std::vector<double>& W0threshold_in, const std::vector<double>& positionDeltaRho_c_in,
-		 const std::vector<double>& vecDeltas_in, double kappa_in, double ecut_in,
+                 const std::vector<double>& vecDeltas_in, double kappa_in, double ecut_in,
                  double showerSigma,
                  reco::CaloCluster::AlgoId algoId_in,
                  bool dependSensor_in,
@@ -103,7 +103,7 @@ HGCalImagingAlgo(const std::vector<double>& W0threshold_in, const std::vector<do
                  double noiseMip_in,
                  VerbosityLevel the_verbosity = pERROR) :
         W0threshold_(W0threshold_in),
-	positionDeltaRho_c_(positionDeltaRho_c_in),
+        positionDeltaRho_c_(positionDeltaRho_c_in),
         vecDeltas_(vecDeltas_in), kappa_(kappa_in),
         ecut_(ecut_in),
         sigma2_(std::pow(showerSigma,2.0)),
@@ -118,10 +118,10 @@ HGCalImagingAlgo(const std::vector<double>& W0threshold_in, const std::vector<do
         verbosity_(the_verbosity),
         initialized_(false),
         points_(2*(maxlayer+1)),
-	minpos_(2*(maxlayer+1),{
+        minpos_(2*(maxlayer+1),{
                 {0.0f,0.0f}
         }),
-	maxpos_(2*(maxlayer+1),{ {0.0f,0.0f} })
+        maxpos_(2*(maxlayer+1),{ {0.0f,0.0f} })
 {
 }
 

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
@@ -49,13 +49,15 @@ public:
 
 enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
-HGCalImagingAlgo() : vecDeltas_(), kappa_(1.), ecut_(0.),
+ HGCalImagingAlgo() : W0threshold_(), positionDeltaRho_c_(),
+        vecDeltas_(), kappa_(1.), ecut_(0.),
         sigma2_(1.0),
         algoId_(reco::CaloCluster::undefined),
         verbosity_(pERROR),initialized_(false){
 }
 
-HGCalImagingAlgo(const std::vector<double>& vecDeltas_in, double kappa_in, double ecut_in,
+ HGCalImagingAlgo(const std::vector<double>& W0threshold_in, const std::vector<double>& positionDeltaRho_c_in,
+		 const std::vector<double>& vecDeltas_in, double kappa_in, double ecut_in,
                  reco::CaloCluster::AlgoId algoId_in,
                  bool dependSensor_in,
                  const std::vector<double>& dEdXweights_in,
@@ -65,6 +67,8 @@ HGCalImagingAlgo(const std::vector<double>& vecDeltas_in, double kappa_in, doubl
                  const std::vector<double>& nonAgedNoises_in,
                  double noiseMip_in,
                  VerbosityLevel the_verbosity = pERROR) :
+        W0threshold_(W0threshold_in),
+        positionDeltaRho_c_(positionDeltaRho_c_in),
         vecDeltas_(vecDeltas_in), kappa_(kappa_in),
         ecut_(ecut_in),
         sigma2_(1.0),
@@ -86,7 +90,8 @@ HGCalImagingAlgo(const std::vector<double>& vecDeltas_in, double kappa_in, doubl
 {
 }
 
-HGCalImagingAlgo(const std::vector<double>& vecDeltas_in, double kappa_in, double ecut_in,
+HGCalImagingAlgo(const std::vector<double>& W0threshold_in, const std::vector<double>& positionDeltaRho_c_in,
+		 const std::vector<double>& vecDeltas_in, double kappa_in, double ecut_in,
                  double showerSigma,
                  reco::CaloCluster::AlgoId algoId_in,
                  bool dependSensor_in,
@@ -96,7 +101,10 @@ HGCalImagingAlgo(const std::vector<double>& vecDeltas_in, double kappa_in, doubl
                  double fcPerEle_in,
                  const std::vector<double>& nonAgedNoises_in,
                  double noiseMip_in,
-                 VerbosityLevel the_verbosity = pERROR) : vecDeltas_(vecDeltas_in), kappa_(kappa_in),
+                 VerbosityLevel the_verbosity = pERROR) :
+        W0threshold_(W0threshold_in),
+	positionDeltaRho_c_(positionDeltaRho_c_in),
+        vecDeltas_(vecDeltas_in), kappa_(kappa_in),
         ecut_(ecut_in),
         sigma2_(std::pow(showerSigma,2.0)),
         algoId_(algoId_in),
@@ -164,6 +172,11 @@ private:
 // last layer per subdetector
 static const unsigned int lastLayerEE = 28;
 static const unsigned int lastLayerFH = 40;
+
+// To compute the cluster position
+//bool usePositionLogW_;
+std::vector<double> W0threshold_;
+std::vector<double> positionDeltaRho_c_;
 
 // The two parameters used to identify clusters
 std::vector<double> vecDeltas_;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
@@ -49,14 +49,14 @@ public:
 
 enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
- HGCalImagingAlgo() : W0threshold_(), positionDeltaRho_c_(),
+ HGCalImagingAlgo() : thresholdW0_(), positionDeltaRho_c_(),
         vecDeltas_(), kappa_(1.), ecut_(0.),
         sigma2_(1.0),
         algoId_(reco::CaloCluster::undefined),
         verbosity_(pERROR),initialized_(false){
 }
 
- HGCalImagingAlgo(const std::vector<double>& W0threshold_in, const std::vector<double>& positionDeltaRho_c_in,
+ HGCalImagingAlgo(const std::vector<double>& thresholdW0_in, const std::vector<double>& positionDeltaRho_c_in,
 		 const std::vector<double>& vecDeltas_in, double kappa_in, double ecut_in,
                  reco::CaloCluster::AlgoId algoId_in,
                  bool dependSensor_in,
@@ -67,7 +67,7 @@ enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
                  const std::vector<double>& nonAgedNoises_in,
                  double noiseMip_in,
                  VerbosityLevel the_verbosity = pERROR) :
-        W0threshold_(W0threshold_in),
+        thresholdW0_(thresholdW0_in),
         positionDeltaRho_c_(positionDeltaRho_c_in),
         vecDeltas_(vecDeltas_in), kappa_(kappa_in),
         ecut_(ecut_in),
@@ -90,7 +90,7 @@ enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 {
 }
 
-HGCalImagingAlgo(const std::vector<double>& W0threshold_in, const std::vector<double>& positionDeltaRho_c_in,
+HGCalImagingAlgo(const std::vector<double>& thresholdW0_in, const std::vector<double>& positionDeltaRho_c_in,
                  const std::vector<double>& vecDeltas_in, double kappa_in, double ecut_in,
                  double showerSigma,
                  reco::CaloCluster::AlgoId algoId_in,
@@ -102,7 +102,7 @@ HGCalImagingAlgo(const std::vector<double>& W0threshold_in, const std::vector<do
                  const std::vector<double>& nonAgedNoises_in,
                  double noiseMip_in,
                  VerbosityLevel the_verbosity = pERROR) :
-        W0threshold_(W0threshold_in),
+        thresholdW0_(thresholdW0_in),
         positionDeltaRho_c_(positionDeltaRho_c_in),
         vecDeltas_(vecDeltas_in), kappa_(kappa_in),
         ecut_(ecut_in),
@@ -174,7 +174,7 @@ static const unsigned int lastLayerEE = 28;
 static const unsigned int lastLayerFH = 40;
 
 // To compute the cluster position
-std::vector<double> W0threshold_;
+std::vector<double> thresholdW0_;
 std::vector<double> positionDeltaRho_c_;
 
 // The two parameters used to identify clusters

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
@@ -174,7 +174,6 @@ static const unsigned int lastLayerEE = 28;
 static const unsigned int lastLayerFH = 40;
 
 // To compute the cluster position
-//bool usePositionLogW_;
 std::vector<double> W0threshold_;
 std::vector<double> positionDeltaRho_c_;
 

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -194,8 +194,6 @@ HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
   unsigned int v_size = v.size();
   unsigned int maxEnergyIndex = 0;
   float maxEnergyValue = 0;
-  //  bool haloOnlyCluster = true;
-  //  unsigned int maxValidDistanceIndex = 0;
 
   // loop over hits in cluster candidate
   // determining the maximum energy hit

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -218,8 +218,12 @@ HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
 
       float rhEnergy = v[i].data.weight;
       total_weight += rhEnergy;
-      x += v[i].data.x * rhEnergy;
-      y += v[i].data.y * rhEnergy;
+      // just fill x, y for scintillator
+      // for Si it is overwritten later anyway
+      if(thick == -1){
+        x += v[i].data.x * rhEnergy;
+        y += v[i].data.y * rhEnergy;
+      }
     }
   }
   // just loop on reduced vector of interesting indices
@@ -233,7 +237,7 @@ HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
       float rhEnergy = v[idx].data.weight;
       if(total_weight == 0. || rhEnergy == 0.) continue;
       float W0_ = W0threshold_[thick];
-      Wi = (W0_ + log(rhEnergy/total_weight)) > 0 ? (W0_ + log(rhEnergy/total_weight)) : 0.;
+      Wi = std::max(W0_ + log(rhEnergy/total_weight), 0.);
       x_log += v[idx].data.x * Wi;
       y_log += v[idx].data.y * Wi;
       total_weight_log += Wi;

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -194,36 +194,60 @@ HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
   unsigned int v_size = v.size();
   unsigned int maxEnergyIndex = 0;
   float maxEnergyValue = 0;
-  bool haloOnlyCluster = true;
+  //  bool haloOnlyCluster = true;
+  //  unsigned int maxValidDistanceIndex = 0;
 
-  // loop over hits in cluster candidate building up weight for
-  // energy-weighted position calculation and determining the maximum
-  // energy hit in case this is a halo-only cluster
+  // loop over hits in cluster candidate
+  // determining the maximum energy hit
   for (unsigned int i = 0; i < v_size; i++) {
-    if (!v[i].data.isHalo) {
-      haloOnlyCluster = false;
-      total_weight += v[i].data.weight;
-      x += v[i].data.x * v[i].data.weight;
-      y += v[i].data.y * v[i].data.weight;
-      z += v[i].data.z * v[i].data.weight;
-    } else {
-      if (v[i].data.weight > maxEnergyValue) {
+    if (v[i].data.weight > maxEnergyValue) {
         maxEnergyValue = v[i].data.weight;
         maxEnergyIndex = i;
-      }
     }
   }
 
-  if (!haloOnlyCluster) {
-    if (total_weight != 0) {
-      auto inv_tot_weight = 1. / total_weight;
-      return math::XYZPoint(x * inv_tot_weight, y * inv_tot_weight,
-                            z * inv_tot_weight);
+ // Si cell or Scintillator. Used to set approach and parameters
+ int thick = rhtools_.getSiThickIndex(v[maxEnergyIndex].data.detid);
+
+  // for hits within positionDeltaRho_c_ from maximum energy hit
+  // build up weight for energy-weighted position
+  // and save corresponding hits indices
+  std::vector<unsigned int> innerIndices;
+  for (unsigned int i = 0; i < v_size; i++) {
+    if (thick == -1 ||
+	distance2(v[i].data, v[maxEnergyIndex].data) < positionDeltaRho_c_[thick]){
+      innerIndices.push_back(i);
+
+      float rhEnergy = v[i].data.weight;
+      total_weight += rhEnergy;
+      x += v[i].data.x * rhEnergy;
+      y += v[i].data.y * rhEnergy;
     }
-  } else if (v_size > 0) {
-    // return position of hit with maximum energy
-    return math::XYZPoint(v[maxEnergyIndex].data.x, v[maxEnergyIndex].data.y,
-                          v[maxEnergyIndex].data.z);
+  }
+  // just loop on reduced vector of interesting indices
+  // to compute log weighting
+  if(thick != -1){ // Silicon case
+    float total_weight_log = 0.f;
+    float x_log = 0.f;
+    float y_log = 0.f;
+    float Wi = 0.f;
+    for (auto idx : innerIndices) {
+      float rhEnergy = v[idx].data.weight;
+      if(total_weight == 0. || rhEnergy == 0.) continue;
+      float W0_ = W0threshold_[thick];
+      Wi = (W0_ + log(rhEnergy/total_weight)) > 0 ? (W0_ + log(rhEnergy/total_weight)) : 0.;
+      x_log += v[idx].data.x * Wi;
+      y_log += v[idx].data.y * Wi;
+      total_weight_log += Wi;
+    }
+    total_weight = total_weight_log;
+    x = x_log;
+    y = y_log;
+  }
+  z = v[maxEnergyIndex].data.z;
+  if (total_weight != 0) {
+    auto inv_tot_weight = 1. / total_weight;
+    return math::XYZPoint(x * inv_tot_weight, y * inv_tot_weight, z);
   }
   return math::XYZPoint(0, 0, 0);
 }

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
@@ -66,7 +66,7 @@ HGCalLayerClusterProducer::HGCalLayerClusterProducer(const edm::ParameterSet &ps
   timeOffset(ps.getParameter<double>("timeOffset")),
   verbosity((HGCalImagingAlgo::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity",3)){
   double ecut = ps.getParameter<double>("ecut");
-  std::vector<double> W0threshold = ps.getParameter<std::vector<double> >("W0threshold");
+  std::vector<double> thresholdW0 = ps.getParameter<std::vector<double> >("thresholdW0");
   std::vector<double> positionDeltaRho_c = ps.getParameter<std::vector<double> >("positionDeltaRho_c");
   std::vector<double> vecDeltas = ps.getParameter<std::vector<double> >("deltac");
   double kappa = ps.getParameter<double>("kappa");
@@ -98,10 +98,10 @@ HGCalLayerClusterProducer::HGCalLayerClusterProducer(const edm::ParameterSet &ps
 
   if(doSharing){
     double showerSigma =  ps.getParameter<double>("showerSigma");
-    algo = std::make_unique<HGCalImagingAlgo>(W0threshold, positionDeltaRho_c,
+    algo = std::make_unique<HGCalImagingAlgo>(thresholdW0, positionDeltaRho_c,
 					      vecDeltas, kappa, ecut, showerSigma, algoId, dependSensor, dEdXweights, thicknessCorrection, fcPerMip, fcPerEle, nonAgedNoises, noiseMip, verbosity);
   }else{
-    algo = std::make_unique<HGCalImagingAlgo>(W0threshold, positionDeltaRho_c,
+    algo = std::make_unique<HGCalImagingAlgo>(thresholdW0, positionDeltaRho_c,
 					      vecDeltas, kappa, ecut, algoId, dependSensor, dEdXweights, thicknessCorrection, fcPerMip, fcPerEle, nonAgedNoises, noiseMip, verbosity);
   }
 
@@ -119,7 +119,7 @@ void HGCalLayerClusterProducer::fillDescriptions(edm::ConfigurationDescriptions&
   edm::ParameterSetDescription desc;
   desc.add<std::string>("detector", "all");
   desc.add<bool>("doSharing", false);
-  desc.add<std::vector<double>>("W0threshold", {
+  desc.add<std::vector<double>>("thresholdW0", {
     2.9,
     2.9,
     2.9

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
@@ -66,6 +66,8 @@ HGCalLayerClusterProducer::HGCalLayerClusterProducer(const edm::ParameterSet &ps
   timeOffset(ps.getParameter<double>("timeOffset")),
   verbosity((HGCalImagingAlgo::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity",3)){
   double ecut = ps.getParameter<double>("ecut");
+  std::vector<double> W0threshold = ps.getParameter<std::vector<double> >("W0threshold");
+  std::vector<double> positionDeltaRho_c = ps.getParameter<std::vector<double> >("positionDeltaRho_c");
   std::vector<double> vecDeltas = ps.getParameter<std::vector<double> >("deltac");
   double kappa = ps.getParameter<double>("kappa");
   std::vector<double> dEdXweights = ps.getParameter<std::vector<double> >("dEdXweights");
@@ -96,9 +98,11 @@ HGCalLayerClusterProducer::HGCalLayerClusterProducer(const edm::ParameterSet &ps
 
   if(doSharing){
     double showerSigma =  ps.getParameter<double>("showerSigma");
-    algo = std::make_unique<HGCalImagingAlgo>(vecDeltas, kappa, ecut, showerSigma, algoId, dependSensor, dEdXweights, thicknessCorrection, fcPerMip, fcPerEle, nonAgedNoises, noiseMip, verbosity);
+    algo = std::make_unique<HGCalImagingAlgo>(W0threshold, positionDeltaRho_c,
+					      vecDeltas, kappa, ecut, showerSigma, algoId, dependSensor, dEdXweights, thicknessCorrection, fcPerMip, fcPerEle, nonAgedNoises, noiseMip, verbosity);
   }else{
-    algo = std::make_unique<HGCalImagingAlgo>(vecDeltas, kappa, ecut, algoId, dependSensor, dEdXweights, thicknessCorrection, fcPerMip, fcPerEle, nonAgedNoises, noiseMip, verbosity);
+    algo = std::make_unique<HGCalImagingAlgo>(W0threshold, positionDeltaRho_c,
+					      vecDeltas, kappa, ecut, algoId, dependSensor, dEdXweights, thicknessCorrection, fcPerMip, fcPerEle, nonAgedNoises, noiseMip, verbosity);
   }
 
 
@@ -115,6 +119,16 @@ void HGCalLayerClusterProducer::fillDescriptions(edm::ConfigurationDescriptions&
   edm::ParameterSetDescription desc;
   desc.add<std::string>("detector", "all");
   desc.add<bool>("doSharing", false);
+  desc.add<std::vector<double>>("W0threshold", {
+    2.9,
+    2.9,
+    2.9
+  });
+  desc.add<std::vector<double>>("positionDeltaRho_c", {
+    1.3,
+    1.3,
+    1.3
+  });
   desc.add<std::vector<double>>("deltac", {
     2.0,
     2.0,


### PR DESCRIPTION
Improved position for 2D clusters, with focus on electromagnetic showers thus concerning 2Dcl centered in the Silicon sensors.
Main changes:
- restrict the hits used to compute the position to those in a given radius around the most energetic hit (1.3cm)
- adopt a log weighting of the energy, that is best suited for exponential shower profiles (with threshold at W0 = 2.9)
- ignore difference between halo and border hits, just use them all
In support of this, see slides attached to the DPG agenda
https://indico.cern.ch/event/776790/contributions/3230583/attachments/1761511/2865143/positionResolutionFor2DClusters_amartell_29Nov.pdf

Further position optimisation will follow a global restyle with optimised parameters of the Imaging algorithm. In the specific for the position:
- same optimisation for Scintillator part 
- same optimisation for "sharing" option enabled