### PR TITLE
 Ancestral Value Maps : 105X

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -897,8 +897,17 @@ class GsfElectron : public RecoCandidate
   float pixelMatchDPhi2() const { return pixelMatchVariables_.dPhi2 ; }
   float pixelMatchDRz1 () const { return pixelMatchVariables_.dRz1  ; }
   float pixelMatchDRz2 () const { return pixelMatchVariables_.dRz2  ; }
+
   private:
     PixelMatchVariables pixelMatchVariables_ ;    
+
+  public:
+    const std::vector<edm::Ptr<reco::GsfElectron> >& parentRefs()const{return parentRefs_;}
+    void addParentRef(edm::Ptr<reco::GsfElectron> ref){parentRefs_.push_back(ref);}
+    void setParentRefs(std::vector<edm::Ptr<reco::GsfElectron> > refs){parentRefs_ = refs;}
+  private: 
+    //needs to access both reco::GsfElectrons, pat::Electrons
+    std::vector<edm::Ptr<reco::GsfElectron> > parentRefs_;
  } ;
 
  } // namespace reco

--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -31,9 +31,6 @@ namespace reco {
     /// default constructor
     Photon() : RecoCandidate() { pixelSeed_=false; }
 
-    /// copy constructor
-    Photon ( const Photon&); 
-
     /// constructor from values
     Photon( const LorentzVector & p4, 
 	    const Point& caloPos, 
@@ -531,6 +528,13 @@ namespace reco {
     float pfMVA() const {return pfID_.mva;}
     // setters
     void setPflowIDVariables ( const PflowIDVariables& pfid ) {  pfID_ = pfid;}         
+
+  public:
+    const std::vector<edm::Ptr<reco::Photon> >& parentRefs()const{return parentRefs_;}
+    void addParentRef(edm::Ptr<reco::Photon> ref){parentRefs_.push_back(ref);}
+    void setParentRefs(std::vector<edm::Ptr<reco::Photon> > refs){parentRefs_ = refs;}
+  private: 
+
     
   private:
     /// check overlap with another candidate
@@ -552,6 +556,9 @@ namespace reco {
     MIPVariables        mipVariableBlock_; 
     PflowIsolationVariables pfIsolation_;
     PflowIDVariables pfID_;    
+    //needs to access both reco::Photons, pat::Photons
+    std::vector<edm::Ptr<reco::Photon> > parentRefs_;
+
   };
 
 }

--- a/DataFormats/EgammaCandidates/src/Photon.cc
+++ b/DataFormats/EgammaCandidates/src/Photon.cc
@@ -14,25 +14,6 @@ Photon::Photon( const LorentzVector & p4,
  {}
 
 
-Photon::Photon( const Photon& rhs ) :
-  RecoCandidate(rhs),
-  caloPosition_(rhs.caloPosition_),
-  photonCore_ ( rhs.photonCore_),
-  pixelSeed_  ( rhs.pixelSeed_ ),
-  fiducialFlagBlock_ ( rhs.fiducialFlagBlock_ ),
-  isolationR04_ ( rhs.isolationR04_),
-  isolationR03_ ( rhs.isolationR03_),
-  showerShapeBlock_ ( rhs.showerShapeBlock_),
-  full5x5_showerShapeBlock_ ( rhs.full5x5_showerShapeBlock_),
-  saturationInfo_ ( rhs.saturationInfo_ ),
-  eCorrections_(rhs.eCorrections_),
-  mipVariableBlock_ (rhs.mipVariableBlock_),
-  pfIsolation_ ( rhs.pfIsolation_ )
- {}
-
-
-
-
 Photon::~Photon() { }
 
 Photon * Photon::clone() const {

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -9,7 +9,8 @@
   </ioread>
 
 
-  <class name="reco::Photon" ClassVersion="17">
+  <class name="reco::Photon" ClassVersion="18">
+   <version ClassVersion="18" checksum="1427192729"/>
    <version ClassVersion="17" checksum="4077732720"/>
    <version ClassVersion="16" checksum="3459546220"/>
    <version ClassVersion="15" checksum="577991108"/>
@@ -233,7 +234,8 @@
    <version ClassVersion="3" checksum="3868678681"/>
   </class>
 
-  <class name="reco::GsfElectron" ClassVersion="20">
+  <class name="reco::GsfElectron" ClassVersion="21">
+   <version ClassVersion="21" checksum="2626127449"/>
    <version ClassVersion="20" checksum="2375747450"/>
    <version ClassVersion="19" checksum="1682285704"/>
    <version ClassVersion="18" checksum="2072747263"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -16,7 +16,8 @@
   <class name="pat::Lepton<reco::BaseTau>" />
 
   <!-- PAT Objects, and embedded data  -->
-  <class name="pat::Electron"  ClassVersion="38">
+  <class name="pat::Electron"  ClassVersion="39">
+   <version ClassVersion="39" checksum="1294487469"/>
    <version ClassVersion="38" checksum="1251314096"/>
    <version ClassVersion="37" checksum="4284869321"/>
    <version ClassVersion="36" checksum="199321903"/>
@@ -215,7 +216,8 @@
   </ioread>
 
   <class name="std::vector<pat::tau::TauPFEssential>" />
-  <class name="pat::Photon"  ClassVersion="21">
+  <class name="pat::Photon"  ClassVersion="22">
+   <version ClassVersion="22" checksum="975066815"/>
    <version ClassVersion="21" checksum="3263223164"/>
    <version ClassVersion="20" checksum="1579185367"/>
    <version ClassVersion="19" checksum="4285818507"/>

--- a/FWCore/Utilities/interface/InputTag.h
+++ b/FWCore/Utilities/interface/InputTag.h
@@ -39,6 +39,8 @@ namespace edm {
     ///product with the label and instance
     std::string const& process() const {return process_;} 
 
+    bool isUnitialized() const {return label_.empty() && instance_.empty() && process_.empty();}
+
     bool willSkipCurrentProcess() const { return skipCurrentProcess_; }
     
     bool operator==(InputTag const& tag) const;

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -378,6 +378,7 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
 	  // ref to base needed for the construction of the pat object
 	  const edm::RefToBase<reco::GsfElectron>& elecsRef = electrons->refAt(idx);
 	  Electron anElectron(elecsRef);
+	  anElectron.addParentRef(elePtr);
 	  anElectron.setPFCandidateRef( pfRef  );
     	  if (addPuppiIsolation_) {		 
 	    anElectron.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[elePtr], (*PUPPIIsolation_neutral_hadrons)[elePtr], (*PUPPIIsolation_photons)[elePtr]);
@@ -575,7 +576,7 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
       reco::CandidateBaseRef elecBaseRef(elecsRef);
       Electron anElectron(elecsRef);
       auto elePtr = electrons -> ptrAt(idx);
-
+      anElectron.addParentRef(elePtr);
       // Is this GsfElectron also identified as an e- in the particle flow?
       bool pfId = false;
 

--- a/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
@@ -116,12 +116,11 @@ pat::PATElectronSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iS
     if( modifyElectron_ ) electronModifier_->setEventContent(iSetup);
 
     std::vector<unsigned int> keys;
-    for (View<pat::Electron>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-        out->push_back(*it);
+    for (auto elePtr : src->ptrs() ){
+        out->push_back(*elePtr);
         pat::Electron & electron = out->back();
-
+	electron.addParentRef(elePtr);
         if( modifyElectron_ ) { electronModifier_->modify(electron); }
-
         if (dropSuperClusters_(electron)) { electron.superCluster_.clear(); electron.embeddedSuperCluster_ = false; }
 	if (dropBasicClusters_(electron)) { electron.basicClusters_.clear();  }
 	if (dropSuperClusters_(electron) || dropPFlowClusters_(electron)) { electron.pflowSuperCluster_.clear(); electron.embeddedPflowSuperCluster_ = false; }

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -6,6 +6,7 @@
 // Framework
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
 
 #include "CommonTools/Utils/interface/StringToEnumValue.h"
 
@@ -354,7 +355,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     reco::PhotonRef photonref(photonHandle,index);
     photons->push_back(photon);
     auto& newPhoton = photons->back();
-   
+    newPhoton.addParentRef(edm::refToPtr(photonref));
+
     if( (applyPhotonCalibOnData_ && theEvent.isRealData()) ||
 	(applyPhotonCalibOnMC_ && !theEvent.isRealData()) ){
       calibratePhoton(newPhoton,photonref,		      
@@ -426,7 +428,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
       reco::PhotonRef ootPhotonref(ootPhotonHandle,index);
       
       ootPhotons->push_back(ootPhoton);
-      
+      ootPhotons->back().addParentRef(edm::refToPtr(ootPhotonref));
+
       //fill photon pfclusteriso valuemap vectors
       int subindex = 0;
       for (const auto& ootPhotonFloatValueMapHandle : ootPhotonFloatValueMapHandles) {
@@ -459,6 +462,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     reco::GsfElectronRef gsfElectronref(gsfElectronHandle,index);
     gsfElectrons->push_back(gsfElectron);
     auto& newGsfElectron = gsfElectrons->back();
+    newGsfElectron.addParentRef(edm::refToPtr(gsfElectronref));
     if( (applyGsfElectronCalibOnData_ && theEvent.isRealData()) ||
 	(applyGsfElectronCalibOnMC_ && !theEvent.isRealData()) ){
       calibrateElectron(newGsfElectron, gsfElectronref,		

--- a/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
+++ b/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
@@ -48,7 +48,7 @@ namespace egmodifier {
     ValueMapData(std::string name,const edm::InputTag& tag):name_(std::move(name)),tag_(tag){}
     
     void setHandle(const edm::Event& evt){if(!token_.isUninitialized()) evt.getByToken(token_,handle_);}
-    void setToken(edm::ConsumesCollector& cc){if(!tag_.label().empty()) token_ = cc.consumes<edm::ValueMap<MapType> >(tag_);}
+    void setToken(edm::ConsumesCollector& cc){if(!tag_.isUnitialized()) token_ = cc.consumes<edm::ValueMap<MapType> >(tag_);}
 
     const std::string& name()const{return name_;}
     void isValid()const {return handle_.isValid();}    

--- a/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
+++ b/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
@@ -10,33 +10,22 @@
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Photon.h"
 
-#include <unordered_map>
-
-namespace {
-  const edm::InputTag empty_tag;
-}
-
 //class: EGExtraInfoModifierFromValueMaps
 //  
 //this is a generalisation of EGExtraInfoModiferFromFloatValueMaps
-//orginal author of EGExtraInfoModiferFromFloatValueMaps : L. Gray (FNAL)
+//orginal author of EGExtraInfoModiferFromFloatValueMaps : L. Gray (FNAL) 
+//although it has been changed so much it is now almost unrecognisable from the original version
 //converter to templated version: S. Harper (RAL)
+//moderniser: S. Harper (RAL)
 //
 //This class allows an data of an arbitrary type in a ValueMap for pat::Electrons or pat::Photons
 //to be put in the pat::Electron/Photon as userData, userInt or userFloat
-//
-//IMPORTANT INFO:
-//by default the ValueMap is keyed to the object the pat::Electron/Photon was created from
-//if you want to use a ValueMap which is keyed to a different collection (ie perhaps the same 
-//as the electrons you are aring, you must set "electronSrc" and "photonSrc" inside the ele/pho configs
-//so if you are running over slimmedElectrons and want to read a ValueMap keyed to slimmedElectrons 
-//you need to set "electron_config.electronSrc = cms.InputTag("slimmedElectrons")"
 //
 //It assumes that the object can be added via pat::PATObject::userData, see pat::PATObject for the 
 //constraints here
 //
 //The class has two template arguements:
-//  MapType : c++ type of the object stored in the value mape
+//  MapType : c++ type of the object stored in the value map
 //  OutputType : c++ type of how you want to store it in the pat::PATObject
 //               this exists so you can specialise int and float (and future exceptions) to use
 //               pat::PATObject::userInt and pat::PATObject::userFloat
@@ -51,72 +40,77 @@ namespace egmodifier{
   class EGID{};//dummy class to be used as a template arguement 
 }
 
-template<typename OutputType>
-class EGXtraModFromVMObjFiller {
-public:
-  EGXtraModFromVMObjFiller()=delete;
-  ~EGXtraModFromVMObjFiller()=delete;
+//our little helper classes
+namespace egmodifier {
+  template<typename MapType>
+  class ValueMapData {
+  public:
+    ValueMapData(std::string name,const edm::InputTag& tag):name_(std::move(name)),tag_(tag){}
+    
+    void setHandle(const edm::Event& evt){if(!token_.isUninitialized()) evt.getByToken(token_,handle_);}
+    void setToken(edm::ConsumesCollector& cc){if(!tag_.label().empty()) token_ = cc.consumes<edm::ValueMap<MapType> >(tag_);}
 
-  //will do a UserData add but specialisations exist for float and ints
-  template<typename ObjType,typename MapType>
-  static void 
-  addValueToObject(ObjType& obj,
-		   const edm::Ptr<reco::Candidate>& ptr,
-		   const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		   const std::pair<const std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > > & val_map,
-		   bool overrideExistingValues);
-  
-  template<typename ObjType,typename MapType>
-  static void 
-  addValuesToObject(ObjType& obj,
-		    const edm::Ptr<reco::Candidate>& ptr,
-		    const std::unordered_map<std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > > & vmaps_token,		  
-		    const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		    bool overrideExistingValues){
-    for( auto itr = vmaps_token.begin(); itr != vmaps_token.end(); ++itr ) {
-      addValueToObject(obj,ptr,vmaps,*itr,overrideExistingValues);
-    }  
-  }
-};		    
-		    
+    const std::string& name()const{return name_;}
+    void isValid()const {return handle_.isValid();}    
+    template<typename RefType>
+    typename edm::ValueMap<MapType>::const_reference_type
+    value(const RefType& ref)const{return (*handle_)[ref];}
+
+  private:
+    std::string name_;
+    edm::InputTag tag_;
+    edm::EDGetTokenT<edm::ValueMap<MapType> > token_;
+    edm::Handle<edm::ValueMap<MapType> > handle_;
+  };
+
+  template<typename OutputType>
+  class EGXtraModFromVMObjFiller {
+  public:
+    EGXtraModFromVMObjFiller()=delete;
+    ~EGXtraModFromVMObjFiller()=delete;
+    
+    template<typename ObjType,typename MapType>
+    static void 
+    addValueToObject(ObjType& obj,
+		     const ValueMapData<MapType>& vmData,
+		     bool overrideExistingValues);
+    
+    template<typename ObjType,typename MapType>
+    static void 
+    addValuesToObject(ObjType& obj,
+		      const std::vector<ValueMapData<MapType> >& vmapsData,
+		      bool overrideExistingValues){
+      for(auto& vmapData : vmapsData){
+	addValueToObject(obj,vmapData,overrideExistingValues);
+      }  
+    }
+    
+    //will do a UserData add but specialisations exist for float and ints
+    //in theory could do most of this with function pointers for the different addX and hasX functions
+    //but specialisations are simplier
+    template<typename ObjType>
+    static void addValue(ObjType& obj,const std::string& name,const OutputType& value){obj.addUserData(name,value,true);}
+    template<typename ObjType>
+    static bool hasValue(ObjType& obj,const std::string& name){return obj.hasUserData(name);}
+    
+  };		    
+}
 
 template<typename MapType,typename OutputType=MapType>
 class EGExtraInfoModifierFromValueMaps : public ModifyObjectValueBase {
 public:
-  using ValMapToken = edm::EDGetTokenT<edm::ValueMap<MapType> >;
-  using ValueMaps = std::unordered_map<std::string,ValMapToken>;
-  using ValueMapsTags = std::unordered_map<std::string,edm::InputTag>;
-  struct electron_config {
-    edm::InputTag electron_src;
-    edm::EDGetTokenT<edm::View<pat::Electron> > tok_electron_src;
-    ValueMapsTags valuemaps;
-    ValueMaps tok_valuemaps;    
-  };
-
-  struct photon_config {
-    edm::InputTag photon_src;
-    edm::EDGetTokenT<edm::View<pat::Photon> > tok_photon_src;
-    ValueMapsTags valuemaps;
-    ValueMaps tok_valuemaps; 
-  };
-
   EGExtraInfoModifierFromValueMaps(const edm::ParameterSet& conf);
   
   void setEvent(const edm::Event&) final;
+  void setEventContent(const edm::EventSetup&) final{}
   void setConsumes(edm::ConsumesCollector&) final;
   
   void modifyObject(pat::Electron&) const final;
   void modifyObject(pat::Photon&) const final;
-
  
 private:
-  electron_config e_conf;
-  photon_config   ph_conf;
-  std::vector<edm::Ptr<reco::GsfElectron>> eles_by_oop; // indexed by original object ptr
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > > ele_vmaps;
-  std::vector<edm::Ptr<reco::Photon>> phos_by_oop;
-  std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > > pho_vmaps;
-  mutable unsigned ele_idx,pho_idx; // hack here until we figure out why some slimmedPhotons don't have original object ptrs
+  std::vector<egmodifier::ValueMapData<MapType> > eleVMData_;
+  std::vector<egmodifier::ValueMapData<MapType> > phoVMData_;
   bool overrideExistingValues_;
 };
 
@@ -125,196 +119,111 @@ template<typename MapType,typename OutputType>
 EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
 EGExtraInfoModifierFromValueMaps(const edm::ParameterSet& conf) :
   ModifyObjectValueBase(conf) {
-  constexpr char electronSrc[] =  "electronSrc";
-  constexpr char photonSrc[] =  "photonSrc";
   overrideExistingValues_ = conf.exists("overrideExistingValues") ? conf.getParameter<bool>("overrideExistingValues") : false;
   if( conf.exists("electron_config") ) {
-    const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
-    if( electrons.exists(electronSrc) ) e_conf.electron_src = electrons.getParameter<edm::InputTag>(electronSrc);
-  
-    const std::vector<std::string> parameters = electrons.getParameterNames();
+    const edm::ParameterSet& ele_cfg = conf.getParameter<edm::ParameterSet>("electron_config");
+    const std::vector<std::string>& parameters = ele_cfg.getParameterNames();
     for( const std::string& name : parameters ) {
-      if( std::string(electronSrc) == name ) continue;
-      if( electrons.existsAs<edm::InputTag>(name) ) {
-        e_conf.valuemaps[name] = electrons.getParameter<edm::InputTag>(name);
+      if( ele_cfg.existsAs<edm::InputTag>(name) ) {
+        eleVMData_.emplace_back(egmodifier::ValueMapData<MapType>(name,ele_cfg.getParameter<edm::InputTag>(name)));
       }
     }    
   }
   if( conf.exists("photon_config") ) {
-    const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
-    if( photons.exists(photonSrc) ) ph_conf.photon_src = photons.getParameter<edm::InputTag>(photonSrc);
-    const std::vector<std::string> parameters = photons.getParameterNames();
+    const edm::ParameterSet& pho_cfg = conf.getParameter<edm::ParameterSet>("photon_config");
+    const std::vector<std::string>& parameters = pho_cfg.getParameterNames();
     for( const std::string& name : parameters ) {
-      if( std::string(photonSrc) == name ) continue;
-      if( photons.existsAs<edm::InputTag>(name) ) {
-        ph_conf.valuemaps[name] = photons.getParameter<edm::InputTag>(name);
+      if( pho_cfg.existsAs<edm::InputTag>(name) ) {
+        phoVMData_.emplace_back(egmodifier::ValueMapData<MapType>(name,pho_cfg.getParameter<edm::InputTag>(name)));
       }
-    } 
+    }    
   }
-  ele_idx = pho_idx = 0;
 }
 
 template<typename MapType,typename OutputType>
 void EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
 setEvent(const edm::Event& evt) {
-  eles_by_oop.clear();
-  phos_by_oop.clear();  
-  ele_vmaps.clear();
-  pho_vmaps.clear();
 
-  ele_idx = pho_idx = 0;
-
-  if( !e_conf.tok_electron_src.isUninitialized() ) {
-    edm::Handle<edm::View<pat::Electron> > eles;
-    evt.getByToken(e_conf.tok_electron_src,eles);
-    
-    eles_by_oop.resize(eles->size());
-    std::copy(eles->ptrs().begin(), eles->ptrs().end(), eles_by_oop.begin());
-  }
-
-  for(auto const& itr : e_conf.tok_valuemaps) evt.getByToken(itr.second,ele_vmaps[itr.second.index()]);
-
-  if( !ph_conf.tok_photon_src.isUninitialized() ) {
-    edm::Handle<edm::View<pat::Photon> > phos;
-    evt.getByToken(ph_conf.tok_photon_src,phos);
-
-    phos_by_oop.resize(phos->size());
-    std::copy(phos->ptrs().begin(), phos->ptrs().end(), phos_by_oop.begin());
-  }
-
-  for(auto const& itr : ph_conf.tok_valuemaps) evt.getByToken(itr.second,pho_vmaps[itr.second.index()]);
-}
-
-namespace {
-  template<typename T>
-  inline void make_consumes(const edm::InputTag& tag,edm::EDGetTokenT<T>& token, edm::ConsumesCollector& cc)
-  { if( !(empty_tag == tag) ) token = cc.consumes<T>(tag); }
+  for( auto& data : eleVMData_) data.setHandle(evt);
+  for( auto& data : phoVMData_) data.setHandle(evt);
+  
 }
 
 template<typename MapType,typename OutputType>
 void EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
-setConsumes(edm::ConsumesCollector& sumes) {
-  //setup electrons
-  if( !(empty_tag == e_conf.electron_src) ) e_conf.tok_electron_src = sumes.consumes<edm::View<pat::Electron> >(e_conf.electron_src);  
-  for(auto const& itr : e_conf.valuemaps) make_consumes(itr.second,e_conf.tok_valuemaps[itr.first],sumes);
-  
-  // setup photons 
-  if( !(empty_tag == ph_conf.photon_src) ) ph_conf.tok_photon_src = sumes.consumes<edm::View<pat::Photon> >(ph_conf.photon_src);
-  for(auto const& itr : ph_conf.valuemaps) make_consumes(itr.second,ph_conf.tok_valuemaps[itr.first],sumes);
-}
-
-namespace {
-  template<typename T, typename U, typename V, typename MapType >
-  inline void assignValue(const T& ptr, const U& tok, const V& map, MapType& value) {
-    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
-  }
+setConsumes(edm::ConsumesCollector& cc) {  
+  for( auto& data : eleVMData_) data.setToken(cc);
+  for( auto& data : phoVMData_) data.setToken(cc);
 }
 
 template<typename MapType,typename OutputType>
 void EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
 modifyObject(pat::Electron& ele) const {
-  // we encounter two cases here, either we are running AOD -> MINIAOD
-  // and the value maps are to the reducedEG object, can use original object ptr
-  // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference
-  edm::Ptr<reco::Candidate> ptr(ele.originalObjectRef());
-  if( !e_conf.tok_electron_src.isUninitialized() ) ptr = eles_by_oop.at(ele_idx);
-  //now we go through and modify the objects using the valuemaps we read in 
-  EGXtraModFromVMObjFiller<OutputType>::addValuesToObject(ele,ptr,e_conf.tok_valuemaps,
-							  ele_vmaps,overrideExistingValues_);
-  ++ele_idx;
+  egmodifier::EGXtraModFromVMObjFiller<OutputType>::addValuesToObject(ele,eleVMData_,overrideExistingValues_);
 }
-
 
 template<typename MapType,typename OutputType>
 void EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
 modifyObject(pat::Photon& pho) const {
-  // we encounter two cases here, either we are running AOD -> MINIAOD
-  // and the value maps are to the reducedEG object, can use original object ptr
-  // or we are running MINIAOD->MINIAOD and we need to fetch the pat objects to reference
-  edm::Ptr<reco::Candidate> ptr(pho.originalObjectRef());
-  if( !ph_conf.tok_photon_src.isUninitialized() ) ptr = phos_by_oop.at(pho_idx);
-  //now we go through and modify the objects using the valuemaps we read in
-  EGXtraModFromVMObjFiller<OutputType>::addValuesToObject(pho,ptr,ph_conf.tok_valuemaps,
-							  pho_vmaps,overrideExistingValues_);
-							  
-  ++pho_idx;
+  egmodifier::EGXtraModFromVMObjFiller<OutputType>::addValuesToObject(pho,phoVMData_,overrideExistingValues_);
 }
-
 
 template<typename OutputType>
 template<typename ObjType,typename MapType>
-void EGXtraModFromVMObjFiller<OutputType>::
+void egmodifier::EGXtraModFromVMObjFiller<OutputType>::
 addValueToObject(ObjType& obj,
-		 const edm::Ptr<reco::Candidate>& ptr,
-		 const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		 const std::pair<const std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > > & val_map,
+		 const egmodifier::ValueMapData<MapType>& mapData,
 		 bool overrideExistingValues)
 {
-  MapType value{};
-  assignValue(ptr,val_map.second,vmaps,value);
-  if( overrideExistingValues || !obj.hasUserData(val_map.first) ) {
-    obj.addUserData(val_map.first,value,true);
-  } else {
-    throw cms::Exception("ValueNameAlreadyExists")
-      << "Trying to add new UserData = " << val_map.first
-      << " failed because it already exists and you didnt specify to override it (set in the config overrideExistingValues=cms.bool(True) )";
+  if(obj.parentRefs().empty()){
+    throw cms::Exception("LogicError") << " object "<<typeid(obj).name()<<" has no parent references, these should be set with ::addParentRef before calling the modifier";
   }
-}  
-
-template<>
-template<typename ObjType,typename MapType>
-void EGXtraModFromVMObjFiller<float>::
-addValueToObject(ObjType& obj,
-		 const edm::Ptr<reco::Candidate>& ptr,
-		 const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		 const std::pair<const std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > >& val_map,
-		 bool overrideExistingValues)
-{
-  float value(0.0);
-  assignValue(ptr,val_map.second,vmaps,value);
-  if( overrideExistingValues || !obj.hasUserFloat(val_map.first) ) {
-    obj.addUserFloat(val_map.first,value,true);
+  auto ptr = obj.parentRefs().back();
+  if( overrideExistingValues || !hasValue(obj,mapData.name()) ) {
+    addValue(obj,mapData.name(),mapData.value(ptr));
   } else {
     throw cms::Exception("ValueNameAlreadyExists")
-      << "Trying to add new UserFloat = " << val_map.first
+      << "Trying to add new UserData = " << mapData.name()
       << " failed because it already exists and you didnt specify to override it (set in the config overrideExistingValues=cms.bool(True) )";
   }
 }
 
+
 template<>
-template<typename ObjType,typename MapType>
-void EGXtraModFromVMObjFiller<int>::
-addValueToObject(ObjType& obj,
-		 const edm::Ptr<reco::Candidate>& ptr,		 
-		 const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<MapType> > >& vmaps,
-		 const std::pair<const std::string,edm::EDGetTokenT<edm::ValueMap<MapType> > >& val_map,
-		 bool overrideExistingValues)
-{
-  int value(0);
-  assignValue(ptr,val_map.second,vmaps,value);
-  if( overrideExistingValues || !obj.hasUserInt(val_map.first) ) {
-    obj.addUserInt(val_map.first,value,true);
-  } else {
-    throw cms::Exception("ValueNameAlreadyExists")
-      << "Trying to add new UserInt = " << val_map.first
-      << " failed because it already exists and you didnt specify to override it (set in the config overrideExistingValues=cms.bool(True) )";
-  }
-}  
+template<typename ObjType>
+void egmodifier::EGXtraModFromVMObjFiller<float>::
+addValue(ObjType& obj,const std::string& name,const float& value){obj.addUserFloat(name,value,true);}
+
+template<>
+template<typename ObjType>
+bool egmodifier::EGXtraModFromVMObjFiller<float>::
+hasValue(ObjType& obj,const std::string& name){return obj.hasUserFloat(name);}
+
+template<>
+template<typename ObjType>
+void egmodifier::EGXtraModFromVMObjFiller<int>::
+addValue(ObjType& obj,const std::string& name,const int& value){obj.addUserInt(name,value,true);}
+
+template<>
+template<typename ObjType>
+bool egmodifier::EGXtraModFromVMObjFiller<int>::
+hasValue(ObjType& obj,const std::string& name){return obj.hasUserInt(name);}
 
 template<>
 template<>
-void EGXtraModFromVMObjFiller<egmodifier::EGID>::
+void egmodifier::EGXtraModFromVMObjFiller<egmodifier::EGID>::
 addValuesToObject(pat::Electron& obj,
-		  const edm::Ptr<reco::Candidate>& ptr,
-		  const std::unordered_map<std::string,edm::EDGetTokenT<edm::ValueMap<float> > > & vmaps_token,		  
-		  const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > >& vmaps,
+		  const std::vector<egmodifier::ValueMapData<float> >& vmapsData,
 		  bool overrideExistingValues)
 {
   std::vector<std::pair<std::string,float >> ids;
-  for( auto itr = vmaps_token.begin(); itr != vmaps_token.end(); ++itr ) {
-    float idVal(0);
-    assignValue(ptr,itr->second,vmaps,idVal);
-    ids.push_back({itr->first,idVal});
+  if(obj.parentRefs().empty()){
+    throw cms::Exception("LogicError") << " object "<<typeid(obj).name()<<" has no parent references, these should be set with ::addParentRef before calling the modifier";
+  }    
+  auto ptr = obj.parentRefs().back();
+  for( auto& vmapData : vmapsData ) {
+    float idVal = vmapData.value(ptr);
+    ids.push_back({vmapData.name(),idVal});
   }   
   std::sort(ids.begin(),ids.end(),[](auto& lhs,auto& rhs){return lhs.first<rhs.first;});
   obj.setElectronIDs(ids);
@@ -322,23 +231,23 @@ addValuesToObject(pat::Electron& obj,
 
 template<>
 template<>
-void EGXtraModFromVMObjFiller<egmodifier::EGID>::
+void egmodifier::EGXtraModFromVMObjFiller<egmodifier::EGID>::
 addValuesToObject(pat::Photon& obj,
-		  const edm::Ptr<reco::Candidate>& ptr,
-		  const std::unordered_map<std::string,edm::EDGetTokenT<edm::ValueMap<float> > > & vmaps_token,		  
-		  const std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > >& vmaps,
+		  const std::vector<egmodifier::ValueMapData<float> >& vmapsData,
 		  bool overrideExistingValues)
 {
   //we do a float->bool conversion here to make things easier to be consistent with electrons
   std::vector<std::pair<std::string,bool> > ids;
-  for( auto itr = vmaps_token.begin(); itr != vmaps_token.end(); ++itr ) {
-    float idVal(0);
-    assignValue(ptr,itr->second,vmaps,idVal);
-    ids.push_back({itr->first,idVal});
+  if(obj.parentRefs().empty()){
+    throw cms::Exception("LogicError") << " object "<<typeid(obj).name()<<" has no parent references, these should be set with ::addParentRef before calling the modifier";
+  }
+  auto ptr = obj.parentRefs().back();
+  for( auto& vmapData : vmapsData ) {
+    float idVal = vmapData.value(ptr);
+    ids.push_back({vmapData.name(),idVal});
   }  
   std::sort(ids.begin(),ids.end(),[](auto& lhs,auto& rhs){return lhs.first<rhs.first;});
   obj.setPhotonIDs(ids);
 }
-
 
 #endif

--- a/RecoEgamma/EgammaTools/plugins/CalibratedElectronProducers.cc
+++ b/RecoEgamma/EgammaTools/plugins/CalibratedElectronProducers.cc
@@ -167,8 +167,11 @@ CalibratedElectronProducerT<T>::produce( edm::Event & iEvent, const edm::EventSe
     ElectronEnergyCalibrator::EventType::DATA : ElectronEnergyCalibrator::EventType::MC; 
   
   
-  for (const auto& ele : *inHandle) {
+  for (size_t eleIdx = 0; eleIdx < inHandle->size(); eleIdx++) {
+    const auto& ele = (*inHandle)[eleIdx];
+    edm::Ptr<T> elePtr(inHandle,eleIdx);
     out->push_back(ele);
+    out->back().addParentRef(elePtr);
     
     if(semiDeterministicRng_) setSemiDetRandomSeed(iEvent,ele,nrObj,out->size());
 

--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleValueMapIsoRhoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleValueMapIsoRhoCut.cc
@@ -82,7 +82,7 @@ operator()(const reco::GsfElectronPtr& cand) const{
 double GsfEleValueMapIsoRhoCut::
 value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);  
-  return (*valueHandle_)[cand];
+  return (*valueHandle_)[ele];
 }
 
 float GsfEleValueMapIsoRhoCut::getRhoCorr(const reco::GsfElectronPtr& cand)const{


### PR DESCRIPTION
This is a rebase of https://github.com/cms-sw/cmssw/pull/25576. Because I like to have the base release in the branch name (I know its easy to  find out but this makes my life a bit easier), I decided to close that PR and reopen it with a new branch. The text of that PR follows below:

Valuemaps are used extensively to associate values with objects. An object is identified via a product id/ index pair, corresponding to a given item in a collection. This is used extensively in the HLT but is also used frequently in RECO. A value map can only be used with a reference to an object from the collection it was created with.

The issue arises in that we often need to make new collections of electrons/photons (such as converting them to pat or updating the objects with new embedded information). Currently when you do this, you need to rekey all the value maps associated with that collection, which to put it mildly is a pain.

This update allows electrons and photons to track which objects they were made from by storing a edm::Ptr to the original object. edm::ValueMap interface has been extended to recognize when this information is available and if the edm::Ptr is invalid, cycle through its parents to see if it finds one that matches the collection it was created from. This means a new collection of pat::Electrons can use value maps keyed to the orginal GsfElectrons. This greatly simplifies the code, look what happens to RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h. ReducedEGProducer will similarly get smaller as it spends some effort rekeying valuemaps. Also makes VID so much easier.

The setting of the parents references is optional and up to the code which creates the new electrons/photons. You may not want to do it for temporary collections for which no value maps are produced.

Note the code refers to parentRefs etc but perhaps I should rename it to pointers as thats what they are.

Finally, this is probably of interest to other POGs who likely have similar issues. As such I'm open to the idea allowing reco::Candidates to track their parents and adding this capability for everybody.

Btw backporting some of this to 102X would be useful, this would make E/gamma user recipes easier. However I'm not going to push for this.

Also while I was compiling half of CMSSW anyways, I added an "unInitialized" method to InputTag, can remove if you like but it made the code a bit more clear.