### PR TITLE
Fix memory hoard in EcalShapeBase

### DIFF
--- a/SimCalorimetry/EcalSimAlgos/src/EcalShapeBase.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalShapeBase.cc
@@ -63,7 +63,8 @@ EcalShapeBase::buildMe()
    m_kNBinsPerNSec     = (unsigned int) (10/time_interval); // used to be an unsigned int = 10 in  < CMSSW10X, should work for time intervals ~0.1, 0.2, 0.5, 1
    m_qNSecPerBin = time_interval/10.; 
 
-   for(unsigned int i = 0; i < m_denseArraySize; ++i) { m_deriv.push_back(0.0); m_shape.push_back(0.0); }
+   m_deriv.resize(m_denseArraySize);
+   m_shape.resize(m_denseArraySize);
 
    const double maxel ( *max_element( shapeArray.begin(), shapeArray.end() ) ) ;
 


### PR DESCRIPTION
This PR fixes the memory hoard reported in
https://hypernews.cern.ch/HyperNews/CMS/get/simDevelopment/1879.html

Basically after the first event, this function just keeps adding zeros to the two vectors.

Tested in 10_4_0, no changes expected.