### PR TITLE
Replace call to Modifier.isChosen() with toModify() in rpcChamberMasker_cff

### DIFF
--- a/SimMuon/RPCDigitizer/python/rpcChamberMasker_cff.py
+++ b/SimMuon/RPCDigitizer/python/rpcChamberMasker_cff.py
@@ -6,10 +6,8 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 
 def appendRPCChamberMaskerAtReco(process):
 
-    if phase2_muon.isChosen():
-        appendRPCChamberMaskerBeforeRecHits(process)
-    else :
-        appendRPCChamberMaskerAtUnpacking(process)
+    phase2_muon.toModify(process, appendRPCChamberMaskerBeforeRecHits)
+    (~phase2_muon).toModify(process, appendRPCChamberMaskerAtUnpacking)
 
     return process
 


### PR DESCRIPTION
Title says it all. I'm assuming these customize functions are still relevant (if not, they could be removed).

Tested in 10_4_0_pre4, no changes expected.