### PR TITLE
Some EcalClusterTools maintainance and energy matrix in Egamma MVA Ntuplizers

### DIFF
--- a/RecoCaloTools/Navigation/interface/CaloRectangle.h
+++ b/RecoCaloTools/Navigation/interface/CaloRectangle.h
@@ -1,0 +1,116 @@
+#ifndef RecoCaloTools_Navigation_CaloRectangle_H
+#define RecoCaloTools_Navigation_CaloRectangle_H
+
+#include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
+
+/*
+ * CaloRectangle is a class to create a rectangular range of DetIds around a
+ * central DetId. Meant to be used for range-based loops to calculate cluster
+ * shape variables.
+ */
+
+struct CaloRectangle {
+    const int ixMin;
+    const int ixMax;
+    const int iyMin;
+    const int iyMax;
+
+    template<class T>
+    auto operator()(T home, CaloTopology const& topology);
+
+};
+
+inline auto makeCaloRectangle(int size) {
+    return CaloRectangle{-size, size, -size, size};
+}
+
+inline auto makeCaloRectangle(int sizeX, int sizeY) {
+    return CaloRectangle{-sizeX, sizeX, -sizeY, sizeY};
+}
+
+template<class T>
+T offsetBy(T start, CaloSubdetectorTopology const& topo, int dX, int dY)
+{
+    for(int x = 0; x < std::abs(dX) && start != T(0); x++) {
+        // east is eta in barrel
+        start = dX > 0 ? topo.goEast(start) : topo.goWest(start);
+    }
+
+    for(int y = 0; y < std::abs(dY) && start != T(0); y++) {
+        // north is phi in barrel
+        start = dY > 0 ? topo.goNorth(start) : topo.goSouth(start);
+    }
+    return start;
+}
+
+template<class T>
+class CaloRectangleRange {
+
+  public:
+
+    class Iterator {
+
+      public:
+
+        Iterator(T const& home, int ix, int iy, CaloRectangle const rectangle, CaloSubdetectorTopology const& topology)
+          : home_(home)
+          , rectangle_(rectangle)
+          , topology_(topology)
+          , ix_(ix)
+          , iy_(iy)
+        {}
+
+        Iterator& operator++() {
+            if(iy_ == rectangle_.iyMax) {
+                iy_ = rectangle_.iyMin;
+                ix_++;
+            } else ++iy_;
+            return *this;
+        }
+
+        int ix() const { return ix_; }
+        int iy() const { return iy_; }
+
+        bool operator==(Iterator const& other) const { return ix_ == other.ix() && iy_ == other.iy(); }
+        bool operator!=(Iterator const& other) const { return ix_ != other.ix() || iy_ != other.iy(); }
+
+        T operator*() const { return offsetBy(home_, topology_, ix_, iy_); }
+
+      private:
+
+        const T home_;
+
+        const CaloRectangle rectangle_;
+        CaloSubdetectorTopology const& topology_;
+
+        int ix_;
+        int iy_;
+    };
+
+  public:
+    CaloRectangleRange(CaloRectangle rectangle, T home, CaloTopology const& topology)
+      : home_(home)
+      , rectangle_(rectangle)
+      , topology_(*topology.getSubdetectorTopology(home))
+    {}
+
+    auto begin() {
+        return Iterator(home_, rectangle_.ixMin, rectangle_.iyMin, rectangle_, topology_);
+    }
+    auto end() {
+        return Iterator(home_, rectangle_.ixMax + 1, rectangle_.iyMin, rectangle_, topology_);
+    }
+
+  private:
+    const T home_;
+    const CaloRectangle rectangle_;
+    CaloSubdetectorTopology const& topology_;
+};
+
+template<class T>
+auto CaloRectangle::operator()(T home, CaloTopology const& topology) {
+    return CaloRectangleRange<T>(*this, home, topology);
+}
+
+#endif

--- a/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
@@ -134,13 +134,9 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es)
            const CaloClusterPtr& bcref = clus1.seed();
            const BasicCluster *bc = bcref.get();
            //Get the maximum detid
-           std::pair<DetId, float> EDetty = 
-			   EcalClusterTools::getMaximum(*bc,rechits);
-           //get the 3x3 array centered on maximum detid.
-           std::vector<DetId> detvec = EcalClusterTools::matrixDetId(topology,EDetty.first, 1);
-           //Loop over the 3x3
-           for (int ik = 0;ik<int(detvec.size());++ik)
-             saveTheseDetIds.push_back(detvec[ik]);
+           DetId maxDetId = EcalClusterTools::getMaximum(*bc,rechits).first;
+           // Loop over the 3x3 array centered on maximum detid
+           for(DetId detId : CaloRectangleRange(1, maxDetId, *topology)) saveTheseDetIds.push_back(detId);
            
          }
          for (int detloop=0; detloop < int(saveTheseDetIds.size());++detloop){
@@ -195,12 +191,9 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es)
            const CaloClusterPtr& bcref = clus1.seed();
            const BasicCluster *bc = bcref.get();
            //Get the maximum detid
-           std::pair<DetId, float> EDetty = EcalClusterTools::getMaximum(*bc,rechits);
-           //get the 3x3 array centered on maximum detid.
-           std::vector<DetId> detvec = EcalClusterTools::matrixDetId(topology,EDetty.first, 1);
-           //Loop over the 3x3
-           for (int ik = 0;ik<int(detvec.size());++ik)
-             saveTheseDetIds.insert(detvec[ik]);
+           DetId maxDetId = EcalClusterTools::getMaximum(*bc,rechits).first;
+           // Loop over the 3x3 array centered on maximum detid
+           for(DetId detId : CaloRectangleRange(1, maxDetId, *topology)) saveTheseDetIds.insert(detId);
          }
          int eecounter=0;
          for (EEDigiCollection::const_iterator blah = digis->begin();

--- a/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
@@ -137,8 +137,7 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es)
            std::pair<DetId, float> EDetty = 
 			   EcalClusterTools::getMaximum(*bc,rechits);
            //get the 3x3 array centered on maximum detid.
-           std::vector<DetId> detvec = 
-			   EcalClusterTools::matrixDetId(topology,EDetty.first, -1, 1, -1, 1);
+           std::vector<DetId> detvec = EcalClusterTools::matrixDetId(topology,EDetty.first, 1);
            //Loop over the 3x3
            for (int ik = 0;ik<int(detvec.size());++ik)
              saveTheseDetIds.push_back(detvec[ik]);
@@ -198,8 +197,7 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es)
            //Get the maximum detid
            std::pair<DetId, float> EDetty = EcalClusterTools::getMaximum(*bc,rechits);
            //get the 3x3 array centered on maximum detid.
-           std::vector<DetId> detvec = 
-			   EcalClusterTools::matrixDetId(topology,EDetty.first, -1, 1, -1, 1);
+           std::vector<DetId> detvec = EcalClusterTools::matrixDetId(topology,EDetty.first, 1);
            //Loop over the 3x3
            for (int ik = 0;ik<int(detvec.size());++ik)
              saveTheseDetIds.insert(detvec[ik]);

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -106,13 +106,13 @@ class EcalClusterLazyToolsT : public EcalClusterLazyToolsBase {
       : EcalClusterLazyToolsBase(ev,es,token1,token2,token3) {}
 
     // Get the rec hit energies in a rectangle matrix around the seed.
-    std::vector<float> getEnergies(reco::BasicCluster const& cluster, CaloRectangle rectangle) const {
+    std::vector<float> energyMatrix(reco::BasicCluster const& cluster, int size) const {
 
         auto recHits = getEcalRecHitCollection(cluster);
         DetId maxId = ClusterTools::getMaximum(cluster, recHits).first;
 
         std::vector<float> energies;
-        for (auto const& detId : rectangle(maxId, *topology_)) {
+        for (auto const& detId : CaloRectangleRange(size, maxId, *topology_)) {
             energies.push_back(ClusterTools::recHitEnergy( detId, recHits));
         }
 

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -2,12 +2,12 @@
 #define RecoEcal_EgammaCoreTools_EcalClusterLazyTools_h
 
 /** \class EcalClusterLazyTools
- *  
+ *
  * various cluster tools (e.g. cluster shapes)
  *
  * \author Federico Ferri
- * 
- * \version $Id: 
+ *
+ * \version $Id:
  *
  */
 
@@ -35,18 +35,16 @@ class EcalClusterLazyToolsBase {
  public:
   EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2);
   EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3);
-  ~EcalClusterLazyToolsBase();
-  
 
-  // get time of basic cluster seed crystal 
+  // get time of basic cluster seed crystal
   float BasicClusterSeedTime(const reco::BasicCluster &cluster);
-  // error-weighted average of time from constituents of basic cluster 
+  // error-weighted average of time from constituents of basic cluster
   float BasicClusterTime(const reco::BasicCluster &cluster, const edm::Event &ev);
   // get BasicClusterSeedTime of the seed basic cluser of the supercluster
   float SuperClusterSeedTime(const reco::SuperCluster &cluster);
   // get BasicClusterTime of the seed basic cluser of the supercluster
   float SuperClusterTime(const reco::SuperCluster &cluster, const edm::Event &ev);
-  
+
   // mapping for preshower rechits
   std::map<DetId, EcalRecHit> rechits_map_;
   // get Preshower hit array
@@ -57,30 +55,26 @@ class EcalClusterLazyToolsBase {
   float eseffsirir( const reco::SuperCluster &cluster );
   float eseffsixix( const reco::SuperCluster &cluster );
   float eseffsiyiy( const reco::SuperCluster &cluster );
-  
-  //  std::vector<int> flagsexcl_;
-  //std::vector<int> severitiesexcl_;
-  // const EcalSeverityLevelAlgo *sevLv;
-  
+
+  EcalRecHitCollection const* getEcalEBRecHitCollection() const { return ebRecHits_; }
+  EcalRecHitCollection const* getEcalEERecHitCollection() const { return eeRecHits_; }
+  EcalRecHitCollection const* getEcalESRecHitCollection() const { return esRecHits_; }
+  EcalIntercalibConstants const& getEcalIntercalibConstants() const { return *icalMap; }
+  edm::ESHandle<EcalLaserDbService> const& getLaserHandle() const { return laser; }
+
  protected:
-  void getGeometry( const edm::EventSetup &es, bool doES=true );
-  void getTopology( const edm::EventSetup &es );
-  void getEBRecHits( const edm::Event &ev );
-  void getEERecHits( const edm::Event &ev );
-  void getESRecHits( const edm::Event &ev );
-  const EcalRecHitCollection * getEcalRecHitCollection( const reco::BasicCluster &cluster );
-  
+  EcalRecHitCollection const* getEcalRecHitCollection( const reco::BasicCluster &cluster ) const;
+
   const CaloGeometry *geometry_;
   const CaloTopology *topology_;
   const EcalRecHitCollection *ebRecHits_;
   const EcalRecHitCollection *eeRecHits_;
   const EcalRecHitCollection *esRecHits_;
-  
-  edm::EDGetTokenT<EcalRecHitCollection> ebRHToken_, eeRHToken_, esRHToken_;
+
+  edm::EDGetTokenT<EcalRecHitCollection> esRHToken_;
 
   std::shared_ptr<CaloSubdetectorTopology const> ecalPS_topology_;
 
-  //const EcalIntercalibConstantMap& icalMap;
   edm::ESHandle<EcalIntercalibConstants> ical;
   const EcalIntercalibConstantMap*        icalMap;
   edm::ESHandle<EcalADCToGeVConstant>    agc;
@@ -88,319 +82,150 @@ class EcalClusterLazyToolsBase {
   void getIntercalibConstants( const edm::EventSetup &es );
   void getADCToGeV           ( const edm::EventSetup &es );
   void getLaserDbService     ( const edm::EventSetup &es );
-  
-  //  std::vector<int> flagsexcl_;
-  //  std::vector<int> severitiesexcl_;
 
- public:
-  inline const EcalRecHitCollection *getEcalEBRecHitCollection(void){return ebRecHits_;};
-  inline const EcalRecHitCollection *getEcalEERecHitCollection(void){return eeRecHits_;};
-  inline const EcalRecHitCollection *getEcalESRecHitCollection(void){return esRecHits_;};
-  inline const EcalIntercalibConstants& getEcalIntercalibConstants(void){return *icalMap;};
-  inline const edm::ESHandle<EcalLaserDbService>& getLaserHandle(void){return laser;};
-  
+ private:
+  void getESRecHits( const edm::Event &ev );
+
 }; // class EcalClusterLazyToolsBase
 
-template<class EcalClusterToolsImpl> 
+template<class ClusterTools>
 class EcalClusterLazyToolsT : public EcalClusterLazyToolsBase {
-    public:
+  public:
 
- EcalClusterLazyToolsT( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2):
-  EcalClusterLazyToolsBase(ev,es,token1,token2) {}
+    EcalClusterLazyToolsT( const edm::Event &ev,
+                           const edm::EventSetup &es,
+                           edm::EDGetTokenT<EcalRecHitCollection> token1,
+                           edm::EDGetTokenT<EcalRecHitCollection> token2 )
+      : EcalClusterLazyToolsBase(ev,es,token1,token2) {}
 
- EcalClusterLazyToolsT( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3):
-  EcalClusterLazyToolsBase(ev,es,token1,token2,token3) {}
-        ~EcalClusterLazyToolsT() {}
+    EcalClusterLazyToolsT( const edm::Event &ev,
+                           const edm::EventSetup &es,
+                           edm::EDGetTokenT<EcalRecHitCollection> token1,
+                           edm::EDGetTokenT<EcalRecHitCollection> token2,
+                           edm::EDGetTokenT<EcalRecHitCollection> token3)
+      : EcalClusterLazyToolsBase(ev,es,token1,token2,token3) {}
 
-        // various energies in the matrix nxn surrounding the maximum energy crystal of the input cluster  
-        //NOTE (29/10/08): we now use an eta/phi coordinate system rather than phi/eta
-        //to minmise possible screwups, for now e5x1 isnt defined all the majority of people who call it actually want e1x5 and 
-        //it is thought it is better that their code doesnt compile rather than pick up the wrong function
-        //therefore in this version and later e1x5 = e5x1 in the old version 
-        //so 1x5 is 1 crystal in eta and 5 crystals in phi
-        //note e3x2 does not have a definate eta/phi geometry, it takes the maximum 3x2 block containing the 
-        //seed regardless of whether that 3 in eta or phi
-        float e1x3( const reco::BasicCluster &cluster );
+    // Get the rec hit energies in a rectangle matrix around the seed.
+    std::vector<float> getEnergies(reco::BasicCluster const& cluster, CaloRectangle rectangle) const {
 
-        float e3x1( const reco::BasicCluster &cluster );
+        auto recHits = getEcalRecHitCollection(cluster);
+        DetId maxId = ClusterTools::getMaximum(cluster, recHits).first;
 
-        float e1x5( const reco::BasicCluster &cluster );
+        std::vector<float> energies;
+        for (auto const& detId : rectangle(maxId, *topology_)) {
+            energies.push_back(ClusterTools::recHitEnergy( detId, recHits));
+        }
 
-        float e5x1( const reco::BasicCluster &cluster );
+        return energies;
+    }
 
-        float e2x2( const reco::BasicCluster &cluster );
+    // various energies in the matrix nxn surrounding the maximum energy crystal of the input cluster
+    //
+    // NOTE (29/10/08): we now use an eta/phi coordinate system rather than
+    //                  phi/eta to minmise possible screwups, for now e5x1 isnt
+    //                  defined all the majority of people who call it actually
+    //                  want e1x5 and it is thought it is better that their code
+    //                  doesnt compile rather than pick up the wrong function
+    //                  therefore in this version and later e1x5 = e5x1 in the old
+    //                  version so 1x5 is 1 crystal in eta and 5 crystals in phi
+    //                  note e3x2 does not have a definate eta/phi geometry, it
+    //                  takes the maximum 3x2 block containing the seed regardless
+    //                  of whether that 3 in eta or phi
+    float e1x3( const reco::BasicCluster &cluster )
+        { return ClusterTools::e1x3( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float e3x1( const reco::BasicCluster &cluster )
+        { return ClusterTools::e3x1( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float e1x5( const reco::BasicCluster &cluster )
+        { return ClusterTools::e1x5( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float e5x1( const reco::BasicCluster &cluster )
+        { return ClusterTools::e5x1( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float e2x2( const reco::BasicCluster &cluster )
+        { return ClusterTools::e2x2( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float e3x2( const reco::BasicCluster &cluster )
+        { return ClusterTools::e3x2( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float e3x3( const reco::BasicCluster &cluster )
+        { return ClusterTools::e3x3( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float e4x4( const reco::BasicCluster &cluster )
+        { return ClusterTools::e4x4( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float e5x5( const reco::BasicCluster &cluster )
+        { return ClusterTools::e5x5( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    int n5x5( const reco::BasicCluster &cluster )
+        { return ClusterTools::n5x5( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    // energy in the 2x5 strip right of the max crystal (does not contain max crystal)
+    // 2 crystals wide in eta, 5 wide in phi.
+    float e2x5Right( const reco::BasicCluster &cluster )
+        { return ClusterTools::e2x5Right( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    // energy in the 2x5 strip left of the max crystal (does not contain max crystal)
+    float e2x5Left( const reco::BasicCluster &cluster )
+        { return ClusterTools::e2x5Left( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    // energy in the 5x2 strip above the max crystal (does not contain max crystal)
+    // 5 crystals wide in eta, 2 wide in phi.
+    float e2x5Top( const reco::BasicCluster &cluster )
+        { return ClusterTools::e2x5Top( cluster, getEcalRecHitCollection(cluster), topology_ ); }
 
-        float e3x2( const reco::BasicCluster &cluster );
+    // energy in the 5x2 strip below the max crystal (does not contain max crystal)
+    float e2x5Bottom( const reco::BasicCluster &cluster )
+        { return ClusterTools::e2x5Bottom( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    // energy in a 2x5 strip containing the seed (max) crystal.
+    // 2 crystals wide in eta, 5 wide in phi.
+    // it is the maximum of either (1x5left + 1x5center) or (1x5right + 1x5center)
+    float e2x5Max( const reco::BasicCluster &cluster )
+        { return ClusterTools::e2x5Max( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    // energies in the crystal left, right, top, bottom w.r.t. to the most energetic crystal
+    float eLeft( const reco::BasicCluster &cluster )
+        { return ClusterTools::eLeft( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float eRight( const reco::BasicCluster &cluster )
+        { return ClusterTools::eRight( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float eTop( const reco::BasicCluster &cluster )
+        { return ClusterTools::eTop( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    float eBottom( const reco::BasicCluster &cluster )
+        { return ClusterTools::eBottom( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    // the energy of the most energetic crystal in the cluster
+    float eMax( const reco::BasicCluster &cluster )
+        { return ClusterTools::eMax( cluster, getEcalRecHitCollection(cluster) ); }
+    // the energy of the second most energetic crystal in the cluster
+    float e2nd( const reco::BasicCluster &cluster )
+        { return ClusterTools::e2nd( cluster, getEcalRecHitCollection(cluster) ); }
 
-        float e3x3( const reco::BasicCluster &cluster );
+    // get the DetId and the energy of the maximum energy crystal of the input cluster
+    std::pair<DetId, float> getMaximum( const reco::BasicCluster &cluster )
+        { return ClusterTools::getMaximum( cluster, getEcalRecHitCollection(cluster) ); }
+    std::vector<float> energyBasketFractionEta( const reco::BasicCluster &cluster )
+        { return ClusterTools::energyBasketFractionEta( cluster, getEcalRecHitCollection(cluster) ); }
+    std::vector<float> energyBasketFractionPhi( const reco::BasicCluster &cluster )
+        { return ClusterTools::energyBasketFractionPhi( cluster, getEcalRecHitCollection(cluster) ); }
 
-        float e4x4( const reco::BasicCluster &cluster );
+    // return a vector v with v[0] = etaLat, v[1] = phiLat, v[2] = lat
+    std::vector<float> lat( const reco::BasicCluster &cluster, bool logW = true, float w0 = 4.7 )
+        { return ClusterTools::lat( cluster, getEcalRecHitCollection(cluster), geometry_, logW, w0 ); }
 
-        float e5x5( const reco::BasicCluster &cluster );
-        int   n5x5( const reco::BasicCluster &cluster );
-        // energy in the 2x5 strip right of the max crystal (does not contain max crystal)
-        // 2 crystals wide in eta, 5 wide in phi.
-        float e2x5Right( const reco::BasicCluster &cluster );
-        // energy in the 2x5 strip left of the max crystal (does not contain max crystal)
-        float e2x5Left( const reco::BasicCluster &cluster );
-        // energy in the 5x2 strip above the max crystal (does not contain max crystal)
-        // 5 crystals wide in eta, 2 wide in phi.
-        float e2x5Top( const reco::BasicCluster &cluster );
+    // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
+    std::vector<float> covariances(const reco::BasicCluster &cluster, float w0 = 4.7 )
+        { return ClusterTools::covariances( cluster, getEcalRecHitCollection(cluster), topology_, geometry_, w0 ); }
 
-        // energy in the 5x2 strip below the max crystal (does not contain max crystal)
-        float e2x5Bottom( const reco::BasicCluster &cluster );
-        // energy in a 2x5 strip containing the seed (max) crystal.
-        // 2 crystals wide in eta, 5 wide in phi.
-        // it is the maximum of either (1x5left + 1x5center) or (1x5right + 1x5center)
-        float e2x5Max( const reco::BasicCluster &cluster );
-        // energies in the crystal left, right, top, bottom w.r.t. to the most energetic crystal
-        float eLeft( const reco::BasicCluster &cluster );
+    // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
+    // this function calculates differences in eta/phi in units of crystals not
+    // global eta/phi this is gives better performance in the crack regions of
+    // the calorimeter but gives otherwise identical results to covariances
+    // function this is only defined for the barrel, it returns covariances when
+    // the cluster is in the endcap Warning: covIEtaIEta has been studied by
+    // egamma, but so far covIPhiIPhi hasnt been studied extensively so there
+    // could be a bug in the covIPhiIEta or covIPhiIPhi calculations. I dont
+    // think there is but as it hasnt been heavily used, there might be one
+    std::vector<float> localCovariances(const reco::BasicCluster &cluster, float w0 = 4.7)
+        { return ClusterTools::localCovariances( cluster, getEcalRecHitCollection(cluster), topology_, w0 ); }
+    std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7)
+        { return ClusterTools::scLocalCovariances( cluster, getEcalRecHitCollection(cluster), topology_, w0 ); }
+    double zernike20( const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7 )
+        { return ClusterTools::zernike20( cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0 ); }
+    double zernike42( const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7 )
+        { return ClusterTools::zernike42( cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0 ); }
 
-        float eRight( const reco::BasicCluster &cluster );
-
-        float eTop( const reco::BasicCluster &cluster );
-
-        float eBottom( const reco::BasicCluster &cluster );
-        // the energy of the most energetic crystal in the cluster
-        float eMax( const reco::BasicCluster &cluster );
-        // the energy of the second most energetic crystal in the cluster
-        float e2nd( const reco::BasicCluster &cluster );
-
-        // get the DetId and the energy of the maximum energy crystal of the input cluster
-        std::pair<DetId, float> getMaximum( const reco::BasicCluster &cluster );
-
-        std::vector<float> energyBasketFractionEta( const reco::BasicCluster &cluster );
-
-        std::vector<float> energyBasketFractionPhi( const reco::BasicCluster &cluster );
-
-        // return a vector v with v[0] = etaLat, v[1] = phiLat, v[2] = lat
-        std::vector<float> lat( const reco::BasicCluster &cluster, bool logW = true, float w0 = 4.7 );
-
-        // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
-        std::vector<float> covariances(const reco::BasicCluster &cluster, float w0 = 4.7 );
-
-        // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
-        //this function calculates differences in eta/phi in units of crystals not global eta/phi
-        //this is gives better performance in the crack regions of the calorimeter but gives otherwise identical results to covariances function
-        //this is only defined for the barrel, it returns covariances when the cluster is in the endcap
-        //Warning: covIEtaIEta has been studied by egamma, but so far covIPhiIPhi hasnt been studied extensively so there could be a bug in 
-        //         the covIPhiIEta or covIPhiIPhi calculations. I dont think there is but as it hasnt been heavily used, there might be one
-        std::vector<float> localCovariances(const reco::BasicCluster &cluster, float w0 = 4.7);
-
-        std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7);
-
-        double zernike20( const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7 );
-        double zernike42( const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7 );
-
-        // get the detId's of a matrix centered in the maximum energy crystal = (0,0)
-        // the size is specified by ixMin, ixMax, iyMin, iyMax in unit of crystals
-        std::vector<DetId> matrixDetId( DetId id, int ixMin, int ixMax, int iyMin, int iyMax );
-        // get the energy deposited in a matrix centered in the maximum energy crystal = (0,0)
-        // the size is specified by ixMin, ixMax, iyMin, iyMax in unit of crystals
-        float matrixEnergy( const reco::BasicCluster &cluster, DetId id, int ixMin, int ixMax, int iyMin, int iyMax );
-  
 }; // class EcalClusterLazyToolsT
 
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e1x3( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e1x3( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
 
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e3x1( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e3x1( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e1x5( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e1x5( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e5x1( const reco::BasicCluster &cluster )
-{
-  return EcalClusterToolsImpl::e5x1( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e2x2( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e2x2( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e3x2( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e3x2( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e3x3( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e3x3( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e4x4( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e4x4( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e5x5( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e5x5( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-int EcalClusterLazyToolsT<EcalClusterToolsImpl>::n5x5( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::n5x5( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e2x5Right( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e2x5Right( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e2x5Left( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e2x5Left( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e2x5Top( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e2x5Top( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e2x5Bottom( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e2x5Bottom( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e2x5Max( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e2x5Max( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::eLeft( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::eLeft( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::eRight( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::eRight( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::eTop( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::eTop( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::eBottom( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::eBottom( cluster, getEcalRecHitCollection(cluster), topology_ );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::eMax( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::eMax( cluster, getEcalRecHitCollection(cluster) );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::e2nd( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::e2nd( cluster, getEcalRecHitCollection(cluster) );
-}
-
-template<class EcalClusterToolsImpl>
-std::pair<DetId, float> EcalClusterLazyToolsT<EcalClusterToolsImpl>::getMaximum( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::getMaximum( cluster, getEcalRecHitCollection(cluster) );
-}
-
-template<class EcalClusterToolsImpl>
-std::vector<float> EcalClusterLazyToolsT<EcalClusterToolsImpl>::energyBasketFractionEta( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::energyBasketFractionEta( cluster, getEcalRecHitCollection(cluster) );
-}
-
-template<class EcalClusterToolsImpl>
-std::vector<float> EcalClusterLazyToolsT<EcalClusterToolsImpl>::energyBasketFractionPhi( const reco::BasicCluster &cluster )
-{
-        return EcalClusterToolsImpl::energyBasketFractionPhi( cluster, getEcalRecHitCollection(cluster) );
-}
-
-template<class EcalClusterToolsImpl>
-std::vector<float> EcalClusterLazyToolsT<EcalClusterToolsImpl>::lat( const reco::BasicCluster &cluster, bool logW, float w0 )
-{
-        return EcalClusterToolsImpl::lat( cluster, getEcalRecHitCollection(cluster), geometry_, logW, w0 );
-}
-
-template<class EcalClusterToolsImpl>
-std::vector<float> EcalClusterLazyToolsT<EcalClusterToolsImpl>::covariances(const reco::BasicCluster &cluster, float w0 )
-{
-        return EcalClusterToolsImpl::covariances( cluster, getEcalRecHitCollection(cluster), topology_, geometry_, w0 );
-}
-
-template<class EcalClusterToolsImpl>
-std::vector<float> EcalClusterLazyToolsT<EcalClusterToolsImpl>::localCovariances(const reco::BasicCluster &cluster, float w0 )
-{
-        return EcalClusterToolsImpl::localCovariances( cluster, getEcalRecHitCollection(cluster), topology_, w0 );
-}
-
-template<class EcalClusterToolsImpl>
-std::vector<float> EcalClusterLazyToolsT<EcalClusterToolsImpl>::scLocalCovariances(const reco::SuperCluster &cluster, float w0 )
-{
-        return EcalClusterToolsImpl::scLocalCovariances( cluster, getEcalRecHitCollection(cluster), topology_, w0 );
-}
-
-template<class EcalClusterToolsImpl>
-double EcalClusterLazyToolsT<EcalClusterToolsImpl>::zernike20( const reco::BasicCluster &cluster, double R0, bool logW, float w0 )
-{
-        return EcalClusterToolsImpl::zernike20( cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0 );
-}
-
-
-template<class EcalClusterToolsImpl>
-double EcalClusterLazyToolsT<EcalClusterToolsImpl>::zernike42( const reco::BasicCluster &cluster, double R0, bool logW, float w0 )
-{
-        return EcalClusterToolsImpl::zernike42( cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0 );
-}
-
-template<class EcalClusterToolsImpl>
-std::vector<DetId> EcalClusterLazyToolsT<EcalClusterToolsImpl>::matrixDetId( DetId id, int ixMin, int ixMax, int iyMin, int iyMax )
-{
-        return EcalClusterToolsImpl::matrixDetId( topology_, id, ixMin, ixMax, iyMin, iyMax );
-}
-
-template<class EcalClusterToolsImpl>
-float EcalClusterLazyToolsT<EcalClusterToolsImpl>::matrixEnergy( const reco::BasicCluster &cluster, DetId id, int ixMin, int ixMax, int iyMin, int iyMax )
-{
-  return EcalClusterToolsImpl::matrixEnergy( cluster, getEcalRecHitCollection(cluster), topology_, id, ixMin, ixMax, iyMin, iyMax );
-}
-
-namespace noZS {
-    typedef EcalClusterLazyToolsT<noZS::EcalClusterTools> EcalClusterLazyTools;
-}
+namespace noZS { typedef EcalClusterLazyToolsT<noZS::EcalClusterTools> EcalClusterLazyTools; }
 typedef EcalClusterLazyToolsT<::EcalClusterTools> EcalClusterLazyTools;
-
 
 
 #endif

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -22,28 +22,11 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 
-namespace {
-
-  template<class T, class R>
-  auto getFromEventSetup(edm::EventSetup const& eventSetup) {
-    edm::ESHandle<T> handle;
-    eventSetup.get<R>().get(handle);
-    return handle.product();
-  }
-
-  auto getRecHits(edm::Event const& event, edm::EDGetTokenT<EcalRecHitCollection> const& token) {
-    edm::Handle< EcalRecHitCollection > recHitsHandle;
-    event.getByToken( token, recHitsHandle );
-    return recHitsHandle.product();
-  }
-
-};
-
 EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2)
-  : geometry_(getFromEventSetup<CaloGeometry, CaloGeometryRecord>(es))
-  , topology_(getFromEventSetup<CaloTopology, CaloTopologyRecord>(es))
-  , ebRecHits_(getRecHits(ev, token1))
-  , eeRecHits_(getRecHits(ev, token2))
+  : geometry_(&edm::get<CaloGeometry,CaloGeometryRecord>(es))
+  , topology_(&edm::get<CaloTopology,CaloTopologyRecord>(es))
+  , ebRecHits_(&edm::get(ev, token1))
+  , eeRecHits_(&edm::get(ev, token2))
 {
   getIntercalibConstants( es );
   getADCToGeV ( es );
@@ -51,10 +34,10 @@ EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const 
 }
 
 EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3)
-  : geometry_(getFromEventSetup<CaloGeometry, CaloGeometryRecord>(es))
-  , topology_(getFromEventSetup<CaloTopology, CaloTopologyRecord>(es))
-  , ebRecHits_(getRecHits(ev, token1))
-  , eeRecHits_(getRecHits(ev, token2))
+  : geometry_(&edm::get<CaloGeometry,CaloGeometryRecord>(es))
+  , topology_(&edm::get<CaloTopology,CaloTopologyRecord>(es))
+  , ebRecHits_(&edm::get(ev, token1))
+  , eeRecHits_(&edm::get(ev, token2))
 {
   const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
   if (geometryES) {

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -22,74 +22,54 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 
-EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2) {
+namespace {
 
-  ebRHToken_ = token1;
-  eeRHToken_ = token2;
- 
-  getGeometry( es , false );
-  getTopology( es );
-  getEBRecHits( ev );
-  getEERecHits( ev );
+  template<class T, class R>
+  auto getFromEventSetup(edm::EventSetup const& eventSetup) {
+    edm::ESHandle<T> handle;
+    eventSetup.get<R>().get(handle);
+    return handle.product();
+  }
+
+  auto getRecHits(edm::Event const& event, edm::EDGetTokenT<EcalRecHitCollection> const& token) {
+    edm::Handle< EcalRecHitCollection > recHitsHandle;
+    event.getByToken( token, recHitsHandle );
+    return recHitsHandle.product();
+  }
+
+};
+
+EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2)
+  : geometry_(getFromEventSetup<CaloGeometry, CaloGeometryRecord>(es))
+  , topology_(getFromEventSetup<CaloTopology, CaloTopologyRecord>(es))
+  , ebRecHits_(getRecHits(ev, token1))
+  , eeRecHits_(getRecHits(ev, token2))
+{
   getIntercalibConstants( es );
   getADCToGeV ( es );
   getLaserDbService ( es );
 }
 
-EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3) {
+EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3)
+  : geometry_(getFromEventSetup<CaloGeometry, CaloGeometryRecord>(es))
+  , topology_(getFromEventSetup<CaloTopology, CaloTopologyRecord>(es))
+  , ebRecHits_(getRecHits(ev, token1))
+  , eeRecHits_(getRecHits(ev, token2))
+{
+  const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+  if (geometryES) {
+    ecalPS_topology_.reset(new EcalPreshowerTopology(geometry_));
+  } else {
+    ecalPS_topology_.reset();
+    edm::LogInfo("subdetector geometry not available") << "EcalPreshower geometry is missing" << std::endl;
+  }
 
-  ebRHToken_ = token1;
-  eeRHToken_ = token2;
   esRHToken_ = token3;
-
-  getGeometry( es );
-  getTopology( es );
-  getEBRecHits( ev );
-  getEERecHits( ev );
   getESRecHits( ev );
+
   getIntercalibConstants( es );
   getADCToGeV ( es );
   getLaserDbService ( es );
-}
-
-EcalClusterLazyToolsBase::~EcalClusterLazyToolsBase()
-{}
-
-void EcalClusterLazyToolsBase::getGeometry( const edm::EventSetup &es, bool doES ) {
-        edm::ESHandle<CaloGeometry> pGeometry;
-        es.get<CaloGeometryRecord>().get(pGeometry);
-        geometry_ = pGeometry.product();
-
-        if(doES){
-          const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-          if (geometryES) {
-            ecalPS_topology_.reset(new EcalPreshowerTopology(geometry_));
-          } else {
-            ecalPS_topology_.reset();
-            edm::LogInfo("subdetector geometry not available") << "EcalPreshower geometry is missing" << std::endl;
-          }
-        }
-        else {
-          ecalPS_topology_.reset();
-        }
-}
-
-void EcalClusterLazyToolsBase::getTopology( const edm::EventSetup &es ) {
-        edm::ESHandle<CaloTopology> pTopology;
-        es.get<CaloTopologyRecord>().get(pTopology);
-        topology_ = pTopology.product();
-}
-
-void EcalClusterLazyToolsBase::getEBRecHits( const edm::Event &ev ) {
-  edm::Handle< EcalRecHitCollection > pEBRecHits;
-  ev.getByToken( ebRHToken_, pEBRecHits );
-  ebRecHits_ = pEBRecHits.product();
-}
-
-void EcalClusterLazyToolsBase::getEERecHits( const edm::Event &ev ) {
-  edm::Handle< EcalRecHitCollection > pEERecHits;
-  ev.getByToken( eeRHToken_, pEERecHits );
-  eeRecHits_ = pEERecHits.product();
 }
 
 void EcalClusterLazyToolsBase::getESRecHits( const edm::Event &ev ) {
@@ -147,7 +127,7 @@ void EcalClusterLazyToolsBase::getLaserDbService     ( const edm::EventSetup &es
 }
 
 
-const EcalRecHitCollection * EcalClusterLazyToolsBase::getEcalRecHitCollection( const reco::BasicCluster &cluster )
+const EcalRecHitCollection * EcalClusterLazyToolsBase::getEcalRecHitCollection( const reco::BasicCluster &cluster ) const
 {
         if ( cluster.size() == 0 ) {
                 throw cms::Exception("InvalidCluster") << "The cluster has no crystals!";

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
@@ -22,7 +22,7 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -47,39 +47,31 @@ Implementation:
 
 
 
-class testEcalClusterLazyTools : public edm::EDAnalyzer {
+class testEcalClusterLazyTools : public edm::global::EDAnalyzer<> {
 public:
   explicit testEcalClusterLazyTools(const edm::ParameterSet&);
-  ~testEcalClusterLazyTools();
-  
-  edm::EDGetTokenT<reco::BasicClusterCollection> barrelClusterToken_;
-  edm::EDGetTokenT<reco::BasicClusterCollection> endcapClusterToken_;
-  edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitToken_;
-  edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitToken_;
   
 private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
+
+  const edm::EDGetTokenT<reco::BasicClusterCollection> barrelClusterToken_;
+  const edm::EDGetTokenT<reco::BasicClusterCollection> endcapClusterToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> barrelRecHitToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> endcapRecHitToken_;
   
 };
 
 
 
 testEcalClusterLazyTools::testEcalClusterLazyTools(const edm::ParameterSet& ps)
-{
-  barrelClusterToken_ =       consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterCollection"));
-  endcapClusterToken_ =       consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterCollection"));
-  reducedBarrelRecHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("reducedBarrelRecHitCollection"));
-  reducedEndcapRecHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("reducedEndcapRecHitCollection"));
-}
-
-
-
-testEcalClusterLazyTools::~testEcalClusterLazyTools()
+  : barrelClusterToken_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterCollection")))
+  , endcapClusterToken_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterCollection")))
+  , barrelRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelRecHitCollection")))
+  , endcapRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapRecHitCollection")))
 {}
 
 
-
-void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSetup& es)
+void testEcalClusterLazyTools::analyze(edm::StreamID, const edm::Event& ev, const edm::EventSetup& es) const
 {
   edm::Handle< reco::BasicClusterCollection > pEBClusters;
   ev.getByToken( barrelClusterToken_, pEBClusters );
@@ -89,7 +81,7 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
   ev.getByToken( endcapClusterToken_, pEEClusters );
   const reco::BasicClusterCollection *eeClusters = pEEClusters.product();
 
-  EcalClusterLazyTools lazyTools( ev, es, reducedBarrelRecHitToken_, reducedEndcapRecHitToken_ );
+  EcalClusterLazyTools lazyTools( ev, es, barrelRecHitToken_, endcapRecHitToken_ );
   
   std::cout << "========== BARREL ==========" << std::endl;
   for (reco::BasicClusterCollection::const_iterator it = ebClusters->begin(); it != ebClusters->end(); ++it ) {
@@ -99,11 +91,12 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
     std::cout << "e1x3..................... " << lazyTools.e1x3( *it ) << std::endl;
     std::cout << "e3x1..................... " << lazyTools.e3x1( *it ) << std::endl;
     std::cout << "e1x5..................... " << lazyTools.e1x5( *it ) << std::endl;
-    //std::cout << "e5x1..................... " << lazyTools.e5x1( *it ) << std::endl;
+    std::cout << "e5x1..................... " << lazyTools.e5x1( *it ) << std::endl;
     std::cout << "e2x2..................... " << lazyTools.e2x2( *it ) << std::endl;
-    std::cout << "e3x3..................... " << lazyTools.e5x5( *it ) << std::endl;
+    std::cout << "e3x3..................... " << lazyTools.e3x3( *it ) << std::endl;
     std::cout << "e4x4..................... " << lazyTools.e4x4( *it ) << std::endl;
-    std::cout << "e5x5..................... " << lazyTools.e3x3( *it ) << std::endl;
+    std::cout << "e5x5..................... " << lazyTools.e5x5( *it ) << std::endl;
+    std::cout << "n5x5..................... " << lazyTools.n5x5( *it ) << std::endl;
     std::cout << "e2x5Right................ " << lazyTools.e2x5Right( *it ) << std::endl;
     std::cout << "e2x5Left................. " << lazyTools.e2x5Left( *it ) << std::endl;
     std::cout << "e2x5Top.................. " << lazyTools.e2x5Top( *it ) << std::endl;
@@ -141,11 +134,12 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
     std::cout << "e1x3..................... " << lazyTools.e1x3( *it ) << std::endl;
     std::cout << "e3x1..................... " << lazyTools.e3x1( *it ) << std::endl;
     std::cout << "e1x5..................... " << lazyTools.e1x5( *it ) << std::endl;
-    //std::cout << "e5x1..................... " << lazyTools.e5x1( *it ) << std::endl;
+    std::cout << "e5x1..................... " << lazyTools.e5x1( *it ) << std::endl;
     std::cout << "e2x2..................... " << lazyTools.e2x2( *it ) << std::endl;
-    std::cout << "e3x3..................... " << lazyTools.e5x5( *it ) << std::endl;
+    std::cout << "e3x3..................... " << lazyTools.e3x3( *it ) << std::endl;
     std::cout << "e4x4..................... " << lazyTools.e4x4( *it ) << std::endl;
-    std::cout << "e5x5..................... " << lazyTools.e3x3( *it ) << std::endl;
+    std::cout << "e5x5..................... " << lazyTools.e5x5( *it ) << std::endl;
+    std::cout << "n5x5..................... " << lazyTools.n5x5( *it ) << std::endl;
     std::cout << "e2x5Right................ " << lazyTools.e2x5Right( *it ) << std::endl;
     std::cout << "e2x5Left................. " << lazyTools.e2x5Left( *it ) << std::endl;
     std::cout << "e2x5Top.................. " << lazyTools.e2x5Top( *it ) << std::endl;

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
@@ -2,7 +2,7 @@
 //
 // Package:    testEcalClusterLazyTools
 // Class:      testEcalClusterLazyTools
-// 
+//
 /**\class testEcalClusterLazyTools testEcalClusterLazyTools.cc
 
 Description: <one line class summary>
@@ -17,48 +17,37 @@ Implementation:
 //
 
 
-// system include files
-#include <memory>
-
-// user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDAnalyzer.h"
-
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-// to access recHits and BasicClusters
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
-
-// to use the cluster tools
 #include "FWCore/Framework/interface/ESHandle.h"
-
-//#include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
-
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
-
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 
+#include <memory>
 
 
-class testEcalClusterLazyTools : public edm::global::EDAnalyzer<> {
+class testEcalClusterLazyTools : public edm::one::EDAnalyzer<> {
 public:
   explicit testEcalClusterLazyTools(const edm::ParameterSet&);
-  
+
 private:
-  virtual void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  using LazyTools = noZS::EcalClusterLazyTools; // alternatively just EcalClusterLazyTools
 
   const edm::EDGetTokenT<reco::BasicClusterCollection> barrelClusterToken_;
   const edm::EDGetTokenT<reco::BasicClusterCollection> endcapClusterToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> barrelRecHitToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> endcapRecHitToken_;
-  
+
 };
 
 
@@ -71,89 +60,89 @@ testEcalClusterLazyTools::testEcalClusterLazyTools(const edm::ParameterSet& ps)
 {}
 
 
-void testEcalClusterLazyTools::analyze(edm::StreamID, const edm::Event& ev, const edm::EventSetup& es) const
+void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSetup& es)
 {
   edm::Handle< reco::BasicClusterCollection > pEBClusters;
   ev.getByToken( barrelClusterToken_, pEBClusters );
   const reco::BasicClusterCollection *ebClusters = pEBClusters.product();
-  
+
   edm::Handle< reco::BasicClusterCollection > pEEClusters;
   ev.getByToken( endcapClusterToken_, pEEClusters );
   const reco::BasicClusterCollection *eeClusters = pEEClusters.product();
 
-  EcalClusterLazyTools lazyTools( ev, es, barrelRecHitToken_, endcapRecHitToken_ );
-  
+  LazyTools lazyTools( ev, es, barrelRecHitToken_, endcapRecHitToken_ );
+
   std::cout << "========== BARREL ==========" << std::endl;
-  for (reco::BasicClusterCollection::const_iterator it = ebClusters->begin(); it != ebClusters->end(); ++it ) {
+  for(auto const& clus : *ebClusters) {
     std::cout << "----- new cluster -----" << std::endl;
-    std::cout << "----------------- size: " << (*it).size() << " energy: " << (*it).energy() << std::endl;
-    
-    std::cout << "e1x3..................... " << lazyTools.e1x3( *it ) << std::endl;
-    std::cout << "e3x1..................... " << lazyTools.e3x1( *it ) << std::endl;
-    std::cout << "e1x5..................... " << lazyTools.e1x5( *it ) << std::endl;
-    std::cout << "e5x1..................... " << lazyTools.e5x1( *it ) << std::endl;
-    std::cout << "e2x2..................... " << lazyTools.e2x2( *it ) << std::endl;
-    std::cout << "e3x3..................... " << lazyTools.e3x3( *it ) << std::endl;
-    std::cout << "e4x4..................... " << lazyTools.e4x4( *it ) << std::endl;
-    std::cout << "e5x5..................... " << lazyTools.e5x5( *it ) << std::endl;
-    std::cout << "n5x5..................... " << lazyTools.n5x5( *it ) << std::endl;
-    std::cout << "e2x5Right................ " << lazyTools.e2x5Right( *it ) << std::endl;
-    std::cout << "e2x5Left................. " << lazyTools.e2x5Left( *it ) << std::endl;
-    std::cout << "e2x5Top.................. " << lazyTools.e2x5Top( *it ) << std::endl;
-    std::cout << "e2x5Bottom............... " << lazyTools.e2x5Bottom( *it ) << std::endl;
-    std::cout << "e2x5Max.................. " << lazyTools.e2x5Max( *it ) << std::endl;
-    std::cout << "eMax..................... " << lazyTools.eMax( *it ) << std::endl;
-    std::cout << "e2nd..................... " << lazyTools.e2nd( *it ) << std::endl;
-    std::vector<float> vEta = lazyTools.energyBasketFractionEta( *it );
+    std::cout << "----------------- size: " << (clus).size() << " energy: " << (clus).energy() << std::endl;
+
+    std::cout << "e1x3..................... " << lazyTools.e1x3( clus ) << std::endl;
+    std::cout << "e3x1..................... " << lazyTools.e3x1( clus ) << std::endl;
+    std::cout << "e1x5..................... " << lazyTools.e1x5( clus ) << std::endl;
+    std::cout << "e5x1..................... " << lazyTools.e5x1( clus ) << std::endl;
+    std::cout << "e2x2..................... " << lazyTools.e2x2( clus ) << std::endl;
+    std::cout << "e3x3..................... " << lazyTools.e3x3( clus ) << std::endl;
+    std::cout << "e4x4..................... " << lazyTools.e4x4( clus ) << std::endl;
+    std::cout << "e5x5..................... " << lazyTools.e5x5( clus ) << std::endl;
+    std::cout << "n5x5..................... " << lazyTools.n5x5( clus ) << std::endl;
+    std::cout << "e2x5Right................ " << lazyTools.e2x5Right( clus ) << std::endl;
+    std::cout << "e2x5Left................. " << lazyTools.e2x5Left( clus ) << std::endl;
+    std::cout << "e2x5Top.................. " << lazyTools.e2x5Top( clus ) << std::endl;
+    std::cout << "e2x5Bottom............... " << lazyTools.e2x5Bottom( clus ) << std::endl;
+    std::cout << "e2x5Max.................. " << lazyTools.e2x5Max( clus ) << std::endl;
+    std::cout << "eMax..................... " << lazyTools.eMax( clus ) << std::endl;
+    std::cout << "e2nd..................... " << lazyTools.e2nd( clus ) << std::endl;
+    std::vector<float> vEta = lazyTools.energyBasketFractionEta( clus );
     std::cout << "energyBasketFractionEta..";
     for (size_t i = 0; i < vEta.size(); ++i ) {
       std::cout << " " << vEta[i];
     }
     std::cout << std::endl;
-    std::vector<float> vPhi = lazyTools.energyBasketFractionPhi( *it );
+    std::vector<float> vPhi = lazyTools.energyBasketFractionPhi( clus );
     std::cout << "energyBasketFractionPhi..";
     for (size_t i = 0; i < vPhi.size(); ++i ) {
       std::cout << " " << vPhi[i];
     }
     std::cout << std::endl;
-    std::vector<float> vLat = lazyTools.lat( *it );
+    std::vector<float> vLat = lazyTools.lat( clus );
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::vector<float> vCov = lazyTools.covariances( *it );
-    std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;  
-    std::vector<float> vLocCov = lazyTools.localCovariances( *it );
+    std::vector<float> vCov = lazyTools.covariances( clus );
+    std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
+    std::vector<float> vLocCov = lazyTools.localCovariances( clus );
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
-    std::cout << "zernike20................ " << lazyTools.zernike20( *it ) << std::endl;
-    std::cout << "zernike42................ " << lazyTools.zernike42( *it ) << std::endl;
+    std::cout << "zernike20................ " << lazyTools.zernike20( clus ) << std::endl;
+    std::cout << "zernike42................ " << lazyTools.zernike42( clus ) << std::endl;
   }
-  
+
   std::cout << "========== ENDCAPS ==========" << std::endl;
-  for (reco::BasicClusterCollection::const_iterator it = eeClusters->begin(); it != eeClusters->end(); ++it ) {
+  for(auto const& clus : *eeClusters) {
     std::cout << "----- new cluster -----" << std::endl;
-    std::cout << "----------------- size: " << (*it).size() << " energy: " << (*it).energy() << std::endl;
-    
-    std::cout << "e1x3..................... " << lazyTools.e1x3( *it ) << std::endl;
-    std::cout << "e3x1..................... " << lazyTools.e3x1( *it ) << std::endl;
-    std::cout << "e1x5..................... " << lazyTools.e1x5( *it ) << std::endl;
-    std::cout << "e5x1..................... " << lazyTools.e5x1( *it ) << std::endl;
-    std::cout << "e2x2..................... " << lazyTools.e2x2( *it ) << std::endl;
-    std::cout << "e3x3..................... " << lazyTools.e3x3( *it ) << std::endl;
-    std::cout << "e4x4..................... " << lazyTools.e4x4( *it ) << std::endl;
-    std::cout << "e5x5..................... " << lazyTools.e5x5( *it ) << std::endl;
-    std::cout << "n5x5..................... " << lazyTools.n5x5( *it ) << std::endl;
-    std::cout << "e2x5Right................ " << lazyTools.e2x5Right( *it ) << std::endl;
-    std::cout << "e2x5Left................. " << lazyTools.e2x5Left( *it ) << std::endl;
-    std::cout << "e2x5Top.................. " << lazyTools.e2x5Top( *it ) << std::endl;
-    std::cout << "e2x5Bottom............... " << lazyTools.e2x5Bottom( *it ) << std::endl;
-    std::cout << "eMax..................... " << lazyTools.eMax( *it ) << std::endl;
-    std::cout << "e2nd..................... " << lazyTools.e2nd( *it ) << std::endl;
-    std::vector<float> vLat = lazyTools.lat( *it );
+    std::cout << "----------------- size: " << (clus).size() << " energy: " << (clus).energy() << std::endl;
+
+    std::cout << "e1x3..................... " << lazyTools.e1x3( clus ) << std::endl;
+    std::cout << "e3x1..................... " << lazyTools.e3x1( clus ) << std::endl;
+    std::cout << "e1x5..................... " << lazyTools.e1x5( clus ) << std::endl;
+    std::cout << "e5x1..................... " << lazyTools.e5x1( clus ) << std::endl;
+    std::cout << "e2x2..................... " << lazyTools.e2x2( clus ) << std::endl;
+    std::cout << "e3x3..................... " << lazyTools.e3x3( clus ) << std::endl;
+    std::cout << "e4x4..................... " << lazyTools.e4x4( clus ) << std::endl;
+    std::cout << "e5x5..................... " << lazyTools.e5x5( clus ) << std::endl;
+    std::cout << "n5x5..................... " << lazyTools.n5x5( clus ) << std::endl;
+    std::cout << "e2x5Right................ " << lazyTools.e2x5Right( clus ) << std::endl;
+    std::cout << "e2x5Left................. " << lazyTools.e2x5Left( clus ) << std::endl;
+    std::cout << "e2x5Top.................. " << lazyTools.e2x5Top( clus ) << std::endl;
+    std::cout << "e2x5Bottom............... " << lazyTools.e2x5Bottom( clus ) << std::endl;
+    std::cout << "eMax..................... " << lazyTools.eMax( clus ) << std::endl;
+    std::cout << "e2nd..................... " << lazyTools.e2nd( clus ) << std::endl;
+    std::vector<float> vLat = lazyTools.lat( clus );
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::vector<float> vCov = lazyTools.covariances( *it );
-    std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl; 
-    std::vector<float> vLocCov = lazyTools.localCovariances( *it );
+    std::vector<float> vCov = lazyTools.covariances( clus );
+    std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
+    std::vector<float> vLocCov = lazyTools.localCovariances( clus );
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
-    std::cout << "zernike20................ " << lazyTools.zernike20( *it ) << std::endl;
-    std::cout << "zernike42................ " << lazyTools.zernike42( *it ) << std::endl;
+    std::cout << "zernike20................ " << lazyTools.zernike20( clus ) << std::endl;
+    std::cout << "zernike42................ " << lazyTools.zernike42( clus ) << std::endl;
   }
 }
 

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.py
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.py
@@ -1,27 +1,26 @@
-from FWCore.ParameterSet.Config import *
+import FWCore.ParameterSet.Config as cms
+from Configuration.AlCa.GlobalTag import GlobalTag
 
-process = Process("test")
-process.extend(include("FWCore/MessageLogger/data/MessageLogger.cfi"))
-#process.MessageLogger.cerr.FwkReport.reportEvery = 50
+process = cms.Process("test")
 
-process.extend(include("RecoEcal/EgammaClusterProducers/data/geometryForClustering.cff"))
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
-input_files = vstring()
-#input_files.append( "/store/relval/2008/4/17/RelVal-RelValTTbar-1208465820/0000/0ABDA540-EE0C-DD11-BA9F-000423D94990.root" )
-input_files.append( "file:/data/ferriff/ClusterMulti5x5/CMSSW_2_1_X_2008-05-14-0200/src/reco.root" )
+input_files = cms.vstring("/store/data/Run2018A/EGamma/AOD/17Sep2018-v2/100000/01EB9686-9A6F-BF48-903A-02F7D9AEB9B9.root")
 
-process.source = Source("PoolSource",
-    fileNames = untracked( input_files )
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked( input_files ) )
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 10 ) )
+
+
+process.testEcalClusterLazyTools = cms.EDAnalyzer("testEcalClusterLazyTools",
+    barrelRecHitCollection = cms.InputTag("reducedEcalRecHitsEB"),
+    endcapRecHitCollection = cms.InputTag("reducedEcalRecHitsEE"),
+    barrelClusterCollection = cms.InputTag("hybridSuperClusters:hybridBarrelBasicClusters"),
+    endcapClusterCollection = cms.InputTag("multi5x5SuperClusters:multi5x5EndcapBasicClusters")
 )
 
-process.maxEvents = untracked.PSet( input = untracked.int32( 10 ) )
-
-
-process.testEcalClusterLazyTools = EDAnalyzer("testEcalClusterLazyTools",
-    reducedBarrelRecHitCollection = InputTag("reducedEcalRecHitsEB"),
-    reducedEndcapRecHitCollection = InputTag("reducedEcalRecHitsEE"),
-    barrelClusterCollection = InputTag("hybridSuperClusters:"),
-    endcapClusterCollection = InputTag("multi5x5BasicClusters:multi5x5EndcapBasicClusters")
-)
-
-process.p1 = Path( process.testEcalClusterLazyTools )
+process.p1 = cms.Path( process.testEcalClusterLazyTools )

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
@@ -2,7 +2,7 @@
 //
 // Package:    testEcalClusterTools
 // Class:      testEcalClusterTools
-// 
+//
 /**\class testEcalClusterTools testEcalClusterTools.cc
 
 Description: <one line class summary>
@@ -16,164 +16,149 @@ Implementation:
 //
 //
 
-
-// system include files
-#include <memory>
-
-// user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-// to access recHits and BasicClusters
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
-
-// to use the cluster tools
 #include "FWCore/Framework/interface/ESHandle.h"
-
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
-
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
-
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
+#include <memory>
 
+class testEcalClusterTools : public edm::global::EDAnalyzer<> {
+  public:
+    explicit testEcalClusterTools(const edm::ParameterSet&);
 
-class testEcalClusterTools : public edm::EDAnalyzer {
-        public:
-                explicit testEcalClusterTools(const edm::ParameterSet&);
-                ~testEcalClusterTools();
+  private:
+    virtual void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
-                edm::InputTag barrelClusterCollection_;
-                edm::InputTag endcapClusterCollection_;
-                edm::InputTag reducedBarrelRecHitCollection_;
-                edm::InputTag reducedEndcapRecHitCollection_;
+    using ClusterTools = noZS::EcalClusterTools; // alternatively noZS::EcalClusterTools
 
-        private:
-                virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    const edm::EDGetToken barrelClusterToken_;
+    const edm::EDGetToken endcapClusterToken_;
+    const edm::EDGetToken barrelRecHitToken_;
+    const edm::EDGetToken endcapRecHitToken_;
 };
 
 
 
 testEcalClusterTools::testEcalClusterTools(const edm::ParameterSet& ps)
+    : barrelClusterToken_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterCollection")))
+    , endcapClusterToken_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterCollection")))
+    , barrelRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelRecHitCollection")))
+    , endcapRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapRecHitCollection")))
+{}
+
+
+
+void testEcalClusterTools::analyze(edm::StreamID, const edm::Event& ev, const edm::EventSetup& es) const
 {
-        barrelClusterCollection_ = ps.getParameter<edm::InputTag>("barrelClusterCollection");
-        endcapClusterCollection_ = ps.getParameter<edm::InputTag>("endcapClusterCollection");
-        reducedBarrelRecHitCollection_ = ps.getParameter<edm::InputTag>("reducedBarrelRecHitCollection");
-        reducedEndcapRecHitCollection_ = ps.getParameter<edm::InputTag>("reducedEndcapRecHitCollection");
-}
+    edm::Handle< EcalRecHitCollection > pEBRecHits;
+    ev.getByToken( barrelRecHitToken_, pEBRecHits );
+    const EcalRecHitCollection *ebRecHits = pEBRecHits.product();
 
+    edm::Handle< EcalRecHitCollection > pEERecHits;
+    ev.getByToken( endcapRecHitToken_, pEERecHits );
+    const EcalRecHitCollection *eeRecHits = pEERecHits.product();
 
+    edm::Handle< reco::BasicClusterCollection > pEBClusters;
+    ev.getByToken( barrelClusterToken_, pEBClusters );
+    const reco::BasicClusterCollection *ebClusters = pEBClusters.product();
 
-testEcalClusterTools::~testEcalClusterTools()
-{
-}
+    edm::Handle< reco::BasicClusterCollection > pEEClusters;
+    ev.getByToken( endcapClusterToken_, pEEClusters );
+    const reco::BasicClusterCollection *eeClusters = pEEClusters.product();
 
+    edm::ESHandle<CaloGeometry> pGeometry;
+    es.get<CaloGeometryRecord>().get(pGeometry);
+    const CaloGeometry *geometry = pGeometry.product();
 
+    edm::ESHandle<CaloTopology> pTopology;
+    es.get<CaloTopologyRecord>().get(pTopology);
+    const CaloTopology *topology = pTopology.product();
 
-void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& es)
-{
-        edm::Handle< reco::BasicClusterCollection > pEBClusters;
-        ev.getByLabel( barrelClusterCollection_, pEBClusters );
-        const reco::BasicClusterCollection *ebClusters = pEBClusters.product();
+    std::cout << "========== BARREL ==========" << std::endl;
+    for(auto const& clus : *ebClusters) {
+        DetId maxId = ClusterTools::getMaximum(clus, eeRecHits).first;
 
-        edm::Handle< reco::BasicClusterCollection > pEEClusters;
-        ev.getByLabel( endcapClusterCollection_, pEEClusters );
-        const reco::BasicClusterCollection *eeClusters = pEEClusters.product();
+        std::cout << "----- new cluster -----" << std::endl;
+        std::cout << "----------------- size: " << clus.size() << " energy: " << clus.energy() << std::endl;
 
-        edm::Handle< EcalRecHitCollection > pEBRecHits;
-        ev.getByLabel( reducedBarrelRecHitCollection_, pEBRecHits );
-        const EcalRecHitCollection *ebRecHits = pEBRecHits.product();
+        std::cout << "e1x3..................... " << ClusterTools::e1x3( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e3x1..................... " << ClusterTools::e3x1( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e1x5..................... " << ClusterTools::e1x5( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e5x1..................... " << ClusterTools::e5x1( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e2x2..................... " << ClusterTools::e2x2( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e3x3..................... " << ClusterTools::e3x3( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e4x4..................... " << ClusterTools::e4x4( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e5x5..................... " << ClusterTools::e5x5( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "n5x5..................... " << ClusterTools::n5x5( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e2x5Right................ " << ClusterTools::e2x5Right( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e2x5Left................. " << ClusterTools::e2x5Left( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e2x5Top.................. " << ClusterTools::e2x5Top( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e2x5Bottom............... " << ClusterTools::e2x5Bottom( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "e2x5Max.................. " << ClusterTools::e2x5Max( clus, ebRecHits, topology ) << std::endl;
+        std::cout << "eMax..................... " << ClusterTools::eMax( clus, ebRecHits ) << std::endl;
+        std::cout << "e2nd..................... " << ClusterTools::e2nd( clus, ebRecHits ) << std::endl;
+        std::vector<float> vEta = ClusterTools::energyBasketFractionEta( clus, ebRecHits );
+        std::cout << "energyBasketFractionEta..";
+        for (auto const& eta : vEta) std::cout << " " << eta;
+        std::cout << std::endl;
+        std::vector<float> vPhi = ClusterTools::energyBasketFractionPhi( clus, ebRecHits );
+        std::cout << "energyBasketFractionPhi..";
+        for (auto const& phi : vPhi) std::cout << " " << phi;
+        std::cout << std::endl;
+        std::vector<float> vLat = ClusterTools::lat( clus, ebRecHits, geometry );
+        std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
+        std::vector<float> vCov = ClusterTools::covariances( clus, ebRecHits, topology, geometry );
+        std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
+        std::vector<float> vLocCov = ClusterTools::localCovariances( clus, ebRecHits, topology );
+        std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
+        std::cout << "zernike20................ " << ClusterTools::zernike20( clus, ebRecHits, geometry ) << std::endl;
+        std::cout << "zernike42................ " << ClusterTools::zernike42( clus, ebRecHits, geometry ) << std::endl;
+        std::cout << "nrSaturatedCrysIn5x5..... " << ClusterTools::nrSaturatedCrysIn5x5( maxId, ebRecHits, topology) << std::endl;
+    }
 
-        edm::Handle< EcalRecHitCollection > pEERecHits;
-        ev.getByLabel( reducedEndcapRecHitCollection_, pEERecHits );
-        const EcalRecHitCollection *eeRecHits = pEERecHits.product();
+    std::cout << "========== ENDCAPS ==========" << std::endl;
+    for(auto const& clus : *eeClusters) {
+        DetId maxId = ClusterTools::getMaximum(clus, eeRecHits).first;
 
-        edm::ESHandle<CaloGeometry> pGeometry;
-        es.get<CaloGeometryRecord>().get(pGeometry);
-        const CaloGeometry *geometry = pGeometry.product();
+        std::cout << "----- new cluster -----" << std::endl;
+        std::cout << "----------------- size: " << clus.size() << " energy: " << clus.energy() << std::endl;
 
-        edm::ESHandle<CaloTopology> pTopology;
-        es.get<CaloTopologyRecord>().get(pTopology);
-        const CaloTopology *topology = pTopology.product();
-
-        std::cout << "========== BARREL ==========" << std::endl;
-        for (reco::BasicClusterCollection::const_iterator it = ebClusters->begin(); it != ebClusters->end(); ++it ) {
-                std::cout << "----- new cluster -----" << std::endl;
-                std::cout << "----------------- size: " << (*it).size() << " energy: " << (*it).energy() << std::endl;
-
-                std::cout << "e1x3..................... " << EcalClusterTools::e1x3( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e3x1..................... " << EcalClusterTools::e3x1( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e1x5..................... " << EcalClusterTools::e1x5( *it, ebRecHits, topology ) << std::endl;
-                //std::cout << "e5x1..................... " << EcalClusterTools::e5x1( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e2x2..................... " << EcalClusterTools::e2x2( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e3x3..................... " << EcalClusterTools::e3x3( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e4x4..................... " << EcalClusterTools::e4x4( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e5x5..................... " << EcalClusterTools::e5x5( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e2x5Right................ " << EcalClusterTools::e2x5Right( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e2x5Left................. " << EcalClusterTools::e2x5Left( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e2x5Top.................. " << EcalClusterTools::e2x5Top( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "e2x5Bottom............... " << EcalClusterTools::e2x5Bottom( *it, ebRecHits, topology ) << std::endl;
-		std::cout << "e2x5Max.................. " << EcalClusterTools::e2x5Max( *it, ebRecHits, topology ) << std::endl;
-                std::cout << "eMax..................... " << EcalClusterTools::eMax( *it, ebRecHits ) << std::endl;
-                std::cout << "e2nd..................... " << EcalClusterTools::e2nd( *it, ebRecHits ) << std::endl;
-                std::vector<float> vEta = EcalClusterTools::energyBasketFractionEta( *it, ebRecHits );
-                std::cout << "energyBasketFractionEta..";
-                for (size_t i = 0; i < vEta.size(); ++i ) {
-                        std::cout << " " << vEta[i];
-                }
-                std::cout << std::endl;
-                std::vector<float> vPhi = EcalClusterTools::energyBasketFractionPhi( *it, ebRecHits );
-                std::cout << "energyBasketFractionPhi..";
-                for (size_t i = 0; i < vPhi.size(); ++i ) {
-                        std::cout << " " << vPhi[i];
-                }
-                std::cout << std::endl;
-                std::vector<float> vLat = EcalClusterTools::lat( *it, ebRecHits, geometry );
-                std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-                std::vector<float> vCov = EcalClusterTools::covariances( *it, ebRecHits, topology, geometry );
-                std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-		std::vector<float> vLocCov = EcalClusterTools::localCovariances( *it, ebRecHits, topology );
-                std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
-                std::cout << "zernike20................ " << EcalClusterTools::zernike20( *it, ebRecHits, geometry ) << std::endl;
-                std::cout << "zernike42................ " << EcalClusterTools::zernike42( *it, ebRecHits, geometry ) << std::endl;
-        }
-
-        std::cout << "========== ENDCAPS ==========" << std::endl;
-        for (reco::BasicClusterCollection::const_iterator it = eeClusters->begin(); it != eeClusters->end(); ++it ) {
-                std::cout << "----- new cluster -----" << std::endl;
-                std::cout << "----------------- size: " << (*it).size() << " energy: " << (*it).energy() << std::endl;
-                
-                std::cout << "e1x3..................... " << EcalClusterTools::e1x3( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e3x1..................... " << EcalClusterTools::e3x1( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e1x5..................... " << EcalClusterTools::e1x5( *it, eeRecHits, topology ) << std::endl;
-                //std::cout << "e5x1..................... " << EcalClusterTools::e5x1( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e2x2..................... " << EcalClusterTools::e2x2( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e3x3..................... " << EcalClusterTools::e3x3( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e4x4..................... " << EcalClusterTools::e4x4( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e5x5..................... " << EcalClusterTools::e5x5( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e2x5Right................ " << EcalClusterTools::e2x5Right( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e2x5Left................. " << EcalClusterTools::e2x5Left( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e2x5Top.................. " << EcalClusterTools::e2x5Top( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "e2x5Bottom............... " << EcalClusterTools::e2x5Bottom( *it, eeRecHits, topology ) << std::endl;
-                std::cout << "eMax..................... " << EcalClusterTools::eMax( *it, eeRecHits ) << std::endl;
-                std::cout << "e2nd..................... " << EcalClusterTools::e2nd( *it, eeRecHits ) << std::endl;
-                std::vector<float> vLat = EcalClusterTools::lat( *it, eeRecHits, geometry );
-                std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-                std::vector<float> vCov = EcalClusterTools::covariances( *it, eeRecHits, topology, geometry );
-                std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-		std::vector<float> vLocCov = EcalClusterTools::localCovariances( *it, eeRecHits, topology );
-                std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
-                std::cout << "zernike20................ " << EcalClusterTools::zernike20( *it, eeRecHits, geometry ) << std::endl;
-                std::cout << "zernike42................ " << EcalClusterTools::zernike42( *it, eeRecHits, geometry ) << std::endl;
-        }
+        std::cout << "e1x3..................... " << ClusterTools::e1x3( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e3x1..................... " << ClusterTools::e3x1( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e1x5..................... " << ClusterTools::e1x5( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e5x1..................... " << ClusterTools::e5x1( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e2x2..................... " << ClusterTools::e2x2( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e3x3..................... " << ClusterTools::e3x3( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e4x4..................... " << ClusterTools::e4x4( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e5x5..................... " << ClusterTools::e5x5( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "n5x5..................... " << ClusterTools::n5x5( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e2x5Right................ " << ClusterTools::e2x5Right( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e2x5Left................. " << ClusterTools::e2x5Left( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e2x5Top.................. " << ClusterTools::e2x5Top( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "e2x5Bottom............... " << ClusterTools::e2x5Bottom( clus, eeRecHits, topology ) << std::endl;
+        std::cout << "eMax..................... " << ClusterTools::eMax( clus, eeRecHits ) << std::endl;
+        std::cout << "e2nd..................... " << ClusterTools::e2nd( clus, eeRecHits ) << std::endl;
+        std::vector<float> vLat = ClusterTools::lat( clus, eeRecHits, geometry );
+        std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
+        std::vector<float> vCov = ClusterTools::covariances( clus, eeRecHits, topology, geometry );
+        std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
+        std::vector<float> vLocCov = ClusterTools::localCovariances( clus, eeRecHits, topology );
+        std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
+        std::cout << "zernike20................ " << ClusterTools::zernike20( clus, eeRecHits, geometry ) << std::endl;
+        std::cout << "zernike42................ " << ClusterTools::zernike42( clus, eeRecHits, geometry ) << std::endl;
+        std::cout << "nrSaturatedCrysIn5x5..... " << ClusterTools::nrSaturatedCrysIn5x5( maxId, eeRecHits, topology) << std::endl;
+    }
 }
 
 //define this as a plug-in

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
@@ -17,7 +17,7 @@ Implementation:
 //
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -33,14 +33,14 @@ Implementation:
 
 #include <memory>
 
-class testEcalClusterTools : public edm::global::EDAnalyzer<> {
+class testEcalClusterTools : public edm::one::EDAnalyzer<> {
   public:
     explicit testEcalClusterTools(const edm::ParameterSet&);
 
   private:
-    virtual void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-    using ClusterTools = noZS::EcalClusterTools; // alternatively noZS::EcalClusterTools
+    using ClusterTools = noZS::EcalClusterTools; // alternatively just EcalClusterTools
 
     const edm::EDGetToken barrelClusterToken_;
     const edm::EDGetToken endcapClusterToken_;
@@ -59,7 +59,7 @@ testEcalClusterTools::testEcalClusterTools(const edm::ParameterSet& ps)
 
 
 
-void testEcalClusterTools::analyze(edm::StreamID, const edm::Event& ev, const edm::EventSetup& es) const
+void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& es)
 {
     edm::Handle< EcalRecHitCollection > pEBRecHits;
     ev.getByToken( barrelRecHitToken_, pEBRecHits );

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.py
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.py
@@ -13,7 +13,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked( input_files ) )
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1000 ) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 10 ) )
 
 
 process.testEcalClusterTools = cms.EDAnalyzer("testEcalClusterTools",

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.py
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.py
@@ -1,27 +1,26 @@
-from FWCore.ParameterSet.Config import *
+import FWCore.ParameterSet.Config as cms
+from Configuration.AlCa.GlobalTag import GlobalTag
 
-process = Process("test")
-process.extend(include("FWCore/MessageLogger/data/MessageLogger.cfi"))
-#process.MessageLogger.cerr.FwkReport.reportEvery = 50
+process = cms.Process("test")
 
-process.extend(include("RecoEcal/EgammaClusterProducers/data/geometryForClustering.cff"))
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
-input_files = vstring()
-#input_files.append( "/store/relval/2008/4/17/RelVal-RelValTTbar-1208465820/0000/0ABDA540-EE0C-DD11-BA9F-000423D94990.root" )
-input_files.append( "file:/data/ferriff/ClusterMulti5x5/CMSSW_2_1_X_2008-05-14-0200/src/reco.root" )
+input_files = cms.vstring("/store/data/Run2018A/EGamma/AOD/17Sep2018-v2/100000/01EB9686-9A6F-BF48-903A-02F7D9AEB9B9.root")
 
-process.source = Source("PoolSource",
-    fileNames = untracked( input_files )
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked( input_files ) )
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1000 ) )
+
+
+process.testEcalClusterTools = cms.EDAnalyzer("testEcalClusterTools",
+    barrelRecHitCollection = cms.InputTag("reducedEcalRecHitsEB"),
+    endcapRecHitCollection = cms.InputTag("reducedEcalRecHitsEE"),
+    barrelClusterCollection = cms.InputTag("hybridSuperClusters:hybridBarrelBasicClusters"),
+    endcapClusterCollection = cms.InputTag("multi5x5SuperClusters:multi5x5EndcapBasicClusters")
 )
 
-process.maxEvents = untracked.PSet( input = untracked.int32( 10 ) )
-
-
-process.testEcalClusterTools = EDAnalyzer("testEcalClusterTools",
-    reducedBarrelRecHitCollection = InputTag("reducedEcalRecHitsEB"),
-    reducedEndcapRecHitCollection = InputTag("reducedEcalRecHitsEE"),
-    barrelClusterCollection = InputTag("hybridSuperClusters"),
-    endcapClusterCollection = InputTag("fixedMatrixBasicClusters:fixedMatrixEndcapBasicClusters")
-)
-
-process.p1 = Path( process.testEcalClusterTools )
+process.p1 = cms.Path( process.testEcalClusterTools )

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVANtuplizer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVANtuplizer.cc
@@ -133,7 +133,7 @@ class ElectronMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResourc
       std::vector<float> vars_;
 
       const bool doEnergyMatrix_;
-      const CaloRectangle caloRectangle_;
+      const int energyMatrixSize_;
 };
 
 //
@@ -177,7 +177,7 @@ ElectronMVANtuplizer::ElectronMVANtuplizer(const edm::ParameterSet& iConfig)
   , nVars_                 (mvaVarMngr_.getNVars())
   , vars_                  (nVars_)
   , doEnergyMatrix_        (iConfig.getParameter<bool>("doEnergyMatrix"))
-  , caloRectangle_         (makeCaloRectangle(iConfig.getParameter<int>("energyMatrixSize")))
+  , energyMatrixSize_      (iConfig.getParameter<int>("energyMatrixSize"))
 {
     // eleMaps
     for (auto const& tag : eleMapTags_) {
@@ -303,7 +303,7 @@ ElectronMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         // Fill the energy matrix around the seed
         if(doEnergyMatrix_) {
             const auto& seed = *(ele->superCluster()->seed());
-            energyMatrix_ = lazyTools->getEnergies(seed, caloRectangle_);
+            energyMatrix_ = lazyTools->energyMatrix(seed, energyMatrixSize_);
         }
 
         // Fill various tree variable

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
@@ -116,7 +116,7 @@ class PhotonMVANtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources
       std::vector<float> vars_;
 
       const bool doEnergyMatrix_;
-      const CaloRectangle caloRectangle_;
+      const int energyMatrixSize_;
 };
 
 enum PhotonMatchType {
@@ -183,7 +183,7 @@ PhotonMVANtuplizer::PhotonMVANtuplizer(const edm::ParameterSet& iConfig)
  , nVars_                 (mvaVarMngr_.getNVars())
  , vars_                  (nVars_)
  , doEnergyMatrix_        (iConfig.getParameter<bool>("doEnergyMatrix"))
- , caloRectangle_         (makeCaloRectangle(iConfig.getParameter<int>("energyMatrixSize")))
+ , energyMatrixSize_      (iConfig.getParameter<int>("energyMatrixSize"))
 {
     // phoMaps
     for (auto const& tag : phoMapTags_) {
@@ -300,7 +300,7 @@ PhotonMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
         // Fill the energy matrix around the seed
         if(doEnergyMatrix_) {
             const auto& seed = *(pho->superCluster()->seed());
-            energyMatrix_ = lazyTools->getEnergies(seed, caloRectangle_);
+            energyMatrix_ = lazyTools->energyMatrix(seed, energyMatrixSize_);
         }
 
         // variables from the text file


### PR DESCRIPTION
Hi,

I always felt the potential of machine learning applied to the ECAL is not fully tapped, while it's 2 dimensional nature provides a very good playing ground to test modern neural network architectures designed for image processing.

To enable quick studies in this direction for myself and everybody, I always wanted to (optionally) add the raw rec hit energies in a N times N matrix around the seed crystal to the Electron/PhotonMVANtuplizers. This is now possible, with N being a configurable parameter.

For this purpose, I wrote a new function `EcalClusterLazyTools<T>::getEnergies` and generally went over the EcalClusterTools/EcalClusterLazyTools duo, tying to make it a bit more slick. This includes:
  * new helper class to easily iterate over rectangular ranges around seed crystals
  * don't separate member function implementation from declaration for template classes because it adds a lot of distracting `template` lines (see the lazy tools)
  * detabify, removal of trailing whitespaces, occasionally better line breaks