### PR TITLE
cleanup uninitialized value use cases based on valgrind checks

### DIFF
--- a/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
+++ b/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
@@ -44,7 +44,7 @@ class GeometryInterface {
 
   struct InterestingQuantities {
     // in this order the struct should fit 2 64bit words and is cheap to copy.
-    const edm::Event* sourceEvent;
+    const edm::Event* sourceEvent = nullptr;
     DetId sourceModule;
     int16_t col = 0;
     int16_t row = 0;

--- a/DQMOffline/Trigger/src/EgHLTOffHelper.cc
+++ b/DQMOffline/Trigger/src/EgHLTOffHelper.cc
@@ -338,6 +338,10 @@ void OffHelper::fillHLTData(const reco::GsfElectron& ele,OffEle::HLTData& hltDat
   }
 
   //Now get HLT p4 from triggerobject
+  //reset the position first
+  hltData.HLTeta = 999;
+  hltData.HLTphi = 999;
+  hltData.HLTenergy = -999;
   trigTools::fillHLTposition(ele,hltData,hltFiltersUsed_,trigEvt_.product(),hltTag_);
   //trigTools::fillHLTposition(phos(),hltFiltersUsed_,l1PreAndSeedFilters_,evtTrigBits,trigEvt_.product(),hltTag_); 
 }
@@ -346,6 +350,10 @@ void OffHelper::fillHLTData(const reco::GsfElectron& ele,OffEle::HLTData& hltDat
 void OffHelper::fillHLTDataPho(const reco::Photon& pho,OffPho::HLTData& hltData)
 {
   //Now get HLT p4 from triggerobject
+  //reset the position first
+  hltData.HLTeta = 999;
+  hltData.HLTphi = 999;
+  hltData.HLTenergy = -999;
   trigTools::fillHLTposition(pho,hltData, hltFiltersUsed_,trigEvt_.product(),hltTag_);
   //trigTools::fillHLTposition(phos(),hltFiltersUsed_,l1PreAndSeedFilters_,evtTrigBits,trigEvt_.product(),hltTag_); 
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
@@ -182,7 +182,7 @@ MuonProducer::MuonProducer(const edm::ParameterSet& pSet):debug_(pSet.getUntrack
 
 /// Destructor
 MuonProducer::~MuonProducer(){ 
-  if (thePFIsoHelper && fillPFIsolation_) delete thePFIsoHelper;
+  if (fillPFIsolation_ && thePFIsoHelper) delete thePFIsoHelper;
 }
 
 

--- a/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
@@ -103,7 +103,7 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
 
   LogDebug ("RPCSimSetup")<<"RPCSimSetUp::setRPCSetUp(vector<NoiseItem>, vector<ClusterSizeItem>)"<<std::endl;
 
-  uint32_t detId, current_detId, this_detId;
+  uint32_t detId = 0, current_detId, this_detId;
   RPCDetId rpcId, current_rpcId, this_rpcId;
   const RPCRoll * current_roll = nullptr;
   const RPCRoll * this_roll = nullptr;


### PR DESCRIPTION
several cases of uninitialized value use were picked up in tests of wf 150.0  (10 events) and 136.85 (100 events) with valgrind.

I expect that only the DQM fixes are consequential and will remove/reduce some cases with random differences.

