### PR TITLE
fix clang warnings in RecoEgamma/Examples

### DIFF
--- a/RecoEgamma/Examples/plugins/ElectronSeedAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/ElectronSeedAnalyzer.cc
@@ -290,8 +290,6 @@ void ElectronSeedAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& 
 
     if (tsos1.isValid()) {
 
-      std::pair<bool,double> est;
-
       //UB add test on phidiff
       float SCl_phi = xmeas.phi();
       float localDphi = SCl_phi-hitPos.phi();

--- a/RecoEgamma/Examples/plugins/GsfElectronFakeAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronFakeAnalyzer.cc
@@ -1388,8 +1388,8 @@ GsfElectronFakeAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
         histSclEt_->Fill(sclRef->energy()*(Rt/R));
         histSclEtVsEta_->Fill(sclRef->eta(),sclRef->energy()*(Rt/R));
         histSclEtVsPhi_->Fill(sclRef->phi(),sclRef->energy()*(Rt/R));
-        if (bestGsfElectron.classification() < 100)  histSclEoEmatchingObject_barrel->Fill(sclRef->energy()/moIter->energy());
-        if (bestGsfElectron.classification() >= 100)  histSclEoEmatchingObject_endcaps->Fill(sclRef->energy()/moIter->energy());
+        if (bestGsfElectron.isEB())  histSclEoEmatchingObject_barrel->Fill(sclRef->energy()/moIter->energy());
+        if (bestGsfElectron.isEE())  histSclEoEmatchingObject_endcaps->Fill(sclRef->energy()/moIter->energy());
         histSclEta_->Fill(sclRef->eta());
         histSclEtaVsPhi_->Fill(sclRef->phi(),sclRef->eta());
         histSclPhi_->Fill(sclRef->phi());

--- a/RecoEgamma/Examples/plugins/GsfElectronMCFakeAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronMCFakeAnalyzer.cc
@@ -1392,8 +1392,8 @@ GsfElectronMCFakeAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
         histSclEt_->Fill(sclRef->energy()*(Rt/R));
         histSclEtVsEta_->Fill(sclRef->eta(),sclRef->energy()*(Rt/R));
         histSclEtVsPhi_->Fill(sclRef->phi(),sclRef->energy()*(Rt/R));
-        if (bestGsfElectron.classification() < 100)  histSclEoEmatchingObject_barrel->Fill(sclRef->energy()/moIter->energy());
-        if (bestGsfElectron.classification() >= 100)  histSclEoEmatchingObject_endcaps->Fill(sclRef->energy()/moIter->energy());
+        if (bestGsfElectron.isEB())  histSclEoEmatchingObject_barrel->Fill(sclRef->energy()/moIter->energy());
+        if (bestGsfElectron.isEE())  histSclEoEmatchingObject_endcaps->Fill(sclRef->energy()/moIter->energy());
         histSclEta_->Fill(sclRef->eta());
         histSclEtaVsPhi_->Fill(sclRef->phi(),sclRef->eta());
         histSclPhi_->Fill(sclRef->phi());


### PR DESCRIPTION
-removed an unused variable
-fixed a case where the wrong member variable was being used to determine if an electron was in the barrel or endcap.