### PR TITLE
[10.5.X][DQM] Fix deps to resolve undefined reference mentioned in UBSAN IBS

### DIFF
--- a/DQM/CSCMonitorModule/plugins/BuildFile.xml
+++ b/DQM/CSCMonitorModule/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <library   file="*.cc" name="DQMCSCMonitorModulePlugins">
   <flags   CPPDEFINES="DQMGLOBAL"/>
   <flags   EDM_PLUGIN="1"/>
+  <use   name="DataFormats/Scalers"/>
   <use   name="DQMServices/ClientConfig"/>
   <use   name="DQMServices/Core"/>
   <use   name="EventFilter/CSCRawToDigi"/>


### PR DESCRIPTION
To resolve
```
  tmp/slc7_amd64_gcc700/src/DQM/CSCMonitorModule/plugins/DQMCSCMonitorModulePlugins/CSCMonitorModule.cc.o:(.data.rel+0x2818): undefined reference to `typeinfo for DcsStatus'
   tmp/slc7_amd64_gcc700/src/DQM/CSCMonitorModule/plugins/DQMCSCMonitorModulePlugins/CSCMonitorModule.cc.o:(.data.rel+0x2858): undefined reference to `typeinfo for DcsStatus'

```