### PR TITLE
Additional PPS tracks information

### DIFF
--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -21,12 +21,16 @@ class CTPPSLocalTrackLite
 {
   public:
 
-    CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), tx(999.), tx_unc(-1.), ty(999.), ty_unc(-1.), chiSquaredOverNDF(-1.), reco_info(CTPPSPixelLocalTrack::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
+    CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), tx(999.), tx_unc(-1.), ty(999.), ty_unc(-1.), 
+    chiSquaredOverNDF(-1.), reco_info(CTPPSPixelLocalTrack::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
     {
     }
 
-    CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float ptx, float ptxu, float pty, float ptyu, float pchiSquaredOverNDF, CTPPSPixelLocalTrack::reconstructionInfo preco_info, unsigned short pNumberOfPointsUsedForFit, float pt, float ptu)
-      : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), tx(ptx), tx_unc(ptxu), ty(pty), ty_unc(ptyu), chiSquaredOverNDF(pchiSquaredOverNDF), reco_info(preco_info), numberOfPointsUsedForFit(pNumberOfPointsUsedForFit), time(pt), time_unc(ptu)
+    CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float ptx, float ptxu, 
+        float pty, float ptyu, float pchiSquaredOverNDF, CTPPSPixelLocalTrack::reconstructionInfo preco_info, 
+        unsigned short pNumberOfPointsUsedForFit, float pt, float ptu)
+      : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), tx(ptx), tx_unc(ptxu), ty(pty), ty_unc(ptyu), chiSquaredOverNDF(pchiSquaredOverNDF), 
+      reco_info(preco_info), numberOfPointsUsedForFit(pNumberOfPointsUsedForFit), time(pt), time_unc(ptu)
     { 
     }
 

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -17,12 +17,13 @@
 class CTPPSLocalTrackLite
 {
   public:
-    CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), tx(999.), tx_unc(-1.), ty(999.), ty_unc(-1.), chiSquaredOverNDF(-1.), reco_info(4), numberOfPointUsedForFit(0), time(0.), time_unc(-1.)
+
+    CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), tx(999.), tx_unc(-1.), ty(999.), ty_unc(-1.), chiSquaredOverNDF(-1.), reco_info(CTPPSPixelLocalTrack::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
     {
     }
 
-    CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float ptx=999., float ptxu=-1., float pty=999., float ptyu=-1., float pchiSquaredOverNDF=-1., unsigned short preco_info=4, unsigned short pNumberOfPointUsedForFit=-1, float pt=0., float ptu=-1.)
-      : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), tx(ptx), tx_unc(ptxu), ty(pty), ty_unc(ptyu), chiSquaredOverNDF(pchiSquaredOverNDF), reco_info(preco_info), numberOfPointUsedForFit(pNumberOfPointUsedForFit), time(pt), time_unc(ptu)
+    CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float ptx, float ptxu, float pty, float ptyu, float pchiSquaredOverNDF, CTPPSPixelLocalTrack::reconstructionInfo preco_info, unsigned short pNumberOfPointsUsedForFit, float pt, float ptu)
+      : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), tx(ptx), tx_unc(ptxu), ty(pty), ty_unc(ptyu), chiSquaredOverNDF(pchiSquaredOverNDF), reco_info(preco_info), numberOfPointsUsedForFit(pNumberOfPointsUsedForFit), time(pt), time_unc(ptu)
     { 
     }
 
@@ -99,7 +100,7 @@ class CTPPSLocalTrackLite
     }
 
     /// returns the track reconstruction info byte
-    inline unsigned int getReco_info() const
+    inline unsigned int getRecoInfo() const
     {
         return reco_info;
     }
@@ -107,12 +108,17 @@ class CTPPSLocalTrackLite
     /// returns the number of points used for fit
     inline unsigned short getNumberOfPointsUsedForFit() const
     {
-        return numberOfPointUsedForFit;
+        return numberOfPointsUsedForFit;
     }   
 
   protected:
     /// RP id
     uint32_t rpId;
+
+    /// local track parameterization
+    /// x = x0 + tx*(z-z0), y = y0 + ty*(z-z0)
+    /// x0, y0, z-z0 in mm
+    /// z0: position of the reference scoring plane (in the middle of the RP)
 
     /// horizontal hit position and uncertainty, mm
     float x, x_unc;
@@ -130,14 +136,15 @@ class CTPPSLocalTrackLite
     float chiSquaredOverNDF;
 
     /// Track information byte for bx-shifted runs: 
-    /// reco_info = 0 -> Default value for tracks reconstructed in non-bx-shifted ROCs
-    /// reco_info = 1 -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
-    /// reco_info = 2 -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
-    /// reco_info = 3 -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
-    unsigned short reco_info;
+    /// reco_info = notShiftedRun    -> Default value for tracks reconstructed in non-bx-shifted ROCs
+    /// reco_info = allShiftedPlanes -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
+    /// reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
+    /// reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
+    /// reco_info = invalid          -> Dummy value. Assigned when reco_info is not computed (i.e. non-pixel tracks)
+    CTPPSPixelLocalTrack::reconstructionInfo reco_info;
 
     /// number of points used for fit
-    unsigned short numberOfPointUsedForFit; 
+    unsigned short numberOfPointsUsedForFit; 
 
     /// time information and uncertainty
     float time, time_unc;

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -136,9 +136,9 @@ class CTPPSLocalTrackLite
     /// reco_info = 3 -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
     unsigned short reco_info;
 
-   	/// number of points used for fit
-   	unsigned short numberOfPointUsedForFit; 
-   	
+    /// number of points used for fit
+    unsigned short numberOfPointUsedForFit; 
+
     /// time information and uncertainty
     float time, time_unc;
 

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -17,56 +17,98 @@
 class CTPPSLocalTrackLite
 {
   public:
-    CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), time(0.), time_unc(-1.)
+    CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), tx(999.), tx_unc(-1.), ty(999.), ty_unc(-1.), chiSquaredOverNDF(-1.), reco_info(4), numberOfPointUsedForFit(0), time(0.), time_unc(-1.)
     {
     }
 
-    CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float pt=0., float ptu=-1.)
-      : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), time(pt), time_unc(ptu)
-    {
+    CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float ptx=999., float ptxu=-1., float pty=999., float ptyu=-1., float pchiSquaredOverNDF=-1., unsigned short preco_info=4, unsigned short pNumberOfPointUsedForFit=-1, float pt=0., float ptu=-1.)
+      : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), tx(ptx), tx_unc(ptxu), ty(pty), ty_unc(ptyu), chiSquaredOverNDF(pchiSquaredOverNDF), reco_info(preco_info), numberOfPointUsedForFit(pNumberOfPointUsedForFit), time(pt), time_unc(ptu)
+    { 
     }
 
     /// returns the RP id
-    uint32_t getRPId() const
+    inline uint32_t getRPId() const
     {
       return rpId;
     }
 
     /// returns the horizontal track position
-    float getX() const
+    inline float getX() const
     {
       return x;
     }
 
     /// returns the horizontal track position uncertainty
-    float getXUnc() const
+    inline float getXUnc() const
     {
       return x_unc;
     }
 
     /// returns the vertical track position
-    float getY() const
+    inline float getY() const
     {
       return y;
     }
 
     /// returns the vertical track position uncertainty
-    float getYUnc() const
+    inline float getYUnc() const
     {
       return y_unc;
     }
 
     /// returns the track time
-    float getTime() const
+    inline float getTime() const
     {
       return time;
     }
 
     /// returns the track time uncertainty
-    float getTimeUnc() const
+    inline float getTimeUnc() const
     {
       return time_unc;
     }
+
+    /// returns the track horizontal angle
+    inline float getTx() const
+    {
+        return tx;
+    }
+
+    /// returns the track horizontal angle uncertainty
+    inline float getTxUnc() const
+    {
+        return tx_unc;
+    }
+    
+    /// returns the track vertical angle
+    inline float getTy() const
+    {
+        return ty;
+    }
+    
+    /// returns the track vertical angle uncertainty
+    inline float getTyUnc() const
+    {
+        return ty_unc;
+    }
+    
+    /// returns the track fit chi Squared over NDF
+    inline float getChiSquaredOverNDF() const
+    {
+        return chiSquaredOverNDF;
+    }
+
+    /// returns the track reconstruction info byte
+    inline unsigned int getReco_info() const
+    {
+        return reco_info;
+    }
+
+    /// returns the number of points used for fit
+    inline unsigned short getNumberOfPointsUsedForFit() const
+    {
+        return numberOfPointUsedForFit;
+    }   
 
   protected:
     /// RP id
@@ -78,8 +120,28 @@ class CTPPSLocalTrackLite
     /// vertical hit position and uncertainty, mm
     float y, y_unc;
 
+    /// horizontal angle and uncertainty, x = x0 + tx*(z-z0)
+    float tx, tx_unc;
+
+    /// vertical angle and uncertainty, y = y0 + ty*(z-z0)
+    float ty, ty_unc;
+
+    /// fit chi^2 over NDF
+    float chiSquaredOverNDF;
+
+    /// Track information byte for bx-shifted runs: 
+    /// reco_info = 0 -> Default value for tracks reconstructed in non-bx-shifted ROCs
+    /// reco_info = 1 -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
+    /// reco_info = 2 -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
+    /// reco_info = 3 -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
+    unsigned short reco_info;
+
+   	/// number of points used for fit
+   	unsigned short numberOfPointUsedForFit; 
+   	
     /// time information and uncertainty
     float time, time_unc;
+
 };
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -11,6 +11,9 @@
 
 #include <cstdint>
 
+#include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
+
+
 /**
  *\brief Local (=single RP) track with essential information only.
  **/

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -22,15 +22,15 @@ class CTPPSLocalTrackLite
   public:
 
     CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), tx(999.), tx_unc(-1.), ty(999.), ty_unc(-1.), 
-    chiSquaredOverNDF(-1.), reco_info(CTPPSPixelLocalTrack::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
+    chiSquaredOverNDF(-1.), pixelTrack_reco_info(CTPPSPixelLocalTrack::ReconstructionInfo::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
     {
     }
 
     CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float ptx, float ptxu, 
-        float pty, float ptyu, float pchiSquaredOverNDF, CTPPSPixelLocalTrack::reconstructionInfo preco_info, 
+        float pty, float ptyu, float pchiSquaredOverNDF, CTPPSPixelLocalTrack::ReconstructionInfo ppixelTrack_reco_info, 
         unsigned short pNumberOfPointsUsedForFit, float pt, float ptu)
       : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), tx(ptx), tx_unc(ptxu), ty(pty), ty_unc(ptyu), chiSquaredOverNDF(pchiSquaredOverNDF), 
-      reco_info(preco_info), numberOfPointsUsedForFit(pNumberOfPointsUsedForFit), time(pt), time_unc(ptu)
+      pixelTrack_reco_info(ppixelTrack_reco_info), numberOfPointsUsedForFit(pNumberOfPointsUsedForFit), time(pt), time_unc(ptu)
     { 
     }
 
@@ -109,7 +109,7 @@ class CTPPSLocalTrackLite
     /// returns the track reconstruction info byte
     inline unsigned int getRecoInfo() const
     {
-        return reco_info;
+        return (unsigned int)pixelTrack_reco_info;
     }
 
     /// returns the number of points used for fit
@@ -143,12 +143,12 @@ class CTPPSLocalTrackLite
     float chiSquaredOverNDF;
 
     /// Track information byte for bx-shifted runs: 
-    /// reco_info = notShiftedRun    -> Default value for tracks reconstructed in non-bx-shifted ROCs
-    /// reco_info = allShiftedPlanes -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
-    /// reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
-    /// reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
-    /// reco_info = invalid          -> Dummy value. Assigned when reco_info is not computed (i.e. non-pixel tracks)
-    CTPPSPixelLocalTrack::reconstructionInfo reco_info;
+    /// pixelTrack_reco_info = notShiftedRun    -> Default value for tracks reconstructed in non-bx-shifted ROCs
+    /// pixelTrack_reco_info = allShiftedPlanes -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
+    /// pixelTrack_reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
+    /// pixelTrack_reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
+    /// pixelTrack_reco_info = invalid          -> Dummy value. Assigned when pixelTrack_reco_info is not computed (i.e. non-pixel tracks)
+    CTPPSPixelLocalTrack::ReconstructionInfo pixelTrack_reco_info;
 
     /// number of points used for fit
     unsigned short numberOfPointsUsedForFit; 

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -11,8 +11,7 @@
 
 #include <cstdint>
 
-#include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
-
+#include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrackRecoInfo.h"
 
 /**
  *\brief Local (=single RP) track with essential information only.
@@ -22,12 +21,12 @@ class CTPPSLocalTrackLite
   public:
 
     CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), tx(999.), tx_unc(-1.), ty(999.), ty_unc(-1.), 
-    chiSquaredOverNDF(-1.), pixelTrack_reco_info(CTPPSPixelLocalTrack::ReconstructionInfo::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
+    chiSquaredOverNDF(-1.), pixelTrack_reco_info(ReconstructionInfo::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
     {
     }
 
     CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float ptx, float ptxu, 
-        float pty, float ptyu, float pchiSquaredOverNDF, CTPPSPixelLocalTrack::ReconstructionInfo ppixelTrack_reco_info, 
+        float pty, float ptyu, float pchiSquaredOverNDF, ReconstructionInfo ppixelTrack_reco_info, 
         unsigned short pNumberOfPointsUsedForFit, float pt, float ptu)
       : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), tx(ptx), tx_unc(ptxu), ty(pty), ty_unc(ptyu), chiSquaredOverNDF(pchiSquaredOverNDF), 
       pixelTrack_reco_info(ppixelTrack_reco_info), numberOfPointsUsedForFit(pNumberOfPointsUsedForFit), time(pt), time_unc(ptu)
@@ -148,7 +147,7 @@ class CTPPSLocalTrackLite
     /// pixelTrack_reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
     /// pixelTrack_reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
     /// pixelTrack_reco_info = invalid          -> Dummy value. Assigned when pixelTrack_reco_info is not computed (i.e. non-pixel tracks)
-    CTPPSPixelLocalTrack::ReconstructionInfo pixelTrack_reco_info;
+    ReconstructionInfo pixelTrack_reco_info;
 
     /// number of points used for fit
     unsigned short numberOfPointsUsedForFit; 

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -21,12 +21,12 @@ class CTPPSLocalTrackLite
   public:
 
     CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), tx(999.), tx_unc(-1.), ty(999.), ty_unc(-1.), 
-    chiSquaredOverNDF(-1.), pixelTrack_reco_info(ReconstructionInfo::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
+    chiSquaredOverNDF(-1.), pixelTrack_reco_info(CTPPSReconstructionInfo::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
     {
     }
 
     CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float ptx, float ptxu, 
-        float pty, float ptyu, float pchiSquaredOverNDF, ReconstructionInfo ppixelTrack_reco_info, 
+        float pty, float ptyu, float pchiSquaredOverNDF, CTPPSReconstructionInfo ppixelTrack_reco_info, 
         unsigned short pNumberOfPointsUsedForFit, float pt, float ptu)
       : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), tx(ptx), tx_unc(ptxu), ty(pty), ty_unc(ptyu), chiSquaredOverNDF(pchiSquaredOverNDF), 
       pixelTrack_reco_info(ppixelTrack_reco_info), numberOfPointsUsedForFit(pNumberOfPointsUsedForFit), time(pt), time_unc(ptu)
@@ -106,9 +106,9 @@ class CTPPSLocalTrackLite
     }
 
     /// returns the track reconstruction info byte
-    inline unsigned int getRecoInfo() const
+    inline CTPPSReconstructionInfo getPixelTrackRecoInfo() const
     {
-        return (unsigned int)pixelTrack_reco_info;
+        return pixelTrack_reco_info;
     }
 
     /// returns the number of points used for fit
@@ -147,7 +147,7 @@ class CTPPSLocalTrackLite
     /// pixelTrack_reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
     /// pixelTrack_reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
     /// pixelTrack_reco_info = invalid          -> Dummy value. Assigned when pixelTrack_reco_info is not computed (i.e. non-pixel tracks)
-    ReconstructionInfo pixelTrack_reco_info;
+    CTPPSReconstructionInfo pixelTrack_reco_info;
 
     /// number of points used for fit
     unsigned short numberOfPointsUsedForFit; 

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -21,12 +21,12 @@ class CTPPSLocalTrackLite
   public:
 
     CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), tx(999.), tx_unc(-1.), ty(999.), ty_unc(-1.), 
-    chiSquaredOverNDF(-1.), pixelTrack_reco_info(CTPPSReconstructionInfo::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
+    chiSquaredOverNDF(-1.), pixelTrack_reco_info(CTPPSpixelLocalTrackReconstructionInfo::invalid), numberOfPointsUsedForFit(0), time(0.), time_unc(-1.)
     {
     }
 
     CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float ptx, float ptxu, 
-        float pty, float ptyu, float pchiSquaredOverNDF, CTPPSReconstructionInfo ppixelTrack_reco_info, 
+        float pty, float ptyu, float pchiSquaredOverNDF, CTPPSpixelLocalTrackReconstructionInfo ppixelTrack_reco_info, 
         unsigned short pNumberOfPointsUsedForFit, float pt, float ptu)
       : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), tx(ptx), tx_unc(ptxu), ty(pty), ty_unc(ptyu), chiSquaredOverNDF(pchiSquaredOverNDF), 
       pixelTrack_reco_info(ppixelTrack_reco_info), numberOfPointsUsedForFit(pNumberOfPointsUsedForFit), time(pt), time_unc(ptu)
@@ -106,7 +106,7 @@ class CTPPSLocalTrackLite
     }
 
     /// returns the track reconstruction info byte
-    inline CTPPSReconstructionInfo getPixelTrackRecoInfo() const
+    inline CTPPSpixelLocalTrackReconstructionInfo getPixelTrackRecoInfo() const
     {
         return pixelTrack_reco_info;
     }
@@ -147,7 +147,7 @@ class CTPPSLocalTrackLite
     /// pixelTrack_reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
     /// pixelTrack_reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
     /// pixelTrack_reco_info = invalid          -> Dummy value. Assigned when pixelTrack_reco_info is not computed (i.e. non-pixel tracks)
-    CTPPSReconstructionInfo pixelTrack_reco_info;
+    CTPPSpixelLocalTrackReconstructionInfo pixelTrack_reco_info;
 
     /// number of points used for fit
     unsigned short numberOfPointsUsedForFit; 

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
@@ -83,7 +83,7 @@ class CTPPSPixelLocalTrack
     ///< covariance matrix size
     static constexpr int covarianceSize = dimension * dimension;
 
-    CTPPSPixelLocalTrack() : z0_(0), chiSquared_(0), valid_(false), numberOfPointsUsedForFit_(0),recoInfo_(ReconstructionInfo::invalid)
+    CTPPSPixelLocalTrack() : z0_(0), chiSquared_(0), valid_(false), numberOfPointsUsedForFit_(0),recoInfo_(CTPPSReconstructionInfo::invalid)
     {
     }
 
@@ -162,10 +162,10 @@ class CTPPSPixelLocalTrack
 
     bool operator< (const CTPPSPixelLocalTrack &r);
 
-    inline ReconstructionInfo getRecoInfo() const { return recoInfo_; }
-    inline void setRecoInfo(ReconstructionInfo recoInfo) { recoInfo_ = recoInfo; }
+    inline CTPPSReconstructionInfo getRecoInfo() const { return recoInfo_; }
+    inline void setRecoInfo(CTPPSReconstructionInfo recoInfo) { recoInfo_ = recoInfo; }
 
-    inline unsigned short getNumberOfPointsUsedForFit() const { return (unsigned short) numberOfPointsUsedForFit_; }
+    inline unsigned short getNumberOfPointsUsedForFit() const { return numberOfPointsUsedForFit_; }
     
   private:
     edm::DetSetVector<CTPPSPixelFittedRecHit> track_hits_vector_;
@@ -188,7 +188,7 @@ class CTPPSPixelLocalTrack
     /// number of points used for the track fit
     int numberOfPointsUsedForFit_;
 
-    ReconstructionInfo recoInfo_;
+    CTPPSReconstructionInfo recoInfo_;
 };
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
@@ -79,7 +79,7 @@ class CTPPSPixelLocalTrack
   /// reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
   /// reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
   /// reco_info = invalid          -> Dummy value. Assigned when reco_info is not computed
-  enum reconstructionInfo: unsigned short {notShiftedRun = 0, allShiftedPlanes = 1, noShiftedPlanes = 2, mixedPlanes = 3, invalid = 5};
+  enum class ReconstructionInfo: unsigned short {notShiftedRun = 0, allShiftedPlanes = 1, noShiftedPlanes = 2, mixedPlanes = 3, invalid = 5};
 
     ///< parameter vector size
     static constexpr int dimension = 4;
@@ -89,7 +89,7 @@ class CTPPSPixelLocalTrack
     ///< covariance matrix size
     static constexpr int covarianceSize = dimension * dimension;
 
-    CTPPSPixelLocalTrack() : z0_(0), chiSquared_(0), valid_(false), numberOfPointsUsedForFit_(0),recoInfo_(reconstructionInfo::invalid)
+    CTPPSPixelLocalTrack() : z0_(0), chiSquared_(0), valid_(false), numberOfPointsUsedForFit_(0),recoInfo_(ReconstructionInfo::invalid)
     {
     }
 
@@ -168,8 +168,8 @@ class CTPPSPixelLocalTrack
 
     bool operator< (const CTPPSPixelLocalTrack &r);
 
-    inline reconstructionInfo getRecoInfo() const { return recoInfo_; }
-    inline void setRecoInfo(reconstructionInfo recoInfo) { recoInfo_ = recoInfo; }
+    inline ReconstructionInfo getRecoInfo() const { return recoInfo_; }
+    inline void setRecoInfo(ReconstructionInfo recoInfo) { recoInfo_ = recoInfo; }
 
     inline unsigned short getNumberOfPointsUsedForFit() const { return (unsigned short) numberOfPointsUsedForFit_; }
     
@@ -194,7 +194,7 @@ class CTPPSPixelLocalTrack
     /// number of points used for the track fit
     int numberOfPointsUsedForFit_;
 
-    reconstructionInfo recoInfo_;
+    ReconstructionInfo recoInfo_;
 };
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
@@ -86,7 +86,7 @@ class CTPPSPixelLocalTrack
     }
 
     CTPPSPixelLocalTrack(float z0, const ParameterVector & track_params_vector,
-      const CovarianceMatrix &par_covariance_matrix, float chiSquared);
+      const CovarianceMatrix &par_covariance_matrix, float chiSquared, unsigned short recoInfo_=0);
 
     ~CTPPSPixelLocalTrack() {}
 
@@ -159,6 +159,10 @@ class CTPPSPixelLocalTrack
     inline void setValid(bool valid) { valid_ = valid; }
 
     bool operator< (const CTPPSPixelLocalTrack &r);
+
+    inline unsigned short getRecoInfo() const { return recoInfo_; }
+
+    inline unsigned short getNumberOfPointUsedForFit() const { return (unsigned short) numberOfPointUsedForFit_; }
     
   private:
     edm::DetSetVector<CTPPSPixelFittedRecHit> track_hits_vector_;
@@ -178,8 +182,15 @@ class CTPPSPixelLocalTrack
     /// fit valid?
     bool valid_;
 
+    /// number of points used for the track fit
     int numberOfPointUsedForFit_;
 
+    /// Track information byte for bx-shifted runs: 
+    /// reco_info = 0 -> Default value for tracks reconstructed in non-bx-shifted ROCs
+    /// reco_info = 1 -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
+    /// reco_info = 2 -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
+    /// reco_info = 3 -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
+    unsigned short recoInfo_;
 };
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
@@ -86,7 +86,7 @@ class CTPPSPixelLocalTrack
     }
 
     CTPPSPixelLocalTrack(float z0, const ParameterVector & track_params_vector,
-      const CovarianceMatrix &par_covariance_matrix, float chiSquared, unsigned short recoInfo);
+      const CovarianceMatrix &par_covariance_matrix, float chiSquared, unsigned short recoInfo = 5);
 
     ~CTPPSPixelLocalTrack() {}
 

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
@@ -23,6 +23,8 @@
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
+
+#include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrackRecoInfo.h"
 //----------------------------------------------------------------------------------------------------
 
 class CTPPSPixelFittedRecHit: public CTPPSPixelRecHit
@@ -72,14 +74,6 @@ class CTPPSPixelLocalTrack
   public:
   
   enum TrackPar {x0 = 0, y0 = 1, tx = 2, ty = 3}; 
-
-  /// Track information byte for bx-shifted runs: 
-  /// reco_info = notShiftedRun    -> Default value for tracks reconstructed in non-bx-shifted ROCs
-  /// reco_info = allShiftedPlanes -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
-  /// reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
-  /// reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
-  /// reco_info = invalid          -> Dummy value. Assigned when reco_info is not computed
-  enum class ReconstructionInfo: unsigned short {notShiftedRun = 0, allShiftedPlanes = 1, noShiftedPlanes = 2, mixedPlanes = 3, invalid = 5};
 
     ///< parameter vector size
     static constexpr int dimension = 4;

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
@@ -86,7 +86,7 @@ class CTPPSPixelLocalTrack
     }
 
     CTPPSPixelLocalTrack(float z0, const ParameterVector & track_params_vector,
-      const CovarianceMatrix &par_covariance_matrix, float chiSquared, unsigned short recoInfo_=0);
+      const CovarianceMatrix &par_covariance_matrix, float chiSquared, unsigned short recoInfo);
 
     ~CTPPSPixelLocalTrack() {}
 

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
@@ -83,7 +83,7 @@ class CTPPSPixelLocalTrack
     ///< covariance matrix size
     static constexpr int covarianceSize = dimension * dimension;
 
-    CTPPSPixelLocalTrack() : z0_(0), chiSquared_(0), valid_(false), numberOfPointsUsedForFit_(0),recoInfo_(CTPPSReconstructionInfo::invalid)
+    CTPPSPixelLocalTrack() : z0_(0), chiSquared_(0), valid_(false), numberOfPointsUsedForFit_(0),recoInfo_(CTPPSpixelLocalTrackReconstructionInfo::invalid)
     {
     }
 
@@ -162,8 +162,8 @@ class CTPPSPixelLocalTrack
 
     bool operator< (const CTPPSPixelLocalTrack &r);
 
-    inline CTPPSReconstructionInfo getRecoInfo() const { return recoInfo_; }
-    inline void setRecoInfo(CTPPSReconstructionInfo recoInfo) { recoInfo_ = recoInfo; }
+    inline CTPPSpixelLocalTrackReconstructionInfo getRecoInfo() const { return recoInfo_; }
+    inline void setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo recoInfo) { recoInfo_ = recoInfo; }
 
     inline unsigned short getNumberOfPointsUsedForFit() const { return numberOfPointsUsedForFit_; }
     
@@ -188,7 +188,7 @@ class CTPPSPixelLocalTrack
     /// number of points used for the track fit
     int numberOfPointsUsedForFit_;
 
-    CTPPSReconstructionInfo recoInfo_;
+    CTPPSpixelLocalTrackReconstructionInfo recoInfo_;
 };
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrackRecoInfo.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrackRecoInfo.h
@@ -1,0 +1,19 @@
+/*
+*
+* This is a part of CTPPS offline software.
+* Author:
+*   Andrea Bellora (andrea.bellora@cern.ch)
+*
+*/
+#ifndef DataFormats_CTPPSReco_CTPPSPixelLocalTrackRecoInfo_H
+#define DataFormats_CTPPSReco_CTPPSPixelLocalTrackRecoInfo_H
+
+  /// Track information byte for bx-shifted runs: 
+  /// reco_info = notShiftedRun    -> Default value for tracks reconstructed in non-bx-shifted ROCs
+  /// reco_info = allShiftedPlanes -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
+  /// reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
+  /// reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
+  /// reco_info = invalid          -> Dummy value. Assigned when reco_info is not computed
+  enum class ReconstructionInfo: unsigned short {notShiftedRun = 0, allShiftedPlanes = 1, noShiftedPlanes = 2, mixedPlanes = 3, invalid = 5};
+
+#endif

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrackRecoInfo.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrackRecoInfo.h
@@ -14,6 +14,6 @@
   /// reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
   /// reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
   /// reco_info = invalid          -> Dummy value. Assigned when reco_info is not computed
-  enum class ReconstructionInfo: unsigned short {notShiftedRun = 0, allShiftedPlanes = 1, noShiftedPlanes = 2, mixedPlanes = 3, invalid = 5};
+  enum class CTPPSReconstructionInfo {notShiftedRun = 0, allShiftedPlanes = 1, noShiftedPlanes = 2, mixedPlanes = 3, invalid = 5};
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrackRecoInfo.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrackRecoInfo.h
@@ -14,6 +14,7 @@
   /// reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
   /// reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
   /// reco_info = invalid          -> Dummy value. Assigned when reco_info is not computed
-  enum class CTPPSReconstructionInfo {notShiftedRun = 0, allShiftedPlanes = 1, noShiftedPlanes = 2, mixedPlanes = 3, invalid = 5};
+  enum class CTPPSpixelLocalTrackReconstructionInfo {notShiftedRun = 0, allShiftedPlanes = 1, noShiftedPlanes = 2, mixedPlanes = 3, invalid = 5};
 
 #endif
+  

--- a/DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h
@@ -115,6 +115,8 @@ class TotemRPLocalTrack
 
     inline double getChiSquaredOverNDF() const { return chiSquared_ / (track_hits_vector_.size() - 4); }
 
+    inline unsigned short getNumberOfPointsUsedForFit() const { return track_hits_vector_.size(); }
+
     /// returns (x, y) vector
     inline TVector2 getTrackPoint(double z) const 
     {

--- a/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
@@ -27,9 +27,9 @@ AlgebraicSymMatrix22 CTPPSPixelLocalTrack::trackPointInterpolationCovariance(flo
 //----------------------------------------------------------------------------------------------------
 
 CTPPSPixelLocalTrack::CTPPSPixelLocalTrack(float z0, const ParameterVector & track_params_vector, 
-      const CovarianceMatrix &par_covariance_matrix, float chiSquared, unsigned short recoInfo) 
+      const CovarianceMatrix &par_covariance_matrix, float chiSquared) 
       : track_params_vector_(track_params_vector), z0_(z0), par_covariance_matrix_(par_covariance_matrix),
-      chiSquared_(chiSquared), valid_(true), numberOfPointUsedForFit_(0), recoInfo_(recoInfo)
+      chiSquared_(chiSquared), valid_(true), numberOfPointsUsedForFit_(0), recoInfo_(reconstructionInfo::invalid)
 {
 
 }

--- a/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
@@ -27,9 +27,9 @@ AlgebraicSymMatrix22 CTPPSPixelLocalTrack::trackPointInterpolationCovariance(flo
 //----------------------------------------------------------------------------------------------------
 
 CTPPSPixelLocalTrack::CTPPSPixelLocalTrack(float z0, const ParameterVector & track_params_vector, 
-      const CovarianceMatrix &par_covariance_matrix, float chiSquared) 
+      const CovarianceMatrix &par_covariance_matrix, float chiSquared, unsigned short recoInfo_) 
       : track_params_vector_(track_params_vector), z0_(z0), par_covariance_matrix_(par_covariance_matrix),
-      chiSquared_(chiSquared), valid_(true), numberOfPointUsedForFit_(0)
+      chiSquared_(chiSquared), valid_(true), numberOfPointUsedForFit_(0), recoInfo_(0)
 {
 
 }

--- a/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
@@ -29,7 +29,7 @@ AlgebraicSymMatrix22 CTPPSPixelLocalTrack::trackPointInterpolationCovariance(flo
 CTPPSPixelLocalTrack::CTPPSPixelLocalTrack(float z0, const ParameterVector & track_params_vector, 
       const CovarianceMatrix &par_covariance_matrix, float chiSquared) 
       : track_params_vector_(track_params_vector), z0_(z0), par_covariance_matrix_(par_covariance_matrix),
-      chiSquared_(chiSquared), valid_(true), numberOfPointsUsedForFit_(0), recoInfo_(ReconstructionInfo::invalid)
+      chiSquared_(chiSquared), valid_(true), numberOfPointsUsedForFit_(0), recoInfo_(CTPPSReconstructionInfo::invalid)
 {
 
 }

--- a/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
@@ -29,7 +29,7 @@ AlgebraicSymMatrix22 CTPPSPixelLocalTrack::trackPointInterpolationCovariance(flo
 CTPPSPixelLocalTrack::CTPPSPixelLocalTrack(float z0, const ParameterVector & track_params_vector, 
       const CovarianceMatrix &par_covariance_matrix, float chiSquared) 
       : track_params_vector_(track_params_vector), z0_(z0), par_covariance_matrix_(par_covariance_matrix),
-      chiSquared_(chiSquared), valid_(true), numberOfPointsUsedForFit_(0), recoInfo_(reconstructionInfo::invalid)
+      chiSquared_(chiSquared), valid_(true), numberOfPointsUsedForFit_(0), recoInfo_(ReconstructionInfo::invalid)
 {
 
 }

--- a/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
@@ -52,4 +52,3 @@ bool CTPPSPixelLocalTrack::operator< (const CTPPSPixelLocalTrack &r)
   return false;
 
 }
-

--- a/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
@@ -27,9 +27,9 @@ AlgebraicSymMatrix22 CTPPSPixelLocalTrack::trackPointInterpolationCovariance(flo
 //----------------------------------------------------------------------------------------------------
 
 CTPPSPixelLocalTrack::CTPPSPixelLocalTrack(float z0, const ParameterVector & track_params_vector, 
-      const CovarianceMatrix &par_covariance_matrix, float chiSquared, unsigned short recoInfo_) 
+      const CovarianceMatrix &par_covariance_matrix, float chiSquared, unsigned short recoInfo) 
       : track_params_vector_(track_params_vector), z0_(z0), par_covariance_matrix_(par_covariance_matrix),
-      chiSquared_(chiSquared), valid_(true), numberOfPointUsedForFit_(0), recoInfo_(0)
+      chiSquared_(chiSquared), valid_(true), numberOfPointUsedForFit_(0), recoInfo_(recoInfo)
 {
 
 }

--- a/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSPixelLocalTrack.cc
@@ -29,7 +29,7 @@ AlgebraicSymMatrix22 CTPPSPixelLocalTrack::trackPointInterpolationCovariance(flo
 CTPPSPixelLocalTrack::CTPPSPixelLocalTrack(float z0, const ParameterVector & track_params_vector, 
       const CovarianceMatrix &par_covariance_matrix, float chiSquared) 
       : track_params_vector_(track_params_vector), z0_(z0), par_covariance_matrix_(par_covariance_matrix),
-      chiSquared_(chiSquared), valid_(true), numberOfPointsUsedForFit_(0), recoInfo_(CTPPSReconstructionInfo::invalid)
+      chiSquared_(chiSquared), valid_(true), numberOfPointsUsedForFit_(0), recoInfo_(CTPPSpixelLocalTrackReconstructionInfo::invalid)
 {
 
 }

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -121,7 +121,7 @@
 
   <class name="CTPPSPixelLocalTrack" ClassVersion="4">
     <version ClassVersion="3" checksum="4150373475"/>    
-    <version ClassVersion="4" checksum="923793481"/>
+    <version ClassVersion="4" checksum="470102069"/>
   </class>
   <ioread sourceClass = "CTPPSPixelLocalTrack" version="[3]" targetClass="CTPPSPixelLocalTrack" source="int numberOfPointUsedForFit_" target="numberOfPointsUsedForFit_">
   <![CDATA[ numberOfPointsUsedForFit_ = onfile.numberOfPointUsedForFit_;
@@ -142,7 +142,7 @@
 
   <class name="CTPPSLocalTrackLite" ClassVersion="4">
     <version ClassVersion="3" checksum="3838813906"/>    
-    <version ClassVersion="4" checksum="3055254667"/>
+    <version ClassVersion="4" checksum="2587349911"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -121,8 +121,12 @@
 
   <class name="CTPPSPixelLocalTrack" ClassVersion="4">
     <version ClassVersion="3" checksum="4150373475"/>    
-    <version ClassVersion="4" checksum="761311401"/>
+    <version ClassVersion="4" checksum="923793481"/>
   </class>
+  <ioread sourceClass = "CTPPSPixelLocalTrack" version="[3]" targetClass="CTPPSPixelLocalTrack" source="int numberOfPointUsedForFit_" target="numberOfPointsUsedForFit_">
+  <![CDATA[ numberOfPointsUsedForFit_ = onfile.numberOfPointUsedForFit_;
+  ]]>
+  </ioread>
   <class name="edm::DetSet<CTPPSPixelLocalTrack>"/>
   <class name="std::vector<CTPPSPixelLocalTrack>"/>
   <class name="std::vector<edm::DetSet<CTPPSPixelLocalTrack> >"/>
@@ -138,7 +142,7 @@
 
   <class name="CTPPSLocalTrackLite" ClassVersion="4">
     <version ClassVersion="3" checksum="3838813906"/>    
-    <version ClassVersion="4" checksum="3542556891"/>
+    <version ClassVersion="4" checksum="3055254667"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -101,8 +101,8 @@
 
 <!-- pixel objects -->
 
-  <class name="CTPPSPixelCluster" ClassVersion="3">
-    <version ClassVersion="3" checksum="2858478211"/>
+  <class name="CTPPSPixelCluster" ClassVersion="4">
+    <version ClassVersion="4" checksum="2858478211"/>
   </class>
   <class name="edm::DetSet<CTPPSPixelCluster>"/>
   <class name="std::vector<CTPPSPixelCluster>"/>
@@ -119,8 +119,8 @@
   <class name="edm::DetSetVector<CTPPSPixelRecHit>"/>
   <class name="edm::Wrapper<edm::DetSetVector<CTPPSPixelRecHit> >"/>
 
-  <class name="CTPPSPixelLocalTrack" ClassVersion="3">
-    <version ClassVersion="3" checksum="761311401"/>
+  <class name="CTPPSPixelLocalTrack" ClassVersion="4">
+    <version ClassVersion="4" checksum="761311401"/>
   </class>
   <class name="edm::DetSet<CTPPSPixelLocalTrack>"/>
   <class name="std::vector<CTPPSPixelLocalTrack>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -119,7 +119,8 @@
   <class name="edm::DetSetVector<CTPPSPixelRecHit>"/>
   <class name="edm::Wrapper<edm::DetSetVector<CTPPSPixelRecHit> >"/>
 
-  <class name="CTPPSPixelLocalTrack" ClassVersion="3">
+  <class name="CTPPSPixelLocalTrack" ClassVersion="4">
+   <version ClassVersion="4" checksum="4102658864"/>
     <version ClassVersion="3" checksum="4150373475"/>
   </class>
   <class name="edm::DetSet<CTPPSPixelLocalTrack>"/>
@@ -135,7 +136,8 @@
 
 <!-- common objects -->
 
-  <class name="CTPPSLocalTrackLite" ClassVersion="3">
+  <class name="CTPPSLocalTrackLite" ClassVersion="4">
+   <version ClassVersion="4" checksum="1924864446"/>
     <version ClassVersion="3" checksum="3838813906"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -119,9 +119,8 @@
   <class name="edm::DetSetVector<CTPPSPixelRecHit>"/>
   <class name="edm::Wrapper<edm::DetSetVector<CTPPSPixelRecHit> >"/>
 
-  <class name="CTPPSPixelLocalTrack" ClassVersion="4">
-   <version ClassVersion="4" checksum="4102658864"/>
-    <version ClassVersion="3" checksum="4150373475"/>
+  <class name="CTPPSPixelLocalTrack" ClassVersion="3">
+    <version ClassVersion="3" checksum="761311401"/>
   </class>
   <class name="edm::DetSet<CTPPSPixelLocalTrack>"/>
   <class name="std::vector<CTPPSPixelLocalTrack>"/>
@@ -136,9 +135,8 @@
 
 <!-- common objects -->
 
-  <class name="CTPPSLocalTrackLite" ClassVersion="4">
-   <version ClassVersion="4" checksum="1924864446"/>
-    <version ClassVersion="3" checksum="3838813906"/>
+  <class name="CTPPSLocalTrackLite" ClassVersion="3">
+    <version ClassVersion="3" checksum="3542556891"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -121,7 +121,7 @@
 
   <class name="CTPPSPixelLocalTrack" ClassVersion="4">
     <version ClassVersion="3" checksum="4150373475"/>    
-    <version ClassVersion="4" checksum="470102069"/>
+    <version ClassVersion="4" checksum="656781101"/>
   </class>
   <ioread sourceClass = "CTPPSPixelLocalTrack" version="[3]" targetClass="CTPPSPixelLocalTrack" source="int numberOfPointUsedForFit_" target="numberOfPointsUsedForFit_">
   <![CDATA[ numberOfPointsUsedForFit_ = onfile.numberOfPointUsedForFit_;
@@ -142,7 +142,7 @@
 
   <class name="CTPPSLocalTrackLite" ClassVersion="4">
     <version ClassVersion="3" checksum="3838813906"/>    
-    <version ClassVersion="4" checksum="2587349911"/>
+    <version ClassVersion="4" checksum="2542912231"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -101,8 +101,8 @@
 
 <!-- pixel objects -->
 
-  <class name="CTPPSPixelCluster" ClassVersion="4">
-    <version ClassVersion="4" checksum="2858478211"/>
+  <class name="CTPPSPixelCluster" ClassVersion="3">
+    <version ClassVersion="3" checksum="2858478211"/>
   </class>
   <class name="edm::DetSet<CTPPSPixelCluster>"/>
   <class name="std::vector<CTPPSPixelCluster>"/>
@@ -120,6 +120,7 @@
   <class name="edm::Wrapper<edm::DetSetVector<CTPPSPixelRecHit> >"/>
 
   <class name="CTPPSPixelLocalTrack" ClassVersion="4">
+    <version ClassVersion="3" checksum="4150373475"/>    
     <version ClassVersion="4" checksum="761311401"/>
   </class>
   <class name="edm::DetSet<CTPPSPixelLocalTrack>"/>
@@ -135,8 +136,9 @@
 
 <!-- common objects -->
 
-  <class name="CTPPSLocalTrackLite" ClassVersion="3">
-    <version ClassVersion="3" checksum="3542556891"/>
+  <class name="CTPPSLocalTrackLite" ClassVersion="4">
+    <version ClassVersion="3" checksum="3838813906"/>    
+    <version ClassVersion="4" checksum="3542556891"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -121,7 +121,7 @@
 
   <class name="CTPPSPixelLocalTrack" ClassVersion="4">
     <version ClassVersion="3" checksum="4150373475"/>    
-    <version ClassVersion="4" checksum="656781101"/>
+    <version ClassVersion="4" checksum="298693321"/>
   </class>
   <ioread sourceClass = "CTPPSPixelLocalTrack" version="[3]" targetClass="CTPPSPixelLocalTrack" source="int numberOfPointUsedForFit_" target="numberOfPointsUsedForFit_">
   <![CDATA[ numberOfPointsUsedForFit_ = onfile.numberOfPointUsedForFit_;
@@ -142,7 +142,7 @@
 
   <class name="CTPPSLocalTrackLite" ClassVersion="4">
     <version ClassVersion="3" checksum="3838813906"/>    
-    <version ClassVersion="4" checksum="2542912231"/>
+    <version ClassVersion="4" checksum="2435718827"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>

--- a/RecoCTPPS/Configuration/python/recoCTPPS_sequences_cff.py
+++ b/RecoCTPPS/Configuration/python/recoCTPPS_sequences_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoCTPPS.TotemRPLocal.totemRPLocalReconstruction_cff import *
 from RecoCTPPS.TotemRPLocal.ctppsDiamondLocalReconstruction_cff import *
-# from RecoCTPPS.TotemRPLocal.totemTimingLocalReconstruction_cff import *
+from RecoCTPPS.TotemRPLocal.totemTimingLocalReconstruction_cff import *
 from RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cff import ctppsLocalTrackLiteProducer
 from RecoCTPPS.PixelLocal.ctppsPixelLocalReconstruction_cff import *
 
@@ -12,7 +12,7 @@ ctppsIncludeAlignmentsFromXML.RealFiles = cms.vstring("Alignment/CTPPS/data/RPix
 recoCTPPSdets = cms.Sequence(
     totemRPLocalReconstruction *
     ctppsDiamondLocalReconstruction *
-    # totemTimingLocalReconstruction *
+    totemTimingLocalReconstruction *
     ctppsPixelLocalReconstruction *
     ctppsLocalTrackLiteProducer
 )

--- a/RecoCTPPS/Configuration/python/recoCTPPS_sequences_cff.py
+++ b/RecoCTPPS/Configuration/python/recoCTPPS_sequences_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoCTPPS.TotemRPLocal.totemRPLocalReconstruction_cff import *
 from RecoCTPPS.TotemRPLocal.ctppsDiamondLocalReconstruction_cff import *
-from RecoCTPPS.TotemRPLocal.totemTimingLocalReconstruction_cff import *
+# from RecoCTPPS.TotemRPLocal.totemTimingLocalReconstruction_cff import *
 from RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cff import ctppsLocalTrackLiteProducer
 from RecoCTPPS.PixelLocal.ctppsPixelLocalReconstruction_cff import *
 
@@ -12,7 +12,7 @@ ctppsIncludeAlignmentsFromXML.RealFiles = cms.vstring("Alignment/CTPPS/data/RPix
 recoCTPPSdets = cms.Sequence(
     totemRPLocalReconstruction *
     ctppsDiamondLocalReconstruction *
-    totemTimingLocalReconstruction *
+    # totemTimingLocalReconstruction *
     ctppsPixelLocalReconstruction *
     ctppsLocalTrackLiteProducer
 )

--- a/RecoCTPPS/PixelLocal/interface/RPixDetTrackFinder.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixDetTrackFinder.h
@@ -31,9 +31,8 @@ class RPixDetTrackFinder{
     virtual ~RPixDetTrackFinder() {};
 
     void setHits(std::map<CTPPSPixelDetId, std::vector<RPixDetPatternFinder::PointInPlane> > *hitMap) {hitMap_ = hitMap; }
-    virtual void findTracks()=0;
+    virtual void findTracks(int run)=0;
     virtual void initialize()=0;
-    virtual void addRecoInfo(int run)=0;
     void clear(){
       localTrackVector_.clear();
     }

--- a/RecoCTPPS/PixelLocal/interface/RPixDetTrackFinder.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixDetTrackFinder.h
@@ -33,6 +33,7 @@ class RPixDetTrackFinder{
     void setHits(std::map<CTPPSPixelDetId, std::vector<RPixDetPatternFinder::PointInPlane> > *hitMap) {hitMap_ = hitMap; }
     virtual void findTracks()=0;
     virtual void initialize()=0;
+    virtual void addRecoInfo(int run)=0;
     void clear(){
       localTrackVector_.clear();
     }

--- a/RecoCTPPS/PixelLocal/interface/RPixPlaneCombinatoryTracking.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixPlaneCombinatoryTracking.h
@@ -27,8 +27,7 @@ class RPixPlaneCombinatoryTracking : public RPixDetTrackFinder{
     RPixPlaneCombinatoryTracking(edm::ParameterSet const& parameterSet);
     ~RPixPlaneCombinatoryTracking() override;
     void initialize() override;
-    void findTracks() override;
-    void addRecoInfo(int run) override;
+    void findTracks(int run) override;
 
   private:
     typedef std::vector<std::vector<uint32_t> > PlaneCombinations;

--- a/RecoCTPPS/PixelLocal/interface/RPixPlaneCombinatoryTracking.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixPlaneCombinatoryTracking.h
@@ -28,6 +28,7 @@ class RPixPlaneCombinatoryTracking : public RPixDetTrackFinder{
     ~RPixPlaneCombinatoryTracking() override;
     void initialize() override;
     void findTracks() override;
+    void addRecoInfo(int run) override;
 
   private:
     typedef std::vector<std::vector<uint32_t> > PlaneCombinations;

--- a/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -249,8 +249,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event& iEvent, const edm::EventS
     trackFinder_->setHits(&hitOnPlaneMap);
     trackFinder_->setGeometry(&geometry);
     trackFinder_->setZ0(geometry.getRPTranslation(romanPotId).z());
-    trackFinder_->findTracks();
-    trackFinder_->addRecoInfo(iEvent.getRun().id().run());
+    trackFinder_->findTracks(iEvent.getRun().id().run());
     std::vector<CTPPSPixelLocalTrack> tmpTracksVector = trackFinder_->getLocalTracks();
 
     if(verbosity_>2)edm::LogInfo("CTPPSPixelLocalTrackProducer")<<"tmpTracksVector = "<<tmpTracksVector.size();

--- a/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -230,7 +230,6 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event& iEvent, const edm::EventS
     for(const auto & hit : pattern){
       CTPPSPixelDetId hitDetId = CTPPSPixelDetId(hit.detId);
       CTPPSPixelDetId tmpRomanPotId = hitDetId.getRPId();
-      
 
       if(tmpRomanPotId!=romanPotId){ //check that the hits belong to the same tracking station
         throw cms::Exception("CTPPSPixelLocalTrackProducer") << "Hits in the pattern must belong to the same tracking station";
@@ -251,6 +250,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event& iEvent, const edm::EventS
     trackFinder_->setGeometry(&geometry);
     trackFinder_->setZ0(geometry.getRPTranslation(romanPotId).z());
     trackFinder_->findTracks();
+    trackFinder_->addRecoInfo(iEvent.getRun().id().run());
     std::vector<CTPPSPixelLocalTrack> tmpTracksVector = trackFinder_->getLocalTracks();
 
     if(verbosity_>2)edm::LogInfo("CTPPSPixelLocalTrackProducer")<<"tmpTracksVector = "<<tmpTracksVector.size();
@@ -258,7 +258,6 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event& iEvent, const edm::EventS
       if(verbosity_>2)edm::LogInfo("CTPPSPixelLocalTrackProducer")<<" ---> To many tracks in the pattern, cleared";
       continue;
     }
-
 
     for(const auto & track : tmpTracksVector){
       ++numberOfTracks;
@@ -274,7 +273,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event& iEvent, const edm::EventS
   for(const auto & track : foundTracks){
     if(verbosity_>1) edm::LogInfo("CTPPSPixelLocalTrackProducer")<<"Track found in detId = "<<track.detId()<< " number = " << track.size() ;
     if(maxTrackPerRomanPot_>=0 && track.size()>(uint32_t)maxTrackPerRomanPot_){
-      if(verbosity_>1) edm::LogInfo("CTPPSPixelLocalTrackProducer")<<" ---> To many tracks in the pot, cleared";
+      if(verbosity_>1) edm::LogInfo("CTPPSPixelLocalTrackProducer")<<" ---> Too many tracks in the pot, cleared";
       CTPPSPixelDetId tmpRomanPotId = CTPPSPixelDetId(track.detId());
       edm::DetSet<CTPPSPixelLocalTrack> &tmpDetSet = foundTracks[tmpRomanPotId];
       tmpDetSet.clear();

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -523,26 +523,54 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
   unsigned short recoInfo = 0;
 
   std::vector<CTPPSPixelLocalTrack> localTrackVectorWithRecoInfo;
-  std::vector<int> periodLimits = {300802,303338,305169,305965};
-  std::map< unsigned short, std::map< CTPPSPixelDetId,std::vector<bool> > > isPlaneShifted;
-  unsigned short shiftedROC = -1;
+
+  // These variables hold the information of the runs when the detector was taking data in 3+3 Mode and which planes were bx-shifted
+  // These values will never be changed and the 3+3 Mode will never be used again in the future
+  const std::vector<int> periodLimits = {300802,303338,305169,305965};
+  const std::map< unsigned short, std::map< CTPPSPixelDetId,std::vector<bool> > > isPlaneShifted =
+  {
+    {
+      0,{
+        {CTPPSPixelDetId(0,2,3),{0,0,0,0,0,0}}, // Shift Period 0 Sec45
+        {CTPPSPixelDetId(1,2,3),{0,0,0,0,0,0}}  // Shift Period 1 Sec45
+      }
+    },
+    {
+      1,{
+        {CTPPSPixelDetId(0,2,3),{1,0,1,1,0,0}}, // Shift Period 1 Sec45
+        {CTPPSPixelDetId(1,2,3),{0,0,0,0,0,0}}  // Shift Period 1 Sec56
+      }
+    },
+    {
+      2,{
+        {CTPPSPixelDetId(0,2,3),{0,0,0,0,0,0}}, // Shift Period 2 Sec45
+        {CTPPSPixelDetId(1,2,3),{0,0,0,0,0,0}}  // Shift Period 2 Sec56
+      }
+    },
+    {
+      3,{
+        {CTPPSPixelDetId(0,2,3),{0,1,0,1,0,1}}, // Shift Period 3 Sec45
+        {CTPPSPixelDetId(1,2,3),{0,0,0,0,0,0}}  // Shift Period 3 Sec56
+      }
+    },
+    {
+      4,{
+        {CTPPSPixelDetId(0,2,3),{0,1,0,1,0,1}}, // Shift Period 4 Sec45
+        {CTPPSPixelDetId(1,2,3),{0,0,1,0,1,1}}  // Shift Period 4 Sec56
+      }
+    }
+  };
+  unsigned short shiftedROC = 10;
   CTPPSPixelIndices pixelIndices;
 
   // Selecting the shifted ROC
   if(romanPotId_.arm() == 0) shiftedROC = 0;
-  else shiftedROC = 5;
+  if(romanPotId_.arm() == 1) shiftedROC = 5;
 
-  // Setting the shifted planes during Shift Periods
-  isPlaneShifted[0][CTPPSPixelDetId(0,2,3)] = {0,0,0,0,0,0}; // Shift Period 0 Sec45
-  isPlaneShifted[0][CTPPSPixelDetId(1,2,3)] = {0,0,0,0,0,0}; // Shift Period 0 Sec56
-  isPlaneShifted[1][CTPPSPixelDetId(0,2,3)] = {1,0,1,1,0,0}; // Shift Period 1 Sec45
-  isPlaneShifted[1][CTPPSPixelDetId(1,2,3)] = {0,0,0,0,0,0}; // Shift Period 1 Sec56
-  isPlaneShifted[2][CTPPSPixelDetId(0,2,3)] = {0,0,0,0,0,0}; // Shift Period 2 Sec45
-  isPlaneShifted[2][CTPPSPixelDetId(1,2,3)] = {0,0,0,0,0,0}; // Shift Period 2 Sec56
-  isPlaneShifted[3][CTPPSPixelDetId(0,2,3)] = {0,1,0,1,0,1}; // Shift Period 3 Sec45
-  isPlaneShifted[3][CTPPSPixelDetId(1,2,3)] = {0,0,0,0,0,0}; // Shift Period 3 Sec56
-  isPlaneShifted[4][CTPPSPixelDetId(0,2,3)] = {0,1,0,1,0,1}; // Shift Period 4 Sec45
-  isPlaneShifted[4][CTPPSPixelDetId(1,2,3)] = {0,0,1,0,1,1}; // Shift Period 4 Sec56
+  if(shiftedROC == 10){
+      edm::LogError("RPixPlaneCombinatoryTracking") << "Error in RPixPlaneCombinatoryTracking::addRecoInfo -> " << "Unidentified ROC to be shifted, skipping addRecoInfo.";
+      return;
+  }
 
   for(const auto & limit : periodLimits){
     if (run >= limit) shiftPeriod++;
@@ -568,7 +596,7 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
       for(const auto & hit : planeHits){
         if(hit.getIsUsedForFit()){
           if(pixelIndices.getROCId(hit.minPixelCol(),hit.minPixelRow()) == shiftedROC) hitInShiftedROC++; // Count how many hits are in the shifted ROC
-          if(isPlaneShifted[shiftPeriod][romanPotId_].at(plane)) bxShiftedPlanesUsed++; // Count how many bx-shifted planes are used
+          if(isPlaneShifted.at(shiftPeriod).at(romanPotId_).at(plane)) bxShiftedPlanesUsed++; // Count how many bx-shifted planes are used
           else bxNonShiftedPlanesUsed++; // Count how many non-bx-shifted planes are used
         }
       }

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -571,7 +571,7 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
   if(romanPotId_.arm() == 1) shiftedROC = 5;
 
   if(shiftedROC == 10){
-      edm::LogInfo("RPixPlaneCombinatoryTracking")<< "Error in RPixPlaneCombinatoryTracking::addRecoInfo -> " << "Unidentified ROC to be shifted, skipping addRecoInfo.";
+      edm::LogError("RPixPlaneCombinatoryTracking")<< "Error in RPixPlaneCombinatoryTracking::addRecoInfo -> " << "Unidentified ROC to be shifted, skipping addRecoInfo.";
       return;
   }
 
@@ -582,6 +582,9 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
   // Loop over found tracks to set recoInfo_
   for(auto & track : localTrackVector_){
     if(romanPotId_ != CTPPSPixelDetId(0,2,3) && romanPotId_ != CTPPSPixelDetId(1,2,3)){
+      track.setRecoInfo(CTPPSPixelLocalTrack::notShiftedRun);
+      if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run<<"\nShift period: "<<shiftPeriod<<"\nTrack belongs to Arm "<<romanPotId_.arm()<<" Station "<<romanPotId_.station();
+
       continue;
     }
     unsigned short bxShiftedPlanesUsed = 0;

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -528,38 +528,38 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
   {
     {
       0,{
-        {CTPPSPixelDetId(0,2,3),{0,0,0,0,0,0}}, // Shift Period 0 Sec45
-        {CTPPSPixelDetId(1,2,3),{0,0,0,0,0,0}}  // Shift Period 1 Sec45
+        {CTPPSPixelDetId(0,2,3),{false,false,false,false,false,false}}, // Shift Period 0 Sec45
+        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 1 Sec45
       }
     },
     {
       1,{
-        {CTPPSPixelDetId(0,2,3),{1,0,1,1,0,0}}, // Shift Period 1 Sec45
-        {CTPPSPixelDetId(1,2,3),{0,0,0,0,0,0}}  // Shift Period 1 Sec56
+        {CTPPSPixelDetId(0,2,3),{true,false,true,true,false,false}}, // Shift Period 1 Sec45
+        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 1 Sec56
       }
     },
     {
       2,{
-        {CTPPSPixelDetId(0,2,3),{0,0,0,0,0,0}}, // Shift Period 2 Sec45
-        {CTPPSPixelDetId(1,2,3),{0,0,0,0,0,0}}  // Shift Period 2 Sec56
+        {CTPPSPixelDetId(0,2,3),{false,false,false,false,false,false}}, // Shift Period 2 Sec45
+        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 2 Sec56
       }
     },
     {
       3,{
-        {CTPPSPixelDetId(0,2,3),{0,1,0,1,0,1}}, // Shift Period 3 Sec45
-        {CTPPSPixelDetId(1,2,3),{0,0,0,0,0,0}}  // Shift Period 3 Sec56
+        {CTPPSPixelDetId(0,2,3),{false,true,false,true,false,true}}, // Shift Period 3 Sec45
+        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 3 Sec56
       }
     },
     {
       4,{
-        {CTPPSPixelDetId(0,2,3),{0,1,0,1,0,1}}, // Shift Period 4 Sec45
-        {CTPPSPixelDetId(1,2,3),{0,0,1,0,1,1}}  // Shift Period 4 Sec56
+        {CTPPSPixelDetId(0,2,3),{false,true,false,true,false,true}}, // Shift Period 4 Sec45
+        {CTPPSPixelDetId(1,2,3),{false,false,true,false,true,true}}  // Shift Period 4 Sec56
       }
     },
     {
       5,{
-        {CTPPSPixelDetId(0,2,3),{0,0,0,0,0,0}}, // Shift Period 0 Sec45
-        {CTPPSPixelDetId(1,2,3),{0,0,0,0,0,0}}  // Shift Period 1 Sec45
+        {CTPPSPixelDetId(0,2,3),{false,false,false,false,false,false}}, // Shift Period 0 Sec45
+        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 1 Sec45
       }
     }
   }; // map< shiftedPeriod, map<DetID,shiftScheme> >
@@ -599,7 +599,7 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
         if(hit.getIsUsedForFit()){
           if(pixelIndices.getROCId(hit.minPixelCol(),hit.minPixelRow()) == shiftedROC) hitInShiftedROC++; // Count how many hits are in the shifted ROC
           if(isPlaneShifted.at(shiftPeriod).at(romanPotId_).at(plane)) bxShiftedPlanesUsed++; // Count how many bx-shifted planes are used
-          else if(isPlaneShifted.at(shiftPeriod).at(romanPotId_) != std::vector<bool>(6,0)) bxNonShiftedPlanesUsed++; // Count how many non-bx-shifted planes are used, only if there are shifted planes 
+          else if(isPlaneShifted.at(shiftPeriod).at(romanPotId_) != std::vector<bool>(6,false)) bxNonShiftedPlanesUsed++; // Count how many non-bx-shifted planes are used, only if there are shifted planes 
         }
       }
     }

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -458,7 +458,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
       if(bxShiftedPlanesUsed >  0 && bxNonShiftedPlanesUsed >  0) track.setRecoInfo(ReconstructionInfo::mixedPlanes);      // Track reconstructed in a shifted ROC, with mixed planes
     }
     if(bxShiftedPlanesUsed + bxNonShiftedPlanesUsed > 6){
-      edm::LogError("RPixPlaneCombinatoryTracking")<< "Error in RPixPlaneCombinatoryTracking::findTracks -> " << "More than 6 points found for a track, skipping.";
+      throw cms::Exception("RPixPlaneCombinatoryTracking")<<"Error in RPixPlaneCombinatoryTracking::findTracks -> " << "More than six points found for a track, skipping.";
       continue;
     }
     if(track.getRecoInfo() == ReconstructionInfo::invalid){

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -423,7 +423,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
   // Loop over found tracks to set recoInfo_
   for(auto & track : localTrackVector_){
     if(romanPotId_ != rpId_arm0_st2 && romanPotId_ != rpId_arm1_st2){
-      track.setRecoInfo(ReconstructionInfo::notShiftedRun);
+      track.setRecoInfo(CTPPSReconstructionInfo::notShiftedRun);
       if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run
         <<"\nTrack belongs to Arm "<<romanPotId_.arm()<<" Station "
         <<romanPotId_.station();
@@ -449,19 +449,19 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
     }
 
     // Set recoInfo_ value
-    track.setRecoInfo(ReconstructionInfo::invalid); // Initially setting it as invalid. It has to match one of the following options.
-    if(hitInShiftedROC < 3) track.setRecoInfo(ReconstructionInfo::notShiftedRun);
+    track.setRecoInfo(CTPPSReconstructionInfo::invalid); // Initially setting it as invalid. It has to match one of the following options.
+    if(hitInShiftedROC < 3) track.setRecoInfo(CTPPSReconstructionInfo::notShiftedRun);
     else{
-      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(ReconstructionInfo::notShiftedRun);    // Default value for runs without bx-shift
-      if(bxShiftedPlanesUsed == 3 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(ReconstructionInfo::allShiftedPlanes); // Track reconstructed in a shifted ROC, only with bx-shifted planes
-      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 3) track.setRecoInfo(ReconstructionInfo::noShiftedPlanes);  // Track reconstructed in a shifted ROC, only with non-bx-shifted planes
-      if(bxShiftedPlanesUsed >  0 && bxNonShiftedPlanesUsed >  0) track.setRecoInfo(ReconstructionInfo::mixedPlanes);      // Track reconstructed in a shifted ROC, with mixed planes
+      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSReconstructionInfo::notShiftedRun);    // Default value for runs without bx-shift
+      if(bxShiftedPlanesUsed == 3 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSReconstructionInfo::allShiftedPlanes); // Track reconstructed in a shifted ROC, only with bx-shifted planes
+      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 3) track.setRecoInfo(CTPPSReconstructionInfo::noShiftedPlanes);  // Track reconstructed in a shifted ROC, only with non-bx-shifted planes
+      if(bxShiftedPlanesUsed >  0 && bxNonShiftedPlanesUsed >  0) track.setRecoInfo(CTPPSReconstructionInfo::mixedPlanes);      // Track reconstructed in a shifted ROC, with mixed planes
     }
     if(bxShiftedPlanesUsed + bxNonShiftedPlanesUsed > 6){
       throw cms::Exception("RPixPlaneCombinatoryTracking")<<"Error in RPixPlaneCombinatoryTracking::findTracks -> " << "More than six points found for a track, skipping.";
       continue;
     }
-    if(track.getRecoInfo() == ReconstructionInfo::invalid){
+    if(track.getRecoInfo() == CTPPSReconstructionInfo::invalid){
       throw cms::Exception("RPixPlaneCombinatoryTracking")<<"Error in RPixPlaneCombinatoryTracking::findTracks -> " << "recoInfo has not been set properly.";
     }
 

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -520,7 +520,13 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
   // 4 -> Starting from run 305965: Sec45 St2 Rp3 Pl 1,3,5 ROC 0 shifted & Sec56 St2 Rp3 Pl 2,4,5 ROC 5 shifted.
 
   unsigned short shiftPeriod = 0;
-  unsigned short recoInfo = -1; // Dummy initiation value
+  unsigned short recoInfo = 5; // Dummy initiation value
+
+  // Track information byte for bx-shifted runs: 
+  // reco_info = 0 -> Default value for tracks reconstructed in non-bx-shifted ROCs
+  // reco_info = 1 -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
+  // reco_info = 2 -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
+  // reco_info = 3 -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted plane
 
   std::vector<CTPPSPixelLocalTrack> localTrackVectorWithRecoInfo;
 

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -513,56 +513,57 @@ std::vector<RPixPlaneCombinatoryTracking::PointAndReferencePair >
 void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
 {
   // Hardcoded shift periods: 
-  // 0 -> Before starting bx shifts.
-  // 1 -> Starting from run 300802: Sec45 St2 Rp3 Pl 0,2,3 ROC 0 shifted.
-  // 2 -> Starting from run 303338: No shift.
-  // 3 -> Starting from run 305169: Sec45 St2 Rp3 Pl 1,3,5 ROC 0 shifted.
-  // 4 -> Starting from run 305965: Sec45 St2 Rp3 Pl 1,3,5 ROC 0 shifted & Sec56 St2 Rp3 Pl 2,4,5 ROC 5 shifted.
-    
-  unsigned short shiftPeriod = 0;
+  // Before run 300802: No shift
+  // Starting from run 300802: Sec45 St2 Rp3 Pl 0,2,3 ROC 0 shifted.
+  // Starting from run 303338: No shift.
+  // Starting from run 305169: Sec45 St2 Rp3 Pl 1,3,5 ROC 0 shifted.
+  // Starting from run 305965: Sec45 St2 Rp3 Pl 1,3,5 ROC 0 shifted & Sec56 St2 Rp3 Pl 2,4,5 ROC 5 shifted.
+  // Starting from run 307083: No shift
 
   // These variables hold the information of the runs when the detector was taking data in 3+3 Mode and which planes were bx-shifted
   // These values will never be changed and the 3+3 Mode will never be used again in the future
-  const std::vector<int> periodLimits = {300802,303338,305169,305965,307083};
-  const std::map< unsigned short, std::map< CTPPSPixelDetId,std::vector<bool> > > isPlaneShifted =
+  const CTPPSPixelDetId rpId_arm0_st2 = CTPPSPixelDetId(0,2,3);
+  const CTPPSPixelDetId rpId_arm1_st2 = CTPPSPixelDetId(1,2,3);
+  static const std::map< unsigned int, std::map< CTPPSPixelDetId,std::vector<bool> > > isPlaneShifted =
   {
     {
       0,{
-        {CTPPSPixelDetId(0,2,3),{false,false,false,false,false,false}}, // Shift Period 0 Sec45
-        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 1 Sec45
+        {rpId_arm0_st2,{false,false,false,false,false,false}}, // Shift Period 0 Sec45
+        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 1 Sec56
       }
     },
     {
-      1,{
-        {CTPPSPixelDetId(0,2,3),{true,false,true,true,false,false}}, // Shift Period 1 Sec45
-        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 1 Sec56
+      300802,{
+        {rpId_arm0_st2,{true,false,true,true,false,false}}, // Shift Period 1 Sec45
+        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 1 Sec56
       }
     },
     {
-      2,{
-        {CTPPSPixelDetId(0,2,3),{false,false,false,false,false,false}}, // Shift Period 2 Sec45
-        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 2 Sec56
+      303338,{
+        {rpId_arm0_st2,{false,false,false,false,false,false}}, // Shift Period 2 Sec45
+        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 2 Sec56
       }
     },
     {
-      3,{
-        {CTPPSPixelDetId(0,2,3),{false,true,false,true,false,true}}, // Shift Period 3 Sec45
-        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 3 Sec56
+      305169,{
+        {rpId_arm0_st2,{false,true,false,true,false,true}}, // Shift Period 3 Sec45
+        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 3 Sec56
       }
     },
     {
-      4,{
-        {CTPPSPixelDetId(0,2,3),{false,true,false,true,false,true}}, // Shift Period 4 Sec45
-        {CTPPSPixelDetId(1,2,3),{false,false,true,false,true,true}}  // Shift Period 4 Sec56
+      305965,{
+        {rpId_arm0_st2,{false,true,false,true,false,true}}, // Shift Period 4 Sec45
+        {rpId_arm1_st2,{false,false,true,false,true,true}}  // Shift Period 4 Sec56
       }
     },
     {
-      5,{
-        {CTPPSPixelDetId(0,2,3),{false,false,false,false,false,false}}, // Shift Period 0 Sec45
-        {CTPPSPixelDetId(1,2,3),{false,false,false,false,false,false}}  // Shift Period 1 Sec45
+      307083,{
+        {rpId_arm0_st2,{false,false,false,false,false,false}}, // Shift Period 0 Sec45
+        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 1 Sec56
       }
     }
   }; // map< shiftedPeriod, map<DetID,shiftScheme> >
+  const auto& shiftStatusInitialRun = isPlaneShifted.lower_bound(run);
   unsigned short shiftedROC = 10;
   CTPPSPixelIndices pixelIndices;
 
@@ -570,20 +571,13 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
   if(romanPotId_.arm() == 0) shiftedROC = 0;
   if(romanPotId_.arm() == 1) shiftedROC = 5;
 
-  if(shiftedROC == 10){
-      edm::LogError("RPixPlaneCombinatoryTracking")<< "Error in RPixPlaneCombinatoryTracking::addRecoInfo -> " << "Unidentified ROC to be shifted, skipping addRecoInfo.";
-      return;
-  }
-
-  for(const auto & limit : periodLimits){
-    if(run >= limit) shiftPeriod++;
-  }
-
   // Loop over found tracks to set recoInfo_
   for(auto & track : localTrackVector_){
-    if(romanPotId_ != CTPPSPixelDetId(0,2,3) && romanPotId_ != CTPPSPixelDetId(1,2,3)){
-      track.setRecoInfo(CTPPSPixelLocalTrack::notShiftedRun);
-      if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run<<"\nShift period: "<<shiftPeriod<<"\nTrack belongs to Arm "<<romanPotId_.arm()<<" Station "<<romanPotId_.station();
+    if(romanPotId_ != rpId_arm0_st2 && romanPotId_ != rpId_arm1_st2){
+      track.setRecoInfo(CTPPSPixelLocalTrack::ReconstructionInfo::notShiftedRun);
+      if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run
+        <<"\nTrack belongs to Arm "<<romanPotId_.arm()<<" Station "
+        <<romanPotId_.station();
 
       continue;
     }
@@ -591,39 +585,43 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
     unsigned short bxNonShiftedPlanesUsed = 0;
     unsigned short hitInShiftedROC = 0;
 
-    edm::DetSetVector<CTPPSPixelFittedRecHit> fittedHits = track.getHits();
-    
+    auto const& fittedHits = track.getHits();
+    auto const& planeFlags = (shiftStatusInitialRun->second).at(romanPotId_);
+
     for(const auto & planeHits : fittedHits){
       unsigned short plane = CTPPSPixelDetId(planeHits.detId()).plane();
       for(const auto & hit : planeHits){
         if(hit.getIsUsedForFit()){
           if(pixelIndices.getROCId(hit.minPixelCol(),hit.minPixelRow()) == shiftedROC) hitInShiftedROC++; // Count how many hits are in the shifted ROC
-          if(isPlaneShifted.at(shiftPeriod).at(romanPotId_).at(plane)) bxShiftedPlanesUsed++; // Count how many bx-shifted planes are used
-          else if(isPlaneShifted.at(shiftPeriod).at(romanPotId_) != std::vector<bool>(6,false)) bxNonShiftedPlanesUsed++; // Count how many non-bx-shifted planes are used, only if there are shifted planes 
+          if(planeFlags.at(plane)) bxShiftedPlanesUsed++; // Count how many bx-shifted planes are used
+          else if(planeFlags != std::vector<bool>(6,false)) bxNonShiftedPlanesUsed++; // Count how many non-bx-shifted planes are used, only if there are shifted planes 
         }
       }
     }
 
     // Set recoInfo_ value
-    track.setRecoInfo(CTPPSPixelLocalTrack::invalid); // Initially setting it as invalid. It has to match one of the following options.
-    if(hitInShiftedROC < 3) track.setRecoInfo(CTPPSPixelLocalTrack::notShiftedRun); 
-    if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 0 && hitInShiftedROC >= 3) track.setRecoInfo(CTPPSPixelLocalTrack::notShiftedRun);    // Default value for runs without bx-shift
-    if(bxShiftedPlanesUsed == 3 && bxNonShiftedPlanesUsed == 0 && hitInShiftedROC >= 3) track.setRecoInfo(CTPPSPixelLocalTrack::allShiftedPlanes); // Track reconstructed in a shifted ROC, only with bx-shifted planes
-    if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 3 && hitInShiftedROC >= 3) track.setRecoInfo(CTPPSPixelLocalTrack::noShiftedPlanes);  // Track reconstructed in a shifted ROC, only with non-bx-shifted planes
-    if(bxShiftedPlanesUsed >  0 && bxNonShiftedPlanesUsed >  0 && hitInShiftedROC >= 3) track.setRecoInfo(CTPPSPixelLocalTrack::mixedPlanes);      // Track reconstructed in a shifted ROC, with mixed planes
-    
+    track.setRecoInfo(CTPPSPixelLocalTrack::ReconstructionInfo::invalid); // Initially setting it as invalid. It has to match one of the following options.
+    if(hitInShiftedROC < 3) track.setRecoInfo(CTPPSPixelLocalTrack::ReconstructionInfo::notShiftedRun);
+    else{
+      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSPixelLocalTrack::ReconstructionInfo::notShiftedRun);    // Default value for runs without bx-shift
+      if(bxShiftedPlanesUsed == 3 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSPixelLocalTrack::ReconstructionInfo::allShiftedPlanes); // Track reconstructed in a shifted ROC, only with bx-shifted planes
+      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 3) track.setRecoInfo(CTPPSPixelLocalTrack::ReconstructionInfo::noShiftedPlanes);  // Track reconstructed in a shifted ROC, only with non-bx-shifted planes
+      if(bxShiftedPlanesUsed >  0 && bxNonShiftedPlanesUsed >  0) track.setRecoInfo(CTPPSPixelLocalTrack::ReconstructionInfo::mixedPlanes);      // Track reconstructed in a shifted ROC, with mixed planes
+    }
     if(bxShiftedPlanesUsed + bxNonShiftedPlanesUsed > 6){
       edm::LogError("RPixPlaneCombinatoryTracking")<< "Error in RPixPlaneCombinatoryTracking::addRecoInfo -> " << "More than 6 points found for a track, skipping.";
       continue;
     }
-    if(track.getRecoInfo() == CTPPSPixelLocalTrack::invalid){
-      edm::LogError("RPixPlaneCombinatoryTracking")<<"Error in RPixPlaneCombinatoryTracking::addRecoInfo -> " << "recoInfo has not been set properly.";
+    if(track.getRecoInfo() == CTPPSPixelLocalTrack::ReconstructionInfo::invalid){
+      throw cms::Exception("RPixPlaneCombinatoryTracking")<<"Error in RPixPlaneCombinatoryTracking::addRecoInfo -> " << "recoInfo has not been set properly.";
     }
 
     if(verbosity_>=2){
-      edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run<<"\nShift period: "<<shiftPeriod<<" Track belongs to Arm "<<romanPotId_.arm()<<" Station "<<romanPotId_.station()
-      <<"\nTrack reconstructed with: "<<bxShiftedPlanesUsed<<" bx-shifted planes, "<<bxNonShiftedPlanesUsed<<" non-bx-shifted planes, "<<hitInShiftedROC<<" hits in the bx-shifted ROC"<<"\nrecoInfo = "<<(unsigned short)track.getRecoInfo();
-      if(shiftPeriod != 0 && shiftPeriod != 2 && shiftPeriod !=  5)edm::LogInfo("RPixPlaneCombinatoryTracking")<<"The shifted ROC is ROC"<<shiftedROC;
+      edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run
+      <<" Track belongs to Arm "<<romanPotId_.arm()<<" Station "<<romanPotId_.station()<<"\nTrack reconstructed with: "
+      <<bxShiftedPlanesUsed<<" bx-shifted planes, "<<bxNonShiftedPlanesUsed<<" non-bx-shifted planes, "<<hitInShiftedROC
+      <<" hits in the bx-shifted ROC"<<"\nrecoInfo = "<<(unsigned short)track.getRecoInfo();
+      if(planeFlags != std::vector<bool>(6,false)) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"The shifted ROC is ROC"<<shiftedROC;
     }
   }
   return;

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -623,15 +623,20 @@ void RPixPlaneCombinatoryTracking::addRecoInfo(int run)
     }
 
     if(verbosity_>=2){
-      edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run;
-      edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Shift period: "<<shiftPeriod;
-      edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Tracks belong to Arm "<<romanPotId_.arm()<<" Station "<<romanPotId_.station();
-      if(shiftPeriod != 0 && shiftPeriod !=  5)edm::LogInfo("RPixPlaneCombinatoryTracking")<<"The shifted ROC is ROC"<<shiftedROC;
-      edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Track reconstructed with: "<<bxShiftedPlanesUsed<<" bx-shifted planes, "<<bxNonShiftedPlanesUsed<<" non-bx-shifted planes, "<<hitInShiftedROC<<" hits in the bx-shifted ROC";
-      edm::LogInfo("RPixPlaneCombinatoryTracking")<<"recoInfo = "<<recoInfo;
+      edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run<<"\nShift period: "<<shiftPeriod<<" Track belongs to Arm "<<romanPotId_.arm()<<" Station "<<romanPotId_.station()
+      <<"\nTrack reconstructed with: "<<bxShiftedPlanesUsed<<" bx-shifted planes, "<<bxNonShiftedPlanesUsed<<" non-bx-shifted planes, "<<hitInShiftedROC<<" hits in the bx-shifted ROC"<<"\nrecoInfo = "<<recoInfo;
+      if(shiftPeriod != 0 && shiftPeriod != 2 && shiftPeriod !=  5)edm::LogInfo("RPixPlaneCombinatoryTracking")<<"The shifted ROC is ROC"<<shiftedROC;
     }
+    
     // Create new track with recoInfo_, put it in localTrackVectorWithRecoInfo and assign localTrackVectorWithRecoInfo to localTrackVector_
-    localTrackVectorWithRecoInfo.push_back(CTPPSPixelLocalTrack(track.getZ0(), track.getParameterVector(), track.getCovarianceMatrix(), track.getChiSquared(), recoInfo));
+    CTPPSPixelLocalTrack trackWithRecoInfo(track.getZ0(), track.getParameterVector(), track.getCovarianceMatrix(), track.getChiSquared(), recoInfo);
+    for(const auto & planeHits : fittedHits){
+      CTPPSPixelDetId hitId = CTPPSPixelDetId(planeHits.detId());
+      for(const auto & hit : planeHits){
+        trackWithRecoInfo.addHit(hitId,hit);
+      }
+    }
+    localTrackVectorWithRecoInfo.push_back(trackWithRecoInfo);
   }
 
   localTrackVector_ = localTrackVectorWithRecoInfo;

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -423,7 +423,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
   // Loop over found tracks to set recoInfo_
   for(auto & track : localTrackVector_){
     if(romanPotId_ != rpId_arm0_st2 && romanPotId_ != rpId_arm1_st2){
-      track.setRecoInfo(CTPPSReconstructionInfo::notShiftedRun);
+      track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::notShiftedRun);
       if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run
         <<"\nTrack belongs to Arm "<<romanPotId_.arm()<<" Station "
         <<romanPotId_.station();
@@ -449,19 +449,19 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
     }
 
     // Set recoInfo_ value
-    track.setRecoInfo(CTPPSReconstructionInfo::invalid); // Initially setting it as invalid. It has to match one of the following options.
-    if(hitInShiftedROC < 3) track.setRecoInfo(CTPPSReconstructionInfo::notShiftedRun);
+    track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::invalid); // Initially setting it as invalid. It has to match one of the following options.
+    if(hitInShiftedROC < 3) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::notShiftedRun);
     else{
-      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSReconstructionInfo::notShiftedRun);    // Default value for runs without bx-shift
-      if(bxShiftedPlanesUsed == 3 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSReconstructionInfo::allShiftedPlanes); // Track reconstructed in a shifted ROC, only with bx-shifted planes
-      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 3) track.setRecoInfo(CTPPSReconstructionInfo::noShiftedPlanes);  // Track reconstructed in a shifted ROC, only with non-bx-shifted planes
-      if(bxShiftedPlanesUsed >  0 && bxNonShiftedPlanesUsed >  0) track.setRecoInfo(CTPPSReconstructionInfo::mixedPlanes);      // Track reconstructed in a shifted ROC, with mixed planes
+      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::notShiftedRun);    // Default value for runs without bx-shift
+      if(bxShiftedPlanesUsed == 3 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::allShiftedPlanes); // Track reconstructed in a shifted ROC, only with bx-shifted planes
+      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 3) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::noShiftedPlanes);  // Track reconstructed in a shifted ROC, only with non-bx-shifted planes
+      if(bxShiftedPlanesUsed >  0 && bxNonShiftedPlanesUsed >  0) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::mixedPlanes);      // Track reconstructed in a shifted ROC, with mixed planes
     }
     if(bxShiftedPlanesUsed + bxNonShiftedPlanesUsed > 6){
       throw cms::Exception("RPixPlaneCombinatoryTracking")<<"Error in RPixPlaneCombinatoryTracking::findTracks -> " << "More than six points found for a track, skipping.";
       continue;
     }
-    if(track.getRecoInfo() == CTPPSReconstructionInfo::invalid){
+    if(track.getRecoInfo() == CTPPSpixelLocalTrackReconstructionInfo::invalid){
       throw cms::Exception("RPixPlaneCombinatoryTracking")<<"Error in RPixPlaneCombinatoryTracking::findTracks -> " << "recoInfo has not been set properly.";
     }
 

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -100,7 +100,8 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       const uint32_t rpId = rpv.detId();
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
-        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), trk.getChiSquaredOverNDF(), CTPPSPixelLocalTrack::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), 
+        trk.getChiSquaredOverNDF(), CTPPSPixelLocalTrack::ReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
       }
     }
   }
@@ -118,7 +119,8 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       const unsigned int rpId = rpv.detId();
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
-        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), 0., 0., 0., 0., 0., CTPPSPixelLocalTrack::invalid, trk.getNumOfPlanes(), trk.getT(), trk.getTSigma() );
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), 
+        0., 0., 0., 0., 0., CTPPSPixelLocalTrack::ReconstructionInfo::invalid, trk.getNumOfPlanes(), trk.getT(), trk.getTSigma() );
       }
     }
   }
@@ -139,7 +141,10 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       if ( !trk.isValid() ) continue;
       if(trk.getTx()>pixelTrackTxMin_ && trk.getTx()<pixelTrackTxMax_
          && trk.getTy()>pixelTrackTyMin_ && trk.getTy()<pixelTrackTyMax_)
-        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), trk.getChiSquaredOverNDF(), trk.getRecoInfo(), trk.getNumberOfPointsUsedForFit(),0.,0. );
+
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), 
+        trk.getChiSquaredOverNDF(), trk.getRecoInfo(), trk.getNumberOfPointsUsedForFit(),0.,0. );
+      
         }
       }
     }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -101,7 +101,7 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
         pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), 
-        trk.getChiSquaredOverNDF(), CTPPSPixelLocalTrack::ReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
+        trk.getChiSquaredOverNDF(), ReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
       }
     }
   }
@@ -120,7 +120,7 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
         pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), 
-        0., 0., 0., 0., 0., CTPPSPixelLocalTrack::ReconstructionInfo::invalid, trk.getNumOfPlanes(), trk.getT(), trk.getTSigma() );
+        0., 0., 0., 0., 0., ReconstructionInfo::invalid, trk.getNumOfPlanes(), trk.getT(), trk.getTSigma() );
       }
     }
   }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -172,8 +172,8 @@ CTPPSLocalTrackLiteProducer::fillDescriptions( edm::ConfigurationDescriptions& d
   desc.add<bool>( "doNothing", true ) // disable the module by default
     ->setComment( "disable the module" );
 
-  desc.add<std::vector<double> >("pixelTrackTxRange",std::vector<double>({-0.03,0.03}) );
-  desc.add<std::vector<double> >("pixelTrackTyRange",std::vector<double>({-0.04,0.04}) );
+  desc.add<std::vector<double> >("pixelTrackTxRange",std::vector<double>({-10.0,10.0}) );
+  desc.add<std::vector<double> >("pixelTrackTyRange",std::vector<double>({-10.0,10.0}) );
 
   descr.add( "ctppsLocalTrackLiteDefaultProducer", desc );
 }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -44,8 +44,7 @@ private:
   bool includePixels_;
   edm::EDGetTokenT< edm::DetSetVector<CTPPSPixelLocalTrack> > pixelTrackToken_;
 
-  std::vector<double> pixelTrackTxRange_;
-  std::vector<double> pixelTrackTyRange_;
+  double pixelTrackTxMin_,pixelTrackTxMax_,pixelTrackTyMin_,pixelTrackTyMax_;
 /// if true, this module will do nothing
 /// needed for consistency with CTPPS-less workflows
   bool doNothing_;
@@ -70,8 +69,10 @@ CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer( const edm::ParameterSe
     pixelTrackToken_   = consumes< edm::DetSetVector<CTPPSPixelLocalTrack> >  (tagPixelTrack);
   }
 
-  pixelTrackTxRange_ = iConfig.getParameter<std::vector<double> >("pixelTrackTxRange");
-  pixelTrackTyRange_ = iConfig.getParameter<std::vector<double> >("pixelTrackTyRange");
+  pixelTrackTxMin_ = iConfig.getParameter<double>("pixelTrackTxMin");
+  pixelTrackTxMax_ = iConfig.getParameter<double>("pixelTrackTxMax");
+  pixelTrackTyMin_ = iConfig.getParameter<double>("pixelTrackTyMin");
+  pixelTrackTyMax_ = iConfig.getParameter<double>("pixelTrackTyMax");
   produces< std::vector<CTPPSLocalTrackLite> >();
 }
 
@@ -99,7 +100,7 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       const uint32_t rpId = rpv.detId();
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
-        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma());
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), trk.getChiSquaredOverNDF(), CTPPSPixelLocalTrack::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
       }
     }
   }
@@ -117,7 +118,7 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       const unsigned int rpId = rpv.detId();
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
-        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getT() );
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), 0., 0., 0., 0., 0., CTPPSPixelLocalTrack::invalid, trk.getNumOfPlanes(), trk.getT(), trk.getTSigma() );
       }
     }
   }
@@ -127,9 +128,6 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
 
   if (includePixels_)
   {
-    // get input from pixel detectors
-    if(pixelTrackTxRange_.size() != 2 || pixelTrackTyRange_.size() != 2) throw cms::Exception("CTPPSLocalTrackLiteProducer") 
-                                 << "Wrong number of parameters in pixel track Tx/Ty range";
     edm::Handle< edm::DetSetVector<CTPPSPixelLocalTrack> > inputPixelTracks;
     if (not pixelTrackToken_.isUninitialized()){
       iEvent.getByToken( pixelTrackToken_, inputPixelTracks );
@@ -139,9 +137,9 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
         const uint32_t rpId = rpv.detId();
         for ( const auto& trk : rpv ) {
       if ( !trk.isValid() ) continue;
-      if(trk.getTx()>pixelTrackTxRange_.at(0) && trk.getTx()<pixelTrackTxRange_.at(1)
-         && trk.getTy()>pixelTrackTyRange_.at(0) && trk.getTy()<pixelTrackTyRange_.at(1) )
-        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), trk.getChiSquaredOverNDF(), trk.getRecoInfo(), trk.getNumberOfPointUsedForFit() );
+      if(trk.getTx()>pixelTrackTxMin_ && trk.getTx()<pixelTrackTxMax_
+         && trk.getTy()>pixelTrackTyMin_ && trk.getTy()<pixelTrackTyMax_)
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), trk.getChiSquaredOverNDF(), trk.getRecoInfo(), trk.getNumberOfPointsUsedForFit(),0.,0. );
         }
       }
     }
@@ -172,8 +170,10 @@ CTPPSLocalTrackLiteProducer::fillDescriptions( edm::ConfigurationDescriptions& d
   desc.add<bool>( "doNothing", true ) // disable the module by default
     ->setComment( "disable the module" );
 
-  desc.add<std::vector<double> >("pixelTrackTxRange",std::vector<double>({-10.0,10.0}) );
-  desc.add<std::vector<double> >("pixelTrackTyRange",std::vector<double>({-10.0,10.0}) );
+  desc.add<double>("pixelTrackTxMin",-10.0);
+  desc.add<double>("pixelTrackTxMax", 10.0);
+  desc.add<double>("pixelTrackTyMin",-10.0);
+  desc.add<double>("pixelTrackTyMax", 10.0);
 
   descr.add( "ctppsLocalTrackLiteDefaultProducer", desc );
 }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -101,7 +101,7 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
         pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), 
-        trk.getChiSquaredOverNDF(), ReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
+        trk.getChiSquaredOverNDF(), CTPPSReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
       }
     }
   }
@@ -120,7 +120,7 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
         pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), 
-        0., 0., 0., 0., 0., ReconstructionInfo::invalid, trk.getNumOfPlanes(), trk.getT(), trk.getTSigma() );
+        0., 0., 0., 0., 0., CTPPSReconstructionInfo::invalid, trk.getNumOfPlanes(), trk.getT(), trk.getTSigma() );
       }
     }
   }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -99,7 +99,7 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       const uint32_t rpId = rpv.detId();
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
-        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma() );
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma());
       }
     }
   }
@@ -141,7 +141,7 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       if ( !trk.isValid() ) continue;
       if(trk.getTx()>pixelTrackTxRange_.at(0) && trk.getTx()<pixelTrackTxRange_.at(1)
          && trk.getTy()>pixelTrackTyRange_.at(0) && trk.getTy()<pixelTrackTyRange_.at(1) )
-        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma() );
+        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), trk.getChiSquaredOverNDF(), trk.getRecoInfo(), trk.getNumberOfPointUsedForFit() );
         }
       }
     }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -112,8 +112,8 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
           float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
           float roundedChiSquaredOverNDF = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
-        pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), 
-        trk.getChiSquaredOverNDF(), CTPPSpixelLocalTrackReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
+        pOut->emplace_back( rpId, roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma, roundedTx, roundedTxSigma, roundedTy, roundedTySigma, 
+        roundedChiSquaredOverNDF, CTPPSpixelLocalTrackReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
       }
     }
   }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -101,6 +101,17 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
       const uint32_t rpId = rpv.detId();
       for ( const auto& trk : rpv ) {
         if ( !trk.isValid() ) continue;
+
+          float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<14>(trk.getX0());
+          float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
+          float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
+          float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
+          float roundedTx = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTx());
+          float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
+          float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
+          float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
+          float roundedChiSquaredOverNDF = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
+
         pOut->emplace_back( rpId, trk.getX0(), trk.getX0Sigma(), trk.getY0(), trk.getY0Sigma(), trk.getTx(), trk.getTxSigma(), trk.getTy(), trk.getTySigma(), 
         trk.getChiSquaredOverNDF(), CTPPSpixelLocalTrackReconstructionInfo::invalid, trk.getNumberOfPointsUsedForFit(),0,0 );
       }
@@ -157,7 +168,7 @@ CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup&
             float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
             float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
             float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
-            float roundedChiSquaredOverNDF = MiniFloatConverter::reduceMantissaToNbitsRounding<9>(trk.getChiSquaredOverNDF());
+            float roundedChiSquaredOverNDF = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
             pOut->emplace_back( rpId, roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma, roundedTx, roundedTxSigma, roundedTy, roundedTySigma, 
             roundedChiSquaredOverNDF, trk.getRecoInfo(), trk.getNumberOfPointsUsedForFit(),0.,0. );


### PR DESCRIPTION
Including additional information about tracks in CTPPSLocalTrackLite class to ease analysis with miniAOD and to cope with a special detector setup used only in 2017 data taking. Modifications needed for UL reprocessing. 
Some details below:
CTPPSPixelLocalTrack:
- Added the recoInfo_ data member. This handles a limited number of 2017 runs due to an alternative readout mode of the PPS pixel detectors that will not be used in the future.
CTPPSLocalTrackLite:
- Added recoInfo, numberOfPointsUsedForFit, Tx and Ty (angles of the tracks) and chiSquaredOverNdF. 

@fabferro @jan-kaspar 
  