### PR TITLE
updated lost plugins definition for SiPixelQuality

### DIFF
--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -76,6 +76,7 @@ equivDict = \
          {'TauReco'               : ['reco::PFJetRef']},
          {'JetReco'               : ['reco::.*Jet','reco::.*Jet(Collection|Ref)']},
          {'HGCDigi'               : ['HGCSample']},
+         {'SiPixelObjects'        : ['SiPixelQuality.*']},
      ]
 
 ignoreEdmDP = {


### PR DESCRIPTION
As we have `CalibTracker/SiPixelQuality`  package that is why duplicate dictionary checking script complains that `CondFormats/SiPixelObjects` should not define SiPixelQuality dictionaries.

This PR updates the duplicate dictionary map to map SiPixelQuality.* dictionaries to SiPixelObjects

[a]
```
CondFormats/SiPixelObjects/src/classes_def.xml
  SiPixelQuality : SiPixelQuality
  SiPixelQuality : SiPixelQuality::disabledModuleType
  SiPixelQuality : vector< SiPixelQuality::disabledModuleType > 
```

