### PR TITLE
remove wf 150.0 2018 HeavyIons scenario from short matrix tests

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -65,7 +65,6 @@ if __name__ == '__main__':
                      136.85, #2018A Egamma data
                      140.53, #2011 HI data
                      140.56, #2018 HI data
-                     150.0, #2018 HI MC
                      158.0, #2018 HI MC with pp-like reco
                      1306.0, #SingleMu Pt1 UP15
                      1325.7, #test NanoAOD from existing MINI


### PR DESCRIPTION
HI reco default is now derived from pp scenario.
wf 150.0 is not representative of anything running in production.
it is effectively superseded by 158.0 which is included in the short matrix already.
