### PR TITLE
Remove std::move to allow better compiler optimization in RecoTracker/SingleTrackPattern

### DIFF
--- a/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
@@ -272,11 +272,11 @@ CRackTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed) const
 
     if (ihit == hitRange.second - 1) {
       TSOS  updatedState=startingTSOS(seed);
-      result.push_back(std::move(TM( invalidState, updatedState, recHit)));
+      result.emplace_back(invalidState, updatedState, recHit);
 
     } 
     else {
-      result.push_back(std::move(TM( invalidState, recHit)));
+      result.emplace_back(invalidState, recHit);
     }
     
   }

--- a/RecoTracker/SingleTrackPattern/src/CosmicTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CosmicTrajectoryBuilder.cc
@@ -284,8 +284,8 @@ void CosmicTrajectoryBuilder::AddHit(Trajectory &traj,
 	   TSOS UpdatedState= theUpdator->update( prSt, *tmphitbestdet);
 	   if (UpdatedState.isValid()){
 
-	     traj.push(std::move(TM(prSt,UpdatedState,RHBuilder->build(Hits[ibestdet])
-			  , chi2min)));
+	     traj.push(TM(prSt,UpdatedState,RHBuilder->build(Hits[ibestdet])
+			  , chi2min));
 	     LogDebug("CosmicTrackFinder") <<
 	       "STATE UPDATED WITH HIT AT POSITION "
 					   <<tmphitbestdet->globalPosition()


### PR DESCRIPTION
This PR fixes the following clang warning
```
warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
```