### PR TITLE
Add edm::ElementID class

### DIFF
--- a/DataFormats/Provenance/interface/ElementID.h
+++ b/DataFormats/Provenance/interface/ElementID.h
@@ -1,0 +1,57 @@
+#ifndef DataFormats_Provenance_ElementID_h
+#define DataFormats_Provenance_ElementID_h
+
+#include "DataFormats/Provenance/interface/ProductID.h"
+
+#include <iosfwd>
+
+namespace edm {
+  /**
+   * ElementID is a unique identifier for an element within a
+   * container. It extends the ProductID concept by adding an index to
+   * an object within a container.
+   *
+   * It provides both index() and key() methods so that it can be used
+   * in place of Ref/Ptr in the interfaces of e.g. ValueMap or Association.
+   */
+  class ElementID {
+  public:
+    using key_type = unsigned int;
+
+    ElementID() = default;
+    explicit ElementID(edm::ProductID id, key_type ind): index_(ind), id_(id) {}
+
+    bool isValid() const { return id_.isValid(); }
+    ProductID id() const { return id_; }
+    key_type index() const { return index_; }
+    key_type key() const { return index_; }
+    void reset() { index_ = 0; id_.reset(); }
+
+    void swap(ElementID& other);
+
+  private:
+    key_type index_ = 0;
+    ProductID id_;
+  };
+
+  inline
+  void swap(ElementID& a, ElementID& b) {
+    a.swap(b);
+  }
+
+  inline
+  bool operator==(ElementID const& lh, ElementID const& rh) {
+    return lh.index() == rh.index() && lh.id() == rh.id();
+  }
+
+  inline
+  bool operator!=(ElementID const& lh, ElementID const& rh) {
+    return !(lh == rh);
+  }
+
+  bool operator<(ElementID const& lh, ElementID const& rh);
+
+  std::ostream& operator<<(std::ostream& os, ElementID const& id);
+}
+
+#endif

--- a/DataFormats/Provenance/src/ElementID.cc
+++ b/DataFormats/Provenance/src/ElementID.cc
@@ -1,0 +1,19 @@
+#include "DataFormats/Provenance/interface/ElementID.h"
+#include <algorithm>
+#include <ostream>
+
+namespace edm {
+  void ElementID::swap(ElementID& other) {
+    std::swap(index_, other.index_);
+    edm::swap(id_, other.id_);
+  }
+
+  bool operator<(ElementID const& lh, ElementID const& rh) {
+    return lh.id() < rh.id() || (lh.id() == rh.id() && lh.index() < rh.index());
+  }
+
+  std::ostream& operator<<(std::ostream& os, ElementID const& id) {
+    os << id.id() << ":" << id.index();
+    return os;
+  }
+}

--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -2,6 +2,7 @@
 #include "DataFormats/Provenance/interface/BranchChildren.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"
+#include "DataFormats/Provenance/interface/ElementID.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/FileFormatVersion.h"
@@ -57,41 +58,4 @@
 
 namespace edm {
   typedef Hash<ModuleDescriptionType> ModuleDescriptionID;
-}
-
-namespace DataFormats_Provenance {
-  struct dictionary {
-  std::pair<edm::BranchKey, edm::BranchDescription> dummyPairBranch;
-  std::map<edm::ParameterSetID, edm::ParameterSetBlob> dummyMapParam;
-  std::map<edm::ProcessHistoryID, edm::ProcessHistory> dummyMapProcH;
-  std::vector<edm::ProcessConfigurationID> dummyVectorProcC;
-  std::vector<edm::ProcessHistory> dummyVectorProcH;
-  std::set<edm::ProcessHistoryID> dummySetProcH;
-  std::pair<edm::ParameterSetID, edm::ParameterSetBlob> dummyPairParam;
-  std::pair<edm::ProcessHistoryID, edm::ProcessHistory> dummyPairProcH;
-  edm::ParentageID dummyParentageID;
-  std::vector<edm::ProductID> dummyVectorProductID;
-  std::vector<edm::BranchID> dummyVectorBranchID;
-  std::set<edm::BranchID> dummySetBranchID;
-  std::map<edm::BranchID, std::set<edm::BranchID> > dummyMapSetBranchID;
-  std::pair<edm::BranchID, std::set<edm::BranchID> > dummyPairSetBranchID;
-  std::vector<edm::EventID> dummyVectorEventID;
-  std::vector<std::vector<edm::EventID> > dummyVectorVectorEventID;
-  std::vector<std::vector<std::vector<edm::EventID> > > dummyVectorVectorVectorEventID;
-  std::vector<edm::ProductProvenance> dummyVectorProductProvenance;
-    std::vector<edm::StoredProductProvenance> dummyVectorStoredProductProvenance;
-  std::vector<std::vector<edm::ParameterSetID> > dummyVectorVectorParameterSetID;
-  std::pair<edm::ProductID, unsigned int> ppui1;
-  std::vector<std::pair<edm::ProductID, unsigned int> > vppui1;
-
-  std::vector<TFormula*> dummyvtfp;
-
-  // The remaining ones are for backward compatibility only.
-  std::vector<edm::EventProcessHistoryID> dummyEventProcessHistory;
-  edm::EntryDescriptionID dummyEntryDescriptionID;
-  std::vector<edm::EventEntryInfo> dummyVectorEventEntryInfo;
-  std::vector<edm::RunLumiEntryInfo> dummyVectorRunLumiEntryInfo;
-
-  std::pair<edm::ModuleDescriptionID, edm::ModuleDescription> dummyPairMod;
-};
 }

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -6,6 +6,9 @@
  <class name="edm::ProductID" ClassVersion="10">
   <version ClassVersion="10" checksum="1501211476"/>
  </class>
+ <class name="edm::ElementID" ClassVersion="3">
+  <version ClassVersion="3" checksum="1958297906"/>
+ </class>
  <class name="edm::BranchID" ClassVersion="10">
   <version ClassVersion="10" checksum="21214741"/>
  </class>

--- a/DataFormats/Provenance/test/BuildFile.xml
+++ b/DataFormats/Provenance/test/BuildFile.xml
@@ -4,6 +4,9 @@
 </bin>
 <bin   file="EntryDescription_t.cpp">
 </bin>
+<bin   file="ElementID_t.cpp">
+  <use name="catch2"/>
+</bin>
 <bin   name="testProductResolverIndexHelper" file="testRunner.cpp productResolverIndexHelper_t.cppunit.cc">
   <use name="DataFormats/TestObjects"/>
 </bin>

--- a/DataFormats/Provenance/test/ElementID_t.cpp
+++ b/DataFormats/Provenance/test/ElementID_t.cpp
@@ -1,0 +1,49 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "DataFormats/Provenance/interface/ElementID.h"
+
+#include <sstream>
+
+TEST_CASE("ElementID", "[ElementID]") {
+  SECTION("Default construction is invalid") {
+    REQUIRE(edm::ElementID{}.isValid() == false);
+  }
+
+  SECTION("Basic operations") {
+    edm::ElementID id{edm::ProductID{1,2}, 3};
+    REQUIRE(id.isValid() == true);
+    REQUIRE(id.id() == edm::ProductID{1,2});
+    REQUIRE(id.key() == 3);
+    REQUIRE(id.index() == 3);
+
+    edm::ElementID id2;
+    edm::swap(id, id2);
+    REQUIRE(id.isValid() == false);
+    REQUIRE(id2.id() == edm::ProductID{1,2});
+    REQUIRE(id2.key() == 3);
+    REQUIRE(id2.index() == 3);
+
+    REQUIRE(id2 == edm::ElementID{edm::ProductID{1,2}, 3});
+    REQUIRE(id2 != edm::ElementID{edm::ProductID{2,2}, 3});
+    REQUIRE(id2 != edm::ElementID{edm::ProductID{1,3}, 3});
+    REQUIRE(id2 != edm::ElementID{edm::ProductID{1,2}, 4});
+
+    REQUIRE(id2 < edm::ElementID{edm::ProductID{1,2}, 4});
+    REQUIRE(id2 < edm::ElementID{edm::ProductID{1,3}, 3});
+    REQUIRE(id2 < edm::ElementID{edm::ProductID{2,2}, 3});
+
+    REQUIRE(not (id2 < id2));
+
+    REQUIRE(edm::ElementID{edm::ProductID{1,2}, 2} < id2);
+    REQUIRE(edm::ElementID{edm::ProductID{1,1}, 3} < id2);
+    REQUIRE(edm::ElementID{edm::ProductID{0,2}, 3} < id2);
+
+    std::stringstream ss;
+    ss << id2;
+    REQUIRE(ss.str() == "1:2:3");
+
+    id2.reset();
+    REQUIRE(id2.isValid() == false);
+  }
+}


### PR DESCRIPTION
In the review of #25593 a concept of a class for `edm::ProductID` and an index came up (e.g. as a lightweight key to `edm::ValueMap`). @Dr15Jones felt that such a class would be useful in general (regardless of #25593), so this PR implements one (`edm::ElementID`).

Tested in CMSSW_10_5_X_2019-01-04-1100.