### PR TITLE
[RFC] Call nanoAOD_runMETfixEE2017() only if the modifiers are chosen

### DIFF
--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -273,14 +273,14 @@ def nanoAOD_customizeData(process):
     process = nanoAOD_customizeCommon(process)
     process = nanoAOD_recalibrateMETs(process,isData=True)
     for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
-        modifier.toModify(process, nanoAOD_runMETfixEE2017(process,isData=True))
+        modifier.toModify(process, lambda p: nanoAOD_runMETfixEE2017(p,isData=True))
     return process
 
 def nanoAOD_customizeMC(process):
     process = nanoAOD_customizeCommon(process)
     process = nanoAOD_recalibrateMETs(process,isData=False)
     for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
-        modifier.toModify(process, nanoAOD_runMETfixEE2017(process,isData=False))
+        modifier.toModify(process, lambda p: nanoAOD_runMETfixEE2017(p,isData=False))
     return process
 
 ### Era dependent customization


### PR DESCRIPTION
The customizations
https://github.com/cms-sw/cmssw/blob/4fdeedc0118aba13987ce237aab0bc9c4b12165f/PhysicsTools/NanoAOD/python/nano_cff.py#L275-L276
and
https://github.com/cms-sw/cmssw/blob/4fdeedc0118aba13987ce237aab0bc9c4b12165f/PhysicsTools/NanoAOD/python/nano_cff.py#L282-L283
were introduced in #25373. The code look like the intention was to call `nanoAOD_runMETfixEE2017()` only if `run2_nanoAOD_94XMiniAODv1` or `run2_nanoAOD_94XMiniAODv2` modifiers are turned on.

The actual behavior is, however, different. The lines 276 and 283 contain a *call* to `nanoAOD_runMETfixEE2017()` function (instead of a function "object" to be called by `toModify()`), so it is called regardless of the status of the two modifiers (and twice because of the loop). The function itself
https://github.com/cms-sw/cmssw/blob/4fdeedc0118aba13987ce237aab0bc9c4b12165f/PhysicsTools/NanoAOD/python/nano_cff.py#L236-L241
does not explicitly return anything, so the return value is `None`. The `Modifier` then interprets that
https://github.com/cms-sw/cmssw/blob/4fdeedc0118aba13987ce237aab0bc9c4b12165f/FWCore/ParameterSet/python/Config.py#L1354
such that the `func` argument is `None`, and there are no keyword arguments, so it has nothing to do.

If my guess above on the intention is correct, this PR suggests to fix the behavior to the intended one.

Tested in 10_4_0.