### PR TITLE
Use strtok_r instead of strtok in SimpleMemoryCheck

### DIFF
--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -661,12 +661,12 @@ namespace edm {
         char buf[128];
         char space[] = " ";
         size_t value;
-
         while(fgets(buf, sizeof(buf), fmeminfo)) {
+          char* saveptr;
           char* token = nullptr;
-          token = strtok(buf, space);
+          token = strtok_r(buf, space, &saveptr);
           if(token != nullptr) {
-            value = atol(strtok(nullptr, space));
+            value = atol(strtok_r(nullptr, space,&saveptr));
             std::string category = token;
             reportMemoryProperties.insert(std::make_pair(category.substr(0, strlen(token)-1), i2str(value)));
           }


### PR DESCRIPTION
Although it was not a thread safety issue, removing strtok does clean up the code.