### PR TITLE
DD4hep:  Add Access to dd4hep::Detector from an EventSetup Source

### DIFF
--- a/DetectorDescription/DDCMS/BuildFile.xml
+++ b/DetectorDescription/DDCMS/BuildFile.xml
@@ -1,4 +1,6 @@
 <use   name="FWCore/PluginManager"/>
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/Utilities"/>
 <use   name="dd4hep"/>
 <use   name="rootmath"/>
 <export>

--- a/DetectorDescription/DDCMS/interface/DDDetector.h
+++ b/DetectorDescription/DDCMS/interface/DDDetector.h
@@ -1,0 +1,20 @@
+#ifndef DETECTOR_DESCRIPTION_DD_DETECTOR_H
+#define DETECTOR_DESCRIPTION_DD_DETECTOR_H
+
+#include <string>
+
+namespace dd4hep {
+  class Detector;
+}
+
+namespace cms  {
+  struct DDDetector {
+    DDDetector();
+    void process(const std::string& file);
+    dd4hep::Detector& description() const { return *m_description; };
+  private:
+    dd4hep::Detector* m_description;
+  };
+}
+
+#endif

--- a/DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h
+++ b/DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h
@@ -1,0 +1,6 @@
+#ifndef GEOMETRY_RECORDS_DETECTOR_DESCRIPTION_RCD_H
+#define GEOMETRY_RECORDS_DETECTOR_DESCRIPTION_RCD_H
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class DetectorDescriptionRcd : public edm::eventsetup::EventSetupRecordImplementation<DetectorDescriptionRcd> {};
+#endif

--- a/DetectorDescription/DDCMS/plugins/BuildFile.xml
+++ b/DetectorDescription/DDCMS/plugins/BuildFile.xml
@@ -1,13 +1,14 @@
 <use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="dd4hep"/>
 <use name="DetectorDescription/DDCMS"/>
 
-<library name="DetectorDescriptionTestPlugins" file="DDTestVectors.cc,DDTestDumpFile.cc,DDTestDumpGeometry.cc" >
+<library name="DetectorDescriptionTestPlugins" file="DDTestVectors.cc,DDTestDumpFile.cc,DDTestDumpGeometry.cc,DDTestNavigateGeometry.cc" >
   <lib name="Geom"/>
   <flags EDM_PLUGIN="1"/>
 </library>
-<library name="DetectorDescriptionPlugins" file="DDCMSDetector.cc" >
+<library name="DetectorDescriptionPlugins" file="DDCMSDetector.cc,DDDetectorESProducer.cc" >
   <lib name="Geom"/>
   <flags EDM_PLUGIN="1"/>
 </library>
@@ -16,6 +17,8 @@
   <flags SKIP_FILE="DDTestVector.cc"/>
   <flags SKIP_FILE="DDTestDumpFile.cc"/>
   <flags SKIP_FILE="DDTestDumpGeometry.cc"/>
+  <flags SKIP_FILE="DDTestNavigateGeometry.cc"/>
+  <flags SKIP_FILE="DDDetectorESProducer.cc"/>
   <use name="rootgeom"/>
   <flags DD4HEP_PLUGIN="1"/>
 </library>

--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -30,7 +30,7 @@
 class DDDetectorESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
 public:
   DDDetectorESProducer(const edm::ParameterSet&);
-  ~DDDetectorESProducer();
+  ~DDDetectorESProducer() override;
   
   using ReturnType = std::unique_ptr<cms::DDDetector>;
   

--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -1,0 +1,81 @@
+// -*- C++ -*-
+//
+// Package:    DetectorDescription/DDDetectorESProducer
+// Class:      DDDetectorESProducer
+// 
+/**\class DDDetectorESProducer
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Ianna Osborne
+//         Created:  Fri, 07 Dec 2018 11:20:52 GMT
+//
+//
+
+#include <memory>
+#include <iostream>
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+
+class DDDetectorESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
+public:
+  DDDetectorESProducer(const edm::ParameterSet&);
+  ~DDDetectorESProducer();
+  
+  using ReturnType = std::unique_ptr<cms::DDDetector>;
+  
+  ReturnType produce(const DetectorDescriptionRcd&);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue&, edm::ValidityInterval&) override;
+  
+private:
+  std::string m_confGeomXMLFiles;
+};
+
+DDDetectorESProducer::DDDetectorESProducer(const edm::ParameterSet& iConfig)
+  : m_confGeomXMLFiles(iConfig.getParameter<std::string>("confGeomXMLFiles"))
+{
+   setWhatProduced(this);
+   findingRecord<DetectorDescriptionRcd>();
+}
+
+DDDetectorESProducer::~DDDetectorESProducer()
+{
+}
+
+void
+DDDetectorESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("confGeomXMLFiles");
+  descriptions.addDefault(desc);
+}
+
+void
+DDDetectorESProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey, const edm::IOVSyncValue& iTime, edm::ValidityInterval& oInterval) {
+  oInterval = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime()); //infinite
+}
+
+DDDetectorESProducer::ReturnType
+DDDetectorESProducer::produce(const DetectorDescriptionRcd& iRecord)
+{
+  auto product = std::make_unique<cms::DDDetector>();
+  product->process(m_confGeomXMLFiles);
+  return product;
+}
+
+#include "FWCore/Framework/interface/SourceFactory.h"
+DEFINE_FWK_EVENTSETUP_SOURCE(DDDetectorESProducer);

--- a/DetectorDescription/DDCMS/plugins/DDTestNavigateGeometry.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestNavigateGeometry.cc
@@ -1,0 +1,97 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "DD4hep/Detector.h"
+#include "DD4hep/DD4hepRootPersistency.h"
+#include "DD4hep/DetectorTools.h"
+#include "DD4hep/VolumeProcessor.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace cms;
+using namespace dd4hep;
+
+namespace {
+  
+  class VolumeProcessor : public dd4hep::PlacedVolumeProcessor {
+  public:
+    VolumeProcessor() = default;
+    virtual ~VolumeProcessor() = default;
+    
+    /// Callback to retrieve PlacedVolume information of an entire Placement
+    virtual int process(dd4hep::PlacedVolume pv, int level, bool recursive) {
+      m_volumes.emplace_back(pv.name());
+      int ret = dd4hep::PlacedVolumeProcessor::process(pv, level, recursive);
+      m_volumes.pop_back();
+      return ret;
+    }
+    
+    /// Volume callback
+    virtual int operator()(dd4hep::PlacedVolume pv, int level) {
+      dd4hep::Volume vol = pv.volume();
+      cout << "Hierarchical level:" << level << "   Placement:";
+      for(const auto& i : m_volumes) cout << "/" << i;
+      cout << "\n\tMaterial:" << vol.material().name()
+	   << "\tSolid:   " << vol.solid().name()
+	   << " [" << vol.solid()->IsA()->GetName() << "]\n";
+      ++m_count;
+      return 1;
+    }
+    int count() const { return m_count; }
+    
+  private:
+    int m_count = 0;
+    vector<string> m_volumes;
+  };
+}
+
+class DDTestNavigateGeometry : public edm::one::EDAnalyzer<> {
+public:
+  explicit DDTestNavigateGeometry(const edm::ParameterSet&);
+
+  void beginJob() override {}
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void endJob() override {}
+};
+
+DDTestNavigateGeometry::DDTestNavigateGeometry(const edm::ParameterSet& iConfig)
+{}
+
+void
+DDTestNavigateGeometry::analyze(const edm::Event&, const edm::EventSetup& iEventSetup)
+{
+  cout << "DDTestNavigateGeometry::analyze:\n";
+  const DetectorDescriptionRcd& ddRecord = iEventSetup.get<DetectorDescriptionRcd>();
+  edm::ESTransientHandle<DDDetector> ddd;
+  ddRecord.get(ddd);
+    
+  dd4hep::Detector& detector = ddd->description();
+
+  string detElementPath;
+  string placedVolPath;
+ 
+  DetElement startDetEl, world = detector.world();
+  PlacedVolume startPVol = world.placement();
+  if( !detElementPath.empty())
+    startDetEl = dd4hep::detail::tools::findElement(detector, detElementPath);
+  else if( !placedVolPath.empty())
+    startPVol = dd4hep::detail::tools::findNode(world.placement(), placedVolPath);
+  if( !startPVol.isValid()) {
+    if( !startDetEl.isValid()) {      
+      except("VolumeScanner", "Failed to find start conditions for the volume scan");
+    }
+    startPVol = startDetEl.placement();
+  }
+
+  VolumeProcessor proc;
+  PlacedVolumeScanner().scanPlacements(proc, startPVol, 0, true);
+  
+  printout(ALWAYS,"VolumeScanner","+++ Visited a total of %d placed volumes.", proc.count());
+}
+
+DEFINE_FWK_MODULE(DDTestNavigateGeometry);

--- a/DetectorDescription/DDCMS/plugins/DDTestNavigateGeometry.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestNavigateGeometry.cc
@@ -21,10 +21,10 @@ namespace {
   class VolumeProcessor : public dd4hep::PlacedVolumeProcessor {
   public:
     VolumeProcessor() = default;
-    virtual ~VolumeProcessor() = default;
+    ~VolumeProcessor() override = default;
     
     /// Callback to retrieve PlacedVolume information of an entire Placement
-    virtual int process(dd4hep::PlacedVolume pv, int level, bool recursive) {
+    int process(dd4hep::PlacedVolume pv, int level, bool recursive) override {
       m_volumes.emplace_back(pv.name());
       int ret = dd4hep::PlacedVolumeProcessor::process(pv, level, recursive);
       m_volumes.pop_back();
@@ -32,7 +32,7 @@ namespace {
     }
     
     /// Volume callback
-    virtual int operator()(dd4hep::PlacedVolume pv, int level) {
+    int operator()(dd4hep::PlacedVolume pv, int level) override {
       dd4hep::Volume vol = pv.volume();
       cout << "Hierarchical level:" << level << "   Placement:";
       for(const auto& i : m_volumes) cout << "/" << i;

--- a/DetectorDescription/DDCMS/src/DDDetector.cc
+++ b/DetectorDescription/DDCMS/src/DDDetector.cc
@@ -1,0 +1,22 @@
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "DD4hep/Detector.h"
+
+#include <iostream>
+
+using namespace cms;
+
+DDDetector::DDDetector()
+  : m_description(nullptr)
+{
+}
+
+void
+DDDetector::process(const std::string& fileName)
+{
+  m_description = &dd4hep::Detector::getInstance();
+
+  std::string name("DD4hep_CompactLoader");
+  const char* files[] = { fileName.c_str(), nullptr };
+  m_description->apply( name.c_str(), 2, (char**)files );
+}
+

--- a/DetectorDescription/DDCMS/src/ES_DDDetector.cc
+++ b/DetectorDescription/DDCMS/src/ES_DDDetector.cc
@@ -1,0 +1,12 @@
+#include "FWCore/Utilities/interface/typelookup.h"
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+
+TYPELOOKUP_DATA_REG( cms::DDDetector );
+
+#include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"
+
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+EVENTSETUP_RECORD_REG(DetectorDescriptionRcd);
+
+#include "FWCore/Framework/interface/data_default_record_trait.h"
+EVENTSETUP_DATA_DEFAULT_RECORD( cms::DDDetector, DetectorDescriptionRcd )

--- a/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
+++ b/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DDCMSDetectorTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.string('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml')
+                                            )
+
+process.test = cms.EDAnalyzer("DDTestNavigateGeometry")
+
+process.p = cms.Path(process.test)


### PR DESCRIPTION
* Access to dd4hep::Detector from EventSetup: the goal is to limit access to the singleton.
* Add an example how to navigate the geometry tree and access a placed volume information

To test:
```
cmsRun DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
```
@Dr15Jones - please, check and comment.

Note: an automated python fragment configuration is not generated, though the ```fillDescriptions``` is defined.