### PR TITLE
New training for anti-e tau-Id

### DIFF
--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -304,6 +304,7 @@ hpsPFTauDiscriminationByMVA6rawElectronRejection = pfRecoTauDiscriminationAgains
     PFTauProducer = cms.InputTag('hpsPFTauProducer'),
     Prediscriminants = requireDecayMode.clone(),
     loadMVAfromDB = cms.bool(True),
+    vetoEcalCracks = cms.bool(True),
     mvaName_NoEleMatch_woGwoGSF_BL = cms.string("RecoTauTag_antiElectronMVA6v1_gbr_NoEleMatch_woGwoGSF_BL"),
     mvaName_NoEleMatch_wGwoGSF_BL = cms.string("RecoTauTag_antiElectronMVA6v1_gbr_NoEleMatch_wGwoGSF_BL"),
     mvaName_woGwGSF_BL = cms.string("RecoTauTag_antiElectronMVA6v1_gbr_woGwGSF_BL"),

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -18,6 +18,7 @@ loadRecoTauTagMVAsFromPrepDB = cms.ESSource( "PoolDBESSource",
                                              pfnPrefix        = cms.untracked.string( '' ),
                                              )
 
+####
 # register tau ID (= isolation) discriminator MVA
 tauIdDiscrMVA_trainings = {
     'tauIdMVAoldDMwoLT' : "tauIdMVAoldDMwoLT",
@@ -297,7 +298,8 @@ for ver2017 in tauIdDiscrMVA_2017_version:
         )
 
 ####
-# register anti-electron discriminator MVA
+## register anti-electron discriminator MVA
+# MVA5
 antiElectronDiscrMVA5_categories = {
      '0' : "gbr_NoEleMatch_woGwoGSF_BL",
      '1' : "gbr_NoEleMatch_woGwGSF_BL",
@@ -335,6 +337,7 @@ for category, gbrForestName in antiElectronDiscrMVA5_categories.items():
             )
         )
 
+# MVA6v1
 antiElectronDiscrMVA6_categories = {
      '0' : "gbr_NoEleMatch_woGwoGSF_BL",
      '2' : "gbr_NoEleMatch_wGwoGSF_BL",
@@ -363,7 +366,28 @@ for category, gbrForestName in antiElectronDiscrMVA6_categories.items():
                 label = cms.untracked.string("RecoTauTag_antiElectronMVA6%s_%s_WP%s" % (antiElectronDiscrMVA6_version, gbrForestName, WP))
             )
         )
+# MVA6v3
+# MB: categories as in MVA6v1
+antiElectronDiscrMVA6_2017_WPs = [ "eff98", "eff90", "eff80", "eff70", "eff60" ]
+antiElectronDiscrMVA6_2017_version = "v3_noeveto"
+for category, gbrForestName in antiElectronDiscrMVA6_categories.items():
+    loadRecoTauTagMVAsFromPrepDB.toGet.append(
+        cms.PSet(
+            record = cms.string('GBRWrapperRcd'),
+            tag = cms.string("RecoTauTag_antiElectronMVA6%s_%s" % (antiElectronDiscrMVA6_2017_version, gbrForestName)),
+            label = cms.untracked.string("RecoTauTag_antiElectronMVA6%s_%s" % (antiElectronDiscrMVA6_2017_version, gbrForestName))
+        )
+    )
+    for WP in antiElectronDiscrMVA6_2017_WPs:
+        loadRecoTauTagMVAsFromPrepDB.toGet.append(
+            cms.PSet(
+                record = cms.string('PhysicsTGraphPayloadRcd'),
+                tag = cms.string("RecoTauTag_antiElectronMVA6%s_%s_WP%s" % (antiElectronDiscrMVA6_2017_version, gbrForestName, WP)),
+                label = cms.untracked.string("RecoTauTag_antiElectronMVA6%s_%s_WP%s" % (antiElectronDiscrMVA6_2017_version, gbrForestName, WP))
+            )
+        )
     
+####
 # register anti-muon discriminator MVA
 antiMuonDiscrMVA_WPs = [ "eff99_5", "eff99_0", "eff98_0" ]
 antiMuonDiscrMVA_version = "v1"

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
@@ -147,6 +147,9 @@ PATTauDiscriminantCutMultiplexer::PATTauDiscriminantCutMultiplexer(const edm::Pa
   key_ = cfg.getParameter<edm::InputTag>("key");
   key_token = consumes<pat::PATTauDiscriminator>(key_);
 
+  verbosity_ = ( cfg.exists("verbosity") ) ?
+    cfg.getParameter<int>("verbosity") : 0;
+
   loadMVAfromDB_ = cfg.exists("loadMVAfromDB") ? cfg.getParameter<bool>("loadMVAfromDB") : false;
   if ( !loadMVAfromDB_ ) {
     if(cfg.exists("inputFileName")){
@@ -179,7 +182,7 @@ PATTauDiscriminantCutMultiplexer::PATTauDiscriminantCutMultiplexer(const edm::Pa
     }
     cuts_[category] = std::move(cut);
   }
-  verbosity_ = ( cfg.exists("verbosity") ) ? cfg.getParameter<int>("verbosity") : 0;
+
   if(verbosity_) std::cout << "constructed " << moduleLabel_ << std::endl;
 }
 

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
@@ -197,7 +197,7 @@ void PATTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const e
     //Only open the file once and we can close it when this routine is done
     // since all objects gotten from the file will have been copied
     std::unique_ptr<TFile> inputFile;
-    if ( mvaOutputNormalizationName_ != "" ) {
+    if ( !mvaOutputNormalizationName_.empty() ) {
       if ( !loadMVAfromDB_ ) {
 	inputFile = openInputFile(inputFileName_);
 	mvaOutput_normalization_ = loadObjectFromFile<TFormula>(*inputFile, mvaOutputNormalizationName_);

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronMVA6.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronMVA6.cc
@@ -33,6 +33,7 @@ class PATTauDiscriminationAgainstElectronMVA6 : public PATTauDiscriminationProdu
 
     srcElectrons = cfg.getParameter<edm::InputTag>("srcElectrons");
     electronToken = consumes<pat::ElectronCollection>(srcElectrons);
+    vetoEcalCracks_ = cfg.getParameter<bool>("vetoEcalCracks");
     verbosity_ = ( cfg.exists("verbosity") ) ?
       cfg.getParameter<int>("verbosity") : 0;
 
@@ -60,7 +61,9 @@ private:
   edm::Handle<TauCollection> taus_;
 
   std::unique_ptr<PATTauDiscriminator> category_output_;
-		
+
+  bool vetoEcalCracks_;
+
   int verbosity_;
 };
 
@@ -110,7 +113,7 @@ double PATTauDiscriminationAgainstElectronMVA6::discriminate(const TauRef& theTa
             hasGsfTrack = theElectron.gsfTrack().isNonnull();
 
 	  // veto taus that go to Ecal crack
-	  if ( isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance) ) {
+	  if ( vetoEcalCracks_ && (isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance)) ) {
 	    // add category index
 	    category_output_->setValue(tauIndex_, category);
 	    // return MVA output value
@@ -145,7 +148,7 @@ double PATTauDiscriminationAgainstElectronMVA6::discriminate(const TauRef& theTa
       if( abs(packedLeadTauCand->pdgId()) == 11 ) hasGsfTrack = true;
           
       // veto taus that go to Ecal crack
-      if ( isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance) ) {
+      if (  vetoEcalCracks_ && (isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance)) ) {
 	// add category index
 	category_output_->setValue(tauIndex_, category);
 	// return MVA output value

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
@@ -36,7 +36,7 @@ class PFRecoTauDiscriminationAgainstElectronMVA6 : public PFTauDiscriminationPro
 
     srcGsfElectrons_ = cfg.getParameter<edm::InputTag>("srcGsfElectrons");
     GsfElectrons_token = consumes<reco::GsfElectronCollection>(srcGsfElectrons_);
-
+    vetoEcalCracks_ = cfg.getParameter<bool>("vetoEcalCracks");
     verbosity_ = ( cfg.exists("verbosity") ) ?
       cfg.getParameter<int>("verbosity") : 0;
 
@@ -64,6 +64,8 @@ private:
   edm::Handle<TauCollection> taus_;
 
   std::unique_ptr<PFTauDiscriminator> category_output_;
+
+  bool vetoEcalCracks_;
 
   int verbosity_;
 };
@@ -144,7 +146,7 @@ double PFRecoTauDiscriminationAgainstElectronMVA6::discriminate(const PFTauRef& 
             hasGsfTrack = theGsfElectron.gsfTrack().isNonnull();
 
 	  //// Veto taus that go to Ecal crack
-	  if ( isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance) ) {
+	  if ( vetoEcalCracks_ && (isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance)) ) {
 	    // add category index
 	    category_output_->setValue(tauIndex_, category);
 	    // return MVA output value
@@ -179,7 +181,7 @@ double PFRecoTauDiscriminationAgainstElectronMVA6::discriminate(const PFTauRef& 
       bool hasGsfTrack = thePFTauRef->leadPFChargedHadrCand()->gsfTrackRef().isNonnull();
       
       //// Veto taus that go to Ecal crack
-      if ( isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance) ) {
+      if ( vetoEcalCracks_ && (isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance)) ) {
 	// add category index
 	category_output_->setValue(tauIndex_, category);
 	// return MVA output value

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
@@ -148,7 +148,6 @@ RecoTauDiscriminantCutMultiplexer::RecoTauDiscriminantCutMultiplexer(const edm::
   verbosity_ = ( cfg.exists("verbosity") ) ?
     cfg.getParameter<int>("verbosity") : 0;
 
-
   loadMVAfromDB_ = cfg.exists("loadMVAfromDB") ? cfg.getParameter<bool>("loadMVAfromDB") : false;
   if ( !loadMVAfromDB_ ) {
     if(cfg.exists("inputFileName")){
@@ -182,8 +181,6 @@ RecoTauDiscriminantCutMultiplexer::RecoTauDiscriminantCutMultiplexer(const edm::
     cuts_[category] = std::move(cut);
   }
 
-  verbosity_ = ( cfg.exists("verbosity") ) ?
-    cfg.getParameter<int>("verbosity") : 0;
   if(verbosity_) std::cout << "constructed " << moduleLabel_ << std::endl;
 }
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
@@ -195,7 +195,7 @@ void RecoTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const 
     //Only open the file once and we can close it when this routine is done
     // since all objects gotten from the file will have been copied
     std::unique_ptr<TFile> inputFile;
-    if ( mvaOutputNormalizationName_ != "" ) {
+    if ( !mvaOutputNormalizationName_.empty() ) {
       if ( !loadMVAfromDB_ ) {
 	inputFile = openInputFile(inputFileName_);
 	mvaOutput_normalization_ = loadObjectFromFile<TFormula>(*inputFile, mvaOutputNormalizationName_);

--- a/RecoTauTag/RecoTau/python/PATTauDiscriminationAgainstElectronMVA6_cfi.py
+++ b/RecoTauTag/RecoTau/python/PATTauDiscriminationAgainstElectronMVA6_cfi.py
@@ -34,5 +34,6 @@ patTauDiscriminationAgainstElectronMVA6 = cms.EDProducer("PATTauDiscriminationAg
     minMVAWgWgsfEC             = cms.double(0.0),
 
     srcElectrons = cms.InputTag('slimmedElectrons'),
+    vetoEcalCracks = cms.bool(True),
     usePhiAtEcalEntranceExtrapolation = cms.bool(False)
 )

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationAgainstElectronMVA6_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationAgainstElectronMVA6_cfi.py
@@ -35,5 +35,6 @@ pfRecoTauDiscriminationAgainstElectronMVA6 = cms.EDProducer("PFRecoTauDiscrimina
     minMVAWgWgsfEC             = cms.double(0.0),
 
     srcGsfElectrons = cms.InputTag('gedGsfElectrons'),
+    vetoEcalCracks = cms.bool(True),
     usePhiAtEcalEntranceExtrapolation = cms.bool(False)
 )

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -705,6 +705,283 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1)
             self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1
 
+        if "againstEle2018" in self.toKeep:
+            antiElectronDiscrMVA6_version = "MVA6v3_noeveto"
+            ### Define new anti-e discriminants
+            ## Raw
+            from RecoTauTag.RecoTau.PATTauDiscriminationAgainstElectronMVA6_cfi import patTauDiscriminationAgainstElectronMVA6
+            self.process.patTauDiscriminationByElectronRejectionMVA62018Raw = patTauDiscriminationAgainstElectronMVA6.clone(
+                Prediscriminants = noPrediscriminants, #already selected for MiniAOD
+                vetoEcalCracks = self.cms.bool(False), #keep taus in EB-EE cracks
+                mvaName_NoEleMatch_wGwoGSF_BL = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL',
+                mvaName_NoEleMatch_wGwoGSF_EC = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC',
+                mvaName_NoEleMatch_woGwoGSF_BL = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL',
+                mvaName_NoEleMatch_woGwoGSF_EC = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC',
+                mvaName_wGwGSF_BL = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL',
+                mvaName_wGwGSF_EC = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC',
+                mvaName_woGwGSF_BL = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL',
+                mvaName_woGwGSF_EC = 'RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC'
+            )
+            ## WPs
+            from RecoTauTag.RecoTau.PATTauDiscriminantCutMultiplexer_cfi import patTauDiscriminantCutMultiplexer
+            # VLoose
+            self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018 = patTauDiscriminantCutMultiplexer.clone(
+                PATTauProducer = self.process.patTauDiscriminationByElectronRejectionMVA62018Raw.PATTauProducer,
+                Prediscriminants = self.process.patTauDiscriminationByElectronRejectionMVA62018Raw.Prediscriminants,
+                toMultiplex = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"),
+                key = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw","category"),
+                mapping = self.cms.VPSet(
+                    self.cms.PSet(
+                        category = self.cms.uint32(0),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_WPeff98'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(2),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_WPeff98'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(5),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_WPeff98'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(7),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_WPeff98'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(8),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_WPeff98'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(10),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_WPeff98'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(13),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_WPeff98'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(15),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_WPeff98'),
+                        variable = self.cms.string('pt')
+                    )
+                )
+            )
+            # Loose
+            self.process.patTauDiscriminationByLooseElectronRejectionMVA62018 = self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018.clone(
+                mapping = self.cms.VPSet(
+                    self.cms.PSet(
+                        category = self.cms.uint32(0),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_WPeff90'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(2),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_WPeff90'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(5),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_WPeff90'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(7),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_WPeff90'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(8),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_WPeff90'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(10),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_WPeff90'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(13),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_WPeff90'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(15),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_WPeff90'),
+                        variable = self.cms.string('pt')
+                    )
+                )
+            )
+            # Medium
+            self.process.patTauDiscriminationByMediumElectronRejectionMVA62018 = self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018.clone(
+                mapping = self.cms.VPSet(
+                    self.cms.PSet(
+                        category = self.cms.uint32(0),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_WPeff80'),
+                        variable = self.cms.string('pt')
+                     ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(2),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_WPeff80'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(5),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_WPeff80'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(7),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_WPeff80'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(8),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_WPeff80'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(10),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_WPeff80'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(13),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_WPeff80'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(15),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_WPeff80'),
+                        variable = self.cms.string('pt')
+                    )
+                )
+            )
+            # Tight
+            self.process.patTauDiscriminationByTightElectronRejectionMVA62018 = self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018.clone(
+                mapping = self.cms.VPSet(
+                    self.cms.PSet(
+                        category = self.cms.uint32(0),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_WPeff70'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(2),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_WPeff70'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(5),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_WPeff70'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(7),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_WPeff70'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(8),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_WPeff70'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(10),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_WPeff70'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(13),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_WPeff70'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(15),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_WPeff70'),
+                        variable = self.cms.string('pt')
+                    )
+                )
+            )
+            # VTight
+            self.process.patTauDiscriminationByVTightElectronRejectionMVA62018 = self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018.clone(
+                mapping = self.cms.VPSet(
+                    self.cms.PSet(
+                        category = self.cms.uint32(0),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_BL_WPeff60'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(2),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_BL_WPeff60'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(5),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_BL_WPeff60'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(7),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_BL_WPeff60'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(8),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_woGwoGSF_EC_WPeff60'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(10),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_NoEleMatch_wGwoGSF_EC_WPeff60'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(13),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_woGwGSF_EC_WPeff60'),
+                        variable = self.cms.string('pt')
+                    ),
+                    self.cms.PSet(
+                        category = self.cms.uint32(15),
+                        cut = self.cms.string('RecoTauTag_antiElectron'+antiElectronDiscrMVA6_version+'_gbr_wGwGSF_EC_WPeff60'),
+                        variable = self.cms.string('pt')
+                    )
+                )
+            )
+            ### Put all new anti-e discrminats to a sequence
+            self.process.patTauDiscriminationByElectronRejectionMVA62018Task = self.cms.Task(
+                self.process.patTauDiscriminationByElectronRejectionMVA62018Raw,
+                self.process.patTauDiscriminationByVLooseElectronRejectionMVA62018,
+                self.process.patTauDiscriminationByLooseElectronRejectionMVA62018,
+                self.process.patTauDiscriminationByMediumElectronRejectionMVA62018,
+                self.process.patTauDiscriminationByTightElectronRejectionMVA62018,
+                self.process.patTauDiscriminationByVTightElectronRejectionMVA62018
+            )
+            self.process.patTauDiscriminationByElectronRejectionMVA62018Seq = self.cms.Sequence(self.process.patTauDiscriminationByElectronRejectionMVA62018Task)
+            self.process.rerunMvaIsolationTask.add(self.process.patTauDiscriminationByElectronRejectionMVA62018Task)
+            self.process.rerunMvaIsolationSequence += self.process.patTauDiscriminationByElectronRejectionMVA62018Seq
+
+            _againstElectronTauIDSources = self.cms.PSet(
+                againstElectronMVA6Raw2018 = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw"),
+                againstElectronMVA6category2018 = self.cms.InputTag("patTauDiscriminationByElectronRejectionMVA62018Raw","category"),
+                againstElectronVLooseMVA62018 = self.cms.InputTag("patTauDiscriminationByVLooseElectronRejectionMVA62018"),
+                againstElectronLooseMVA62018 = self.cms.InputTag("patTauDiscriminationByLooseElectronRejectionMVA62018"),
+                againstElectronMediumMVA62018 = self.cms.InputTag("patTauDiscriminationByMediumElectronRejectionMVA62018"),
+                againstElectronTightMVA62018 = self.cms.InputTag("patTauDiscriminationByTightElectronRejectionMVA62018"),
+                againstElectronVTightMVA62018 = self.cms.InputTag("patTauDiscriminationByVTightElectronRejectionMVA62018")
+            )
+            _tauIDSourcesWithAgainistEle = self.cms.PSet(
+                tauIDSources.clone(),
+                _againstElectronTauIDSources
+            )
+            tauIDSources =_tauIDSourcesWithAgainistEle.clone()
+
+        ##
         print('Embedding new TauIDs into \"'+self.updatedTauName+'\"')
         embedID = self.cms.EDProducer("PATTauIDEmbedder",
             src = self.cms.InputTag('slimmedTaus'),

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -17,7 +17,8 @@ process.load('Configuration.Geometry.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-process.GlobalTag.globaltag = '103X_upgrade2018_realistic_v8'
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic', '')
 
 # Input source
 process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(
@@ -34,7 +35,8 @@ tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
                     toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2",
                                "deepTau2017v1",
                                "DPFTau_2016_v0",
-                               # "DPFTau_2016_v1"
+                               # "DPFTau_2016_v1",
+                               "againstEle2018",
                                ])
 tauIdEmbedder.runTauID()
 


### PR DESCRIPTION
This PR adds configuration for payloads with a new training of anti-e tau-Id. It follows changes introduced by #24800.
In addition, this PR adds a switch to remove/keep tau candidates in the EB-EE crack regions (|eta|~1.5). Those regions are covered by the new training (but not by the old one) to allow recovery of efficiency. By default the switch is set to value recovering previous behavior (removal of candidates in EB-EE cracks) thus this does not breaks backward compatibility.
We intend to backport this PR to 102X and 94X to be used in Run-2 analyses and be included to NanoAOD with 102X (different PR via NanoAOD repo will be prepared). 