### PR TITLE
Add SwitchProducer mechanism to allow runtime decision which algorithm implementation to run

### DIFF
--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -47,6 +47,7 @@ namespace edm {
     
     //Not const thread-safe update
     void unsafe_setWrapper(std::unique_ptr<WrapperBase> iValue) const;
+    void unsafe_setWrapper(std::shared_ptr<WrapperBase const> iValue) const; // for SwitchProducer
     
     void resetBranchDescription(std::shared_ptr<BranchDescription const> bd);
 

--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -32,8 +32,7 @@ namespace edm {
     Provenance const& provenance() const { return prov_;}
     
     WrapperBase const* wrapper() const { return wrapper_.get();}
-    WrapperBase* wrapper() { return wrapper_.get(); }
-    WrapperBase* unsafe_wrapper() const { return wrapper_.get(); }
+    WrapperBase* unsafe_wrapper() const { return const_cast<WrapperBase*>(wrapper_.get()); }
     std::shared_ptr<WrapperBase const> sharedConstWrapper() const {
       return wrapper_;
     }
@@ -79,7 +78,7 @@ namespace edm {
 
   private:
     // "non-const data" (updated every event)
-    mutable std::shared_ptr<WrapperBase> wrapper_;
+    mutable std::shared_ptr<WrapperBase const> wrapper_;
     Provenance prov_;
   };
 

--- a/DataFormats/Common/src/ProductData.cc
+++ b/DataFormats/Common/src/ProductData.cc
@@ -40,6 +40,6 @@ namespace edm {
   }
 
   void ProductData::unsafe_setWrapper(std::shared_ptr<WrapperBase const> iValue) const {
-    wrapper_ = std::const_pointer_cast<WrapperBase>(std::move(iValue));
+    wrapper_ = std::move(iValue);
   }
 }

--- a/DataFormats/Common/src/ProductData.cc
+++ b/DataFormats/Common/src/ProductData.cc
@@ -38,4 +38,8 @@ namespace edm {
   void ProductData::unsafe_setWrapper(std::unique_ptr<WrapperBase> iValue) const {
     wrapper_ = std::move(iValue);
   }
+
+  void ProductData::unsafe_setWrapper(std::shared_ptr<WrapperBase const> iValue) const {
+    wrapper_ = std::const_pointer_cast<WrapperBase>(std::move(iValue));
+  }
 }

--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -101,6 +101,14 @@ namespace edm {
     int basketSize() const {return transient_.basketSize_;}
     void setBasketSize(int size) {transient_.basketSize_ = size;}
 
+    bool isSwitchAlias() const {return not transient_.switchAliasModuleLabel_.empty();}
+    std::string const& switchAliasModuleLabel() const { return transient_.switchAliasModuleLabel_; }
+    void setSwitchAliasModuleLabel(std::string label) {transient_.switchAliasModuleLabel_ = std::move(label);}
+    BranchID const& switchAliasForBranchID() const {return transient_.switchAliasForBranchID_;}
+    void setSwitchAliasForBranch(BranchDescription const& aliasForBranch);
+
+    bool isAnyAlias() const {return isAlias() or isSwitchAlias();}
+
     ParameterSetID const& parameterSetID() const {return transient_.parameterSetID_;}
     std::string const& moduleName() const {return transient_.moduleName_;}
 
@@ -139,6 +147,14 @@ namespace edm {
 
       // The wrapped class name, which is currently derivable fron the other attributes.
       std::string wrappedName_;
+
+      // For SwitchProducer alias, the label of the aliased-for label; otherwise empty
+      std::string switchAliasModuleLabel_;
+
+      // Need a separate (transient) BranchID for switch, because
+      // otherwise originalBranchID() gives wrong answer when reading
+      // from a file (leading to wrong ProductProvenance to be retrieved)
+      BranchID switchAliasForBranchID_;
 
       // A TypeWithDict object for the wrapped object
       TypeWithDict wrappedType_;

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -238,6 +238,27 @@ namespace edm {
   }
 
   void
+  BranchDescription::setSwitchAliasForBranch(BranchDescription const& aliasForBranch) {
+    if(branchType_ != aliasForBranch.branchType()) {
+      throw Exception(errors::LogicError) << "BranchDescription::setSwitchAliasForBranch: branchType ("
+                                          << branchType_ << ") differs from aliasForBranch ("
+                                          << aliasForBranch.branchType() << ").\nPlease report this error to the FWCore developers";
+    }
+    if(produced() != aliasForBranch.produced()) {
+      throw Exception(errors::LogicError) << "BranchDescription::setSwitchAliasForBranch: produced differs from aliasForBranch.\nPlease report this error to the FWCore developers";
+    }
+    if(unwrappedTypeID().typeInfo() != aliasForBranch.unwrappedType().typeInfo()) {
+      throw Exception(errors::LogicError) << "BranchDescription::setSwitchAliasForBranch: unwrapped type info ("
+                                          << unwrappedTypeID().name() << ") differs from aliasForBranch ("
+                                          << aliasForBranch.unwrappedType().typeInfo().name() << ").\nPlease report this error to the FWCore developers";
+    }
+
+    branchAliases_ = aliasForBranch.branchAliases();
+    transient_.switchAliasForBranchID_ = aliasForBranch.branchID();
+    transient_.availableOnlyAtEndTransition_ = aliasForBranch.availableOnlyAtEndTransition();
+  }
+
+  void
   BranchDescription::write(std::ostream& os) const {
     os << "Branch Type = " << branchType() << std::endl;
     os << "Process Name = " << processName() << std::endl;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -220,6 +220,8 @@ namespace edm {
     void addInputProduct(std::shared_ptr<BranchDescription const> bd);
     void addUnscheduledProduct(std::shared_ptr<BranchDescription const> bd);
     void addAliasedProduct(std::shared_ptr<BranchDescription const> bd);
+    void addSwitchProducerProduct(std::shared_ptr<BranchDescription const> bd);
+    void addSwitchAliasProduct(std::shared_ptr<BranchDescription const> bd);
     void addParentProcessProduct(std::shared_ptr<BranchDescription const> bd);
     
 

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -34,15 +34,19 @@ namespace edm {
     };
 
     struct TypeLabelItem {
+      enum class AliasType { kBranchAlias, kSwitchAlias };
+
       TypeLabelItem (Transition const& transition, TypeID const& tid, std::string pin) :
 	      transition_(transition),
         typeID_(tid),
         productInstanceName_(std::move(pin)),
-        branchAlias_() {}
+        branchAlias_(),
+        aliasType_(AliasType::kBranchAlias) {}
       Transition transition_;
       TypeID typeID_;
       std::string productInstanceName_;
       std::string branchAlias_;
+      AliasType aliasType_;
     };
 
     struct BranchAliasSetter {
@@ -51,6 +55,11 @@ namespace edm {
       
       BranchAliasSetter& setBranchAlias(std::string alias) {
         value_.branchAlias_ = std::move(alias);
+        return *this;
+      }
+      BranchAliasSetter& setSwitchAlias(std::string moduleLabel) {
+        value_.branchAlias_ = std::move(moduleLabel);
+        value_.aliasType_ = TypeLabelItem::AliasType::kSwitchAlias;
         return *this;
       }
       TypeLabelItem& value_;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -143,7 +143,7 @@ namespace edm {
       BranchDescription const& bd = prod.second;
       if(bd.branchType() == branchType_) {
         if(isForPrimaryProcess or bd.processName() == pc.processName()) {
-          if(bd.isAlias()) {
+          if(bd.isAnyAlias()) {
             hasAliases = true;
           } else {
             auto cbd = std::make_shared<BranchDescription const>(bd);
@@ -171,9 +171,25 @@ namespace edm {
     if(hasAliases) {
       for(auto const& prod : prodsList) {
         BranchDescription const& bd = prod.second;
-        if(bd.isAlias() && bd.branchType() == branchType_) {
+        if(bd.isAnyAlias() && bd.branchType() == branchType_) {
           auto cbd = std::make_shared<BranchDescription const>(bd);
-          addAliasedProduct(cbd);
+          if(bd.isSwitchAlias()) {
+            assert(branchType_ == InEvent);
+            // Need different implementation for SwitchProducers not
+            // in any Path (onDemand) and for those in a Path in order
+            // to prevent the switch-aliased-for EDProducers from
+            // being run when the SwitchProducer is in a Path after a
+            // failing EDFilter.
+            if(bd.onDemand()) {
+              addSwitchAliasProduct(cbd);
+            }
+            else {
+              addSwitchProducerProduct(cbd);
+            }
+          }
+          else {
+            addAliasedProduct(cbd);
+          }
         }
       }
     }
@@ -328,6 +344,22 @@ namespace edm {
     assert(index != ProductResolverIndexInvalid);
 
     addProductOrThrow(std::make_unique<AliasProductResolver>(std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
+  }
+
+  void
+  Principal::addSwitchProducerProduct(std::shared_ptr<BranchDescription const> bd) {
+    ProductResolverIndex index = preg_->indexFrom(bd->switchAliasForBranchID());
+    assert(index != ProductResolverIndexInvalid);
+
+    addProductOrThrow(std::make_unique<SwitchProducerProductResolver>(std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
+  }
+
+  void
+  Principal::addSwitchAliasProduct(std::shared_ptr<BranchDescription const> bd) {
+    ProductResolverIndex index = preg_->indexFrom(bd->switchAliasForBranchID());
+    assert(index != ProductResolverIndexInvalid);
+
+    addProductOrThrow(std::make_unique<SwitchAliasProductResolver>(std::move(bd), dynamic_cast<ProducedProductResolver&>(*productResolvers_[index])));
   }
 
   void
@@ -681,7 +713,7 @@ namespace edm {
         if (process == bd.processName()) {
 
           // Ignore aliases to avoid matching the same product multiple times.
-          if(bd.isAlias()) {
+          if(bd.isAnyAlias()) {
             continue;
           }
 
@@ -816,7 +848,7 @@ namespace edm {
   Principal::getAllProvenance(std::vector<Provenance const*>& provenances) const {
     provenances.clear();
     for(auto const& productResolver : *this) {
-      if(productResolver->singleProduct() && productResolver->provenanceAvailable() && !productResolver->branchDescription().isAlias()) {
+      if(productResolver->singleProduct() && productResolver->provenanceAvailable() && !productResolver->branchDescription().isAnyAlias()) {
         // We do not attempt to get the event/lumi/run status from the provenance,
         // because the per event provenance may have been dropped.
         if(productResolver->provenance()->branchDescription().present()) {
@@ -833,7 +865,7 @@ namespace edm {
   Principal::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
     provenances.clear();
     for(auto const& productResolver : *this) {
-      if(productResolver->singleProduct() && !productResolver->branchDescription().isAlias()) {
+      if(productResolver->singleProduct() && !productResolver->branchDescription().isAnyAlias()) {
         if(productResolver->stableProvenance()->branchDescription().present()) {
            provenances.push_back(productResolver->stableProvenance());
         }

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -89,6 +89,13 @@ namespace edm {
                               type,
                               true,
                               isEndTransition(p->transition_));
+      if(p->aliasType_ == TypeLabelItem::AliasType::kSwitchAlias) {
+        if(p->branchAlias_.empty()) {
+          throw edm::Exception(edm::errors::LogicError) << "Branch alias type has been set to SwitchAlias, but the alias content is empty.\n"
+                                                        << "Please report this error to the FWCore developers";
+        }
+        pdesc.setSwitchAliasModuleLabel(p->branchAlias_);
+      }
       setIsMergeable(pdesc);
 
       if (pdesc.transient()) {

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -289,6 +289,81 @@ namespace edm {
 
     typedef std::vector<std::string> vstring;
 
+    void processSwitchProducers(ParameterSet const& proc_pset, std::string const& processName, ProductRegistry& preg) {
+      // Update Switch BranchDescriptions for the chosen case
+      std::vector<BranchKey> chosenBranches;
+      std::map<std::string, std::vector<std::string> > allCasesMap;
+      for(auto& prod: preg.productListUpdator()) {
+        if(prod.second.isSwitchAlias()) {
+          if(allCasesMap.find(prod.second.moduleLabel()) == allCasesMap.end()) {
+            auto const& switchPSet = proc_pset.getParameter<edm::ParameterSet>(prod.second.moduleLabel());
+            allCasesMap[prod.second.moduleLabel()] = switchPSet.getParameter<std::vector<std::string>>("@all_cases");
+          }
+
+          for(auto const& item: preg.productList()) {
+            if(item.second.branchType() == prod.second.branchType() and
+               item.second.unwrappedTypeID().typeInfo() == prod.second.unwrappedTypeID().typeInfo() and
+               item.first.moduleLabel() == prod.second.switchAliasModuleLabel() and
+               item.first.productInstanceName() == prod.second.productInstanceName()
+               ) {
+              if(item.first.processName() != processName) {
+                throw Exception(errors::LogicError)
+                  << "Encountered a BranchDescription that is aliased-for by SwitchProducer, and whose processName " << item.first.processName() << " differs from current process " << processName
+                  << ". Module label is " << item.first.moduleLabel() << ".\nPlease contact a framework developer.";
+              }
+              prod.second.setSwitchAliasForBranch(item.second);
+              chosenBranches.push_back(prod.first); // with moduleLabel of the Switch
+            }
+          }
+        }
+      }
+      if(allCasesMap.empty())
+        return;
+
+      std::sort(chosenBranches.begin(), chosenBranches.end());
+
+      // Check that non-chosen cases declare exactly the same branches
+      auto foundBranches = std::vector<bool>(chosenBranches.size(), false);
+      for(auto const& switchItem: allCasesMap) {
+        auto const& switchLabel = switchItem.first;
+        auto const& caseLabels = switchItem.second;
+        for(auto const& caseLabel: caseLabels) {
+          std::fill(foundBranches.begin(), foundBranches.end(), false);
+          for(auto const& item: preg.productList()) {
+            if(item.first.moduleLabel() == caseLabel) {
+              auto range = std::equal_range(chosenBranches.begin(), chosenBranches.end(), BranchKey(item.first.friendlyClassName(),
+                                                                                                    switchLabel,
+                                                                                                    item.first.productInstanceName(),
+                                                                                                    item.first.processName()));
+              if(range.first == range.second) {
+                throw Exception(errors::Configuration)
+                  << "SwitchProducer " << switchLabel << " has a case " << caseLabel << " with a product " << item.first << " that is not produced by the chosen case " << proc_pset.getParameter<edm::ParameterSet>(switchLabel).getUntrackedParameter<std::string>("@chosen_case");
+              }
+              assert(std::distance(range.first, range.second) == 1);
+              foundBranches[std::distance(chosenBranches.begin(), range.first)] = true;
+
+              // Check that there are no BranchAliases for any of the cases
+              auto const& bd = item.second;
+              if(not bd.branchAliases().empty()) {
+                auto ex = Exception(errors::UnimplementedFeature) << "SwitchProducer does not support ROOT branch aliases. Got the following ROOT branch aliases for SwitchProducer with label " << switchLabel << " for case " << caseLabel << ":";
+                for(auto const& item: bd.branchAliases()) {
+                  ex << " " << item;
+                }
+                throw ex;
+              }
+            }
+          }
+
+          for(size_t i=0; i<chosenBranches.size(); i++) {
+            if(not foundBranches[i]) {
+              throw Exception(errors::Configuration)
+                << "SwitchProducer " << switchLabel << " has a case " << caseLabel << " that does not produce a product " << chosenBranches[i] << " that is produced by the chosen case " << proc_pset.getParameter<edm::ParameterSet>(switchLabel).getUntrackedParameter<std::string>("@chosen_case");
+            }
+          }
+        }
+      }
+    }
+
     void reduceParameterSet(ParameterSet& proc_pset,
                             vstring const& end_path_name_list,
                             vstring& modulesInConfig,
@@ -535,6 +610,7 @@ namespace edm {
     reduceParameterSet(proc_pset, tns.getEndPaths(), modulesInConfig, usedModuleLabels,
                        outputModulePathPositions);
     processEDAliases(proc_pset, processConfiguration->processName(), preg);
+    processSwitchProducers(proc_pset, processConfiguration->processName(), preg);
     proc_pset.registerIt();
     processConfiguration->setParameterSetID(proc_pset.id());
     processConfiguration->setProcessConfigurationID();

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -128,13 +128,20 @@
     <use   name="FWCore/Version"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="SwitchProducer_t.cpp">
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/TestProcessor"/>
+    <use   name="DataFormats/Provenance"/>
+    <use   name="catch2"/>
+  </bin>
   <library   file="TestPSetAnalyzer.cc" name="TestPSetAnalyzer">
     <flags   EDM_PLUGIN="1"/>
     <use   name="DataFormats/Provenance"/>
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc, WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc" name="SomeTestModules">
+  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc, WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc" name="SomeTestModules">
     <flags   EDM_PLUGIN="1"/>
     <lib   name="FWCoreIntegrationWaitingServer"/>
     <use   name="FWCore/Framework"/>

--- a/FWCore/Integration/test/SwitchProducerProvenanceAnalyzer.cc
+++ b/FWCore/Integration/test/SwitchProducerProvenanceAnalyzer.cc
@@ -1,0 +1,97 @@
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Provenance/interface/Provenance.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace edm {
+  class EventSetup;
+  class StreamID;
+}
+
+namespace edmtest {
+  class SwitchProducerProvenanceAnalyzer: public edm::global::EDAnalyzer<> {
+  public:
+    explicit SwitchProducerProvenanceAnalyzer(edm::ParameterSet const& iConfig);
+    void analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const& iSetup) const override;
+
+  private:
+    void testProduct(edm::Handle<IntProduct> const& prod, int mode, edm::Event const& iEvent) const;
+
+    edm::EDGetTokenT<IntProduct> inputToken1_;
+    edm::EDGetTokenT<IntProduct> inputToken2_;
+  };
+
+  SwitchProducerProvenanceAnalyzer::SwitchProducerProvenanceAnalyzer(edm::ParameterSet const& iConfig):
+    inputToken1_(consumes<IntProduct>(iConfig.getParameter<edm::InputTag>("src1"))),
+    inputToken2_(consumes<IntProduct>(iConfig.getParameter<edm::InputTag>("src2")))
+  {}
+    
+  void SwitchProducerProvenanceAnalyzer::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const& iSetup) const {
+    edm::Handle<IntProduct> h;
+    iEvent.getByToken(inputToken1_, h);
+    testProduct(h, iEvent.id().luminosityBlock(), iEvent);
+    
+    iEvent.getByToken(inputToken2_, h);
+    testProduct(h, iEvent.id().luminosityBlock(), iEvent);
+  }
+
+  void SwitchProducerProvenanceAnalyzer::testProduct(edm::Handle<IntProduct> const& prod, int mode, edm::Event const& iEvent) const {
+    assert(prod->value == mode);
+
+    edm::Provenance const *provenance = prod.provenance();
+    assert(provenance != nullptr);
+    auto const *productProvenance = provenance->productProvenance();
+    assert(productProvenance != nullptr);
+    auto const *processHistory = provenance->processHistoryPtr();
+    assert(processHistory != nullptr);
+
+    edm::pset::Registry const *psetRegistry = edm::pset::Registry::instance();
+    assert(psetRegistry != nullptr);
+
+    auto const& moduleLabel = provenance->moduleLabel();
+
+    // Switch output should not look like an alias
+    assert(productProvenance->branchID() == provenance->branchID());
+
+    // Check that the provenance of the Switch itself is recorded correctly
+    for(edm::ProcessConfiguration const& pc: *processHistory) {
+      if(pc.processName() == provenance->processName()) {
+        edm::ParameterSetID const& psetID = pc.parameterSetID();
+        edm::ParameterSet const *processPSet = psetRegistry->getMapped(psetID);
+        assert(processPSet);
+        auto const& modPSet = processPSet->getParameterSet(moduleLabel);
+        assert(modPSet.getParameter<std::string>("@module_edm_type") == "EDProducer");
+        assert(modPSet.getParameter<std::string>("@module_type") == "SwitchProducer");
+        assert(modPSet.getParameter<std::string>("@module_label") == moduleLabel);
+        auto const& allCases = modPSet.getParameter<std::vector<std::string>>("@all_cases");
+        assert(allCases.size() == 2);
+        assert(allCases[0] == moduleLabel+"@test1");
+        assert(allCases[1] == moduleLabel+"@test2");
+        assert(modPSet.exists("@chosen_case") == false);
+      }
+    }
+
+    // Check the parentage (foo -> foo@case -> possible input)
+    auto const& parent = productProvenance->parentage();
+    // Here is where Switch differs from a normal EDProducer: each Switch output branch has exactly one parent
+    assert(parent.parents().size() == 1);
+    auto const& parentProvenance = iEvent.getProvenance(parent.parents()[0]);
+    assert(parentProvenance.branchDescription().moduleLabel() == moduleLabel+"@test"+std::to_string(mode));
+
+    // Check grandparent as well
+    auto const *parentProductProvenance = parentProvenance.productProvenance();
+    assert(parentProductProvenance != nullptr);
+    auto const& grandParent = parentProductProvenance->parentage();
+    assert(grandParent.parents().size() == 1); // behaviour of the AddIntsProducer
+    auto const& grandParentProvenance = iEvent.getProvenance(grandParent.parents()[0]);
+    assert(grandParentProvenance.branchDescription().moduleLabel() == moduleLabel+std::to_string(mode));
+  }
+}
+using edmtest::SwitchProducerProvenanceAnalyzer;
+DEFINE_FWK_MODULE(SwitchProducerProvenanceAnalyzer);

--- a/FWCore/Integration/test/SwitchProducer_t.cpp
+++ b/FWCore/Integration/test/SwitchProducer_t.cpp
@@ -1,0 +1,299 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+
+#include <iostream>
+
+static constexpr auto s_tag = "[SwitchProducer]";
+
+TEST_CASE("Configuration", s_tag) {
+  const std::string baseConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (True, -9)
+            ), **kargs)
+
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = cms.EDProducer('IntProducer', ivalue = cms.int32(1)),
+   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet())
+)
+process.moduleToTest(process.s)
+)_"};
+
+  const std::string baseConfigTest2Disabled{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (False, -9)
+            ), **kargs)
+
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = cms.EDProducer('IntProducer', ivalue = cms.int32(1)),
+   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet())
+)
+process.moduleToTest(process.s)
+)_"};
+
+  SECTION("Configuration hash is not changed") {
+    auto pset = edm::boost_python::readConfig(baseConfig);
+    auto psetTest2Disabled = edm::boost_python::readConfig(baseConfigTest2Disabled);
+    pset->registerIt();
+    psetTest2Disabled->registerIt();
+    REQUIRE(pset->id() == psetTest2Disabled->id());
+  }
+
+  edm::test::TestProcessor::Config config{ baseConfig };
+  edm::test::TestProcessor::Config configTest2Disabled{ baseConfigTest2Disabled };
+
+  SECTION("Base configuration is OK") {
+    REQUIRE_NOTHROW(edm::test::TestProcessor(config));
+  }
+
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+
+  SECTION("Test2 enabled") {
+    edm::test::TestProcessor tester(config);
+    auto event = tester.test();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 2);
+  }
+
+  SECTION("Test2 disabled") {
+    edm::test::TestProcessor tester(configTest2Disabled);
+    auto event = tester.test();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 1);
+  }
+};
+
+TEST_CASE("Configuration with many branches", s_tag) {
+  const std::string baseConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (True, -9)
+            ), **kargs)
+
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(11)),
+                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(21)))),
+   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(12)),
+                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(22))))
+)
+process.moduleToTest(process.s)
+)_"};
+  const std::string baseConfigTest2Disabled{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (False, -9)
+            ), **kargs)
+
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(11)),
+                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(21)))),
+   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(12)),
+                                                                                       cms.PSet(instance=cms.string('bar'),value=cms.int32(22))))
+)
+process.moduleToTest(process.s)
+)_"};
+
+  edm::test::TestProcessor::Config config{ baseConfig };
+  edm::test::TestProcessor::Config configTest2Disabled{ baseConfigTest2Disabled };
+
+  SECTION("Test2 enabled") {
+    edm::test::TestProcessor tester(config);
+    auto event = tester.test();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 2);
+    REQUIRE(event.get<edmtest::IntProduct>("foo")->value == 12);
+    REQUIRE(event.get<edmtest::IntProduct>("bar")->value == 22);
+  }
+
+  SECTION("Test2 disabled") {
+    edm::test::TestProcessor tester(configTest2Disabled);
+    auto event = tester.test();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 1);
+    REQUIRE(event.get<edmtest::IntProduct>("foo")->value == 11);
+    REQUIRE(event.get<edmtest::IntProduct>("bar")->value == 21);
+  }
+
+}
+
+
+TEST_CASE("Configuration with different branches", s_tag) {
+  const std::string baseConfig1{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (True, -9)
+            ), **kargs)
+
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet()),
+   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3))))
+)
+process.moduleToTest(process.s)
+)_"};
+
+    const std::string baseConfig2{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (True, -9)
+            ), **kargs)
+
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3)))),
+   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet())
+)
+process.moduleToTest(process.s, cms.Task(process.i))
+)_"};
+
+  SECTION("Different branches are not allowed") {
+    edm::test::TestProcessor::Config config1{ baseConfig1 };
+    REQUIRE_THROWS_WITH(edm::test::TestProcessor(config1), Catch::Contains("that does not produce a product") && Catch::Contains("that is produced by the chosen case"));
+
+    edm::test::TestProcessor::Config config2{ baseConfig2 };
+    REQUIRE_THROWS(edm::test::TestProcessor(config1), Catch::Contains("with a product") && Catch::Contains("that is not produced by the chosen case"));
+  }
+}
+
+
+
+TEST_CASE("Configuration with lumi and run", s_tag) {
+  const std::string baseConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (True, -9)
+            ), **kargs)
+
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = cms.EDProducer('ThingProducer', nThings = cms.int32(10)),
+   test2 = cms.EDProducer('ThingProducer', nThings = cms.int32(20))
+)
+process.moduleToTest(process.s)
+)_"};
+
+  edm::test::TestProcessor::Config config{ baseConfig };
+
+  SECTION("Lumi and run products are not supported") {
+    REQUIRE_THROWS_WITH(edm::test::TestProcessor(config), Catch::Contains("SwitchProducer does not support non-event branches"));
+  }
+};
+
+
+TEST_CASE("Configuration with ROOT branch alias", s_tag) {
+  const std::string baseConfig1{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (True, -9)
+            ), **kargs)
+
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3)))),
+   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(4),branchAlias=cms.string('bar'))))
+)
+process.moduleToTest(process.s)
+)_"};
+
+    const std::string baseConfig2{
+R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (True, -9)
+            ), **kargs)
+
+process = TestProcess()
+process.s = SwitchProducerTest(
+   test1 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3),branchAlias=cms.string('bar')))),
+   test2 = cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(4))))
+)
+process.moduleToTest(process.s)
+)_"};
+
+  SECTION("ROOT branch aliases are not supported for the chosen case") {
+    edm::test::TestProcessor::Config config{ baseConfig1 };
+    REQUIRE_THROWS_WITH(edm::test::TestProcessor(config), Catch::Contains("SwitchProducer does not support ROOT branch aliases"));
+  }
+
+  SECTION("ROOT branch aliases are not supported for the non-chosen case") {
+    edm::test::TestProcessor::Config config{ baseConfig2 };
+    REQUIRE_THROWS_WITH(edm::test::TestProcessor(config), Catch::Contains("SwitchProducer does not support ROOT branch aliases"));
+  }
+}

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+test=testSwitchProducer
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+  echo "*************************************************"
+  echo "SwitchProducer in a Task"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Task_cfg.py || die "cmsRun ${test}Task_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer in a Task, case test2 disabled"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Task_cfg.py disableTest2 || die "cmsRun ${test}Task_cfg.py 2" $?
+
+  echo "*************************************************"
+  echo "Merge outputs"
+  edmCopyPickMerge outputFile=testSwitchProducerMerge1.root inputFiles=file:testSwitchProducerTask1.root inputFiles=file:testSwitchProducerTask2.root || die "edmCopyPickMerge 1" $?
+  echo "*************************************************"
+  echo "Merge outputs in reverse order"
+  edmCopyPickMerge outputFile=testSwitchProducerMerge2.root inputFiles=file:testSwitchProducerTask2.root inputFiles=file:testSwitchProducerTask1.root || die "edmCopyPickMerge 2" $?
+
+  echo "*************************************************"
+  echo "Test provenance of merged output"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerMerge1.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py 1" $?
+  echo "*************************************************"
+  echo "Test provenance of reversely merged output"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py 2" $?
+
+  
+  echo "*************************************************"
+  echo "SwitchProducer in a Path"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Path_cfg.py || die "cmsRun ${test}Path_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer in a Path, case test2 disabled"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Path_cfg.py disableTest2 || die "cmsRun ${test}Path_cfg.py 2" $?
+
+
+  echo "*************************************************"
+  echo "SwitchProducer in a Path after a failing filter"
+  cmsRun ${LOCAL_TEST_DIR}/${test}PathFilter_cfg.py || die "cmsRun ${test}PathFilter_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer in a Path after a failing filter, case test2 disabled"
+  cmsRun ${LOCAL_TEST_DIR}/${test}PathFilter_cfg.py disableTest2 || die "cmsRun ${test}PathFilter_cfg.py 2" $?
+
+popd
+
+exit 0

--- a/FWCore/Integration/test/testSwitchProducerPathFilter_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerPathFilter_cfg.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+enableTest2 = (sys.argv[-1] != "disableTest2")
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (enableTest2, -9)
+            ), **kargs)
+
+process = cms.Process("PROD1")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("EmptySource")
+if enableTest2:
+    process.source.firstLuminosityBlock = cms.untracked.uint32(2)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSwitchProducerPath%d.root' % (1 if enableTest2 else 2,)),
+    outputCommands = cms.untracked.vstring(
+        'keep *_intProducer_*_*'
+    )
+)
+
+process.intProducer1 = cms.EDProducer("FailingProducer")
+process.intProducer2 = cms.EDProducer("FailingProducer")
+
+process.intProducer = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
+    test2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer2"))
+)
+
+process.f = cms.EDFilter("TestFilterModule", acceptValue = cms.untracked.int32(-1))
+
+process.t = cms.Task(process.intProducer1, process.intProducer2)
+process.p = cms.Path(process.f+process.intProducer, process.t)
+
+process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerPath_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerPath_cfg.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+enableTest2 = (sys.argv[-1] != "disableTest2")
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (enableTest2, -9)
+            ), **kargs)
+
+process = cms.Process("PROD1")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("EmptySource")
+if enableTest2:
+    process.source.firstLuminosityBlock = cms.untracked.uint32(2)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSwitchProducerPathFilter%d.root' % (1 if enableTest2 else 2,)),
+    outputCommands = cms.untracked.vstring(
+        'keep *_intProducer_*_*'
+    )
+)
+
+process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
+process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2))
+if enableTest2:
+    process.intProducer1.throw = cms.untracked.bool(True)
+else:
+    process.intProducer2.throw = cms.untracked.bool(True)
+
+process.intProducer = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
+    test2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer2"))
+)
+
+process.t = cms.Task(process.intProducer1, process.intProducer2)
+process.p = cms.Path(process.intProducer, process.t)
+
+process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerProvenanceAnalyzer_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerProvenanceAnalyzer_cfg.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+import sys
+
+process = cms.Process("ANA1")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring("file:"+sys.argv[-1])
+)
+
+process.analyzer = cms.EDAnalyzer("SwitchProducerProvenanceAnalyzer",
+    src1 = cms.InputTag("intProducer"),
+    src2 = cms.InputTag("intProducer", "other")
+)
+
+process.p = cms.Path(process.analyzer)

--- a/FWCore/Integration/test/testSwitchProducerTask_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerTask_cfg.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+enableTest2 = (sys.argv[-1] != "disableTest2")
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda: (True, -10),
+                test2 = lambda: (enableTest2, -9)
+            ), **kargs)
+
+process = cms.Process("PROD1")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("EmptySource")
+if enableTest2:
+    process.source.firstLuminosityBlock = cms.untracked.uint32(2)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSwitchProducerTask%d.root' % (1 if enableTest2 else 2,)),
+    outputCommands = cms.untracked.vstring(
+        'keep *_intProducer_*_*'
+    )
+)
+
+process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
+process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2))
+if enableTest2:
+    process.intProducer1.throw = cms.untracked.bool(True)
+else:
+    process.intProducer2.throw = cms.untracked.bool(True)
+
+process.intProducer = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
+    test2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer2"))
+)
+
+process.t = cms.Task(process.intProducer, process.intProducer1, process.intProducer2)
+process.p = cms.Path(process.t)
+
+process.e = cms.EndPath(process.out)

--- a/FWCore/Modules/src/SwitchProducer.cc
+++ b/FWCore/Modules/src/SwitchProducer.cc
@@ -1,0 +1,52 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+namespace edm {
+  /**
+   * This class is the physical EDProducer part of the SwitchProducer
+   * infrastructure. It must be configured only with the
+   * SwitchProducer python construct.
+   *
+   * The purposes of this EDProducer are
+   * - Create the consumes() links to the chosen case to make the prefetching work correclty
+   * - Forward the produces() information to create proper BranchDescription objects
+   */
+  class SwitchProducer: public global::EDProducer<> {
+  public:
+    explicit SwitchProducer(ParameterSet const& iConfig);
+    ~SwitchProducer() override = default;
+     static void fillDescriptions(ConfigurationDescriptions& descriptions);
+    void produce(StreamID, Event& e, EventSetup const& c) const final {}
+  };
+
+  SwitchProducer::SwitchProducer(ParameterSet const& iConfig) {
+    auto const& moduleLabel = iConfig.getParameter<std::string>("@module_label");
+    auto const& chosenLabel = iConfig.getUntrackedParameter<std::string>("@chosen_case");
+    callWhenNewProductsRegistered([=](edm::BranchDescription const& iBranch) {
+        if(iBranch.moduleLabel() == chosenLabel) {
+          if(iBranch.branchType() != InEvent) {
+            throw Exception(errors::UnimplementedFeature) << "SwitchProducer does not support non-event branches. Got " << iBranch.branchType() << " for SwitchProducer with label " << moduleLabel << " whose chosen case is " << chosenLabel << ".";
+          }
+
+          // With consumes, create the connection to the chosen case EDProducer for prefetching
+          this->consumes(edm::TypeToGet{iBranch.unwrappedTypeID(),PRODUCT_TYPE},
+                         edm::InputTag{iBranch.moduleLabel(), iBranch.productInstanceName(), iBranch.processName()});
+          // With produces, create a producer-like BranchDescription
+          // early-enough for it to be flagged as non-OnDemand in case
+          // the SwithcProducer is on a Path
+          this->produces(iBranch.unwrappedTypeID(), iBranch.productInstanceName()).setSwitchAlias(iBranch.moduleLabel());
+        }
+      });
+  }
+
+  void SwitchProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    ParameterSetDescription desc;
+    desc.add<std::vector<std::string>>("@all_cases");
+    desc.addUntracked<std::string>("@chosen_case");
+    descriptions.addDefault(desc);
+  }
+}
+
+using edm::SwitchProducer;
+DEFINE_FWK_MODULE(SwitchProducer);

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1550,6 +1550,16 @@ if __name__=="__main__":
         def newPSet(self):
             return TestMakePSet()
 
+    class SwitchProducerTest(SwitchProducer):
+        def __init__(self, **kargs):
+            super(SwitchProducerTest,self).__init__(
+                dict(
+                    test1 = lambda: (True, -10),
+                    test2 = lambda: (True, -9),
+                    test3 = lambda: (True, -8),
+                    test4 = lambda: (True, -7)
+                ), **kargs)
+
     class TestModuleCommand(unittest.TestCase):
         def setUp(self):
             """Nothing to do """
@@ -2653,6 +2663,31 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             self.assertEqual((True,1),p.values["ref2"][1].values["b"][1].values["a"])
             self.assertEqual((True,1),p.values["ref4"][1][0].values["a"])
             self.assertEqual((True,1),p.values["ref4"][1][1].values["a"])
+        def testSwitchProducer(self):
+            proc = Process("test")
+            proc.sp = SwitchProducerTest(test2 = EDProducer("Foo",
+                                                            a = int32(1),
+                                                            b = PSet(c = int32(2))),
+                                         test1 = EDProducer("Bar",
+                                                            aa = int32(11),
+                                                            bb = PSet(cc = int32(12))))
+            proc.a = EDProducer("A")
+            proc.s = Sequence(proc.a + proc.sp)
+            proc.t = Task(proc.a, proc.sp)
+            proc.p = Path()
+            proc.p.associate(proc.t)
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual((True,"EDProducer"), p.values["sp"][1].values["@module_edm_type"])
+            self.assertEqual((True, "SwitchProducer"), p.values["sp"][1].values["@module_type"])
+            self.assertEqual((True, "sp"), p.values["sp"][1].values["@module_label"])
+            self.assertEqual((True, ["sp@test1", "sp@test2"]), p.values["sp"][1].values["@all_cases"])
+            self.assertEqual((False, "sp@test2"), p.values["sp"][1].values["@chosen_case"])
+            self.assertEqual(["a", "sp", "sp@test1", "sp@test2"], p.values["@all_modules"][1])
+            self.assertEqual((True,"EDProducer"), p.values["sp@test1"][1].values["@module_edm_type"])
+            self.assertEqual((True,"Bar"), p.values["sp@test1"][1].values["@module_type"])
+            self.assertEqual((True,"EDProducer"), p.values["sp@test2"][1].values["@module_edm_type"])
+            self.assertEqual((True,"Foo"), p.values["sp@test2"][1].values["@module_type"])
         def testPrune(self):
             p = Process("test")
             p.a = EDAnalyzer("MyAnalyzer")
@@ -3188,4 +3223,42 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.a.type_(), "YourAnalyzer3")
             (m3 | m4).toReplaceWith(p.a, EDAnalyzer("YourAnalyzer4"))
             self.assertEqual(p.a.type_(), "YourAnalyzer3")
+
+            # SwitchProducer
+            sp = SwitchProducerTest(test1 = EDProducer("Foo",
+                                                       a = int32(1),
+                                                       b = PSet(c = int32(2))),
+                                    test2 = EDProducer("Bar",
+                                                       aa = int32(11),
+                                                       bb = PSet(cc = int32(12))))
+            m = Modifier()
+            m._setChosen()
+            # Modify parameters
+            m.toModify(sp,
+                       test1 = dict(a = 4, b = dict(c = None)),
+                       test2 = dict(aa = 15, bb = dict(cc = 45, dd = string("foo"))))
+            self.assertEqual(sp.test1.a.value(), 4)
+            self.assertEqual(sp.test1.b.hasParameter("c"), False)
+            self.assertEqual(sp.test2.aa.value(), 15)
+            self.assertEqual(sp.test2.bb.cc.value(), 45)
+            self.assertEqual(sp.test2.bb.dd.value(), "foo")
+            # Replace a producer
+            m.toReplaceWith(sp.test1, EDProducer("Fred", x = int32(42)))
+            self.assertEqual(sp.test1.type_(), "Fred")
+            self.assertEqual(sp.test1.x.value(), 42)
+            self.assertRaises(TypeError, lambda: m.toReplaceWith(sp.test1, EDAnalyzer("Foo")))
+            # Alternative way (only to be allow same syntax to be used as for adding)
+            m.toModify(sp, test2 = EDProducer("Xyzzy", x = int32(24)))
+            self.assertEqual(sp.test2.type_(), "Xyzzy")
+            self.assertEqual(sp.test2.x.value(), 24)
+            self.assertRaises(TypeError, lambda: m.toModify(sp, test2 = EDAnalyzer("Foo")))
+            # Add a producer
+            m.toModify(sp, test3 = EDProducer("Wilma", y = int32(24)))
+            self.assertEqual(sp.test3.type_(), "Wilma")
+            self.assertEqual(sp.test3.y.value(), 24)
+            self.assertRaises(TypeError, lambda: m.toModify(sp, test4 = EDAnalyzer("Foo")))
+            # Remove a producer
+            m.toModify(sp, test2 = None)
+            self.assertEqual(hasattr(sp, "test2"), False)
+
     unittest.main()

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -880,8 +880,7 @@ class Process(object):
     def _insertManyInto(self, parameterSet, label, itemDict, tracked):
         l = []
         for name,value in six.iteritems(itemDict):
-            newLabel = value.nameInProcessDesc_(name)
-            l.append(newLabel)
+            value.appendToProcessDescList_(l, name)
             value.insertInto(parameterSet, name)
         # alphabetical order is easier to compare with old language
         l.sort()

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -663,12 +663,12 @@ def _modifyParametersFromDict(params, newParams, errorRaiser, keyDepth=""):
                             plist[k] = v
                     else:
                         raise ValueError("Attempted to change non PSet value "+keyDepth+" using a dictionary")
-                elif isinstance(value,_ParameterTypeBase) or (isinstance(key, int)):
+                elif isinstance(value,_ParameterTypeBase) or (isinstance(key, int)) or isinstance(value, _TypedParameterizable):
                     params[key] = value
                 else:
                     params[key].setValue(value)
             else:
-                if isinstance(value,_ParameterTypeBase):
+                if isinstance(value,_ParameterTypeBase) or isinstance(value, _TypedParameterizable):
                     params[key]=value
                 else:
                     errorRaiser(key)

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -437,6 +437,8 @@ class _TypedParameterizable(_Parameterizable):
         return myname;
     def moduleLabel_(self, myname):
         return myname
+    def appendToProcessDescList_(self, lst, myname):
+        lst.append(self.nameInProcessDesc_(myname))
     def insertInto(self, parameterSet, myname):
         newpset = parameterSet.newPSet()
         newpset.addString(True, "@module_label", self.moduleLabel_(myname))

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -5,6 +5,7 @@ from SequenceTypes import _SequenceLeaf
 from Types import vstring
 
 import six
+import copy
 from ExceptionHandling import *
 class Service(_ConfigureComponent,_TypedParameterizable,_Unlabelable):
     def __init__(self,type_,*arg,**kargs):
@@ -210,11 +211,221 @@ class Looper(_ConfigureComponent,_TypedParameterizable):
         return "@main_looper"
 
 
+# Need to be a module-level function for the configuration with a
+# SwitchProducer to be pickleable.
+def _switch_cpu():
+    return (True, 1)
+
+class SwitchProducer(EDProducer):
+    """This purpose class is to provide a switch of EDProducers for a single module/product label.
+
+    The decision is done at the time when the python configuration is
+    translated to C++. This class is generic, and intended to be
+    inherited for concrete switches. Example:
+
+    class SwitchProducerFoo(SwitchProducer):
+        def __init__(self, **kargs):
+            super(SwitchProducerFoo,self).__init__(
+                dict(case1 = case1Func, case2 = case2Func),
+                **kargs
+            )
+
+    foo = SwitchProducerFoo(
+        case1 = EDProducer("Producer1"),
+        case2 = EDProducer("Producer2")
+    )
+
+    Here case1Func and case2Func are functions that return a (bool,
+    int) tuple, where the bool tells whether that case is enabled or
+    not, and the int tells the priority of that case. The case with
+    the highest priority among those that are enabled will get chosen.
+
+    The end result is that the product(s) labeled as "foo" will be
+    produced with one of the producers. It would be good if their
+    output product types and instance names would be the same (or very
+    close).
+    """
+    def __init__(self, caseFunctionDict, **kargs):
+        super(SwitchProducer,self).__init__(None)
+        self._caseFunctionDict = copy.copy(caseFunctionDict)
+        self.__setParameters(kargs)
+        self._isModified = False
+
+    @staticmethod
+    def getCpu():
+        """Returns a function that returns the priority for a CPU "computing device". Intended to be used by deriving classes."""
+        return _switch_cpu
+
+    def _chooseCase(self):
+        """Returns the name of the chosen case."""
+        cases = self.parameterNames_()
+        bestCase = None
+        for case in cases:
+            (enabled, priority) = self._caseFunctionDict[case]()
+            if enabled and (bestCase is None or bestCase[0] < priority):
+                bestCase = (priority, case)
+        if bestCase is None:
+            raise RuntimeError("All cases '%s' were disabled" % (str(cases)))
+        return bestCase[1]
+
+    def _getProducer(self):
+        """Returns the EDroducer of the chosen case"""
+        return self.__dict__[self._chooseCase()]
+
+    def __addParameter(self, name, value):
+        if not (isinstance(value, EDProducer) and not isinstance(value, SwitchProducer)):
+            raise TypeError(name+" does not already exist, so it can only be set to a cms.EDProducer")
+        if name not in self._caseFunctionDict:
+            raise ValueError("Case '%s' is not allowed (allowed ones are %s)" % (name, ",".join(six.iterkeys(self._caseFunctionDict))))
+        if name in self.__dict__:
+            message = "Duplicate insert of member " + name
+            message += "\nThe original parameters are:\n"
+            message += self.dumpPython() + '\n'
+            raise ValueError(message)
+        self.__dict__[name]=value
+        self._Parameterizable__parameterNames.append(name)
+        self._isModified = True
+
+    def __setParameters(self, parameters):
+        for name, value in six.iteritems(parameters):
+            self.__addParameter(name, value)
+
+    def __setattr__(self, name, value):
+        # Following snippet copied and customized from
+        # _Parameterizable in order to support Modifier.toModify
+        #
+        #since labels are not supposed to have underscores at the beginning
+        # I will assume that if we have such then we are setting an internal variable
+        if self.isFrozen() and not (name in ["_Labelable__label","_isFrozen"] or name.startswith('_')):
+            message = "Object already added to a process. It is read only now\n"
+            message +=  "    %s = %s" %(name, value)
+            message += "\nThe original parameters are:\n"
+            message += self.dumpPython() + '\n'
+            raise ValueError(message)
+        # underscored names bypass checking for _ParameterTypeBase
+        if name[0]=='_':
+            super(SwitchProducer, self).__setattr__(name,value)
+        elif not name in self.__dict__:
+            self.__addParameter(name, value)
+            self._isModified = True
+        else:
+            if not (isinstance(value, EDProducer) and not isinstance(value, SwitchProducer)):
+                raise TypeError(name+" can only be set to a cms.EDProducer")
+            # We should always receive an cms.EDProducer
+            self.__dict__[name] = value
+            self._isModified = True
+
+    def clone(self, **params):
+        returnValue = SwitchProducer.__new__(type(self))
+
+        # Need special treatment as cms.EDProducer is not a valid parameter type (except in this case)
+        myparams = dict()
+        for name, value in six.iteritems(params):
+            if value is None:
+                continue
+            elif isinstance(value, dict):
+                myparams[name] = self.__dict__[name].clone(**value)
+            else: # value is an EDProducer
+                myparams[name] = value.clone()
+
+        # Add the ones that were not customized
+        for name in self.parameterNames_():
+            if name not in params:
+                myparams[name] = self.__dict__[name].clone()
+        returnValue.__init__(**myparams)
+        returnValue._isModified = False
+        returnValue._isFrozen = False
+        saveOrigin(returnValue, 1)
+        return returnValue
+
+    def dumpPython(self, options=PrintOptions()):
+        # Note that if anyone uses the generic SwitchProducer instead
+        # of a derived-one, the information on the functions for the
+        # producer decision is lost
+        result = "%s(" % self.__class__.__name__ # not including cms. since the deriving classes are not in cms "namespace"
+        options.indent()
+        for resource in sorted(self.parameterNames_()):
+            result += "\n" + options.indentation() + resource + " = " + getattr(self, resource).dumpPython(options).rstrip() + ","
+        if result[-1] == ",":
+            result = result.rstrip(",")
+        options.unindent()
+        result += "\n)\n"
+        return result
+
+    def nameInProcessDesc_(self, myname):
+        return myname
+    def moduleLabel_(self, myname):
+        return myname
+    def caseLabel_(self, name, case):
+        return name+"@"+case
+    def appendToProcessDescList_(self, lst, myname):
+        # This way we can insert the chosen EDProducer to @all_modules
+        # so that we get easily a worker for it
+        lst.append(myname)
+        for case in self.parameterNames_():
+            lst.append(self.caseLabel_(myname, case))
+
+    def insertInto(self, parameterSet, myname):
+        for case in self.parameterNames_():
+            producer = self.__dict__[case]
+            producer.insertInto(parameterSet, self.caseLabel_(myname, case))
+        newpset = parameterSet.newPSet()
+        newpset.addString(True, "@module_label", self.moduleLabel_(myname))
+        newpset.addString(True, "@module_type", "SwitchProducer")
+        newpset.addString(True, "@module_edm_type", "EDProducer")
+        newpset.addVString(True, "@all_cases", [myname+"@"+p for p in self.parameterNames_()])
+        newpset.addString(False, "@chosen_case", myname+"@"+self._chooseCase())
+        parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
+
+    def _placeImpl(self,name,proc):
+        proc._placeProducer(name,self)
+        for case in self.parameterNames_():
+            # Note that these don't end up in @all_modules
+            # automatically because they're not part of any
+            # Task/Sequence/Path
+            proc._placeProducer(self.caseLabel_(name, case), self.__dict__[case])
+
+    def _clonesequence(self, lookuptable):
+        try:
+            return lookuptable[id(self)]
+        except:
+            raise ModuleCloneError(self._errorstr())
+    def _errorstr(self):
+        return "SwitchProducer"
+
 
 if __name__ == "__main__":
     import unittest
     from Types import *
     from SequenceTypes import *
+
+    class SwitchProducerTest(SwitchProducer):
+        def __init__(self, **kargs):
+            super(SwitchProducerTest,self).__init__(
+                dict(
+                    test1 = lambda: (True, -10),
+                    test2 = lambda: (True, -9),
+                    test3 = lambda: (True, -8)
+                ), **kargs)
+    class SwitchProducerTest1Dis(SwitchProducer):
+        def __init__(self, **kargs):
+            super(SwitchProducerTest1Dis,self).__init__(
+                dict(
+                    test1 = lambda: (False, -10),
+                    test2 = lambda: (True, -9)
+                ), **kargs)
+    class SwitchProducerTest2Dis(SwitchProducer):
+        def __init__(self, **kargs):
+            super(SwitchProducerTest2Dis,self).__init__(
+                dict(
+                    test1 = lambda: (True, -10),
+                    test2 = lambda: (False, -9)
+                ), **kargs)
+    class SwitchProducerPickleable(SwitchProducer):
+        def __init__(self, **kargs):
+            super(SwitchProducerPickleable,self).__init__(
+                dict(cpu = SwitchProducer.getCpu()), **kargs)
+
     class TestModules(unittest.TestCase):
         def testEDAnalyzer(self):
             empty = EDAnalyzer("Empty")
@@ -285,6 +496,9 @@ if __name__ == "__main__":
             m = EDProducer("x")
             self.assertTrue(m._isTaskComponent())
             self.assertTrue(m.isLeaf())
+            m = SwitchProducerTest(test1=EDProducer("x"))
+            self.assertTrue(m._isTaskComponent())
+            self.assertTrue(m.isLeaf())
             m = EDFilter("x")
             self.assertTrue(m._isTaskComponent())
             self.assertTrue(m.isLeaf())
@@ -313,5 +527,112 @@ if __name__ == "__main__":
             m = Task()
             self.assertTrue(m._isTaskComponent())
             self.assertFalse(m.isLeaf())
+
+        def testSwitchProducer(self):
+            # Constructor
+            sp = SwitchProducerTest(test1 = EDProducer("Foo"), test2 = EDProducer("Bar"))
+            self.assertEqual(sp.test1.type_(), "Foo")
+            self.assertEqual(sp.test2.type_(), "Bar")
+            self.assertRaises(ValueError, lambda: SwitchProducerTest(nonexistent = EDProducer("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = EDAnalyzer("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = EDFilter("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = Source("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = OutputModule("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = Looper("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = EDAlias()))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = Service("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESSource("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESProducer("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESPrefer("Foo")))
+            self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = SwitchProducerTest(test1 = EDProducer("Foo"))))
+
+            # Case decision
+            sp = SwitchProducerTest(test1 = EDProducer("Foo"), test2 = EDProducer("Bar"))
+            self.assertEqual(sp._getProducer().type_(), "Bar")
+            sp = SwitchProducerTest1Dis(test1 = EDProducer("Foo"), test2 = EDProducer("Bar"))
+            self.assertEqual(sp._getProducer().type_(), "Bar")
+            sp = SwitchProducerTest2Dis(test1 = EDProducer("Foo"), test2 = EDProducer("Bar"))
+            self.assertEqual(sp._getProducer().type_(), "Foo")
+            sp = SwitchProducerTest(test1 = EDProducer("Bar"))
+            self.assertEqual(sp._getProducer().type_(), "Bar")
+            sp = SwitchProducerTest1Dis(test1 = EDProducer("Bar"))
+            self.assertRaises(RuntimeError, sp._getProducer)
+
+            # Mofications
+            from Types import int32, string, PSet
+            sp = SwitchProducerTest(test1 = EDProducer("Foo",
+                                                       a = int32(1),
+                                                       b = PSet(c = int32(2))),
+                                    test2 = EDProducer("Bar",
+                                                       aa = int32(11),
+                                                       bb = PSet(cc = int32(12))))
+            # Simple clone
+            cl = sp.clone()
+            self.assertEqual(cl.test1.type_(), "Foo")
+            self.assertEqual(cl.test1.a.value(), 1)
+            self.assertEqual(cl.test1.b.c.value(), 2)
+            self.assertEqual(cl.test2.type_(), "Bar")
+            self.assertEqual(cl.test2.aa.value(), 11)
+            self.assertEqual(cl.test2.bb.cc.value(), 12)
+            # Modify clone
+            cl.test1.a = 3
+            self.assertEqual(cl.test1.a.value(), 3)
+            cl.test1 = EDProducer("Fred")
+            self.assertEqual(cl.test1.type_(), "Fred")
+            def _assignEDAnalyzer():
+                cl.test1 = EDAnalyzer("Foo")
+            self.assertRaises(TypeError, _assignEDAnalyzer)
+            def _assignSwitchProducer():
+                cl.test1 = SwitchProducerTest(test1 = SwitchProducerTest(test1 = EDProducer("Foo")))
+            self.assertRaises(TypeError, _assignSwitchProducer)
+            # Modify values with a dict
+            cl = sp.clone(test1 = dict(a = 4, b = dict(c = None)),
+                          test2 = dict(aa = 15, bb = dict(cc = 45, dd = string("foo"))))
+            self.assertEqual(cl.test1.a.value(), 4)
+            self.assertEqual(cl.test1.b.hasParameter("c"), False)
+            self.assertEqual(cl.test2.aa.value(), 15)
+            self.assertEqual(cl.test2.bb.cc.value(), 45)
+            self.assertEqual(cl.test2.bb.dd.value(), "foo")
+            # Replace/add/remove EDProducers
+            cl = sp.clone(test1 = EDProducer("Fred", x = int32(42)),
+                          test3 = EDProducer("Wilma", y = int32(24)),
+                          test2 = None)
+            self.assertEqual(cl.test1.type_(), "Fred")
+            self.assertEqual(cl.test1.x.value(), 42)
+            self.assertEqual(cl.test3.type_(), "Wilma")
+            self.assertEqual(cl.test3.y.value(), 24)
+            self.assertEqual(hasattr(cl, "test2"), False)
+            self.assertRaises(TypeError, lambda: sp.clone(test1 = EDAnalyzer("Foo")))
+            self.assertRaises(TypeError, lambda: sp.clone(test1 = SwitchProducerTest(test1 = SwitchProducerTest(test1 = EDProducer("Foo")))))
+
+            # Dump
+            sp = SwitchProducerTest(test2 = EDProducer("Foo",
+                                                       a = int32(1),
+                                                       b = PSet(c = int32(2))),
+                                    test1 = EDProducer("Bar",
+                                                       aa = int32(11),
+                                                       bb = PSet(cc = int32(12))))
+            self.assertEqual(sp.dumpPython(),
+"""SwitchProducerTest(
+    test1 = cms.EDProducer("Bar",
+        aa = cms.int32(11),
+        bb = cms.PSet(
+            cc = cms.int32(12)
+        )
+    ),
+    test2 = cms.EDProducer("Foo",
+        a = cms.int32(1),
+        b = cms.PSet(
+            c = cms.int32(2)
+        )
+    )
+)
+""")
+            # Pickle
+            import pickle
+            sp = SwitchProducerPickleable(cpu = EDProducer("Foo"))
+            pkl = pickle.dumps(sp)
+            unpkl = pickle.loads(pkl)
+            self.assertEqual(unpkl.cpu.type_(), "Foo")
 
     unittest.main()

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1167,6 +1167,9 @@ class EDAlias(_ConfigureComponent,_Labelable):
     def nameInProcessDesc_(self, myname):
         return myname;
 
+    def appendToProcessDescList_(self, lst, myname):
+        lst.append(self.nameInProcessDesc_(myname))
+
     def insertInto(self, parameterSet, myname):
         newpset = parameterSet.newPSet()
         newpset.addString(True, "@module_label", myname)


### PR DESCRIPTION
This PR provides an implementation for a `SwitchProducer` to allow a runtime decision on which EDProducer from a given set to run for a given module label. The main use case in mind are heterogeneous/offloaded/accelerated algorithms, where we would run the accelerated EDProducer if the accelerator device is available in the system, and run the "legacy" CPU EDProducer otherwise.

For a given accelerator type, the generic `SwitchProducer` is supposed to be inherited along
```python
def _switch_foo():
    return (isFooDeviceEnabled(), 2)

class SwitchProducerFoo(cms.SwitchProducer):
    def __init__(self, **kargs):
        super(SwitchProducerFoo,self).__init__(
            dict(cpu = SwitchProducer.getCpu(),
                 foo = _switch_foo),
            **kargs
        )
```
Here the deriving class provides a dictionary of possible cases along with functions that return a `(bool, int)` tuple. The `bool` tells whether that device type is enabled on the machine, and the `int` gives a priority of that device wrt. other devices. `SwitchProducer.getCpu()` returns a function for the CPU (always enabled, priority `1`). Note that in order to be able to pickle the configuration, these functions have to be at (python) module level (i.e. e.g. lambdas or static methods are not sufficient).

The decision logic chooses the case that has the largest priority among those that are enabled. The decision is made at the point where the python configuration is transformed for C++, i.e. in case of production at the worker node.

The switch decision does not affect the configuration hash, meaning that the framework will consider a run/lumi/event produced with `isFooDeviceEnabled() == False` the same as with `True`.

The concrete `SwitchProducerFoo` would then be used along (e.g. in a `cfi` file)
```python
bar = SwitchProducerFoo(
    cpu = cms.EDProducer("Bar", ...),
    foo = cms.EDProducer("BarOnFooDevice", ...)
)
```
In this example, if `isFooDeviceEnabled()` returns
* `True` => `BarOnFooDevice` EDProducer is run
* `False` => `Bar` EDProducer is run

The switched EDProducers are required to declare exactly the same products with the `produces()` call.

When a client asks for a products if `bar`, it will get pointed to the exactly the same `edm::Wrapper` that contains the product by the chosen EDProducer. The additional "layer' is, however, tracked in provenance, such that the parent of a product `bar` is `bar@cpu` or `bar@foo`, depending which one of the EDProducers was run.

The python interface is likely to evolve with more experience with it, with accelerated EDProducers, and with devices beyond CUDA. Note that this PR adds only the generic infrastructure, a CUDA-specific implementation will follow in a separate PR (or e.g. as part of the effort of #25353).

Tested in 10_4_0_pre3, no changes expected.