### PR TITLE
fix unintialized value use in RunManagerMTWorker 

### DIFF
--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -142,12 +142,12 @@ RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::Co
   m_pCustomUIsession(iConfig.getUntrackedParameter<edm::ParameterSet>("CustomUIsession")),
   m_p(iConfig)
 {
-  initializeTLS();
   m_simEvent.reset(nullptr);
   m_sVerbose.reset(nullptr);
   std::vector<edm::ParameterSet> watchers = 
     iConfig.getParameter<std::vector<edm::ParameterSet> >("Watchers");
   m_hasWatchers = (watchers.empty()) ? false : true;
+  initializeTLS();
 }
 
 RunManagerMTWorker::~RunManagerMTWorker() {


### PR DESCRIPTION
make sure m_hasWatchers is set before using it

This was reported in my recent valgrind run using wf 150.0 in CMSSW_10_5_X_2019-01-04-1100

@mdhildreth @civanch please check and prepare backports as needed