### PR TITLE
L1T offline DQM - Fix logic error in L1T muon DQM

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -40,6 +40,9 @@ MuonGmtPair::MuonGmtPair(const reco::Muon *muon, const l1t::Muon *regMu, const P
         if (trajectory.isValid()) {
             m_eta = trajectory.globalPosition().eta();
             m_phi = trajectory.globalPosition().phi();
+        } else {
+            m_eta = 999.;
+            m_phi = 999.;
         }
     } else {
         m_eta = 999.;


### PR DESCRIPTION
Fix logic error found by static checks.
Garbage values for muon coordinates in case the extrapolated trajectory is not valid.