### PR TITLE
Fix clang warnings in RecoTracker/DebugTools

### DIFF
--- a/RecoTracker/DebugTools/plugins/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/plugins/CkfDebugTrackCandidateMaker.h
@@ -25,7 +25,7 @@ namespace cms {
 
   private:
     virtual TrajectorySeedCollection::const_iterator 
-      lastSeed(TrajectorySeedCollection& theSeedColl){return theSeedColl.begin()+1;}
+      lastSeed(TrajectorySeedCollection const& theSeedColl) override {return theSeedColl.begin()+1;}
 
     void initDebugger(edm::EventSetup const & es){
       dbg = new CkfDebugger(es, consumesCollector());

--- a/RecoTracker/DebugTools/plugins/CkfDebugTrajectoryBuilder.h
+++ b/RecoTracker/DebugTools/plugins/CkfDebugTrajectoryBuilder.h
@@ -21,15 +21,15 @@ class CkfDebugTrajectoryBuilder: public CkfTrajectoryBuilder{
  private:
   mutable CkfDebugger * theDbg;
   bool analyzeMeasurementsDebugger(TempTrajectory& traj, const std::vector<TM>& meas,
-				   const MeasurementTracker* theMeasurementTracker, const Propagator* theForwardPropagator, 
+				   const MeasurementTrackerEvent* theMeasurementTracker, const Propagator* theForwardPropagator,
 				   const Chi2MeasurementEstimatorBase* theEstimator, 
-				   const TransientTrackingRecHitBuilder * theTTRHBuilder) const { 
+				   const TransientTrackingRecHitBuilder * theTTRHBuilder) const override {
     return theDbg->analyseCompatibleMeasurements(traj.toTrajectory(),meas,theMeasurementTracker,theForwardPropagator,theEstimator,theTTRHBuilder);
   };
   bool analyzeMeasurementsDebugger(Trajectory& traj, const std::vector<TM>& meas,
-				   const MeasurementTracker* theMeasurementTracker, const Propagator* theForwardPropagator, 
+				   const MeasurementTrackerEvent* theMeasurementTracker, const Propagator* theForwardPropagator,
 				   const Chi2MeasurementEstimatorBase* theEstimator, 
-				   const TransientTrackingRecHitBuilder * theTTRHBuilder) const { 
+				   const TransientTrackingRecHitBuilder * theTTRHBuilder) const override {
     return theDbg->analyseCompatibleMeasurements(traj,meas,theMeasurementTracker,theForwardPropagator,theEstimator,theTTRHBuilder);
   };
   void fillSeedHistoDebugger(std::vector<TrajectoryMeasurement>::iterator begin, 

--- a/RecoTracker/DebugTools/plugins/CkfDebugger.cc
+++ b/RecoTracker/DebugTools/plugins/CkfDebugger.cc
@@ -5,7 +5,7 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "Geometry/CommonTopologies/interface/Topology.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
-#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 #include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
@@ -196,7 +196,7 @@ void CkfDebugger::dumpSimHit(const SimHit& hit) const
 
 bool CkfDebugger::analyseCompatibleMeasurements(const Trajectory& traj,
 						const std::vector<TrajectoryMeasurement>& meas,
-						const MeasurementTracker* aMeasurementTracker, 
+						const MeasurementTrackerEvent* aMeasurementTracker,
 						const Propagator*                     propagator,
 						const Chi2MeasurementEstimatorBase*   estimator,
 						const TransientTrackingRecHitBuilder* aTTRHBuilder)

--- a/RecoTracker/DebugTools/plugins/CkfDebugger.h
+++ b/RecoTracker/DebugTools/plugins/CkfDebugger.h
@@ -31,7 +31,7 @@
 class Trajectory;
 class TrajectoryMeasurement;
 class PSimHit;
-class MeasurementTracker;
+class MeasurementTrackerEvent;
 class TrajectoryStateOnSurface;
 class MagneticField;
 class Chi2MeasurementEstimator;
@@ -57,7 +57,7 @@ class CkfDebugger {
 
   bool analyseCompatibleMeasurements( const Trajectory&,
 				      const std::vector<TrajectoryMeasurement>&,
-				      const MeasurementTracker*,
+				      const MeasurementTrackerEvent*,
 				      const Propagator*,
 				      const Chi2MeasurementEstimatorBase*,
 				      const TransientTrackingRecHitBuilder*);
@@ -103,7 +103,7 @@ class CkfDebugger {
   const Propagator*                theForwardPropagator;
   TrackerHitAssociator::Config     trackerHitAssociatorConfig_; 
   TrackerHitAssociator*      hitAssociator;
-  const MeasurementTracker*        theMeasurementTracker;
+  const MeasurementTrackerEvent*   theMeasurementTracker;
   const TransientTrackingRecHitBuilder* theTTRHBuilder;
   const TrackerTopology *theTopo;
   NavigationSchool const * theNavSchool;


### PR DESCRIPTION
Clang warned about these functions hiding virtual functions of the base class, that are fixed here by using the correct signature and adding the `override` keyword.

No changes expected.