### PR TITLE
[10.6.X][GEOMETRY] Fix deps to resolve undefined reference mentioned in UBSAN IBS

### DIFF
--- a/DetectorDescription/DDCMS/BuildFile.xml
+++ b/DetectorDescription/DDCMS/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="dd4hep"/>
 <use   name="rootmath"/>
+<use   name="rooteve"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DetectorDescription/DDCMS/BuildFile.xml
+++ b/DetectorDescription/DDCMS/BuildFile.xml
@@ -3,7 +3,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="dd4hep"/>
 <use   name="rootmath"/>
-<use   name="rooteve"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Geometry/GlobalTrackingGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/GlobalTrackingGeometryBuilder/test/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="Geometry/RPCGeometry"/>
 <use   name="Geometry/DTGeometry"/>
 <use   name="Geometry/CSCGeometry"/>
+<use   name="Geometry/MTDGeometryBuilder"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="rootcore"/>


### PR DESCRIPTION
To resolve
```
tmp/slc7_amd64_gcc700/src/Geometry/GlobalTrackingGeometryBuilder/test/testGlobalTrackingGeometry/GlobalTrackingGeometryTest.cc.o:(.data.rel+0x10d8): undefined reference to `typeinfo for MTDGeometry'
```
