### PR TITLE
[10.5.X][RECONSTRUCTION] Fix deps to resolve undefined reference mentioned in UBSAN IBS

### DIFF
--- a/RecoTracker/TrackProducer/test/BuildFile.xml
+++ b/RecoTracker/TrackProducer/test/BuildFile.xml
@@ -44,6 +44,7 @@
 </library>
 <library   file="FakeCPEFiller.cc" name="FakeCPEFiller">
   <use   name="SimTracker/TrackerHitAssociation"/>
+  <use   name="RecoTracker/TransientTrackingRecHit"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
 


### PR DESCRIPTION
To resolve
```
  tmp/slc7_amd64_gcc700/src/RecoTracker/TrackProducer/test/FakeCPEFiller/FakeCPEFiller.cc.o:(.data.rel+0x1bd8): undefined reference to `typeinfo for TkTransientTrackingRecHitBuilder'

```