### PR TITLE
Remove inappropriate use of std::move

### DIFF
--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.cc
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.cc
@@ -34,7 +34,7 @@ MuIsoDepositCopyProducer::MuIsoDepositCopyProducer(const ParameterSet& par) :
   
   for (unsigned int i = 0; i < theDepositNames.size(); ++i){
     std::string alias = theConfig.getParameter<std::string>("@module_label");
-    if (theDepositNames[i] != "") alias += "_" + theDepositNames[i];
+    if (!theDepositNames[i].empty()) alias += "_" + theDepositNames[i];
     produces<reco::IsoDepositMap>(theDepositNames[i]).setBranchAlias(alias);
   }
   for (unsigned int iDep = 0; iDep < theInputTags.size(); ++iDep)

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.cc
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositCopyProducer.cc
@@ -60,7 +60,7 @@ void MuIsoDepositCopyProducer::produce(Event& event, const EventSetup& eventSetu
     Handle<reco::IsoDepositMap > inDep;
     event.getByToken(theInputTokens[iDep], inDep);
 
-    event.put(std::move(std::make_unique<reco::IsoDepositMap>(*inDep)), theDepositNames[iDep]);
+    event.put(std::make_unique<reco::IsoDepositMap>(*inDep), theDepositNames[iDep]);
   }//! end iDep
 
   LogTrace(metname) <<" END OF EVENT " <<"================================";


### PR DESCRIPTION
Moving an temporary prevents copy elision optimization. This was found by clang.