### PR TITLE
update PFCluster calibration for HGCal v9 geometry

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -27,8 +27,8 @@ _simClusterMapper_HGCal = cms.PSet(
     useMCFractionsForExclEnergy = cms.bool(False),
     thresholdsByDetector = cms.VPSet(
     ),
-    hadronCalib = hadronCorrections,
-    egammaCalib = egammaCorrections,
+    hadronCalib = hadronCorrections.value,
+    egammaCalib = egammaCorrections.value,
     calibMinEta = minEtaCorrection,
     calibMaxEta = maxEtaCorrection,
     simClusterSrc = cms.InputTag("mix:MergedCaloTruth")

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
@@ -2,5 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 minEtaCorrection = cms.double(1.4)
 maxEtaCorrection = cms.double(3.0)
-hadronCorrections = cms.vdouble(1.28, 1.28, 1.24, 1.19, 1.17, 1.17, 1.17, 1.17)  
-egammaCorrections = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.01, 1.01, 1.01)
+hadronCorrections = cms.vdouble(1.24, 1.24, 1.24, 1.23, 1.24, 1.25, 1.29, 1.29)
+egammaCorrections = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.03, 1.04, 1.04)
+
+hadronCorrections_hgcalV9 = cms.vdouble(1.28, 1.28, 1.24, 1.19, 1.17, 1.17, 1.17, 1.17)
+egammaCorrections_hgcalV9 = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.01, 1.01, 1.01)
+
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify(hadronCorrections = hadronCorrections_hgcalV9)
+phase2_hgcalV9.toModify(egammaCorrections = egammaCorrections_hgcalV9)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
@@ -2,5 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 minEtaCorrection = cms.double(1.4)
 maxEtaCorrection = cms.double(3.0)
-hadronCorrections = cms.vdouble(1.24, 1.24, 1.24, 1.23, 1.24, 1.25, 1.29, 1.29)  
-egammaCorrections = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.03, 1.04, 1.04)  
+hadronCorrections = cms.vdouble(1.28, 1.28, 1.24, 1.19, 1.17, 1.17, 1.17, 1.17)  
+egammaCorrections = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.01, 1.01, 1.01)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
@@ -2,12 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 minEtaCorrection = cms.double(1.4)
 maxEtaCorrection = cms.double(3.0)
-hadronCorrections = cms.vdouble(1.24, 1.24, 1.24, 1.23, 1.24, 1.25, 1.29, 1.29)
-egammaCorrections = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.03, 1.04, 1.04)
+hadronCorrections = cms.PSet(value = cms.vdouble(1.24, 1.24, 1.24, 1.23, 1.24, 1.25, 1.29, 1.29))
+egammaCorrections = cms.PSet(value = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.03, 1.04, 1.04))
 
 hadronCorrections_hgcalV9 = cms.vdouble(1.28, 1.28, 1.24, 1.19, 1.17, 1.17, 1.17, 1.17)
 egammaCorrections_hgcalV9 = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.01, 1.01, 1.01)
 
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
-phase2_hgcalV9.toModify(hadronCorrections = hadronCorrections_hgcalV9)
-phase2_hgcalV9.toModify(egammaCorrections = egammaCorrections_hgcalV9)
+phase2_hgcalV9.toModify(hadronCorrections, value = hadronCorrections_hgcalV9)
+phase2_hgcalV9.toModify(egammaCorrections, value = egammaCorrections_hgcalV9)


### PR DESCRIPTION
Details of the calibration procedure can be taken from the followings sets of slides presented at the [HGCAL DPG simulation and performance meeting](https://indico.cern.ch/event/776790/) on 28th November:

- [photons](https://indico.cern.ch/event/776790/)
- [pions](https://indico.cern.ch/event/776790/contributions/3230584/attachments/1761518/2858298/20181128_HGCalDPG_PFCluster_PionScaleResolution_D28.pdf)

The methodology is the same for both and has not changed w.r.t. the previous iteration (but with the old geometry). The final results tables (using particles with pT = 50 GeV) can be found on page 8 of the respective presentations.