### PR TITLE
Use unique bin names in L1TdeStage2CaloLayer1

### DIFF
--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -282,7 +282,7 @@ void L1TdeStage2CaloLayer1::bookHistograms(DQMStore::IBooker &ibooker, const edm
   last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(2, "Et ratio Mismatch");
   last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(3, "Feature bit Mismatch");
   last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(4, "-");
-  for (size_t i=0; i<20; ++i) last20MismatchArray_.at(i) = {"-", 0};
-  for (size_t i=1; i<=20; ++i) last20Mismatches_->getTH2F()->GetYaxis()->SetBinLabel(i, "-");
+  for (size_t i=0; i<last20MismatchArray_.size(); ++i) last20MismatchArray_[i] = {"-"+std::to_string(i), 0};
+  for (size_t i=1; i<=20; ++i) last20Mismatches_->getTH2F()->GetYaxis()->SetBinLabel(i, ("-"+std::to_string(i)).c_str());
 }
 


### PR DESCRIPTION
In the newest version of ROOT, histograms with named bins are merged via the bin's name, not the index. This means we must avoid bins having the same bin names.

L1TdeStage2CaloLayer1 has a histogram where the default bin names are set to '-' and then later changed if filled in. This change guarantees uniqueness for the bin names.