### PR TITLE
Fix the forgotten new default for 2018 HI vertex smearing (as in 10_3_X)

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -61,4 +61,4 @@ VtxSmeared = {
     'RealisticPbPbCollision2018' : 'IOMC.EventVertexGenerators.VtxSmearedRealisticPbPbCollision2018_cfi',
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
-VtxSmearedHIDefaultKey='RealisticHICollision2015'
+VtxSmearedHIDefaultKey='RealisticPbPbCollision2018'


### PR DESCRIPTION
Fixing the missing change in #25390 that is instead present in the 10_3_X backport #25419 .
Supersedes #25456 .