### PR TITLE
Clean-up Geant4 sensitive detectors 7

### DIFF
--- a/SimG4CMS/CherenkovAnalysis/BuildFile.xml
+++ b/SimG4CMS/CherenkovAnalysis/BuildFile.xml
@@ -4,15 +4,12 @@
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="SimG4Core/SensitiveDetector"/>
 <use   name="SimG4Core/Notification"/>
-<use   name="SimG4Core/Application"/>
 <use   name="SimG4CMS/Calo"/>
 <use   name="DataFormats/Math"/>
 <use   name="SimDataFormats/SimHitMaker"/>
 <use   name="SimDataFormats/CaloHit"/>
 <use   name="DetectorDescription/Core"/>
-<use   name="boost"/>
 <use   name="geant4core"/>
-<use   name="root"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -2,10 +2,8 @@
 #define SimG4CMS_DreamSD_h
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "G4String.hh"
 #include "G4PhysicsOrderedFreeVector.hh"
 
 #include <map>
@@ -14,8 +12,6 @@ const int MAXPHOTONS = 500; // Maximum number of photons we can store
 
 class G4LogicalVolume;
 
-class TTree;
-
 class DreamSD : public CaloSD {
 
 public:    
@@ -23,12 +19,11 @@ public:
   DreamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
   ~DreamSD() override {}
-  //  bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+
   uint32_t setDetUnitId(const G4Step*) override;
 
 protected:
 
-  // G4bool getStepInfo(G4Step* aStep) override;
   double getEnergyDeposit(const G4Step* ) override;
   void   initRun() override;
 
@@ -39,8 +34,8 @@ private:
 
   void           initMap(const std::string&, const DDCompactView &);
   double         curve_LY(const G4Step*, int); 
-  const double   crystalLength(G4LogicalVolume*) const;
-  const double   crystalWidth(G4LogicalVolume*) const;
+  double         crystalLength(G4LogicalVolume*) const;
+  double         crystalWidth(G4LogicalVolume*) const;
 
   /// Returns the total energy due to Cherenkov radiation
   double         cherenkovDeposit_(const G4Step* aStep );
@@ -66,12 +61,8 @@ private:
   /// Table of Cherenkov angle integrals vs photon momentum
   std::unique_ptr<G4PhysicsOrderedFreeVector> chAngleIntegrals_;
   G4MaterialPropertiesTable* materialPropertiesTable;
-  // Histogramming
-  TTree* ntuple_;
-  int nphotons_;
-  float px_[MAXPHOTONS],py_[MAXPHOTONS],pz_[MAXPHOTONS];
-  float x_[MAXPHOTONS],y_[MAXPHOTONS],z_[MAXPHOTONS];
 
+  int nphotons_;
 };
 
 #endif // DreamSD_h

--- a/SimG4CMS/CherenkovAnalysis/interface/PMTResponse.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/PMTResponse.h
@@ -6,19 +6,12 @@
 ///   Encodes the PMT response function
 ///
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 class PMTResponse {
 
 public:    
 
-  /// Default constructor
-  PMTResponse() {}
-
   /// Return efficiency for given photon wavelength (in nm)
-  static const double  getEfficiency( const double& waveLengthNm );
-
-private:    
+  static double getEfficiency( const double& waveLengthNm );
 
 };
 

--- a/SimG4CMS/CherenkovAnalysis/plugins/BuildFile.xml
+++ b/SimG4CMS/CherenkovAnalysis/plugins/BuildFile.xml
@@ -1,16 +1,13 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="SimG4Core/SensitiveDetector"/>
 <use   name="SimG4Core/Notification"/>
-<use   name="SimG4Core/Application"/>
 <use   name="SimG4CMS/Calo"/>
 <use   name="SimDataFormats/SimHitMaker"/>
 <use   name="SimDataFormats/CaloHit"/>
 <use   name="DetectorDescription/Core"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="boost"/>
 <use   name="geant4core"/>
-<use   name="root"/>
 <library   file="*.cc" name="SimG4CMSCherenkovAnalysisPlugins">
   <use   name="SimG4CMS/CherenkovAnalysis"/>
   <flags   EDM_PLUGIN="1"/>

--- a/SimG4CMS/CherenkovAnalysis/src/PMTResponse.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/PMTResponse.cc
@@ -1,17 +1,17 @@
-#include "TMath.h"
-
 #include "SimG4CMS/CherenkovAnalysis/interface/PMTResponse.h"
 
+#include <cmath>
+
 //________________________________________________________________________________________
-const double PMTResponse::getEfficiency( const double& waveLengthNm ) {
+double PMTResponse::getEfficiency( const double& waveLengthNm ) {
 
   // Overall range
   if ( waveLengthNm<300. || waveLengthNm>850 ) return 0.;
 
   // Parameterisation
   if ( waveLengthNm<500. )
-    return TMath::Exp(+waveLengthNm/144.3 - 5.0752);
+    return std::exp(+waveLengthNm/144.3 - 5.0752);
   else
-    return TMath::Exp(-waveLengthNm/290.7 + 0.1105);
+    return std::exp(-waveLengthNm/290.7 + 0.1105);
   
 }

--- a/SimG4CMS/HcalTestBeam/BuildFile.xml
+++ b/SimG4CMS/HcalTestBeam/BuildFile.xml
@@ -12,7 +12,6 @@
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="geant4core"/>
-<use   name="boost"/>
 <use   name="root"/>
 <use   name="hepmc"/>
 <use   name="rootmath"/>

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
@@ -24,7 +24,7 @@
 #include "SimG4CMS/HcalTestBeam/interface/HcalTB02NumberingScheme.h"
 
 #include "G4String.hh"
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class HcalTB02SD : public CaloSD {
 

--- a/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
@@ -86,22 +86,18 @@ HcalTB02SD::~HcalTB02SD() {
  
 double HcalTB02SD::getEnergyDeposit(const G4Step * aStep) {
   
-  if (aStep == nullptr) {
-    return 0;
-  } else {
-    auto const preStepPoint = aStep->GetPreStepPoint();
-    auto const & nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
+  auto const preStepPoint = aStep->GetPreStepPoint();
+  auto const & nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
 
-    // take into account light collection curve for crystals
-    double weight = 1.;
-    if (useWeight) weight *= curve_LY(nameVolume, preStepPoint);
-    if (useBirk)   weight *= getAttenuation(aStep, birk1, birk2, birk3);
-    double edep   = aStep->GetTotalEnergyDeposit() * weight;
-    LogDebug("HcalTBSim") << "HcalTB02SD:: " << nameVolume
-			  <<" Light Collection Efficiency " << weight 
-			  << " Weighted Energy Deposit " << edep/MeV << " MeV";
-    return edep;
-  } 
+  // take into account light collection curve for crystals
+  double weight = 1.;
+  if (useWeight) weight *= curve_LY(nameVolume, preStepPoint);
+  if (useBirk)   weight *= getAttenuation(aStep, birk1, birk2, birk3);
+  double edep   = aStep->GetTotalEnergyDeposit() * weight;
+  LogDebug("HcalTBSim") << "HcalTB02SD:: " << nameVolume
+			<<" Light Collection Efficiency " << weight 
+			<< " Weighted Energy Deposit " << edep/MeV << " MeV";
+  return edep;
 }
 
 uint32_t HcalTB02SD::setDetUnitId(const G4Step * aStep) { 

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
@@ -13,7 +13,7 @@
 #include "DetectorDescription/Core/interface/DDSplit.h"
 #include "DetectorDescription/Core/interface/DDValue.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/Exception.h" 
 
 #include "G4Step.hh"
 #include "G4Track.hh"
@@ -89,7 +89,6 @@ HcalTB06BeamSD::HcalTB06BeamSD(const std::string& name,
   } else {
     matName = "Not Found";
   }
-
   edm::LogInfo("HcalTB06BeamSD") << "HcalTB06BeamSD: Material name for " 
 				 << attribute << " = " << name << ":" 
 				 << matName;

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -242,8 +242,7 @@ void RunManager::initG4(const edm::EventSetup & es)
   
   std::pair< std::vector<SensitiveTkDetector*>,
     std::vector<SensitiveCaloDetector*> > sensDets = 
-    m_attach->create(*world,(*pDD),catalog_,m_p,m_trackManager.get(),
-		     m_registry);
+    m_attach->create((*pDD),catalog_,m_p,m_trackManager.get(),m_registry);
       
   m_sensTkDets.swap(sensDets.first);
   m_sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -111,8 +111,8 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
     << "RunManagerMT: start initialisation of geometry";
   
   // DDDWorld: get the DDCV from the ES and use it to build the World
-  G4LogicalVolumeToDDLogicalPartMap map_;
-  m_world.reset(new DDDWorld(pDD, map_, m_catalog, false));
+  G4LogicalVolumeToDDLogicalPartMap map_lv;
+  m_world.reset(new DDDWorld(pDD, map_lv, m_catalog, false));
   m_registry.dddWorldSignal_(m_world.get());
 
   // setup the magnetic field
@@ -177,7 +177,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   m_physicsList->SetCutsWithDefault();
 
   if(m_pPhysics.getParameter<bool>("CutsPerRegion")) {
-    m_prodCuts.reset(new DDG4ProductionCuts(map_, verb, m_pPhysics));	
+    m_prodCuts.reset(new DDG4ProductionCuts(map_lv, verb, m_pPhysics));	
     m_prodCuts->update();
   }
   
@@ -288,8 +288,9 @@ void RunManagerMT::DumpMagneticField(const G4Field* field) const
       << " RunManager WARNING : "
       << "error opening file <" << m_FieldFile << "> for magnetic field";
   } else {
+    // CMS magnetic field volume
     double rmax = 9000*mm;
-    double zmax = 16000*mm;
+    double zmax = 24000*mm;
 
     double dr = 5*cm;
     double dz = 20*cm;

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -44,6 +44,8 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
 
 #include "G4Event.hh"
 #include "G4Run.hh"
@@ -245,10 +247,7 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
   AttachSD attach;
   std::pair< std::vector<SensitiveTkDetector*>,
     std::vector<SensitiveCaloDetector*> > sensDets =
-    attach.create(runManagerMaster.world(),
-                  (*pDD),
-                  runManagerMaster.catalog(),
-                  m_p,
+    attach.create(*pDD, runManagerMaster.catalog(), m_p,
                   m_tls->trackManager.get(),
                   *(m_tls->registry.get()));
 

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -44,9 +44,9 @@ G4LogicalVolume * DDG4Builder::convertLV(const DDLogicalPart & part) {
   LogDebug("SimG4CoreGeometry") << "DDG4Builder::convertLV(): DDLogicalPart = " << part << "\n";
   G4LogicalVolume * result = logs_[part];
   if (!result) {
-    G4VSolid * s   = convertSolid(part.solid());
-    G4Material * m = convertMaterial(part.material());
-    result = new G4LogicalVolume(s,m,part.name().name());
+    G4VSolid * g4s   = convertSolid(part.solid());
+    G4Material * g4m = convertMaterial(part.material());
+    result = new G4LogicalVolume(g4s,g4m,part.name().name());
     map_.insert(result,part);
     DDG4Dispatchable * disp = new DDG4Dispatchable(&part,result);	
     theVectorOfDDG4Dispatchables_->push_back(disp);
@@ -194,42 +194,40 @@ DDGeometryReturnType DDG4Builder::BuildGeometry() {
   return DDGeometryReturnType(world,map_,catalog);    
 }
 
-int DDG4Builder::getInt(const std::string & s, const DDLogicalPart & part)
+int DDG4Builder::getInt(const std::string & ss, const DDLogicalPart & part)
 {
-  DDValue val(s);
+  DDValue val(ss);
   std::vector<const DDsvalues_type *> result = part.specifics();
-  std::vector<const DDsvalues_type *>::iterator it = result.begin();
   bool foundIt = false;
-  for (; it != result.end(); ++it) {
-    foundIt = DDfetch(*it,val);
+  for (auto stype : result) {
+    foundIt = DDfetch(stype,val);
     if (foundIt) break;
   }    
   if (foundIt) { 
     std::vector<double> temp = val.doubles();
     if (temp.size() != 1) {
-      edm::LogError("SimG4CoreGeometry") << " DDG4Builder - ERROR: I need only 1 " << s;
-      throw cms::Exception("SimG4CoreGeometry", " DDG4Builder::getInt() Problem with Region tags - one and only one allowed: " + s);
+      edm::LogError("SimG4CoreGeometry") << " DDG4Builder - ERROR: I need only 1 " << ss;
+      throw cms::Exception("SimG4CoreGeometry", " DDG4Builder::getInt() Problem with Region tags - one and only one allowed: " + ss);
     }      
     return int(temp[0]);
   }
   else return 0;
 }
 
-double DDG4Builder::getDouble(const std::string & s, 
+double DDG4Builder::getDouble(const std::string & ss, 
 			      const DDLogicalPart & part) {
-  DDValue val(s);
+  DDValue val(ss);
   std::vector<const DDsvalues_type *> result = part.specifics();
-  std::vector<const DDsvalues_type *>::iterator it = result.begin();
   bool foundIt = false;
-  for (; it != result.end(); ++it) {
-    foundIt = DDfetch(*it,val);
+  for (auto stype : result) {
+    foundIt = DDfetch(stype,val);
     if (foundIt) break;
   }    
   if (foundIt) { 
     std::vector<std::string> temp = val.strings();
     if (temp.size() != 1) {
-      edm::LogError("SimG4CoreGeometry") << " DDG4Builder - ERROR: I need only 1 " << s ;
-      throw cms::Exception("SimG4CoreGeometry", " DDG4Builder::getDouble() Problem with Region tags - one and only one allowed: " + s);
+      edm::LogError("SimG4CoreGeometry") << " DDG4Builder - ERROR: I need only 1 " << ss;
+      throw cms::Exception("SimG4CoreGeometry", " DDG4Builder::getDouble() Problem with Region tags - one and only one allowed: " + ss);
     }
     double v;
     std::string unit;

--- a/SimG4Core/Geometry/src/DDG4SensitiveConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SensitiveConverter.cc
@@ -5,9 +5,6 @@
 
 #include "G4LogicalVolume.hh"
 
-//using std::string;
-//using std::vector;
-
 DDG4SensitiveConverter::DDG4SensitiveConverter() {}
 
 DDG4SensitiveConverter::~DDG4SensitiveConverter() {}
@@ -17,8 +14,7 @@ SensitiveDetectorCatalog DDG4SensitiveConverter::upDate(const DDG4DispContainer 
   LogDebug("SimG4CoreGeometry") <<" DDG4SensitiveConverter::upDate() starts" ;
   SensitiveDetectorCatalog catalog;
 
-  for (unsigned int i=0; i<ddg4s.size(); i++)  {
-    DDG4Dispatchable * ddg4 = ddg4s[i];
+  for (auto ddg4 : ddg4s)  {
     const DDLogicalPart * part   = (ddg4->getDDLogicalPart());
     G4LogicalVolume *     result = (ddg4->getG4LogicalVolume());
   
@@ -27,7 +23,7 @@ SensitiveDetectorCatalog DDG4SensitiveConverter::upDate(const DDG4DispContainer 
     std::string fff        = result->GetName();
     if (sClassName != "NotFound") {
       LogDebug("SimG4CoreGeometry") << " DDG4SensitiveConverter: Sensitive " << fff
-				    << " Class Name " << sClassName << " ROU Name " << sROUName ;	    
+				    << " Class Name " << sClassName << " ROU Name " << sROUName;
       fff = result->GetName();
       catalog.insert(sClassName,sROUName,fff);
     }

--- a/SimG4Core/Geometry/src/DDG4SensitiveConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SensitiveConverter.cc
@@ -5,8 +5,8 @@
 
 #include "G4LogicalVolume.hh"
 
-using std::string;
-using std::vector;
+//using std::string;
+//using std::vector;
 
 DDG4SensitiveConverter::DDG4SensitiveConverter() {}
 
@@ -35,22 +35,21 @@ SensitiveDetectorCatalog DDG4SensitiveConverter::upDate(const DDG4DispContainer 
   return catalog;
 }
 
-std::string DDG4SensitiveConverter::getString(const std::string & s, 
+std::string DDG4SensitiveConverter::getString(const std::string & ss, 
 					      const DDLogicalPart * part) {
   std::vector<std::string> temp;
-  DDValue val(s);
+  DDValue val(ss);
   std::vector<const DDsvalues_type *> result = part->specifics();
-  std::vector<const DDsvalues_type *>::iterator it = result.begin();
   bool foundIt = false;
-  for (; it != result.end(); ++it) {
-    foundIt = DDfetch(*it,val);
+  for (auto stype : result) {
+    foundIt = DDfetch(stype,val);
     if (foundIt) break;
   }    
   if (foundIt) { 
     temp = val.strings(); 
     if (temp.size() != 1) {
-      edm::LogError("SimG4CoreGeometry") << "DDG4SensitiveConverter - ERROR: I need 1 " << s << " tags" ;
-      throw cms::Exception("SimG4CoreGeometry", " DDG4SensitiveConverter::getString Problem with Region tags - one and only one allowed: " + s);
+      edm::LogError("SimG4CoreGeometry") << "DDG4SensitiveConverter - ERROR: I need 1 " << ss << " tags" ;
+      throw cms::Exception("SimG4CoreGeometry", " DDG4SensitiveConverter::getString Problem with Region tags - one and only one allowed: " + ss);
     }
     return temp[0]; 
   }

--- a/SimG4Core/GeometryProducer/BuildFile.xml
+++ b/SimG4Core/GeometryProducer/BuildFile.xml
@@ -5,7 +5,8 @@
 <use   name="SimG4Core/Geometry"/>
 <use   name="SimG4Core/SensitiveDetector"/>
 <use   name="SimG4Core/MagneticField"/>
-<use   name="SimG4Core/Application"/>
+<use   name="MagneticField/Engine"/>
+<use   name="MagneticField/Records"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -139,7 +139,7 @@ void GeometryProducer::produce(edm::Event & e, const edm::EventSetup & es)
        {
            std::pair< std::vector<SensitiveTkDetector*>,
                std::vector<SensitiveCaloDetector*> > 
-             sensDets = m_attach->create(*world,(*pDD),catalog_,m_p,m_trackManager.get(),m_registry);
+             sensDets = m_attach->create((*pDD),catalog_,m_p,m_trackManager.get(),m_registry);
           
            m_sensTkDets.swap(sensDets.first);
            m_sensCaloDets.swap(sensDets.second);

--- a/SimG4Core/SensitiveDetector/BuildFile.xml
+++ b/SimG4Core/SensitiveDetector/BuildFile.xml
@@ -1,8 +1,8 @@
+<use   name="FWCore/MessageLogger"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="SimG4Core/Geometry"/>
+<use   name="SimG4Core/Notification"/>
+<use   name="geant4core"/>
 <export>
   <lib   name="1"/>
 </export>
-<use   name="SimG4Core/Geometry"/>
-<use   name="SimG4Core/Notification"/>
-<use   name="boost"/>
-<use   name="geant4core"/>
-<use   name="sigcpp"/>

--- a/SimG4Core/SensitiveDetector/interface/AttachSD.h
+++ b/SimG4Core/SensitiveDetector/interface/AttachSD.h
@@ -1,13 +1,13 @@
 #ifndef SimG4Core_SensitiveDetector_AttachSD_h
 #define SimG4Core_SensitiveDetector_AttachSD_h
 
-
-#include "SimG4Core/Geometry/interface/DDDWorld.h"
 #include <vector>
 
 namespace edm {
   class ParameterSet;
 }
+class DDCompactView;
+class SensitiveDetectorCatalog;
 class SensitiveTkDetector;
 class SensitiveCaloDetector;
 class SimActivityRegistry;
@@ -21,11 +21,11 @@ public:
 
   std::pair< std::vector<SensitiveTkDetector*>,
     std::vector<SensitiveCaloDetector*> > 
-    create(const DDDWorld &, const DDCompactView &,
-	   const SensitiveDetectorCatalog &,
-	   edm::ParameterSet const &,
-	   const SimTrackManager*,
-	   SimActivityRegistry& reg ) const;
+    create(const DDCompactView &,
+           const SensitiveDetectorCatalog &,
+           edm::ParameterSet const &,
+           const SimTrackManager*,
+           SimActivityRegistry& reg ) const;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
@@ -13,7 +13,7 @@ public:
   explicit SensitiveCaloDetector(const std::string & iname, const DDCompactView & cpv,
 				 const SensitiveDetectorCatalog & clg,
 				 edm::ParameterSet const & p) :
-  SensitiveDetector(iname,cpv,clg,p) {}
+  SensitiveDetector(iname,cpv,clg,p,true) {};
 
   virtual void fillHits(edm::PCaloHitContainer &, const std::string& hname) = 0;
 };

--- a/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
@@ -11,8 +11,8 @@ class SensitiveCaloDetector : public SensitiveDetector
 {
 public:
   explicit SensitiveCaloDetector(const std::string & iname, const DDCompactView & cpv,
-				 const SensitiveDetectorCatalog & clg,
-				 edm::ParameterSet const & p) :
+                                 const SensitiveDetectorCatalog & clg,
+                                 edm::ParameterSet const & p) :
   SensitiveDetector(iname,cpv,clg,p,true) {};
 
   virtual void fillHits(edm::PCaloHitContainer &, const std::string& hname) = 0;

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -25,7 +25,9 @@ public:
   explicit SensitiveDetector(const std::string & iname, 
                              const DDCompactView & cpv,
 			     const SensitiveDetectorCatalog &,
-			     edm::ParameterSet const & p);
+			     edm::ParameterSet const & p,
+                             bool calo = false);
+
   ~SensitiveDetector() override;
 
   void Initialize(G4HCofThisEvent * eventHC) override;
@@ -37,6 +39,8 @@ public:
 
   inline const std::vector<std::string>& getNames() const { return namesOfSD; }
  
+  inline bool isCaloSD() const { return isCalo; }
+
 protected:
 
   // generic geometry methods, all coordinates in mm
@@ -60,6 +64,7 @@ private:
   void AssignSD(const std::string & vname);
 
   std::vector<std::string> namesOfSD;
+  bool isCalo;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -24,9 +24,9 @@ class SensitiveDetector : public G4VSensitiveDetector
 public:
   explicit SensitiveDetector(const std::string & iname, 
                              const DDCompactView & cpv,
-			     const SensitiveDetectorCatalog &,
-			     edm::ParameterSet const & p,
-                             bool calo = false);
+                             const SensitiveDetectorCatalog &,
+                             edm::ParameterSet const & p,
+                             bool calo);
 
   ~SensitiveDetector() override;
 
@@ -37,9 +37,9 @@ public:
   virtual uint32_t setDetUnitId(const G4Step * step) = 0;
   virtual void clearHits() = 0;
 
-  inline const std::vector<std::string>& getNames() const { return namesOfSD; }
+  inline const std::vector<std::string>& getNames() const { return m_namesOfSD; }
  
-  inline bool isCaloSD() const { return isCalo; }
+  inline bool isCaloSD() const { return m_isCalo; }
 
 protected:
 
@@ -48,6 +48,7 @@ protected:
   Local3DPoint InitialStepPosition(const G4Step * step, coordinates) const;
   Local3DPoint FinalStepPosition(const G4Step * step, coordinates) const;
 
+  // local coordinates to the volume, in which the step is done
   Local3DPoint LocalPreStepPosition(const G4Step * step) const;
   Local3DPoint LocalPostStepPosition(const G4Step * step) const;
 
@@ -63,8 +64,8 @@ private:
 
   void AssignSD(const std::string & vname);
 
-  std::vector<std::string> namesOfSD;
-  bool isCalo;
+  std::vector<std::string> m_namesOfSD;
+  bool m_isCalo;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -10,38 +10,41 @@
 //         Created:  Mon Nov 14 11:56:05 EST 2005
 //
 
-// system include files
-#include <memory>
-
 // user include files
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
 #include "SimG4Core/Notification/interface/SimActivityRegistryEnroller.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 // forward declarations
+class DDCompactView;
+class SimTrackManager;
+class SimActivityRegistry;
+class SensitiveDetectorCatalog;
+
+namespace edm{
+  class ParameterSet;
+}
 
 template<class T>
 class SensitiveDetectorMaker : public SensitiveDetectorMakerBase
 {
 public:
-  SensitiveDetectorMaker(){}
+  explicit SensitiveDetectorMaker() {};
 
   // ---------- const member functions ---------------------
-  void make(const std::string& iname,
-	    const DDCompactView& cpv,
-	    const SensitiveDetectorCatalog& clg,
-	    const edm::ParameterSet& p,
-	    const SimTrackManager* man,
-	    SimActivityRegistry& reg,
-	    std::auto_ptr<SensitiveTkDetector>& oTK,
-	    std::auto_ptr<SensitiveCaloDetector>& oCalo) const override
+  SensitiveDetector* make(const std::string& iname,
+                          const DDCompactView& cpv,
+                          const SensitiveDetectorCatalog& clg,
+                          const edm::ParameterSet& p,
+                          const SimTrackManager* man,
+                          SimActivityRegistry& reg) const override
   {
-    std::auto_ptr<T> returnValue(new T(iname, cpv, clg, p, man));
-    SimActivityRegistryEnroller::enroll(reg, returnValue.get());
-
-    convertTo(returnValue.get(), oTK, oCalo);
-    //ownership was passed in the previous function
-    returnValue.release();
-  }
+    T* sd = new T(iname, cpv, clg, p, man);
+    SimActivityRegistryEnroller::enroll(reg, sd);
+    return static_cast<SensitiveDetector*>(sd);
+  };
 
 private:
   SensitiveDetectorMaker(const SensitiveDetectorMaker&) = delete;

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -11,15 +11,13 @@
 
 // system include files
 #include <string>
-#include <memory>
 
-// user include files
-#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
-#include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
 // forward declarations
 class SimActivityRegistry;
 class DDCompactView;
 class SimTrackManager;
+class SensitiveCaloDetector;
+class SensitiveTkDetector;
 
 namespace edm{
   class ParameterSet;
@@ -29,32 +27,16 @@ class SensitiveDetectorMakerBase
 {
 
 public:
-  SensitiveDetectorMakerBase(){}
-  virtual ~SensitiveDetectorMakerBase(){}
+  explicit SensitiveDetectorMakerBase() {};
+  virtual ~SensitiveDetectorMakerBase() {};
 
   // ---------- const member functions ---------------------
-  virtual void make(const std::string& iname,
-		    const DDCompactView& cpv,
-		    const SensitiveDetectorCatalog& clg,
-		    const edm::ParameterSet& p,
-		    const SimTrackManager* man,
-		    SimActivityRegistry& reg,
-		    std::auto_ptr<SensitiveTkDetector>& oTK,
-		    std::auto_ptr<SensitiveCaloDetector>& oCalo) const =0;
-      
-protected:
-  //used to identify which type of Sensitive Detector we have
-  void convertTo( SensitiveTkDetector* iFrom, 
-		  std::auto_ptr<SensitiveTkDetector>& oTo,
-		  std::auto_ptr<SensitiveCaloDetector>) const{
-    oTo = std::auto_ptr<SensitiveTkDetector>(iFrom);
-  }
-
-  void convertTo( SensitiveCaloDetector* iFrom,
-		  std::auto_ptr<SensitiveTkDetector>,
-		  std::auto_ptr<SensitiveCaloDetector>& oTo) const{
-    oTo = std::auto_ptr<SensitiveCaloDetector>(iFrom);
-  }
+  virtual SensitiveDetector* make(const std::string& iname,
+                                  const DDCompactView& cpv,
+                                  const SensitiveDetectorCatalog& clg,
+                                  const edm::ParameterSet& p,
+                                  const SimTrackManager* man,
+                                  SimActivityRegistry& reg) const = 0;
 
 private:
   SensitiveDetectorMakerBase(const SensitiveDetectorMakerBase&) = delete;

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -9,6 +9,8 @@
 //         Created:  Mon Nov 14 11:50:24 EST 2005
 //
 
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
+
 // system include files
 #include <string>
 
@@ -16,8 +18,7 @@
 class SimActivityRegistry;
 class DDCompactView;
 class SimTrackManager;
-class SensitiveCaloDetector;
-class SensitiveTkDetector;
+class SensitiveDetectorCatalog;
 
 namespace edm{
   class ParameterSet;
@@ -25,7 +26,6 @@ namespace edm{
 
 class SensitiveDetectorMakerBase
 {
-
 public:
   explicit SensitiveDetectorMakerBase() {};
   virtual ~SensitiveDetectorMakerBase() {};

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h
@@ -1,9 +1,10 @@
 #ifndef SimG4Core_SensitiveDetector_SensitiveDetectorPluginFactory_H
 #define SimG4Core_SensitiveDetector_SensitiveDetectorPluginFactory_H
 
-# include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
-# include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h"
-# include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h"
+#include "FWCore/PluginManager/interface/PluginFactory.h"
 
 #include <string>
 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
@@ -9,9 +9,9 @@ class SensitiveTkDetector : public SensitiveDetector
 {
 public:
   explicit SensitiveTkDetector(const std::string & iname, const DDCompactView & cpv,
-			       const SensitiveDetectorCatalog & clg,
-			       edm::ParameterSet const & p) : 
-  SensitiveDetector(iname, cpv, clg, p) {}
+                               const SensitiveDetectorCatalog & clg,
+                               edm::ParameterSet const & p) : 
+  SensitiveDetector(iname, cpv, clg, p, false) {}
   virtual void fillHits(edm::PSimHitContainer &, const std::string& hname) = 0;
 
 };

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -1,23 +1,24 @@
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
-#include <string>
-#include <vector>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <string>
+#include <sstream>
 
 AttachSD::AttachSD() {}
 
 AttachSD::~AttachSD() {}
 
 std::pair< std::vector<SensitiveTkDetector*>,
-	   std::vector<SensitiveCaloDetector*> > 
-AttachSD::create(const DDDWorld & w, 
-		 const DDCompactView & cpv,
-		 const SensitiveDetectorCatalog & clg,
-		 edm::ParameterSet const & p,
-		 const SimTrackManager* man,
-		 SimActivityRegistry& reg) const
+           std::vector<SensitiveCaloDetector*> > 
+AttachSD::create(const DDCompactView & cpv,
+                 const SensitiveDetectorCatalog & clg,
+                 edm::ParameterSet const & p,
+                 const SimTrackManager* man,
+                 SimActivityRegistry& reg) const
 {
   std::pair< std::vector<SensitiveTkDetector *>,std::vector<SensitiveCaloDetector*> > detList;
   const std::vector<std::string>& rouNames = clg.readoutNames();
@@ -27,22 +28,22 @@ AttachSD::create(const DDDWorld & w,
   for (auto & rname : rouNames) {
     std::string className = clg.className(rname);
     temp.reset(SensitiveDetectorPluginFactory::get()->create(className));
-    std::auto_ptr<SensitiveTkDetector> tkDet;
-    std::auto_ptr<SensitiveCaloDetector> caloDet;
-    temp.get()->make(rname,cpv,clg,p,man,reg,tkDet,caloDet);
-    edm::LogVerbatim("SimG4CoreSensitiveDetector") 
-      << " AttachSD: created a " << className << " with name " << rname 
-      << " TkDet <" << tkDet.get() << "> caloDet<" << caloDet.get() << ">"
-      << " temp= <" << temp.get() << ">";
-    if(tkDet.get()){
-      detList.first.push_back(tkDet.get());
-      tkDet.release();
+
+    SensitiveDetector* sd = temp.get()->make(rname,cpv,clg,p,man,reg);
+    
+    std::stringstream ss;
+    ss << " AttachSD: created a " << className << " with name " << rname;
+ 
+    if(sd->isCaloSD()) {
+      SensitiveCaloDetector* caloDet = (SensitiveCaloDetector*)(sd);
+      detList.second.push_back(caloDet);
+      ss << " + calo SD"; 
+    } else {
+      SensitiveTkDetector* tkDet = (SensitiveTkDetector*)(sd);
+      detList.first.push_back(tkDet);
+      ss << " + tracking SD"; 
     }
-    if(caloDet.get()){
-      detList.second.push_back(caloDet.get());
-      caloDet.release();
-    }
+    edm::LogVerbatim("SimG4CoreSensitiveDetector") << ss.str();
   }      
   return detList;
 }
-

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -18,8 +18,9 @@
 SensitiveDetector::SensitiveDetector(const std::string & iname, 
 				     const DDCompactView & cpv,
 				     const SensitiveDetectorCatalog & clg,
-				     edm::ParameterSet const & p) :
-  G4VSensitiveDetector(iname) 
+				     edm::ParameterSet const & p,
+				     bool calo) :
+  G4VSensitiveDetector(iname), isCalo(calo)
 {
   // for CMS hits
   namesOfSD.push_back(iname);

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -20,10 +20,10 @@ SensitiveDetector::SensitiveDetector(const std::string & iname,
 				     const SensitiveDetectorCatalog & clg,
 				     edm::ParameterSet const & p,
 				     bool calo) :
-  G4VSensitiveDetector(iname), isCalo(calo)
+  G4VSensitiveDetector(iname), m_isCalo(calo)
 {
   // for CMS hits
-  namesOfSD.push_back(iname);
+  m_namesOfSD.push_back(iname);
 
   // Geant4 hit collection
   collectionName.insert(iname);
@@ -112,8 +112,8 @@ TrackInformation* SensitiveDetector::cmsTrackInformation(const G4Track* aTrack)
 
 void SensitiveDetector::setNames(const std::vector<std::string>& hnames)
 {
-  namesOfSD.clear();
-  namesOfSD = hnames;
+  m_namesOfSD.clear();
+  m_namesOfSD = hnames;
 }
 
 void SensitiveDetector::NaNTrap(const G4Step* aStep) const


### PR DESCRIPTION
In this PR only simple technical clean-up of base classes of Geant4 sensitive detectors (SD) is proposed. The correctness of this PR corresponds to "no change" in comparisons. What was improved:
1) removed remaining auto_ptr 
2) removed unused dependence of SD from DDDWorld, only DDCompactView is used
3) removed remaining dependences from SD sub-libraries on SimG4Core/Application (potential circular dependence)
4) use more forward declarations, removed unused includes
5) improved verbose output
6) removed analysis objects from SD classes
7) followed CMSSW code guidelines