### PR TITLE
Changed forward declaration of EVTColContainer to struct

### DIFF
--- a/HLTriggerOffline/Higgs/interface/HLTHiggsPlotter.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsPlotter.h
@@ -42,7 +42,7 @@
 
 const unsigned int kNull = (unsigned int) -1;
 
-class EVTColContainer;
+struct EVTColContainer;
 
 class HLTHiggsPlotter 
 {

--- a/HLTriggerOffline/Higgs/interface/HLTHiggsSubAnalysis.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsSubAnalysis.h
@@ -56,7 +56,7 @@
 #include<map>
 #include<cstring>
 
-class EVTColContainer;
+struct EVTColContainer;
 
 class HLTHiggsSubAnalysis 
 {	

--- a/HLTriggerOffline/Higgs/interface/HLTHiggsValidator.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsValidator.h
@@ -27,7 +27,7 @@
 #include <cstring>
 
 
-class EVTColContainer;
+struct EVTColContainer;
 
 class HLTHiggsValidator : public DQMEDAnalyzer
 {


### PR DESCRIPTION
This fixes a clang warning.