### PR TITLE
[10.5.X][UPGRADE_L1] Fix deps to resolve undefined reference mentioned in UBSAN IBS

### DIFF
--- a/L1Trigger/L1THGCal/BuildFile.xml
+++ b/L1Trigger/L1THGCal/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="Geometry/Records"/>
 <use   name="DataFormats/L1THGCal"/>
 <use   name="CommonTools/Utils"/>
-
+<use   name="Geometry/HcalTowerAlgo"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
To resolve
```
  tmp/slc7_amd64_gcc700/src/L1Trigger/L1THGCal/src/L1TriggerL1THGCal/HGCalTriggerTools.cc.o:(.data.rel+0x458): undefined reference to `typeinfo for HcalGeometry'
   tmp/slc7_amd64_gcc700/src/L1Trigger/L1THGCal/src/L1TriggerL1THGCal/HGCalTriggerTools.cc.o:(.data.rel+0x498): undefined reference to `typeinfo for HcalGeometry'

```