### PR TITLE
[10.5.X][GENERATORS] Fix deps to resolve undefined reference mentioned in UBSAN IBS

### DIFF
--- a/GeneratorInterface/ExhumeInterface/test/BuildFile.xml
+++ b/GeneratorInterface/ExhumeInterface/test/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/Math"/>
+<use   name="DataFormats/Candidate"/>
 <flags   EDM_PLUGIN="1"/>
 <library   file="ExhumeAnalyzer.cc" name="ExhumeAnalyzer">
   <use   name="CommonTools/UtilAlgos"/>


### PR DESCRIPTION
To resolve
```
 tmp/slc7_amd64_gcc700/src/GeneratorInterface/ExhumeInterface/test/ExhumeAnalyzer/ExhumeAnalyzer.cc.o:(.data.rel+0x2c58): undefined reference to `typeinfo for reco::LeafCandidate'
```