### PR TITLE
Fix LogDebug in HLTrigger/Muon package

### DIFF
--- a/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
@@ -36,6 +36,7 @@ namespace {
     std::vector<double> const& v_;
   };
 
+#if defined(EDM_ML_DEBUG)
   std::ostream& operator<<(std::ostream& iS, Out const& iO) {
     iS<<"[";
     for( double v: iO.v_) {
@@ -44,7 +45,7 @@ namespace {
     iS<<"]";
     return iS;
   }
-
+#endif
 }
 
 HLTMuonDimuonL3Filter::HLTMuonDimuonL3Filter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
@@ -228,8 +229,6 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 
      edm::Handle<trigger::TriggerFilterObjectWithRefs> level1Cands;
      std::vector<l1t::MuonRef> vl1cands;
-     std::vector<l1t::MuonRef>::iterator vl1cands_begin;
-     std::vector<l1t::MuonRef>::iterator vl1cands_end;
 
      bool check_l1match = true;
 

--- a/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
@@ -29,6 +29,24 @@ using namespace trigger;
 //
 // constructors and destructor
 //
+namespace {
+  struct Out {
+    Out(std::vector<double> const& v): v_(v) {}
+
+    std::vector<double> const& v_;
+  };
+
+  std::ostream& operator<<(std::ostream& iS, Out const& iO) {
+    iS<<"[";
+    for( double v: iO.v_) {
+      iS<<v<<" ";
+    }
+    iS<<"]";
+    return iS;
+  }
+
+}
+
 HLTMuonDimuonL3Filter::HLTMuonDimuonL3Filter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
    beamspotTag_       (iConfig.getParameter< edm::InputTag > ("BeamSpotTag")),
    beamspotToken_     (consumes<reco::BeamSpot>(beamspotTag_)),
@@ -79,9 +97,9 @@ HLTMuonDimuonL3Filter::HLTMuonDimuonL3Filter(const edm::ParameterSet& iConfig) :
       << " " << min_Nhits_
       << " " << max_Dr_
       << " " << max_Dz_
-      << " " << chargeOpt_ << " " << min_PtPair_
-      << " " << min_PtMax_ << " " << min_PtMin_
-      << " " << min_InvMass_ << " " << max_InvMass_
+      << " " << chargeOpt_ << " " << Out(min_PtPair_)
+      << " " << Out(min_PtMax_) << " " << Out(min_PtMin_)
+      << " " << Out(min_InvMass_) << " " << Out(max_InvMass_)
       << " " << min_Acop_ << " " << max_Acop_
       << " " << min_PtBalance_ << " " << max_PtBalance_
       << " " << nsigma_Pt_

--- a/HLTrigger/Muon/plugins/HLTMuonPFIsoFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonPFIsoFilter.cc
@@ -27,7 +27,7 @@ HLTMuonPFIsoFilter::HLTMuonPFIsoFilter(const edm::ParameterSet& iConfig) : HLTFi
    candTag_ 	      (iConfig.getParameter< edm::InputTag > ("CandTag") ),
    previousCandTag_   (iConfig.getParameter< edm::InputTag > ("PreviousCandTag")),
    depTag_  	      (iConfig.getParameter< std::vector< edm::InputTag > >("DepTag" ) ),
-   depToken_(0),
+   depToken_(),
    rhoTag_  	      (iConfig.getParameter< edm::InputTag >("RhoTag" ) ),
    maxIso_  	      (iConfig.getParameter<double>("MaxIso" ) ),
    min_N_   	      (iConfig.getParameter<int> ("MinN")),
@@ -35,20 +35,23 @@ HLTMuonPFIsoFilter::HLTMuonPFIsoFilter(const edm::ParameterSet& iConfig) : HLTFi
    doRho_	      (iConfig.getParameter<bool> ("applyRhoCorrection")),
    effArea_	      (iConfig.getParameter<double> ("EffectiveArea"))
 {
-  std::stringstream tags;
-  for (unsigned int i=0;i!=depTag_.size();++i) {
-    depToken_.push_back(consumes<edm::ValueMap<double> >(depTag_[i]));
-    tags<<" PFIsoTag["<<i<<"] : "<<depTag_[i].encode()<<" \n";
+  depToken_.reserve(depTag_.size());
+  for (auto const& t: depTag_) {
+    depToken_.push_back(consumes<edm::ValueMap<double> >(t));
   }
 
   candToken_            = consumes<reco::RecoChargedCandidateCollection>(candTag_);
   previousCandToken_    = consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_);
   if (doRho_) rhoToken_ = consumes<double>(rhoTag_);
 
-  LogDebug("HLTMuonPFIsoFilter") << " candTag : " << candTag_.encode()
-				<< "\n" << tags 
-				<< "  MinN : " << min_N_;
-
+  LogDebug("HLTMuonPFIsoFilter").log( [this](auto& l) {
+      l << " candTag : " << candTag_.encode()
+        << "\n" ;
+      for (unsigned int i=0;i!=depTag_.size();++i) {
+        l<<" PFIsoTag["<<i<<"] : "<<depTag_[i].encode()<<" \n";
+      }
+      l << "  MinN : " << min_N_;
+    });
   produces<edm::ValueMap<bool> >();
 }
 


### PR DESCRIPTION
The clang static analyzer appears to be using the compilation option EDM_ML_DEBUG as true. This forces actually compiling LogDebug which was failing for this package.