### PR TITLE
Declare MuonShower as a struct, not a class

### DIFF
--- a/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
@@ -40,7 +40,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
-namespace reco {class TransientTrack; class MuonShower;}
+namespace reco {class TransientTrack; struct MuonShower;}
 
 class MuonServiceProxy;
 class Trajectory;


### PR DESCRIPTION
This fixes a clang warning.