### PR TITLE
Fix incorrect address usage in VirtualJetProducer

### DIFF
--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -620,7 +620,7 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
       rhos->reserve(nEta);
       sigmas->reserve(nEta);
       fastjet::ClusterSequenceAreaBase const* clusterSequenceWithArea =
-        dynamic_cast<fastjet::ClusterSequenceAreaBase const *> ( &*fjClusterSeq_ );
+        dynamic_cast<fastjet::ClusterSequenceAreaBase const *> ( fjClusterSeq_.get() );
 
       if (clusterSequenceWithArea ==nullptr ){
 	if (!fjJets_.empty()) {
@@ -646,7 +646,7 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
       double mean_area = 0;
       
       fastjet::ClusterSequenceAreaBase const* clusterSequenceWithArea =
-        dynamic_cast<fastjet::ClusterSequenceAreaBase const *> ( &*fjClusterSeq_ );
+        dynamic_cast<fastjet::ClusterSequenceAreaBase const *> ( fjClusterSeq_.get() );
       if (clusterSequenceWithArea ==nullptr ){
 	if (!fjJets_.empty()) {
 	  throw cms::Exception("LogicError")<<"fjClusterSeq is not initialized while inputs are present\n ";


### PR DESCRIPTION
The code was getting the address from a boost::shared_ptr by doing '&*ptr' and passing that value to a dynamic_cast. This caused a crash under fully optimized clang because the compiler is allowed to assume that references do not point to 'null' memory. This allowed the clang compiler to remove the check for null in the dynamic_cast call.