### PR TITLE
Removed unused variables in HLTrigger/Muon

### DIFF
--- a/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
@@ -210,8 +210,6 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 
      edm::Handle<trigger::TriggerFilterObjectWithRefs> level1Cands;
      std::vector<l1t::MuonRef> vl1cands;
-     std::vector<l1t::MuonRef>::iterator vl1cands_begin;
-     std::vector<l1t::MuonRef>::iterator vl1cands_end;
 
      bool check_l1match = true;
 

--- a/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.cc
@@ -195,8 +195,6 @@ bool HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trig
 
      edm::Handle<trigger::TriggerFilterObjectWithRefs> level1Cands;
      std::vector<l1t::MuonRef> vl1cands;
-     std::vector<l1t::MuonRef>::iterator vl1cands_begin;
-     std::vector<l1t::MuonRef>::iterator vl1cands_end;
 
      bool check_l1match = true;
 


### PR DESCRIPTION
This fixes clang warnings.