### PR TITLE
Fixes OOTPU for BTLDigitisation

### DIFF
--- a/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
@@ -88,14 +88,16 @@ void BTLTileDeviceSim::getHitsResponse(const std::vector<std::tuple<int,uint32_t
     if ( smearLightCollTime_ > 0. )
       toa += CLHEP::RandGaussQ::shoot(hre, 0., smearLightCollTime_);
 
-    // --- Accumulate the energy of simHits in the same crystal
-    if ( toa < bxTime_ )  // this is to simulate the charge integration in a 25 ns window
-      (simHitIt->second).hit_info[0][0] += Npe;
+    if ( toa > bxTime_ || toa < 0 ) //just consider BX==0
+      continue;
 
+    (simHitIt->second).hit_info[0][0] += Npe;
+    
     // --- Store the time of the first SimHit
-    if( (simHitIt->second).hit_info[1][0] == 0 )
+    if( (simHitIt->second).hit_info[1][0] == 0 ||
+	toa < (simHitIt->second).hit_info[1][0]
+	)
       (simHitIt->second).hit_info[1][0] = toa;
-
+    
   } // hitRef loop
-
 }


### PR DESCRIPTION
Fixes a problem of using OOTPU hits in BTL giving rise to a large peak at saturated TDC value. Important to be taken for the ongoing DIGI-RECO MTD TDR campaign.
Plots are the BTL rechits time as obtained from a SingleMu Pt10 GUN with average 10 PU events before and after the fix:
Before
![screen shot 2018-12-13 at 18 40 30](https://user-images.githubusercontent.com/4571680/49962988-0ea7aa80-ff17-11e8-8b9c-a6b3ef670967.png)
After
![screen shot 2018-12-13 at 20 39 24](https://user-images.githubusercontent.com/4571680/49963115-63e3bc00-ff17-11e8-8ed1-22cc301a69f6.png)


 