### PR TITLE
[RFC] Add Pixel "Stuck TBM" simulation workflows to RelVal matrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -21,6 +21,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #   2018 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
 #        (TTbar trackingOnly, pixelTrackingOnly)
 #         he collapse: TTbar, TTbar PU, TTbar design
+#         killStuckTBM: TTbar, ZMM
 #   2019 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
 numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
            10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
@@ -28,8 +29,10 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            10801.0,10802.0,10803.0,10804.0,10805.0,10806.0,10807.0,10808.0,10809.0,10859.0,10871.0,
            10842.0,10824.0,10825.0,10826.0,10823.0,11024.0,11025.0,11224.0,
            10824.1,10824.5,
+           12424.0,12442.0,
            10824.6,11024.6,11224.6,
            11642.0,11624.0,11625.0,11626.0,11623.0,11824.0,11825.0,12024.0]
+
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows: continue
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -21,6 +21,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #   2018 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
 #        (TTbar trackingOnly, pixelTrackingOnly)
 #         he collapse: TTbar, TTbar PU, TTbar design
+#         killStuckTBM: TTbar, ZMM
 #   2019 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
 numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
            10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
@@ -29,6 +30,7 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            10842.0,10824.0,10825.0,10826.0,10823.0,11024.0,11025.0,11224.0,
            10824.1,10824.5,
            10824.6,11024.6,11224.6,
+           10824.7,10842.7,
            11642.0,11624.0,11625.0,11626.0,11623.0,11824.0,11825.0,12024.0]
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows: continue

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -21,7 +21,6 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #   2018 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
 #        (TTbar trackingOnly, pixelTrackingOnly)
 #         he collapse: TTbar, TTbar PU, TTbar design
-#         killStuckTBM: TTbar, ZMM
 #   2019 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
 numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
            10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
@@ -29,10 +28,8 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            10801.0,10802.0,10803.0,10804.0,10805.0,10806.0,10807.0,10808.0,10809.0,10859.0,10871.0,
            10842.0,10824.0,10825.0,10826.0,10823.0,11024.0,11025.0,11224.0,
            10824.1,10824.5,
-           12424.0,12442.0,
            10824.6,11024.6,11224.6,
            11642.0,11624.0,11625.0,11626.0,11623.0,11824.0,11825.0,12024.0]
-
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows: continue
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2894,6 +2894,15 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom
                                       }
 
+    upgradeStepDict['DigiKillPixelStuckTBM'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:%s'%(hltversion),
+                                                   '--conditions':gt,
+                                                   '--datatier':'GEN-SIM-DIGI-RAW',
+                                                   '-n':'10',
+                                                   '--eventcontent':'FEVTDEBUGHLT',
+                                                   '--geometry' : geom,
+                                                   '--customise_commands':'"process.mix.digitizers.pixel.KillBadFEDChannels = cms.bool(True); process.GlobalTag.toGet = cms.VPSet(cms.PSet(record = cms.string(\'SiPixelStatusScenarioProbabilityRcd\'),tag = cms.string(\'SiPixelQualityProbabilities_noPU_v0_mc\'),connect = cms.string(\'sqlite_file:/afs/cern.ch/user/m/musich/public/forStuckTBM/SiPixelStatusScenarioProbabilities_noPU_2018.db\')),cms.PSet(record = cms.string(\'SiPixelStatusScenariosRcd\'),tag = cms.string(\'SiPixelFEDChannelContainer_StuckTBM_2018_v1_mc\'),connect = cms.string(\'sqlite_file:/afs/cern.ch/user/m/musich/public/forStuckTBM/SiPixelStatusScenarios_v1.db\')))"'
+                                      }
+
     # Adding Track trigger step in step2
     upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2900,7 +2900,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                                    '-n':'10',
                                                    '--eventcontent':'FEVTDEBUGHLT',
                                                    '--geometry' : geom,
-                                                   '--customise_commands':'"process.mix.digitizers.pixel.KillBadFEDChannels = cms.bool(True); process.GlobalTag.toGet = cms.VPSet(cms.PSet(record = cms.string(\'SiPixelStatusScenarioProbabilityRcd\'),tag = cms.string(\'SiPixelQualityProbabilities_noPU_v0_mc\'),connect = cms.string(\'sqlite_file:/afs/cern.ch/user/m/musich/public/forStuckTBM/SiPixelStatusScenarioProbabilities_noPU_2018.db\')),cms.PSet(record = cms.string(\'SiPixelStatusScenariosRcd\'),tag = cms.string(\'SiPixelFEDChannelContainer_StuckTBM_2018_v1_mc\'),connect = cms.string(\'sqlite_file:/afs/cern.ch/user/m/musich/public/forStuckTBM/SiPixelStatusScenarios_v1.db\')))"'
+                                                   '--customise_commands':'"process.mix.digitizers.pixel.KillBadFEDChannels = cms.bool(True); process.GlobalTag.toGet = cms.VPSet(cms.PSet(record = cms.string(\'SiPixelStatusScenarioProbabilityRcd\'),tag = cms.string(\'SiPixelQualityProbabilities_2018_noPU_v0_mc\'),connect = cms.string(\'frontier://FrontierPrep/CMS_CONDITIONS\')),cms.PSet(record = cms.string(\'SiPixelStatusScenariosRcd\'),tag = cms.string(\'SiPixelFEDChannelContainer_StuckTBM_2018_v0_mc\'),connect = cms.string(\'frontier://FrontierPrep/CMS_CONDITIONS\')))"'
                                       }
 
     # Adding Track trigger step in step2

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2894,15 +2894,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom
                                       }
 
-    upgradeStepDict['DigiKillPixelStuckTBM'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:%s'%(hltversion),
-                                                   '--conditions':gt,
-                                                   '--datatier':'GEN-SIM-DIGI-RAW',
-                                                   '-n':'10',
-                                                   '--eventcontent':'FEVTDEBUGHLT',
-                                                   '--geometry' : geom,
-                                                   '--customise': 'SimTracker/SiPixelDigitizer/customiseStuckTBMSimulation.activateStuckTBMSimulation2018NoPU' 
-                                                   }
-
     # Adding Track trigger step in step2
     upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3029,6 +3029,10 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
         stepName = step + upgradeSteps['heCollapse']['suffix']
         upgradeStepDict[stepName][k] = merge([{'--procModifiers': 'run2_HECollapse_2018'}, upgradeStepDict[step][k]])
 
+    for step in upgradeSteps['killStuckTBM']['steps']:
+        stepName = step + upgradeSteps['killStuckTBM']['suffix']
+        upgradeStepDict[stepName][k] = merge([{'--customise': 'SimTracker/SiPixelDigitizer/customiseStuckTBMSimulation.activateStuckTBMSimulation2018NoPU'}, upgradeStepDict[step][k]])
+
     # setup PU
     if k2 in PUDataSets:
         # Setup premixing stage1

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2900,8 +2900,8 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                                    '-n':'10',
                                                    '--eventcontent':'FEVTDEBUGHLT',
                                                    '--geometry' : geom,
-                                                   '--customise_commands':'"process.mix.digitizers.pixel.KillBadFEDChannels = cms.bool(True); process.GlobalTag.toGet = cms.VPSet(cms.PSet(record = cms.string(\'SiPixelStatusScenarioProbabilityRcd\'),tag = cms.string(\'SiPixelQualityProbabilities_2018_noPU_v0_mc\'),connect = cms.string(\'frontier://FrontierPrep/CMS_CONDITIONS\')),cms.PSet(record = cms.string(\'SiPixelStatusScenariosRcd\'),tag = cms.string(\'SiPixelFEDChannelContainer_StuckTBM_2018_v0_mc\'),connect = cms.string(\'frontier://FrontierPrep/CMS_CONDITIONS\')))"'
-                                      }
+                                                   '--customise': 'SimTracker/SiPixelDigitizer/customiseStuckTBMSimulation.activateStuckTBMSimulation2018NoPU' 
+                                                   }
 
     # Adding Track trigger step in step2
     upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:%s'%(hltversion),

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -18,6 +18,8 @@ def makeStepName(key,frag,step,suffix):
 neutronKeys = ['2023D17','2023D19','2023D21','2023D22','2023D23','2023D24','2023D25','2023D28','2023D29','2023D30','2023D31','2023D33','2023D34','2023D35','2023D36','2023D37']
 neutronFrags = ['ZMM_14','MinBias_14TeV']
 
+tbmFrags = ['TTbar_13','ZMM_13']
+
 #just define all of them
 
 for year in upgradeKeys:
@@ -87,6 +89,10 @@ for year in upgradeKeys:
             # special workflows for HE
             if upgradeDatasetFromFragment[frag]=="TTbar_13" and '2018' in key:
                 workflows[numWF+upgradeSteps['heCollapse']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['heCollapse']]
+
+            # special workflows for stuck TBM
+            if any(upgradeDatasetFromFragment[frag]==nfrag for nfrag in tbmFrags) and '2018' in key:
+                workflows[numWF+upgradeSteps['killStuckTBM']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['killStuckTBM']]
 
             # premixing stage1, only for NuGun
             if upgradeDatasetFromFragment[frag]=="NuGun" and 'PU' in key and '2023' in key:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -191,6 +191,16 @@ upgradeSteps['heCollapse'] = {
     'suffix' : '_heCollapse',
     'offset' : 0.6,
 }
+upgradeSteps['killStuckTBM'] = {
+    'steps' : [
+        'DigiFull',
+    ],
+    'PU' : [
+        'DigiFull',
+    ],
+    'suffix' : '_killStuckTBM',
+    'offset' : 0.7,
+}
 upgradeSteps['Premix'] = {
     'steps' : [],
     'PU': [

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -17,7 +17,6 @@ upgradeKeys[2017] = [
 #    '2019PU',
     '2019Design',
 #    '2019DesignPU',
-    '2018KillStuckTBM'
 ]
 
 upgradeKeys[2023] = [
@@ -85,7 +84,6 @@ upgradeSteps['baseline'] = {
         'GenSimHLBeamSpotFull',
         'GenSimHLBeamSpotFull14',
         'DigiFull',
-        'DigiKillPixelStuckTBM',
         'DigiFullTrigger',
         'RecoFullLocal',
         'RecoFull',
@@ -267,8 +265,6 @@ upgradeProperties[2017]['2018PU'] = deepcopy(upgradeProperties[2017]['2018'])
 upgradeProperties[2017]['2018PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU','NanoFull']
 upgradeProperties[2017]['2018DesignPU'] = deepcopy(upgradeProperties[2017]['2018Design'])
 upgradeProperties[2017]['2018DesignPU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU']
-upgradeProperties[2017]['2018KillStuckTBM'] = deepcopy(upgradeProperties[2017]['2018'])
-upgradeProperties[2017]['2018KillStuckTBM']['ScenToRun'] = ['GenSimFull','DigiKillPixelStuckTBM','RecoFull','HARVESTFull']
 
 upgradeProperties[2023] = {
     '2023D17' : {

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -17,6 +17,7 @@ upgradeKeys[2017] = [
 #    '2019PU',
     '2019Design',
 #    '2019DesignPU',
+    '2018KillStuckTBM'
 ]
 
 upgradeKeys[2023] = [
@@ -84,6 +85,7 @@ upgradeSteps['baseline'] = {
         'GenSimHLBeamSpotFull',
         'GenSimHLBeamSpotFull14',
         'DigiFull',
+        'DigiKillPixelStuckTBM',
         'DigiFullTrigger',
         'RecoFullLocal',
         'RecoFull',
@@ -265,6 +267,8 @@ upgradeProperties[2017]['2018PU'] = deepcopy(upgradeProperties[2017]['2018'])
 upgradeProperties[2017]['2018PU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU','NanoFull']
 upgradeProperties[2017]['2018DesignPU'] = deepcopy(upgradeProperties[2017]['2018Design'])
 upgradeProperties[2017]['2018DesignPU']['ScenToRun'] = ['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU']
+upgradeProperties[2017]['2018KillStuckTBM'] = deepcopy(upgradeProperties[2017]['2018'])
+upgradeProperties[2017]['2018KillStuckTBM']['ScenToRun'] = ['GenSimFull','DigiKillPixelStuckTBM','RecoFull','HARVESTFull']
 
 upgradeProperties[2023] = {
     '2023D17' : {

--- a/SimTracker/SiPixelDigitizer/python/customiseStuckTBMSimulation.py
+++ b/SimTracker/SiPixelDigitizer/python/customiseStuckTBMSimulation.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+#
+# activate the stuck-TBM simulation and loads from DB the corresponding conditions
+#
+def activateStuckTBMSimulation2018NoPU(process):
+
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'pixel'):
+        print("activating Pixel Stuck TBM Simulation")
+        process.mix.digitizers.pixel.KillBadFEDChannels = cms.bool(True)
+
+    if not hasattr(process.GlobalTag,'toGet'):
+        process.GlobalTag.toGet=cms.VPSet()
+
+    process.GlobalTag.toGet.extend(cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenarioProbabilityRcd'),
+                                                      tag = cms.string('SiPixelQualityProbabilities_2018_noPU_v0_mc'),
+                                                      connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS')),
+                                             cms.PSet(record = cms.string('SiPixelStatusScenariosRcd'),
+                                                      tag = cms.string('SiPixelFEDChannelContainer_StuckTBM_2018_v0_mc'),
+                                                      connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS')
+                                                      )
+                                             )
+                                   )            
+    return process
+                


### PR DESCRIPTION
Greetings, 
this PR introduces (temporarily) 2018 MC workflows testing the Pixel Stuck TBM simulation (introduced recently in https://github.com/cms-sw/cmssw/pull/25466) in the relval matrix. 
As the feature is switched off by default and the necessary DB conditions are not (yet) available via `autoCond`, the activation flag and the conditions are supplied via customization of the DIGI step.
At the moment only the 2018 (noPU) case is treated as the conditions for the other cases (2017 and PU!=0) are still in the process of being derived.
cc @tsusa 