### PR TITLE
MTD geometry: Update MTDGeometryBuilder test to make it really useful for MTD reco geometry

### DIFF
--- a/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
@@ -4,8 +4,10 @@ process = cms.Process("GeometryTest")
 # empty input service, fire 10 events
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
+process.MessageLogger.cerr.INFO.limit = -1
+
 # Choose Tracker Geometry
-process.load("Configuration.Geometry.GeometryExtended2023D24_cff")
+process.load("Configuration.Geometry.GeometryExtended2023D35_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi")
 


### PR DESCRIPTION
The original tracker geometry test copied in MTDGeometryBuilder is updated to produce a useful dump to check the reconstruction geometry and topology for MTD.

Used to dump existing geometries scenarios proposed for the forthcoming 10_4_0_mtd2 build.