### PR TITLE
[HBHE] Use uniform timeslew parameters

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/HcalTimeSlew_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/HcalTimeSlew_cff.py
@@ -1,18 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
 HcalTimeSlewEP = cms.ESSource("HcalTimeSlewEP",
-    appendToDataLabel = cms.string("HBHE"),                              
+    appendToDataLabel = cms.string("HBHE"),
     # For method2/simulation
     timeSlewParametersM2 = cms.VPSet(
-        cms.PSet(#Slow    
+        cms.PSet(#Slow
             tzero = cms.double(23.960177), slope = cms.double(-3.178648), tmax = cms.double(16.00)),
         cms.PSet(#Medium
-            tzero = cms.double(13.307784), slope = cms.double(-1.556668), tmax = cms.double(10.00)),
+            tzero = cms.double(11.977461), slope = cms.double(-1.5610227), tmax = cms.double(10.00)),
         cms.PSet(#Fast
             tzero = cms.double(9.109694),  slope = cms.double(-1.075824), tmax = cms.double(6.25))
     ),
-    # For method3                          
-    timeSlewParametersM3 = cms.VPSet(        
+    # For method3
+    timeSlewParametersM3 = cms.VPSet(
         cms.PSet(#TestStand (Parameters not used)
             cap = cms.double(6.0), tspar0 = cms.double(12.2999), tspar1 = cms.double(-2.19142), tspar2 = cms.double(0.0),  tspar0_siPM = cms.double(0.0), tspar1_siPM = cms.double(0.0), tspar2_siPM = cms.double(0.0)),
         cms.PSet(#Data
@@ -23,9 +23,3 @@ HcalTimeSlewEP = cms.ESSource("HcalTimeSlewEP",
             cap = cms.double(6.0), tspar0 = cms.double(12.2999), tspar1 = cms.double(-2.19142), tspar2 = cms.double(0.0),  tspar0_siPM = cms.double(0.0), tspar1_siPM = cms.double(0.0), tspar2_siPM = cms.double(0.0))
     )
 )
-
-from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-#HBHE2018  -  Medium
-run2_HE_2018.toModify(
-    HcalTimeSlewEP, timeSlewParametersM2 = {
-        1: dict(tzero = cms.double(11.977461), slope = cms.double(-1.5610227),tmax = cms.double(10.00))})


### PR DESCRIPTION
HCAL DPG wants to use uniform QIE timeslew parameters for ultra-rereco based on DN-17-036. The measurement was done with QIE8 in 2003, and the data was re-analyzed for a better extraction of parameters. Since there is no reason for QIE11 and QIE8 timeslews to be different, same parameters are used for both QIE8 and QIE11. 

The changes in cmssw are 

- The modifier for 2018_HE is removed 
- One set of parameters is used for all eras and for both HB and HE. 

This will affect both data and MC. 