### PR TITLE
Modernized the memory handling of Hadronizers

### DIFF
--- a/GeneratorInterface/Core/interface/BaseHadronizer.h
+++ b/GeneratorInterface/Core/interface/BaseHadronizer.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
@@ -51,18 +51,19 @@ namespace gen {
 
     // GenRunInfo and GenEvent passing
     GenRunInfoProduct &getGenRunInfo() { return genRunInfo_; }
-    HepMC::GenEvent *getGenEvent() { return genEvent_.release(); }
-    GenEventInfoProduct *getGenEventInfo() { return genEventInfo_.release(); }
-    virtual GenLumiInfoHeader *getGenLumiInfoHeader() const;
-    
-    void resetEvent(HepMC::GenEvent *event) { genEvent_.reset(event); }
-    void resetEventInfo(GenEventInfoProduct *eventInfo) { genEventInfo_.reset(eventInfo); }
+    std::unique_ptr<HepMC::GenEvent> getGenEvent() { return std::move(genEvent_); }
+    std::unique_ptr<GenEventInfoProduct> getGenEventInfo() { return std::move(genEventInfo_); }
+    virtual std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const;
+    std::unique_ptr<lhef::LHEEvent> getLHEEvent() { return std::move(lheEvent_);}
+
+    void resetEvent(std::unique_ptr<HepMC::GenEvent> event) { genEvent_ = std::move(event); }
+    void resetEventInfo(std::unique_ptr<GenEventInfoProduct> eventInfo) { genEventInfo_ = std::move(eventInfo); }
 
     // LHERunInfo and LHEEvent passing
-    const boost::shared_ptr<lhef::LHERunInfo> &getLHERunInfo() const { return lheRunInfo_; }
+    const std::shared_ptr<lhef::LHERunInfo> &getLHERunInfo() const { return lheRunInfo_; }
 
-    void setLHERunInfo(lhef::LHERunInfo *runInfo) { lheRunInfo_.reset(runInfo); }
-    void setLHEEvent(lhef::LHEEvent *event) { lheEvent_.reset(event); }
+    void setLHERunInfo(std::unique_ptr<lhef::LHERunInfo> runInfo) { lheRunInfo_ = std::move(runInfo); }
+    void setLHEEvent(std::unique_ptr<lhef::LHEEvent> event) { lheEvent_ = std::move(event); }
 
     // interface for accessing the EDM information from the hadronizer
     void setEDMEvent(edm::Event &event) { edmEvent_ = &event; }
@@ -101,7 +102,7 @@ namespace gen {
     std::unique_ptr<HepMC::GenEvent>      genEvent_;
     std::unique_ptr<GenEventInfoProduct>  genEventInfo_;
 
-    boost::shared_ptr<lhef::LHERunInfo> lheRunInfo_;
+    std::shared_ptr<lhef::LHERunInfo>     lheRunInfo_;
     std::unique_ptr<lhef::LHEEvent>       lheEvent_;
 
     edm::Event                          *edmEvent_;

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -157,7 +157,7 @@ namespace edm
 	//
 	if ( !hadronizer_.decay() ) return false;
 	
-	event = std::unique_ptr<HepMC::GenEvent>(hadronizer_.getGenEvent());
+	event = hadronizer_.getGenEvent();
 	if ( !event.get() ) return false; 
 	
 	// The external decay driver is being added to the system,
@@ -180,7 +180,7 @@ namespace edm
     //
     // fisrt of all, put back modified event tree (after external decay)
     //
-    hadronizer_.resetEvent( event.release() );
+    hadronizer_.resetEvent( std::move(event) );
 	
     //
     // now run residual decays
@@ -189,7 +189,7 @@ namespace edm
     	
     hadronizer_.finalizeEvent();
     
-    event.reset( hadronizer_.getGenEvent() );
+    event =  hadronizer_.getGenEvent();
     if ( !event.get() ) return false;
     
     event->set_event_number( ev.id().event() );
@@ -197,7 +197,7 @@ namespace edm
     //
     // tutto bene - finally, form up EDM products !
     //
-    std::unique_ptr<GenEventInfoProduct> genEventInfo(hadronizer_.getGenEventInfo());
+    auto genEventInfo = hadronizer_.getGenEventInfo();
     if (!genEventInfo.get())
       { 
 	// create GenEventInfoProduct from HepMC event in case hadronizer didn't provide one

--- a/GeneratorInterface/Core/src/BaseHadronizer.cc
+++ b/GeneratorInterface/Core/src/BaseHadronizer.cc
@@ -44,9 +44,9 @@ const std::vector<std::string> BaseHadronizer::theSharedResources;
 
   }
   
-  GenLumiInfoHeader *BaseHadronizer::getGenLumiInfoHeader() const {
+  std::unique_ptr<GenLumiInfoHeader> BaseHadronizer::getGenLumiInfoHeader() const {
     
-    GenLumiInfoHeader *genLumiInfoHeader = new GenLumiInfoHeader();
+    auto genLumiInfoHeader = std::make_unique<GenLumiInfoHeader>();
     
     //fill information on randomized configs for parameter scans
     genLumiInfoHeader->setRandomConfigIndex(randomIndex_);

--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -7,8 +7,6 @@
 #include <vector>
 #include <string>
 
-#include <boost/shared_ptr.hpp>
-
 #include "HepMC/GenEvent.h"
 #include "HepMC/GenVertex.h"
 #include "HepMC/PdfInfo.h"
@@ -24,22 +22,22 @@ namespace lhef {
 
 class LHEEvent {
     public:
-	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
+	LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
 	         std::istream &in);
-	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
+	LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
 	         const HEPEUP &hepeup);
-	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
+	LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
 	         const HEPEUP &hepeup,
 	         const LHEEventProduct::PDF *pdf,
 	         const std::vector<std::string> &comments);
-	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
+	LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
 	         const LHEEventProduct &product);
 	~LHEEvent();
 
 	typedef LHEEventProduct::PDF PDF;
 	typedef LHEEventProduct::WGT WGT;
 
-	const boost::shared_ptr<LHERunInfo> &getRunInfo() const { return runInfo; }
+	const std::shared_ptr<LHERunInfo> &getRunInfo() const { return runInfo; }
 	const HEPEUP *getHEPEUP() const { return &hepeup; }
 	const HEPRUP *getHEPRUP() const { return runInfo->getHEPRUP(); }
 	const PDF *getPDF() const { return pdf.get(); }
@@ -85,7 +83,7 @@ class LHEEvent {
 	static bool checkHepMCTree(const HepMC::GenEvent *event);
 	HepMC::GenParticle *makeHepMCParticle(unsigned int i) const;
 
-	const boost::shared_ptr<LHERunInfo>	runInfo;
+	const std::shared_ptr<LHERunInfo>	runInfo;
 
 	HEPEUP					hepeup;
 	std::unique_ptr<PDF>			pdf;

--- a/GeneratorInterface/LHEInterface/interface/LHEReader.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEReader.h
@@ -5,8 +5,6 @@
 #include <vector>
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace lhef {
@@ -24,7 +22,7 @@ class LHEReader {
 	          unsigned int skip = 0);
 	~LHEReader();
 
-	boost::shared_ptr<LHEEvent> next(bool* newFileOpened = nullptr);
+	std::shared_ptr<LHEEvent> next(bool* newFileOpened = nullptr);
 
     private:
 	class Source;
@@ -41,7 +39,7 @@ class LHEReader {
 
 	std::unique_ptr<Source>		curSource;
 	std::unique_ptr<XMLDocument>	curDoc;
-	boost::shared_ptr<LHERunInfo>	curRunInfo;
+	std::shared_ptr<LHERunInfo>	curRunInfo;
 	std::unique_ptr<XMLHandler>	handler;
 	std::shared_ptr<void>           platform;
 };

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -97,9 +97,9 @@ private:
   std::string outputContents_;
 
   std::unique_ptr<lhef::LHEReader>	reader_;
-  boost::shared_ptr<lhef::LHERunInfo>	runInfoLast;
-  boost::shared_ptr<lhef::LHERunInfo>	runInfo;
-  boost::shared_ptr<lhef::LHEEvent>	partonLevel;
+  std::shared_ptr<lhef::LHERunInfo>	runInfoLast;
+  std::shared_ptr<lhef::LHERunInfo>	runInfo;
+  std::shared_ptr<lhef::LHEEvent>	partonLevel;
   boost::ptr_deque<LHERunInfoProduct>	runInfoProducts;
   bool					wasMerged;
   
@@ -513,7 +513,7 @@ void ExternalLHEProducer::nextEvent()
   if (!partonLevel)
     return;
 
-  boost::shared_ptr<lhef::LHERunInfo> runInfoThis = partonLevel->getRunInfo();
+  std::shared_ptr<lhef::LHERunInfo> runInfoThis = partonLevel->getRunInfo();
   if (runInfoThis != runInfoLast) {
     runInfo = runInfoThis;
     runInfoLast = runInfoThis;

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -54,8 +54,8 @@ private:
 
   std::unique_ptr<lhef::LHEReader>      reader_;
 
-  boost::shared_ptr<lhef::LHERunInfo>	runInfoLast_;
-  boost::shared_ptr<lhef::LHEEvent>	partonLevel_;
+  std::shared_ptr<lhef::LHERunInfo>	runInfoLast_;
+  std::shared_ptr<lhef::LHEEvent>	partonLevel_;
 
   std::unique_ptr<LHERunInfoProduct>	runInfoProductLast_;
   edm::LHEProvenanceHelper		lheProvenanceHelper_;

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -33,7 +33,7 @@ static int skipWhitespace(std::istream &in)
 
 namespace lhef {
 
-LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
+LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
                    std::istream &in) :
   runInfo(runInfo), weights_(0), counted(false), 
   readAttemptCounter(0), npLO_(-99), npNLO_(-99)
@@ -113,14 +113,14 @@ LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
 	    " content after event data." << std::endl;
 }
 
-LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
+LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
                    const HEPEUP &hepeup) :
 	runInfo(runInfo), hepeup(hepeup), counted(false), readAttemptCounter(0),
         npLO_(-99), npNLO_(-99)
 {
 }
 
-LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
+LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
                    const HEPEUP &hepeup,
                    const LHEEventProduct::PDF *pdf,
                    const std::vector<std::string> &comments) :
@@ -130,7 +130,7 @@ LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
 {
 }
 
-LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
+LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
                    const LHEEventProduct &product) :
 	runInfo(runInfo), hepeup(product.hepeup()),
 	pdf(product.pdf() ? new PDF(*product.pdf()) : nullptr),

--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -487,7 +487,7 @@ LHEReader::~LHEReader()
   curSource.release();
 }
 
-  boost::shared_ptr<LHEEvent> LHEReader::next(bool* newFileOpened)
+  std::shared_ptr<LHEEvent> LHEReader::next(bool* newFileOpened)
   {
     while(curDoc.get() || curIndex < fileURLs.size() || (fileURLs.empty() && !strName.empty() ) ) {
       if (!curDoc.get()) {
@@ -520,7 +520,7 @@ LHEReader::~LHEReader()
         if (!curDoc->parse()) {
           curDoc.reset();
           logFileAction("  Closed LHE file ", fileURLs[curIndex - 1]);
-          return boost::shared_ptr<LHEEvent>();
+          return std::shared_ptr<LHEEvent>();
         }
         break;
         
@@ -559,7 +559,7 @@ LHEReader::~LHEReader()
         }
         
         if (maxEvents == 0)
-          return boost::shared_ptr<LHEEvent>();
+          return std::shared_ptr<LHEEvent>();
         else if (maxEvents > 0)
           maxEvents--;
 
@@ -567,7 +567,7 @@ LHEReader::~LHEReader()
 	data.str(handler->buffer);
 	handler->buffer.clear();
 
-	boost::shared_ptr<LHEEvent> lheevent;
+	std::shared_ptr<LHEEvent> lheevent;
 	lheevent.reset(new LHEEvent(curRunInfo, data));
 	const XMLHandler::wgt_info& info = handler->weightsinevent;
 	for( size_t i=0; i< info.size(); ++i ) {
@@ -586,7 +586,7 @@ LHEReader::~LHEReader()
       }
     }
     
-    return boost::shared_ptr<LHEEvent>();
+    return std::shared_ptr<LHEEvent>();
   }
   
 } // namespace lhef

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -93,7 +93,7 @@ class Pythia8Hadronizer : public Py8InterfaceBase {
 
     const char *classname() const override { return "Pythia8Hadronizer"; }
     
-    GenLumiInfoHeader *getGenLumiInfoHeader() const override;
+  std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const override;
     
   private:
 
@@ -944,8 +944,8 @@ void Pythia8Hadronizer::finalizeEvent()
   }
 }
 
-GenLumiInfoHeader *Pythia8Hadronizer::getGenLumiInfoHeader() const {
-  GenLumiInfoHeader *genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
+std::unique_ptr<GenLumiInfoHeader> Pythia8Hadronizer::getGenLumiInfoHeader() const {
+  auto genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
   
   //fill lhe headers
   //*FIXME* initrwgt header is corrupt due to pythia bug

--- a/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
@@ -52,7 +52,7 @@ public:
   bool rearrangeWeights;
   bool residualDecay();
   void finalizeEvent();
-  GenLumiInfoHeader *getGenLumiInfoHeader() const override;
+  std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const override;
   const char *classname() const { return "SherpaHadronizer"; }
 
 
@@ -261,7 +261,7 @@ bool SherpaHadronizer::generatePartonsAndHadronize()
   }
   if (rc) {
     //convert it to HepMC2
-    HepMC::GenEvent* evt = new HepMC::GenEvent();
+    auto evt = std::make_unique<HepMC::GenEvent>();
     Generator->FillHepMCEvent(*evt);
 
     // in case of unweighted events sherpa puts the max weight as event weight.
@@ -317,7 +317,7 @@ bool SherpaHadronizer::generatePartonsAndHadronize()
     if(unweighted){
         evt->weights()[0]/=weight_normalization;
     }
-    resetEvent(evt);
+    resetEvent(std::move(evt));
     return true;
   }
   else {
@@ -365,8 +365,8 @@ double CMS_SHERPA_RNG::Get() {
   return randomEngine->flat();
 
 }
-GenLumiInfoHeader *SherpaHadronizer::getGenLumiInfoHeader() const {
-  GenLumiInfoHeader *genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
+std::unique_ptr<GenLumiInfoHeader> SherpaHadronizer::getGenLumiInfoHeader() const {
+  auto genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
 
   if(rearrangeWeights){
       edm::LogPrint("SherpaHadronizer") << "The order of event weights was changed!" ;


### PR DESCRIPTION
-Switched from boost::shared_ptr to std::shared_ptr
-Use std::unique_ptr directly to transfer memory ownership