### PR TITLE
fix clang warnings in MuonAnalysis/MomentumScaleCalibration

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/plugins/Histograms.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/Histograms.h
@@ -1423,7 +1423,7 @@ class HLikelihoodVSPart : public Histograms
     Fill(CLHEP::HepLorentzVector(p4.x(),p4.y(),p4.z(),p4.t()), likeValue);
   }
   
-   virtual void Fill(CLHEP::HepLorentzVector momentum, double likeValue) { 
+  void Fill(const CLHEP::HepLorentzVector& momentum, const double& likeValue) override { 
      hLikeVSPt_->Fill(momentum.perp(),likeValue); 
      hLikeVSEta_->Fill(momentum.eta(),likeValue); 
      hLikeVSPhi_->Fill(momentum.phi(),likeValue); 
@@ -1903,6 +1903,7 @@ class HCovarianceVSxy : public Histograms
     }
   }
 
+  using Histograms::Get;
   double Get( const double & x, const double & y ) const {
     // Need to convert the (x,y) values to the array indeces
     int xIndex = getXindex(x);


### PR DESCRIPTION
Fixed virtual function hiding.
This was found by clang.