### PR TITLE
Switching the mode of charge asymmetry evaluation

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -65,7 +65,7 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
 
         # If False, calculate charge asymmetry only when both PMT
         # anodes have "OK" status (or were mapped into "OK" status)
-        alwaysCalculateQAsymmetry = cms.bool(True)
+        alwaysCalculateQAsymmetry = cms.bool(False)
     ),
 
     # Reconstruction algorithm data to fetch from DB, if any


### PR DESCRIPTION
Changing the mode of charge asymmetry evaluation for HF PMTs. For more detail, see #24832 with subsequent documentation in https://indico.cern.ch/event/776884/contributions/3232807/attachments/1763620/2862279/20181130_Jae_RECO_UltraLegacyPlanForHCAL.pdf (slide 5).

This change should not cause a modification of MC relval results. Minor changes are expected for data.
