### PR TITLE
Remove duplicate entry in Geometry/GlobalTrackingGeometryBuilder/test/BuildFile.xml

### DIFF
--- a/Geometry/GlobalTrackingGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/GlobalTrackingGeometryBuilder/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
-<use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>
 <use   name="Geometry/GEMGeometry"/>
 <use   name="Geometry/RPCGeometry"/>


### PR DESCRIPTION
Removes the following warning from scram
```
***WARNING: Multiple usage of "Geometry/TrackerGeometryBuilder". Please cleanup "use" in "non-export" section of "src/Geometry/GlobalTrackingGeometryBuilder/test/BuildFile".
```