### PR TITLE
Fix thread safety of EgammaHLTPixelMatchElectronProducers

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchElectronProducers.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchElectronProducers.h
@@ -8,15 +8,19 @@
 // $Id: EgammaHLTPixelMatchElectronProducers.h,v 1.3 2009/10/14 14:32:23 covarell Exp $
   
   
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
 
+#include "RecoEgamma/EgammaHLTAlgos/interface/EgammaHLTPixelMatchElectronAlgo.h"
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
+
 
 #include <string>
+#include <memory>
 
 namespace edm {
   class ConfigurationDescriptions;
@@ -24,21 +28,18 @@ namespace edm {
 
 class EgammaHLTPixelMatchElectronAlgo;
 
-class EgammaHLTPixelMatchElectronProducers : public edm::global::EDProducer<> {
+class EgammaHLTPixelMatchElectronProducers : public edm::stream::EDProducer<> {
 
  public:
 
   explicit EgammaHLTPixelMatchElectronProducers(const edm::ParameterSet& conf);
-  ~EgammaHLTPixelMatchElectronProducers() override;
 
-  void produce(edm::StreamID sid, edm::Event& e, const edm::EventSetup& c) const override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
  private:
 
-  const edm::ParameterSet conf_;
-
-  EgammaHLTPixelMatchElectronAlgo* algo_;
-  std::string  seedProducer_;
+  EgammaHLTPixelMatchElectronAlgo algo_;
+  const edm::EDPutTokenT<reco::ElectronCollection> token_;
 };
 #endif

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchElectronProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchElectronProducers.cc
@@ -19,6 +19,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchElectronProducers.h"
 
@@ -31,23 +32,15 @@
 
 using namespace reco;
  
-EgammaHLTPixelMatchElectronProducers::EgammaHLTPixelMatchElectronProducers(const edm::ParameterSet& iConfig) : conf_(iConfig) {
-
-  consumes<TrackCollection>(conf_.getParameter<edm::InputTag>("TrackProducer"));
-  consumes<GsfTrackCollection>(conf_.getParameter<edm::InputTag>("GsfTrackProducer"));
-  consumes<BeamSpot>(conf_.getParameter<edm::InputTag>("BSProducer"));
-
-  //create algo
-  algo_ = new EgammaHLTPixelMatchElectronAlgo(conf_, consumesCollector());
-
-  //register your products
-  produces<ElectronCollection>();
+EgammaHLTPixelMatchElectronProducers::EgammaHLTPixelMatchElectronProducers(const edm::ParameterSet& iConfig) : 
+  algo_(iConfig,consumesCollector()),
+  token_(  produces<ElectronCollection>() )
+{
+  consumes<TrackCollection>(iConfig.getParameter<edm::InputTag>("TrackProducer"));
+  consumes<GsfTrackCollection>(iConfig.getParameter<edm::InputTag>("GsfTrackProducer"));
+  consumes<BeamSpot>(iConfig.getParameter<edm::InputTag>("BSProducer"));
 }
 
-
-EgammaHLTPixelMatchElectronProducers::~EgammaHLTPixelMatchElectronProducers() {
-  delete algo_;
-}
 
 void EgammaHLTPixelMatchElectronProducers::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
@@ -60,18 +53,18 @@ void EgammaHLTPixelMatchElectronProducers::fillDescriptions(edm::ConfigurationDe
 }
 
 // ------------ method called to produce the data  ------------
-void EgammaHLTPixelMatchElectronProducers::produce(edm::StreamID sid, edm::Event& e, const edm::EventSetup& iSetup) const {
+void EgammaHLTPixelMatchElectronProducers::produce(edm::Event& e, const edm::EventSetup& iSetup) {
   // Update the algorithm conditions
-  algo_->setupES(iSetup);  
+  algo_.setupES(iSetup);  
   
   // Create the output collections   
-  auto pOutEle = std::make_unique<ElectronCollection>();
+  ElectronCollection  outEle;
   
   // invoke algorithm
-    algo_->run(e,*pOutEle);
+    algo_.run(e,outEle);
 
   // put result into the Event
-    e.put(std::move(pOutEle));
+    e.emplace(token_,std::move(outEle));
 }
 
 


### PR DESCRIPTION
EgammaHLTPixelMatchElectronAlgo is not thread safe and can not be used as a member function of a edm::global module. Converting EgammaHLTPixelMatchElectronProducers to a stream module fixes the problem.
Also did some simple code modernization of the module.