### PR TITLE
Define new run2_miniAOD_devel and run2_nanoAOD_102Xv1 modifiers

### DIFF
--- a/Configuration/Eras/python/Modifier_run2_miniAOD_devel_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_miniAOD_devel_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_miniAOD_devel = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run2_nanoAOD_102Xv1_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_nanoAOD_102Xv1_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_nanoAOD_102Xv1 = cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -57,6 +57,7 @@ class Eras (object):
                            'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigation', 'run2_miniAOD_80XLegacy','run2_miniAOD_94XFall17', 'run2_nanoAOD_92X',
                            'run2_nanoAOD_94XMiniAODv1', 'run2_nanoAOD_94XMiniAODv2', 'run2_nanoAOD_94X2016',
+                           'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1',
                            'hcalHardcodeConditions', 'hcalSkipPacker']
         internalUseModChains = ['run2_2017_noTrackingModifier']
 


### PR DESCRIPTION
As agreed for support of running on different miniAOD in nanoAOD production, and for protecting backports that would modify the miniAOD content.