### PR TITLE
Fixed broken include guard in L1TMuonBarrelKalmanLUTs

### DIFF
--- a/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanLUTs.h
+++ b/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanLUTs.h
@@ -1,5 +1,5 @@
-#ifndef __L1TMuonBarelKalmanLUTs_h
-#define __L1TMuonBarrelKalmanLUTs_h
+#ifndef L1Trigger_L1TMuonBarrel_L1TMuonBarrelKalmanLUTs_h
+#define L1Trigger_L1TMuonBarrel_L1TMuonBarrelKalmanLUTs_h
 
 #include <cstdlib>
 #include "TH1.h"


### PR DESCRIPTION
Also made the guard conform to CMS standards.
The problem was uncovered by clang.