### PR TITLE
SiStripAPVGain PCL: protect reading G1 gain from DB

### DIFF
--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -74,6 +74,7 @@ void
 SiStripGainsPCLHarvester::beginRun(edm::Run const& run, const edm::EventSetup& iSetup)
 {
   using namespace edm;
+  static constexpr float defaultGainTick = 690./640.;
 
   this->checkBookAPVColls(iSetup); // check whether APV colls are booked and do so if not yet done
   this->checkAndRetrieveTopology(iSetup);
@@ -98,7 +99,7 @@ SiStripGainsPCLHarvester::beginRun(edm::Run const& run, const edm::EventSetup& i
     if(APV->PreviousGain!=1 and newPreviousGain!=APV->PreviousGain)edm::LogWarning("SiStripGainPCLHarvester")<< "WARNING: ParticleGain in the global tag changed\n";
     APV->PreviousGain = newPreviousGain;
     
-    float newPreviousGainTick = gainHandle->getApvGain(APV->APVId,gainHandle->getRange(APV->DetId, 0),0);
+    float newPreviousGainTick = APV->isMasked ? defaultGainTick : gainHandle->getApvGain(APV->APVId,gainHandle->getRange(APV->DetId, 0),0);
     if(APV->PreviousGainTick!=1 and newPreviousGainTick!=APV->PreviousGainTick){
       edm::LogWarning("SiStripGainPCLHarvester")<< "WARNING: TickMarkGain in the global tag changed\n"<< std::endl
 						 <<" APV->SubDet: "<< APV->SubDet << " APV->APVId:" << APV->APVId << std::endl

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -102,7 +102,8 @@ void
 SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, edm::EventSetup const& iSetup, APVGain::APVGainHistograms & histograms) const {
   
   using namespace edm;
-  
+  static constexpr float defaultGainTick = 690./640.;
+
   // fills the APV collections at each begin run 
   edm::ESHandle<TrackerGeometry> tkGeom_;
   iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom_ );
@@ -129,7 +130,7 @@ SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, edm::EventSetup const& i
     if(APV->PreviousGain!=1 and newPreviousGain!=APV->PreviousGain)edm::LogWarning("SiStripGainPCLWorker")<< "WARNING: ParticleGain in the global tag changed\n";
     APV->PreviousGain = newPreviousGain;
     
-    float newPreviousGainTick = gainHandle->getApvGain(APV->APVId,gainHandle->getRange(APV->DetId, 0),0);
+    float newPreviousGainTick = APV->isMasked ? defaultGainTick : gainHandle->getApvGain(APV->APVId,gainHandle->getRange(APV->DetId, 0),0);
     if(APV->PreviousGainTick!=1 and newPreviousGainTick!=APV->PreviousGainTick){
       edm::LogWarning("SiStripGainPCLWorker")<< "WARNING: TickMarkGain in the global tag changed\n"<< std::endl
 					     <<" APV->SubDet: "<< APV->SubDet << " APV->APVId:" << APV->APVId << std::endl


### PR DESCRIPTION
... as the measurement not necessarily available for all channels in Run-1 IOVs.
Solves issue https://github.com/cms-sw/cmssw/issues/23798.