### PR TITLE
Removed unused variables in RecoEgamma/EgammaPhotonProducers

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonCoreProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonCoreProducer.cc
@@ -91,7 +91,6 @@ void GEDPhotonCoreProducer::produce(edm::Event &theEvent, const edm::EventSetup&
 
 
   // Loop over PF candidates and get only photons
-  reco::ElectronSeedCollection::const_iterator pixelSeedItr;
   for(unsigned int lCand=0; lCand < pfCandidateHandle->size(); lCand++) {
     reco::PFCandidateRef candRef (reco::PFCandidateRef(pfCandidateHandle,lCand));
 

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonCoreProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonCoreProducer.cc
@@ -130,10 +130,7 @@ void PhotonCoreProducer::fillPhotonCollection(edm::Event& evt,
 					      const edm::Handle<reco::ConversionCollection> & conversionHandle,
 					      const edm::Handle<reco::ElectronSeedCollection> & pixelSeedHandle,
 					      reco::PhotonCoreCollection & outputPhotonCoreCollection, int& iSC) {
-  
 
-  
-  reco::ElectronSeedCollection::const_iterator pixelSeedItr;
   for(unsigned int lSC=0; lSC < scHandle->size(); lSC++) {
     
     // get SuperClusterRef


### PR DESCRIPTION
This fixes a clang warning.