### PR TITLE
fix typo to resolve uninitialized value use in pyquen.F

### DIFF
--- a/GeneratorInterface/PyquenInterface/src/pyquen.F
+++ b/GeneratorInterface/PyquenInterface/src/pyquen.F
@@ -1237,7 +1237,7 @@ c      INTEGER PYK,PYCHGE,PYCOMP
       GOTO2                                                            
  9    K2=K3                                                            
       GOTO2                                                             
- 8    P=F(K3)                                                          
+ 8    R=F(K3)                                                          
       RETURN                                                          
  3    B1=A(K1)                                                          
       B2=A(K1+1)                                                      


### PR DESCRIPTION
this was found in a follow up to uninit value use in  valgrind run of wf 150.0.

Without the fix, there are multiple instances of uninitialized values both in ```HYINIT``` and in ```HYEVNT```.

The fix correctly assigns a result from the function grid values when the coordinate is exactly on a grid point. 

