### PR TITLE
Remove invalid tool from IORawData/DTCommissioning/plugins/BuildFile.xml

### DIFF
--- a/IORawData/DTCommissioning/plugins/BuildFile.xml
+++ b/IORawData/DTCommissioning/plugins/BuildFile.xml
@@ -4,7 +4,6 @@
   <use   name="DataFormats/FEDRawData"/>
   <use   name="DataFormats/Provenance"/>
   <use   name="IORawData/DTCommissioning"/>
-  <use   name="castor"/>
   <flags   EDM_PLUGIN="1"/>
   <use   name="xrootd"/>
   <flags   cppflags="-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64"/>


### PR DESCRIPTION
Removes the following warning from scram
```
****WARNING: Invalid tool castor. Please fix src/IORawData/DTCommissioning/plugins/BuildFile.xml file.
```