### PR TITLE
TkAl: making mille job submission via condor possible

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
@@ -296,7 +296,7 @@ if not args.fireMerge:
                     # need standard format for job number
                     lib.JOBSTATUS[i] = 'SUBTD'
                     lib.JOBID[i] = match.group(1)
-                if fire_htcondor: lib.JOBID[i] += ".0"
+                    if fire_htcondor: lib.JOBID[i] += ".0"
                 else:
                     print('Submission of %03d seems to have failed: %s' % (lib.JOBNUMBER[i],result), end=' ')
                 nSub +=1

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
@@ -39,7 +39,7 @@ def forward_proxy(rundir):
     shutil.copyfile(local_proxy, os.path.join(rundir,".user_proxy"))
 
 
-def write_HTCondor_submit_file(path, script, config, lib):
+def write_HTCondor_submit_file_pede(path, script, config, lib):
     """Writes 'job.submit' file in `path`.
 
     Arguments:
@@ -118,6 +118,44 @@ periodic_remove       = !regexp("group_u_CMS.e_cms_caf_bigmem", AccountingGroup)
 
     return job_submit_file
 
+def write_HTCondor_submit_file_mille(path, script, lib, proxy_path=None):
+    """Writes 'job.submit' file in `path`.
+
+    Arguments:
+    - `path`: job directory
+    - `script`: script to be executed
+    - `lib`: MPS lib object
+    - `proxy_path`: path to proxy (only used in case of requested proxy forward)
+    """
+
+    resources = lib.get_class("mille").split("_")[1:] # strip off 'htcondor'
+    job_flavour = resources[-1]
+
+    job_submit_template="""\
+universe              = vanilla
+executable            = {script:s}
+output                = {jobm:s}/STDOUT
+error                 = {jobm:s}/STDOUT
+log                   = {jobm:s}/HTCJOB
+notification          = Always
+transfer_output_files = ""
+
++JobFlavour           = "{flavour:s}"
+"""
+    if proxy_path is not None:
+        job_submit_template += """\
++x509userproxy        = "{proxy:s}"
+"""
+    job_submit_template += "\nqueue\n"
+
+    job_submit_file = os.path.join(Path, "job.submit")
+    with open(job_submit_file, "w") as f:
+        f.write(job_submit_template.format(script = os.path.abspath(script),
+                                           jobm = os.path.abspath(path),
+                                           flavour = job_flavour,
+                                           proxy = proxy_path))
+
+    return job_submit_file
 
 
 
@@ -227,8 +265,18 @@ if not args.fireMerge:
 
                 # submit a new job with 'bsub -J ...' and check output
                 # for some reasons LSF wants script with full path
-                submission = 'bsub -J %s %s %s/%s/theScript.sh' % \
-                      (theJobName, resources, theJobData, lib.JOBDIR[i])
+                if fire_htcondor:
+                    Path = os.path.join(theJobData,lib.JOBDIR[i])
+                    scriptPath = os.path.join(Path, "theScript.sh")
+                    if args.forwardProxy:
+                        job_submit_file = write_HTCondor_submit_file_mille(Path, scriptPath, lib,os.path.join(Path,".user_proxy"))
+                    else:
+                        job_submit_file = write_HTCondor_submit_file_mille(Path, scriptPath, lib)
+                    submission = "condor_submit -batch-name %s %s"%\
+                          (theJobName, job_submit_file)
+                else:
+                    submission = 'bsub -J %s %s %s/%s/theScript.sh' % \
+                          (theJobName, resources, theJobData, lib.JOBDIR[i])
                 print(submission)
                 try:
                     result = subprocess.check_output(submission,
@@ -240,11 +288,15 @@ if not args.fireMerge:
                 result = result.strip()
 
                 # check if job was submitted and updating jobdatabase
-                match = re.search('Job <(\d+)> is submitted', result)
+                if fire_htcondor:
+                    match = re.search(r"1 job\(s\) submitted to cluster (\d+)\.", result)
+                else:
+                    match = re.search('Job <(\d+)> is submitted', result)
                 if match:
                     # need standard format for job number
                     lib.JOBSTATUS[i] = 'SUBTD'
                     lib.JOBID[i] = match.group(1)
+                if fire_htcondor: lib.JOBID[i] += ".0"
                 else:
                     print('Submission of %03d seems to have failed: %s' % (lib.JOBNUMBER[i],result), end=' ')
                 nSub +=1
@@ -306,7 +358,7 @@ else:
                 mergeCfg = mergeCfg.strip()
 
                 if fire_htcondor:
-                    job_submit_file = write_HTCondor_submit_file(Path, scriptPath, mergeCfg, lib)
+                    job_submit_file = write_HTCondor_submit_file_pede(Path, scriptPath, mergeCfg, lib)
 
                 # make a backup copy of the cfg
                 backupCfgPath  = os.path.join(Path, mergeCfg+".bak")
@@ -348,7 +400,7 @@ else:
                 mergeCfg = mergeCfg.replace('\n','')
 
                 if fire_htcondor:
-                    job_submit_file = write_HTCondor_submit_file(Path, scriptPath, mergeCfg, lib)
+                    job_submit_file = write_HTCondor_submit_file_pede(Path, scriptPath, mergeCfg, lib)
 
                 # restore the backup copy of the cfg
                 backupCfgPath  = Path+'/%s.bak' % mergeCfg

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setup.py
@@ -86,7 +86,9 @@ if not os.access("mps.db", os.R_OK): args.append = False
 allowed_mille_classes = ("lxplus", "cmscaf1nh", "cmscaf1nd", "cmscaf1nw",
                          "cmscafspec1nh", "cmscafspec1nd", "cmscafspec1nw",
                          "8nm", "1nh", "8nh", "1nd", "2nd", "1nw", "2nw",
-                         "cmsexpress")
+                         "cmsexpress","htcondor_espresso","htcondor_microcentury",
+                         "htcondor_longlunch","htcondor_workday","htcondor_tomorrow",
+                         "htcondor_testmatch","htcondor_nextweek")
 if lib.get_class("mille") not in allowed_mille_classes:
     print("Bad job class for mille in class", args.job_class)
     print("Allowed classes:")

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_update.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_update.py
@@ -61,7 +61,7 @@ print("submitted jobs:", len(submitted_jobs))
 # deal with submitted jobs by looking into output of shell (bjobs/condor_q)
 if len(submitted_jobs) > 0:
     job_status = {}
-    if "htcondor" in lib.get_class("pede"):
+    if "htcondor" in lib.get_class("pede") or "htcondor" in lib.get_class("mille"):
         condor_q = subprocess.check_output(["condor_q", "-af:j",
                                             "JobStatus", "RemoteSysCpu"],
                                            stderr = subprocess.STDOUT)
@@ -128,7 +128,7 @@ for job_id, mps_index in submitted_jobs.items(): # IMPORTANT to copy here (no it
         continue
 
     # check if it is a HTCondor job already moved to "history"
-    elif "htcondor" in lib.get_class("pede"):
+    elif "htcondor" in lib.get_class("pede") or "htcondor" in lib.get_class("mille"):
         userlog = os.path.join("jobData", lib.JOBDIR[mps_index], "HTCJOB")
         condor_h = subprocess.check_output(["condor_history", job_id, "-limit", "1",
                                             "-userlog", userlog,


### PR DESCRIPTION
This adds the functionality to submit all parts of the MillePede alignment algorithm to condor (in preparation of LSF-CAF decommissioning). For now LSF submission is still the default, but condor submission is fully supported.
Note that the submission could be made more efficient, as at the moment now we submit one job per cluster - submitting multiple jobs per cluster requires some overhaul of the current workflow. I have some ideas but this will take a bit more time to get right, and so will follow later. 