### PR TITLE
Use of edm::View<T>::ptrs() in RecoEgamma and work on EGRegressionModifierV1/2

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackEcalImpactPoint.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackEcalImpactPoint.cc
@@ -116,15 +116,14 @@ std::vector<math::XYZPointF> ConversionTrackEcalImpactPoint::find( const std::ve
       int ibc=0;
       goodBC=0;
 
-      for (unsigned i = 0; i < bcHandle->size(); ++i ) {
-	float dEta= bcHandle->ptrAt(i)->position().eta() - ecalImpactPosition.eta()  ;
-	float dPhi= bcHandle->ptrAt(i)->position().phi() - ecalImpactPosition.phi()  ;
-	if ( sqrt(dEta*dEta + dPhi*dPhi)  <  bcDistanceToTrack ) {
+      for(auto const& bc : bcHandle->ptrs()) {
+        float dEta= bc->position().eta() - ecalImpactPosition.eta();
+        float dPhi= bc->position().phi() - ecalImpactPosition.phi();
+        if ( sqrt(dEta*dEta + dPhi*dPhi)  <  bcDistanceToTrack ) {
           goodBC=ibc;
-	  bcDistanceToTrack=sqrt(dEta*dEta + dPhi*dPhi);
-	} 
-        ibc++;	
-
+          bcDistanceToTrack = sqrt(dEta*dEta + dPhi*dPhi);
+        } 
+        ibc++;
       }
 
       matchingBC[iTrk]=bcHandle->ptrAt(goodBC);

--- a/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
@@ -372,15 +372,15 @@ std::vector<const reco::CaloCluster*> InOutConversionSeedFinder::getSecondCaloCl
   
   Geom::Phi<float> convPhi(conversionPosition.phi() );
 
-  for(auto const& bc : bcCollection_->ptrs())
+  for(auto const& bc : *bcCollection_)
   {
-    Geom::Phi<float> bcPhi( bc->position().phi() );
+    Geom::Phi<float> bcPhi( bc.position().phi() );
     
     // Require phi of cluster to be consistent with the conversion position and the track charge
     
     if (std::abs(bcPhi-convPhi ) < .5 &&
         ((charge<0 && bcPhi-convPhi >-.5) || 
-         (charge>0 && bcPhi-convPhi <.5))) result.push_back(bc.get());
+         (charge>0 && bcPhi-convPhi <.5))) result.push_back(&bc);
   }
 
   return result;

--- a/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
@@ -370,40 +370,20 @@ std::vector<const reco::CaloCluster*> InOutConversionSeedFinder::getSecondCaloCl
   
   std::vector<const reco::CaloCluster*> result;
   
- //std::cout << "InOutConversionSeedFinder::getSecondCaloClusters" <<  "\n"; 
-  
-  Geom::Phi<float> theConvPhi(conversionPosition.phi() );
+  Geom::Phi<float> convPhi(conversionPosition.phi() );
 
-  for (unsigned i = 0; i < bcCollection_->size(); ++i ) {
+  for(auto const& bc : bcCollection_->ptrs())
+  {
+    Geom::Phi<float> bcPhi( bc->position().phi() );
     
-    Geom::Phi<float> theBcPhi( bcCollection_->ptrAt(i)->position().phi()   );
-   //std::cout<< "InOutConversionSeedFinder::getSecondCaloClusters  BC energy " <<  bcCollection_->ptrAt(i)->energy() << " Calo cluster phi " << theBcPhi << " " <<  bcCollection_->ptrAt(i)->position().phi()<<  " theConvPhi " << theConvPhi << "\n";
+    // Require phi of cluster to be consistent with the conversion position and the track charge
     
-    // Require phi of cluster to be consistent with the conversion 
-    // position and the track charge
-    
-    
-    if (fabs(theBcPhi-theConvPhi ) < .5 &&
-        ((charge<0 && theBcPhi-theConvPhi >-.5) || 
-         (charge>0 && theBcPhi-theConvPhi <.5))){
-      ////std::cout << "InOutConversionSeedFinder::getSecondCaloClusters  Adding bc pointer " << &(*bcItr) << "  to vector:" << "\n";
-      
-      //result.push_back(&(*bcItr));
-
-      result.push_back(&(*(bcCollection_->ptrAt(i))  ));
-
-    }
-    
-    
-    
-    
+    if (std::abs(bcPhi-convPhi ) < .5 &&
+        ((charge<0 && bcPhi-convPhi >-.5) || 
+         (charge>0 && bcPhi-convPhi <.5))) result.push_back(bc.get());
   }
-  
-  
-  
+
   return result;
-  
-  
 }
 
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConvertedPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConvertedPhotonProducer.h
@@ -59,7 +59,7 @@ class ConvertedPhotonProducer : public edm::stream::EDProducer<> {
 			 const edm::OrphanHandle<reco::ConversionCollection> & conversionHandle,
 			 reco::ConversionCollection & outputCollection);
 			   
-  std::vector<reco::ConversionRef> solveAmbiguity( const edm::OrphanHandle<reco::ConversionCollection> & conversionHandle, reco::CaloClusterPtr& sc);
+  std::vector<reco::ConversionRef> solveAmbiguity( const edm::OrphanHandle<reco::ConversionCollection> & conversionHandle, reco::CaloClusterPtr const& sc);
 
   float calculateMinApproachDistance ( const reco::TrackRef& track1, const reco::TrackRef& track2);
   void getCircleCenter(const reco::TrackRef& tk, double r, double& x0, double& y0);

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionProducer.cc
@@ -195,13 +195,7 @@ ConversionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   //build map of ConversionTracks ordered in eta
   std::multimap<float, edm::Ptr<reco::ConversionTrack> > convTrackMap;
-  edm::PtrVector<reco::ConversionTrack> trackPtrVector;
-  for (size_t i = 0; i < trackCollectionHandle->size(); ++i)
-    trackPtrVector.push_back(trackCollectionHandle->ptrAt(i));
-
-  for (edm::PtrVector<reco::ConversionTrack>::const_iterator tk_ref = trackPtrVector.begin(); tk_ref != trackPtrVector.end(); ++tk_ref ){
-    convTrackMap.insert(std::make_pair((*tk_ref)->track()->eta(),*tk_ref));
-  }
+  for(auto const& t : trackCollectionHandle->ptrs()) convTrackMap.emplace(t->track()->eta(),t);
 
   edm::Handle<reco::VertexCollection> vertexHandle;
   reco::VertexCollection vertexCollection;
@@ -282,30 +276,21 @@ void ConversionProducer::buildSuperAndBasicClusterGeoMap(const edm::Event& iEven
       << "Error! Can't get the endcap basic clusters!";
   }
 
-  edm::Handle<edm::View<reco::CaloCluster> > bcHandle = bcBarrelHandle;
-  edm::Handle<edm::View<reco::CaloCluster> > scHandle = scBarrelHandle;
-
-  if ( bcHandle.isValid()  ) {    
-    for (unsigned jj = 0; jj < 2; ++jj ){
-      for (unsigned ii = 0; ii < bcHandle->size(); ++ii ) {
-	if (bcHandle->ptrAt(ii)->energy()>energyBC_)
-	  basicClusterPtrs.insert(std::make_pair(bcHandle->ptrAt(ii)->position().eta(), bcHandle->ptrAt(ii)));
+  if( bcBarrelHandle.isValid()  ) {    
+    for(auto const& handle : {bcBarrelHandle, bcEndcapHandle} ) {
+      for(auto const& bc : handle->ptrs()) {
+        if(bc->energy() > energyBC_) basicClusterPtrs.emplace(bc->position().eta(), bc);
       }
-      bcHandle = bcEndcapHandle;
     }
   }
 
-
-  if ( scHandle.isValid()  ) {
-    for (unsigned jj = 0; jj < 2; ++jj ){
-      for (unsigned ii = 0; ii < scHandle->size(); ++ii ) {
-	if (scHandle->ptrAt(ii)->energy()>minSCEt_)
-	  superClusterPtrs.insert(std::make_pair(scHandle->ptrAt(ii)->position().eta(), scHandle->ptrAt(ii)));
+  if( scBarrelHandle.isValid()  ) {    
+    for(auto const& handle : {scBarrelHandle, scEndcapHandle} ) {
+      for(auto const& sc : handle->ptrs()) {
+        if(sc->energy() > minSCEt_) superClusterPtrs.emplace(sc->position().eta(), sc);
       }
-      scHandle = scEndcapHandle;
     } 
   }
-
 
 }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
@@ -327,10 +327,8 @@ void ConversionTrackCandidateProducer::buildCollections(bool isBarrel,
   //const CaloGeometry* geometry = theCaloGeom_.product();
 
   //  Loop over SC in the barrel and reconstruct converted photons
-  for (unsigned i = 0; i < scHandle->size(); ++i ) {
-
-    reco::CaloClusterPtr aClus= scHandle->ptrAt(i);
-  
+  for(auto const& aClus : scHandle->ptrs())
+  {
     // preselection based in Et and H/E cut. 
     if (aClus->energy()/cosh(aClus->eta()) <= minSCEt_) continue;
     if (aClus->eta() > 1.479 && aClus->eta() < 1.556 ) continue;

--- a/RecoEgamma/EgammaPhotonProducers/src/ConvertedPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConvertedPhotonProducer.cc
@@ -340,9 +340,8 @@ void ConvertedPhotonProducer::buildCollections ( edm::EventSetup const & es,
   //  Loop over SC in the barrel and reconstruct converted photons
   int myCands=0;
   reco::CaloClusterPtrVector scPtrVec;
-  for (unsigned i = 0; i < scHandle->size(); ++i ) {
-    reco::CaloClusterPtr aClus= scHandle->ptrAt(i);
-
+  for(auto const& aClus : scHandle->ptrs())
+  {
     // preselection based in Et and H/E cut
     if (aClus->energy()/cosh(aClus->eta()) <= minSCEt_) continue;
     const reco::CaloCluster* pClus=&(*aClus);
@@ -587,11 +586,8 @@ void ConvertedPhotonProducer::cleanCollections(const edm::Handle<edm::View<reco:
 
 
   reco::Conversion* newCandidate=nullptr;
-  for(unsigned int lSC=0; lSC < scHandle->size(); lSC++) {
-    
-    // get pointer to SC
-    reco::CaloClusterPtr aClus= scHandle->ptrAt(lSC);    
-        
+  for(auto const& aClus : scHandle->ptrs())
+  {
     // SC energy preselection
     if (aClus->energy()/cosh(aClus->eta()) <= minSCEt_) continue;
 
@@ -634,7 +630,7 @@ void ConvertedPhotonProducer::cleanCollections(const edm::Handle<edm::View<reco:
 
 
 
-std::vector<reco::ConversionRef>  ConvertedPhotonProducer::solveAmbiguity(const edm::OrphanHandle<reco::ConversionCollection> & conversionHandle, reco::CaloClusterPtr& scRef) {
+std::vector<reco::ConversionRef>  ConvertedPhotonProducer::solveAmbiguity(const edm::OrphanHandle<reco::ConversionCollection> & conversionHandle, reco::CaloClusterPtr const& scRef) {
   std::multimap<double, reco::ConversionRef, std::greater<double> >   convMap;
 
   for ( unsigned int icp=0; icp< conversionHandle->size(); icp++) {

--- a/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
+++ b/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
@@ -113,14 +113,12 @@ void MVAValueMapProducer<ParticleType>::produce(edm::StreamID, edm::Event& iEven
     std::vector<int>   mvaCategories;
 
     // Loop over particles
-    for (size_t i = 0; i < src->size(); ++i)
+    for (auto const& cand : src->ptrs())
     {
-      auto iCand = src->ptrAt(i);
-
-      std::vector<float> auxVariables = variableHelper_.getAuxVariables(iCand, iEvent);
+      std::vector<float> auxVariables = variableHelper_.getAuxVariables(cand, iEvent);
 
       int cat = -1; // Passed by reference to the mvaValue function to store the category
-      const float response = mvaEstimators_[iEstimator]->mvaValue( &(*iCand), auxVariables, cat );
+      const float response = mvaEstimators_[iEstimator]->mvaValue( cand.get(), auxVariables, cat );
       mvaRawValues.push_back( response ); // The MVA score
       mvaValues.push_back( 2.0/(1.0+exp(-2.0*response))-1 ); // MVA output between -1 and 1
       mvaCategories.push_back( cat );

--- a/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
@@ -242,7 +242,13 @@ modifyObject(pat::Electron& ele) const {
   // and the value maps are to the reducedEG object, can use original object ptr
   // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference    
   edm::Ptr<reco::Candidate> ptr(ele.originalObjectRef());
+
+
+  // The calls to this function should be matched to the order of the electrons
+  // in eles_by_oop. In case it is called too many times, it will throw thanks
+  // to the use of std::vector<T>::at().
   if( !e_conf.tok_electron_src.isUninitialized() ) ptr = eles_by_oop.at(ele_idx);
+
   //now we go through and modify the objects using the valuemaps we read in
   auto full5x5 = ele.full5x5_showerShape();
   assignValue(ptr,e_conf.tok_sigmaEtaEta,ele_vmaps,full5x5.sigmaEtaEta);
@@ -268,7 +274,12 @@ modifyObject(pat::Photon& pho) const {
   // and the value maps are to the reducedEG object, can use original object ptr
   // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference
   edm::Ptr<reco::Candidate> ptr(pho.originalObjectRef());
+
+  // The calls to this function should be matched to the order of the electrons
+  // in eles_by_oop. In case it is called too many times, it will throw thanks
+  // to the use of std::vector<T>::at().
   if( !ph_conf.tok_photon_src.isUninitialized() ) ptr = phos_by_oop.at(pho_idx);
+
   //now we go through and modify the objects using the valuemaps we read in
   auto full5x5 = pho.full5x5_showerShapeVariables();
   assignValue(ptr,ph_conf.tok_sigmaEtaEta,pho_vmaps,full5x5.sigmaEtaEta);

--- a/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
@@ -189,7 +189,12 @@ modifyObject(pat::Electron& ele) const {
   // and the value maps are to the reducedEG object, can use original object ptr
   // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference    
   edm::Ptr<reco::Candidate> ptr(ele.originalObjectRef());
+
+  // The calls to this function should be matched to the order of the electrons
+  // in eles_by_oop. In case it is called too many times, it will throw thanks
+  // to the use of std::vector<T>::at().
   if( !e_conf.tok_electron_src.isUninitialized() ) ptr = eles_by_oop.at(ele_idx);
+
   //now we go through and modify the objects using the valuemaps we read in
   auto pfIso = ele.pfIsolationVariables();
     
@@ -214,7 +219,12 @@ modifyObject(pat::Photon& pho) const {
   // and the value maps are to the reducedEG object, can use original object ptr
   // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference
   edm::Ptr<reco::Candidate> ptr(pho.originalObjectRef());
+
+  // The calls to this function should be matched to the order of the electrons
+  // in eles_by_oop. In case it is called too many times, it will throw thanks
+  // to the use of std::vector<T>::at().
   if( !ph_conf.tok_photon_src.isUninitialized() ) ptr = phos_by_oop.at(pho_idx);
+
   //now we go through and modify the objects using the valuemaps we read in
   auto pfIso = pho.getPflowIsolationVariables();
 

--- a/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
@@ -55,7 +55,6 @@ public:
   EGPfIsolationModifierFromValueMaps(const edm::ParameterSet& conf);
   
   void setEvent(const edm::Event&) final;
-  void setEventContent(const edm::EventSetup&) final;
   void setConsumes(edm::ConsumesCollector&) final;
   
   void modifyObject(pat::Electron&) const final;
@@ -64,9 +63,9 @@ public:
 private:
   electron_config e_conf;
   photon_config   ph_conf;
-  std::unordered_map<unsigned,edm::Ptr<reco::GsfElectron> > eles_by_oop; // indexed by original object ptr
+  std::vector<edm::Ptr<reco::GsfElectron>> eles_by_oop; // indexed by original object ptr
   std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > > ele_vmaps;
-  std::unordered_map<unsigned,edm::Ptr<reco::Photon> > phos_by_oop;
+  std::vector<edm::Ptr<reco::Photon>> phos_by_oop;
   std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > > pho_vmaps;
   mutable unsigned ele_idx,pho_idx; // hack here until we figure out why some slimmedPhotons don't have original object ptrs
 };
@@ -121,10 +120,8 @@ setEvent(const edm::Event& evt) {
     edm::Handle<edm::View<pat::Electron> > eles;
     evt.getByToken(e_conf.tok_electron_src,eles);
     
-    for( unsigned i = 0; i < eles->size(); ++i ) {
-      edm::Ptr<pat::Electron> ptr = eles->ptrAt(i);
-      eles_by_oop[i] = ptr;
-    }
+    eles_by_oop.resize(eles->size());
+    std::copy(eles->ptrs().begin(), eles->ptrs().end(), eles_by_oop.begin());
   }
 
   for( const std::string& varname : electron_vars ) {
@@ -137,10 +134,8 @@ setEvent(const edm::Event& evt) {
     edm::Handle<edm::View<pat::Photon> > phos;
     evt.getByToken(ph_conf.tok_photon_src,phos);
 
-    for( unsigned i = 0; i < phos->size(); ++i ) {
-      edm::Ptr<pat::Photon> ptr = phos->ptrAt(i);
-      phos_by_oop[i] = ptr;
-    }
+    phos_by_oop.resize(phos->size());
+    std::copy(phos->ptrs().begin(), phos->ptrs().end(), phos_by_oop.begin());
   }
   
   for( const std::string& varname : photon_vars ) {
@@ -148,10 +143,6 @@ setEvent(const edm::Event& evt) {
     if( inputs.find(varname) == inputs.end() ) continue;
     get_product(evt,std::get<1>(inputs[varname]),pho_vmaps);
   }   
-}
-
-void EGPfIsolationModifierFromValueMaps::
-setEventContent(const edm::EventSetup& evs) {
 }
 
 namespace {
@@ -198,15 +189,7 @@ modifyObject(pat::Electron& ele) const {
   // and the value maps are to the reducedEG object, can use original object ptr
   // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference    
   edm::Ptr<reco::Candidate> ptr(ele.originalObjectRef());
-  if( !e_conf.tok_electron_src.isUninitialized() ) {
-    auto key = eles_by_oop.find(ele_idx);
-    if( key != eles_by_oop.end() ) {
-      ptr = key->second;
-    } else {
-      throw cms::Exception("BadElectronKey")
-        << "Original object pointer with key = " << ele.originalObjectRef().key() << " not found in cache!";
-    }
-  }
+  if( !e_conf.tok_electron_src.isUninitialized() ) ptr = eles_by_oop.at(ele_idx);
   //now we go through and modify the objects using the valuemaps we read in
   auto pfIso = ele.pfIsolationVariables();
     
@@ -231,16 +214,7 @@ modifyObject(pat::Photon& pho) const {
   // and the value maps are to the reducedEG object, can use original object ptr
   // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference
   edm::Ptr<reco::Candidate> ptr(pho.originalObjectRef());
-  if( !ph_conf.tok_photon_src.isUninitialized() ) {
-    auto key = phos_by_oop.find(pho_idx);
-    if( key != phos_by_oop.end() ) {
-      ptr = key->second;
-    } else {
-      throw cms::Exception("BadPhotonKey")
-        << "Original object pointer with key = " << pho.originalObjectRef().key() << " not found in cache!";
-    }
-  }
-
+  if( !ph_conf.tok_photon_src.isUninitialized() ) ptr = phos_by_oop.at(pho_idx);
   //now we go through and modify the objects using the valuemaps we read in
   auto pfIso = pho.getPflowIsolationVariables();
 

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.cc
@@ -1,0 +1,15 @@
+#include "RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.h"
+
+std::vector<const GBRForestD*> retrieveGBRForests(edm::EventSetup const& evs, std::vector<std::string> const& names)
+{
+  std::vector<const GBRForestD*> items;
+  edm::ESHandle<GBRForestD> handle;
+
+  for(auto const& name : names) {
+    evs.get<GBRDWrapperRcd>().get(name, handle);
+    items.push_back(handle.product());
+  }
+
+  return items;
+}
+

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.h
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.h
@@ -1,0 +1,14 @@
+#ifndef RecoEgamma_EgammaTools_EGRegressionModifier_H
+#define RecoEgamma_EgammaTools_EGRegressionModifier_H
+
+#include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
+#include "CondFormats/EgammaObjects/interface/GBRForestD.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include <string>
+#include <vector>
+
+std::vector<const GBRForestD*> retrieveGBRForests(edm::EventSetup const& evs, std::vector<std::string> const& names);
+
+#endif

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
@@ -27,16 +27,10 @@ namespace {
 
 class EGRegressionModifierV1 : public ModifyObjectValueBase {
 public:
-  typedef edm::EDGetTokenT<edm::ValueMap<float> > ValMapFloatToken;
-  typedef edm::EDGetTokenT<edm::ValueMap<int> > ValMapIntToken;
-  typedef std::pair<edm::InputTag, ValMapFloatToken> ValMapFloatTagTokenPair;
-  typedef std::pair<edm::InputTag, ValMapIntToken> ValMapIntTagTokenPair;
 
   struct electron_config {
     edm::InputTag electron_src;
     edm::EDGetTokenT<edm::View<pat::Electron> > tok_electron_src;
-    std::unordered_map<std::string, ValMapFloatTagTokenPair> tag_float_token_map;
-    std::unordered_map<std::string, ValMapIntTagTokenPair> tag_int_token_map;
 
     std::vector<std::string> condnames_mean_50ns;
     std::vector<std::string> condnames_sigma_50ns;
@@ -49,8 +43,6 @@ public:
   struct photon_config {
     edm::InputTag photon_src;
     edm::EDGetTokenT<edm::View<pat::Photon> > tok_photon_src;
-    std::unordered_map<std::string, ValMapFloatTagTokenPair> tag_float_token_map;
-    std::unordered_map<std::string, ValMapIntTagTokenPair> tag_int_token_map;
 
     std::vector<std::string> condnames_mean_50ns;
     std::vector<std::string> condnames_sigma_50ns;
@@ -59,7 +51,6 @@ public:
   };
 
   EGRegressionModifierV1(const edm::ParameterSet& conf);
-  ~EGRegressionModifierV1() override {};
     
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
@@ -69,18 +60,12 @@ public:
   void modifyObject(reco::Photon&) const final;
   
   // just calls reco versions
-  void modifyObject(pat::Electron&) const final; 
-  void modifyObject(pat::Photon&) const final;
+  void modifyObject(pat::Electron& ele) const final { modifyObject(static_cast<reco::GsfElectron&>(ele)); }
+  void modifyObject(pat::Photon& pho) const final { modifyObject(static_cast<reco::Photon&>(pho)); }
 
 private:
   electron_config e_conf;
   photon_config   ph_conf;
-  std::unordered_map<unsigned,edm::Ptr<reco::GsfElectron> > eles_by_oop; // indexed by original object ptr
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > > ele_vmaps;
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<int> > > ele_int_vmaps;
-  std::unordered_map<unsigned,edm::Ptr<reco::Photon> > phos_by_oop;
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > > pho_vmaps;
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<int> > > pho_int_vmaps;
 
   bool autoDetectBunchSpacing_;
   int bunchspacing_;
@@ -124,33 +109,15 @@ EGRegressionModifierV1::EGRegressionModifierV1(const edm::ParameterSet& conf) :
     bunchspacing_ = conf.getParameter<int>("manualBunchSpacing");
   }
 
-  constexpr char electronSrc[] =  "electronSrc";
-  constexpr char photonSrc[] =  "photonSrc";
-
   if(conf.exists("electron_config")) {
     const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
-    if( electrons.exists(electronSrc) ) 
-      e_conf.electron_src = electrons.getParameter<edm::InputTag>(electronSrc);
+    if( electrons.exists("electronSrc") ) 
+      e_conf.electron_src = electrons.getParameter<edm::InputTag>("electronSrc");
     
     std::vector<std::string> intValueMaps;
     if ( electrons.existsAs<std::vector<std::string> >("intValueMaps")) 
       intValueMaps = electrons.getParameter<std::vector<std::string> >("intValueMaps");
 
-    const std::vector<std::string> parameters = electrons.getParameterNames();
-    for( const std::string& name : parameters ) {
-      if( std::string(electronSrc) == name ) 
-	continue;
-      if( electrons.existsAs<edm::InputTag>(name)) {
-	for (auto vmp : intValueMaps) {
-	  if (name == vmp) {
-	    e_conf.tag_int_token_map[name] = ValMapIntTagTokenPair(electrons.getParameter<edm::InputTag>(name), ValMapIntToken());
-	    break;
-	  } 
-	}
-	e_conf.tag_float_token_map[name] = ValMapFloatTagTokenPair(electrons.getParameter<edm::InputTag>(name), ValMapFloatToken());
-      }
-    }
-    
     e_conf.condnames_mean_50ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_50ns");
     e_conf.condnames_sigma_50ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_50ns");
     e_conf.condnames_mean_25ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_25ns");
@@ -162,27 +129,12 @@ EGRegressionModifierV1::EGRegressionModifierV1(const edm::ParameterSet& conf) :
   if( conf.exists("photon_config") ) { 
     const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
 
-    if( photons.exists(photonSrc) ) 
-      ph_conf.photon_src = photons.getParameter<edm::InputTag>(photonSrc);
+    if( photons.exists("photonSrc") ) 
+      ph_conf.photon_src = photons.getParameter<edm::InputTag>("photonSrc");
 
     std::vector<std::string> intValueMaps;
     if ( photons.existsAs<std::vector<std::string> >("intValueMaps")) 
       intValueMaps = photons.getParameter<std::vector<std::string> >("intValueMaps");
-
-    const std::vector<std::string> parameters = photons.getParameterNames();
-    for( const std::string& name : parameters ) {
-      if( std::string(photonSrc) == name ) 
-	continue;
-      if( photons.existsAs<edm::InputTag>(name)) {
-	for (auto vmp : intValueMaps) {
-	  if (name == vmp) {
-	    ph_conf.tag_int_token_map[name] = ValMapIntTagTokenPair(photons.getParameter<edm::InputTag>(name), ValMapIntToken());
-	    break;
-	  } 
-	}
-	ph_conf.tag_float_token_map[name] = ValMapFloatTagTokenPair(photons.getParameter<edm::InputTag>(name), ValMapFloatToken());
-      }
-    }
 
     ph_conf.condnames_mean_50ns = photons.getParameter<std::vector<std::string>>("regressionKey_50ns");
     ph_conf.condnames_sigma_50ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_50ns");
@@ -191,66 +143,18 @@ EGRegressionModifierV1::EGRegressionModifierV1(const edm::ParameterSet& conf) :
   }
 }
 
-namespace {
-  template<typename T>
-  inline void get_product(const edm::Event& evt,
-                          const edm::EDGetTokenT<edm::ValueMap<T> >& tok,
-                          std::unordered_map<unsigned, edm::Handle<edm::ValueMap<T> > >& map) {
-    evt.getByToken(tok,map[tok.index()]);
-  }
-}
-
 void EGRegressionModifierV1::setEvent(const edm::Event& evt) {
-  eles_by_oop.clear();
-  phos_by_oop.clear();  
-  ele_vmaps.clear();
-  ele_int_vmaps.clear();
-  pho_vmaps.clear();
-  pho_int_vmaps.clear();
   
   if( !e_conf.tok_electron_src.isUninitialized() ) {
     edm::Handle<edm::View<pat::Electron> > eles;
     evt.getByToken(e_conf.tok_electron_src, eles);
-    
-    for(auto const& ptr : eles->ptrs()) {
-      eles_by_oop[ptr->originalObjectRef().key()] = ptr;
-    }    
   }
 
-  for (std::unordered_map<std::string, ValMapFloatTagTokenPair>::iterator imap = e_conf.tag_float_token_map.begin(); 
-       imap != e_conf.tag_float_token_map.end(); 
-       imap++) {
-    get_product(evt, imap->second.second, ele_vmaps);
-  }
-
-  for (std::unordered_map<std::string, ValMapIntTagTokenPair>::iterator imap = e_conf.tag_int_token_map.begin(); 
-       imap != e_conf.tag_int_token_map.end(); 
-       imap++) {
-    get_product(evt, imap->second.second, ele_int_vmaps);
-  }
-  
   if( !ph_conf.tok_photon_src.isUninitialized() ) {
     edm::Handle<edm::View<pat::Photon> > phos;
     evt.getByToken(ph_conf.tok_photon_src,phos);
-  
-    for(auto const& ptr : phos->ptrs()) {
-      phos_by_oop[ptr->originalObjectRef().key()] = ptr;
-    }
   }
    
-
-  for (std::unordered_map<std::string, ValMapFloatTagTokenPair>::iterator imap = ph_conf.tag_float_token_map.begin(); 
-       imap != ph_conf.tag_float_token_map.end(); 
-       imap++) {
-    get_product(evt, imap->second.second, pho_vmaps);
-  }
-
-  for (std::unordered_map<std::string, ValMapIntTagTokenPair>::iterator imap = ph_conf.tag_int_token_map.begin(); 
-       imap != ph_conf.tag_int_token_map.end(); 
-       imap++) {
-    get_product(evt, imap->second.second, pho_int_vmaps);
-  }
-  
   if (autoDetectBunchSpacing_) {
       edm::Handle<unsigned int> bunchSpacingH;
       evt.getByToken(bunchSpacingToken_,bunchSpacingH);
@@ -299,20 +203,6 @@ void EGRegressionModifierV1::setEventContent(const edm::EventSetup& evs) {
   }
 }
 
-namespace {
-  template<typename T, typename U, typename V>
-  inline void make_consumes(T& tag,U& tok,V& sume) { 
-    if(!(empty_tag == tag)) 
-      tok = sume.template consumes<edm::ValueMap<float> >(tag); 
-  }
-
-  template<typename T, typename U, typename V>
-  inline void make_int_consumes(T& tag,U& tok,V& sume) { 
-    if(!(empty_tag == tag)) 
-      tok = sume.template consumes<edm::ValueMap<int> >(tag); 
-  }
-}
-
 void EGRegressionModifierV1::setConsumes(edm::ConsumesCollector& sumes) {
  
   rhoToken_ = sumes.consumes<double>(rhoTag_);
@@ -325,40 +215,10 @@ void EGRegressionModifierV1::setConsumes(edm::ConsumesCollector& sumes) {
   if(!(empty_tag == e_conf.electron_src))
     e_conf.tok_electron_src = sumes.consumes<edm::View<pat::Electron> >(e_conf.electron_src);  
 
-  for ( std::unordered_map<std::string, ValMapFloatTagTokenPair>::iterator imap = e_conf.tag_float_token_map.begin(); 
-	imap != e_conf.tag_float_token_map.end(); 
-	imap++) {
-    make_consumes(imap->second.first, imap->second.second, sumes);
-  }  
-
-  for ( std::unordered_map<std::string, ValMapIntTagTokenPair>::iterator imap = e_conf.tag_int_token_map.begin(); 
-	imap != e_conf.tag_int_token_map.end(); 
-	imap++) {
-    make_int_consumes(imap->second.first, imap->second.second, sumes);
-  }  
-  
   // setup photons 
   if(!(empty_tag == ph_conf.photon_src)) 
     ph_conf.tok_photon_src = sumes.consumes<edm::View<pat::Photon> >(ph_conf.photon_src);
 
-  for ( std::unordered_map<std::string, ValMapFloatTagTokenPair>::iterator imap = ph_conf.tag_float_token_map.begin(); 
-	imap != ph_conf.tag_float_token_map.end(); 
-	imap++) {
-    make_consumes(imap->second.first, imap->second.second, sumes);
-  }  
-
-  for ( std::unordered_map<std::string, ValMapIntTagTokenPair>::iterator imap = ph_conf.tag_int_token_map.begin(); 
-	imap != ph_conf.tag_int_token_map.end(); 
-	imap++) {
-    make_int_consumes(imap->second.first, imap->second.second, sumes);
-  }  
-}
-
-namespace {
-  template<typename T, typename U, typename V, typename Z>
-  inline void assignValue(const T& ptr, const U& tok, const V& map, Z& value) {
-    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
-  }
 }
 
 void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
@@ -555,10 +415,6 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   ele.correctMomentum(newMomentum, ele.trackMomentumError(), combinedMomentumError);
 }
 
-void EGRegressionModifierV1::modifyObject(pat::Electron& ele) const {
-  modifyObject(static_cast<reco::GsfElectron&>(ele));
-}
-
 void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   // regression calculation needs no additional valuemaps
   
@@ -658,8 +514,4 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
 
   double sigmacor = sigma*ecor;
   pho.setCorrectedEnergy(reco::Photon::P4type::regression2, ecor, sigmacor, true);     
-}
-
-void EGRegressionModifierV1::modifyObject(pat::Photon& pho) const {
-  modifyObject(static_cast<reco::Photon&>(pho));
 }

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
@@ -2,7 +2,16 @@
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
-#include "RecoEgamma/EgammaTools/plugins/EGRegressionModifier.h"
+#include "RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.h"
+#include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
+
+#include <vdt/vdtMath.h>
 
 class EGRegressionModifierV1 : public ModifyObjectValueBase {
 public:

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
@@ -7,22 +7,6 @@
 class EGRegressionModifierV1 : public ModifyObjectValueBase {
 public:
 
-  struct ElectronConfig {
-    std::vector<std::string> condnames_mean_50ns;
-    std::vector<std::string> condnames_sigma_50ns;
-    std::vector<std::string> condnames_mean_25ns;
-    std::vector<std::string> condnames_sigma_25ns;
-    std::string condnames_weight_50ns;
-    std::string condnames_weight_25ns;
-  };
-
-  struct PhotonConfig {
-    std::vector<std::string> condnames_mean_50ns;
-    std::vector<std::string> condnames_sigma_50ns;
-    std::vector<std::string> condnames_mean_25ns;
-    std::vector<std::string> condnames_sigma_25ns;
-  };
-
   EGRegressionModifierV1(const edm::ParameterSet& conf);
 
   void setEvent(const edm::Event&) final;
@@ -37,62 +21,70 @@ public:
   void modifyObject(pat::Photon& pho) const final { modifyObject(static_cast<reco::Photon&>(pho)); }
 
 private:
-  ElectronConfig e_conf;
-  PhotonConfig   ph_conf;
 
-  bool autoDetectBunchSpacing_;
+  struct CondNames {
+    std::vector<std::string> mean50ns;
+    std::vector<std::string> sigma50ns;
+    std::vector<std::string> mean25ns;
+    std::vector<std::string> sigma25ns;
+  };
+
+  CondNames eleCondNames_;
+  CondNames phoCondNames_;
+
+  std::string condNamesWeight50ns_;
+  std::string condNamesWeight25ns_;
+
+  const bool autoDetectBunchSpacing_;
   int bunchspacing_;
   edm::InputTag bunchspacingTag_;
   edm::EDGetTokenT<unsigned int> bunchSpacingToken_;
   float rhoValue_;
-  edm::InputTag rhoTag_;
+  const edm::InputTag rhoTag_;
   edm::EDGetTokenT<double> rhoToken_;
   int nVtx_;
-  edm::InputTag vtxTag_;
+  const edm::InputTag vtxTag_;
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
   edm::Handle<reco::VertexCollection> vtxH_;
-  bool applyExtraHighEnergyProtection_;
+  const bool applyExtraHighEnergyProtection_;
 
   const edm::EventSetup* iSetup_;
 
-  std::vector<const GBRForestD*> ph_forestH_mean_;
-  std::vector<const GBRForestD*> ph_forestH_sigma_;
-  std::vector<const GBRForestD*> e_forestH_mean_;
-  std::vector<const GBRForestD*> e_forestH_sigma_;
-  const GBRForest* ep_forestH_weight_;
+  std::vector<const GBRForestD*> phoForestsMean_;
+  std::vector<const GBRForestD*> phoForestsSigma_;
+  std::vector<const GBRForestD*> eleForestsMean_;
+  std::vector<const GBRForestD*> eleForestsSigma_;
+  const GBRForest* epForest_;
 };
 
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory, EGRegressionModifierV1, "EGRegressionModifierV1");
 
-EGRegressionModifierV1::EGRegressionModifierV1(const edm::ParameterSet& conf) :
-  ModifyObjectValueBase(conf) {
+EGRegressionModifierV1::EGRegressionModifierV1(const edm::ParameterSet& conf)
+  : ModifyObjectValueBase(conf)
+  , autoDetectBunchSpacing_(conf.getParameter<bool>("autoDetectBunchSpacing"))
+  , bunchspacing_(autoDetectBunchSpacing_ ? 450 : conf.getParameter<int>("manualBunchSpacing"))
+  , bunchspacingTag_(autoDetectBunchSpacing_ ? conf.getParameter<edm::InputTag>("bunchSpacingTag") : edm::InputTag())
+  , rhoTag_(conf.getParameter<edm::InputTag>("rhoCollection"))
+  , vtxTag_(conf.getParameter<edm::InputTag>("vertexCollection"))
+  , applyExtraHighEnergyProtection_(conf.getParameter<bool>("applyExtraHighEnergyProtection"))
+{
+  const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
+  eleCondNames_ = CondNames {
+      .mean50ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_50ns"),
+      .sigma50ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_50ns"),
+      .mean25ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_25ns"),
+      .sigma25ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_25ns")
+  };
+  condNamesWeight50ns_  = electrons.getParameter<std::string>("combinationKey_50ns");
+  condNamesWeight25ns_  = electrons.getParameter<std::string>("combinationKey_25ns");
 
-  bunchspacing_ = 450;
-  autoDetectBunchSpacing_ = conf.getParameter<bool>("autoDetectBunchSpacing");
-  applyExtraHighEnergyProtection_ = conf.getParameter<bool>("applyExtraHighEnergyProtection");
-
-  rhoTag_ = conf.getParameter<edm::InputTag>("rhoCollection");
-  vtxTag_ = conf.getParameter<edm::InputTag>("vertexCollection");
-
-  if (autoDetectBunchSpacing_) {
-    bunchspacingTag_ = conf.getParameter<edm::InputTag>("bunchSpacingTag");
-  } else {
-    bunchspacing_ = conf.getParameter<int>("manualBunchSpacing");
-  }
-
-  const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("ElectronConfig");
-  e_conf.condnames_mean_50ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_50ns");
-  e_conf.condnames_sigma_50ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_50ns");
-  e_conf.condnames_mean_25ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_25ns");
-  e_conf.condnames_sigma_25ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_25ns");
-  e_conf.condnames_weight_50ns  = electrons.getParameter<std::string>("combinationKey_50ns");
-  e_conf.condnames_weight_25ns  = electrons.getParameter<std::string>("combinationKey_25ns");
-
-  const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("PhotonConfig");
-  ph_conf.condnames_mean_50ns = photons.getParameter<std::vector<std::string>>("regressionKey_50ns");
-  ph_conf.condnames_sigma_50ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_50ns");
-  ph_conf.condnames_mean_25ns = photons.getParameter<std::vector<std::string>>("regressionKey_25ns");
-  ph_conf.condnames_sigma_25ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_25ns");
+  const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
+  phoCondNames_ = CondNames {
+      .mean50ns  = photons.getParameter<std::vector<std::string>>("regressionKey_50ns"),
+      .sigma50ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_50ns"),
+      .mean25ns  = photons.getParameter<std::vector<std::string>>("regressionKey_25ns"),
+      .sigma25ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_25ns")
+  };
 }
 
 void EGRegressionModifierV1::setEvent(const edm::Event& evt)
@@ -115,16 +107,16 @@ void EGRegressionModifierV1::setEventContent(const edm::EventSetup& evs)
 {
   iSetup_ = &evs;
 
-  ph_forestH_mean_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? ph_conf.condnames_mean_25ns  : ph_conf.condnames_mean_50ns);
-  ph_forestH_sigma_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? ph_conf.condnames_sigma_25ns  : ph_conf.condnames_sigma_50ns);
+  phoForestsMean_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? phoCondNames_.mean25ns  : phoCondNames_.mean50ns);
+  phoForestsSigma_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? phoCondNames_.sigma25ns  : phoCondNames_.sigma50ns);
 
-  e_forestH_mean_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? e_conf.condnames_mean_25ns  : e_conf.condnames_mean_50ns);
-  e_forestH_sigma_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? e_conf.condnames_sigma_25ns  : e_conf.condnames_sigma_50ns);
+  eleForestsMean_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? eleCondNames_.mean25ns  : eleCondNames_.mean50ns);
+  eleForestsSigma_ = retrieveGBRForests(evs, (bunchspacing_ == 25) ? eleCondNames_.sigma25ns  : eleCondNames_.sigma50ns);
 
   edm::ESHandle<GBRForest> forestEH;
-  const std::string ep_condnames_weight  = (bunchspacing_ == 25) ? e_conf.condnames_weight_25ns  : e_conf.condnames_weight_50ns;
+  const std::string ep_condnames_weight  = (bunchspacing_ == 25) ? condNamesWeight25ns_  : condNamesWeight50ns_;
   evs.get<GBRWrapperRcd>().get(ep_condnames_weight, forestEH);
-  ep_forestH_weight_ = forestEH.product();
+  epForest_ = forestEH.product();
 }
 
 void EGRegressionModifierV1::setConsumes(edm::ConsumesCollector& sumes) {
@@ -139,28 +131,28 @@ void EGRegressionModifierV1::setConsumes(edm::ConsumesCollector& sumes) {
 void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   // regression calculation needs no additional valuemaps
 
-  const reco::SuperClusterRef& the_sc = ele.superCluster();
-  const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();
-  const int numberOfClusters =  the_sc->clusters().size();
-  const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
+  const reco::SuperClusterRef& superClus = ele.superCluster();
+  const edm::Ptr<reco::CaloCluster>& theseed = superClus->seed();
+  const int numberOfClusters =  superClus->clusters().size();
+  const bool missing_clusters = !superClus->clusters()[numberOfClusters-1].isAvailable();
 
   if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
 
   std::array<float, 33> eval;
-  const double raw_energy = the_sc->rawEnergy();
+  const double rawEnergy = superClus->rawEnergy();
   const auto& ess = ele.showerShape();
 
   // SET INPUTS
   eval[0]  = nVtx_;
-  eval[1]  = raw_energy;
-  eval[2]  = the_sc->eta();
-  eval[3]  = the_sc->phi();
-  eval[4]  = the_sc->etaWidth();
-  eval[5]  = the_sc->phiWidth();
+  eval[1]  = rawEnergy;
+  eval[2]  = superClus->eta();
+  eval[3]  = superClus->phi();
+  eval[4]  = superClus->etaWidth();
+  eval[5]  = superClus->phiWidth();
   eval[6]  = ess.r9;
-  eval[7]  = theseed->energy()/raw_energy;
-  eval[8]  = ess.eMax/raw_energy;
-  eval[9]  = ess.e2nd/raw_energy;
+  eval[7]  = theseed->energy()/rawEnergy;
+  eval[8]  = ess.eMax/rawEnergy;
+  eval[9]  = ess.e2nd/rawEnergy;
   eval[10] = (ess.eLeft + ess.eRight != 0.f  ? (ess.eLeft-ess.eRight)/(ess.eLeft+ess.eRight) : 0.f);
   eval[11] = (ess.eTop  + ess.eBottom != 0.f ? (ess.eTop-ess.eBottom)/(ess.eTop+ess.eBottom) : 0.f);
   eval[12] = ess.sigmaIetaIeta;
@@ -183,7 +175,7 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   size_t iclus = 0;
   float maxDR = 0;
   // loop over all clusters that aren't the seed
-  for (auto const& pclus : the_sc->clusters())
+  for (auto const& pclus : superClus->clusters())
   {
     if(theseed == pclus )
       continue;
@@ -206,10 +198,10 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   eval[16] = clusterMaxDR;
   eval[17] = clusterMaxDRDPhi;
   eval[18] = clusterMaxDRDEta;
-  eval[19] = clusterMaxDRRawEnergy/raw_energy;
-  eval[20] = clusterRawEnergy[0]/raw_energy;
-  eval[21] = clusterRawEnergy[1]/raw_energy;
-  eval[22] = clusterRawEnergy[2]/raw_energy;
+  eval[19] = clusterMaxDRRawEnergy/rawEnergy;
+  eval[20] = clusterRawEnergy[0]/rawEnergy;
+  eval[21] = clusterRawEnergy[1]/rawEnergy;
+  eval[22] = clusterRawEnergy[2]/rawEnergy;
   eval[23] = clusterDPhiToSeed[0];
   eval[24] = clusterDPhiToSeed[1];
   eval[25] = clusterDPhiToSeed[2];
@@ -218,25 +210,25 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   eval[28] = clusterDEtaToSeed[2];
 
   // calculate coordinate variables
-  const bool iseb = ele.isEB();
+  const bool isEB = ele.isEB();
   float dummy;
   int iPhi;
   int iEta;
   float cryPhi;
   float cryEta;
-  EcalClusterLocal _ecalLocal;
+  EcalClusterLocal ecalLocal;
   if (ele.isEB())
-    _ecalLocal.localCoordsEB(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
+    ecalLocal.localCoordsEB(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
   else
-    _ecalLocal.localCoordsEE(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
+    ecalLocal.localCoordsEE(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
 
-  if (iseb) {
+  if (isEB) {
     eval[29] = cryEta;
     eval[30] = cryPhi;
     eval[31] = iEta;
     eval[32] = iPhi;
   } else {
-    eval[29] = the_sc->preshowerEnergy()/the_sc->rawEnergy();
+    eval[29] = superClus->preshowerEnergy()/superClus->rawEnergy();
   }
 
   //magic numbers for MINUIT-like transformation of BDT output onto limited range
@@ -251,13 +243,11 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
   constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);
 
-  int coridx = 0;
-  if (!iseb)
-    coridx = 1;
+  const int coridx = isEB ? 0 : 1;
 
   //these are the actual BDT responses
-  double rawmean = e_forestH_mean_[coridx]->GetResponse(eval.data());
-  double rawsigma = e_forestH_sigma_[coridx]->GetResponse(eval.data());
+  double rawmean = eleForestsMean_[coridx]->GetResponse(eval.data());
+  double rawsigma = eleForestsSigma_[coridx]->GetResponse(eval.data());
 
   //apply transformation to limited output range (matching the training)
   double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
@@ -266,8 +256,8 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   //regression target is ln(Etrue/Eraw)
   //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
   double ecor = mean*(eval[1]);
-  if (!iseb)
-    ecor = mean*(eval[1]+the_sc->preshowerEnergy());
+  if (!isEB)
+    ecor = mean*(eval[1]+superClus->preshowerEnergy());
   const double sigmacor = sigma*ecor;
 
   ele.setCorrectedEcalEnergy(ecor);
@@ -277,7 +267,7 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   std::array<float, 11> eval_ep;
 
   const float ep = ele.trackMomentumAtVtx().R();
-  const float tot_energy = the_sc->rawEnergy()+the_sc->preshowerEnergy();
+  const float tot_energy = superClus->rawEnergy()+superClus->preshowerEnergy();
   const float momentumError = ele.trackMomentumError();
   const float trkMomentumRelError = ele.trackMomentumError()/ep;
   const float eOverP = tot_energy*mean/ep;
@@ -291,11 +281,11 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   eval_ep[7] = ele.ecalDriven();
   eval_ep[8] = ele.trackerDrivenSeed();
   eval_ep[9] = int(ele.classification());//eleClass;
-  eval_ep[10] = iseb;
+  eval_ep[10] = isEB;
 
   // CODE FOR FUTURE SEMI_PARAMETRIC
-  //double rawweight = ep_forestH_mean_[coridx]->GetResponse(eval_ep.data());
-  ////rawsigma = ep_forestH_sigma_[coridx]->GetResponse(eval.data());
+  //double rawweight = ep_forestsMean_[coridx]->GetResponse(eval_ep.data());
+  ////rawsigma = ep_forestsSigma_[coridx]->GetResponse(eval.data());
   //double weight = meanoffset + meanscale*vdt::fast_sin(rawweight);
   ////sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
 
@@ -306,19 +296,18 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
        (!applyExtraHighEnergyProtection_ || ((momentumError < 10.*ep) || (ecor < 200.)))
        ) {
     // protection against crazy track measurement
-    weight = std::clamp(ep_forestH_weight_->GetResponse(eval_ep.data()), 0., 1.);
+    weight = std::clamp(epForest_->GetResponse(eval_ep.data()), 0., 1.);
   }
 
   double combinedMomentum = weight*ele.trackMomentumAtVtx().R() + (1.-weight)*ecor;
   double combinedMomentumError = sqrt(weight*weight*ele.trackMomentumError()*ele.trackMomentumError() + (1.-weight)*(1.-weight)*sigmacor*sigmacor);
 
   math::XYZTLorentzVector oldMomentum = ele.p4();
-  math::XYZTLorentzVector newMomentum = math::XYZTLorentzVector( oldMomentum.x()*combinedMomentum/oldMomentum.t(),
-                                                                 oldMomentum.y()*combinedMomentum/oldMomentum.t(),
-                                                                 oldMomentum.z()*combinedMomentum/oldMomentum.t(),
-                                                                 combinedMomentum );
+  math::XYZTLorentzVector newMomentum( oldMomentum.x()*combinedMomentum/oldMomentum.t(),
+                                       oldMomentum.y()*combinedMomentum/oldMomentum.t(),
+                                       oldMomentum.z()*combinedMomentum/oldMomentum.t(),
+                                       combinedMomentum );
 
-  //ele.correctEcalEnergy(combinedMomentum, combinedMomentumError);
   ele.correctMomentum(newMomentum, ele.trackMomentumError(), combinedMomentumError);
 }
 
@@ -326,29 +315,29 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   // regression calculation needs no additional valuemaps
 
   std::array<float, 35> eval;
-  const reco::SuperClusterRef& the_sc = pho.superCluster();
-  const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();
+  const reco::SuperClusterRef& superClus = pho.superCluster();
+  const edm::Ptr<reco::CaloCluster>& theseed = superClus->seed();
 
-  const int numberOfClusters =  the_sc->clusters().size();
-  const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
+  const int numberOfClusters =  superClus->clusters().size();
+  const bool missing_clusters = !superClus->clusters()[numberOfClusters-1].isAvailable();
 
   if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
 
-  const double raw_energy = the_sc->rawEnergy();
+  const double rawEnergy = superClus->rawEnergy();
   const auto& ess = pho.showerShapeVariables();
 
   // SET INPUTS
-  eval[0]  = raw_energy;
+  eval[0]  = rawEnergy;
   eval[1]  = pho.r9();
-  eval[2]  = the_sc->etaWidth();
-  eval[3]  = the_sc->phiWidth();
+  eval[2]  = superClus->etaWidth();
+  eval[3]  = superClus->phiWidth();
   eval[4]  = std::max(0,numberOfClusters - 1);
   eval[5]  = pho.hadronicOverEm();
   eval[6]  = rhoValue_;
   eval[7]  = nVtx_;
-  eval[8] = theseed->eta()-the_sc->position().Eta();
-  eval[9] = reco::deltaPhi(theseed->phi(),the_sc->position().Phi());
-  eval[10] = theseed->energy()/raw_energy;
+  eval[8] = theseed->eta()-superClus->position().Eta();
+  eval[9] = reco::deltaPhi(theseed->phi(),superClus->position().Phi());
+  eval[10] = theseed->energy()/rawEnergy;
   eval[11] = ess.e3x3/ess.e5x5;
   eval[12] = ess.sigmaIetaIeta;
   eval[13] = ess.sigmaIphiIphi;
@@ -365,8 +354,8 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   eval[24] = ess.e2x5Top/ess.e5x5;
   eval[25] = ess.e2x5Bottom/ess.e5x5;
 
-  const bool iseb = pho.isEB();
-  if (iseb) {
+  const bool isEB = pho.isEB();
+  if (isEB) {
     EBDetId ebseedid(theseed->seed());
     eval[26] = pho.e5x5()/theseed->energy();
     int ieta = ebseedid.ieta();
@@ -382,9 +371,9 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
     eval[34] = iphi;  /// duplicated variables but this was trained like that
   } else {
     EEDetId eeseedid(theseed->seed());
-    eval[26] = the_sc->preshowerEnergy()/raw_energy;
-    eval[27] = the_sc->preshowerEnergyPlane1()/raw_energy;
-    eval[28] = the_sc->preshowerEnergyPlane2()/raw_energy;
+    eval[26] = superClus->preshowerEnergy()/rawEnergy;
+    eval[27] = superClus->preshowerEnergyPlane1()/rawEnergy;
+    eval[28] = superClus->preshowerEnergyPlane2()/rawEnergy;
     eval[29] = eeseedid.ix();
     eval[30] = eeseedid.iy();
   }
@@ -401,23 +390,19 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   const double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
   const double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);
 
-  int coridx = 0;
-  if (!iseb)
-    coridx = 1;
+  const int coridx = isEB ? 0 : 1;
 
   //these are the actual BDT responses
-  double rawmean = ph_forestH_mean_[coridx]->GetResponse(eval.data());
-  double rawsigma = ph_forestH_sigma_[coridx]->GetResponse(eval.data());
+  const double rawmean = phoForestsMean_[coridx]->GetResponse(eval.data());
+  const double rawsigma = phoForestsSigma_[coridx]->GetResponse(eval.data());
   //apply transformation to limited output range (matching the training)
-  double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
-  double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+  const double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
+  const double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
 
   //regression target is ln(Etrue/Eraw)
   //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
-  double ecor = mean*eval[0];
-  if (!iseb)
-    ecor = mean*(eval[0]+the_sc->preshowerEnergy());
+  const double ecor = isEB ? mean*eval[0] : mean*(eval[0]+superClus->preshowerEnergy());
 
-  double sigmacor = sigma*ecor;
+  const double sigmacor = sigma*ecor;
   pho.setCorrectedEnergy(reco::Photon::P4type::regression2, ecor, sigmacor, true);
 }

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
@@ -212,8 +212,7 @@ void EGRegressionModifierV1::setEvent(const edm::Event& evt) {
     edm::Handle<edm::View<pat::Electron> > eles;
     evt.getByToken(e_conf.tok_electron_src, eles);
     
-    for( unsigned i = 0; i < eles->size(); ++i ) {
-      edm::Ptr<pat::Electron> ptr = eles->ptrAt(i);
+    for(auto const& ptr : eles->ptrs()) {
       eles_by_oop[ptr->originalObjectRef().key()] = ptr;
     }    
   }
@@ -234,8 +233,7 @@ void EGRegressionModifierV1::setEvent(const edm::Event& evt) {
     edm::Handle<edm::View<pat::Photon> > phos;
     evt.getByToken(ph_conf.tok_photon_src,phos);
   
-    for( unsigned i = 0; i < phos->size(); ++i ) {
-      edm::Ptr<pat::Photon> ptr = phos->ptrAt(i);
+    for(auto const& ptr : phos->ptrs()) {
       phos_by_oop[ptr->originalObjectRef().key()] = ptr;
     }
   }

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV1.cc
@@ -24,14 +24,14 @@ public:
   };
 
   EGRegressionModifierV1(const edm::ParameterSet& conf);
-    
+
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
   void setConsumes(edm::ConsumesCollector&) final;
-  
+
   void modifyObject(reco::GsfElectron&) const final;
   void modifyObject(reco::Photon&) const final;
-  
+
   // just calls reco versions
   void modifyObject(pat::Electron& ele) const final { modifyObject(static_cast<reco::GsfElectron&>(ele)); }
   void modifyObject(pat::Photon& pho) const final { modifyObject(static_cast<reco::Photon&>(pho)); }
@@ -56,9 +56,9 @@ private:
   const edm::EventSetup* iSetup_;
 
   std::vector<const GBRForestD*> ph_forestH_mean_;
-  std::vector<const GBRForestD*> ph_forestH_sigma_; 
+  std::vector<const GBRForestD*> ph_forestH_sigma_;
   std::vector<const GBRForestD*> e_forestH_mean_;
-  std::vector<const GBRForestD*> e_forestH_sigma_; 
+  std::vector<const GBRForestD*> e_forestH_sigma_;
   const GBRForest* ep_forestH_weight_;
 };
 
@@ -73,7 +73,7 @@ EGRegressionModifierV1::EGRegressionModifierV1(const edm::ParameterSet& conf) :
 
   rhoTag_ = conf.getParameter<edm::InputTag>("rhoCollection");
   vtxTag_ = conf.getParameter<edm::InputTag>("vertexCollection");
-  
+
   if (autoDetectBunchSpacing_) {
     bunchspacingTag_ = conf.getParameter<edm::InputTag>("bunchSpacingTag");
   } else {
@@ -87,7 +87,7 @@ EGRegressionModifierV1::EGRegressionModifierV1(const edm::ParameterSet& conf) :
   e_conf.condnames_sigma_25ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_25ns");
   e_conf.condnames_weight_50ns  = electrons.getParameter<std::string>("combinationKey_50ns");
   e_conf.condnames_weight_25ns  = electrons.getParameter<std::string>("combinationKey_25ns");
-  
+
   const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("PhotonConfig");
   ph_conf.condnames_mean_50ns = photons.getParameter<std::vector<std::string>>("regressionKey_50ns");
   ph_conf.condnames_sigma_50ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_50ns");
@@ -106,7 +106,7 @@ void EGRegressionModifierV1::setEvent(const edm::Event& evt)
   edm::Handle<double> rhoH;
   evt.getByToken(rhoToken_, rhoH);
   rhoValue_ = *rhoH;
-  
+
   evt.getByToken(vtxToken_, vtxH_);
   nVtx_ = vtxH_->size();
 }
@@ -124,11 +124,11 @@ void EGRegressionModifierV1::setEventContent(const edm::EventSetup& evs)
   edm::ESHandle<GBRForest> forestEH;
   const std::string ep_condnames_weight  = (bunchspacing_ == 25) ? e_conf.condnames_weight_25ns  : e_conf.condnames_weight_50ns;
   evs.get<GBRWrapperRcd>().get(ep_condnames_weight, forestEH);
-  ep_forestH_weight_ = forestEH.product(); 
+  ep_forestH_weight_ = forestEH.product();
 }
 
 void EGRegressionModifierV1::setConsumes(edm::ConsumesCollector& sumes) {
- 
+
   rhoToken_ = sumes.consumes<double>(rhoTag_);
   vtxToken_ = sumes.consumes<reco::VertexCollection>(vtxTag_);
 
@@ -145,18 +145,18 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
 
   if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
-  
-  std::array<float, 33> eval;  
-  const double raw_energy = the_sc->rawEnergy(); 
+
+  std::array<float, 33> eval;
+  const double raw_energy = the_sc->rawEnergy();
   const auto& ess = ele.showerShape();
 
   // SET INPUTS
-  eval[0]  = nVtx_;  
+  eval[0]  = nVtx_;
   eval[1]  = raw_energy;
   eval[2]  = the_sc->eta();
   eval[3]  = the_sc->phi();
   eval[4]  = the_sc->etaWidth();
-  eval[5]  = the_sc->phiWidth(); 
+  eval[5]  = the_sc->phiWidth();
   eval[6]  = ess.r9;
   eval[7]  = theseed->energy()/raw_energy;
   eval[8]  = ess.eMax/raw_energy;
@@ -167,7 +167,7 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   eval[13] = ess.sigmaIetaIphi;
   eval[14] = ess.sigmaIphiIphi;
   eval[15] = std::max(0,numberOfClusters-1);
-  
+
   // calculate sub-cluster variables
   std::vector<float> clusterRawEnergy;
   clusterRawEnergy.resize(std::max(3, numberOfClusters), 0);
@@ -179,18 +179,18 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   float clusterMaxDRDPhi = 999.;
   float clusterMaxDRDEta = 999.;
   float clusterMaxDRRawEnergy = 0.;
-  
+
   size_t iclus = 0;
   float maxDR = 0;
-  // loop over all clusters that aren't the seed  
+  // loop over all clusters that aren't the seed
   for (auto const& pclus : the_sc->clusters())
   {
-    if(theseed == pclus ) 
+    if(theseed == pclus )
       continue;
     clusterRawEnergy[iclus]  = pclus->energy();
     clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(),theseed->phi());
     clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
-    
+
     // find cluster with max dR
     const auto the_dr = reco::deltaR(*pclus, *theseed);
     if(the_dr > maxDR) {
@@ -199,10 +199,10 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
       clusterMaxDRDPhi = clusterDPhiToSeed[iclus];
       clusterMaxDRDEta = clusterDEtaToSeed[iclus];
       clusterMaxDRRawEnergy = clusterRawEnergy[iclus];
-    }      
+    }
     ++iclus;
   }
-  
+
   eval[16] = clusterMaxDR;
   eval[17] = clusterMaxDRDPhi;
   eval[18] = clusterMaxDRDEta;
@@ -216,18 +216,18 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   eval[26] = clusterDEtaToSeed[0];
   eval[27] = clusterDEtaToSeed[1];
   eval[28] = clusterDEtaToSeed[2];
-  
+
   // calculate coordinate variables
-  const bool iseb = ele.isEB();  
+  const bool iseb = ele.isEB();
   float dummy;
   int iPhi;
   int iEta;
   float cryPhi;
   float cryEta;
   EcalClusterLocal _ecalLocal;
-  if (ele.isEB()) 
+  if (ele.isEB())
     _ecalLocal.localCoordsEB(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
-  else 
+  else
     _ecalLocal.localCoordsEE(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
 
   if (iseb) {
@@ -245,35 +245,35 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   constexpr double meanlimhigh = 2.0;
   constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
   constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
-  
+
   constexpr double sigmalimlow  = 0.0002;
   constexpr double sigmalimhigh = 0.5;
   constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
-  constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);  
-  
+  constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);
+
   int coridx = 0;
   if (!iseb)
     coridx = 1;
-    
+
   //these are the actual BDT responses
   double rawmean = e_forestH_mean_[coridx]->GetResponse(eval.data());
   double rawsigma = e_forestH_sigma_[coridx]->GetResponse(eval.data());
-  
+
   //apply transformation to limited output range (matching the training)
   double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
   double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
-  
+
   //regression target is ln(Etrue/Eraw)
   //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
   double ecor = mean*(eval[1]);
-  if (!iseb)  
+  if (!iseb)
     ecor = mean*(eval[1]+the_sc->preshowerEnergy());
   const double sigmacor = sigma*ecor;
-  
+
   ele.setCorrectedEcalEnergy(ecor);
   ele.setCorrectedEcalEnergyError(sigmacor);
-    
-  // E-p combination 
+
+  // E-p combination
   std::array<float, 11> eval_ep;
 
   const float ep = ele.trackMomentumAtVtx().R();
@@ -283,7 +283,7 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   const float eOverP = tot_energy*mean/ep;
   eval_ep[0] = tot_energy*mean;
   eval_ep[1] = sigma/mean;
-  eval_ep[2] = ep; 
+  eval_ep[2] = ep;
   eval_ep[3] = trkMomentumRelError;
   eval_ep[4] = sigma/mean/trkMomentumRelError;
   eval_ep[5] = tot_energy*mean/ep;
@@ -292,7 +292,7 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   eval_ep[8] = ele.trackerDrivenSeed();
   eval_ep[9] = int(ele.classification());//eleClass;
   eval_ep[10] = iseb;
-  
+
   // CODE FOR FUTURE SEMI_PARAMETRIC
   //double rawweight = ep_forestH_mean_[coridx]->GetResponse(eval_ep.data());
   ////rawsigma = ep_forestH_sigma_[coridx]->GetResponse(eval.data());
@@ -301,7 +301,7 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
 
   // CODE FOR STANDARD BDT
   double weight = 0.;
-  if ( eOverP > 0.025 && 
+  if ( eOverP > 0.025 &&
        std::abs(ep-ecor) < 15.*std::sqrt( momentumError*momentumError + sigmacor*sigmacor ) &&
        (!applyExtraHighEnergyProtection_ || ((momentumError < 10.*ep) || (ecor < 200.)))
        ) {
@@ -313,44 +313,44 @@ void EGRegressionModifierV1::modifyObject(reco::GsfElectron& ele) const {
   double combinedMomentumError = sqrt(weight*weight*ele.trackMomentumError()*ele.trackMomentumError() + (1.-weight)*(1.-weight)*sigmacor*sigmacor);
 
   math::XYZTLorentzVector oldMomentum = ele.p4();
-  math::XYZTLorentzVector newMomentum = math::XYZTLorentzVector(oldMomentum.x()*combinedMomentum/oldMomentum.t(),
-								oldMomentum.y()*combinedMomentum/oldMomentum.t(),
-								oldMomentum.z()*combinedMomentum/oldMomentum.t(),
-								combinedMomentum);
- 
+  math::XYZTLorentzVector newMomentum = math::XYZTLorentzVector( oldMomentum.x()*combinedMomentum/oldMomentum.t(),
+                                                                 oldMomentum.y()*combinedMomentum/oldMomentum.t(),
+                                                                 oldMomentum.z()*combinedMomentum/oldMomentum.t(),
+                                                                 combinedMomentum );
+
   //ele.correctEcalEnergy(combinedMomentum, combinedMomentumError);
   ele.correctMomentum(newMomentum, ele.trackMomentumError(), combinedMomentumError);
 }
 
 void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   // regression calculation needs no additional valuemaps
-  
+
   std::array<float, 35> eval;
   const reco::SuperClusterRef& the_sc = pho.superCluster();
   const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();
-  
+
   const int numberOfClusters =  the_sc->clusters().size();
   const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
 
   if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
 
-  const double raw_energy = the_sc->rawEnergy(); 
+  const double raw_energy = the_sc->rawEnergy();
   const auto& ess = pho.showerShapeVariables();
 
   // SET INPUTS
   eval[0]  = raw_energy;
   eval[1]  = pho.r9();
   eval[2]  = the_sc->etaWidth();
-  eval[3]  = the_sc->phiWidth(); 
+  eval[3]  = the_sc->phiWidth();
   eval[4]  = std::max(0,numberOfClusters - 1);
   eval[5]  = pho.hadronicOverEm();
   eval[6]  = rhoValue_;
-  eval[7]  = nVtx_;  
+  eval[7]  = nVtx_;
   eval[8] = theseed->eta()-the_sc->position().Eta();
   eval[9] = reco::deltaPhi(theseed->phi(),the_sc->position().Phi());
   eval[10] = theseed->energy()/raw_energy;
   eval[11] = ess.e3x3/ess.e5x5;
-  eval[12] = ess.sigmaIetaIeta;  
+  eval[12] = ess.sigmaIetaIeta;
   eval[13] = ess.sigmaIphiIphi;
   eval[14] = ess.sigmaIetaIphi/(ess.sigmaIphiIphi*ess.sigmaIetaIeta);
   eval[15] = ess.maxEnergyXtal/ess.e5x5;
@@ -358,7 +358,7 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   eval[17] = ess.eTop/ess.e5x5;
   eval[18] = ess.eBottom/ess.e5x5;
   eval[19] = ess.eLeft/ess.e5x5;
-  eval[20] = ess.eRight/ess.e5x5;  
+  eval[20] = ess.eRight/ess.e5x5;
   eval[21] = ess.e2x5Max/ess.e5x5;
   eval[22] = ess.e2x5Left/ess.e5x5;
   eval[23] = ess.e2x5Right/ess.e5x5;
@@ -376,7 +376,7 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
     int signieta = ieta > 0 ? +1 : -1; /// this is 1*abs(ieta)/ieta in original training
     eval[29] = (ieta-signieta)%5;
     eval[30] = (iphi-1)%2;
-    eval[31] = (abs(ieta)<=25)*((ieta-signieta)) + (abs(ieta)>25)*((ieta-26*signieta)%20);  
+    eval[31] = (abs(ieta)<=25)*((ieta-signieta)) + (abs(ieta)>25)*((ieta-26*signieta)%20);
     eval[32] = (iphi-1)%20;
     eval[33] = ieta;  /// duplicated variables but this was trained like that
     eval[34] = iphi;  /// duplicated variables but this was trained like that
@@ -395,12 +395,12 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   const double meanlimhigh = 2.0;
   const double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
   const double meanscale   = 0.5*(meanlimhigh-meanlimlow);
-  
+
   const double sigmalimlow  = 0.0002;
   const double sigmalimhigh = 0.5;
   const double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
-  const double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);  
- 
+  const double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);
+
   int coridx = 0;
   if (!iseb)
     coridx = 1;
@@ -415,9 +415,9 @@ void EGRegressionModifierV1::modifyObject(reco::Photon& pho) const {
   //regression target is ln(Etrue/Eraw)
   //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
   double ecor = mean*eval[0];
-  if (!iseb) 
+  if (!iseb)
     ecor = mean*(eval[0]+the_sc->preshowerEnergy());
 
   double sigmacor = sigma*ecor;
-  pho.setCorrectedEnergy(reco::Photon::P4type::regression2, ecor, sigmacor, true);     
+  pho.setCorrectedEnergy(reco::Photon::P4type::regression2, ecor, sigmacor, true);
 }

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
@@ -211,8 +211,7 @@ void EGRegressionModifierV2::setEvent(const edm::Event& evt) {
     edm::Handle<edm::View<pat::Electron> > eles;
     evt.getByToken(e_conf.tok_electron_src, eles);
     
-    for( unsigned i = 0; i < eles->size(); ++i ) {
-      edm::Ptr<pat::Electron> ptr = eles->ptrAt(i);
+    for(auto const& ptr : eles->ptrs()) {
       eles_by_oop[ptr->originalObjectRef().key()] = ptr;
     }    
   }
@@ -233,8 +232,7 @@ void EGRegressionModifierV2::setEvent(const edm::Event& evt) {
     edm::Handle<edm::View<pat::Photon> > phos;
     evt.getByToken(ph_conf.tok_photon_src,phos);
   
-    for( unsigned i = 0; i < phos->size(); ++i ) {
-      edm::Ptr<pat::Photon> ptr = phos->ptrAt(i);
+    for(auto const& ptr : phos->ptrs()) {
       phos_by_oop[ptr->originalObjectRef().key()] = ptr;
     }
   }

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
@@ -1,6 +1,15 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
-#include "RecoEgamma/EgammaTools/plugins/EGRegressionModifier.h"
+#include "RecoEgamma/EgammaTools/plugins/EGRegressionModifierHelpers.h"
+#include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
+
+#include <vdt/vdtMath.h>
 
 class EGRegressionModifierV2 : public ModifyObjectValueBase {
 

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -6,15 +6,15 @@ regressionModifier = \
               rhoCollection = cms.InputTag('fixedGridRhoFastjetAll'),
               
               electron_config = cms.PSet( # EB, EE
-                regressionKey_ecalonly  = cms.vstring('electron_eb_ECALonly_lowpt', 'electron_eb_ECALonly', 'electron_ee_ECALonly_lowpt', 'electron_ee_ECALonly'),
-                uncertaintyKey_ecalonly = cms.vstring('electron_eb_ECALonly_lowpt_var', 'electron_eb_ECALonly_var', 'electron_ee_ECALonly_lowpt_var', 'electron_ee_ECALonly_var'),
-                regressionKey_ecaltrk  = cms.vstring('electron_eb_ECALTRK_lowpt', 'electron_eb_ECALTRK', 'electron_ee_ECALTRK_lowpt', 'electron_ee_ECALTRK'),
-                uncertaintyKey_ecaltrk = cms.vstring('electron_eb_ECALTRK_lowpt_var', 'electron_eb_ECALTRK_var', 'electron_ee_ECALTRK_lowpt_var', 'electron_ee_ECALTRK_var'),
+                regressionKey  = cms.vstring('electron_eb_ECALonly_lowpt', 'electron_eb_ECALonly', 'electron_ee_ECALonly_lowpt', 'electron_ee_ECALonly',
+                                             'electron_eb_ECALTRK_lowpt', 'electron_eb_ECALTRK', 'electron_ee_ECALTRK_lowpt', 'electron_ee_ECALTRK'),
+                uncertaintyKey = cms.vstring('electron_eb_ECALonly_lowpt_var', 'electron_eb_ECALonly_var', 'electron_ee_ECALonly_lowpt_var', 'electron_ee_ECALonly_var',
+                                             'electron_eb_ECALTRK_lowpt_var', 'electron_eb_ECALTRK_var', 'electron_ee_ECALTRK_lowpt_var', 'electron_ee_ECALTRK_var'),
                                           ),
               
               photon_config   = cms.PSet( # EB, EE
-                regressionKey_ecalonly  = cms.vstring('photon_eb_ECALonly_lowpt', 'photon_eb_ECALonly', 'photon_ee_ECALonly_lowpt', 'photon_ee_ECALonly'),
-                uncertaintyKey_ecalonly = cms.vstring('photon_eb_ECALonly_lowpt_var', 'photon_eb_ECALonly_var', 'photon_ee_ECALonly_lowpt_var', 'photon_ee_ECALonly_var'),
+                regressionKey  = cms.vstring('photon_eb_ECALonly_lowpt', 'photon_eb_ECALonly', 'photon_ee_ECALonly_lowpt', 'photon_ee_ECALonly'),
+                uncertaintyKey = cms.vstring('photon_eb_ECALonly_lowpt_var', 'photon_eb_ECALonly_var', 'photon_ee_ECALonly_lowpt_var', 'photon_ee_ECALonly_var'),
                                           ),
 
               lowEnergy_ECALonlyThr = cms.double(99999.),

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronHEEPIDValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronHEEPIDValueMapProducer.cc
@@ -216,8 +216,7 @@ void ElectronHEEPIDValueMapProducer::produce(edm::Event& iEvent, const edm::Even
   
   std::vector<float> eleTrkPtIso;
   std::vector<int> eleNrSaturateIn5x5;
-  for(size_t eleNr=0;eleNr<eleHandle->size();eleNr++){
-    auto elePtr = eleHandle->ptrAt(eleNr);
+  for(auto const& elePtr : eleHandle->ptrs()) {
     eleTrkPtIso.push_back(calTrkIso(*elePtr,*eleHandle,candHandles,candVetos));
     eleNrSaturateIn5x5.push_back(nrSaturatedCrysIn5x5(*elePtr,ebRecHitHandle,eeRecHitHandle,caloTopoHandle));    
   }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronHEEPIDValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronHEEPIDValueMapProducer.cc
@@ -216,9 +216,9 @@ void ElectronHEEPIDValueMapProducer::produce(edm::Event& iEvent, const edm::Even
   
   std::vector<float> eleTrkPtIso;
   std::vector<int> eleNrSaturateIn5x5;
-  for(auto const& elePtr : eleHandle->ptrs()) {
-    eleTrkPtIso.push_back(calTrkIso(*elePtr,*eleHandle,candHandles,candVetos));
-    eleNrSaturateIn5x5.push_back(nrSaturatedCrysIn5x5(*elePtr,ebRecHitHandle,eeRecHitHandle,caloTopoHandle));    
+  for(auto const& ele : *eleHandle) {
+    eleTrkPtIso.push_back(calTrkIso(ele,*eleHandle,candHandles,candVetos));
+    eleNrSaturateIn5x5.push_back(nrSaturatedCrysIn5x5(ele,ebRecHitHandle,eeRecHitHandle,caloTopoHandle));    
   }
   
   writeValueMap(iEvent,eleHandle,eleTrkPtIso,eleTrkPtIsoLabel_);  

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVANtuplizer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVANtuplizer.cc
@@ -69,8 +69,8 @@ class ElectronMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResourc
       // method called once each job just after ending the event loop
       void endJob() override {};
 
-      template<class T, class V>
-      int matchToTruth(const T &el, const V &genParticles, int &genIdx);
+      int matchToTruth(reco::GsfElectron const& electron,
+                       edm::View<reco::GenParticle> const& genParticles) const;
 
       // ----------member data ---------------------------
 
@@ -83,7 +83,6 @@ class ElectronMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResourc
       float eleQ_;
       int ele3Q_;
       int matchedToGenEle_;
-      int matchedGenIdx_;
 
 
       // gap variables
@@ -308,13 +307,9 @@ ElectronMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         iEvent.getByToken(mvaCatTokens_[k],mvaCats[k]);
     }
 
-    eleIndex_ = -1;
-    for(size_t iEle = 0; iEle < src->size(); ++iEle) {
-
-        ++eleIndex_;
-
-        const auto ele =  src->ptrAt(iEle);
-
+    eleIndex_ = src->size();
+    for(auto const& ele : src->ptrs())
+    {
         eleQ_ = ele->charge();
         ele3Q_ = ele->chargeInfo().isGsfCtfScPixConsistent;
 
@@ -328,7 +323,7 @@ ElectronMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         }
 
         if (isMC_) {
-            matchedToGenEle_ = matchToTruth( ele, genParticles, matchedGenIdx_);
+            matchedToGenEle_ = matchToTruth( *ele, *genParticles);
         }
 
         // gap variables
@@ -361,41 +356,33 @@ ElectronMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
 }
 
-template<class T, class V>
-int ElectronMVANtuplizer::matchToTruth(const T &el, const V &genParticles, int &genIdx){
-
-  genIdx = -1;
-
+int ElectronMVANtuplizer::matchToTruth(reco::GsfElectron const& electron,
+                                       edm::View<reco::GenParticle> const& genParticles) const
+{
   //
   // Explicit loop and geometric matching method (advised by Josh Bendavid)
   //
 
   // Find the closest status 1 gen electron to the reco electron
   double dR = 999;
-  for(size_t i=0; i<genParticles->size();i++){
-    const auto particle = genParticles->ptrAt(i);
+  reco::GenParticle const* closestElectron = nullptr;
+  for(auto const& particle : genParticles) {
     // Drop everything that is not electron or not status 1
-    if( abs(particle->pdgId()) != 11 || particle->status() != 1 )
+    if( std::abs(particle.pdgId()) != 11 || particle.status() != 1 )
       continue;
     //
-    double dRtmp = ROOT::Math::VectorUtil::DeltaR( el->p4(), particle->p4() );
+    double dRtmp = ROOT::Math::VectorUtil::DeltaR( electron.p4(), particle.p4() );
     if( dRtmp < dR ){
       dR = dRtmp;
-      genIdx = i;
+      closestElectron = &particle;
     }
   }
   // See if the closest electron is close enough. If not, no match found.
-  if( genIdx == -1 || dR >= deltaR_ ) {
-    return UNMATCHED;
-  }
+  if( closestElectron == nullptr || dR >= deltaR_ ) return UNMATCHED;
 
-  const auto closestElectron = genParticles->ptrAt(genIdx);
+  if( closestElectron->fromHardProcessFinalState() ) return TRUE_PROMPT_ELECTRON;
 
-  if( closestElectron->fromHardProcessFinalState() )
-    return TRUE_PROMPT_ELECTRON;
-
-  if( closestElectron->isDirectHardProcessTauDecayProductFinalState() )
-    return TRUE_ELECTRON_FROM_TAU;
+  if( closestElectron->isDirectHardProcessTauDecayProductFinalState() ) return TRUE_ELECTRON_FROM_TAU;
 
   // What remains is true non-prompt electrons
   return TRUE_NON_PROMPT_ELECTRON;

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -212,9 +212,8 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
     std::vector<float> vars[nVars_];
 
     // reco::Photon::superCluster() is virtual so we can exploit polymorphism
-    for (unsigned i = 0; i < src->size(); ++i) {
-        const auto& iPho = src->ptrAt(i);
-
+    for(auto const& iPho : src->ptrs())
+    {
         //
         // Compute full 5x5 quantities
         //
@@ -232,9 +231,9 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
         vars[4].push_back(lazyToolnoZS->e2x5Max(theseed));
         vars[5].push_back(lazyToolnoZS->e5x5(theseed));
         vars[6].push_back(lazyToolnoZS->eseffsirir(*(iPho->superCluster())));
-        vars[7].push_back(vars[2][i] / vars[5][i]);
-        vars[8].push_back(vars[3][i] / vars[5][i]);
-        vars[9].push_back(vars[4][i] / vars[5][i]);
+        vars[7].push_back(vars[2].back() / vars[5].back());
+        vars[8].push_back(vars[3].back() / vars[5].back());
+        vars[9].push_back(vars[4].back() / vars[5].back());
 
         //
         // Compute absolute uncorrected isolations with footprint removal
@@ -250,11 +249,10 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
         float photonIsoSum = 0.;
 
         // Loop over all PF candidates
-        for (unsigned int idxcand = 0; idxcand < pfCandsHandle->size(); ++idxcand) {
-
+        for(auto const& iCand : pfCandsHandle->ptrs())
+        {
             // Here, the type will be a simple reco::Candidate. We cast it
             // for full PFCandidate or PackedCandidate below as necessary
-            const auto& iCand = pfCandsHandle->ptrAt(idxcand);
 
             // One would think that we should check that this iCand from the
             // generic PF collection is not identical to the iPho photon for
@@ -282,7 +280,7 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
                 if(isInFootprint((*particleBasedIsolationMap)[iPho], iCand))
                     continue;
             } else {
-                edm::Ptr<pat::Photon> patPhotonPtr(src->ptrAt(i));
+                edm::Ptr<pat::Photon> patPhotonPtr(iPho);
                 if(isInFootprint(patPhotonPtr->associatedPackedPFCandidates(), iCand))
                     continue;
             }
@@ -335,7 +333,7 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
             vars[17].push_back(0.f);
             vars[18].push_back(0.f);
         } else {
-            edm::Ptr<pat::Photon> patPhotonPtr{ src->ptrAt(i) };
+            edm::Ptr<pat::Photon> patPhotonPtr{ iPho };
             vars[17].push_back(patPhotonPtr->hcalPFClusterIso());
             vars[18].push_back(patPhotonPtr->ecalPFClusterIso());
         }

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
@@ -274,12 +274,8 @@ PhotonMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
         iEvent.getByToken(mvaCatTokens_[k],mvaCats[k]);
     }
 
-    int nPho = src->size();
-
-    for(int iPho = 0; iPho < nPho; ++iPho) {
-
-        const auto pho =  src->ptrAt(iPho);
-
+    for(auto const& pho : src->ptrs())
+    {
         if (pho->pt() < ptThreshold_) {
             continue;
         }


### PR DESCRIPTION
Hi,

while working on my analysis I realized that there is `edm::View<T>::ptrs()` to get read-only access to the edm pointers directly. Helped me getting my code cleaner with more range-based loops! I propose here to do the same refreshing for RecoEgamma to promote this pattern a little bit.

While looking for calls to `edm::View<T>::ptrAt()`, which indicate there is potential for a range-based loop, I stumbled upon the EGRegressionModifierV1 and EGRegressionModifierV2 which horrified me slightly: half of the code was just copy-paste remnant boilerplate code that is not used, so I also worked on that.

Local matrix tests pass. 