### PR TITLE
Make sure named bins are unique in HLTObjectsMonitor

### DIFF
--- a/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
@@ -613,7 +613,7 @@ void HLTObjectsMonitor::bookHistograms(DQMStore::IBooker & ibooker, edm::Run con
     for (auto const& p :  hltPlots_) {
       //only add a bin if this is the first time we've seen the name
       if( -1 == plotNamesToBins_[p.pathNAME]) {
-        plotNamesToBins_[p.pathNAME] = i;
+        plotNamesToBins_[p.pathNAME] = ++i;
         eventsPlot_->setBinLabel(i,p.pathNAME);
         if ( debug_ )
           std::cout << p.pathNAME << " --> bin: " << i << std::endl;

--- a/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
@@ -2,7 +2,6 @@
 #include <memory>
 #include <sys/time.h>
 #include <cstdlib>
-#include <unordered_set>
 #include <unordered_map>
 
 // user include files
@@ -347,7 +346,7 @@ HLTObjectsMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 
   // loop over path
   int ibin = -1;
-  std::unordered_set<int> plottedPathNameIndices;
+  std::vector<bool> plottedPathIndices(plotNamesToBins_.size(),false);
   for (auto & plot : hltPlots_) {
     ibin++;
     if ( plot.pathIDX <= 0 ) continue;
@@ -355,8 +354,8 @@ HLTObjectsMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     if ( triggerResults->accept(plot.pathIDX) ) {
       //We only want to fill this once per pathNAME per event
       auto index = plotNamesToBins_[plot.pathNAME];
-      if(plottedPathNameIndices.end() == plottedPathNameIndices.find(index)) {
-        plottedPathNameIndices.insert(index);
+      if(not plottedPathIndices[index]) {
+        plottedPathIndices[index] = true;
         if ( debug_ )
           std::cout << plot.pathNAME << " --> bin: " << ibin << std::endl;
         eventsPlot_->Fill(index);


### PR DESCRIPTION
In the newest version of ROOT, histograms with named bins are
merged via the bin's name, not the index. This means we must
avoid bins having the same bin names.
HLTObjectsMonitor has a histogram which uses path names for the
bin names. In the past, multiple bins could have the same path
name. This change guarantees uniqueness for the bin names and
only fills a bin once per event.