### PR TITLE
Forward declare DetLayer as a class, not struct

### DIFF
--- a/HLTriggerOffline/Muon/interface/PropagateToMuon.h
+++ b/HLTriggerOffline/Muon/interface/PropagateToMuon.h
@@ -21,7 +21,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
-struct DetLayer; // #include "TrackingTools/DetLayers/interface/DetLayer.h" // forward declaration can suffice
+class DetLayer; // #include "TrackingTools/DetLayers/interface/DetLayer.h" // forward declaration can suffice
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 


### PR DESCRIPTION
This fixes a clang warning.