### PR TITLE
Pass ConsumesCollector to ModifyObjectValueBase-derived classes in the constructor

### DIFF
--- a/CommonTools/CandAlgos/interface/ModifyObjectValueBase.h
+++ b/CommonTools/CandAlgos/interface/ModifyObjectValueBase.h
@@ -17,14 +17,13 @@
 
 class ModifyObjectValueBase {
  public:
- ModifyObjectValueBase(const edm::ParameterSet& conf) : 
+  ModifyObjectValueBase(const edm::ParameterSet& conf) :
   name_( conf.getParameter<std::string>("modifierName") ) {}
 
   virtual ~ModifyObjectValueBase() {}
 
   virtual void setEvent(const edm::Event&) {}
   virtual void setEventContent(const edm::EventSetup&) {}
-  virtual void setConsumes(edm::ConsumesCollector&) {}
   
   virtual void modifyObject(reco::GsfElectron&) const { 
     throw cms::Exception("InvalidConfiguration") 
@@ -76,7 +75,7 @@ class ModifyObjectValueBase {
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< ModifyObjectValueBase* (const edm::ParameterSet&) > ModifyObjectValueFactory;
+typedef edmplugin::PluginFactory< ModifyObjectValueBase* (const edm::ParameterSet&, edm::ConsumesCollector&) > ModifyObjectValueFactory;
 #endif
 
 #endif

--- a/PhysicsTools/PatAlgos/interface/ObjectModifier.h
+++ b/PhysicsTools/PatAlgos/interface/ObjectModifier.h
@@ -46,12 +46,7 @@ namespace pat {
       const std::string& mname = iconf.getParameter<std::string>("modifierName");
       ModifyObjectValueBase* plugin = 
         ModifyObjectValueFactory::get()->create(mname,iconf);
-      if( nullptr != plugin ) {
-        modifiers_.push_back(ModifierPointer(plugin));
-      } else {
-        throw cms::Exception("BadPluginName")
-          << "The requested modifier: " << mname << " is not available!";
-      }
+      modifiers_.emplace_back(plugin);
     }
   }
 }

--- a/PhysicsTools/PatAlgos/interface/ObjectModifier.h
+++ b/PhysicsTools/PatAlgos/interface/ObjectModifier.h
@@ -10,7 +10,7 @@ namespace pat {
   public:
     typedef std::unique_ptr<ModifyObjectValueBase> ModifierPointer;
 
-    ObjectModifier(const edm::ParameterSet& conf);
+    ObjectModifier(const edm::ParameterSet& conf, edm::ConsumesCollector&& cc);
     ~ObjectModifier() {}
 
     void setEvent(const edm::Event& event) {
@@ -23,11 +23,6 @@ namespace pat {
         modifiers_[i]->setEventContent(setup);
     }
 
-    void setConsumes(edm::ConsumesCollector& sumes) {
-      for( unsigned i = 0; i < modifiers_.size(); ++i )
-        modifiers_[i]->setConsumes(sumes);
-    }
-
     void modify(T& obj) const {
       for( unsigned i = 0; i < modifiers_.size(); ++i )
         modifiers_[i]->modifyObject(obj);
@@ -38,14 +33,14 @@ namespace pat {
   };
 
   template<class T>
-  ObjectModifier<T>::ObjectModifier(const edm::ParameterSet& conf) {
+  ObjectModifier<T>::ObjectModifier(const edm::ParameterSet& conf, edm::ConsumesCollector&& cc) {
     const std::vector<edm::ParameterSet>& mods = 
       conf.getParameterSetVector("modifications");
     for(unsigned i = 0; i < mods.size(); ++i ) {
       const edm::ParameterSet& iconf = mods[i];
       const std::string& mname = iconf.getParameter<std::string>("modifierName");
       ModifyObjectValueBase* plugin = 
-        ModifyObjectValueFactory::get()->create(mname,iconf);
+        ModifyObjectValueFactory::get()->create(mname,iconf,cc);
       modifiers_.emplace_back(plugin);
     }
   }

--- a/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducer.h
@@ -23,11 +23,9 @@ namespace pat {
       //set our input source
       src_ = consumes<edm::View<T> >(conf.getParameter<edm::InputTag>("src"));
       //setup modifier
-      edm::ConsumesCollector sumes(consumesCollector());      
       const edm::ParameterSet& mod_config = 
         conf.getParameter<edm::ParameterSet>("modifierConfig");
-      modifier_.reset( new Modifier(mod_config) );
-      modifier_->setConsumes(sumes);
+      modifier_ = std::make_unique<Modifier>(mod_config, consumesCollector());
       //declare products
       produces<Collection>();
     }

--- a/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
@@ -72,13 +72,9 @@ pat::PATElectronSlimmer::PATElectronSlimmer(const edm::ParameterSet & iConfig) :
     reducedEndcapRecHitCollectionToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection"))),
     modifyElectron_(iConfig.getParameter<bool>("modifyElectrons"))
 {
-    edm::ConsumesCollector sumes(consumesCollector());
     if( modifyElectron_ ) {
       const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      electronModifier_.reset(new pat::ObjectModifier<pat::Electron>(mod_config) );
-      electronModifier_->setConsumes(sumes);
-    } else {
-      electronModifier_.reset(nullptr);
+      electronModifier_ = std::make_unique<pat::ObjectModifier<pat::Electron>>(mod_config, consumesCollector());
     }
 
     mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEB"));

--- a/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
@@ -62,13 +62,9 @@ pat::PATJetSlimmer::PATJetSlimmer(const edm::ParameterSet & iConfig) :
             pf2pc_ = consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
         }
     }
-    edm::ConsumesCollector sumes(consumesCollector());
     if( modifyJet_ ) {
       const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      jetModifier_.reset(new pat::ObjectModifier<pat::Jet>(mod_config) );
-      jetModifier_->setConsumes(sumes);
-    } else {
-      jetModifier_.reset(nullptr);
+      jetModifier_ = std::make_unique<pat::ObjectModifier<pat::Jet>>(mod_config, consumesCollector());
     }
     produces<std::vector<pat::Jet> >();
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
@@ -66,13 +66,9 @@ pat::PATMuonSlimmer::PATMuonSlimmer(const edm::ParameterSet & iConfig) :
         for (const edm::InputTag &tag : pf2pc) pf2pc_.push_back(consumes<edm::Association<pat::PackedCandidateCollection>>(tag));
     }
 
-    edm::ConsumesCollector sumes(consumesCollector());
     if( modifyMuon_ ) {
       const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      muonModifier_.reset(new pat::ObjectModifier<pat::Muon>(mod_config) );
-      muonModifier_->setConsumes(sumes);
-    } else {
-      muonModifier_.reset(nullptr);
+      muonModifier_ = std::make_unique<pat::ObjectModifier<pat::Muon>>(mod_config, consumesCollector());
     }
     produces<std::vector<pat::Muon> >();
     if( saveSegments_ ) {

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
@@ -68,13 +68,9 @@ pat::PATPhotonSlimmer::PATPhotonSlimmer(const edm::ParameterSet & iConfig) :
     reducedEndcapRecHitCollectionToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection"))),
     modifyPhoton_(iConfig.getParameter<bool>("modifyPhotons"))
 {
-    edm::ConsumesCollector sumes(consumesCollector());
     if( modifyPhoton_ ) {
       const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      photonModifier_.reset(new pat::ObjectModifier<pat::Photon>(mod_config) );
-      photonModifier_->setConsumes(sumes);
-    } else {
-      photonModifier_.reset(nullptr);
+      photonModifier_ = std::make_unique<pat::ObjectModifier<pat::Photon>>(mod_config, consumesCollector());
     }
     
     mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEB"));

--- a/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
@@ -47,13 +47,9 @@ pat::PATTauSlimmer::PATTauSlimmer(const edm::ParameterSet & iConfig) :
     dropPFSpecific_(iConfig.exists("dropPFSpecific") ? iConfig.getParameter<bool>("dropPFSpecific") : true),
     modifyTau_(iConfig.getParameter<bool>("modifyTaus"))
 {
-    edm::ConsumesCollector sumes(consumesCollector());
     if( modifyTau_ ) {
       const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      tauModifier_.reset(new pat::ObjectModifier<pat::Tau>(mod_config) );
-      tauModifier_->setConsumes(sumes);
-    } else {
-      tauModifier_.reset(nullptr);
+      tauModifier_ = std::make_unique<pat::ObjectModifier<pat::Tau>>(mod_config, consumesCollector());
     }
     produces<std::vector<pat::Tau> >();
 }

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
@@ -33,11 +33,10 @@ GEDGsfElectronFinalizer::GEDGsfElectronFinalizer( const edm::ParameterSet & cfg 
    if( cfg.existsAs<edm::ParameterSet>("regressionConfig") ) {
      const edm::ParameterSet& iconf = cfg.getParameterSet("regressionConfig");
      const std::string& mname = iconf.getParameter<std::string>("modifierName");
+     edm::ConsumesCollector&& cc = consumesCollector();
      ModifyObjectValueBase* plugin = 
-       ModifyObjectValueFactory::get()->create(mname,iconf);
+       ModifyObjectValueFactory::get()->create(mname,iconf,cc);
      gedRegression_.reset(plugin);
-     edm::ConsumesCollector sumes = consumesCollector();
-     gedRegression_->setConsumes(sumes);
    } else {
      gedRegression_.reset(nullptr);
    }

--- a/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
@@ -53,10 +53,8 @@ PhotonEnergyCorrector::PhotonEnergyCorrector( const edm::ParameterSet& config, e
     const edm::ParameterSet& regr_conf = 
       config.getParameterSet("regressionConfig");
     const std::string& mname = regr_conf.getParameter<std::string>("modifierName");
-    ModifyObjectValueBase* regr = ModifyObjectValueFactory::get()->create(mname,regr_conf);
+    ModifyObjectValueBase* regr = ModifyObjectValueFactory::get()->create(mname,regr_conf,iC);
     gedRegression_.reset(regr);
-  } else {
-    gedRegression_.reset(nullptr);
   }
 
   // ingredient for energy regression

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -167,10 +167,6 @@ GEDPhotonProducer::GEDPhotonProducer(const edm::ParameterSet& config) :
 
   thePhotonEnergyCorrector_ = 
     new PhotonEnergyCorrector(conf_, consumesCollector());
-  if( conf_.existsAs<edm::ParameterSet>("regressionConfig") ) {
-    auto sumes = consumesCollector();
-    thePhotonEnergyCorrector_->gedRegression()->setConsumes(sumes);
-  }
 
   //AA
 

--- a/RecoEgamma/EgammaTools/plugins/EG8XObjectUpdateModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EG8XObjectUpdateModifier.cc
@@ -19,12 +19,11 @@
 
 class EG8XObjectUpdateModifier : public ModifyObjectValueBase {
 public:
-  EG8XObjectUpdateModifier(const edm::ParameterSet& conf);
+  EG8XObjectUpdateModifier(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
   ~EG8XObjectUpdateModifier() override{}
   
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
-  void setConsumes(edm::ConsumesCollector&) final;
   
   void modifyObject(reco::GsfElectron& ele) const final;
   void modifyObject(reco::Photon& pho) const final;
@@ -40,24 +39,16 @@ private:
   edm::Handle<EcalRecHitCollection> ecalRecHitsEEHandle_;
   edm::EDGetTokenT<EcalRecHitCollection> ecalRecHitsEBToken_;
   edm::EDGetTokenT<EcalRecHitCollection> ecalRecHitsEEToken_;
-  edm::InputTag ecalRecHitsEBTag_;
-  edm::InputTag ecalRecHitsEETag_;
   
 };
 
-EG8XObjectUpdateModifier::EG8XObjectUpdateModifier(const edm::ParameterSet& conf):
+EG8XObjectUpdateModifier::EG8XObjectUpdateModifier(const edm::ParameterSet& conf, edm::ConsumesCollector& cc):
   ModifyObjectValueBase(conf),
-  ecalRecHitsEBTag_(conf.getParameter<edm::InputTag>("ecalRecHitsEB")),
-  ecalRecHitsEETag_(conf.getParameter<edm::InputTag>("ecalRecHitsEE"))
+  ecalRecHitsEBToken_(cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("ecalRecHitsEB"))),
+  ecalRecHitsEEToken_(cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("ecalRecHitsEE")))
 {
   
 
-}
-
-void EG8XObjectUpdateModifier::setConsumes(edm::ConsumesCollector& cc)
-{
-  ecalRecHitsEBToken_ = cc.consumes<EcalRecHitCollection>(ecalRecHitsEBTag_);
-  ecalRecHitsEEToken_ = cc.consumes<EcalRecHitCollection>(ecalRecHitsEETag_);
 }
 
 void EG8XObjectUpdateModifier::setEvent(const edm::Event& iEvent)

--- a/RecoEgamma/EgammaTools/plugins/EGEtScaleSysModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGEtScaleSysModifier.cc
@@ -28,12 +28,11 @@
 
 class EGEtScaleSysModifier : public ModifyObjectValueBase {
 public:
-  EGEtScaleSysModifier(const edm::ParameterSet& conf);
+  EGEtScaleSysModifier(const edm::ParameterSet& conf, edm::ConsumesCollector&);
   ~EGEtScaleSysModifier() override{}
   
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
-  void setConsumes(edm::ConsumesCollector&) final;
   
   void modifyObject(pat::Electron& ele) const final;
   void modifyObject(pat::Photon& pho) const final;
@@ -85,7 +84,7 @@ private:
   std::unique_ptr<UncertFuncBase> uncertFunc_;
 };
 
-EGEtScaleSysModifier::EGEtScaleSysModifier(const edm::ParameterSet& conf):
+EGEtScaleSysModifier::EGEtScaleSysModifier(const edm::ParameterSet& conf, edm::ConsumesCollector&):
   ModifyObjectValueBase(conf),
   epCombTool_(conf.getParameter<edm::ParameterSet>("epCombConfig"))
 {
@@ -96,11 +95,6 @@ EGEtScaleSysModifier::EGEtScaleSysModifier(const edm::ParameterSet& conf):
   }else{
     throw cms::Exception("ConfigError") <<"Error constructing EGEtScaleSysModifier, function name "<<funcName<<" not valid";
   } 
-
-}
-
-void EGEtScaleSysModifier::setConsumes(edm::ConsumesCollector& cc)
-{
 
 }
 

--- a/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
@@ -10,6 +10,8 @@
 namespace {
   const edm::EDGetTokenT<edm::ValueMap<float> > empty_token;
   const edm::InputTag empty_tag("");
+  template<typename T, typename U, typename V>
+  inline void make_consumes(const T& tag, edm::EDGetTokenT<U>& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<U>(tag); }
 }
 
 #include <unordered_map>
@@ -17,18 +19,6 @@ namespace {
 class EGFull5x5ShowerShapeModifierFromValueMaps : public ModifyObjectValueBase {
 public:
   struct electron_config {
-    edm::InputTag electron_src;
-    edm::InputTag sigmaEtaEta ;
-    edm::InputTag sigmaIetaIeta ;
-    edm::InputTag sigmaIphiIphi ;
-    edm::InputTag e1x5 ;
-    edm::InputTag e2x5Max ;
-    edm::InputTag e5x5 ;
-    edm::InputTag r9 ;
-    edm::InputTag hcalDepth1OverEcal ;     
-    edm::InputTag hcalDepth2OverEcal ;
-    edm::InputTag hcalDepth1OverEcalBc ; 
-    edm::InputTag hcalDepth2OverEcalBc ;
     edm::EDGetTokenT<edm::View<pat::Electron> > tok_electron_src;
     edm::EDGetTokenT<edm::ValueMap<float> > tok_sigmaEtaEta ;
     edm::EDGetTokenT<edm::ValueMap<float> > tok_sigmaIetaIeta ;
@@ -44,18 +34,6 @@ public:
   };
 
   struct photon_config {
-    edm::InputTag photon_src ;
-    edm::InputTag sigmaEtaEta ;
-    edm::InputTag sigmaIetaIeta ;
-    edm::InputTag e1x5 ;
-    edm::InputTag e2x5 ;
-    edm::InputTag e3x3 ;
-    edm::InputTag e5x5 ;
-    edm::InputTag maxEnergyXtal ; 
-    edm::InputTag hcalDepth1OverEcal ;
-    edm::InputTag hcalDepth2OverEcal ;
-    edm::InputTag hcalDepth1OverEcalBc;
-    edm::InputTag hcalDepth2OverEcalBc;
     edm::EDGetTokenT<edm::View<pat::Photon> > tok_photon_src;
     edm::EDGetTokenT<edm::ValueMap<float> > tok_sigmaEtaEta ;
     edm::EDGetTokenT<edm::ValueMap<float> > tok_sigmaIetaIeta ;
@@ -70,11 +48,10 @@ public:
     edm::EDGetTokenT<edm::ValueMap<float> > tok_hcalDepth2OverEcalBc;
   };
 
-  EGFull5x5ShowerShapeModifierFromValueMaps(const edm::ParameterSet& conf);
+  EGFull5x5ShowerShapeModifierFromValueMaps(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
   
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
-  void setConsumes(edm::ConsumesCollector&) final;
   
   void modifyObject(pat::Electron&) const final;
   void modifyObject(pat::Photon&) const final;
@@ -94,37 +71,37 @@ DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
 		  "EGFull5x5ShowerShapeModifierFromValueMaps");
 
 EGFull5x5ShowerShapeModifierFromValueMaps::
-EGFull5x5ShowerShapeModifierFromValueMaps(const edm::ParameterSet& conf) :
+EGFull5x5ShowerShapeModifierFromValueMaps(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) :
   ModifyObjectValueBase(conf) {
   if( conf.exists("electron_config") ) {
     const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
-    if( electrons.exists("electronSrc") ) e_conf.electron_src = electrons.getParameter<edm::InputTag>("electronSrc");
-    if( electrons.exists("sigmaEtaEta") ) e_conf.sigmaEtaEta = electrons.getParameter<edm::InputTag>("sigmaEtaEta");
-    if( electrons.exists("sigmaIetaIeta") ) e_conf.sigmaIetaIeta = electrons.getParameter<edm::InputTag>("sigmaIetaIeta");
-    if( electrons.exists("sigmaIphiIphi") ) e_conf.sigmaIphiIphi = electrons.getParameter<edm::InputTag>("sigmaIphiIphi");
-    if( electrons.exists("e1x5") ) e_conf.e1x5 = electrons.getParameter<edm::InputTag>("e1x5");
-    if( electrons.exists("e2x5Max") ) e_conf.e2x5Max = electrons.getParameter<edm::InputTag>("e2x5Max");
-    if( electrons.exists("e5x5") ) e_conf.e5x5 = electrons.getParameter<edm::InputTag>("e5x5");
-    if( electrons.exists("r9") ) e_conf.r9 = electrons.getParameter<edm::InputTag>("r9");
-    if( electrons.exists("hcalDepth1OverEcal") ) e_conf.hcalDepth1OverEcal = electrons.getParameter<edm::InputTag>("hcalDepth1OverEcal");
-    if( electrons.exists("hcalDepth2OverEcal") ) e_conf.hcalDepth2OverEcal = electrons.getParameter<edm::InputTag>("hcalDepth2OverEcal");
-    if( electrons.exists("hcalDepth1OverEcalBc") ) e_conf.hcalDepth1OverEcalBc = electrons.getParameter<edm::InputTag>("hcalDepth1OverEcalBc");
-    if( electrons.exists("hcalDepth2OverEcalBc") ) e_conf.hcalDepth2OverEcalBc = electrons.getParameter<edm::InputTag>("hcalDepth2OverEcalBc");
+    if( electrons.exists("electronSrc") ) make_consumes(electrons.getParameter<edm::InputTag>("electronSrc"), e_conf.tok_electron_src, cc);
+    if( electrons.exists("sigmaEtaEta") ) make_consumes(electrons.getParameter<edm::InputTag>("sigmaEtaEta"), e_conf.tok_sigmaEtaEta, cc);
+    if( electrons.exists("sigmaIetaIeta") ) make_consumes(electrons.getParameter<edm::InputTag>("sigmaIetaIeta"), e_conf.tok_sigmaIetaIeta, cc);
+    if( electrons.exists("sigmaIphiIphi") ) make_consumes(electrons.getParameter<edm::InputTag>("sigmaIphiIphi"), e_conf.tok_sigmaIphiIphi, cc);
+    if( electrons.exists("e1x5") ) make_consumes(electrons.getParameter<edm::InputTag>("e1x5"), e_conf.tok_e1x5, cc);
+    if( electrons.exists("e2x5Max") ) make_consumes(electrons.getParameter<edm::InputTag>("e2x5Max"), e_conf.tok_e2x5Max, cc);
+    if( electrons.exists("e5x5") ) make_consumes(electrons.getParameter<edm::InputTag>("e5x5"), e_conf.tok_e5x5, cc);
+    if( electrons.exists("r9") ) make_consumes(electrons.getParameter<edm::InputTag>("r9"), e_conf.tok_r9, cc);
+    if( electrons.exists("hcalDepth1OverEcal") ) make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth1OverEcal"), e_conf.tok_hcalDepth1OverEcal, cc);
+    if( electrons.exists("hcalDepth2OverEcal") ) make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth2OverEcal"), e_conf.tok_hcalDepth2OverEcal, cc);
+    if( electrons.exists("hcalDepth1OverEcalBc") ) make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth1OverEcalBc"), e_conf.tok_hcalDepth1OverEcalBc, cc);
+    if( electrons.exists("hcalDepth2OverEcalBc") ) make_consumes(electrons.getParameter<edm::InputTag>("hcalDepth2OverEcalBc"), e_conf.tok_hcalDepth2OverEcalBc, cc);
   }
   if( conf.exists("photon_config") ) {
     const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
-    if( photons.exists("photonSrc") ) ph_conf.photon_src = photons.getParameter<edm::InputTag>("photonSrc");
-    if( photons.exists("sigmaEtaEta") ) ph_conf.sigmaEtaEta = photons.getParameter<edm::InputTag>("sigmaEtaEta");
-    if( photons.exists("sigmaIetaIeta") ) ph_conf.sigmaIetaIeta = photons.getParameter<edm::InputTag>("sigmaIetaIeta");
-    if( photons.exists("e1x5") ) ph_conf.e1x5 = photons.getParameter<edm::InputTag>("e1x5");
-    if( photons.exists("e2x5") ) ph_conf.e2x5 = photons.getParameter<edm::InputTag>("e2x5");
-    if( photons.exists("e3x3") ) ph_conf.e3x3 = photons.getParameter<edm::InputTag>("e3x3");
-    if( photons.exists("e5x5") ) ph_conf.e5x5 = photons.getParameter<edm::InputTag>("e5x5");
-    if( photons.exists("maxEnergyXtal") ) ph_conf.maxEnergyXtal = photons.getParameter<edm::InputTag>("maxEnergyXtal");
-    if( photons.exists("hcalDepth1OverEcal") ) ph_conf.hcalDepth1OverEcal = photons.getParameter<edm::InputTag>("hcalDepth1OverEcal");
-    if( photons.exists("hcalDepth2OverEcal") ) ph_conf.hcalDepth2OverEcal = photons.getParameter<edm::InputTag>("hcalDepth2OverEcal");
-    if( photons.exists("hcalDepth1OverEcalBc") ) ph_conf.hcalDepth1OverEcalBc = photons.getParameter<edm::InputTag>("hcalDepth1OverEcalBc");
-    if( photons.exists("hcalDepth2OverEcalBc") ) ph_conf.hcalDepth2OverEcalBc = photons.getParameter<edm::InputTag>("hcalDepth2OverEcalBc");
+    if( photons.exists("photonSrc") ) make_consumes(photons.getParameter<edm::InputTag>("photonSrc"), ph_conf.tok_photon_src, cc);
+    if( photons.exists("sigmaEtaEta") ) make_consumes(photons.getParameter<edm::InputTag>("sigmaEtaEta"), ph_conf.tok_sigmaEtaEta, cc);
+    if( photons.exists("sigmaIetaIeta") ) make_consumes(photons.getParameter<edm::InputTag>("sigmaIetaIeta"), ph_conf.tok_sigmaIetaIeta, cc);
+    if( photons.exists("e1x5") ) make_consumes(photons.getParameter<edm::InputTag>("e1x5"), ph_conf.tok_e1x5, cc);
+    if( photons.exists("e2x5") ) make_consumes(photons.getParameter<edm::InputTag>("e2x5"), ph_conf.tok_e2x5, cc);
+    if( photons.exists("e3x3") ) make_consumes(photons.getParameter<edm::InputTag>("e3x3"), ph_conf.tok_e3x3, cc);
+    if( photons.exists("e5x5") ) make_consumes(photons.getParameter<edm::InputTag>("e5x5"), ph_conf.tok_e5x5, cc);
+    if( photons.exists("maxEnergyXtal") ) make_consumes(photons.getParameter<edm::InputTag>("maxEnergyXtal"), ph_conf.tok_maxEnergyXtal, cc);
+    if( photons.exists("hcalDepth1OverEcal") ) make_consumes(photons.getParameter<edm::InputTag>("hcalDepth1OverEcal"), ph_conf.tok_hcalDepth1OverEcal, cc);
+    if( photons.exists("hcalDepth2OverEcal") ) make_consumes(photons.getParameter<edm::InputTag>("hcalDepth2OverEcal"), ph_conf.tok_hcalDepth2OverEcal, cc);
+    if( photons.exists("hcalDepth1OverEcalBc") ) make_consumes(photons.getParameter<edm::InputTag>("hcalDepth1OverEcalBc"), ph_conf.tok_hcalDepth1OverEcalBc, cc);
+    if( photons.exists("hcalDepth2OverEcalBc") ) make_consumes(photons.getParameter<edm::InputTag>("hcalDepth2OverEcalBc"), ph_conf.tok_hcalDepth2OverEcalBc, cc);
   }
   
   ele_idx = pho_idx = 0;
@@ -191,42 +168,6 @@ setEvent(const edm::Event& evt) {
 
 void EGFull5x5ShowerShapeModifierFromValueMaps::
 setEventContent(const edm::EventSetup& evs) {
-}
-
-namespace {
-  template<typename T, typename U, typename V>
-  inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
-}
-
-void EGFull5x5ShowerShapeModifierFromValueMaps::
-setConsumes(edm::ConsumesCollector& sumes) {
-  //setup electrons
-  if( !(empty_tag == e_conf.electron_src) ) e_conf.tok_electron_src = sumes.consumes<edm::View<pat::Electron> >(e_conf.electron_src);  
-  make_consumes(e_conf.sigmaEtaEta,e_conf.tok_sigmaEtaEta,sumes);
-  make_consumes(e_conf.sigmaIetaIeta,e_conf.tok_sigmaIetaIeta,sumes);
-  make_consumes(e_conf.sigmaIphiIphi,e_conf.tok_sigmaIphiIphi,sumes);
-  make_consumes(e_conf.e1x5,e_conf.tok_e1x5,sumes);
-  make_consumes(e_conf.e2x5Max,e_conf.tok_e2x5Max,sumes);
-  make_consumes(e_conf.e5x5,e_conf.tok_e5x5,sumes);
-  make_consumes(e_conf.r9,e_conf.tok_r9,sumes);
-  make_consumes(e_conf.hcalDepth1OverEcal,e_conf.tok_hcalDepth1OverEcal,sumes);
-  make_consumes(e_conf.hcalDepth2OverEcal,e_conf.tok_hcalDepth2OverEcal,sumes);
-  make_consumes(e_conf.hcalDepth1OverEcalBc,e_conf.tok_hcalDepth1OverEcalBc,sumes);
-  make_consumes(e_conf.hcalDepth2OverEcalBc,e_conf.tok_hcalDepth2OverEcalBc,sumes);    
-
-  // setup photons 
-  if( !(empty_tag == ph_conf.photon_src) ) ph_conf.tok_photon_src = sumes.consumes<edm::View<pat::Photon> >(ph_conf.photon_src);
-  make_consumes(ph_conf.sigmaEtaEta,ph_conf.tok_sigmaEtaEta,sumes);
-  make_consumes(ph_conf.sigmaIetaIeta,ph_conf.tok_sigmaIetaIeta,sumes);
-  make_consumes(ph_conf.e1x5,ph_conf.tok_e1x5,sumes);
-  make_consumes(ph_conf.e2x5,ph_conf.tok_e2x5,sumes);
-  make_consumes(ph_conf.e3x3,ph_conf.tok_e3x3,sumes);
-  make_consumes(ph_conf.e5x5,ph_conf.tok_e5x5,sumes);
-  make_consumes(ph_conf.maxEnergyXtal,ph_conf.tok_maxEnergyXtal,sumes);
-  make_consumes(ph_conf.hcalDepth1OverEcal,ph_conf.tok_hcalDepth1OverEcal,sumes);
-  make_consumes(ph_conf.hcalDepth2OverEcal,ph_conf.tok_hcalDepth2OverEcal,sumes);
-  make_consumes(ph_conf.hcalDepth1OverEcalBc,ph_conf.tok_hcalDepth1OverEcalBc,sumes);
-  make_consumes(ph_conf.hcalDepth2OverEcalBc,ph_conf.tok_hcalDepth2OverEcalBc,sumes);   
 }
 
 namespace {

--- a/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
@@ -37,25 +37,21 @@ namespace {
 
 class EGPfIsolationModifierFromValueMaps : public ModifyObjectValueBase {
 public:
-  typedef std::tuple<edm::InputTag,edm::EDGetTokenT<edm::ValueMap<float> > > tag_and_token;
-  typedef std::unordered_map<std::string,tag_and_token> input_map;
+  typedef std::unordered_map<std::string, edm::EDGetTokenT<edm::ValueMap<float> > > input_map;
   
   struct electron_config {
-    edm::InputTag electron_src;    
     edm::EDGetTokenT<edm::View<pat::Electron> > tok_electron_src;
     input_map electron_inputs;
   };
   
   struct photon_config {
-    edm::InputTag photon_src;    
     edm::EDGetTokenT<edm::View<pat::Photon> > tok_photon_src;
     input_map photon_inputs;
   };
 
-  EGPfIsolationModifierFromValueMaps(const edm::ParameterSet& conf);
+  EGPfIsolationModifierFromValueMaps(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
   
   void setEvent(const edm::Event&) final;
-  void setConsumes(edm::ConsumesCollector&) final;
   
   void modifyObject(pat::Electron&) const final;
   void modifyObject(pat::Photon&) const final;
@@ -75,23 +71,23 @@ DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
 		  "EGPfIsolationModifierFromValueMaps");
 
 EGPfIsolationModifierFromValueMaps::
-EGPfIsolationModifierFromValueMaps(const edm::ParameterSet& conf) :
+EGPfIsolationModifierFromValueMaps(const edm::ParameterSet& conf, edm::ConsumesCollector& cc) :
   ModifyObjectValueBase(conf) {
   if( conf.exists("electron_config") ) {
     const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
-    if( electrons.exists("electronSrc") ) e_conf.electron_src = electrons.getParameter<edm::InputTag>("electronSrc");
+    if( electrons.exists("electronSrc") ) e_conf.tok_electron_src = cc.consumes<edm::View<pat::Electron>>(electrons.getParameter<edm::InputTag>("electronSrc"));
     for( const std::string& varname : electron_vars ) {
       if( electrons.exists(varname) ) {
-        std::get<0>(e_conf.electron_inputs[varname]) = electrons.getParameter<edm::InputTag>(varname);
+        e_conf.electron_inputs[varname] = cc.consumes<edm::ValueMap<float>>(electrons.getParameter<edm::InputTag>(varname));
       }
     }      
   }
   if( conf.exists("photon_config") ) {
     const edm::ParameterSet& photons = conf.getParameter<edm::ParameterSet>("photon_config");
-    if( photons.exists("photonSrc") ) ph_conf.photon_src = photons.getParameter<edm::InputTag>("photonSrc");  
+    if( photons.exists("photonSrc") ) ph_conf.tok_photon_src = cc.consumes<edm::View<pat::Photon>>(photons.getParameter<edm::InputTag>("photonSrc"));
     for( const std::string& varname : photon_vars ) {
       if( photons.exists(varname) ) {
-        std::get<0>(ph_conf.photon_inputs[varname]) = photons.getParameter<edm::InputTag>(varname);
+        ph_conf.photon_inputs[varname] = cc.consumes<edm::ValueMap<float>>(photons.getParameter<edm::InputTag>(varname));
       }
     }     
   }
@@ -127,7 +123,7 @@ setEvent(const edm::Event& evt) {
   for( const std::string& varname : electron_vars ) {
     auto& inputs = e_conf.electron_inputs;
     if( inputs.find(varname) == inputs.end() ) continue;
-    get_product(evt,std::get<1>(inputs[varname]),ele_vmaps);
+    get_product(evt,inputs[varname],ele_vmaps);
   }  
 
   if( !ph_conf.tok_photon_src.isUninitialized() ) {
@@ -141,35 +137,7 @@ setEvent(const edm::Event& evt) {
   for( const std::string& varname : photon_vars ) {
     auto& inputs = ph_conf.photon_inputs;
     if( inputs.find(varname) == inputs.end() ) continue;
-    get_product(evt,std::get<1>(inputs[varname]),pho_vmaps);
-  }   
-}
-
-namespace {
-  template<typename T, typename U, typename V>
-  inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
-}
-
-void EGPfIsolationModifierFromValueMaps::
-setConsumes(edm::ConsumesCollector& sumes) {
-  //setup electrons
-  if( !(empty_tag == e_conf.electron_src) ) e_conf.tok_electron_src = sumes.consumes<edm::View<pat::Electron> >(e_conf.electron_src);  
-  
-  for( const std::string& varname : electron_vars ) {
-    auto& inputs = e_conf.electron_inputs;
-    if( inputs.find(varname) == inputs.end() ) continue;
-    auto& the_tuple = inputs[varname];
-    make_consumes(std::get<0>(the_tuple),std::get<1>(the_tuple),sumes);
-  }  
-
-  // setup photons 
-  if( !(empty_tag == ph_conf.photon_src) ) ph_conf.tok_photon_src = sumes.consumes<edm::View<pat::Photon> >(ph_conf.photon_src);
-
-  for( const std::string& varname : photon_vars ) {
-    auto& inputs = ph_conf.photon_inputs;
-    if( inputs.find(varname) == inputs.end() ) continue;
-    auto& the_tuple = inputs[varname];
-    make_consumes(std::get<0>(the_tuple),std::get<1>(the_tuple),sumes);
+    get_product(evt,inputs[varname],pho_vmaps);
   }   
 }
 
@@ -178,7 +146,7 @@ namespace {
   inline void assignValue(const T& ptr, const U& input_map, const std::string& name, const V& map, float& value) {
     auto itr = input_map.find(name);
     if( itr == input_map.end() ) return;
-    const auto& tok = std::get<1>(itr->second);
+    const auto& tok = itr->second;
     if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
   }
 }

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV2.cc
@@ -14,11 +14,10 @@
 class EGRegressionModifierV2 : public ModifyObjectValueBase {
 
 public:
-  EGRegressionModifierV2(const edm::ParameterSet& conf);
+  EGRegressionModifierV2(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
 
   void setEvent(const edm::Event&) final;
   void setEventContent(const edm::EventSetup&) final;
-  void setConsumes(edm::ConsumesCollector&) final;
 
   void modifyObject(reco::GsfElectron&) const final;
   void modifyObject(reco::Photon&) const final;
@@ -37,7 +36,6 @@ private:
   CondNames phoCondNames_;
 
   float rhoValue_;
-  const edm::InputTag rhoTag_;
   edm::EDGetTokenT<double> rhoToken_;
 
   const edm::EventSetup* iSetup_;
@@ -59,9 +57,9 @@ private:
 
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory, EGRegressionModifierV2, "EGRegressionModifierV2");
 
-EGRegressionModifierV2::EGRegressionModifierV2(const edm::ParameterSet& conf)
+EGRegressionModifierV2::EGRegressionModifierV2(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
   : ModifyObjectValueBase(conf)
-  , rhoTag_(conf.getParameter<edm::InputTag>("rhoCollection"))
+  , rhoToken_(cc.consumes<double>(conf.getParameter<edm::InputTag>("rhoCollection")))
   , lowEnergyEcalOnlyThr_(conf.getParameter<double>("lowEnergy_ECALonlyThr"))
   , lowEnergyEcalTrackThr_(conf.getParameter<double>("lowEnergy_ECALTRKThr"))
   , highEnergyEcalTrackThr_(conf.getParameter<double>("highEnergy_ECALTRKThr"))
@@ -107,11 +105,6 @@ void EGRegressionModifierV2::setEventContent(const edm::EventSetup& evs)
 
   eleForestsMean_ = retrieveGBRForests(evs, eleCondNames_.mean);
   eleForestsSigma_ = retrieveGBRForests(evs, eleCondNames_.sigma);
-}
-
-void EGRegressionModifierV2::setConsumes(edm::ConsumesCollector& sumes)
-{
-  rhoToken_ = sumes.consumes<double>(rhoTag_);
 }
 
 void EGRegressionModifierV2::modifyObject(reco::GsfElectron& ele) const {


### PR DESCRIPTION
It was noticed in https://github.com/cms-sw/cmssw/pull/25593#discussion_r245819810 that `ModifyObjectValueBase`-derived classes (like `pat::ObjectModifier`) taking `ConsumesCollector` not via the constructor but via `setConsumes()` function call. This PR restructures `ModifyObjectValueBase` hierarchy such that the `ConsumesCollector` is passed via constructor.

Tested in CMSSW_10_5_X_2019-01-04-1100, no changes expected.