### PR TITLE
[HBHE] Mahi configuration change: 8 pulses without baseline

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -33,11 +33,11 @@ def customiseForUncollapsed(process):
 
     for producer in producers_by_type(process, "PFMultiDepthClusterProducer"):
         producer.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector[1].logWeightDenominator = _thresholdsHEphase1HCAL
-    
+
     for producer in producers_by_type(process, "PFRecHitProducer"):
         if producer.producers[0].name.value() == 'PFHBHERecHitCreator':
             producer.producers[0].qualityTests[0].cuts[1].threshold = _thresholdsHEphase1Rec
-    
+
     for producer in producers_by_type(process, "CaloTowersCreator"):
         producer.HcalPhase     = cms.int32(1)
         producer.HESThreshold1 = cms.double(0.1)
@@ -52,8 +52,13 @@ def customiseForUncollapsed(process):
     process.HLTStoppedHSCPLocalHcalReco = cms.Sequence( process.hltHcalDigis + process.hltHbhereco )
 
 
-    return process    
+    return process
 
+# Set new variable use8ts for Mahi
+def customiseFor25469(process):
+    for producer in producers_by_type(process, "HBHEPhase1Reconstructor"):
+        producer.use8ts                = cms.bool(False)
+    return process
 
 def customiseFor21664_forMahiOn(process):
     for producer in producers_by_type(process, "HBHEPhase1Reconstructor"):
@@ -96,23 +101,23 @@ def customiseFor2017DtUnpacking(process):
 # particleFlowRechitECAL new default value "false" flag to be added
 def customiseForEcalTestPR22254Default(process):
 
-    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
-        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']:
+        if hasattr(process,hltParticleFlowRecHitECAL):
             module = getattr(process,hltParticleFlowRecHitECAL)
 
-            for producer in module.producers: 
+            for producer in module.producers:
                 if hasattr(producer,'srFlags'):
                     producer.srFlags = cms.InputTag("")
                 if hasattr(producer,'qualityTests'):
                     for qualityTest in producer.qualityTests:
                         if hasattr(qualityTest,'thresholds'):
                             qualityTest.applySelectionsToAllCrystals = cms.bool(True)
-                        
+
     return process
 
 
 
-# 
+#
 # The three different set of thresholds will be used to study
 # possible new thresholds of pfrechits and effects on high level objects
 # The values proposed (A, B, C) are driven by expected noise levels
@@ -123,22 +128,22 @@ def customiseForEcalTestPR22254thresholdA(process):
     from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
     from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import _particle_flow_zero_suppression_ECAL_2018_A
 
-    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
-        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']:
+        if hasattr(process,hltParticleFlowRecHitECAL):
             module = getattr(process,hltParticleFlowRecHitECAL)
 
-            for producer in module.producers: 
+            for producer in module.producers:
                 if hasattr(producer,'srFlags'):
                     producer.srFlags = cms.InputTag("")
                 if hasattr(producer,'qualityTests'):
                     for qualityTest in producer.qualityTests:
                         if hasattr(qualityTest,'thresholds'):
-                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_A.thresholds 
+                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_A.thresholds
                             qualityTest.applySelectionsToAllCrystals = cms.bool(True)
-                        
+
     return process
 
-                   
+
 
 
 
@@ -147,19 +152,19 @@ def customiseForEcalTestPR22254thresholdB(process):
     from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
     from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import _particle_flow_zero_suppression_ECAL_2018_B
 
-    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
-        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']:
+        if hasattr(process,hltParticleFlowRecHitECAL):
             module = getattr(process,hltParticleFlowRecHitECAL)
 
-            for producer in module.producers: 
+            for producer in module.producers:
                 if hasattr(producer,'srFlags'):
                     producer.srFlags = cms.InputTag("")
                 if hasattr(producer,'qualityTests'):
                     for qualityTest in producer.qualityTests:
                         if hasattr(qualityTest,'thresholds'):
-                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_B.thresholds 
+                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_B.thresholds
                             qualityTest.applySelectionsToAllCrystals = cms.bool(True)
-                        
+
     return process
 
 
@@ -170,19 +175,19 @@ def customiseForEcalTestPR22254thresholdC(process):
     from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
     from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import _particle_flow_zero_suppression_ECAL_2018_C
 
-    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
-        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']:
+        if hasattr(process,hltParticleFlowRecHitECAL):
             module = getattr(process,hltParticleFlowRecHitECAL)
 
-            for producer in module.producers: 
+            for producer in module.producers:
                 if hasattr(producer,'srFlags'):
                     producer.srFlags = cms.InputTag("")
                 if hasattr(producer,'qualityTests'):
                     for qualityTest in producer.qualityTests:
                         if hasattr(qualityTest,'thresholds'):
-                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_C.thresholds 
+                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_C.thresholds
                             qualityTest.applySelectionsToAllCrystals = cms.bool(True)
-                        
+
     return process
 
 
@@ -191,5 +196,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseFor25469(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -33,11 +33,11 @@ def customiseForUncollapsed(process):
 
     for producer in producers_by_type(process, "PFMultiDepthClusterProducer"):
         producer.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector[1].logWeightDenominator = _thresholdsHEphase1HCAL
-
+    
     for producer in producers_by_type(process, "PFRecHitProducer"):
         if producer.producers[0].name.value() == 'PFHBHERecHitCreator':
             producer.producers[0].qualityTests[0].cuts[1].threshold = _thresholdsHEphase1Rec
-
+    
     for producer in producers_by_type(process, "CaloTowersCreator"):
         producer.HcalPhase     = cms.int32(1)
         producer.HESThreshold1 = cms.double(0.1)
@@ -52,13 +52,8 @@ def customiseForUncollapsed(process):
     process.HLTStoppedHSCPLocalHcalReco = cms.Sequence( process.hltHcalDigis + process.hltHbhereco )
 
 
-    return process
+    return process    
 
-# Set new variable use8ts for Mahi
-def customiseFor25469(process):
-    for producer in producers_by_type(process, "HBHEPhase1Reconstructor"):
-        producer.use8ts                = cms.bool(False)
-    return process
 
 def customiseFor21664_forMahiOn(process):
     for producer in producers_by_type(process, "HBHEPhase1Reconstructor"):
@@ -101,23 +96,23 @@ def customiseFor2017DtUnpacking(process):
 # particleFlowRechitECAL new default value "false" flag to be added
 def customiseForEcalTestPR22254Default(process):
 
-    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']:
-        if hasattr(process,hltParticleFlowRecHitECAL):
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
             module = getattr(process,hltParticleFlowRecHitECAL)
 
-            for producer in module.producers:
+            for producer in module.producers: 
                 if hasattr(producer,'srFlags'):
                     producer.srFlags = cms.InputTag("")
                 if hasattr(producer,'qualityTests'):
                     for qualityTest in producer.qualityTests:
                         if hasattr(qualityTest,'thresholds'):
                             qualityTest.applySelectionsToAllCrystals = cms.bool(True)
-
+                        
     return process
 
 
 
-#
+# 
 # The three different set of thresholds will be used to study
 # possible new thresholds of pfrechits and effects on high level objects
 # The values proposed (A, B, C) are driven by expected noise levels
@@ -128,22 +123,22 @@ def customiseForEcalTestPR22254thresholdA(process):
     from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
     from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import _particle_flow_zero_suppression_ECAL_2018_A
 
-    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']:
-        if hasattr(process,hltParticleFlowRecHitECAL):
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
             module = getattr(process,hltParticleFlowRecHitECAL)
 
-            for producer in module.producers:
+            for producer in module.producers: 
                 if hasattr(producer,'srFlags'):
                     producer.srFlags = cms.InputTag("")
                 if hasattr(producer,'qualityTests'):
                     for qualityTest in producer.qualityTests:
                         if hasattr(qualityTest,'thresholds'):
-                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_A.thresholds
+                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_A.thresholds 
                             qualityTest.applySelectionsToAllCrystals = cms.bool(True)
-
+                        
     return process
 
-
+                   
 
 
 
@@ -152,19 +147,19 @@ def customiseForEcalTestPR22254thresholdB(process):
     from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
     from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import _particle_flow_zero_suppression_ECAL_2018_B
 
-    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']:
-        if hasattr(process,hltParticleFlowRecHitECAL):
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
             module = getattr(process,hltParticleFlowRecHitECAL)
 
-            for producer in module.producers:
+            for producer in module.producers: 
                 if hasattr(producer,'srFlags'):
                     producer.srFlags = cms.InputTag("")
                 if hasattr(producer,'qualityTests'):
                     for qualityTest in producer.qualityTests:
                         if hasattr(qualityTest,'thresholds'):
-                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_B.thresholds
+                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_B.thresholds 
                             qualityTest.applySelectionsToAllCrystals = cms.bool(True)
-
+                        
     return process
 
 
@@ -175,19 +170,19 @@ def customiseForEcalTestPR22254thresholdC(process):
     from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
     from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import _particle_flow_zero_suppression_ECAL_2018_C
 
-    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']:
-        if hasattr(process,hltParticleFlowRecHitECAL):
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
             module = getattr(process,hltParticleFlowRecHitECAL)
 
-            for producer in module.producers:
+            for producer in module.producers: 
                 if hasattr(producer,'srFlags'):
                     producer.srFlags = cms.InputTag("")
                 if hasattr(producer,'qualityTests'):
                     for qualityTest in producer.qualityTests:
                         if hasattr(qualityTest,'thresholds'):
-                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_C.thresholds
+                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_C.thresholds 
                             qualityTest.applySelectionsToAllCrystals = cms.bool(True)
-
+                        
     return process
 
 
@@ -196,6 +191,5 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-    process = customiseFor25469(process)
 
     return process

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -134,7 +134,7 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
   }
   else {
     bxSize = bxSizeConf_;
-    nnlsWork_.bxOffset = bxOffsetConf_;
+    nnlsWork_.bxOffset = bxOffsetConf_ + (nnlsWork_.tsOffset + activeBXs_[0]);
   }
 
   nnlsWork_.nPulseTot = bxSize;
@@ -147,7 +147,7 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
   }
   else {
     for (unsigned int iBX=0; iBX<bxSize; ++iBX) {
-      nnlsWork_.bxs.coeffRef(iBX) = activeBXs_[iBX];
+      nnlsWork_.bxs.coeffRef(iBX) = activeBXs_[iBX] - ( nnlsWork_.tsOffset + activeBXs_[0]);
     }
   }
 
@@ -275,12 +275,12 @@ void MahiFit::updatePulseShape(double itQ, FullSampleVector &pulseShape, FullSam
 
   //in the 2018+ case where the sample of interest (SOI) is in TS3, add an extra offset to align 
   //with previous SOI=TS4 case assumed by psfPtr_->getPulseShape()
-  int delta =nnlsWork_. tsOffset == 3 ? 1 : 0;
+  int delta =  4 - nnlsWork_. tsOffset;
 
   for (unsigned int iTS=0; iTS<nnlsWork_.tsSize; ++iTS) {
 
     pulseShape.coeffRef(iTS+nnlsWork_.maxoffset) = nnlsWork_.pulseN[iTS+delta];
-    pulseDeriv.coeffRef(iTS+nnlsWork_.maxoffset) = 0.5*(nnlsWork_.pulseM[iTS+delta]+nnlsWork_.pulseP[iTS+delta])/(2*nnlsWork_.dt);
+    pulseDeriv.coeffRef(iTS+nnlsWork_.maxoffset) = 0.5*(nnlsWork_.pulseM[iTS+delta]-nnlsWork_.pulseP[iTS+delta])/(2*nnlsWork_.dt);
 
     nnlsWork_.pulseM[iTS] -= nnlsWork_.pulseN[iTS];
     nnlsWork_.pulseP[iTS] -= nnlsWork_.pulseN[iTS];

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -291,8 +291,9 @@ void MahiFit::updatePulseShape(double itQ, FullSampleVector &pulseShape, FullSam
       
       double tmp = 0.5*( nnlsWork_.pulseP[iTS+delta]*nnlsWork_.pulseP[jTS+delta] +
 			 nnlsWork_.pulseM[iTS+delta]*nnlsWork_.pulseM[jTS+delta] );
-
+  
       pulseCov(jTS+nnlsWork_.maxoffset,iTS+nnlsWork_.maxoffset) += tmp;      
+      if(iTS!=jTS) pulseCov(iTS+nnlsWork_.maxoffset,jTS+nnlsWork_.maxoffset) += tmp;
       
     }
   }

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -292,7 +292,6 @@ void MahiFit::updatePulseShape(double itQ, FullSampleVector &pulseShape, FullSam
       double tmp = 0.5*( nnlsWork_.pulseP[iTS+delta]*nnlsWork_.pulseP[jTS+delta] +
 			 nnlsWork_.pulseM[iTS+delta]*nnlsWork_.pulseM[jTS+delta] );
 
-      pulseCov(iTS+nnlsWork_.maxoffset,jTS+nnlsWork_.maxoffset) += tmp;
       pulseCov(jTS+nnlsWork_.maxoffset,iTS+nnlsWork_.maxoffset) += tmp;      
       
     }
@@ -572,7 +571,7 @@ void MahiFit::phase1Debug(const HBHEChannelInfo& channelData,
     else if (nnlsWork_.bxs.coeff(iBX)==1) {
       mdi.nEnergy=nnlsWork_.ampVec.coeff(iBX);
       for(unsigned int iTS=0; iTS<nnlsWork_.tsSize; ++iTS){
-	mdi.nPulse[iTS] = nnlsWork_.pulseMat.col(iBX).coeff(iTS);
+        mdi.nPulse[iTS] = nnlsWork_.pulseMat.col(iBX).coeff(iTS);
       }
     }
   }  

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -134,7 +134,7 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
   }
   else {
     bxSize = bxSizeConf_;
-    nnlsWork_.bxOffset = bxOffsetConf_ + (nnlsWork_.tsOffset + activeBXs_[0]);
+    nnlsWork_.bxOffset = bxOffsetConf_ + ((static_cast<int>(nnlsWork_.tsOffset) + activeBXs_[0]) >= 0 ? 0 : (nnlsWork_.tsOffset + activeBXs_[0]));
   }
 
   nnlsWork_.nPulseTot = bxSize;
@@ -147,7 +147,7 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
   }
   else {
     for (unsigned int iBX=0; iBX<bxSize; ++iBX) {
-      nnlsWork_.bxs.coeffRef(iBX) = activeBXs_[iBX] - ( nnlsWork_.tsOffset + activeBXs_[0]);
+      nnlsWork_.bxs.coeffRef(iBX) = activeBXs_[iBX] - ((static_cast<int>(nnlsWork_.tsOffset) + activeBXs_[0]) >= 0 ? 0 : (nnlsWork_.tsOffset + activeBXs_[0]));
     }
   }
 
@@ -172,13 +172,11 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
       nnlsWork_.pulseMat.col(iBX) = SampleVector::Ones(nnlsWork_.tsSize);
     }
     else {
-
       updatePulseShape(nnlsWork_.amplitudes.coeff(nnlsWork_.tsOffset + offset), 
 		       nnlsWork_.pulseShapeArray[iBX], 
 		       nnlsWork_.pulseDerivArray[iBX],
 		       nnlsWork_.pulseCovArray[iBX]);
       
-
       nnlsWork_.pulseMat.col(iBX) = nnlsWork_.pulseShapeArray[iBX].segment(nnlsWork_.maxoffset - offset, nnlsWork_.tsSize);
     }
   }

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -74,6 +74,9 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
     double ped = channelData.tsPedestal(iTS);
 
     nnlsWork_.amplitudes.coeffRef(iTS) = charge - ped;
+   
+    // protect from negativity by putting 0 when charge - ped < 0
+    if(nnlsWork_.amplitudes.coeffRef(iTS)<0) nnlsWork_.amplitudes.coeffRef(iTS)=0; 
 
     //ADC granularity
     double noiseADC = (1./sqrt(12))*channelData.tsDFcPerADC(iTS);

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -134,7 +134,7 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
   }
   else {
     bxSize = bxSizeConf_;
-    nnlsWork_.bxOffset = bxOffsetConf_ + ((static_cast<int>(nnlsWork_.tsOffset) + activeBXs_[0]) >= 0 ? 0 : (nnlsWork_.tsOffset + activeBXs_[0]));
+    nnlsWork_.bxOffset = static_cast<int>(nnlsWork_.tsOffset) >= bxOffsetConf_ ? bxOffsetConf_ : nnlsWork_.tsOffset;
   }
 
   nnlsWork_.nPulseTot = bxSize;

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -75,9 +75,6 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
 
     nnlsWork_.amplitudes.coeffRef(iTS) = charge - ped;
    
-    // protect from negativity by putting 0 when charge - ped < 0
-    if(nnlsWork_.amplitudes.coeffRef(iTS)<0) nnlsWork_.amplitudes.coeffRef(iTS)=0; 
-
     //ADC granularity
     double noiseADC = (1./sqrt(12))*channelData.tsDFcPerADC(iTS);
 

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
@@ -3,10 +3,10 @@ import FWCore.ParameterSet.Config as cms
 # Configuration parameters for Mahi
 mahiParameters = cms.PSet(
 
-    dynamicPed        = cms.bool(True),
+    dynamicPed        = cms.bool(False),
     ts4Thresh         = cms.double(0.0),
     chiSqSwitch       = cms.double(15.0),
-    activeBXs         = cms.vint32(-1, 0, 1),
+    activeBXs         = cms.vint32(-3, -2, -1, 0, 1, 2, 3, 4),
     nMaxItersMin      = cms.int32(500),
     nMaxItersNNLS     = cms.int32(500),
     deltaChiSqThresh  = cms.double(1e-3),

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -45,6 +45,10 @@ hbheprereco = cms.EDProducer(
     # collection will not include such channels even if this flag is set.
     saveDroppedInfos = cms.bool(False),
 
+    # Flag to use only 8 TSs for reconstruction. This should be in effect
+    # only when there are 10 TSs, e.g., <=2017
+    use8ts = cms.bool(True),
+
     # Parameters which define how we calculate the charge for the basic SiPM
     # nonlinearity correction. To sum up the charge in all time slices
     # (e.g., for cosmics), set sipmQTSShift to -100 and sipmQNTStoSum to 200.

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -506,14 +506,12 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
         int soiCapid = 4;
         
         // Use only 8 TSs when there are 10 TSs 
-        int shiftOneTS = 0;
-        if(use8ts_ && maxTS==10) shiftOneTS = 1;
+        const int shiftOneTS = use8ts_ && maxTS == static_cast<int>(HBHEChannelInfo::MAXSAMPLES) ? 1 : 0;
+        const int nCycles = maxTS - shiftOneTS;
 
         // Go over time slices and fill the samples
-        for (int ts = 0; ts < maxTS; ++ts)
+        for (int ts = shiftOneTS; ts < nCycles; ++ts)
         {
-            if(use8ts_ && maxTS==10 && (ts==0 || ts==(maxTS-1))) continue;
-
             auto s(frame[ts]);
             const uint8_t adc = s.adc();
             const int capid = s.capid();
@@ -531,7 +529,7 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
             channelInfo->setSample(ts-shiftOneTS, adc, dfc, rawCharge,
                                    pedestal, pedestalWidth,
                                    gain, gainWidth, t);
-            if ((ts-shiftOneTS) == (soi-shiftOneTS))
+            if (ts == soi)
                 soiCapid = capid;
         }
 
@@ -775,7 +773,7 @@ HBHEPhase1Reconstructor::fillDescriptions(edm::ConfigurationDescriptions& descri
     desc.add<bool>("tsFromDB");
     desc.add<bool>("recoParamsFromDB");
     desc.add<bool>("saveEffectivePedestal", false);
-    desc.add<bool>("use8ts");
+    desc.add<bool>("use8ts", false);
     desc.add<int>("sipmQTSShift", 0);
     desc.add<int>("sipmQNTStoSum", 3);
     desc.add<bool>("setNegativeFlagsQIE8");


### PR DESCRIPTION
HCAL DPG wants to make changes to the configuration of Mahi; we like to use 8 pulses instead of 3 and remove the baseline. 

It was noticed that Mahi fit sometimes does not fit data correctly, particularly when there is a significant charge in OOT time slices. Also, the baseline is occasionally incapable of extracting a flat component properly. 

We tested various configurations (different number of pulses and with/without baseline), and found that the 8-pulse without baseline fit performs best.  

Details can be found in [1]. There are links to more studies (p35). 

[1] https://indico.cern.ch/event/774376/contributions/3230469/attachments/1764961/2865685/20181204_Jae_HCALDPG_RecoConfigUL.pdf