### PR TITLE
Tunings to improve MTD track efficiency. Retain only best matching hit in a layer

### DIFF
--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -349,7 +349,7 @@ namespace {
     if( comp.first ) {    
       vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos,*prop,theEstimator);
       if (!compDets.empty()) {
-	MTDTrackingRecHit* best = 0;
+	MTDTrackingRecHit* best = nullptr;
 	double best_chi2 = std::numeric_limits<double>::max();
 	for( const auto& detWithState : compDets ) {	
 	  auto range = hits.equal_range(detWithState.first->geographicalId(),cmp_for_detset);	  

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -135,8 +135,8 @@ TrackExtenderWithMTDT<TrackCollection>::TrackExtenderWithMTDT(const ParameterSet
   mtdRecHitBuilder_(iConfig.getParameter<std::string>("MTDRecHitBuilder")),
   propagator_(iConfig.getParameter<std::string>("Propagator")),
   transientTrackBuilder_(iConfig.getParameter<std::string>("TransientTrackBuilder")) {
-  constexpr float maxChi2=25.;
-  constexpr float nSigma=3.;
+  constexpr float maxChi2=500.;
+  constexpr float nSigma=10.;
   theEstimator = std::make_unique<Chi2MeasurementEstimator>(maxChi2,nSigma);
   
   theTransformer = std::make_unique<TrackTransformer>(iConfig.getParameterSet("TrackTransformer"));
@@ -349,23 +349,23 @@ namespace {
     if( comp.first ) {    
       vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos,*prop,theEstimator);
       if (!compDets.empty()) {
+	MTDTrackingRecHit* best = 0;
+	double best_chi2 = std::numeric_limits<double>::max();
 	for( const auto& detWithState : compDets ) {	
 	  auto range = hits.equal_range(detWithState.first->geographicalId(),cmp_for_detset);	  
 	  for( auto detitr = range.first; detitr != range.second; ++detitr ) {
-	    auto best = detitr->end();
-	    double best_chi2 = std::numeric_limits<double>::max();
 	    for( auto itr = detitr->begin(); itr != detitr->end(); ++itr ) {
 	      auto est =  theEstimator.estimate(detWithState.second,*itr);
 	      if( est.first && est.second < best_chi2 ) { // just take the best chi2
-		best = itr;
+		best = &(*itr);
 		best_chi2 = est.second;
 	      }
+	      
 	    }
-	    if( best != detitr->end() ) {
-	      output.push_back(hitbuilder.build(&*best));
-	    }
-	  }	  	  
-	}      
+	  }
+	}
+	if( best ) 
+	  output.push_back(hitbuilder.build(best));
       }
     }
   }


### PR DESCRIPTION
Tunings to improve the efficiency for pions and PU200 of the MTD trackExtender. Retain only the best  matching MTD hit in a layer to avoid issues @PU200 when increasing the estimator cuts.
Further improvements for pions require modification to the MTD DetLayer

![divide_mtdtrack_eta_by_track_eta_mupucomp](https://user-images.githubusercontent.com/4571680/51071309-4a857b00-164f-11e9-9505-d491db711676.png)

![divide_mtdtrack_eta_by_track_eta_mupicomp](https://user-images.githubusercontent.com/4571680/51071310-5113f280-164f-11e9-9869-501f95702683.png)

![divide_mtdtrack_pt_by_track_pt_mupucomp](https://user-images.githubusercontent.com/4571680/51071394-8240f280-1650-11e9-8698-c09b37b833ca.png)

![divide_mtdtrack_pt_by_track_pt_mupicomp](https://user-images.githubusercontent.com/4571680/51071403-9127a500-1650-11e9-8d06-500ed10b3447.png)

More plots here:
https://meridian.web.cern.ch/meridian/plots/MTD/10_4_0_mtd3/TestTrackTuning/

@lgray @bendavid @franzoni @fabiocos 