### PR TITLE
Add treatment for C-style arrays in friendly class names

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -26,6 +26,7 @@ namespace edm {
     static std::regex const reTemplateArgs("[^<]*<(.*)>$");
     static std::regex const reTemplateClass("([^<>,]+<[^<>]*>)");
     static std::regex const rePointer("\\*");
+    static std::regex const reArray("\\[\\]");
     static std::string const emptyString("");
 
     std::string handleNamespaces(std::string const& iIn) {
@@ -81,6 +82,7 @@ namespace edm {
        using std::regex;
        std::string name = regex_replace(iIn, reWrapper, "$1");
        name = regex_replace(name,rePointer,"ptr");
+       name = regex_replace(name,reArray,"As");
        name = regex_replace(name,reAIKR,"");
        name = regex_replace(name,reclangabi,"std::");
        name = regex_replace(name,reCXX11,"std::");

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -93,6 +93,9 @@ void testfriendlyName::test()
   classToFriendly.insert( Values("edm::RefVector<edm::AssociationMap<edm::OneToOne<std::vector<reco::BasicCluster>,std::vector<reco::ClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> >,edm::Ref<std::vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::ClusterShape>,reco::ClusterShape> > >,edm::AssociationMap<edm::OneToOne<std::vector<reco::BasicCluster>,std::vector<reco::ClusterShape>,unsigned int> >::Find>",
                                  "recoBasicClustersToOnerecoClusterShapesAssociationRefs"));
   classToFriendly.insert( Values("std::vector<std::pair<const pat::Muon *, TLorentzVector>>","constpatMuonptrTLorentzVectorstdpairs") );
+  classToFriendly.insert( Values("int[]", "intAs") );
+  classToFriendly.insert( Values("foo<int[]>", "intAsfoo") );
+  classToFriendly.insert( Values("bar<foo<int[]>>", "intAsfoobar") );
   
   
   for(std::map<std::string, std::string>::iterator itInfo = classToFriendly.begin(),


### PR DESCRIPTION
I noticed that product class names like `bar<foo<int[]>>` lead to infinite loop within the friendly name system (to reproduce run `edmToFriendlyClassName "bar<foo<int[]>>" `). I suppose that happens because the brackets `[]` have a special meaning in the regex syntax, and this replacement
https://github.com/cms-sw/cmssw/blob/623eb3549b81dd5ac779e94de6fac2d35aa36274/FWCore/Utilities/src/FriendlyName.cc#L123-L125
ends up doing nothing when `theSub` is `int[]`. Rather than to mess with the regexes, this PR suggests to add a "standard rename" for C-style arrays.

Tested in 10_4_0_pre3, no changes expected.
