### PR TITLE
Remove nearly all calls to Modifier.isChosen() from L1T configurations

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRawDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawDM_cff.py
@@ -52,18 +52,16 @@ run2_HCAL_2017.toModify( hcalRawDatauHTR,
 )
 
 
-if 'caloLayer1RawFed1354' in globals():
-    from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-
-    stage2L1Trigger.toModify(caloLayer1RawFed1354,
-                             ecalDigis= "DMEcalTriggerPrimitiveDigis",
-                             hcalDigis= "DMHcalTriggerPrimitiveDigis"
-                             )
-    stage2L1Trigger.toModify(caloLayer1RawFed1356,
-                             ecalDigis= "DMEcalTriggerPrimitiveDigis",
-                             hcalDigis= "DMHcalTriggerPrimitiveDigis"
-                             )
-    stage2L1Trigger.toModify(caloLayer1RawFed1358,
-                             ecalDigis= "DMEcalTriggerPrimitiveDigis",
-                             hcalDigis= "DMHcalTriggerPrimitiveDigis"
-                             )
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(caloLayer1RawFed1354,
+                         ecalDigis= "DMEcalTriggerPrimitiveDigis",
+                         hcalDigis= "DMHcalTriggerPrimitiveDigis"
+                         )
+stage2L1Trigger.toModify(caloLayer1RawFed1356,
+                         ecalDigis= "DMEcalTriggerPrimitiveDigis",
+                         hcalDigis= "DMHcalTriggerPrimitiveDigis"
+                         )
+stage2L1Trigger.toModify(caloLayer1RawFed1358,
+                         ecalDigis= "DMEcalTriggerPrimitiveDigis",
+                         hcalDigis= "DMHcalTriggerPrimitiveDigis"
+                         )

--- a/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
@@ -20,13 +20,13 @@ hgcalVFEProducer.fhDigis = "mixData:HGCDigisHEfront"
 hgcalVFEProducer.bhDigis = "mixData:HGCDigisHEback"
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not stage2L1Trigger.isChosen():
-    (~premix_stage2).toModify(simRpcTriggerDigis, label = 'mixData')
-    simRctDigis.hcalDigis=cms.VInputTag(cms.InputTag("DMHcalTriggerPrimitiveDigis"))   
-    simRctDigis.ecalDigis=cms.VInputTag(cms.InputTag("DMEcalTriggerPrimitiveDigis"))   
-else:
-    #seems likely that this code does not support 2015 MC...
-    (~premix_stage2).toModify(simTwinMuxDigis, RPC_Source = 'mixData')
-    (~premix_stage2).toModify(simOmtfDigis, srcRPC = 'mixData')
-    simCaloStage2Layer1Digis.ecalToken = cms.InputTag("DMEcalTriggerPrimitiveDigis")
-    simCaloStage2Layer1Digis.hcalToken = cms.InputTag("DMHcalTriggerPrimitiveDigis")
+# Legacy and Stage-1 Trigger
+(~premix_stage2).toModify(simRpcTriggerDigis, label = 'mixData')
+simRctDigis.hcalDigis=["DMHcalTriggerPrimitiveDigis"]
+simRctDigis.ecalDigis=["DMEcalTriggerPrimitiveDigis"]
+# Stage-2 Trigger
+#seems likely that this code does not support 2015 MC...
+(~premix_stage2).toModify(simTwinMuxDigis, RPC_Source = 'mixData')
+(~premix_stage2).toModify(simOmtfDigis, srcRPC = 'mixData')
+simCaloStage2Layer1Digis.ecalToken = "DMEcalTriggerPrimitiveDigis"
+simCaloStage2Layer1Digis.hcalToken = "DMHcalTriggerPrimitiveDigis"

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_CalouGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_CalouGT_cff.py
@@ -11,118 +11,118 @@ if not (stage2L1Trigger.isChosen()):
 else:
     print("L1T INFO:  L1REPACK:CalouGT (intended for 2016/2017 data), reemulates the Calo part, uses unpacked Muons, and reemulates uGT.")
 
-    # First, Unpack all inputs to L1:
-    import EventFilter.L1TRawToDigi.bmtfDigis_cfi
-    unpackBmtf = EventFilter.L1TRawToDigi.bmtfDigis_cfi.bmtfDigis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+# First, Unpack all inputs to L1:
+import EventFilter.L1TRawToDigi.bmtfDigis_cfi
+unpackBmtf = EventFilter.L1TRawToDigi.bmtfDigis_cfi.bmtfDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
-    unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
-        DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess())) 
+import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
+unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
+    DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
         
-    import EventFilter.L1TRawToDigi.emtfStage2Digis_cfi
-    unpackEmtf = EventFilter.L1TRawToDigi.emtfStage2Digis_cfi.emtfStage2Digis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.L1TRawToDigi.emtfStage2Digis_cfi
+unpackEmtf = EventFilter.L1TRawToDigi.emtfStage2Digis_cfi.emtfStage2Digis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
         
-    import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
-    unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
-        producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
+unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
+    producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.CSCRawToDigi.cscUnpacker_cfi
-    unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
-        InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.CSCRawToDigi.cscUnpacker_cfi
+unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
+    InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.DTRawToDigi.dtunpacker_cfi
-    unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
-        inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.DTRawToDigi.dtunpacker_cfi
+unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
+    inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
-    unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
-    unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
+unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
-    unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    # Second, unpacker of inputs to uGT:
-    # #################################
-    import EventFilter.L1TRawToDigi.gtStage2Digis_cfi
-    unpackGtStage2 = EventFilter.L1TRawToDigi.gtStage2Digis_cfi.gtStage2Digis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+# Second, unpacker of inputs to uGT:
+# #################################
+import EventFilter.L1TRawToDigi.gtStage2Digis_cfi
+unpackGtStage2 = EventFilter.L1TRawToDigi.gtStage2Digis_cfi.gtStage2Digis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    # For simplicity, re-emulate the entire L1T (will not use Muon part)
-    # ################################################################
+# For simplicity, re-emulate the entire L1T (will not use Muon part)
+# ################################################################
 
-    from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
-    simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
-        cms.InputTag('unpackHcal'),
-        cms.InputTag('unpackHcal')
-    )
-    simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
-        cms.InputTag('unpackHcal'),     # upgrade HBHE
-        cms.InputTag('unpackHcal')      # upgrade HF
-    )
+from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
+simHcalTriggerPrimitiveDigis.inputLabel = [
+    'unpackHcal',
+    'unpackHcal'
+]
+simHcalTriggerPrimitiveDigis.inputUpgradeLabel = [
+    'unpackHcal',     # upgrade HBHE
+    'unpackHcal'      # upgrade HF
+]
 
-    from L1Trigger.Configuration.SimL1Emulator_cff import *
+from L1Trigger.Configuration.SimL1Emulator_cff import *
     
-    simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
-    simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'unpackCSC', 'MuonCSCComparatorDigi' )
-    simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'unpackCSC', 'MuonCSCWireDigi' )
+simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
+simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = 'unpackCSC:MuonCSCComparatorDigi'
+simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = 'unpackCSC:MuonCSCWireDigi'
 
-    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPC')
-    simTwinMuxDigis.DTDigi_Source      = cms.InputTag("simDtTriggerPrimitiveDigis")
-    simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
+simTwinMuxDigis.RPC_Source         = 'unpackRPC'
+simTwinMuxDigis.DTDigi_Source      = "simDtTriggerPrimitiveDigis"
+simTwinMuxDigis.DTThetaDigi_Source = "simDtTriggerPrimitiveDigis"
 
-    # -----------------------------------------------------------
-    # change when availalbe simTwinMux and reliable DTTPs, CSCTPs
-    cutlist=['simDtTriggerPrimitiveDigis','simCscTriggerPrimitiveDigis','simTwinMuxDigis']
-    for b in cutlist:
-        SimL1EmulatorCore.remove(b)
-    # -----------------------------------------------------------
+# -----------------------------------------------------------
+# change when availalbe simTwinMux and reliable DTTPs, CSCTPs
+cutlist=['simDtTriggerPrimitiveDigis','simCscTriggerPrimitiveDigis','simTwinMuxDigis']
+for b in cutlist:
+    SimL1EmulatorCore.remove(b)
+# -----------------------------------------------------------
 
-    # BMTF
-    simBmtfDigis.DTDigi_Source       = cms.InputTag("unpackBmtf")
-    simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("unpackBmtf")
+# BMTF
+simBmtfDigis.DTDigi_Source       = "unpackBmtf"
+simBmtfDigis.DTDigi_Theta_Source = "unpackBmtf"
 
-    # OMTF
-    simOmtfDigis.srcRPC              = cms.InputTag('unpackRPC')
-    simOmtfDigis.srcDTPh             = cms.InputTag("unpackBmtf")
-    simOmtfDigis.srcDTTh             = cms.InputTag("unpackBmtf")
-    simOmtfDigis.srcCSC              = cms.InputTag("unpackCsctf") ## Replace when emtfStage2Digis give equal data-emulator agreement
+# OMTF
+simOmtfDigis.srcRPC              = 'unpackRPC'
+simOmtfDigis.srcDTPh             = "unpackBmtf"
+simOmtfDigis.srcDTTh             = "unpackBmtf"
+simOmtfDigis.srcCSC              = "unpackCsctf" ## Replace when emtfStage2Digis give equal data-emulator agreement
 
-    # EMTF
-    simEmtfDigis.CSCInput            = cms.InputTag("unpackEmtf") 
-    simEmtfDigis.RPCInput            = cms.InputTag('unpackRPC')
+# EMTF
+simEmtfDigis.CSCInput            = "unpackEmtf"
+simEmtfDigis.RPCInput            = 'unpackRPC'
 
-    simCaloStage2Layer1Digis.ecalToken = cms.InputTag('unpackEcal:EcalTriggerPrimitives')
-    simCaloStage2Layer1Digis.hcalToken = cms.InputTag('unpackHcal')
+simCaloStage2Layer1Digis.ecalToken = 'unpackEcal:EcalTriggerPrimitives'
+simCaloStage2Layer1Digis.hcalToken = 'unpackHcal'
 
-    # uGT inputs for Muons are from unpacked
-    simGtStage2Digis.MuonInputTag   = cms.InputTag("unpackGtStage2","Muon")
+# uGT inputs for Muons are from unpacked
+simGtStage2Digis.MuonInputTag   = "unpackGtStage2","Muon"
 
-    # Finally, pack the newly re-emulated L1T parts back into RAW
-    # Calo packer
-    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
-    # uGT packer
-    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
+# Finally, pack the newly re-emulated L1T parts back into RAW
+# Calo packer
+from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
+# uGT packer
+from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
 
-    # combine the new L1 RAW with existing RAW for other FEDs
-    import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
-    rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
-        verbose = cms.untracked.int32(0),
-        RawCollectionList = cms.VInputTag(
-            cms.InputTag('packCaloStage2'),
-            cms.InputTag('packGtStage2'),
-            cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
-            )
-        )
+# combine the new L1 RAW with existing RAW for other FEDs
+import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
+rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
+    verbose = 0,
+    RawCollectionList = [
+        'packCaloStage2',
+        'packGtStage2',
+        cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
+        ]
+    )
 
 
-    
-    SimL1Emulator = cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackEmtf+unpackCsctf+unpackBmtf+unpackGtStage2
+SimL1Emulator = cms.Sequence()
+stage2L1Trigger.toReplaceWith(SimL1Emulator, cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackEmtf+unpackCsctf+unpackBmtf+unpackGtStage2
                                  +SimL1EmulatorCore+packCaloStage2
-                                 +packGtStage2+rawDataCollector)
+                                 +packGtStage2+rawDataCollector))

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
@@ -11,91 +11,91 @@ if not (stage2L1Trigger.isChosen()):
 else:
     print("L1T INFO:  L1REPACK:Full2015Data will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output.")
 
-    # First, Unpack all inputs to L1:
-    import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
-    unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
-        DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+# First, Unpack all inputs to L1:
+import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
+unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
+    DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
-    unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
-        producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
+unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
+    producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.CSCRawToDigi.cscUnpacker_cfi
-    unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
-        InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.CSCRawToDigi.cscUnpacker_cfi
+unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
+    InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.DTRawToDigi.dtunpacker_cfi
-    unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
-        inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.DTRawToDigi.dtunpacker_cfi
+unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
+    inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
-    unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
-    unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
+unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
-    unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    # Second, Re-Emulate the entire L1T
+# Second, Re-Emulate the entire L1T
 
-    # NOTE:  2016 HCAL HF TPs require a new emulation
-    from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
-    simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
-        cms.InputTag('unpackHcal'),
-        cms.InputTag('unpackHcal')
+# NOTE:  2016 HCAL HF TPs require a new emulation
+from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
+simHcalTriggerPrimitiveDigis.inputLabel = [
+    'unpackHcal',
+    'unpackHcal'
+]
+
+from L1Trigger.Configuration.SimL1Emulator_cff import *
+simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
+simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = 'unpackCSC:MuonCSCComparatorDigi'
+simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = 'unpackCSC:MuonCSCWireDigi'
+
+simTwinMuxDigis.RPC_Source = 'unpackRPC'
+simTwinMuxDigis.DTDigi_Source = "unpackDttf"
+simTwinMuxDigis.DTThetaDigi_Source = "unpackDttf"
+
+# BMTF
+simBmtfDigis.DTDigi_Source       = "simTwinMuxDigis"
+simBmtfDigis.DTDigi_Theta_Source = "unpackDttf"
+
+# OMTF
+simOmtfDigis.srcRPC                = 'unpackRPC'
+simOmtfDigis.srcDTPh               = "unpackDttf"
+simOmtfDigis.srcDTTh               = "unpackDttf"
+simOmtfDigis.srcCSC                = "unpackCsctf"
+
+# EMTF
+simEmtfDigis.CSCInput              = "unpackCsctf"
+simEmtfDigis.RPCInput              = 'unpackRPC'
+
+simCaloStage2Layer1Digis.ecalToken = 'unpackEcal:EcalTriggerPrimitives'
+simCaloStage2Layer1Digis.hcalToken = 'simHcalTriggerPrimitiveDigis'
+
+
+# Finally, pack the new L1T output back into RAW
+    
+from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
+from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
+from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
+
+# combine the new L1 RAW with existing RAW for other FEDs
+import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
+rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
+    verbose = 0,
+    RawCollectionList = [
+        'packCaloStage2',
+        'packGmtStage2',
+        'packGtStage2',
+        cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
+        ]
     )
 
-    from L1Trigger.Configuration.SimL1Emulator_cff import *
-    simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
-    simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'unpackCSC', 'MuonCSCComparatorDigi' )
-    simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'unpackCSC', 'MuonCSCWireDigi' )
 
-    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPC')
-    simTwinMuxDigis.DTDigi_Source = cms.InputTag("unpackDttf")
-    simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("unpackDttf")
-
-    # BMTF
-    simBmtfDigis.DTDigi_Source       = cms.InputTag("simTwinMuxDigis")
-    simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("unpackDttf")
-
-    # OMTF
-    simOmtfDigis.srcRPC                = cms.InputTag('unpackRPC')
-    simOmtfDigis.srcDTPh               = cms.InputTag("unpackDttf")
-    simOmtfDigis.srcDTTh               = cms.InputTag("unpackDttf")
-    simOmtfDigis.srcCSC                = cms.InputTag("unpackCsctf")
-
-    # EMTF
-    simEmtfDigis.CSCInput              = cms.InputTag("unpackCsctf")
-    simEmtfDigis.RPCInput              = cms.InputTag('unpackRPC')
-
-    simCaloStage2Layer1Digis.ecalToken = cms.InputTag('unpackEcal:EcalTriggerPrimitives')
-    simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
-
-
-    # Finally, pack the new L1T output back into RAW
-    
-    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
-    from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
-    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
-
-    # combine the new L1 RAW with existing RAW for other FEDs
-    import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
-    rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
-        verbose = cms.untracked.int32(0),
-        RawCollectionList = cms.VInputTag(
-            cms.InputTag('packCaloStage2'),
-            cms.InputTag('packGmtStage2'),
-            cms.InputTag('packGtStage2'),
-            cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
-            )
-        )
-
-
-    
-    SimL1Emulator = cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackDttf+unpackCsctf
+SimL1Emulator = cms.Sequence()
+stage2L1Trigger.toReplaceWith(SimL1Emulator, cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackDttf+unpackCsctf
                                  +simHcalTriggerPrimitiveDigis+SimL1EmulatorCore+packCaloStage2
-                                 +packGmtStage2+packGtStage2+rawDataCollector)
+                                 +packGmtStage2+packGtStage2+rawDataCollector))

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
@@ -11,105 +11,106 @@ if not (stage2L1Trigger.isChosen()):
 else:
     print("L1T INFO:  L1REPACK:FullMC  will unpack Calorimetry and Muon L1T inputs, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output.")
 
-    # First, Unpack all inputs to L1:
+# First, Unpack all inputs to L1:
 
-    import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
-    unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.DTRawToDigi.dtunpacker_cfi
-    unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
-        inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.DTRawToDigi.dtunpacker_cfi
+unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
+    inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.CSCRawToDigi.cscUnpacker_cfi
-    unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
-        InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.CSCRawToDigi.cscUnpacker_cfi
+unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
+    InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
-    unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
+unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
-    unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    # Second, Re-Emulate the entire L1T
-    #
-    # Legacy trigger primitive emulations still running in 2016 trigger:
-    #
-    from SimCalorimetry.Configuration.SimCalorimetry_cff import *
+# Second, Re-Emulate the entire L1T
+#
+# Legacy trigger primitive emulations still running in 2016 trigger:
+#
+from SimCalorimetry.Configuration.SimCalorimetry_cff import *
 
-    # Ecal TPs
-    # cannot simulate EcalTPs, don't have EcalUnsuppressedDigis in RAW
-    #     simEcalTriggerPrimitiveDigis.Label = 'unpackEcal'
-    # further downstream, use unpacked EcalTPs
+# Ecal TPs
+# cannot simulate EcalTPs, don't have EcalUnsuppressedDigis in RAW
+#     simEcalTriggerPrimitiveDigis.Label = 'unpackEcal'
+# further downstream, use unpacked EcalTPs
 
-    # Hcal TPs
-    simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
-        cms.InputTag('unpackHcal'),
-        cms.InputTag('unpackHcal')
-    )
-    simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
-        cms.InputTag('unpackHcal'),     # upgrade HBHE
-        cms.InputTag('unpackHcal')      # upgrade HF
-    )
+# Hcal TPs
+simHcalTriggerPrimitiveDigis.inputLabel = [
+    'unpackHcal',
+    'unpackHcal'
+]
+simHcalTriggerPrimitiveDigis.inputUpgradeLabel = [
+    'unpackHcal',     # upgrade HBHE
+    'unpackHcal'      # upgrade HF
+]
 
-    from L1Trigger.Configuration.SimL1Emulator_cff import *
-    # DT TPs
-    simDtTriggerPrimitiveDigis.digiTag                    = 'unpackDT'
-    # CSC TPs
-    simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag('unpackCSC', 'MuonCSCComparatorDigi' )
-    simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'unpackCSC', 'MuonCSCWireDigi' )
+from L1Trigger.Configuration.SimL1Emulator_cff import *
+# DT TPs
+simDtTriggerPrimitiveDigis.digiTag                    = 'unpackDT'
+# CSC TPs
+simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = 'unpackCSC:MuonCSCComparatorDigi'
+simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = 'unpackCSC:MuonCSCWireDigi'
 
-    # TWIN-MUX
-    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPC')
-    simTwinMuxDigis.DTDigi_Source      = cms.InputTag("simDtTriggerPrimitiveDigis")
-    simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
+# TWIN-MUX
+simTwinMuxDigis.RPC_Source         = 'unpackRPC'
+simTwinMuxDigis.DTDigi_Source      = "simDtTriggerPrimitiveDigis"
+simTwinMuxDigis.DTThetaDigi_Source = "simDtTriggerPrimitiveDigis"
 
-    # BMTF
-    simBmtfDigis.DTDigi_Source       = cms.InputTag("simTwinMuxDigis")
-    simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
+# BMTF
+simBmtfDigis.DTDigi_Source       = "simTwinMuxDigis"
+simBmtfDigis.DTDigi_Theta_Source = "simDtTriggerPrimitiveDigis"
 
-    # OMTF
-    simOmtfDigis.srcRPC              = cms.InputTag('unpackRPC')
-    simOmtfDigis.srcDTPh             = cms.InputTag("simDtTriggerPrimitiveDigis")
-    simOmtfDigis.srcDTTh             = cms.InputTag("simDtTriggerPrimitiveDigis")
-    simOmtfDigis.srcCSC              = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED')
+# OMTF
+simOmtfDigis.srcRPC              = 'unpackRPC'
+simOmtfDigis.srcDTPh             = "simDtTriggerPrimitiveDigis"
+simOmtfDigis.srcDTTh             = "simDtTriggerPrimitiveDigis"
+simOmtfDigis.srcCSC              = 'simCscTriggerPrimitiveDigis:MPCSORTED'
 
-    # EMTF
-    simEmtfDigis.CSCInput            = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED')
-    simEmtfDigis.RPCInput            = cms.InputTag('unpackRPC')
+# EMTF
+simEmtfDigis.CSCInput            = 'simCscTriggerPrimitiveDigis:MPCSORTED'
+simEmtfDigis.RPCInput            = 'unpackRPC'
 
-    # CALO Layer1
-    simCaloStage2Layer1Digis.ecalToken = cms.InputTag('unpackEcal:EcalTriggerPrimitives')
-    simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
+# CALO Layer1
+simCaloStage2Layer1Digis.ecalToken = 'unpackEcal:EcalTriggerPrimitives'
+simCaloStage2Layer1Digis.hcalToken = 'simHcalTriggerPrimitiveDigis'
 
-    # Finally, pack the new L1T output back into RAW
-    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
-    from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
-    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
+# Finally, pack the new L1T output back into RAW
+from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
+from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
+from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
 
-    # combine the new L1 RAW with existing RAW for other FEDs
-    import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
-    rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
-        verbose = cms.untracked.int32(0),
-        RawCollectionList = cms.VInputTag(
-            cms.InputTag('packCaloStage2'),
-            cms.InputTag('packGmtStage2'),
-            cms.InputTag('packGtStage2'),
+# combine the new L1 RAW with existing RAW for other FEDs
+import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
+rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
+    verbose = 0,
+        RawCollectionList = [
+            'packCaloStage2',
+            'packGmtStage2',
+            'packGtStage2',
             cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
-            )
-        )
+        ]
+    )
 
-    SimL1Emulator = cms.Sequence(unpackRPC
-                                + unpackDT
-                                + unpackCSC
-                                + unpackEcal
-                                + unpackHcal
-                                #+ simEcalTriggerPrimitiveDigis
-                                + simHcalTriggerPrimitiveDigis
-                                + SimL1EmulatorCore
-                                + packCaloStage2
-                                + packGmtStage2
-                                + packGtStage2
-                                + rawDataCollector)
+SimL1Emulator = cms.Sequence()
+stage2L1Trigger.toReplaceWith(SimL1Emulator, cms.Sequence(unpackRPC
+                                                          + unpackDT
+                                                          + unpackCSC
+                                                          + unpackEcal
+                                                          + unpackHcal
+                                                          #+ simEcalTriggerPrimitiveDigis
+                                                          + simHcalTriggerPrimitiveDigis
+                                                          + SimL1EmulatorCore
+                                                          + packCaloStage2
+                                                          + packGmtStage2
+                                                          + packGtStage2
+                                                          + rawDataCollector))

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
@@ -11,112 +11,111 @@ if not (stage2L1Trigger.isChosen()):
 else:
     print("L1T INFO:  L1REPACK:FullSimTP (intended for 2016 data) will unpack all L1T inputs, re-emulate Trigger Primitives, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output.")
 
-    # First, Unpack all inputs to L1:
-    import EventFilter.L1TRawToDigi.bmtfDigis_cfi
-    unpackBmtf = EventFilter.L1TRawToDigi.bmtfDigis_cfi.bmtfDigis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+# First, Unpack all inputs to L1:
+import EventFilter.L1TRawToDigi.bmtfDigis_cfi
+unpackBmtf = EventFilter.L1TRawToDigi.bmtfDigis_cfi.bmtfDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
-    unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
-        DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
+unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
+    DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
         
-    import EventFilter.L1TRawToDigi.emtfStage2Digis_cfi
-    unpackEmtf = EventFilter.L1TRawToDigi.emtfStage2Digis_cfi.emtfStage2Digis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.L1TRawToDigi.emtfStage2Digis_cfi
+unpackEmtf = EventFilter.L1TRawToDigi.emtfStage2Digis_cfi.emtfStage2Digis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
         
 
-    import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
-    unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
-        producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
+unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
+    producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.CSCRawToDigi.cscUnpacker_cfi
-    unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
-        InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.CSCRawToDigi.cscUnpacker_cfi
+unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
+    InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.DTRawToDigi.dtunpacker_cfi
-    unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
-        inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.DTRawToDigi.dtunpacker_cfi
+unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
+    inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
-    unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
-    unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
+unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
-    unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    # Second, Re-Emulate the entire L1T
+# Second, Re-Emulate the entire L1T
 
-    from SimCalorimetry.EcalTrigPrimProducers.ecalTriggerPrimitiveDigis_cfi import *
-    #from L1Trigger.Configuration.CaloTriggerPrimitives_cff import *
-    simEcalTriggerPrimitiveDigis.InstanceEB = cms.string('ebDigis')
-    simEcalTriggerPrimitiveDigis.InstanceEE = cms.string('eeDigis')
-    simEcalTriggerPrimitiveDigis.Label = 'unpackEcal'
-    from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
-    simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
-        cms.InputTag('unpackHcal'),
-        cms.InputTag('unpackHcal')
+from SimCalorimetry.EcalTrigPrimProducers.ecalTriggerPrimitiveDigis_cfi import *
+#from L1Trigger.Configuration.CaloTriggerPrimitives_cff import *
+simEcalTriggerPrimitiveDigis.InstanceEB = 'ebDigis'
+simEcalTriggerPrimitiveDigis.InstanceEE = 'eeDigis'
+simEcalTriggerPrimitiveDigis.Label = 'unpackEcal'
+from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
+simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag[
+    'unpackHcal',
+    'unpackHcal'
+]
+simHcalTriggerPrimitiveDigis.inputUpgradeLabel = [
+    'unpackHcal',     # upgrade HBHE
+    'unpackHcal'      # upgrade HF
+]
+
+from L1Trigger.Configuration.SimL1Emulator_cff import *
+    
+simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
+simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = 'unpackCSC:MuonCSCComparatorDigi'
+simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = 'unpackCSC:MuonCSCWireDigi'
+
+simTwinMuxDigis.RPC_Source         = 'unpackRPC'
+# simTwinMuxDigis.DTDigi_Source      = "simDtTriggerPrimitiveDigis"  # DEFAULT
+# simTwinMuxDigis.DTThetaDigi_Source = "simDtTriggerPrimitiveDigis"  # DEFAULT
+
+# BMTF
+# simBmtfDigis.DTDigi_Source       = "simTwinMuxDigis"               # DEFAULT
+# simBmtfDigis.DTDigi_Theta_Source = "simDtTriggerPrimitiveDigis"    # DEFAULT
+
+# OMTF
+simOmtfDigis.srcRPC              = 'unpackRPC'
+# simOmtfDigis.srcDTPh             = "simDtTriggerPrimitiveDigis"    # DEFAULT
+# simOmtfDigis.srcDTTh             = "simDtTriggerPrimitiveDigis"    # DEFAULT
+simOmtfDigis.srcCSC              = "unpackCsctf"
+# simOmtfDigis.srcCSC              = "simCscTriggerPrimitiveDigis"   # DEFAULT
+
+# EMTF
+simEmtfDigis.CSCInput            = "unpackEmtf"
+# simEmtfDigis.CSCInput            = "simCscTriggerPrimitiveDigis"     # DEFAULT
+simEmtfDigis.RPCInput            = 'unpackRPC'
+
+# simCaloStage2Layer1Digis.ecalToken = 'simEcalTriggerPrimitiveDigis'  # DEFAULT
+# simCaloStage2Layer1Digis.hcalToken = 'simHcalTriggerPrimitiveDigis'  # DEFAULT
+
+# Finally, pack the new L1T output back into RAW
+    
+from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
+from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
+from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
+
+# combine the new L1 RAW with existing RAW for other FEDs
+import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
+rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
+    verbose = 0,
+    RawCollectionList = [
+        'packCaloStage2',
+        'packGmtStage2',
+        'packGtStage2',
+        cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
+        ]
     )
-    simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
-        cms.InputTag('unpackHcal'),     # upgrade HBHE
-        cms.InputTag('unpackHcal')      # upgrade HF
-    )
 
-    from L1Trigger.Configuration.SimL1Emulator_cff import *
-    
-    simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
-    simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'unpackCSC', 'MuonCSCComparatorDigi' )
-    simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'unpackCSC', 'MuonCSCWireDigi' )
-
-    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPC')
-    # simTwinMuxDigis.DTDigi_Source      = cms.InputTag("simDtTriggerPrimitiveDigis")  # DEFAULT
-    # simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("simDtTriggerPrimitiveDigis")  # DEFAULT
-
-    # BMTF
-    # simBmtfDigis.DTDigi_Source       = cms.InputTag("simTwinMuxDigis")               # DEFAULT
-    # simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("simDtTriggerPrimitiveDigis")    # DEFAULT
-
-    # OMTF
-    simOmtfDigis.srcRPC              = cms.InputTag('unpackRPC')
-    # simOmtfDigis.srcDTPh             = cms.InputTag("simDtTriggerPrimitiveDigis")    # DEFAULT
-    # simOmtfDigis.srcDTTh             = cms.InputTag("simDtTriggerPrimitiveDigis")    # DEFAULT
-    simOmtfDigis.srcCSC              = cms.InputTag("unpackCsctf")   
-    # simOmtfDigis.srcCSC              = cms.InputTag("simCscTriggerPrimitiveDigis")   # DEFAULT
-
-    # EMTF
-    simEmtfDigis.CSCInput            = cms.InputTag("unpackEmtf") 
-    # simEmtfDigis.CSCInput            = cms.InputTag("simCscTriggerPrimitiveDigis")     # DEFAULT
-    simEmtfDigis.RPCInput            = cms.InputTag('unpackRPC')
-
-    # simCaloStage2Layer1Digis.ecalToken = cms.InputTag('simEcalTriggerPrimitiveDigis')  # DEFAULT
-    # simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')  # DEFAULT
-
-    # Finally, pack the new L1T output back into RAW
-    
-    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
-    from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
-    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
-
-    # combine the new L1 RAW with existing RAW for other FEDs
-    import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
-    rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
-        verbose = cms.untracked.int32(0),
-        RawCollectionList = cms.VInputTag(
-            cms.InputTag('packCaloStage2'),
-            cms.InputTag('packGmtStage2'),
-            cms.InputTag('packGtStage2'),
-            cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
-            )
-        )
-
-
-    
-    SimL1Emulator = cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackEmtf+unpackCsctf+unpackBmtf
+SimL1Emulator = cms.Sequence()
+stage2L1Trigger.toReplaceWith(SimL1Emulator, cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackEmtf+unpackCsctf+unpackBmtf
                                  +simEcalTriggerPrimitiveDigis
                                  +simHcalTriggerPrimitiveDigis
                                  +SimL1EmulatorCore+packCaloStage2
-                                 +packGmtStage2+packGtStage2+rawDataCollector)
+                                 +packGmtStage2+packGtStage2+rawDataCollector))

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -13,133 +13,134 @@ if not (stage2L1Trigger.isChosen()):
 else:
     print("L1T INFO:  L1REPACK:Full (intended for 2016 & 2017 data) will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output.")
 
-    # First, Unpack all inputs to L1:
+# First, Unpack all inputs to L1:
     
-    import EventFilter.L1TRawToDigi.bmtfDigis_cfi
-    unpackBmtf = EventFilter.L1TRawToDigi.bmtfDigis_cfi.bmtfDigis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.L1TRawToDigi.bmtfDigis_cfi
+unpackBmtf = EventFilter.L1TRawToDigi.bmtfDigis_cfi.bmtfDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
-    unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
-        DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess())) 
+import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
+unpackDttf = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(
+    DTTF_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
         
-    import EventFilter.L1TRawToDigi.omtfStage2Digis_cfi
-    unpackOmtf = EventFilter.L1TRawToDigi.omtfStage2Digis_cfi.omtfStage2Digis.clone(
-        inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.L1TRawToDigi.omtfStage2Digis_cfi
+unpackOmtf = EventFilter.L1TRawToDigi.omtfStage2Digis_cfi.omtfStage2Digis.clone(
+    inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
         
-    import EventFilter.L1TRawToDigi.emtfStage2Digis_cfi
-    unpackEmtf = EventFilter.L1TRawToDigi.emtfStage2Digis_cfi.emtfStage2Digis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.L1TRawToDigi.emtfStage2Digis_cfi
+unpackEmtf = EventFilter.L1TRawToDigi.emtfStage2Digis_cfi.emtfStage2Digis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
         
-    import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
-    unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
-        producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
+unpackCsctf = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(
+    producer = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.CSCRawToDigi.cscUnpacker_cfi
-    unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
-        InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.CSCRawToDigi.cscUnpacker_cfi
+unpackCSC = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone(
+    InputObjects = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.DTRawToDigi.dtunpacker_cfi
-    unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
-        inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.DTRawToDigi.dtunpacker_cfi
+unpackDT = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone(
+    inputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
-    unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+unpackRPC = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.RPCRawToDigi.rpcTwinMuxRawToDigi_cfi
-    unpackRPCTwinMux = EventFilter.RPCRawToDigi.rpcTwinMuxRawToDigi_cfi.rpcTwinMuxRawToDigi.clone(
-        inputTag = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.RPCRawToDigi.rpcTwinMuxRawToDigi_cfi
+unpackRPCTwinMux = EventFilter.RPCRawToDigi.rpcTwinMuxRawToDigi_cfi.rpcTwinMuxRawToDigi.clone(
+    inputTag = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi
-    unpackTwinMux = EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi.twinMuxStage2Digis.clone(
-        DTTM7_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+import EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi
+unpackTwinMux = EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi.twinMuxStage2Digis.clone(
+    DTTM7_FED_Source = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
         
-    import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
-    unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
+unpackEcal = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
-    unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    import EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi
-    unpackLayer1 = EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi.l1tCaloLayer1Digis.clone(
-        fedRawDataLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
+import EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi
+unpackLayer1 = EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi.l1tCaloLayer1Digis.clone(
+    fedRawDataLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    # Second, Re-Emulate the entire L1T
+# Second, Re-Emulate the entire L1T
 
-    from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
-    simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
-        cms.InputTag('unpackHcal'),
-        cms.InputTag('unpackHcal')
+from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
+simHcalTriggerPrimitiveDigis.inputLabel = [
+    'unpackHcal',
+    'unpackHcal'
+]
+simHcalTriggerPrimitiveDigis.inputUpgradeLabel = [
+    'unpackHcal',     # upgrade HBHE
+    'unpackHcal'      # upgrade HF
+]
+
+from L1Trigger.Configuration.SimL1Emulator_cff import *
+    
+simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
+simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = 'unpackCSC:MuonCSCComparatorDigi'
+simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = 'unpackCSC:MuonCSCWireDigi'
+
+simTwinMuxDigis.RPC_Source         = 'unpackRPCTwinMux'
+simTwinMuxDigis.DTDigi_Source      = "unpackTwinMux:PhIn"
+simTwinMuxDigis.DTThetaDigi_Source = "unpackTwinMux:ThIn"
+
+# -----------------------------------------------------------
+# change when availalbe simTwinMux and reliable DTTPs, CSCTPs
+cutlist=['simDtTriggerPrimitiveDigis','simCscTriggerPrimitiveDigis']
+for b in cutlist:
+    SimL1EmulatorCore.remove(b)
+# -----------------------------------------------------------
+
+# BMTF
+simBmtfDigis.DTDigi_Source       = "simTwinMuxDigis"
+simBmtfDigis.DTDigi_Theta_Source = "unpackBmtf"
+
+# OMTF
+simOmtfDigis.srcRPC              = 'unpackRPC'
+simOmtfDigis.srcDTPh             = "unpackBmtf"
+simOmtfDigis.srcDTTh             = "unpackBmtf"
+simOmtfDigis.srcCSC              = "unpackCsctf"
+stage2L1Trigger_2017.toModify(simOmtfDigis,
+    srcRPC  = 'unpackOmtf',
+    srcCSC  = 'unpackOmtf',
+    srcDTPh = 'unpackOmtf',
+    srcDTTh = 'unpackOmtf'
+)
+
+# EMTF
+simEmtfDigis.CSCInput            = "unpackEmtf"
+simEmtfDigis.RPCInput            = 'unpackRPC'
+
+simCaloStage2Layer1Digis.ecalToken = 'unpackEcal:EcalTriggerPrimitives'
+simCaloStage2Layer1Digis.hcalToken = 'unpackLayer1'
+
+# Finally, pack the new L1T output back into RAW
+    
+from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
+from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
+from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
+
+# combine the new L1 RAW with existing RAW for other FEDs
+import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
+rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
+    verbose = 0,
+    RawCollectionList = [
+        'packCaloStage2',
+        'packGmtStage2',
+        'packGtStage2',
+        cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
+        ]
     )
-    simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
-        cms.InputTag('unpackHcal'),     # upgrade HBHE
-        cms.InputTag('unpackHcal')      # upgrade HF
-    )
-
-    from L1Trigger.Configuration.SimL1Emulator_cff import *
-    
-    simDtTriggerPrimitiveDigis.digiTag = 'unpackDT'
-    simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'unpackCSC', 'MuonCSCComparatorDigi' )
-    simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'unpackCSC', 'MuonCSCWireDigi' )
-
-    simTwinMuxDigis.RPC_Source         = cms.InputTag('unpackRPCTwinMux')
-    simTwinMuxDigis.DTDigi_Source      = cms.InputTag("unpackTwinMux:PhIn")
-    simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("unpackTwinMux:ThIn")
-
-    # -----------------------------------------------------------
-    # change when availalbe simTwinMux and reliable DTTPs, CSCTPs
-    cutlist=['simDtTriggerPrimitiveDigis','simCscTriggerPrimitiveDigis']
-    for b in cutlist:
-        SimL1EmulatorCore.remove(b)
-    # -----------------------------------------------------------
-
-    # BMTF
-    simBmtfDigis.DTDigi_Source       = cms.InputTag("simTwinMuxDigis")
-    simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("unpackBmtf")
-
-    # OMTF
-    simOmtfDigis.srcRPC              = cms.InputTag('unpackRPC')
-    simOmtfDigis.srcDTPh             = cms.InputTag("unpackBmtf")
-    simOmtfDigis.srcDTTh             = cms.InputTag("unpackBmtf")
-    simOmtfDigis.srcCSC              = cms.InputTag("unpackCsctf") 
-    if (stage2L1Trigger_2017.isChosen()):
-        simOmtfDigis.srcRPC          = cms.InputTag('unpackOmtf')
-        simOmtfDigis.srcCSC          = cms.InputTag('unpackOmtf')
-        simOmtfDigis.srcDTPh         = cms.InputTag('unpackOmtf')
-        simOmtfDigis.srcDTTh         = cms.InputTag('unpackOmtf')
-
-    # EMTF
-    simEmtfDigis.CSCInput            = cms.InputTag("unpackEmtf") 
-    simEmtfDigis.RPCInput            = cms.InputTag('unpackRPC')
-
-    simCaloStage2Layer1Digis.ecalToken = cms.InputTag('unpackEcal:EcalTriggerPrimitives')
-    simCaloStage2Layer1Digis.hcalToken = cms.InputTag('unpackLayer1')
-
-    # Finally, pack the new L1T output back into RAW
-    
-    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import caloStage2Raw as packCaloStage2
-    from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import gmtStage2Raw as packGmtStage2
-    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
-
-    # combine the new L1 RAW with existing RAW for other FEDs
-    import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
-    rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
-        verbose = cms.untracked.int32(0),
-        RawCollectionList = cms.VInputTag(
-            cms.InputTag('packCaloStage2'),
-            cms.InputTag('packGmtStage2'),
-            cms.InputTag('packGtStage2'),
-            cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
-            )
-        )
 
 
-    
-    SimL1Emulator = cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackRPCTwinMux+unpackTwinMux+unpackOmtf+unpackEmtf+unpackCsctf+unpackBmtf
-                                 +unpackLayer1
-                                 +SimL1EmulatorCore+packCaloStage2
-                                 +packGmtStage2+packGtStage2+rawDataCollector)
+SimL1Emulator = cms.Sequence()
+stage2L1Trigger.toReplaceWith(SimL1Emulator, cms.Sequence(unpackEcal+unpackHcal+unpackCSC+unpackDT+unpackRPC+unpackRPCTwinMux+unpackTwinMux+unpackOmtf+unpackEmtf+unpackCsctf+unpackBmtf
+                                                          +unpackLayer1
+                                                          +SimL1EmulatorCore+packCaloStage2
+                                                          +packGmtStage2+packGtStage2+rawDataCollector))
 

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
@@ -11,46 +11,46 @@ if not (stage2L1Trigger.isChosen()):
 else:
     print("L1T INFO:  L1REPACK:uGT (intended for 2016 data) will unpack uGMT and CaloLaye2 outputs and re-emulate uGT")
 
-    # First, inputs to uGT:
-    import EventFilter.L1TRawToDigi.gtStage2Digis_cfi
-    unpackGtStage2 = EventFilter.L1TRawToDigi.gtStage2Digis_cfi.gtStage2Digis.clone(
-        InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))    
+# First, inputs to uGT:
+import EventFilter.L1TRawToDigi.gtStage2Digis_cfi
+unpackGtStage2 = EventFilter.L1TRawToDigi.gtStage2Digis_cfi.gtStage2Digis.clone(
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-    from L1Trigger.Configuration.SimL1Emulator_cff import *
-    simGtStage2Digis.MuonInputTag   = cms.InputTag("unpackGtStage2","Muon")
-    simGtStage2Digis.EGammaInputTag = cms.InputTag("unpackGtStage2","EGamma")
-    simGtStage2Digis.TauInputTag    = cms.InputTag("unpackGtStage2","Tau")
-    simGtStage2Digis.JetInputTag    = cms.InputTag("unpackGtStage2","Jet")
-    simGtStage2Digis.EtSumInputTag  = cms.InputTag("unpackGtStage2","EtSum")
-    simGtStage2Digis.ExtInputTag    = cms.InputTag("unpackGtStage2") # as in default
+from L1Trigger.Configuration.SimL1Emulator_cff import *
+simGtStage2Digis.MuonInputTag   = "unpackGtStage2:Muon"
+simGtStage2Digis.EGammaInputTag = "unpackGtStage2:EGamma"
+simGtStage2Digis.TauInputTag    = "unpackGtStage2:Tau"
+simGtStage2Digis.JetInputTag    = "unpackGtStage2:Jet"
+simGtStage2Digis.EtSumInputTag  = "unpackGtStage2:EtSum"
+simGtStage2Digis.ExtInputTag    = "unpackGtStage2" # as in default
 
 
-    # Finally, pack the new L1T output back into RAW
+# Finally, pack the new L1T output back into RAW
     
-    # pack simulated uGT
-    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
-    packGtStage2.MuonInputTag   = cms.InputTag("unpackGtStage2","Muon")
-    packGtStage2.EGammaInputTag = cms.InputTag("unpackGtStage2","EGamma")
-    packGtStage2.TauInputTag    = cms.InputTag("unpackGtStage2","Tau")
-    packGtStage2.JetInputTag    = cms.InputTag("unpackGtStage2","Jet")
-    packGtStage2.EtSumInputTag  = cms.InputTag("unpackGtStage2","EtSum")
-    packGtStage2.GtInputTag     = cms.InputTag("simGtStage2Digis") # as in default
-    packGtStage2.ExtInputTag    = cms.InputTag("unpackGtStage2") # as in default
+# pack simulated uGT
+from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
+packGtStage2.MuonInputTag   = "unpackGtStage2:Muon"
+packGtStage2.EGammaInputTag = "unpackGtStage2:EGamma"
+packGtStage2.TauInputTag    = "unpackGtStage2:Tau"
+packGtStage2.JetInputTag    = "unpackGtStage2:Jet"
+packGtStage2.EtSumInputTag  = "unpackGtStage2:EtSum"
+packGtStage2.GtInputTag     = "simGtStage2Digis" # as in default
+packGtStage2.ExtInputTag    = "unpackGtStage2" # as in default
     
 
-    # combine the new L1 RAW with existing RAW for other FEDs
-    import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
-    rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
-        verbose = cms.untracked.int32(0),
-        RawCollectionList = cms.VInputTag(
-            cms.InputTag('packGtStage2'),
-            cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
-            )
-        )
+# combine the new L1 RAW with existing RAW for other FEDs
+import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi
+rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawDataCollector.clone(
+    verbose = 0,
+    RawCollectionList = [
+        'packGtStage2'.
+        cms.InputTag('rawDataCollector', processName=cms.InputTag.skipCurrentProcess()),
+        ]
+    )
 
 
-    
-    SimL1Emulator = cms.Sequence(unpackGtStage2
-                                +SimL1TGlobal
-                                +packGtStage2
-                                +rawDataCollector)
+SimL1Emulator = cms.Sequence()
+stage2L1Trigger.toReplaceWith(SimL1Emulator, cms.Sequence(unpackGtStage2
+                                                          +SimL1TGlobal
+                                                          +packGtStage2
+                                                          +rawDataCollector))

--- a/HLTrigger/Configuration/python/CustomConfigs.py
+++ b/HLTrigger/Configuration/python/CustomConfigs.py
@@ -43,22 +43,28 @@ def Base(process):
 def L1T(process):
 #   modifications when running L1T only
 
-    labels = ['gtDigis','simGtDigis','newGtDigis','hltGtDigis']
-    for label in labels:
-        if label in process.__dict__:
-            process.load('L1Trigger.GlobalTriggerAnalyzer.l1GtTrigReport_cfi')
-            process.l1GtTrigReport.L1GtRecordInputTag = cms.InputTag( label )
-            process.L1AnalyzerEndpath = cms.EndPath( process.l1GtTrigReport )
-            process.schedule.append(process.L1AnalyzerEndpath)
+    def _legacyStage1(process):
+        labels = ['gtDigis','simGtDigis','newGtDigis','hltGtDigis']
+        for label in labels:
+            if label in process.__dict__:
+                process.load('L1Trigger.GlobalTriggerAnalyzer.l1GtTrigReport_cfi')
+                process.l1GtTrigReport.L1GtRecordInputTag = cms.InputTag( label )
+                process.L1AnalyzerEndpath = cms.EndPath( process.l1GtTrigReport )
+                process.schedule.append(process.L1AnalyzerEndpath)
 
-    labels = ['gtStage2Digis','simGtStage2Digis','newGtStage2Digis','hltGtStage2Digis']
-    for label in labels:
-        if label in process.__dict__:
-            process.load('L1Trigger.L1TGlobal.L1TGlobalSummary_cfi')
-            process.L1TGlobalSummary.AlgInputTag = cms.InputTag( label )
-            process.L1TGlobalSummary.ExtInputTag = cms.InputTag( label )
-            process.L1TAnalyzerEndpath = cms.EndPath(process.L1TGlobalSummary )
-            process.schedule.append(process.L1TAnalyzerEndpath)
+    def _stage2(process):
+        labels = ['gtStage2Digis','simGtStage2Digis','newGtStage2Digis','hltGtStage2Digis']
+        for label in labels:
+            if label in process.__dict__:
+                process.load('L1Trigger.L1TGlobal.L1TGlobalSummary_cfi')
+                process.L1TGlobalSummary.AlgInputTag = cms.InputTag( label )
+                process.L1TGlobalSummary.ExtInputTag = cms.InputTag( label )
+                process.L1TAnalyzerEndpath = cms.EndPath(process.L1TGlobalSummary )
+                process.schedule.append(process.L1TAnalyzerEndpath)
+
+    from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+    (~stage2L1Trigger).toModify(process, _legacyStage1)
+    stage2L1Trigger.toModify(process, _stage2)
 
     if hasattr(process,'TriggerMenu'):
         delattr(process,'TriggerMenu')
@@ -72,19 +78,25 @@ def L1THLT(process):
 #   modifications when running L1T+HLT
 
     if not ('HLTAnalyzerEndpath' in process.__dict__) :
-        if 'hltGtDigis' in process.__dict__:
-            from HLTrigger.Configuration.HLT_Fake_cff import fragment
-            process.hltL1GtTrigReport = fragment.hltL1GtTrigReport
-            process.hltTrigReport = fragment.hltTrigReport
-            process.HLTAnalyzerEndpath = cms.EndPath(process.hltGtDigis + process.hltL1GtTrigReport + process.hltTrigReport)
-            process.schedule.append(process.HLTAnalyzerEndpath)
+        def _legacyStage1(process):
+            if 'hltGtDigis' in process.__dict__:
+                from HLTrigger.Configuration.HLT_Fake_cff import fragment
+                process.hltL1GtTrigReport = fragment.hltL1GtTrigReport
+                process.hltTrigReport = fragment.hltTrigReport
+                process.HLTAnalyzerEndpath = cms.EndPath(process.hltGtDigis + process.hltL1GtTrigReport + process.hltTrigReport)
+                process.schedule.append(process.HLTAnalyzerEndpath)
 
-        if 'hltGtStage2ObjectMap' in process.__dict__:
-            from HLTrigger.Configuration.HLT_FULL_cff import fragment
-            process.hltL1TGlobalSummary = fragment.hltL1TGlobalSummary
-            process.hltTrigReport = fragment.hltTrigReport
-            process.HLTAnalyzerEndpath = cms.EndPath(process.hltGtStage2Digis + process.hltL1TGlobalSummary + process.hltTrigReport)
-            process.schedule.append(process.HLTAnalyzerEndpath)
+        def _stage2(process):
+            if 'hltGtStage2ObjectMap' in process.__dict__:
+                from HLTrigger.Configuration.HLT_FULL_cff import fragment
+                process.hltL1TGlobalSummary = fragment.hltL1TGlobalSummary
+                process.hltTrigReport = fragment.hltTrigReport
+                process.HLTAnalyzerEndpath = cms.EndPath(process.hltGtStage2Digis + process.hltL1TGlobalSummary + process.hltTrigReport)
+                process.schedule.append(process.HLTAnalyzerEndpath)
+
+        from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+        (~stage2L1Trigger).toModify(process, _legacyStage1)
+        stage2L1Trigger.toModify(process, _stage2)
 
     if hasattr(process,'TriggerMenu'):
         delattr(process,'TriggerMenu')

--- a/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
+++ b/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
@@ -10,7 +10,6 @@ import sys
 
 # Modify the Raw Data Collection Raw collection List to include upgrade collections where appropriate:
 from EventFilter.RawDataCollector.rawDataCollector_cfi import *
-_RawCollectionListOrig = rawDataCollector.RawCollectionList[:]
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 stage1L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("caloStage1Raw")) )
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger

--- a/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
+++ b/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
@@ -22,56 +22,41 @@ stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list
 #
 # Legacy Trigger:
 #
-if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-    # legacy L1 packages:
-    from EventFilter.CSCTFRawToDigi.csctfpacker_cfi import *
-    from EventFilter.DTTFRawToDigi.dttfpacker_cfi import *
-    from EventFilter.GctRawToDigi.gctDigiToRaw_cfi import *
-    from EventFilter.L1GlobalTriggerRawToDigi.l1GtPack_cfi import *
-    from EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmPack_cfi import *
-    csctfpacker.lctProducer = "simCscTriggerPrimitiveDigis:MPCSORTED"
-    csctfpacker.trackProducer = 'simCsctfTrackDigis'
-    dttfpacker.DTDigi_Source = 'simDtTriggerPrimitiveDigis'
-    dttfpacker.DTTracks_Source = "simDttfDigis:DTTF"
-    gctDigiToRaw.rctInputLabel = 'simRctDigis'
-    gctDigiToRaw.gctInputLabel = 'simGctDigis'
-    l1GtPack.DaqGtInputTag = 'simGtDigis'
-    l1GtPack.MuGmtInputTag = 'simGmtDigis'
-    l1GtEvmPack.EvmGtInputTag = 'simGtDigis'
-    L1TDigiToRaw = cms.Sequence(csctfpacker+dttfpacker+gctDigiToRaw+l1GtPack+l1GtEvmPack)
+# legacy L1 packages:
+from EventFilter.CSCTFRawToDigi.csctfpacker_cfi import *
+from EventFilter.DTTFRawToDigi.dttfpacker_cfi import *
+from EventFilter.GctRawToDigi.gctDigiToRaw_cfi import *
+from EventFilter.L1GlobalTriggerRawToDigi.l1GtPack_cfi import *
+from EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmPack_cfi import *
+csctfpacker.lctProducer = "simCscTriggerPrimitiveDigis:MPCSORTED"
+csctfpacker.trackProducer = 'simCsctfTrackDigis'
+dttfpacker.DTDigi_Source = 'simDtTriggerPrimitiveDigis'
+dttfpacker.DTTracks_Source = "simDttfDigis:DTTF"
+gctDigiToRaw.rctInputLabel = 'simRctDigis'
+gctDigiToRaw.gctInputLabel = 'simGctDigis'
+l1GtPack.DaqGtInputTag = 'simGtDigis'
+l1GtPack.MuGmtInputTag = 'simGmtDigis'
+l1GtEvmPack.EvmGtInputTag = 'simGtDigis'
+L1TDigiToRaw = cms.Sequence(csctfpacker+dttfpacker+gctDigiToRaw+l1GtPack+l1GtEvmPack)
+
 #
 # Stage-1 Trigger
 #
-if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-    # legacy L1 packers, still in use for 2015:
-    from EventFilter.CSCTFRawToDigi.csctfpacker_cfi import *
-    from EventFilter.DTTFRawToDigi.dttfpacker_cfi import *
-    
-    from EventFilter.L1GlobalTriggerRawToDigi.l1GtPack_cfi import *
-    csctfpacker.lctProducer = "simCscTriggerPrimitiveDigis:MPCSORTED"
-    csctfpacker.trackProducer = 'simCsctfTrackDigis'
-    dttfpacker.DTDigi_Source = 'simDtTriggerPrimitiveDigis'
-    dttfpacker.DTTracks_Source = "simDttfDigis:DTTF"
-    l1GtPack.DaqGtInputTag = 'simGtDigis'
-    l1GtPack.MuGmtInputTag = 'simGmtDigis'
-
-    # Initially, the stage-1 was packed via GCT... this is no longer needed.
-    # (but still needed for RCT digis!)
-    from EventFilter.GctRawToDigi.gctDigiToRaw_cfi import *
-    gctDigiToRaw.gctInputLabel = 'simCaloStage1LegacyFormatDigis'
-    gctDigiToRaw.rctInputLabel = 'simRctDigis'
-    from EventFilter.L1TRawToDigi.caloStage1Raw_cfi import *
-    L1TDigiToRaw = cms.Sequence(csctfpacker+dttfpacker+l1GtPack+caloStage1Raw)
+# legacy L1 packers, still in use for 2015:
+# Initially, the stage-1 was packed via GCT... this is no longer needed.
+# (but still needed for RCT digis!)
+(stage1L1Trigger & ~stage2L1Trigger).toModify(gctDigiToRaw, gctInputLabel = 'simCaloStage1LegacyFormatDigis')
+from EventFilter.L1TRawToDigi.caloStage1Raw_cfi import *
+(stage1L1Trigger & ~stage2L1Trigger).toReplaceWith(L1TDigiToRaw, cms.Sequence(csctfpacker+dttfpacker+l1GtPack+caloStage1Raw))
 
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
-    from EventFilter.L1TRawToDigi.caloLayer1Raw_cfi import *
-    from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import *
-    from EventFilter.L1TRawToDigi.bmtfStage2Raw_cfi import *
-    from EventFilter.L1TRawToDigi.omtfStage2Raw_cfi import *
-    from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import *
-    from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import *
-    # Missing: muon EMTF
-    L1TDigiToRaw = cms.Sequence(caloLayer1Raw + caloStage2Raw + bmtfStage2Raw + omtfStage2Raw + gmtStage2Raw + gtStage2Raw)
+from EventFilter.L1TRawToDigi.caloLayer1Raw_cfi import *
+from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import *
+from EventFilter.L1TRawToDigi.bmtfStage2Raw_cfi import *
+from EventFilter.L1TRawToDigi.omtfStage2Raw_cfi import *
+from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import *
+from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import *
+# Missing: muon EMTF
+(stage2L1Trigger).toReplaceWith(L1TDigiToRaw, cms.Sequence(caloLayer1Raw + caloStage2Raw + bmtfStage2Raw + omtfStage2Raw + gmtStage2Raw + gtStage2Raw))

--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -10,93 +10,53 @@ import FWCore.ParameterSet.Config as cms
 import sys
 
 
-def unpack_legacy():
-    global L1TRawToDigi_Legacy
-    global csctfDigis, dttfDigis, gctDigis, gtDigis, gtEvmDigis
-    import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
-    csctfDigis = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone()
-    import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
-    dttfDigis = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone()
-    import EventFilter.GctRawToDigi.l1GctHwDigis_cfi
-    gctDigis = EventFilter.GctRawToDigi.l1GctHwDigis_cfi.l1GctHwDigis.clone()
-    import EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi
-    gtDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone()
-    import EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi
-    gtEvmDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi.l1GtEvmUnpack.clone()
-    #
-    csctfDigis.producer = 'rawDataCollector'
-    dttfDigis.DTTF_FED_Source = 'rawDataCollector'
-    gctDigis.inputLabel = 'rawDataCollector'
-    gtDigis.DaqGtInputTag = 'rawDataCollector'
-    gtEvmDigis.EvmGtInputTag = 'rawDataCollector'
-    L1TRawToDigi_Legacy = cms.Task(csctfDigis,dttfDigis,gctDigis,gtDigis,gtEvmDigis)
-    
-
-def unpack_stage1():
-    global csctfDigis, dttfDigis, gtDigis,caloStage1Digis,caloStage1FinalDigis,gctDigis
-    global caloStage1LegacyFormatDigis
-    global L1TRawToDigi_Stage1    
-    import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
-    csctfDigis = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone()
-    import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
-    dttfDigis = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone()
-    import EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi
-    gtDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone()
-    from EventFilter.L1TRawToDigi.caloStage1Digis_cfi import caloStage1Digis
-    # this adds the physical ET to unpacked data
-    from L1Trigger.L1TCalorimeter.caloStage1LegacyFormatDigis_cfi import caloStage1LegacyFormatDigis
-    from L1Trigger.L1TCalorimeter.caloStage1FinalDigis_cfi import caloStage1FinalDigis
-    csctfDigis.producer = 'rawDataCollector'
-    dttfDigis.DTTF_FED_Source = 'rawDataCollector'
-    gtDigis.DaqGtInputTag = 'rawDataCollector'
-    # unpack GCT digis too, so DQM offline doesn't crash:
-    import EventFilter.GctRawToDigi.l1GctHwDigis_cfi
-    gctDigis = EventFilter.GctRawToDigi.l1GctHwDigis_cfi.l1GctHwDigis.clone()
-    gctDigis.inputLabel = 'rawDataCollector'
-    L1TRawToDigi_Stage1 = cms.Task(csctfDigis,dttfDigis,gtDigis,caloStage1Digis,caloStage1FinalDigis,caloStage1LegacyFormatDigis,gctDigis)    
-
-def unpack_stage2():
-    global L1TRawToDigi_Stage2
-    global rpcTwinMuxRawToDigi, twinMuxStage2Digis, bmtfDigis, omtfStage2Digis, rpcCPPFRawToDigi, emtfStage2Digis, caloLayer1Digis, caloStage2Digis, gmtStage2Digis, gtStage2Digis,L1TRawToDigi_Stage2    
-    from EventFilter.RPCRawToDigi.rpcTwinMuxRawToDigi_cfi import rpcTwinMuxRawToDigi
-    from EventFilter.RPCRawToDigi.RPCCPPFRawToDigi_cfi import rpcCPPFRawToDigi
-    from EventFilter.L1TRawToDigi.bmtfDigis_cfi import bmtfDigis 
-    from EventFilter.L1TRawToDigi.omtfStage2Digis_cfi import omtfStage2Digis
-    from EventFilter.L1TRawToDigi.emtfStage2Digis_cfi import emtfStage2Digis
-    from EventFilter.L1TRawToDigi.caloLayer1Digis_cfi import caloLayer1Digis
-    from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import caloStage2Digis
-    from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import gmtStage2Digis
-    from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
-    from EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi import twinMuxStage2Digis
-    L1TRawToDigi_Stage2 = cms.Task(rpcTwinMuxRawToDigi, twinMuxStage2Digis, bmtfDigis, omtfStage2Digis, rpcCPPFRawToDigi, emtfStage2Digis, caloLayer1Digis, caloStage2Digis, gmtStage2Digis, gtStage2Digis)
-    
 #
 # Legacy Trigger:
 #
-from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-    unpack_legacy()
-    L1TRawToDigiTask = cms.Task(L1TRawToDigi_Legacy);
+import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
+csctfDigis = EventFilter.CSCTFRawToDigi.csctfunpacker_cfi.csctfunpacker.clone(producer = 'rawDataCollector')
+import EventFilter.DTTFRawToDigi.dttfunpacker_cfi
+dttfDigis = EventFilter.DTTFRawToDigi.dttfunpacker_cfi.dttfunpacker.clone(DTTF_FED_Source = 'rawDataCollector')
+import EventFilter.GctRawToDigi.l1GctHwDigis_cfi
+gctDigis = EventFilter.GctRawToDigi.l1GctHwDigis_cfi.l1GctHwDigis.clone(inputLabel = 'rawDataCollector')
+import EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi
+gtDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone(DaqGtInputTag = 'rawDataCollector')
+import EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi
+gtEvmDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtEvmUnpack_cfi.l1GtEvmUnpack.clone(EvmGtInputTag = 'rawDataCollector')
+L1TRawToDigi_Legacy = cms.Task(csctfDigis,dttfDigis,gctDigis,gtDigis,gtEvmDigis)
+L1TRawToDigiTask = cms.Task(L1TRawToDigi_Legacy)
 
 #
 # Stage-1 Trigger
 #
-if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-    unpack_stage1()
-    L1TRawToDigiTask = cms.Task(L1TRawToDigi_Stage1)
+from EventFilter.L1TRawToDigi.caloStage1Digis_cfi import caloStage1Digis
+# this adds the physical ET to unpacked data
+from L1Trigger.L1TCalorimeter.caloStage1LegacyFormatDigis_cfi import caloStage1LegacyFormatDigis
+from L1Trigger.L1TCalorimeter.caloStage1FinalDigis_cfi import caloStage1FinalDigis
+from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+L1TRawToDigi_Stage1 = L1TRawToDigi_Legacy.copyAndExclude([gctDigis, gtDigis, gtEvmDigis])
+L1TRawToDigi_Stage1.add(gtDigis,caloStage1Digis,caloStage1FinalDigis,caloStage1LegacyFormatDigis,gctDigis)
+(stage1L1Trigger & ~stage2L1Trigger).toReplaceWith(L1TRawToDigiTask, cms.Task(L1TRawToDigi_Stage1))
 
 #
 # Stage-2 Trigger:  fow now, unpack Stage 1 and Stage 2 (in case both available)
 #
-if stage2L1Trigger.isChosen():
-    unpack_stage1()
-    unpack_stage2()
-    L1TRawToDigiTask = cms.Task(L1TRawToDigi_Stage1,L1TRawToDigi_Stage2)
-    # we only warn if it is stage-2 era and it is an essential, always present, stage-2 payload:
-    caloStage2Digis.MinFeds = cms.uint32(1)
-    gmtStage2Digis.MinFeds = cms.uint32(1)
-    gtStage2Digis.MinFeds = cms.uint32(1)
-    
+from EventFilter.RPCRawToDigi.rpcTwinMuxRawToDigi_cfi import rpcTwinMuxRawToDigi
+from EventFilter.RPCRawToDigi.RPCCPPFRawToDigi_cfi import rpcCPPFRawToDigi
+from EventFilter.L1TRawToDigi.bmtfDigis_cfi import bmtfDigis
+from EventFilter.L1TRawToDigi.omtfStage2Digis_cfi import omtfStage2Digis
+from EventFilter.L1TRawToDigi.emtfStage2Digis_cfi import emtfStage2Digis
+from EventFilter.L1TRawToDigi.caloLayer1Digis_cfi import caloLayer1Digis
+from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import caloStage2Digis
+from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import gmtStage2Digis
+from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
+from EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi import twinMuxStage2Digis
+# we only warn if it is stage-2 era and it is an essential, always present, stage-2 payload:
+stage2L1Trigger.toModify(caloStage2Digis, MinFeds = cms.uint32(1))
+stage2L1Trigger.toModify(gmtStage2Digis, MinFeds = cms.uint32(1))
+stage2L1Trigger.toModify(gtStage2Digis, MinFeds = cms.uint32(1))
+L1TRawToDigi_Stage2 = cms.Task(rpcTwinMuxRawToDigi, twinMuxStage2Digis, bmtfDigis, omtfStage2Digis, rpcCPPFRawToDigi, emtfStage2Digis, caloLayer1Digis, caloStage2Digis, gmtStage2Digis, gtStage2Digis)
+stage2L1Trigger.toReplaceWith(L1TRawToDigiTask, cms.Task(L1TRawToDigi_Stage1,L1TRawToDigi_Stage2))
 
 L1TRawToDigi = cms.Sequence(L1TRawToDigiTask)

--- a/L1Trigger/Configuration/python/SimL1TechnicalTriggers_cff.py
+++ b/L1Trigger/Configuration/python/SimL1TechnicalTriggers_cff.py
@@ -26,9 +26,8 @@ import SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi
 simCastorTechTrigDigis = SimCalorimetry.CastorTechTrigProducer.castorTTRecord_cfi.simCastorTTRecord.clone()
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage2L1Trigger.isChosen()):
-    SimL1TechnicalTriggers = cms.Sequence( 
+(~stage2L1Trigger).toReplaceWith(SimL1TechnicalTriggers, cms.Sequence(
         simBscDigis + 
         simRpcTechTrigDigis + 
         simHcalTechTrigDigis +
-        simCastorTechTrigDigis )
+        simCastorTechTrigDigis ))

--- a/L1Trigger/Configuration/python/customiseReEmul.py
+++ b/L1Trigger/Configuration/python/customiseReEmul.py
@@ -64,34 +64,39 @@ def L1TReEmulFromRAW2015(process):
     process.simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'muonCSCDigis', 'MuonCSCComparatorDigi')
     process.simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'muonCSCDigis', 'MuonCSCWireDigi' )  
 
-    if stage2L1Trigger.isChosen():
-        process.simTwinMuxDigis.RPC_Source         = cms.InputTag('muonRPCDigis')
+    stage2L1Trigger.toModify(process.simTwinMuxDigis,
+        RPC_Source         = 'muonRPCDigis',
         # When available, this will switch to TwinMux input Digis:
-        process.simTwinMuxDigis.DTDigi_Source      = cms.InputTag("dttfDigis")
-        process.simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("dttfDigis")
-        process.simOmtfDigis.srcRPC                = cms.InputTag('muonRPCDigis')
-        process.simBmtfDigis.DTDigi_Source         = cms.InputTag("simTwinMuxDigis")
-        process.simBmtfDigis.DTDigi_Theta_Source   = cms.InputTag("dttfDigis")
-        process.simEmtfDigis.CSCInput              = cms.InputTag("csctfDigis")
-        process.simEmtfDigis.RPCInput              = cms.InputTag('muonRPCDigis')
-        process.simOmtfDigis.srcCSC                = cms.InputTag("csctfDigis")
-        process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("ecalDigis:EcalTriggerPrimitives")
-        process.L1TReEmulPath = cms.Path(process.L1TReEmul)    
-        process.schedule.append(process.L1TReEmulPath)
-        # quiet warning abouts missing Stage-2 payloads, since they won't reliably exist in 2015 data.
-        if hasattr(process, "caloStage2Digis"):
-            process.caloStage2Digis.MinFeds = cms.uint32(0)
-        if hasattr(process, "gmtStage2Digis"):
-            process.gmtStage2Digis.MinFeds = cms.uint32(0)
-        if hasattr(process, "gtStage2Digis"):
-            process.gtStage2Digis.MinFeds = cms.uint32(0)            
-    else:
-        process.simRctDigis.ecalDigis = cms.VInputTag('simEcalTriggerPrimitiveDigis')
-        process.simRctDigis.hcalDigis = cms.VInputTag('simHcalTriggerPrimitiveDigis')
-        process.simRpcTriggerDigis.label = 'muonRPCDigis'
-        process.simRpcTechTrigDigis.RPCDigiLabel  = 'muonRPCDigis'
-        process.L1TReEmulPath = cms.Path(process.L1TReEmul)    
-        process.schedule.append(process.L1TReEmulPath)
+        DTDigi_Source      = "dttfDigis",
+        DTThetaDigi_Source = "dttfDigis"
+    )
+    stage2L1Trigger.toModify(process.simOmtfDigis,
+        srcRPC = 'muonRPCDigis',
+        srcCSC = "csctfDigis"
+    )
+    stage2L1Trigger.toModify(process.simBmtfDigis,
+        DTDigi_Source         = "simTwinMuxDigis",
+        DTDigi_Theta_Source   = "dttfDigis"
+    )
+    stage2L1Trigger.toModify(process.simEmtfDigis,
+        CSCInput = "csctfDigis",
+        RPCInput = 'muonRPCDigis'
+    )
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis, ecalToken = "ecalDigis:EcalTriggerPrimitives")
+    # quiet warning abouts missing Stage-2 payloads, since they won't reliably exist in 2015 data.
+    stage2L1Trigger.toModify(process.caloStage2Digis, MinFeds = 0)
+    stage2L1Trigger.toModify(process.gmtStage2Digis, MinFeds = 0)
+    stage2L1Trigger.toModify(process.gtStage2Digis, MinFeds = 0)
+
+    (~stage2L1Trigger).toModify(process.simRctDigis,
+        ecalDigis = ['simEcalTriggerPrimitiveDigis'],
+        hcalDigis = ['simHcalTriggerPrimitiveDigis']
+    )
+    (~stage2L1Trigger).toModify(process.simRpcTriggerDigis, label = 'muonRPCDigis')
+    (~stage2L1Trigger).toModify(process.simRpcTechTrigDigis, RPCDigiLabel  = 'muonRPCDigis')
+
+    process.L1TReEmulPath = cms.Path(process.L1TReEmul)
+    process.schedule.append(process.L1TReEmulPath)
 
     print("# L1TReEmul sequence:  ")
     print("# {0}".format(process.L1TReEmul))
@@ -100,15 +105,13 @@ def L1TReEmulFromRAW2015(process):
 
 def L1TReEmulMCFromRAW2015(process):
     L1TReEmulFromRAW2015(process)
-    if stage2L1Trigger.isChosen():
-            process.simEmtfDigis.CSCInput           = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED')
-            process.simOmtfDigis.srcCSC             = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED')
+    stage2L1Trigger.toModify(process.simEmtfDigis, CSCInput = 'simCscTriggerPrimitiveDigis:MPCSORTED')
+    stage2L1Trigger.toModify(process.simOmtfDigis, srcCSC   = 'simCscTriggerPrimitiveDigis:MPCSORTED')
     return process
 
 def L1TReEmulFromRAW2015simCaloTP(process):
     L1TReEmulFromRAW2015(process)
-    if stage2L1Trigger.isChosen():
-            process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("simEcalTriggerPrimitiveDigis")
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis, ecalToken = "simEcalTriggerPrimitiveDigis")
     return process
 
 def L1TReEmulFromRAW2016(process):
@@ -126,47 +129,58 @@ def L1TReEmulFromRAW2016(process):
     process.simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'muonCSCDigis', 'MuonCSCComparatorDigi')
     process.simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'muonCSCDigis', 'MuonCSCWireDigi' )  
     process.L1TReEmul = cms.Sequence(process.simEcalTriggerPrimitiveDigis * process.simHcalTriggerPrimitiveDigis * process.SimL1Emulator)
-    if stage2L1Trigger.isChosen():
-        #cutlist=['simDtTriggerPrimitiveDigis','simCscTriggerPrimitiveDigis']
-        #for b in cutlist:
-        #    process.SimL1Emulator.remove(getattr(process,b))
-        # TwinMux
-        process.simTwinMuxDigis.RPC_Source         = cms.InputTag('RPCTwinMuxRawToDigi')
-        process.simTwinMuxDigis.DTDigi_Source      = cms.InputTag('twinMuxStage2Digis:PhIn')
-        process.simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag('twinMuxStage2Digis:ThIn')
-        # BMTF
-        process.simBmtfDigis.DTDigi_Source         = cms.InputTag('simTwinMuxDigis')
-        process.simBmtfDigis.DTDigi_Theta_Source   = cms.InputTag('bmtfDigis')
-        # OMTF
-        process.simOmtfDigis.srcRPC                = cms.InputTag('muonRPCDigis')
-        process.simOmtfDigis.srcCSC                = cms.InputTag('csctfDigis')
-        process.simOmtfDigis.srcDTPh               = cms.InputTag('bmtfDigis')
-        process.simOmtfDigis.srcDTTh               = cms.InputTag('bmtfDigis')
-        # EMTF
-        process.simEmtfDigis.CSCInput              = cms.InputTag('emtfStage2Digis')
-        process.simEmtfDigis.RPCInput              = cms.InputTag('muonRPCDigis')
-        # Calo Layer1
-        process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag('ecalDigis:EcalTriggerPrimitives')
-        process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag('hcalDigis:')
-        process.L1TReEmulPath = cms.Path(process.L1TReEmul)    
-        process.schedule.append(process.L1TReEmulPath)
-        return process
-    else:
-        process.simRctDigis.ecalDigis = cms.VInputTag( cms.InputTag( 'ecalDigis:EcalTriggerPrimitives' ) )
-        process.simRctDigis.hcalDigis = cms.VInputTag('hcalDigis:')
-        process.simRpcTriggerDigis.label         = 'muonRPCDigis'
-        process.L1TReEmulPath = cms.Path(process.L1TReEmul)    
-        process.schedule.append(process.L1TReEmulPath)
-        return process
+
+    #cutlist=['simDtTriggerPrimitiveDigis','simCscTriggerPrimitiveDigis']
+    #for b in cutlist:
+    #    process.SimL1Emulator.remove(getattr(process,b))
+    # TwinMux
+    stage2L1Trigger.toModify(process.simTwinMuxDigis,
+        RPC_Source         = 'RPCTwinMuxRawToDigi',
+        DTDigi_Source      = 'twinMuxStage2Digis:PhIn',
+        DTThetaDigi_Source = 'twinMuxStage2Digis:ThIn'
+    )
+    # BMTF
+    stage2L1Trigger.toModify(process.simBmtfDigis,
+        DTDigi_Source       = 'simTwinMuxDigis',
+        DTDigi_Theta_Source = 'bmtfDigis'
+    )
+    # OMTF
+    stage2L1Trigger.toModify(process.simOmtfDigis,
+        srcRPC  = 'muonRPCDigis',
+        srcCSC  = 'csctfDigis',
+        srcDTPh = 'bmtfDigis',
+        srcDTTh = 'bmtfDigis'
+    )
+    # EMTF
+    stage2L1Trigger.toModify(process.simEmtfDigis,
+        CSCInput = 'emtfStage2Digis',
+        RPCInput = 'muonRPCDigis'
+    )
+    # Calo Layer1
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis,
+        ecalToken = 'ecalDigis:EcalTriggerPrimitives',
+        hcalToken = 'hcalDigis:'
+    )
+
+    (~stage2L1Trigger).toModify(process.simRctDigis,
+        ecalDigis = ['ecalDigis:EcalTriggerPrimitives'],
+        hcalDigis = ['hcalDigis:']
+    )
+    (~stage2L1Trigger).toModify(process.simRpcTriggerDigis, label = 'muonRPCDigis')
+
+    process.L1TReEmulPath = cms.Path(process.L1TReEmul)    
+    process.schedule.append(process.L1TReEmulPath)
+    return process
 
 def L1TReEmulFromRAW(process):
     L1TReEmulFromRAW2016(process)
 
-    if stage2L1Trigger_2017.isChosen():
-        process.simOmtfDigis.srcRPC                = cms.InputTag('omtfStage2Digis')
-        process.simOmtfDigis.srcCSC                = cms.InputTag('omtfStage2Digis')
-        process.simOmtfDigis.srcDTPh               = cms.InputTag('omtfStage2Digis')
-        process.simOmtfDigis.srcDTTh               = cms.InputTag('omtfStage2Digis')
+    stage2L1Trigger_2017.toModify(process.simOmtfDigis,
+        srcRPC   = 'omtfStage2Digis',
+        srcCSC   = 'omtfStage2Digis',
+        srcDTPh  = 'omtfStage2Digis',
+        srcDTTh  = 'omtfStage2Digis'
+    )
 
     print("# L1TReEmul sequence:  ")
     print("# {0}".format(process.L1TReEmul))
@@ -182,13 +196,14 @@ def L1TReEmulFromNANO(process):
 
     process.load('L1Trigger.Configuration.SimL1Emulator_cff')
     process.L1TReEmul = cms.Sequence(process.SimL1TGlobal)
-    if stage2L1Trigger_2017.isChosen():
-        process.simGtStage2Digis.ExtInputTag = cms.InputTag("hltGtStage2Digis")
-        process.simGtStage2Digis.MuonInputTag = cms.InputTag("hltGtStage2Digis", "Muon")
-        process.simGtStage2Digis.EtSumInputTag = cms.InputTag("hltGtStage2Digis", "EtSum")
-        process.simGtStage2Digis.EGammaInputTag = cms.InputTag("hltGtStage2Digis", "EGamma")
-        process.simGtStage2Digis.TauInputTag = cms.InputTag("hltGtStage2Digis", "Tau")
-        process.simGtStage2Digis.JetInputTag = cms.InputTag("hltGtStage2Digis", "Jet")
+    stage2L1Trigger_2017.toModify(process.simGtStage2Digis,
+        ExtInputTag = "hltGtStage2Digis",
+        MuonInputTag = "hltGtStage2Digis:Muon",
+        EtSumInputTag = "hltGtStage2Digis:EtSum",
+        EGammaInputTag = "hltGtStage2Digis:EGamma",
+        TauInputTag = "hltGtStage2Digis:Tau",
+        JetInputTag = "hltGtStage2Digis:Jet"
+    )
         
     process.L1TReEmulPath = cms.Path(process.L1TReEmul)    
     process.schedule.append(process.L1TReEmulPath)
@@ -213,35 +228,33 @@ def L1TReEmulFromRAWCalo(process):
 
 def L1TReEmulMCFromRAW(process):
     L1TReEmulFromRAW(process)
-    if stage2L1Trigger.isChosen():
-            process.simEmtfDigis.CSCInput           = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED')
-            process.simOmtfDigis.srcCSC             = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED')
+    stage2L1Trigger.toModify(process.simEmtfDigis, CSCInput = 'simCscTriggerPrimitiveDigis:MPCSORTED')
+    stage2L1Trigger.toModify(process.simOmtfDigis, srcCSC   = 'simCscTriggerPrimitiveDigis:MPCSORTED')
     return process
 
 def L1TReEmulMCFromRAWSimEcalTP(process):
     L1TReEmulMCFromRAW(process)
-    if stage2L1Trigger.isChosen():
-            process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("simEcalTriggerPrimitiveDigis")
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis, ecalToken = "simEcalTriggerPrimitiveDigis")
     return process
 
 def L1TReEmulMCFromRAWSimHcalTP(process):
     L1TReEmulMCFromRAW(process)
-    if stage2L1Trigger.isChosen():
-            process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis, hcalToken = 'simHcalTriggerPrimitiveDigis')
     return process
 
 def L1TReEmulMCFrom90xRAWSimHcalTP(process):
     L1TReEmulMCFromRAW(process)
-    if stage2L1Trigger.isChosen():
-            process.simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
-                cms.InputTag('simHcalUnsuppressedDigis'),
-                cms.InputTag('simHcalUnsuppressedDigis')
-            )
-            process.simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
-                cms.InputTag('simHcalUnsuppressedDigis:HBHEQIE11DigiCollection'),
-                cms.InputTag('simHcalUnsuppressedDigis:HFQIE10DigiCollection')
-            )
-            process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
+    stage2L1Trigger.toModify(process.simHcalTriggerPrimitiveDigis,
+        inputLabel = [
+            'simHcalUnsuppressedDigis',
+            'simHcalUnsuppressedDigis'
+        ],
+        inputUpgradeLabel = [
+            'simHcalUnsuppressedDigis:HBHEQIE11DigiCollection',
+            'simHcalUnsuppressedDigis:HFQIE10DigiCollection'
+        ]
+    )
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis, hcalToken = 'simHcalTriggerPrimitiveDigis')
     return process
     #inputUpgradeLabel = cms.VInputTag(
     #    cms.InputTag('simHcalUnsuppressedDigis:HBHEQIE11DigiCollection'),
@@ -249,44 +262,52 @@ def L1TReEmulMCFrom90xRAWSimHcalTP(process):
 
 def L1TReEmulMCFromRAWSimCalTP(process):
     L1TReEmulMCFromRAW(process)
-    if stage2L1Trigger.isChosen():
-            process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("simEcalTriggerPrimitiveDigis")
-            process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis,
+        ecalToken = "simEcalTriggerPrimitiveDigis",
+        hcalToken = 'simHcalTriggerPrimitiveDigis'
+    ) 
     return process
 
 def L1TReEmulFromRAWsimEcalTP(process):
     L1TReEmulFromRAW(process)
-    if stage2L1Trigger.isChosen():
-            process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("simEcalTriggerPrimitiveDigis")
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis, ecalToken = "simEcalTriggerPrimitiveDigis")
     return process
 
 def L1TReEmulFromRAWsimHcalTP(process):
     L1TReEmulFromRAW(process)
-    if stage2L1Trigger.isChosen():
-            process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis, hcalToken = 'simHcalTriggerPrimitiveDigis')
     return process
 
 def L1TReEmulFromRAWsimTP(process):
     L1TReEmulFromRAW(process)
-    if stage2L1Trigger.isChosen():
-        # TwinMux
-        process.simTwinMuxDigis.RPC_Source         = cms.InputTag('muonRPCDigis')
-        process.simTwinMuxDigis.DTDigi_Source      = cms.InputTag('simDtTriggerPrimitiveDigis')
-        process.simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag('simDtTriggerPrimitiveDigis')
-        # BMTF
-        process.simBmtfDigis.DTDigi_Source         = cms.InputTag('simTwinMuxDigis')
-        process.simBmtfDigis.DTDigi_Theta_Source   = cms.InputTag('simDtTriggerPrimitiveDigis')
-        # OMTF
-        process.simOmtfDigis.srcRPC                = cms.InputTag('muonRPCDigis')
-        process.simOmtfDigis.srcCSC                = cms.InputTag('simCscTriggerPrimitiveDigis')
-        process.simOmtfDigis.srcDTPh               = cms.InputTag('simDtTriggerPrimitiveDigis')
-        process.simOmtfDigis.srcDTTh               = cms.InputTag('simDtTriggerPrimitiveDigis')
-        # EMTF
-        process.simEmtfDigis.CSCInput              = cms.InputTag('simCscTriggerPrimitiveDigis')
-        process.simEmtfDigis.RPCInput              = cms.InputTag('muonRPCDigis')
-        # Layer1
-        process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("simEcalTriggerPrimitiveDigis")
-        process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag('simHcalTriggerPrimitiveDigis')
+    # TwinMux
+    stage2L1Trigger.toModify(process.simTwinMuxDigis,
+        RPC_Source         = 'muonRPCDigis',
+        DTDigi_Source      = 'simDtTriggerPrimitiveDigis',
+        DTThetaDigi_Source = 'simDtTriggerPrimitiveDigis'
+    )
+    # BMTF
+    stage2L1Trigger.toModify(process.simBmtfDigis,
+        DTDigi_Source         = 'simTwinMuxDigis',
+        DTDigi_Theta_Source   = 'simDtTriggerPrimitiveDigis'
+    )
+    # OMTF
+    stage2L1Trigger.toModify(process.simOmtfDigis,
+        srcRPC  = 'muonRPCDigis',
+        srcCSC  = 'simCscTriggerPrimitiveDigis',
+        srcDTPh = 'simDtTriggerPrimitiveDigis',
+        srcDTTh = 'simDtTriggerPrimitiveDigis'
+    )
+    # EMTF
+    stage2L1Trigger.toModify(process.simEmtfDigis,
+        CSCInput = 'simCscTriggerPrimitiveDigis',
+        RPCInput = 'muonRPCDigis'
+    )
+    # Layer1
+    stage2L1Trigger.toModify(process.simCaloStage2Layer1Digis,
+        ecalToken = "simEcalTriggerPrimitiveDigis",
+        hcalToken = 'simHcalTriggerPrimitiveDigis'
+    )
     return process
 
 def L1TReEmulFromRAWLegacyMuon(process):

--- a/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
@@ -16,31 +16,25 @@ from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-#if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-#    sys.stderr.write("L1TCalorimeter conditions configured for Run1 (Legacy) trigger. \n")
-# 
+
+def _load(process, f):
+    process.load(f)
 
 #
 # Stage-1 Trigger
 #
-if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-    # Switch between HI and PP calo configuration:
-    if (run2_HI_specific.isChosen()):
-        from L1Trigger.L1TCalorimeter.caloConfigStage1HI_cfi import *
-    else:
-        from L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi import *
-    # Override Calo Scales:
-    from L1Trigger.L1TCalorimeter.caloScalesStage1_cff import *
-    # CaloParams is in the DB for Stage-1
+# Switch between HI and PP calo configuration:
+modifyL1TCalorimeterHackConditions_stage1HI = (stage1L1Trigger & ~stage2L1Trigger & run2_HI_specific).makeProcessModifier(lambda p: _load(p, "L1Trigger.L1TCalorimeter.caloConfigStage1HI_cfi"))
+modifyL1TCalorimeterHackConditions_stage1PP = (stage1L1Trigger & ~stage2L1Trigger & ~run2_HI_specific).makeProcessModifier(lambda p: _load(p, "L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi"))
+# Override Calo Scales:
+modifyL1TCalorimeterHackConditions_stage1Common = (stage1L1Trigger & ~stage2L1Trigger).makeProcessModifier(lambda p: _load(p, "L1Trigger.L1TCalorimeter.caloScalesStage1_cff"))
+# CaloParams is in the DB for Stage-1
+
 
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
-    if pA_2016.isChosen():
-        from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_1_HI_cfi import *    
-    else:
-        from L1Trigger.L1TCalorimeter.caloStage2Params_2017_v1_8_4_cfi import *    
-    
-    # What about CaloConfig?  Related:  How will we switch PP/HH?
-    #
+modifyL1TCalorimeterHackConditions_stage2PA = (stage2L1Trigger & pA_2016).makeProcessModifier(lambda p: _load(p, "L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_1_HI_cfi"))
+modifyL1TCalorimeterHackConditions_stage2PP = (stage2L1Trigger & ~pA_2016).makeProcessModifier(lambda p: _load(p, "L1Trigger.L1TCalorimeter.caloStage2Params_2017_v1_8_4_cfi"))
+# What about CaloConfig?  Related:  How will we switch PP/HH?
+#

--- a/L1Trigger/L1TCalorimeter/python/simDigis_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/simDigis_cff.py
@@ -4,53 +4,49 @@ import sys
 #
 # Legacy Trigger:
 #
-from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
 # -  RCT (Regional Calorimeter Trigger) emulator
-    import L1Trigger.RegionalCaloTrigger.rctDigis_cfi
-    simRctDigis = L1Trigger.RegionalCaloTrigger.rctDigis_cfi.rctDigis.clone()
-    simRctDigis.ecalDigis = cms.VInputTag( cms.InputTag( 'simEcalTriggerPrimitiveDigis' ) )
-    simRctDigis.hcalDigis = cms.VInputTag( cms.InputTag( 'simHcalTriggerPrimitiveDigis' ) )
+import L1Trigger.RegionalCaloTrigger.rctDigis_cfi
+simRctDigis = L1Trigger.RegionalCaloTrigger.rctDigis_cfi.rctDigis.clone(
+    ecalDigis = ['simEcalTriggerPrimitiveDigis'],
+    hcalDigis = ['simHcalTriggerPrimitiveDigis']
+)
 # - GCT (Global Calorimeter Trigger) emulator
-    import L1Trigger.GlobalCaloTrigger.gctDigis_cfi
-    simGctDigis = L1Trigger.GlobalCaloTrigger.gctDigis_cfi.gctDigis.clone()
-    simGctDigis.inputLabel = 'simRctDigis'
-    SimL1TCalorimeter = cms.Sequence(simRctDigis + simGctDigis)
+import L1Trigger.GlobalCaloTrigger.gctDigis_cfi
+simGctDigis = L1Trigger.GlobalCaloTrigger.gctDigis_cfi.gctDigis.clone(
+    inputLabel = 'simRctDigis'
+)
+SimL1TCalorimeter = cms.Sequence(simRctDigis + simGctDigis)
 
 #
 # Stage-1 Trigger
 #
-if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-#
-# -  RCT (Regional Calorimeter Trigger) emulator
-#
-    import L1Trigger.RegionalCaloTrigger.rctDigis_cfi
-    simRctDigis = L1Trigger.RegionalCaloTrigger.rctDigis_cfi.rctDigis.clone()
-    simRctDigis.ecalDigis = cms.VInputTag( cms.InputTag( 'simEcalTriggerPrimitiveDigis' ) )
-    simRctDigis.hcalDigis = cms.VInputTag( cms.InputTag( 'simHcalTriggerPrimitiveDigis' ) )
 #
 # - Stage-1 Layer-2 Calorimeter Trigger Emulator, with required converters (Stage-1 mixes legacy and upgrade) 
 #
-    from L1Trigger.L1TCalorimeter.simRctUpgradeFormatDigis_cfi import *
-    from L1Trigger.L1TCalorimeter.simCaloStage1Digis_cfi import *
-    from L1Trigger.L1TCalorimeter.simCaloStage1FinalDigis_cfi import *
-    from L1Trigger.L1TCalorimeter.simCaloStage1LegacyFormatDigis_cfi import *
-    from L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi import *
-    SimL1TCalorimeter = cms.Sequence(simRctDigis + simRctUpgradeFormatDigis + simCaloStage1Digis + simCaloStage1FinalDigis + simCaloStage1LegacyFormatDigis)
+from L1Trigger.L1TCalorimeter.simRctUpgradeFormatDigis_cfi import *
+from L1Trigger.L1TCalorimeter.simCaloStage1Digis_cfi import *
+from L1Trigger.L1TCalorimeter.simCaloStage1FinalDigis_cfi import *
+from L1Trigger.L1TCalorimeter.simCaloStage1LegacyFormatDigis_cfi import *
+from L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi import *
+from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+(stage1L1Trigger & ~stage2L1Trigger).toReplaceWith(SimL1TCalorimeter, cms.Sequence(simRctDigis + simRctUpgradeFormatDigis + simCaloStage1Digis + simCaloStage1FinalDigis + simCaloStage1LegacyFormatDigis))
+
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
-    # select one of the following two options:
-    # - layer1 from L1Trigger/L1TCalorimeter package
-    #from L1Trigger.L1TCalorimeter.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
-    # - layer1 from L1Trigger/L1TCaloLayer1 package
-    from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
-    from L1Trigger.L1TCalorimeter.simCaloStage2Digis_cfi import simCaloStage2Digis
+# select one of the following two options:
+# - layer1 from L1Trigger/L1TCalorimeter package
+#from L1Trigger.L1TCalorimeter.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
+# - layer1 from L1Trigger/L1TCaloLayer1 package
+from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
+from L1Trigger.L1TCalorimeter.simCaloStage2Digis_cfi import simCaloStage2Digis
+stage2L1Trigger.toReplaceWith(SimL1TCalorimeter, cms.Sequence( simCaloStage2Layer1Digis + simCaloStage2Digis ))
+
+def _modifyStage2L1TriggerCaloParams(process):
     from CondCore.CondDB.CondDB_cfi import CondDB
     CondDB.connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-    l1conddb = cms.ESSource("PoolDBESSource",
+    process.l1conddb = cms.ESSource("PoolDBESSource",
        CondDB,
        toGet   = cms.VPSet(
             cms.PSet(
@@ -59,6 +55,4 @@ if stage2L1Trigger.isChosen():
             )
        )
     )
-    SimL1TCalorimeter = cms.Sequence( simCaloStage2Layer1Digis + simCaloStage2Digis )
-
-    
+modifySimDigis_stage2L1TriggerCaloPArams = stage2L1Trigger.makeProcessModifier(_modifyStage2L1TriggerCaloParams)

--- a/L1Trigger/L1TCommon/test/reEmul.py
+++ b/L1Trigger/L1TCommon/test/reEmul.py
@@ -20,7 +20,10 @@ from __future__ import print_function
 
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
-from Configuration.StandardSequences.Eras import eras
+from Configuration.Eras.Era_Run2_25ns_cff import Run2_25ns
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 import os
 import sys
 import commands
@@ -42,19 +45,19 @@ options.parseArguments()
 
 if (options.era == 'stage1'):
     print("INFO: runnings L1T Stage-1 (2015) Re-Emulation")
-    process = cms.Process("L1TReEmulation", eras.Run2_25ns)
+    process = cms.Process("L1TReEmulation", Run2_25ns)
 elif (options.era == 'stage2'):
     print("INFO: runnings L1T Stage-2 (2016) Re-Emulation")    
-    process = cms.Process("L1TReEmulation", eras.Run2_2016)
+    process = cms.Process("L1TReEmulation", Run2_2016)
 else:
     print("ERROR: unknown era:  ", options.era, "\n")
     exit(0)
 
 if (options.output == 'DEFAULT'):
-    if (eras.stage1L1Trigger.isChosen()):
-        options.output ='l1t_stage1.root'
-    if (eras.stage2L1Trigger.isChosen()):
-        options.output ='l1t_stage2.root'
+    tmp = cms.PSet(output = cms.string(""))
+    stage1L1Trigger.toModify(tmp, output ='l1t_stage1.root')
+    stage2L1Trigger.toModify(tmp, output ='l1t_stage2.root')
+    options.output = tmp.output.value()
 print("INFO: output:  ", options.output)
 
 print("INFO: input:  ", options.input)
@@ -85,14 +88,13 @@ from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 #   best for now to use MC GT, even when running over a data file, and just
 #   ignore the main DT TP emulator warnings...  (In future we'll override only
 #   L1T emulator related conditions, so you can use a data GT)
-if (eras.stage1L1Trigger.isChosen()):
-    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 # Note:  For stage-2, all conditions are overriden by local config file.  Use data tag: 
 
-if (eras.stage2L1Trigger.isChosen()):
-    #process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
-    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
-    process.GlobalTag.toGet = cms.VPSet(
+stage2L1Trigger.toReplaceWith(process.GlobalTag,
+    #GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+    GlobalTag(process.GlobalTag, 'auto:run2_data', '').clone(
+    toGet = cms.VPSet(
         cms.PSet(record = cms.string("DTCCBConfigRcd"),
                  tag = cms.string("DTCCBConfig_NOSingleL_V05_mc"),
                  connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
@@ -110,6 +112,7 @@ if (eras.stage2L1Trigger.isChosen()):
                  connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
                  ),
         )
+))
 
 #### Sim L1 Emulator Sequence:
 process.load('Configuration.StandardSequences.RawToDigi_cff')
@@ -123,18 +126,14 @@ process.dumpES = cms.EDAnalyzer("PrintEventSetupContent")
 
 
 import L1Trigger.L1TCommon.l1tSummaryStage1Digis_cfi
-import L1Trigger.L1TCommon.l1tSummaryStage2Digis_cfi
-if (eras.stage1L1Trigger.isChosen()):
-    process.l1tSummaryA = L1Trigger.L1TCommon.l1tSummaryStage1Digis_cfi.l1tSummaryStage1Digis.clone()
-if (eras.stage2L1Trigger.isChosen()):
-    process.l1tSummaryA = L1Trigger.L1TCommon.l1tSummaryStage2Digis_cfi.l1tSummaryStage2Digis.clone()
+import L1Trigger.L1TCommon.l1tSummaryStage2Digis_cf
+process.l1tSummaryA = L1Trigger.L1TCommon.l1tSummaryStage1Digis_cfi.l1tSummaryStage1Digis.clone()
+stage2L1Trigger.toReplaceWith(process.l1tSummaryA, L1Trigger.L1TCommon.l1tSummaryStage2Digis_cfi.l1tSummaryStage2Digis.clone())
 
 import L1Trigger.L1TCommon.l1tSummaryStage1SimDigis_cfi
 import L1Trigger.L1TCommon.l1tSummaryStage2SimDigis_cfi
-if (eras.stage1L1Trigger.isChosen()):
-    process.l1tSummaryB = L1Trigger.L1TCommon.l1tSummaryStage1SimDigis_cfi.l1tSummaryStage1SimDigis.clone()
-if (eras.stage2L1Trigger.isChosen()):
-    process.l1tSummaryB = L1Trigger.L1TCommon.l1tSummaryStage2SimDigis_cfi.l1tSummaryStage2SimDigis.clone()
+process.l1tSummaryB = L1Trigger.L1TCommon.l1tSummaryStage1SimDigis_cfi.l1tSummaryStage1SimDigis.clone()
+stage2L1Trigger.toReplaceWith(process.l1tSummaryB, L1Trigger.L1TCommon.l1tSummaryStage2SimDigis_cfi.l1tSummaryStage2SimDigis.clone())
 
 # Additional output definition
 # TTree output file
@@ -177,21 +176,21 @@ process.l1EventTree = cms.EDAnalyzer("L1EventTreeProducer",
 )
 
 # Stage-1 Ntuple will not contain muons, and might (investigating) miss some Taus.  (Work underway)
-process.l1UpgradeTree = cms.EDAnalyzer("L1UpgradeTreeProducer")
-if (eras.stage1L1Trigger.isChosen()):
-    process.l1UpgradeTree.egToken      = cms.untracked.InputTag("simCaloStage1FinalDigis")
-    process.l1UpgradeTree.tauTokens    = cms.untracked.VInputTag("simCaloStage1FinalDigis:rlxTaus","simCaloStage1FinalDigis:isoTaus")
-    process.l1UpgradeTree.jetToken     = cms.untracked.InputTag("simCaloStage1FinalDigis")
-    process.l1UpgradeTree.muonToken    = cms.untracked.InputTag("None")
-    process.l1UpgradeTree.sumToken     = cms.untracked.InputTag("simCaloStage1FinalDigis","")
-    process.l1UpgradeTree.maxL1Upgrade = cms.uint32(60)
-if (eras.stage2L1Trigger.isChosen()):
-    process.l1UpgradeTree.egToken      = cms.untracked.InputTag("simCaloStage2Digis")
-    process.l1UpgradeTree.tauTokens    = cms.untracked.VInputTag("simCaloStage2Digis")
-    process.l1UpgradeTree.jetToken     = cms.untracked.InputTag("simCaloStage2Digis")
-    process.l1UpgradeTree.muonToken    = cms.untracked.InputTag("simGmtStage2Digis")
-    process.l1UpgradeTree.sumToken     = cms.untracked.InputTag("simCaloStage2Digis","")
-    process.l1UpgradeTree.maxL1Upgrade = cms.uint32(60)
+process.l1UpgradeTree = cms.EDAnalyzer("L1UpgradeTreeProducer",
+    egToken      = cms.untracked.InputTag("simCaloStage1FinalDigis"),
+    tauTokens    = cms.untracked.VInputTag("simCaloStage1FinalDigis:rlxTaus","simCaloStage1FinalDigis:isoTaus"),
+    jetToken     = cms.untracked.InputTag("simCaloStage1FinalDigis"),
+    muonToken    = cms.untracked.InputTag("None"),
+    sumToken     = cms.untracked.InputTag("simCaloStage1FinalDigis",""),
+    maxL1Upgrade = cms.uint32(60)
+)
+stage2L1Trigger.toModify(process.l1UpgradeTree,
+    egToken      = "simCaloStage2Digis",
+    tauTokens    = ["simCaloStage2Digis"],
+    jetToken     = "simCaloStage2Digis",
+    muonToken    = "simGmtStage2Digis",
+    sumToken     = "simCaloStage2Digis"
+)
 
 
 process.L1TSeq = cms.Sequence(   process.RawToDigi        
@@ -212,24 +211,26 @@ process.schedule = cms.Schedule(process.L1TPath)
 
 # Re-emulating, so don't unpack L1T output, might not even exist...
 # Also, remove uneeded unpackers for speed.
-if (eras.stage2L1Trigger.isChosen()):
-    process.L1TSeq.remove(process.gmtStage2Digis)
-    process.L1TSeq.remove(process.caloStage2Digis)
-    process.L1TSeq.remove(process.gtStage2Digis)
-    process.L1TSeq.remove(process.siPixelDigis)
-    process.L1TSeq.remove(process.siStripDigis)
-    process.L1TSeq.remove(process.castorDigis)
-    process.L1TSeq.remove(process.scalersRawToDigi)
-    process.L1TSeq.remove(process.tcdsDigis)
-if (eras.stage1L1Trigger.isChosen()):
-    process.L1TSeq.remove(process.caloStage1Digis)
-    process.L1TSeq.remove(process.caloStage1FinalDigis)
-    process.L1TSeq.remove(process.gtDigis)
-    process.L1TSeq.remove(process.siPixelDigis)
-    process.L1TSeq.remove(process.siStripDigis)
-    process.L1TSeq.remove(process.castorDigis)
-    process.L1TSeq.remove(process.scalersRawToDigi)
-    process.L1TSeq.remove(process.tcdsDigis)
+stage2L1Trigger.toReplaceWith(process.L1TSeq, process.L1TSeq.copyAndExclude([
+    process.gmtStage2Digis,
+    process.caloStage2Digis,
+    process.gtStage2Digis,
+    process.siPixelDigis,
+    process.siStripDigis,
+    process.castorDigis,
+    process.scalersRawToDigi,
+    process.tcdsDigis
+]))
+stage1L1Trigger.toReplaceWith(process.L1TSeq, process.L1TSeq.copyAndExclude([
+    process.caloStage1Digis,
+    process.caloStage1FinalDigis,
+    process.gtDigis,
+    process.siPixelDigis,
+    process.siStripDigis,
+    process.castorDigis,
+    process.scalersRawToDigi,
+    process.tcdsDigis
+]))
 
 print(process.L1TSeq)
 print(process.L1TReEmulateFromRAW)

--- a/L1Trigger/L1TGlobal/python/hackConditions_cff.py
+++ b/L1Trigger/L1TGlobal/python/hackConditions_cff.py
@@ -16,21 +16,20 @@ import sys
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-#if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-#    sys.stderr.write("L1TGlobal conditions configured for Run1 (Legacy) trigger. \n")
-#
 
 #
 # Stage-1 Trigger:  No Hacks Needed
 #
-#if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-#    sys.stderr.write("L1TGlobal Conditions configured for Stage-1 (2015) trigger. \n")
 
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
-    from L1Trigger.L1TGlobal.GlobalParameters_cff import *
-    from L1Trigger.L1TGlobal.PrescalesVetos_cff import *
-#   from L1Trigger.L1TGlobal.TriggerMenu_cff import *
-#   TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2015_25nsStage1_v7_uGT.xml')
+def _load(process, fs):
+    for f in fs:
+        process.load(f)
+    #process.TriggerMenu.L1TriggerMenuFile = 'L1Menu_Collisions2015_25nsStage1_v7_uGT.xml'
+modifyL1TGlobalHackConditions_stage2 = stage2L1Trigger.makeProcessModifier(lambda p: _load(p, [
+    "L1Trigger.L1TGlobal.GlobalParameters_cff",
+    "L1Trigger.L1TGlobal.PrescalesVetos_cff",
+#   "L1Trigger.L1TGlobal.TriggerMenu_cff"
+]))

--- a/L1Trigger/L1TGlobal/python/simDigis_cff.py
+++ b/L1Trigger/L1TGlobal/python/simDigis_cff.py
@@ -8,29 +8,28 @@ import sys
 #
 # Legacy Trigger:
 #
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage2L1Trigger.isChosen()):
 #
 # -  Global Trigger emulator
 #
-    import L1Trigger.GlobalTrigger.gtDigis_cfi
-    simGtDigis = L1Trigger.GlobalTrigger.gtDigis_cfi.gtDigis.clone()
-    simGtDigis.GmtInputTag = 'simGmtDigis'
-    simGtDigis.GctInputTag = 'simGctDigis'
-    simGtDigis.TechnicalTriggersInputTags = cms.VInputTag(
-        cms.InputTag( 'simBscDigis' ), 
-        cms.InputTag( 'simRpcTechTrigDigis' ),
-        cms.InputTag( 'simHcalTechTrigDigis' ),
-        cms.InputTag( 'simCastorTechTrigDigis' )
-        )
-    SimL1TGlobal = cms.Sequence(simGtDigis)
+import L1Trigger.GlobalTrigger.gtDigis_cfi
+simGtDigis = L1Trigger.GlobalTrigger.gtDigis_cfi.gtDigis.clone(
+    GmtInputTag = 'simGmtDigis',
+    GctInputTag = 'simGctDigis',
+    TechnicalTriggersInputTags = [
+        'simBscDigis',
+        'simRpcTechTrigDigis',
+        'simHcalTechTrigDigis',
+        'simCastorTechTrigDigis'
+    ]
+)
+SimL1TGlobal = cms.Sequence(simGtDigis)
 
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
 #
 # -  Global Trigger emulator
 #
-    from L1Trigger.L1TGlobal.simGtStage2Digis_cfi import *
-    SimL1TGlobal = cms.Sequence(simGtStage2Digis)
+from L1Trigger.L1TGlobal.simGtStage2Digis_cfi import *
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toReplaceWith(SimL1TGlobal, cms.Sequence(simGtStage2Digis))

--- a/L1Trigger/L1TMuon/python/hackConditions_cff.py
+++ b/L1Trigger/L1TMuon/python/hackConditions_cff.py
@@ -11,22 +11,20 @@ import sys
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-#if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-#    sys.stderr.write("L1TMuon conditions configured for Run1 (Legacy) trigger. \n")
-# 
 
 #
 # Stage-1 Trigger:  No Hacks Needed
-#
-#if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-#    sys.stderr.write("L1TMuon Conditions configured for Stage-1 (2015) trigger. \n")
 
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
-    from L1Trigger.L1TTwinMux.fakeTwinMuxParams_cff import *
-    from L1Trigger.L1TMuonBarrel.fakeBmtfParams_cff import *
-    from L1Trigger.L1TMuonOverlap.fakeOmtfParams_cff import *
-    from L1Trigger.L1TMuonEndCap.fakeEmtfParams_cff import *
-    from L1Trigger.L1TMuon.fakeGmtParams_cff import *
+def _load(process, fs):
+    for f in fs:
+        process.load(f)
+modifyL1TMuonHackConditions_stage2 = stage2L1Trigger.makeProcessModifier(lambda p: _load(p, [
+    "L1Trigger.L1TTwinMux.fakeTwinMuxParams_cff",
+    "L1Trigger.L1TMuonBarrel.fakeBmtfParams_cff",
+    "L1Trigger.L1TMuonOverlap.fakeOmtfParams_cff",
+    "L1Trigger.L1TMuonEndCap.fakeEmtfParams_cff",
+    "L1Trigger.L1TMuon.fakeGmtParams_cff"
+]))

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -7,80 +7,84 @@ import sys
 #  - DT TP emulator
 from L1Trigger.DTTrigger.dtTriggerPrimitiveDigis_cfi import *
 import L1Trigger.DTTrigger.dtTriggerPrimitiveDigis_cfi
-simDtTriggerPrimitiveDigis = L1Trigger.DTTrigger.dtTriggerPrimitiveDigis_cfi.dtTriggerPrimitiveDigis.clone()
-
-simDtTriggerPrimitiveDigis.digiTag = 'simMuonDTDigis'
+simDtTriggerPrimitiveDigis = L1Trigger.DTTrigger.dtTriggerPrimitiveDigis_cfi.dtTriggerPrimitiveDigis.clone(
+    digiTag = 'simMuonDTDigis'
+)
 #simDtTriggerPrimitiveDigis.debug = cms.untracked.bool(True)
 
 # - CSC TP emulator
 from L1Trigger.CSCCommonTrigger.CSCCommonTrigger_cfi import *
 import L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi
-simCscTriggerPrimitiveDigis = L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi.cscTriggerPrimitiveDigis.clone()
-simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'simMuonCSCDigis', 'MuonCSCComparatorDigi' )
-simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'simMuonCSCDigis', 'MuonCSCWireDigi' )
+simCscTriggerPrimitiveDigis = L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigis_cfi.cscTriggerPrimitiveDigis.clone(
+    CSCComparatorDigiProducer = 'simMuonCSCDigis:MuonCSCComparatorDigi',
+    CSCWireDigiProducer       = 'simMuonCSCDigis:MuonCSCWireDigi'
+)
 
 SimL1TMuonCommon = cms.Sequence(simDtTriggerPrimitiveDigis + simCscTriggerPrimitiveDigis)
 
 #
 # Legacy Trigger:
 #
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-if not (stage2L1Trigger.isChosen()):
 #
 # - CSC Track Finder emulator
 #
-    import L1Trigger.CSCTrackFinder.csctfTrackDigis_cfi
-    simCsctfTrackDigis = L1Trigger.CSCTrackFinder.csctfTrackDigis_cfi.csctfTrackDigis.clone()
-    simCsctfTrackDigis.SectorReceiverInput = cms.untracked.InputTag( 'simCscTriggerPrimitiveDigis', 'MPCSORTED' )
-    simCsctfTrackDigis.DTproducer = 'simDtTriggerPrimitiveDigis'
-    import L1Trigger.CSCTrackFinder.csctfDigis_cfi
-    simCsctfDigis = L1Trigger.CSCTrackFinder.csctfDigis_cfi.csctfDigis.clone()
-    simCsctfDigis.CSCTrackProducer = 'simCsctfTrackDigis'
+import L1Trigger.CSCTrackFinder.csctfTrackDigis_cfi
+simCsctfTrackDigis = L1Trigger.CSCTrackFinder.csctfTrackDigis_cfi.csctfTrackDigis.clone(
+    SectorReceiverInput = 'simCscTriggerPrimitiveDigis:MPCSORTED',
+    DTproducer = 'simDtTriggerPrimitiveDigis'
+)
+import L1Trigger.CSCTrackFinder.csctfDigis_cfi
+simCsctfDigis = L1Trigger.CSCTrackFinder.csctfDigis_cfi.csctfDigis.clone(
+    CSCTrackProducer = 'simCsctfTrackDigis'
+)
 #
 # - DT Track Finder emulator
 # 
-    import L1Trigger.DTTrackFinder.dttfDigis_cfi
-    simDttfDigis = L1Trigger.DTTrackFinder.dttfDigis_cfi.dttfDigis.clone()
-    simDttfDigis.DTDigi_Source  = 'simDtTriggerPrimitiveDigis'
-    simDttfDigis.CSCStub_Source = 'simCsctfTrackDigis'
+import L1Trigger.DTTrackFinder.dttfDigis_cfi
+simDttfDigis = L1Trigger.DTTrackFinder.dttfDigis_cfi.dttfDigis.clone(
+    DTDigi_Source  = 'simDtTriggerPrimitiveDigis',
+    CSCStub_Source = 'simCsctfTrackDigis'
+)
 #
 # - RPC PAC Trigger emulator
 #
-    from L1Trigger.RPCTrigger.rpcTriggerDigis_cff import *
-    simRpcTriggerDigis = L1Trigger.RPCTrigger.rpcTriggerDigis_cff.rpcTriggerDigis.clone()
-    simRpcTriggerDigis.label = 'simMuonRPCDigis'
+from L1Trigger.RPCTrigger.rpcTriggerDigis_cff import *
+simRpcTriggerDigis = L1Trigger.RPCTrigger.rpcTriggerDigis_cff.rpcTriggerDigis.clone(
+    label = 'simMuonRPCDigis'
+)
 #
 # - Global Muon Trigger emulator
 #
-    import L1Trigger.GlobalMuonTrigger.gmtDigis_cfi
-    simGmtDigis = L1Trigger.GlobalMuonTrigger.gmtDigis_cfi.gmtDigis.clone()
-    simGmtDigis.DTCandidates   = cms.InputTag( 'simDttfDigis', 'DT' )
-    simGmtDigis.CSCCandidates  = cms.InputTag( 'simCsctfDigis', 'CSC' )
-    simGmtDigis.RPCbCandidates = cms.InputTag( 'simRpcTriggerDigis', 'RPCb' )
-    simGmtDigis.RPCfCandidates = cms.InputTag( 'simRpcTriggerDigis', 'RPCf' )
+import L1Trigger.GlobalMuonTrigger.gmtDigis_cfi
+simGmtDigis = L1Trigger.GlobalMuonTrigger.gmtDigis_cfi.gmtDigis.clone(
+    DTCandidates   = 'simDttfDigis:DT',
+    CSCCandidates  = 'simCsctfDigis:CSC',
+    RPCbCandidates = 'simRpcTriggerDigis:RPCb',
+    RPCfCandidates = 'simRpcTriggerDigis:RPCf',
 #   Note: GMT requires input from calorimeter emulators, namely MipIsoData from GCT
-    simGmtDigis.MipIsoData     = 'simRctDigis'
+    MipIsoData     = 'simRctDigis'
+)
 #
 #
-    SimL1TMuon = cms.Sequence(SimL1TMuonCommon + simCsctfTrackDigis + simCsctfDigis + simDttfDigis + simRpcTriggerDigis + simGmtDigis)
+SimL1TMuon = cms.Sequence(SimL1TMuonCommon + simCsctfTrackDigis + simCsctfDigis + simDttfDigis + simRpcTriggerDigis + simGmtDigis)
 
 #
 # Stage-2 Trigger
 #
-if stage2L1Trigger.isChosen():
-    from L1Trigger.L1TTwinMux.simTwinMuxDigis_cfi import *
-    from L1Trigger.L1TMuonBarrel.simBmtfDigis_cfi import *
-    from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *
-    from L1Trigger.L1TMuonOverlap.simOmtfDigis_cfi import *
-    from L1Trigger.L1TMuon.simGmtCaloSumDigis_cfi import *
-    from L1Trigger.L1TMuon.simGmtStage2Digis_cfi import *
+from L1Trigger.L1TTwinMux.simTwinMuxDigis_cfi import *
+from L1Trigger.L1TMuonBarrel.simBmtfDigis_cfi import *
+from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *
+from L1Trigger.L1TMuonOverlap.simOmtfDigis_cfi import *
+from L1Trigger.L1TMuon.simGmtCaloSumDigis_cfi import *
+from L1Trigger.L1TMuon.simGmtStage2Digis_cfi import *
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #
 #
-    SimL1TMuon = cms.Sequence(SimL1TMuonCommon + simTwinMuxDigis + simBmtfDigis + simEmtfDigis + simOmtfDigis + simGmtCaloSumDigis + simGmtStage2Digis)
+stage2L1Trigger.toReplaceWith(SimL1TMuon, cms.Sequence(SimL1TMuonCommon + simTwinMuxDigis + simBmtfDigis + simEmtfDigis + simOmtfDigis + simGmtCaloSumDigis + simGmtStage2Digis))
 
-    from L1Trigger.ME0Trigger.me0TriggerPseudoDigis_cff import *
-    _phase2_SimL1TMuon = SimL1TMuon.copy()
-    _phase2_SimL1TMuon += me0TriggerPseudoDigiSequence
+from L1Trigger.ME0Trigger.me0TriggerPseudoDigis_cff import *
+_phase2_SimL1TMuon = SimL1TMuon.copy()
+_phase2_SimL1TMuon += me0TriggerPseudoDigiSequence
 
-    from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-    phase2_muon.toReplaceWith( SimL1TMuon, _phase2_SimL1TMuon )
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+(stage2L1Trigger & phase2_muon).toReplaceWith( SimL1TMuon, _phase2_SimL1TMuon )

--- a/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 
 from L1Trigger.L1TNtuples.l1CaloTowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTfMuonTree_cfi import *
@@ -18,26 +18,27 @@ l1CaloTowerEmuTree.hcalToken = cms.untracked.InputTag("simHcalTriggerPrimitiveDi
 l1CaloTowerEmuTree.l1TowerToken = cms.untracked.InputTag("simCaloStage2Layer1Digis")
 l1CaloTowerEmuTree.l1ClusterToken = cms.untracked.InputTag("simCaloStage2Digis", "MP")
 
-l1UpgradeEmuTree = l1UpgradeTree.clone()
-l1UpgradeEmuTree.egToken = cms.untracked.InputTag("simCaloStage2Digis")
-l1UpgradeEmuTree.tauTokens = cms.untracked.VInputTag("simCaloStage2Digis")
-l1UpgradeEmuTree.jetToken = cms.untracked.InputTag("simCaloStage2Digis")
-l1UpgradeEmuTree.muonToken = cms.untracked.InputTag("simGmtStage2Digis")
-#l1UpgradeEmuTree.muonToken = cms.untracked.InputTag("muonLegacyInStage2FormatDigis")
-l1UpgradeEmuTree.sumToken = cms.untracked.InputTag("simCaloStage2Digis")
+l1UpgradeEmuTree = l1UpgradeTree.clone(
+    egToken = "simCaloStage1FinalDigis",
+    tauTokens = ["simCaloStage1FinalDigis:rlxTaus"],
+    jetToken = "simCaloStage1FinalDigis",
+    muonToken = "simGtDigis",
+    sumToken = "simCaloStage1FinalDigis",
+)
+stage2L1Trigger.toModify(l1UpgradeEmuTree,
+    egToken = "simCaloStage2Digis",
+    tauTokens = ["simCaloStage2Digis"],
+    jetToken = "simCaloStage2Digis",
+    muonToken = "simGmtStage2Digis",
+    #muonToken = "muonLegacyInStage2FormatDigis",
+    sumToken = "simCaloStage2Digis"
+)
 
 #l1legacyMuonEmuTree = l1UpgradeTree.clone()
 #l1legacyMuonEmuTree.muonToken = cms.untracked.InputTag("muonLegacyInStage2FormatDigis","imdMuonsLegacy")
 
 l1uGTEmuTree = l1uGTTree.clone()
 l1uGTEmuTree.ugtToken = cms.InputTag("simGtStage2Digis")
-
-if eras.stage1L1Trigger.isChosen() or eras.Run2_25ns.isChosen():
-    l1UpgradeEMUTree.egToken = "simCaloStage1FinalDigis"
-    l1UpgradeEMUTree.tauTokens = cms.untracked.VInputTag("simCaloStage1FinalDigis:rlxTaus")
-    l1UpgradeEMUTree.jetToken = "simCaloStage1FinalDigis"
-    l1UpgradeEMUTree.muonToken = "simGtDigis"
-    l1UpgradeEMUTree.sumToken = "simCaloStage1FinalDigis"
 
 L1NtupleEMU = cms.Sequence(
   l1EventTree


### PR DESCRIPTION
This PR includes a suggestion on how to modify bunch of L1T configuration files to remove nearly all calls to `cms.Modifier.isChosen()`. It includes also some "modernization" of the customization style on the modified parts.

Tested in 10_4_0_pre4 (full matrix runs), no changes expected.
