### PR TITLE
Avoid hiding base class method 'trajectories'

### DIFF
--- a/RecoMuon/GlobalTrackFinder/interface/GlobalMuonTrajectoryBuilder.h
+++ b/RecoMuon/GlobalTrackFinder/interface/GlobalMuonTrajectoryBuilder.h
@@ -30,6 +30,8 @@ class GlobalMuonTrajectoryBuilder : public GlobalTrajectoryBuilderBase {
     /// destructor
     ~GlobalMuonTrajectoryBuilder() override;
 
+    using GlobalTrajectoryBuilderBase::trajectories;
+
     /// reconstruct trajectories from standalone and tracker only Tracks    
     MuonTrajectoryBuilder::CandidateContainer trajectories(const TrackCand&) override;
 


### PR DESCRIPTION
This fixes a clang warning.