### PR TITLE
Avoid printing statistics if hadronizer has not been initialized properly

### DIFF
--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -67,6 +67,7 @@ namespace edm
     Decayer*              decayer_;
     unsigned int          nEventsInLumiBlock_;
     unsigned int          nThreads_{1};
+    bool                  initialized_ = false;
   };
 
   //------------------------------------------------------------------------
@@ -222,9 +223,11 @@ namespace edm
     // the contained hadronizer that would report the integrated
     // luminosity.
 
-    hadronizer_.statistics();
+    if(initialized_) {
+      hadronizer_.statistics();
     
-    if ( decayer_ ) decayer_->statistics();
+      if ( decayer_ ) decayer_->statistics();
+    }
     
     std::unique_ptr<GenRunInfoProduct> griproduct(new GenRunInfoProduct(hadronizer_.getGenRunInfo()));
     r.put(std::move(griproduct));
@@ -274,7 +277,7 @@ namespace edm
          
     std::unique_ptr<GenLumiInfoHeader> genLumiInfoHeader(hadronizer_.getGenLumiInfoHeader());
     lumi.put(std::move(genLumiInfoHeader));
-
+    initialized_ = true;
   }
 
   template <class HAD, class DEC>

--- a/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/test/BuildFile.xml
@@ -12,3 +12,8 @@
 <library file="ZJetsAnalyzer.cc,analyserhepmc/LeptonAnalyserHepMC.cc,analyserhepmc/JetInputHepMC.cc" name="ZJetsTestAnalyzer">
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<bin file="test_catch2_*.cc" name="testGeneratorInterfacePythia8InterfaceTP">
+  <use name="FWCore/TestProcessor"/>
+  <use name="catch2"/>
+</bin>

--- a/GeneratorInterface/Pythia8Interface/test/test_catch2_Pythia8GeneratorFilter.cc
+++ b/GeneratorInterface/Pythia8Interface/test/test_catch2_Pythia8GeneratorFilter.cc
@@ -1,0 +1,56 @@
+#include "catch.hpp"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+static constexpr auto s_tag = "[Pythia8GeneratorFilter]";
+
+TEST_CASE("Standard checks of Pythia8GeneratorFilter", s_tag) {
+  const std::string baseConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+process.RandomNumberGeneratorService.toTest = process.RandomNumberGeneratorService.generator.clone()
+process.toTest = cms.EDFilter("Pythia8GeneratorFilter",
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                        'PhaseSpace:pTHatMin = 20.'),
+        parameterSets = cms.vstring('pythia8_example02')
+    )
+)
+process.moduleToTest(process.toTest)
+)_"
+  };
+  
+  edm::test::TestProcessor::Config config{ baseConfig };  
+  SECTION("base configuration is OK") {
+    REQUIRE_NOTHROW(edm::test::TestProcessor(config));
+  }
+  
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+    
+    REQUIRE_NOTHROW(tester.test());
+  }
+  
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+    
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+
+}
+
+//Add additional TEST_CASEs to exercise the modules capabilities

--- a/GeneratorInterface/Pythia8Interface/test/test_catch2_main.cc
+++ b/GeneratorInterface/Pythia8Interface/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"


### PR DESCRIPTION
AddOn tests in #25577 showed a segfault in `Pythia8::Pythia::stat()` when an exception was thrown by another module in `beginRun()`
```
#4  <signal handler called>
#5  0x00007f26e3093e01 in Pythia8::Pythia::stat() () from .../external/slc7_amd64_gcc700/lib/libpythia8.so
#6  0x00007f26e5dbcca0 in Pythia8Hadronizer::statistics() () from .../lib/slc7_amd64_gcc700/pluginGeneratorInterfacePythia8Filters.so
#7  0x00007f26e5df82ba in edm::GeneratorFilter<Pythia8Hadronizer, gen::ExternalDecayDriver>::endRunProduce(edm::Run&, edm::EventSetup const&) () from .../lib/slc7_amd64_gcc700/pluginGeneratorInterfacePythia8Filters.so
#8  0x00007f27057736f3 in edm::one::EDFilterBase::doEndRun(edm::RunPrincipal const&, edm::EventSetup const&, edm::ModuleCallingContext const*) () from .../lib/slc7_amd64_gcc700/libFWCoreFramework.so
#9  0x00007f2705728420 in edm::WorkerT<edm::one::EDFilterBase>::implDoEnd(edm::RunPrincipal const&, edm::EventSetup const&, edm::ModuleCallingContext const*) () from .../lib/slc7_amd64_gcc700/libFWCoreFramework.so
```
A unit test with `TestProcessor` (included) confirms the segfault in case the `Run` has no `LuminosityBlock`s (in which case the Pythia8's initialization has not been called). This PR suggests to add a boolean flag to `GeneratorFilter` template to avoid calling the `endRun` statistics printouts if the hadronizer+decayer have not been initialized (assuming the `endRun` printout is really needed).

Tested in 10_4_0_pre4, no changes expected.

@Dr15Jones 