### PR TITLE
Removed unused variables in RecoEgamma/EgammaIsolationALgos

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
@@ -222,9 +222,6 @@ void EgammaRecHitExtractor::collect(reco::IsoDeposit &deposit,
 
       if (barrel) {
 	// new rechit flag checks
-	//vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), j->recoFlag());
-	//if (vit != flagsexclEB_.end())
-	//  continue;
 	if (!j->checkFlag(EcalRecHit::kGood)) {
 	  if (j->checkFlags(flagsexclEB_)) {
 	    continue;
@@ -232,9 +229,6 @@ void EgammaRecHitExtractor::collect(reco::IsoDeposit &deposit,
 	}
       } else {
 	// new rechit flag checks
-	//vit = std::find(flagsexclEE_.begin(), flagsexclEE_.end(), j->recoFlag());
-	//if (vit != flagsexclEE_.end())
-	//  continue;
 	if (!j->checkFlag(EcalRecHit::kGood)) {
 	  if (j->checkFlags(flagsexclEE_)) {
 	    continue;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
@@ -220,7 +220,6 @@ void EgammaRecHitExtractor::collect(reco::IsoDeposit &deposit,
 	  continue;
       }
 
-      std::vector<int>::const_iterator vit;
       if (barrel) {
 	// new rechit flag checks
 	//vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), j->recoFlag());

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
@@ -144,7 +144,6 @@ EleIsoDetIdCollectionProducer::produce (edm::Event& iEvent, const edm::EventSetu
                   return;
               }
 
-              std::vector<int>::const_iterator vit;
               if (isBarrel) {
                 // new rechit flag checks
                 //vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), ((EcalRecHit*)(&*recIt))->recoFlag());

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
@@ -146,9 +146,6 @@ EleIsoDetIdCollectionProducer::produce (edm::Event& iEvent, const edm::EventSetu
 
               if (isBarrel) {
                 // new rechit flag checks
-                //vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), ((EcalRecHit*)(&*recIt))->recoFlag());
-                //if (vit != flagsexclEB_.end())
-                //  continue;
                 if (!(recIt.checkFlag(EcalRecHit::kGood))) {
                   if (recIt.checkFlags(flagsexclEB_)) {                
                     return;
@@ -156,9 +153,6 @@ EleIsoDetIdCollectionProducer::produce (edm::Event& iEvent, const edm::EventSetu
                 }
               } else {
                 // new rechit flag checks
-                //vit = std::find(flagsexclEE_.begin(), flagsexclEE_.end(), ((EcalRecHit*)(&*recIt))->recoFlag());
-                //if (vit != flagsexclEE_.end())
-                //  continue;
                 if (!(recIt.checkFlag(EcalRecHit::kGood))) {
                   if (recIt.checkFlags(flagsexclEE_)) {                
                     return;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
@@ -143,7 +143,6 @@ GamIsoDetIdCollectionProducer::produce (edm::Event& iEvent,
                     return;
                 }
 
-                std::vector<int>::const_iterator vit;
                 if (isBarrel) {
                   // new rechit flag checks
                   //vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), recIt->recoFlag());

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
@@ -145,9 +145,6 @@ GamIsoDetIdCollectionProducer::produce (edm::Event& iEvent,
 
                 if (isBarrel) {
                   // new rechit flag checks
-                  //vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), recIt->recoFlag());
-                  //if (vit != flagsexclEB_.end())
-                  //  continue;
                   if (!recIt->checkFlag(EcalRecHit::kGood)) {
                     if (recIt->checkFlags(flagsexclEB_)) {                
                       return;
@@ -155,9 +152,6 @@ GamIsoDetIdCollectionProducer::produce (edm::Event& iEvent,
                   }
                 } else {
                   // new rechit flag checks
-                  //vit = std::find(flagsexclEE_.begin(), flagsexclEE_.end(), recIt->recoFlag());
-                  //if (vit != flagsexclEE_.end())
-                  //  continue;
                   if (!recIt->checkFlag(EcalRecHit::kGood)) {
                     if (recIt->checkFlags(flagsexclEE_)) {                
                       return;


### PR DESCRIPTION
This fixes the clang warnings.