### PR TITLE
Only call consumes in ElectronSeedProducer if actually needed

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -121,7 +121,6 @@ ElectronSeedProducer::ElectronSeedProducer( const edm::ParameterSet& iConfig )
     }
 
   edm::ParameterSet rpset = conf.getParameter<edm::ParameterSet>("RegionPSet");
-  filterVtxTag_ = consumes<std::vector<reco::Vertex> >(rpset.getParameter<edm::InputTag> ("VertexProducer"));
 
   ElectronSeedGenerator::Tokens esg_tokens;
   esg_tokens.token_bs = beamSpotTag_;
@@ -150,7 +149,8 @@ ElectronSeedProducer::ElectronSeedProducer( const edm::ParameterSet& iConfig )
   if (prefilteredSeeds_) {
     SeedFilter::Tokens sf_tokens;
     sf_tokens.token_bs  = beamSpotTag_;
-    sf_tokens.token_vtx = filterVtxTag_;
+    sf_tokens.token_vtx = consumes<std::vector<reco::Vertex> >(rpset.getParameter<edm::InputTag> ("VertexProducer"));
+
     edm::ConsumesCollector iC = consumesCollector();
     seedFilter_.reset(new SeedFilter(conf, sf_tokens, iC));
   }

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
@@ -64,7 +64,6 @@ class ElectronSeedProducer : public edm::stream::EDProducer<>
     
     edm::EDGetTokenT<reco::SuperClusterCollection> superClusters_[2] ;
     std::vector<edm::EDGetTokenT<TrajectorySeedCollection>> initialSeeds_ ;
-    edm::EDGetTokenT<std::vector<reco::Vertex> > filterVtxTag_;
     edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_ ;
     edm::EDGetTokenT<EcalRecHitCollection> ebRecHitCollection_;
     edm::EDGetTokenT<EcalRecHitCollection> eeRecHitCollection_;


### PR DESCRIPTION
A data product is only consumed if a particular parameter value is used.