### PR TITLE
[10.5.X][SIMULATION] Fix deps to resolve undefined reference mentioned in UBSAN IBS

### DIFF
--- a/SimG4Core/HelpfulWatchers/BuildFile.xml
+++ b/SimG4Core/HelpfulWatchers/BuildFile.xml
@@ -8,3 +8,4 @@
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="MagneticField/Engine"/>
 <use   name="MagneticField/Records"/>
+<use   name="SimG4Core/Physics"/>


### PR DESCRIPTION
To Resolve
```
  tmp/slc7_amd64_gcc700/src/SimG4Core/HelpfulWatchers/src/SimG4CoreHelpfulWatchers/MonopoleSteppingAction.cc.o:(.data.rel+0x1f18): undefined reference to `typeinfo for Monopole'
   tmp/slc7_amd64_gcc700/src/SimG4Core/HelpfulWatchers/src/SimG4CoreHelpfulWatchers/MonopoleSteppingAction.cc.o:(.data.rel+0x1f58): undefined reference to `typeinfo for Monopole'

```