### PR TITLE
Fix missing initializations and dead assignments in RecoMET/METAlgorithms

### DIFF
--- a/RecoMET/METAlgorithms/src/GlobalHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/GlobalHaloAlgo.cc
@@ -48,13 +48,18 @@ reco::GlobalHaloData GlobalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeomet
   float METOverSumEt = TheCaloMET.sumEt() ? TheCaloMET.pt() / TheCaloMET.sumEt() : 0 ;
   TheGlobalHaloData.SetMETOverSumEt(METOverSumEt);
 
-  //int EcalOverlapping_CSCRecHits[73];
-  //int EcalOverlapping_CSCSegments[73];
-
   int EcalOverlapping_CSCRecHits[361];
   int EcalOverlapping_CSCSegments[361];
   int HcalOverlapping_CSCRecHits[73];
   int HcalOverlapping_CSCSegments[73];
+  for( int i = 0 ; i < 361 ; i++ ) {
+    EcalOverlapping_CSCRecHits[i] = 0;
+    EcalOverlapping_CSCSegments[i] = 0;
+    if( i < 73 ) {
+      HcalOverlapping_CSCRecHits[i] = 0;
+      HcalOverlapping_CSCSegments[i] = 0;
+    }
+  }
 
   if( TheCSCSegments.isValid() )
     {

--- a/RecoMET/METAlgorithms/src/GlobalHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/GlobalHaloAlgo.cc
@@ -48,18 +48,10 @@ reco::GlobalHaloData GlobalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeomet
   float METOverSumEt = TheCaloMET.sumEt() ? TheCaloMET.pt() / TheCaloMET.sumEt() : 0 ;
   TheGlobalHaloData.SetMETOverSumEt(METOverSumEt);
 
-  int EcalOverlapping_CSCRecHits[361];
-  int EcalOverlapping_CSCSegments[361];
-  int HcalOverlapping_CSCRecHits[73];
-  int HcalOverlapping_CSCSegments[73];
-  for( int i = 0 ; i < 361 ; i++ ) {
-    EcalOverlapping_CSCRecHits[i] = 0;
-    EcalOverlapping_CSCSegments[i] = 0;
-    if( i < 73 ) {
-      HcalOverlapping_CSCRecHits[i] = 0;
-      HcalOverlapping_CSCSegments[i] = 0;
-    }
-  }
+  int EcalOverlapping_CSCRecHits[361] = {};
+  int EcalOverlapping_CSCSegments[361] = {};
+  int HcalOverlapping_CSCRecHits[73] = {};
+  int HcalOverlapping_CSCSegments[73] = {};
 
   if( TheCSCSegments.isValid() )
     {

--- a/RecoMET/METAlgorithms/src/MuonMETAlgo.cc
+++ b/RecoMET/METAlgorithms/src/MuonMETAlgo.cc
@@ -319,8 +319,6 @@ void MuonMETAlgo::correctMETforMuon(double& deltax, double& deltay, double bfiel
         double temp = 2*TMath::Pi() - fabs(ecalPhi);
         ecalPhi = -1*temp*ecalPhi/fabs(ecalPhi);
       }
-      xEcal = r2dEcal*TMath::Cos(ecalPhi);
-      yEcal = r2dEcal*TMath::Sin(ecalPhi);
       
       //Hcal
       dphi = mu_phi - hcalPhi;
@@ -331,9 +329,6 @@ void MuonMETAlgo::correctMETforMuon(double& deltax, double& deltay, double bfiel
         double temp = 2*TMath::Pi() - fabs(hcalPhi);
 	hcalPhi = -1*temp*hcalPhi/fabs(hcalPhi);
       }
-      xHcal = r2dHcal*TMath::Cos(hcalPhi);
-      yHcal = r2dHcal*TMath::Sin(hcalPhi);
-
          
       //Ho
       dphi = mu_phi - hoPhi;
@@ -344,8 +339,6 @@ void MuonMETAlgo::correctMETforMuon(double& deltax, double& deltay, double bfiel
         double temp = 2*TMath::Pi() - fabs(hoPhi);
         hoPhi = -1*temp*hoPhi/fabs(hoPhi);
       }
-      xHo = r2dHo*TMath::Cos(hoPhi);
-      yHo = r2dHo*TMath::Sin(hoPhi);
       
     }
   }

--- a/RecoMET/METAlgorithms/src/MuonMETAlgo.cc
+++ b/RecoMET/METAlgorithms/src/MuonMETAlgo.cc
@@ -297,11 +297,6 @@ void MuonMETAlgo::correctMETforMuon(double& deltax, double& deltay, double bfiel
     hcalPhi   = atan2(yHcal,xHcal);
     hoTheta   = TMath::ACos(zHo/sqrt(pow(xHo,2) + pow(yHo,2)+pow(zHo,2)));
     hoPhi     = atan2(yHo,xHo);
-
-    //2d radius in x-y plane
-    double r2dEcal = sqrt(pow(xEcal,2)+pow(yEcal,2));
-    double r2dHcal = sqrt(pow(xHcal,2)+pow(yHcal,2));
-    double r2dHo   = sqrt(pow(xHo,2)  +pow(yHo,2));
     
     /*
       the above prescription is for right handed helicies only


### PR DESCRIPTION
Found by static analyzer:
- Dead assignments in RecoMET/METAlgorithms/src/MuonMETAlgo.cc
- Missing initializations in RecoMET/METAlgorithms/src/GlobalHaloAlgo.cc

I wonder whether the missing initializations are anyhow affecting the final results (which should be the case, unless the compiler implicitly initialize to 0 all uninitialized integers...)