### PR TITLE
Few refinements on top of Stuck-TBM simulation CondFormats payload writers and readers

### DIFF
--- a/CalibTracker/SiPixelESProducers/test/PixelFEDChannelCollectionMapTestReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/PixelFEDChannelCollectionMapTestReader.cc
@@ -62,13 +62,40 @@ PixelFEDChannelCollectionMapTestReader::analyze(const edm::Event& e, const edm::
   context.get<SiPixelFEDChannelContainerESProducerRcd>().get(PixelFEDChannelCollectionMapHandle);
   edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<"got context"<<std::endl;
 
-  const PixelFEDChannelCollectionMap* quality_map=PixelFEDChannelCollectionMapHandle.product();
+  const PixelFEDChannelCollectionMap* thePixelFEDChannelCollectionMap=PixelFEDChannelCollectionMapHandle.product();
   edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<"got SiPixelFEDChannelContainer* "<< std::endl;
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "print  pointer address : " ;
-  //edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << quality_map << std::endl;
-  
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "Size "  <<  quality_map->size() << std::endl;     
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") <<"Content of myQuality_Map "<<std::endl;
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "print  pointer address : " << thePixelFEDChannelCollectionMap << std::endl;  
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "Size: "  << thePixelFEDChannelCollectionMap->size() << std::endl;
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "Content of my PixelFEDChanneCollectionlMap: "<<std::endl;
+
+  FILE* pFile=NULL;
+  if(formatedOutput_!="")pFile=fopen(formatedOutput_.c_str(), "w");
+  if(pFile){
+    
+    fprintf(pFile,"PixelFEDChannelCollectionMap::printAll() \n");
+    fprintf(pFile," =================================================================================================================== \n"); 
+      
+    for(auto it = thePixelFEDChannelCollectionMap->begin(); it != thePixelFEDChannelCollectionMap->end() ; ++it){
+      fprintf(pFile," =================================================================================================================== \n");
+      fprintf(pFile,"run : %s \n ",(it->first).c_str());
+      const auto& thePixelFEDChannels = it->second;
+
+      //std:: cout << thePixelFEDChannels.size() << std::endl;
+      // for (edmNew::DetSetVector<PixelFEDChannel>::const_iterator DSViter = thePixelFEDChannels.begin(); DSViter != thePixelFEDChannels.end(); DSViter++) {
+      //       unsigned int theDetId = DSViter->id();
+      //       std:: cout << theDetId << std::endl;
+      // }
+
+      for (const auto& disabledChannels: thePixelFEDChannels) {
+	//loop over different PixelFED in a PixelFED vector (module)
+       fprintf(pFile,"DetId : %i \n",disabledChannels.detId());
+       for(const auto& ch: disabledChannels) {
+         fprintf(pFile,"fed : %i | link : %2i | roc_first : %2i | roc_last: %2i \n",ch.fed, ch.link,  ch.roc_first, ch.roc_last);       
+         //std::cout <<  disabledChannels.detId() << " "<< ch.fed << " " << ch.link << " " << ch.roc_first << " " << ch.roc_last << std::endl;
+       } // loop over disable channels
+      } // loop over the detSetVector
+    } // main loop on the map
+  } // if file exists
 
 }
 

--- a/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker.cc
@@ -1,0 +1,142 @@
+#include <string>
+#include <iostream>
+#include <map>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityFromDbRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFEDChannelContainer.h"
+#include "CondFormats/DataRecord/interface/SiPixelStatusScenariosRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelQualityProbabilities.h"
+#include "CondFormats/DataRecord/interface/SiPixelStatusScenarioProbabilityRcd.h"
+
+class SiPixelBadFEDChannelSimulationSanityChecker : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiPixelBadFEDChannelSimulationSanityChecker(edm::ParameterSet const& p); 
+  ~SiPixelBadFEDChannelSimulationSanityChecker(); 
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+private:
+    
+  virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+
+  // ----------member data ---------------------------
+  const bool printdebug_;
+  
+};
+  
+SiPixelBadFEDChannelSimulationSanityChecker::SiPixelBadFEDChannelSimulationSanityChecker(edm::ParameterSet const& p):
+  printdebug_(p.getUntrackedParameter<bool>("printDebug",true))
+{ 
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")<<"SiPixelBadFEDChannelSimulationSanityChecker"<<std::endl;
+}
+
+SiPixelBadFEDChannelSimulationSanityChecker::~SiPixelBadFEDChannelSimulationSanityChecker() {  
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")<<"~SiPixelBadFEDChannelSimulationSanityChecker "<<std::endl;
+}
+
+void
+SiPixelBadFEDChannelSimulationSanityChecker::analyze(const edm::Event& e, const edm::EventSetup& context){
+  
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") <<"### SiPixelBadFEDChannelSimulationSanityChecker::analyze  ###"<<std::endl;
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
+  
+  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenariosRcd")); 
+  if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    //record not found
+    edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") <<"Record \"SiPixelStatusScenariosRcd"<<"\" does not exist "<<std::endl;
+  }
+  
+  //this part gets the handle of the event source and the record (i.e. the Database)
+  edm::ESHandle<SiPixelFEDChannelContainer> qualityCollectionHandle;  
+  context.get<SiPixelStatusScenariosRcd>().get(qualityCollectionHandle);
+  const SiPixelFEDChannelContainer* quality_map=qualityCollectionHandle.product();
+
+  edm::eventsetup::EventSetupRecordKey recordKey2(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenarioProbabilityRcd>"));
+    
+  if( recordKey2.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    //record not found
+    edm::LogWarning("SiPixelQualityProbabilitiesTestReader") <<"Record \"SiPixelStatusScenarioProbabilityRcd>"<<"\" does not exist "<<std::endl;
+  }
+  
+  //this part gets the handle of the event source and the record (i.e. the Database)
+  edm::ESHandle<SiPixelQualityProbabilities> scenarioProbabilityHandle;  
+  context.get<SiPixelStatusScenarioProbabilityRcd>().get(scenarioProbabilityHandle);
+  const SiPixelQualityProbabilities* myProbabilities=scenarioProbabilityHandle.product();
+
+  SiPixelFEDChannelContainer::SiPixelBadFEDChannelsScenarioMap m_qualities = quality_map->getScenarioMap();
+  SiPixelQualityProbabilities:: probabilityMap m_probabilities = myProbabilities->getProbability_Map();    
+
+  std::vector<std::string> allScenarios = quality_map->getScenarioList();
+  std::vector<std::string> allScenariosInProb;
+
+  for(auto it = m_probabilities.begin(); it != m_probabilities.end() ; ++it){
+    //int PUbin = it->first;
+    for (const auto &entry : it->second){
+      auto scenario    = entry.first;
+      auto probability = entry.second;
+      if(probability!=0){
+	if(std::find(allScenariosInProb.begin(), allScenariosInProb.end(), scenario) == allScenariosInProb.end()) {
+	  allScenariosInProb.push_back(scenario);
+	}
+
+	// if(m_qualities.find(scenario) == m_qualities.end()){
+	//   edm::LogWarning("SiPixelBadFEDChannelSimulationSanityChecker") <<"Pretty worrying! the scenario: " << scenario << " (prob:" << probability << ") is not found in the map!!"<<std::endl; 
+	// } else {
+	//   edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") << "scenario: "<< scenario << " is in the map! (all is good)"<< std::endl;  
+	// }
+	
+      } // if prob!=0
+    } // loop on the scenarios for that PU bin
+  } // loop on PU bins
+  
+  std::vector<std::string> notFound;
+  std::copy_if(allScenariosInProb.begin(), allScenariosInProb.end(), std::back_inserter(notFound),
+	       [&allScenarios](const std::string& arg)
+	       { return (std::find(allScenarios.begin(),allScenarios.end(), arg) == allScenarios.end());});
+  
+  if(notFound.size()!=0){
+    for(const auto &entry : notFound){
+      edm::LogWarning("SiPixelBadFEDChannelSimulationSanityChecker") <<"Pretty worrying! the scenario: " << entry <<"  is not found in the map!!"<<std::endl; 
+
+      if(printdebug_){
+	edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")<<" This scenario is found in: "<< std::endl;
+	for(auto it = m_probabilities.begin(); it != m_probabilities.end() ; ++it){
+	  int PUbin = it->first;
+
+	  for (const auto &pair : it->second){
+	    if(pair.first == entry){
+	      edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker") <<" - PU bin "<< PUbin <<" with probability: "<< pair.second << std::endl;
+	    } // if the scenario matches
+	  } // loop on scenarios
+	} // loop on PU
+      } // if printdebug
+      edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")<<"=============================================="<<std::endl;
+    } // loop on scenarios not found
+
+    edm::LogWarning("SiPixelBadFEDChannelSimulationSanityChecker") <<" ====> A total of "<< notFound.size() <<" scenarios are not found in the map!"<<std::endl;
+
+  } else {
+    edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")<<"================================================================================="<<std::endl;
+    edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")    <<" All scenarios in probability record are found in the scenario map, (all is good)!"<< std::endl;
+    edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")<<"================================================================================="<<std::endl;
+  }
+
+}
+
+void
+SiPixelBadFEDChannelSimulationSanityChecker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Tries sanity of Pixel Stuck TBM simulation");
+  desc.addUntracked<bool>("printDebug",true);
+  descriptions.add("SiPixelBadFEDChannelSimulationSanityChecker",desc);
+}
+
+DEFINE_FWK_MODULE(SiPixelBadFEDChannelSimulationSanityChecker);

--- a/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker_cfg.py
+++ b/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker_cfg.py
@@ -1,0 +1,78 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ProcessOne")
+
+##
+## MessageLogger
+##
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.categories.append("SiPixelBadFEDChannelSimulationSanityChecker")  
+process.MessageLogger.categories.append("SiPixelFEDChannelContainer")
+process.MessageLogger.categories.append("SiPixelQualityProbabilities")    
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiPixelBadFEDChannelSimulationSanityChecker  = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    SiPixelFEDChannelContainer              = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    SiPixelQualityProbabilities             = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    )
+process.MessageLogger.statistics.append('cout')  
+
+##
+## Empty Source
+##
+process.source = cms.Source("EmptyIOVSource",
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(1),
+                            lastValue = cms.uint64(1),
+                            interval = cms.uint64(1)
+                            )
+##
+## Get the payload(s)
+##
+from CondCore.CondDB.CondDB_cfi import *
+#CondDBQualityCollection = CondDB.clone(connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"))
+CondDBQualityCollection = CondDB.clone(connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"))
+process.dbInput = cms.ESSource("PoolDBESSource",
+                               CondDBQualityCollection,
+                               toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenariosRcd'),
+                                                          #tag = cms.string('SiPixelFEDChannelContainer_StuckTBM_2018_v0_mc') # choose tag you want
+                                                          tag = cms.string('SiPixelFEDChannelContainer_2018_run_322633_v0_mc') # choose tag you want
+                                                          )
+                                                 )
+                               )
+
+#CondDBProbabilities = CondDB.clone(connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"))
+CondDBProbabilities = CondDB.clone(connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"))
+process.dbInput2 = cms.ESSource("PoolDBESSource",
+                                CondDBProbabilities,
+                                toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenarioProbabilityRcd'),
+                                                           #tag = cms.string('SiPixelQualityProbabilities_2018_noPU_v0_mc') # choose tag you want
+                                                           tag = cms.string('SiPixelQualityProbabilities_2018_322633_v0_mc') # choose tag you want
+                                                           )
+                                                  )
+                                )
+
+##
+## Retrieve it and check it's available in the ES
+##
+process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
+                             toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenariosRcd'),
+                                                        data = cms.vstring('SiPixelFEDChannelContainer')
+                                                        ),
+                                               cms.PSet(record = cms.string('SiPixelStatusScenarioProbabilityRcd'),
+                                                        data = cms.vstring('SiPixelQualityProbabilities')
+                                                        )
+                                               ),
+                             verbose = cms.untracked.bool(True)
+                             )
+##
+## Read it back
+##
+process.ReadDB = cms.EDAnalyzer("SiPixelBadFEDChannelSimulationSanityChecker")
+process.ReadDB.printDebug = cms.untracked.bool(True)
+process.p = cms.Path(process.get+process.ReadDB)

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter_cfg.py
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter_cfg.py
@@ -5,7 +5,7 @@ process = cms.Process("ProcessOne")
 ## MessageLogger
 ##
 process.load('FWCore.MessageService.MessageLogger_cfi')   
-process.MessageLogger.categories.append("SiPixelFEDChannelContainerTestWriter")  
+process.MessageLogger.categories.append("SiPixelFEDChannelContainerFromQualityConverter")  
 process.MessageLogger.categories.append("SiPixelFEDChannelContainer")  
 process.MessageLogger.destinations = cms.untracked.vstring("cout")
 process.MessageLogger.cout = cms.untracked.PSet(
@@ -14,7 +14,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
     FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
                                    reportEvery = cms.untracked.int32(1000)
                                    ),                                                      
-    SiPixelFEDChannelContainerTestWriter = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    SiPixelFEDChannelContainerFromQualityConverter = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
     SiPixelFEDChannelContainer           = cms.untracked.PSet( limit = cms.untracked.int32(-1))
     )
 process.MessageLogger.statistics.append('cout')  
@@ -29,8 +29,8 @@ process.source = cms.Source("EmptySource",
                             numberEventsInLuminosityBlock = cms.untracked.uint32(1),
                             )
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(25000000))
-#process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000))
+#process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(25000000))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000))
 
 ##
 ## Database output service
@@ -42,7 +42,8 @@ process.CondDB.connect = "frontier://FrontierProd/CMS_CONDITIONS"
 process.dbInput = cms.ESSource("PoolDBESSource",
                                process.CondDB,
                                toGet = cms.VPSet(cms.PSet(record = cms.string("SiPixelQualityFromDbRcd"),
-                                                          tag = cms.string("SiPixelQuality_byPCL_stuckTBM_v1")
+                                                          #tag = cms.string("SiPixelQuality_byPCL_stuckTBM_v1")
+                                                          tag = cms.string("SiPixelQuality_byPCL_other_v1")
                                                           ),
                                                  cms.PSet(record = cms.string("SiPixelFedCablingMapRcd"),
                                                           tag = cms.string("SiPixelFedCablingMap_phase1_v7")
@@ -52,7 +53,7 @@ process.dbInput = cms.ESSource("PoolDBESSource",
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:SiPixelStatusScenarios_v1.db'
+process.CondDB.connect = 'sqlite_file:SiPixelStatusScenarios_v2.db'
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),
@@ -62,8 +63,9 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                                             )
                                           )
 
-process.WriteInDB = cms.EDAnalyzer("SiPixelFEDChannelContainerTestWriter",
-                                   record= cms.string('SiPixelStatusScenariosRcd'),
+process.WriteInDB = cms.EDAnalyzer("SiPixelFEDChannelContainerFromQualityConverter",
+                                   record = cms.string('SiPixelStatusScenariosRcd'),
+                                   removeEmptyPayloads = cms.untracked.bool(True)
                                    )
 
 process.p = cms.Path(process.WriteInDB)

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerTestReader.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerTestReader.cc
@@ -64,9 +64,7 @@ SiPixelFEDChannelContainerTestReader::analyze(const edm::Event& e, const edm::Ev
 
   const SiPixelFEDChannelContainer* quality_map=qualityCollectionHandle.product();
   edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<"got SiPixelFEDChannelContainer* "<< std::endl;
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "print  pointer address : " ;
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << quality_map << std::endl;
-  
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "print  pointer address : " << quality_map << std::endl;  
   edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "Size "  <<  quality_map->size() << std::endl;     
   edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<"Content of myQuality_Map "<<std::endl;
   // use built-in method in the CondFormat to print the content
@@ -91,7 +89,7 @@ SiPixelFEDChannelContainerTestReader::analyze(const edm::Event& e, const edm::Ev
 	fprintf(pFile,"DetId : %i \n",detId.rawId());
 	for(const auto& entry: thePixelFEDChannel.second) {
 	  //unsigned int fed, link, roc_first, roc_last;
-	  fprintf(pFile,"fed : %i | link : %i | roc_first : %i | roc_last: %i: \n",entry.fed, entry.link,  entry.roc_first, entry.roc_last);	  
+	  fprintf(pFile,"fed : %i | link : %2i | roc_first : %2i | roc_last: %2i \n",entry.fed, entry.link,  entry.roc_first, entry.roc_last);	  
 	}
       }
     }

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
@@ -53,6 +53,7 @@ class SiPixelFEDChannelContainerWriteFromASCII : public edm::one::EDAnalyzer<>  
       const std::string m_record;
       const std::string m_SnapshotInputs;
       const bool printdebug_;
+      const bool addDefault_;
       SiPixelFEDChannelContainer* myQualities;
 
 };
@@ -63,7 +64,8 @@ class SiPixelFEDChannelContainerWriteFromASCII : public edm::one::EDAnalyzer<>  
 SiPixelFEDChannelContainerWriteFromASCII::SiPixelFEDChannelContainerWriteFromASCII(const edm::ParameterSet& iConfig):
   m_record(iConfig.getParameter<std::string>("record")),
   m_SnapshotInputs(iConfig.getParameter<std::string>("snapshots")),
-  printdebug_(iConfig.getUntrackedParameter<bool>("printDebug",false))
+  printdebug_(iConfig.getUntrackedParameter<bool>("printDebug",false)),
+  addDefault_(iConfig.getUntrackedParameter<bool>("addDefault",false))
 {
   //now do what ever initialization is needed
   myQualities = new SiPixelFEDChannelContainer();
@@ -144,6 +146,12 @@ void
 SiPixelFEDChannelContainerWriteFromASCII::endJob() 
 {
 
+  // adds an empty payload with name "default" => no channels are masked
+  if(addDefault_){
+    SiPixelFEDChannelContainer::SiPixelFEDChannelCollection theBadFEDChannels;
+    myQualities->setScenario("default",theBadFEDChannels);
+  }
+
   edm::LogInfo("SiPixelFEDChannelContainerWriteFromASCII")<<"Size of SiPixelFEDChannelContainer object "<< myQualities->size() <<std::endl<<std::endl;
 
   // Form the data here
@@ -161,6 +169,7 @@ SiPixelFEDChannelContainerWriteFromASCII::fillDescriptions(edm::ConfigurationDes
   edm::ParameterSetDescription desc;
   desc.setComment("Writes payloads of type SiPixelFEDChannelContainer from input ASCII files");
   desc.addUntracked<bool>("printDebug",true);
+  desc.addUntracked<bool>("addDefault",true);
   desc.add<std::string>("snapshots","");
   desc.add<std::string>("record","SiPixelStatusScenariosRcd");
   descriptions.add("SiPixelFEDChannelContainerWriteFromASCII",desc);

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestReader.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestReader.cc
@@ -46,11 +46,11 @@ SiPixelQualityProbabilitiesTestReader::analyze(const edm::Event& e, const edm::E
   edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
   edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
   
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenariosRcd"));
+  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenarioProbabilityRcd"));
     
   if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
     //record not found
-    edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"Record \"SiPixelStatusScenariosRcd"<<"\" does not exist "<<std::endl;
+    edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"Record \"SiPixelStatusScenarioProbabilityRcd"<<"\" does not exist "<<std::endl;
   }
   
   //this part gets the handle of the event source and the record (i.e. the Database)
@@ -62,8 +62,7 @@ SiPixelQualityProbabilitiesTestReader::analyze(const edm::Event& e, const edm::E
 
   const SiPixelQualityProbabilities* myProbabilities=scenarioProbabilityHandle.product();
   edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"got SiPixelQualityProbabilities* "<< std::endl;
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "print  pointer address : " ;
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << myProbabilities << std::endl;
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "print  pointer address : " << myProbabilities << std::endl ;
   
   edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "Size "  << myProbabilities->size() << std::endl;     
   edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"Content of my Probabilities "<<std::endl;

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
@@ -1,0 +1,145 @@
+// -*- C++ -*-
+//
+// Package:    CondFormats/SiPixelObjects
+// Class:      SiPixelQualityProbabilitiesTestWriter
+// 
+/**\class SiPixelQualityProbabilitiesTestWriter SiPixelQualityProbabilitiesTestWriter.cc CondFormats/SiPixelObjects/plugins/SiPixelQualityProbabilitiesTestWriter.cc
+ Description: class to build the SiPixel Quality probabilities 
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Wed, 30 Nov 2018 13:22:00 GMT
+//
+//
+
+// system include files
+#include <memory>
+#include <fstream>
+
+// user include files
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelQualityProbabilities.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityFromDbRcd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+//
+// class declaration
+//
+
+class SiPixelQualityProbabilitiesWriteFromASCII : public edm::one::EDAnalyzer<>  {
+   public:
+      explicit SiPixelQualityProbabilitiesWriteFromASCII(const edm::ParameterSet&);
+      ~SiPixelQualityProbabilitiesWriteFromASCII();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+
+      // ----------member data ---------------------------
+      const std::string m_ProbInputs;
+      const std::string m_record;
+      const bool printdebug_;
+      SiPixelQualityProbabilities* myProbabilities;
+
+};
+
+//
+// constructors and destructor
+//
+SiPixelQualityProbabilitiesWriteFromASCII::SiPixelQualityProbabilitiesWriteFromASCII(const edm::ParameterSet& iConfig):
+  m_ProbInputs(iConfig.getParameter<std::string>("probabilities")),
+  m_record(iConfig.getParameter<std::string>("record")),
+  printdebug_(iConfig.getUntrackedParameter<bool>("printDebug",false))
+{
+  //now do what ever initialization is needed
+  myProbabilities = new SiPixelQualityProbabilities();
+}
+
+
+SiPixelQualityProbabilitiesWriteFromASCII::~SiPixelQualityProbabilitiesWriteFromASCII()
+{
+  delete myProbabilities;
+}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+SiPixelQualityProbabilitiesWriteFromASCII::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+   std::ifstream myfile(m_ProbInputs); 
+   std::string line;
+
+   SiPixelQualityProbabilities::probabilityVec myProbVector;
+
+   if (myfile.is_open()){
+     while (getline (myfile, line)) {
+       edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << line << std::endl;
+       std::istringstream iss (line);            
+       std::string scenario="";
+       float prob(0.);
+       iss >> scenario >> prob;
+       auto idAndProb = std::make_pair(scenario,prob);
+       myProbVector.push_back(idAndProb); 
+     }  
+     myProbabilities->setProbabilities(0,myProbVector);
+     myfile.close();
+   }
+
+   if(printdebug_){
+     edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII")<<"Content of SiPixelQualityProbabilities "<<std::endl;
+     // use buil-in method in the CondFormat
+     myProbabilities->printAll();
+   }
+}
+   
+// ------------ method called once each job just before starting event loop  ------------
+void 
+SiPixelQualityProbabilitiesWriteFromASCII::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+SiPixelQualityProbabilitiesWriteFromASCII::endJob() 
+{
+
+  edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII")<<"Size of SiPixelQualityProbabilities object "<< myProbabilities->size() <<std::endl<<std::endl;
+
+  // Form the data here
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  if( poolDbService.isAvailable() ){
+    cond::Time_t valid_time = poolDbService->currentTime(); 
+    // this writes the payload to begin in current run defined in cfg
+    poolDbService->writeOne(myProbabilities,valid_time, m_record);
+  } 
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+SiPixelQualityProbabilitiesWriteFromASCII::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Writes payloads of type SiPixelQualityProbabilities");
+  desc.addUntracked<bool>("printDebug",true);
+  desc.add<std::string>("record","SiPixelStatusScenarioProbabilityRcd");
+  desc.add<std::string>("probabilities","");
+  descriptions.add("SiPixelQualityProbabilitiesWriteFromASCII",desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiPixelQualityProbabilitiesWriteFromASCII);

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII_cfg.py
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII_cfg.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("ProcessOne")
+
+##
+## MessageLogger
+##
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.categories.append("SiPixelQualityProbabilitiesWriteFromASCII")  
+process.MessageLogger.categories.append("SiPixelQualityProbabilities")  
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiPixelQualityProbabilitiesWriteFromASCII = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    SiPixelQualityProbabilities           = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    )
+process.MessageLogger.statistics.append('cout')  
+
+##
+## Empty source
+##
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(1),
+                            numberEventsInRun    = cms.untracked.uint32(1),
+                            firstLuminosityBlock = cms.untracked.uint32(1),
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+                            )
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1))
+
+##
+## Database output service
+##
+process.load("CondCore.CondDB.CondDB_cfi")
+
+##
+## Output database (in this case local sqlite file)
+##
+process.CondDB.connect = 'sqlite_file:SiPixelStatusScenarioProbabilities_noPU.db'
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDB,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenarioProbabilityRcd'),
+                                                                     tag = cms.string('SiPixelQualityProbabilities_noPU_v0_mc')
+                                                                     )
+                                                            )
+                                          )
+
+
+process.WriteInDB = cms.EDAnalyzer("SiPixelQualityProbabilitiesWriteFromASCII",
+                                   printDebug    = cms.untracked.bool(True),
+                                   record        = cms.string('SiPixelStatusScenarioProbabilityRcd'),
+                                   probabilities = cms.string('prob_noPU_2018.txt'),
+                                   )
+
+process.p = cms.Path(process.WriteInDB)


### PR DESCRIPTION
This PR adds few refinements left over in https://github.com/cms-sw/cmssw/pull/25466
Main features:
 - Add possibility to write default (= empty `PixelFEDChannel` payloads) to `SiPixelFEDChannelContainerWriteFromASCII`, add possiblity to skip outputing empty PixelFEDChannel payload in `SiPixelFEDChannelContainerTestWriter`
 - Rename `SiPixelFEDChannelContainerTestWriter` to `SiPixelFEDChannelContainerFromQualityConverter`for clarity
 - Add `SiPixelBadFEDChannelSimulationSanityChecker` to check consistency of `SiPixelQualityProbabilities` and `SiPixelFEDChannelContainer` payloads
- Add `SiPixelQualityProbabilitiesWriteFromASCII`

No change is meant in any production workflow.