### PR TITLE
New TrackingRecHitRange and use it in RecoParticleFlow

### DIFF
--- a/DataFormats/CSCRecHit/test/CSCSharesInputTest.cc
+++ b/DataFormats/CSCRecHit/test/CSCSharesInputTest.cc
@@ -67,7 +67,7 @@ void CSCSharesInputTest::analyze(const edm::Event &myEvent, const edm::EventSetu
 		perEventData[2] += track->recHitsSize();
 		perMuonData[0] += track->recHitsSize();
 		
-        for(auto const& jHit : track->recHits()) {
+		for(auto const& jHit : track->recHits()) {
 			
 			// AllMatched:SomeMatched:AllWiresMatched:SomeWiresMatched:AllStripsMatched:SomeStripsMatched:NotMatched
 			float perRecHitData[7] = {0,0,0,0,0,0,0};

--- a/DataFormats/CSCRecHit/test/CSCSharesInputTest.cc
+++ b/DataFormats/CSCRecHit/test/CSCSharesInputTest.cc
@@ -67,13 +67,13 @@ void CSCSharesInputTest::analyze(const edm::Event &myEvent, const edm::EventSetu
 		perEventData[2] += track->recHitsSize();
 		perMuonData[0] += track->recHitsSize();
 		
-		for (trackingRecHit_iterator jHit = track->recHitsBegin(); jHit != track->recHitsEnd(); ++jHit) {
+        for(auto const& jHit : track->recHits()) {
 			
 			// AllMatched:SomeMatched:AllWiresMatched:SomeWiresMatched:AllStripsMatched:SomeStripsMatched:NotMatched
 			float perRecHitData[7] = {0,0,0,0,0,0,0};
 			
 			// Kill us quickly if this is not a CSCRecHit.  Also allows us to use the CSCRecHit version of sharesInput, which we like.
-			const CSCRecHit2D *myHit = dynamic_cast<const CSCRecHit2D *>((*jHit));
+			const CSCRecHit2D *myHit = dynamic_cast<const CSCRecHit2D *>(jHit);
 			if (myHit == 0) {
 				++counts_["NotMatchedRecHits"];
 				++perEventData[9];

--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -101,6 +101,9 @@ public:
     unsigned int innerDetId() const {
         return extra_->innerDetId();
     }
+
+    /// Access to reconstructed hits on the track.
+    auto recHits() const { return extra_->recHits(); }
    
     /// Iterator to first hit on the track.
     trackingRecHit_iterator recHitsBegin() const {

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -25,18 +25,6 @@ public:
     using TrajParams = std::vector<LocalTrajectoryParameters>;
     using Chi2sFive = std::vector<unsigned char>;
 
-    /// class which implemebts begin() and end() to enable range-based loop on RecHits
-    class TrackingRecHitCollectionWindow {
-      public:
-        TrackingRecHitCollectionWindow(trackingRecHit_iterator begin, trackingRecHit_iterator end)
-            : begin_(begin), end_(end) {}
-        trackingRecHit_iterator begin() const { return begin_; }
-        trackingRecHit_iterator end() const { return end_; }
-      private:
-        const trackingRecHit_iterator begin_;
-        const trackingRecHit_iterator end_;
-    };
-
     /// default constructor
     TrackExtraBase() : m_firstHit(-1), m_nHits(0) { }
 
@@ -57,9 +45,7 @@ public:
     }
 
     /// accessor to RecHits
-    TrackingRecHitCollectionWindow recHits() const {
-        return TrackingRecHitCollectionWindow(recHitsBegin(), recHitsEnd());
-    }
+    auto recHits() const { return TrackingRecHitRange(recHitsBegin(), recHitsEnd()); }
 
     /// first iterator over RecHits
     trackingRecHit_iterator recHitsBegin() const {

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -25,6 +25,18 @@ public:
     using TrajParams = std::vector<LocalTrajectoryParameters>;
     using Chi2sFive = std::vector<unsigned char>;
 
+    /// class which implemebts begin() and end() to enable range-based loop on RecHits
+    class TrackingRecHitCollectionWindow {
+      public:
+        TrackingRecHitCollectionWindow(trackingRecHit_iterator begin, trackingRecHit_iterator end)
+            : begin_(begin), end_(end) {}
+        trackingRecHit_iterator begin() const { return begin_; }
+        trackingRecHit_iterator end() const { return end_; }
+      private:
+        const trackingRecHit_iterator begin_;
+        const trackingRecHit_iterator end_;
+    };
+
     /// default constructor
     TrackExtraBase() : m_firstHit(-1), m_nHits(0) { }
 
@@ -44,6 +56,10 @@ public:
         return m_nHits;
     }
 
+    /// accessor to RecHits
+    TrackingRecHitCollectionWindow recHits() const {
+        return TrackingRecHitCollectionWindow(recHitsBegin(), recHitsEnd());
+    }
 
     /// first iterator over RecHits
     trackingRecHit_iterator recHitsBegin() const {

--- a/DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h
+++ b/DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h
@@ -5,6 +5,7 @@
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/OwnVector.h"
+#include "FWCore/Utilities/interface/Range.h"
 
 class TrackingRecHit;
 /// collection of TrackingRecHits
@@ -17,5 +18,7 @@ typedef edm::RefProd<TrackingRecHitCollection> TrackingRecHitRefProd;
 typedef edm::RefVector<TrackingRecHitCollection> TrackingRecHitRefVector;
 /// iterator over a vector of reference to TrackingRecHit in the same collection
 typedef TrackingRecHitCollection::base::const_iterator trackingRecHit_iterator;
+/// Range class to enable range-based loops for a tracks RecHits
+using TrackingRecHitRange = edm::Range<trackingRecHit_iterator>;
 
 #endif

--- a/FWCore/Utilities/interface/Range.h
+++ b/FWCore/Utilities/interface/Range.h
@@ -1,0 +1,26 @@
+#ifndef FWCore_Utilities_Range_h
+#define FWCore_Utilities_Range_h
+
+namespace edm
+{
+     /*
+      *class which implements begin() and end() to use range-based loop with
+      pairs of iterators or pointers.
+      */
+
+     template<class T>
+     class Range
+     {
+       public:
+         Range(T begin, T end) : begin_(begin), end_(end) {}
+
+         T begin() const { return begin_; }
+         T end() const { return end_; }
+
+       private:
+         const T begin_;
+         const T end_;
+     };
+ };
+
+#endif

--- a/RecoMuon/TrackingTools/src/MuonSegmentMatcher.cc
+++ b/RecoMuon/TrackingTools/src/MuonSegmentMatcher.cc
@@ -76,13 +76,13 @@ vector<const DTRecSegment4D*> MuonSegmentMatcher::matchDT(const reco::Track &muo
   bool segments = false;
 
   // Loop and select DT recHits
-  for(trackingRecHit_iterator hit = muon.recHitsBegin(); hit != muon.recHitsEnd(); ++hit) {
-    if (!(*hit)->isValid()) continue; 
-    if ( (*hit)->geographicalId().det() != DetId::Muon ) continue; 
-    if ( (*hit)->geographicalId().subdetId() != MuonSubdetId::DT ) continue;
-    if (!(*hit)->recHits().empty()) 
-      if ((*(*hit)->recHits().begin())->recHits().size()>1) segments = true;
-    dtHits.push_back(*hit);
+  for(auto const& hit : muon.recHits()) {
+    if (!hit->isValid()) continue; 
+    if ( hit->geographicalId().det() != DetId::Muon ) continue; 
+    if ( hit->geographicalId().subdetId() != MuonSubdetId::DT ) continue;
+    if (!hit->recHits().empty()) 
+      if ((*hit->recHits().begin())->recHits().size()>1) segments = true;
+    dtHits.push_back(hit);
   }
   
   //  cout << "Muon DT hits found: " << dtHits.size() << " segments " << segments << endl;
@@ -258,22 +258,22 @@ vector<const CSCSegment*> MuonSegmentMatcher::matchCSC(const reco::Track& muon, 
 
     bool segments = false;
 
-    for(trackingRecHit_iterator hitC = muon.recHitsBegin(); hitC != muon.recHitsEnd(); ++hitC) {
-      if (!(*hitC)->isValid()) continue; 
-      if ( (*hitC)->geographicalId().det() != DetId::Muon ) continue; 
-      if ( (*hitC)->geographicalId().subdetId() != MuonSubdetId::CSC ) continue;
-      if (!(*hitC)->isValid()) continue;
-      if ( (*hitC)->recHits().size()>1) segments = true;
+    for(auto const& hitC : muon.recHits()) {
+      if (!hitC->isValid()) continue; 
+      if ( hitC->geographicalId().det() != DetId::Muon ) continue; 
+      if ( hitC->geographicalId().subdetId() != MuonSubdetId::CSC ) continue;
+      if (!hitC->isValid()) continue;
+      if ( hitC->recHits().size()>1) segments = true;
 
       //DETECTOR CONSTRUCTION
-      DetId id = (*hitC)->geographicalId();
+      DetId id = hitC->geographicalId();
       CSCDetId cscDetIdHit(id.rawId());
 
       if (segments) {
 	if(!(myChamber.rawId()==cscDetIdHit.rawId())) continue; 
 
         // and compare the local positions
-        LocalPoint positionLocalCSC = (*hitC)->localPosition();
+        LocalPoint positionLocalCSC = hitC->localPosition();
 	LocalPoint segLocalCSC = segmentCSC->localPosition();
 	if ((fabs(positionLocalCSC.x()-segLocalCSC.x())<CSCXCut) && 
 	    (fabs(positionLocalCSC.y()-segLocalCSC.y())<CSCYCut)) 
@@ -288,14 +288,14 @@ vector<const CSCSegment*> MuonSegmentMatcher::matchCSC(const reco::Track& muon, 
 
       countMuonCSCHits++;
 
-      LocalPoint positionLocalCSC = (*hitC)->localPosition();
+      LocalPoint positionLocalCSC = hitC->localPosition();
 	
       for (vector<CSCRecHit2D>::const_iterator hiti=CSCRechits2D.begin(); hiti!=CSCRechits2D.end(); hiti++) {
 
 	if ( !hiti->isValid()) continue; 
 	CSCDetId cscDetId((hiti->geographicalId()).rawId());
 		
-	if ((*hitC)->geographicalId().rawId()!=(hiti->geographicalId()).rawId()) continue;
+	if (hitC->geographicalId().rawId()!=(hiti->geographicalId()).rawId()) continue;
 
 	LocalPoint segLocalCSC = hiti->localPosition();
 	//		cout<<"Layer Id (MuonHit) =  "<<cscDetIdHit<<" Muon Local Position (det frame) "<<positionLocalCSC <<endl;
@@ -338,18 +338,18 @@ vector<const RPCRecHit*> MuonSegmentMatcher::matchRPC(const reco::Track& muon, c
     LocalPoint posLocalRPC = hitRPC->localPosition();
     bool matched=false;
 
-    for(trackingRecHit_iterator hitC = muon.recHitsBegin(); hitC != muon.recHitsEnd(); ++hitC) {
-      if (!(*hitC)->isValid()) continue; 
-      if ( (*hitC)->geographicalId().det() != DetId::Muon ) continue; 
-      if ( (*hitC)->geographicalId().subdetId() != MuonSubdetId::RPC ) continue;
-      if (!(*hitC)->isValid()) continue;
+    for(auto const& hitC : muon.recHits()) {
+      if (!hitC->isValid()) continue; 
+      if ( hitC->geographicalId().det() != DetId::Muon ) continue; 
+      if ( hitC->geographicalId().subdetId() != MuonSubdetId::RPC ) continue;
+      if (!hitC->isValid()) continue;
 
       //DETECTOR CONSTRUCTION
-      DetId id = (*hitC)->geographicalId();
+      DetId id = hitC->geographicalId();
       RPCDetId rpcDetIdHit(id.rawId());
       
       if (rpcDetIdHit!=myChamber) continue;
-      LocalPoint posLocalMuon = (*hitC)->localPosition();
+      LocalPoint posLocalMuon = hitC->localPosition();
 	
 //		cout<<"Layer Id (MuonHit) =  "<<rpcDetIdHit<<" Muon Local Position (det frame) "<<posLocalMuon <<endl;
 //		cout<<"Layer Id  (RPCHit) =  "<<myChamber<<"  Hit Local Position (det frame) "<<posLocalRPC <<endl;

--- a/RecoMuon/TrackingTools/src/SegmentsTrackAssociator.cc
+++ b/RecoMuon/TrackingTools/src/SegmentsTrackAssociator.cc
@@ -76,22 +76,22 @@ MuonTransientTrackingRecHit::MuonRecHitContainer SegmentsTrackAssociator::associ
   MuonTransientTrackingRecHit::MuonRecHitContainer selectedCscSegments;
 
   //loop over recHit
-  for(trackingRecHit_iterator recHit =  Track.recHitsBegin(); recHit != Track.recHitsEnd(); ++recHit){
+  for(auto const& recHit : Track.recHits()) {
 
-    if(!(*recHit)->isValid()) continue;
+    if(!recHit->isValid()) continue;
 
     
     numRecHit++;
  
     //get the detector Id
-    DetId idRivHit = (*recHit)->geographicalId();
+    DetId idRivHit = recHit->geographicalId();
       
 
     // DT recHits
     if (idRivHit.det() == DetId::Muon && idRivHit.subdetId() == MuonSubdetId::DT ) {
 
       // get the RecHit Local Position
-      LocalPoint posTrackRecHit = (*recHit)->localPosition(); 
+      LocalPoint posTrackRecHit = recHit->localPosition(); 
 
       DTRecSegment4DCollection::range range; 	
       numRecHitDT++;
@@ -160,7 +160,7 @@ MuonTransientTrackingRecHit::MuonRecHitContainer SegmentsTrackAssociator::associ
     if (idRivHit.det() == DetId::Muon && idRivHit.subdetId() == MuonSubdetId::CSC ) {
 
       // get the RecHit Local Position
-      LocalPoint posTrackRecHit = (*recHit)->localPosition(); 
+      LocalPoint posTrackRecHit = recHit->localPosition(); 
 
       CSCSegmentCollection::range range; 
       numRecHitCSC++;

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -549,15 +549,10 @@ ConvBremSeedProducer::makeTrajectoryState( const DetLayer* layer,
     (GlobalTrajectoryParameters( pos, mom, TrackCharge( pp.charge()), field), *plane);
 }
 bool ConvBremSeedProducer::isGsfTrack(const reco::Track & tkv, const TrackingRecHit *h ){
-  auto ib=tkv.recHitsBegin();
-  auto ie=tkv.recHitsEnd();
   bool istaken=false;
-  //  for (;ib!=ie-2;++ib){
-    for (;ib!=ie;++ib){
-    if (istaken) continue;
-    if (!((*ib)->isValid())) continue;
- 
-    istaken = (*ib)->sharesInput(h,TrackingRecHit::all);
+  for(auto const& hit : tkv.recHits()) {
+    if (istaken || !hit->isValid()) continue;
+    istaken = hit->sharesInput(h,TrackingRecHit::all);
   }
   return istaken;
 }

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
@@ -490,27 +490,19 @@ void PFSimParticleProducer::getSimIDs( const TrackHandle& trackh,
 
     for(unsigned i=0;i<trackh->size(); i++) {
       
-      reco::PFRecTrackRef ref( trackh,i );
-      const reco::PFRecTrack& PFT   = *ref;
-      const reco::TrackRef& trackref = PFT.trackRef();
+      const reco::PFRecTrackRef ref( trackh,i );
       
-      trackingRecHit_iterator rhitbeg 
-	= trackref->recHitsBegin();
-      trackingRecHit_iterator rhitend 
-	= trackref->recHitsEnd();
-      for (trackingRecHit_iterator it = rhitbeg;  
-	   it != rhitend; it++){
+      for(auto const& hit : ref->trackRef()->recHits())
+      {
+        if( hit->isValid() ) {
 
-	if( (*it)->isValid() ){
+          auto rechit = dynamic_cast<const FastTrackerRecHit*>(hit);
 
-	  const FastTrackerRecHit * rechit 
-	    = (const FastTrackerRecHit*) (*it);
-
-	  for(unsigned int st_index=0;st_index<rechit->nSimTrackIds();++st_index){
-	      recTrackSimID.push_back(rechit->simTrackId(st_index));
-	  }
-	  break;
-	}
+          for(unsigned int st_index=0;st_index<rechit->nSimTrackIds();++st_index){
+              recTrackSimID.push_back(rechit->simTrackId(st_index));
+          }
+          break;
+        }
       }//loop track rechit
     }//loop recTracks
   }//track handle valid

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -370,10 +370,7 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	    trk_ecalDphi = trk_ecalDphi_;
       
 	    Trajectory::ConstRecHitContainer tmp;
-            auto hb = Tk[i].recHitsBegin();
-            for(unsigned int h=0;h<Tk[i].recHitsSize();h++){
-              auto recHit = *(hb+h); tmp.push_back(recHit->cloneSH());
-            }
+            for(auto const& hit : Tk[i].recHits()) tmp.push_back(hit->cloneSH());
             auto const & theTrack = Tk[i]; 
             GlobalVector gv(theTrack.innerMomentum().x(),theTrack.innerMomentum().y(),theTrack.innerMomentum().z());
             GlobalPoint  gp(theTrack.innerPosition().x(),theTrack.innerPosition().y(),theTrack.innerPosition().z());

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
@@ -98,12 +98,12 @@ PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup)
 		  double like2=-999;
 		  //number of shared hits
 		  int shared=0;
-          for(auto const& hit1 : trackRef1->recHits()) if(hit1->isValid()) {
-            //count number of shared hits
-            for(auto const& hit2 : trackRef2->recHits()) {
-                if(hit2->isValid() && hit1->sharesInput(hit2, TrackingRecHit::some)) shared++;
-            }
-          }
+		  for(auto const& hit1 : trackRef1->recHits()) if(hit1->isValid()) {
+		    //count number of shared hits
+		    for(auto const& hit2 : trackRef2->recHits()) {
+		        if(hit2->isValid() && hit1->sharesInput(hit2, TrackingRecHit::some)) shared++;
+		    }
+		  }
 		  float frac=0;
 		  //number of valid hits in tracks that are duplicates
 		  float size1=trackRef1->found();

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
@@ -98,17 +98,12 @@ PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup)
 		  double like2=-999;
 		  //number of shared hits
 		  int shared=0;
-		  for(trackingRecHit_iterator iHit1=trackRef1->recHitsBegin(); iHit1!=trackRef1->recHitsEnd(); iHit1++) 
-		    {
-		      const TrackingRecHit *h_1=(*iHit1);
-		      if(h_1->isValid()){		  
-			for(trackingRecHit_iterator iHit2=trackRef2->recHitsBegin(); iHit2!=trackRef2->recHitsEnd(); iHit2++)
-			  {
-			    const TrackingRecHit *h_2=(*iHit2);
-			    if(h_2->isValid() && h_1->sharesInput(h_2, TrackingRecHit::some))shared++;//count number of shared hits
-			  }
-		      }
-		    }		  
+          for(auto const& hit1 : trackRef1->recHits()) if(hit1->isValid()) {
+            //count number of shared hits
+            for(auto const& hit2 : trackRef2->recHits()) {
+                if(hit2->isValid() && hit1->sharesInput(hit2, TrackingRecHit::some)) shared++;
+            }
+          }
 		  float frac=0;
 		  //number of valid hits in tracks that are duplicates
 		  float size1=trackRef1->found();

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -421,26 +421,16 @@ PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection  & PfRTkColl,
       float det=fabs(pft->trackRef()->eta()-gsftk.eta());
       float dr =sqrt(dph*dph+det*det);  
       
-      trackingRecHit_iterator  hhit=
-	pft->trackRef()->recHitsBegin();
-      trackingRecHit_iterator  hhit_end=
-	pft->trackRef()->recHitsEnd();
-      
-    
-      
-      for(;hhit!=hhit_end;++hhit){
-	if (!(*hhit)->isValid()) continue;
-	TrajectorySeed::const_iterator hit=
-	  gsftk.seedRef()->recHits().first;
-	TrajectorySeed::const_iterator hit_end=
-	  gsftk.seedRef()->recHits().second;
- 	for(;hit!=hit_end;++hit){
-	  if (!(hit->isValid())) continue;
-	  if((*hhit)->sharesInput(&*(hit),TrackingRecHit::all))  ish++; 
-	//   if((hit->geographicalId()==(*hhit)->geographicalId())&&
-        //     (((*hhit)->localPosition()-hit->localPosition()).mag()<0.01)) ish++;
- 	}	
-	
+      for(auto const& hhit : pft->trackRef()->recHits()) {
+        if (!hhit->isValid()) continue;
+        TrajectorySeed::const_iterator hit = gsftk.seedRef()->recHits().first;
+        TrajectorySeed::const_iterator hit_end = gsftk.seedRef()->recHits().second;
+        for(;hit!=hit_end;++hit) {
+          if (!(hit->isValid())) continue;
+          if(hhit->sharesInput(&*(hit),TrackingRecHit::all)) ish++;
+          // if((hit->geographicalId()==hhit->geographicalId())&&
+          //     ((hhit->localPosition()-hit->localPosition()).mag()<0.01)) ish++;
+        }
       }
       
 
@@ -1045,20 +1035,16 @@ bool PFElecTkProducer::isInnerMost(const reco::GsfTrackRef& nGsfTrack,
   
   // retrieve first valid hit
   int gsfHitCounter1 = 0 ;
-  trackingRecHit_iterator elHitsIt1 ;
-  for
-    ( elHitsIt1 = nGsfTrack->recHitsBegin() ;
-     elHitsIt1 != nGsfTrack->recHitsEnd() ;
-     elHitsIt1++, gsfHitCounter1++ )
-    { if (((**elHitsIt1).isValid())) break ; }
+  for(auto const& hit : nGsfTrack->recHits()) {
+    if (hit->isValid()) break ;
+    gsfHitCounter1++;
+  }
   
   int gsfHitCounter2 = 0 ;
-  trackingRecHit_iterator elHitsIt2 ;
-  for
-    ( elHitsIt2 = iGsfTrack->recHitsBegin() ;
-     elHitsIt2 != iGsfTrack->recHitsEnd() ;
-     elHitsIt2++, gsfHitCounter2++ )
-    { if (((**elHitsIt2).isValid())) break ; }
+  for(auto const& hit : iGsfTrack->recHits()) {
+    if (hit->isValid()) break ;
+    gsfHitCounter2++;
+  }
   
   uint32_t gsfHit1 = gsfHitPattern1.getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter1) ;
   uint32_t gsfHit2 = gsfHitPattern2.getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter2) ;

--- a/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
@@ -353,32 +353,22 @@ ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>& the
 	detaBremKF = minDEtaBremKF;
 	
 	// Number of commont hits
-	trackingRecHit_iterator  nhit=refGsf->recHitsBegin();
-	trackingRecHit_iterator  nhit_end=refGsf->recHitsEnd();
-	unsigned int tmp_sh = 0;
+	unsigned int tmpSh = 0;
 	//uint ish=0;
 	int kfhitcounter=0;
-	for (;nhit!=nhit_end;++nhit){
-	  if ((*nhit)->isValid()){
-	    trackingRecHit_iterator  ihit=trkRef->recHitsBegin();
-	    trackingRecHit_iterator  ihit_end=trkRef->recHitsEnd();
-	    kfhitcounter=0;	    
-	    for (;ihit!=ihit_end;++ihit){
-	      if ((*ihit)->isValid()) {
-		// method 1
-		if((*nhit)->sharesInput(&*(*ihit),TrackingRecHit::all))  tmp_sh++;
-		kfhitcounter++; 
-		// method 2 to switch in case of problem with rechit collections
-		//  if(((*ihit)->geographicalId()==(*nhit)->geographicalId())&&
-		//  (((*nhit)->localPosition()-(*ihit)->localPosition()).mag()<0.01)) ish++;
-		
-		
-	      }
-	    }
-	  }
-	}
+    for(auto const& nhit : refGsf->recHits()) if (nhit->isValid()) {
+        kfhitcounter=0;
+        for(auto const& ihit : trkRef->recHits()) if (ihit->isValid()) {
+        // method 1
+        if(nhit->sharesInput(ihit,TrackingRecHit::all)) tmpSh++;
+        kfhitcounter++; 
+        // method 2 to switch in case of problem with rechit collections
+        // if((ihit->geographicalId()==nhit->geographicalId())&&
+        //     ((nhit->localPosition()-ihit->localPosition()).mag()<0.01)) ish++;
+        }
+    }
 	  
-	nHITS1 = tmp_sh;
+	nHITS1 = tmpSh;
 
 	TString weightfilepath ="";
 	double mvaValue =  -10; 

--- a/RecoVertex/V0Producer/test/V0Analyzer.cc
+++ b/RecoVertex/V0Producer/test/V0Analyzer.cc
@@ -740,15 +740,14 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
       if( theVtxTrax[0]->recHitsSize() && theVtxTrax[1]->recHitsSize() ) {
 	double nHits1 = (double) theVtxTrax[0]->numberOfValidHits();
 	double nHits2 = (double) theVtxTrax[1]->numberOfValidHits();
-	/*trackingRecHit_iterator tk1HitIt = theVtxTrax[0]->recHitsBegin();
-	trackingRecHit_iterator tk2HitIt = theVtxTrax[1]->recHitsBegin();
+	/*
 
 	double nHits1 = 0.;
 	double nHits2 = 0.;
-	for( ; tk1HitIt < theVtxTrax[0]->recHitsEnd(); tk1HitIt++) {
-	  const TrackingRecHit* tk1HitPtr = (*tk1HitIt).get();
-	  if( (*tk1HitIt)->isValid() ) nHits1 += 1.;
-	  if( (*tk1HitIt)->isValid() && hitsOkay) {
+    for(auto const& tk1Hit : theVtxTrax[0]->recHits()) {
+	  const TrackingRecHit* tk1HitPtr = tk1Hit.get();
+	  if( tk1Hit->isValid() ) nHits1 += 1.;
+	  if( tk1Hit->isValid() && hitsOkay) {
 	    GlobalPoint tk1HitPosition
 	      = trackerGeom->idToDet(tk1HitPtr->
 				     geographicalId())->
@@ -766,10 +765,10 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
 	  }
 	}
 
-	for( ; tk2HitIt < theVtxTrax[1]->recHitsEnd(); tk2HitIt++) {
-	  const TrackingRecHit* tk2HitPtr = (*tk2HitIt).get();
-	  if( (*tk2HitIt)->isValid() ) nHits2 += 1.;
-	  if( (*tk2HitIt)->isValid() && hitsOkay) {
+	for(auto const& tk2Hit : theVtxTrax[1]->recHits()) {
+	  const TrackingRecHit* tk2HitPtr = tk2Hit.get();
+	  if( tk2Hit->isValid() ) nHits2 += 1.;
+	  if( tk2Hit->isValid() && hitsOkay) {
 	    GlobalPoint tk2HitPosition
 	      = trackerGeom->idToDet(tk2HitPtr->
 				     geographicalId())->


### PR DESCRIPTION
This PR suggests to add a member function to TrackExtraBase which returns an instance of the new TrackingRecHitRange (template instantiation of new edm::ConstRange<T>) that can be used to express range-based loops over the RecHits associated to a track. I think this would be beneficial for the modernization of reconstruction code, as I show at the example of RecoParticleFlow, where I replaced all occurrences of recHitsBegin and recHitsEnd.

Local matrix tests pass.