### PR TITLE
Adding time threshold compatibility to MTDThresholdClusterizer

### DIFF
--- a/RecoLocalFastTime/FTLClusterizer/interface/MTDThresholdClusterizer.h
+++ b/RecoLocalFastTime/FTLClusterizer/interface/MTDThresholdClusterizer.h
@@ -71,6 +71,7 @@ class MTDThresholdClusterizer : public MTDClusterizerBase {
   float theHitThreshold;    // Hit threshold 
   float theSeedThreshold;     // MTD cluster seed 
   float theClusterThreshold;  // Cluster threshold 
+  float theTimeThreshold; // Time compatibility between new hit and seed
 
   //! Geometry-related information
   int  theNumOfRows;

--- a/RecoLocalFastTime/FTLClusterizer/plugins/MTDClusterProducer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/plugins/MTDClusterProducer.cc
@@ -109,6 +109,7 @@ MTDClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<double>("HitThreshold", 0.);
   desc.add<double>("SeedThreshold", 0.);
   desc.add<double>("ClusterThreshold", 0.);
+  desc.add<double>("TimeThreshold", 10.);
   descriptions.add("mtdClusterProducer", desc);
 }
   

--- a/RecoLocalFastTime/FTLClusterizer/plugins/MTDClusterProducer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/plugins/MTDClusterProducer.cc
@@ -106,10 +106,7 @@ MTDClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<std::string>("BarrelClusterName", "FTLBarrel");
   desc.add<std::string>("EndcapClusterName", "FTLEndcap");
   desc.add<std::string>("ClusterMode","MTDThresholdClusterizer");
-  desc.add<double>("HitThreshold", 0.);
-  desc.add<double>("SeedThreshold", 0.);
-  desc.add<double>("ClusterThreshold", 0.);
-  desc.add<double>("TimeThreshold", 10.);
+  MTDThresholdClusterizer::fillDescriptions(desc);
   descriptions.add("mtdClusterProducer", desc);
 }
   

--- a/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
@@ -31,6 +31,7 @@ MTDThresholdClusterizer::MTDThresholdClusterizer
     theHitThreshold( conf.getParameter<double>("HitThreshold") ),
     theSeedThreshold( conf.getParameter<double>("SeedThreshold") ),
     theClusterThreshold( conf.getParameter<double>("ClusterThreshold") ),
+    theTimeThreshold( conf.getParameter<double>("TimeThreshold") ),
     theNumOfRows(0), theNumOfCols(0), theCurrentId(0), 
     theBuffer(theNumOfRows, theNumOfCols ),
     bufferAlreadySet(false)
@@ -46,6 +47,7 @@ MTDThresholdClusterizer::fillDescriptions(edm::ParameterSetDescription& desc) {
   desc.add<double>("HitThreshold", 0.);
   desc.add<double>("SeedThreshold", 0.);
   desc.add<double>("ClusterThreshold", 0.);
+  desc.add<double>("TimeThreshold", 5.);
 }
 
 //----------------------------------------------------------------------------
@@ -256,6 +258,8 @@ MTDThresholdClusterizer::make_cluster( const FTLCluster::FTLHitPos& hit )
       for ( auto c = std::max(0,int(acluster.y[curInd]-1)); c < std::min(int(acluster.y[curInd]+2),int(theBuffer.columns())) && !stopClus; ++c) {
 	  for ( auto r = std::max(0,int(acluster.x[curInd]-1)); r < std::min(int(acluster.x[curInd]+2),int(theBuffer.rows()))  && !stopClus; ++r)  {
 	  if ( theBuffer.energy(r,c) > theHitThreshold) {
+	    if (fabs(theBuffer.time(r,c) - seed_time) > theTimeThreshold*sqrt( theBuffer.time_error(r,c)*theBuffer.time_error(r,c) + seed_time_error*seed_time_error))
+	      continue;
 	    FTLCluster::FTLHitPos newhit(r,c);
 	    if (!acluster.add( newhit, theBuffer.energy(r,c), theBuffer.time(r,c), theBuffer.time_error(r,c))) 
 	      {

--- a/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
@@ -258,7 +258,7 @@ MTDThresholdClusterizer::make_cluster( const FTLCluster::FTLHitPos& hit )
       for ( auto c = std::max(0,int(acluster.y[curInd]-1)); c < std::min(int(acluster.y[curInd]+2),int(theBuffer.columns())) && !stopClus; ++c) {
 	  for ( auto r = std::max(0,int(acluster.x[curInd]-1)); r < std::min(int(acluster.x[curInd]+2),int(theBuffer.rows()))  && !stopClus; ++r)  {
 	  if ( theBuffer.energy(r,c) > theHitThreshold) {
-	    if (fabs(theBuffer.time(r,c) - seed_time) > theTimeThreshold*sqrt( theBuffer.time_error(r,c)*theBuffer.time_error(r,c) + seed_time_error*seed_time_error))
+	    if (std::abs(theBuffer.time(r,c) - seed_time) > theTimeThreshold*sqrt( theBuffer.time_error(r,c)*theBuffer.time_error(r,c) + seed_time_error*seed_time_error))
 	      continue;
 	    FTLCluster::FTLHitPos newhit(r,c);
 	    if (!acluster.add( newhit, theBuffer.energy(r,c), theBuffer.time(r,c), theBuffer.time_error(r,c))) 

--- a/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
@@ -47,7 +47,7 @@ MTDThresholdClusterizer::fillDescriptions(edm::ParameterSetDescription& desc) {
   desc.add<double>("HitThreshold", 0.);
   desc.add<double>("SeedThreshold", 0.);
   desc.add<double>("ClusterThreshold", 0.);
-  desc.add<double>("TimeThreshold", 5.);
+  desc.add<double>("TimeThreshold", 10.);
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This PR improves the MTD clusters @PU200 introducing a configurable time compatibility threshold (now set to a very loose @10sigma of the sigma of difference) between the seed and the hits to be attached to the cluster. It improves significantly the purity of the hits attached to the clusters as can be seen here:

Energy PU comparison in BTL with new configuration (Single MU)
![btlbestcluster_energy_mupucomp-new](https://user-images.githubusercontent.com/4571680/51087931-f3200180-1759-11e9-8784-1d16f3ba4909.png)

Old configuration
![btlbestcluster_energy_mupucomp-old](https://user-images.githubusercontent.com/4571680/51087943-16e34780-175a-11e9-9c85-f50a544d5fee.png)

Cluster size and time shows a similar behaviour:
![btlbestcluster_time_mupucomp](https://user-images.githubusercontent.com/4571680/51087967-5ca01000-175a-11e9-8bbb-6d4c9a5a8d4d.png)
![btlbestcluster_size_mupucomp](https://user-images.githubusercontent.com/4571680/51087968-6164c400-175a-11e9-8a93-95ff3e8d6198.png)
![etlbestcluster_size_mupucomp](https://user-images.githubusercontent.com/4571680/51087969-645fb480-175a-11e9-86e7-38f91d10a21f.png)

Efficiency of the best hit matching is not affected:
![divide_btlmatchedbestclustertrack_eta_by_btltrack_eta_mupuoldcomp](https://user-images.githubusercontent.com/4571680/51087996-c3bdc480-175a-11e9-8374-760c3c13ac4b.png)

Important to be used in the next mtd release
@lgray @bendavid  @fabiocos  @franzoni 