### PR TITLE
Replaced some deprecated std functions

### DIFF
--- a/DQMOffline/JetMET/interface/SusyDQM/alpha_T.h
+++ b/DQMOffline/JetMET/interface/SusyDQM/alpha_T.h
@@ -14,7 +14,7 @@ struct alpha_T {
     if( p4s.size() < 2 ) return 0;
     
     std::vector<double> pTs;  
-    transform( p4s.begin(), p4s.end(), back_inserter(pTs), std::mem_fun_ref(&LorentzV::Pt));
+    transform( p4s.begin(), p4s.end(), back_inserter(pTs), std::mem_fn(&LorentzV::Pt));
     
     const double DsumPT = minimum_deltaSumPT( pTs );
     const double sumPT = accumulate( pTs.begin(), pTs.end(), double(0) );

--- a/HLTrigger/JetMET/interface/AlphaT.h
+++ b/HLTrigger/JetMET/interface/AlphaT.h
@@ -31,19 +31,10 @@ private:
 
 // -----------------------------------------------------------------------------
 template<class T>
-AlphaT::AlphaT(std::vector<T const *> const & p4, bool setDHtZero, bool use_et /* = true */) {
-  std::transform( p4.begin(), p4.end(), back_inserter(et_), ( use_et ? std::mem_fun(&T::Et) : std::mem_fun(&T::Pt) ) );
-  std::transform( p4.begin(), p4.end(), back_inserter(px_), std::mem_fun(&T::Px) );
-  std::transform( p4.begin(), p4.end(), back_inserter(py_), std::mem_fun(&T::Py) );
-  setDHtZero_ = setDHtZero;
-}
-
-// -----------------------------------------------------------------------------
-template<class T>
 AlphaT::AlphaT(std::vector<T> const & p4, bool setDHtZero, bool use_et /* = true */) {
-  std::transform( p4.begin(), p4.end(), back_inserter(et_), std::mem_fun_ref( use_et ? &T::Et : &T::Pt ) );
-  std::transform( p4.begin(), p4.end(), back_inserter(px_), std::mem_fun_ref(&T::Px) );
-  std::transform( p4.begin(), p4.end(), back_inserter(py_), std::mem_fun_ref(&T::Py) );
+  std::transform( p4.begin(), p4.end(), back_inserter(et_), std::mem_fn( use_et ? &T::Et : &T::Pt ) );
+  std::transform( p4.begin(), p4.end(), back_inserter(px_), std::mem_fn(&T::Px) );
+  std::transform( p4.begin(), p4.end(), back_inserter(py_), std::mem_fn(&T::Py) );
   setDHtZero_ = setDHtZero;
 }
 

--- a/PhysicsTools/MVATrainer/interface/SourceVariableSet.h
+++ b/PhysicsTools/MVATrainer/interface/SourceVariableSet.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <vector>
 #include <algorithm>
+#include <functional>
 
 #include "PhysicsTools/MVAComputer/interface/AtomicId.h"
 #include "PhysicsTools/MVATrainer/interface/SourceVariable.h"
@@ -35,7 +36,7 @@ class SourceVariableSet {
 			return vars.size();
 		else
 			return std::count_if(vars.begin(), vars.end(),
-			                     std::mem_fun_ref(&PosVar::noMagic));
+			                     std::mem_fn(&PosVar::noMagic));
 	}
 
     private:

--- a/RecoEgamma/EgammaTools/interface/ThreadSafeStringCut.h
+++ b/RecoEgamma/EgammaTools/interface/ThreadSafeStringCut.h
@@ -28,7 +28,7 @@ class ThreadSafeStringCut
       , expr_(std::move(other.expr_))
     {}
 
-    typename std::result_of<F&(T)>::type operator()(const T & t) const
+    typename std::invoke_result_t<F,T> operator()(const T & t) const
     {
         std::lock_guard<std::mutex> guard(mutex_);
         return func_(t);

--- a/RecoTauTag/RecoTau/interface/RecoTauDiscriminantFunctions.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauDiscriminantFunctions.h
@@ -18,7 +18,7 @@
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include <vector>
 
-namespace reco { namespace tau { namespace disc {
+namespace reco::tau::disc {
 
 // Save typing
 typedef const PFTau& Tau;
@@ -122,5 +122,5 @@ VDouble InvariantMassOfSignalWithFiltered(Tau);
 VDouble InvariantMass(Tau);
 VDouble OutlierMass(Tau);
 
-}}} // end namespace reco::tau::disc
+} // end namespace reco::tau::disc
 #endif

--- a/RecoTauTag/RecoTau/src/RecoTauDiscriminantFunctions.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauDiscriminantFunctions.cc
@@ -13,23 +13,17 @@ namespace reco::tau::disc {
 // Helper functions
 namespace {
 
-const PFCandidate& removeRef(const PFCandidatePtr& pfRef) {
-  return *pfRef;
-}
-
-const RecoTauPiZero& removeRef(const RecoTauPiZero& piZero) {
-  return piZero;
-}
-
-// Function = A CandidateType member function or any function taking a CandidateType
-template<typename T, typename Function>
-VDouble extract(const std::vector<T>& cands, Function function) {
+template<class T, class F>
+VDouble extract(std::vector<T> const& cands, F f) {
   VDouble output( cands.size() );
-  using CandidateType = decltype(removeRef(std::declval<T>()));
-  // Wrap function in std::funtion such that member function pointers and other
-  // functions (lambdas, normal functions, etc.) can be used in the same way
-  std::function<double(CandidateType const&)> stdFunction{ function };
-  for(auto const& x : cands) output.push_back(stdFunction(removeRef(x)));
+  for(auto const& x : cands) output.push_back(f(x));
+  return output;
+}
+
+template<class T, class F>
+VDouble extract(std::vector<edm::Ptr<T>> const& cands, F f) {
+  VDouble output( cands.size() );
+  for(auto const& x : cands) output.push_back(f(*x));
   return output;
 }
 
@@ -204,7 +198,7 @@ VDouble Dalitz2(Tau tau) {
 }
 
 double IsolationChargedSumHard(Tau tau) {
-  VDouble isocands = extract(tau.isolationPFChargedHadrCands(),&PFCandidate::pt);
+  VDouble isocands = extract(tau.isolationPFChargedHadrCands(), std::mem_fn(&PFCandidate::pt));
   double output = 0.0;
   for(double pt : isocands) {
     if (pt > 1.0)
@@ -214,7 +208,7 @@ double IsolationChargedSumHard(Tau tau) {
 }
 
 double IsolationChargedSumSoft(Tau tau) {
-  VDouble isocands = extract(tau.isolationPFChargedHadrCands(),&PFCandidate::pt);
+  VDouble isocands = extract(tau.isolationPFChargedHadrCands(), std::mem_fn(&PFCandidate::pt));
   double output = 0.0;
   for(double pt : isocands) {
     if (pt < 1.0)
@@ -233,7 +227,7 @@ double IsolationChargedSumSoftRelative(Tau tau) {
 }
 
 double IsolationECALSumHard(Tau tau) {
-  VDouble isocands = extract(tau.isolationPFGammaCands(),&PFCandidate::pt);
+  VDouble isocands = extract(tau.isolationPFGammaCands(), std::mem_fn(&PFCandidate::pt));
   double output = 0.0;
   for(double pt : isocands) {
     if (pt > 1.5)
@@ -243,7 +237,7 @@ double IsolationECALSumHard(Tau tau) {
 }
 
 double IsolationECALSumSoft(Tau tau) {
-  VDouble isocands = extract(tau.isolationPFGammaCands(),&PFCandidate::pt);
+  VDouble isocands = extract(tau.isolationPFGammaCands(), std::mem_fn(&PFCandidate::pt));
   double output = 0.0;
   for(double pt : isocands) {
     if (pt < 1.5)
@@ -326,11 +320,11 @@ double NeutralOutlierSumPt(Tau tau) {
 
 // Quantities associated to tracks - that are not the main track
 VDouble TrackPt(Tau tau) {
-  return extract(notMainTrack(tau), &PFCandidate::pt);
+  return extract(notMainTrack(tau), std::mem_fn(&PFCandidate::pt));
 }
 
 VDouble TrackEta(Tau tau) {
-  return extract(notMainTrack(tau), &PFCandidate::eta);
+  return extract(notMainTrack(tau), std::mem_fn(&PFCandidate::eta));
 }
 
 VDouble TrackAngle(Tau tau) {
@@ -339,11 +333,11 @@ VDouble TrackAngle(Tau tau) {
 
 // Quantities associated to PiZeros
 VDouble PiZeroPt(Tau tau) {
-  return extract(tau.signalPiZeroCandidates(), &RecoTauPiZero::pt);
+  return extract(tau.signalPiZeroCandidates(), std::mem_fn(&RecoTauPiZero::pt));
 }
 
 VDouble PiZeroEta(Tau tau) {
-  return extract(tau.signalPiZeroCandidates(), &RecoTauPiZero::eta);
+  return extract(tau.signalPiZeroCandidates(), std::mem_fn(&RecoTauPiZero::eta));
 }
 
 VDouble PiZeroAngle(Tau tau) {
@@ -352,7 +346,7 @@ VDouble PiZeroAngle(Tau tau) {
 
 // Isolation quantities
 VDouble OutlierPt(Tau tau) {
-  return extract(tau.isolationPFCands(), &PFCandidate::pt);
+  return extract(tau.isolationPFCands(), std::mem_fn(&PFCandidate::pt));
 }
 
 VDouble OutlierAngle(Tau tau) {
@@ -360,7 +354,7 @@ VDouble OutlierAngle(Tau tau) {
 }
 
 VDouble ChargedOutlierPt(Tau tau) {
-  return extract(tau.isolationPFChargedHadrCands(),&PFCandidate::pt);
+  return extract(tau.isolationPFChargedHadrCands(), std::mem_fn(&PFCandidate::pt));
 }
 
 VDouble ChargedOutlierAngle(Tau tau) {
@@ -368,7 +362,7 @@ VDouble ChargedOutlierAngle(Tau tau) {
 }
 
 VDouble NeutralOutlierPt(Tau tau) {
-  return extract(tau.isolationPFGammaCands(),&PFCandidate::pt);
+  return extract(tau.isolationPFGammaCands(), std::mem_fn(&PFCandidate::pt));
 }
 
 VDouble NeutralOutlierAngle(Tau tau) {

--- a/RecoTauTag/RecoTau/src/RecoTauDiscriminantFunctions.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauDiscriminantFunctions.cc
@@ -13,17 +13,13 @@ namespace reco::tau::disc {
 // Helper functions
 namespace {
 
+template<class T> T const& removePtr(T const& t) { return t; }
+template<class T> T const& removePtr(edm::Ptr<T> const& t) { return *t; }
+
 template<class T, class F>
 VDouble extract(std::vector<T> const& cands, F f) {
   VDouble output( cands.size() );
-  for(auto const& x : cands) output.push_back(f(x));
-  return output;
-}
-
-template<class T, class F>
-VDouble extract(std::vector<edm::Ptr<T>> const& cands, F f) {
-  VDouble output( cands.size() );
-  for(auto const& x : cands) output.push_back(f(*x));
+  for(auto const& x : cands) output.push_back(f(removePtr(x)));
   return output;
 }
 

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -817,8 +817,7 @@ GroupedCkfTrajectoryBuilder::groupedIntermediaryClean (TempTrajectoryContainer& 
   return result;
 */
   theTrajectories.erase(std::remove_if( theTrajectories.begin(),theTrajectories.end(),
-                                        std::not1(std::mem_fun_ref(&TempTrajectory::isValid))),
- //                                     boost::bind(&TempTrajectory::isValid,_1)), 
+                                        std::not_fn(&TempTrajectory::isValid)),
                         theTrajectories.end());
 }
 
@@ -890,8 +889,8 @@ GroupedCkfTrajectoryBuilder::rebuildSeedingRegion(const TrajectorySeed&seed,
   //
   result.swap(rebuiltTrajectories);
   result.erase(std::remove_if( result.begin(),result.end(),
-			       std::not1(std::mem_fun_ref(&TempTrajectory::isValid))),
-	       result.end());
+                               std::not_fn(&TempTrajectory::isValid)),
+               result.end());
 }
 
 int

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -362,8 +362,8 @@ namespace cms{
 	if ( maxSeedsBeforeCleaning_ >0 && rawResult.size() > maxSeedsBeforeCleaning_+lastCleanResult) {
           theTrajectoryCleaner->clean(rawResult);
           rawResult.erase(std::remove_if(rawResult.begin()+lastCleanResult,rawResult.end(),
-					 std::not1(std::mem_fun_ref(&Trajectory::isValid))),
-			  rawResult.end());
+                                         std::not_fn(&Trajectory::isValid)),
+                          rawResult.end());
           lastCleanResult=rawResult.size();
         }
         }
@@ -416,8 +416,8 @@ namespace cms{
 
       vector<Trajectory> & unsmoothedResult(rawResult);
       unsmoothedResult.erase(std::remove_if(unsmoothedResult.begin(),unsmoothedResult.end(),
-					    std::not1(std::mem_fun_ref(&Trajectory::isValid))),
-			     unsmoothedResult.end());
+                                            std::not_fn(&Trajectory::isValid)),
+                             unsmoothedResult.end());
       unsmoothedResult.shrink_to_fit();
       // If requested, reverse the trajectories creating a new 1-hit seed on the last measurement of the track
       if (reverseTrajectories) {

--- a/RecoTracker/CkfPattern/src/IntermediateTrajectoryCleaner.cc
+++ b/RecoTracker/CkfPattern/src/IntermediateTrajectoryCleaner.cc
@@ -56,8 +56,7 @@ IntermediateTrajectoryCleaner::clean(IntermediateTrajectoryCleaner::TempTrajecto
     }
   }
   theTrajectories.erase(std::remove_if( theTrajectories.begin(),theTrajectories.end(),
-					std::not1(std::mem_fun_ref(&TempTrajectory::isValid))),
- //					boost::bind(&TempTrajectory::isValid,_1)), 
-			theTrajectories.end());
+                                        std::not_fn(&TempTrajectory::isValid)),
+                        theTrajectories.end());
 }
 #endif

--- a/TopQuarkAnalysis/TopHitFit/src/Lepjets_Event.cc
+++ b/TopQuarkAnalysis/TopHitFit/src/Lepjets_Event.cc
@@ -40,8 +40,6 @@
 
 
 using std::stable_sort;
-using std::less;
-using std::not2;
 using std::remove_if;
 using std::abs;
 
@@ -441,8 +439,8 @@ void Lepjets_Event::sort ()
 // Purpose: Sort the objects in the event in order of descending pt.
 //
 {
-  std::stable_sort (_leps.begin(), _leps.end(), not2 (less<Lepjets_Event_Lep> ()));
-  std::stable_sort (_jets.begin(), _jets.end(), not2 (less<Lepjets_Event_Lep> ()));
+  std::stable_sort (_leps.begin(), _leps.end(), std::not_fn(std::less<Lepjets_Event_Lep>()));
+  std::stable_sort (_jets.begin(), _jets.end(), std::not_fn(std::less<Lepjets_Event_Lep>()));
 }
 
 


### PR DESCRIPTION
Part of my occasional PRs to modernize CMSSW.

I propose to replace the deprecated `std::not1`, `std::not2`, `std::mem_fun_ref`, `std::result_of` in CMSSW with what is recommended in modern C++ (`std::mem_fn`, `std::not_fn` and `std::invoke_result`).

Local matrix tests pass.