### PR TITLE
MTD: Add PMTDParameters to the GeometryObjects serialization test

### DIFF
--- a/CondFormats/GeometryObjects/test/testSerializationGeometryObjects.cpp
+++ b/CondFormats/GeometryObjects/test/testSerializationGeometryObjects.cpp
@@ -17,6 +17,7 @@ int main()
     testSerialization<PTrackerParameters::Item>();
     testSerialization<HcalParameters>();
     testSerialization<PHGCalParameters>();
+    testSerialization<PMTDParameters>();
 
     return 0;
 }


### PR DESCRIPTION
Addition of PMTDParameters to the unit test for serialization in CondFormats/GeometryObjects. Descoped in #25417 to speed it up, added back here as non critical (but still useful).