### PR TITLE
Add CoralServiceWrapper to allow edm::PluginFactory to return std::unique_ptr

### DIFF
--- a/CondCore/CondDB/interface/CoralServiceFactory.h
+++ b/CondCore/CondDB/interface/CoralServiceFactory.h
@@ -1,6 +1,7 @@
 #ifndef CondCore_CondDB_CoralServiceFactory_h
 #define CondCore_CondDB_CoralServiceFactory_h
 #include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "CondCore/CondDB/interface/CoralServiceWrapper.h"
 #include <string>
 //
 // Package:     CondCore/CondDB
@@ -21,7 +22,7 @@ namespace coral{
   class Service;
 }
 namespace cond{
-  typedef edmplugin::PluginFactory< coral::Service*(const std::string&) > CoralServicePluginFactory;
+  typedef edmplugin::PluginFactory< cond::CoralServiceWrapperBase*() > CoralServicePluginFactory;
   
   class CoralServiceFactory{
   public:

--- a/CondCore/CondDB/interface/CoralServiceMacros.h
+++ b/CondCore/CondDB/interface/CoralServiceMacros.h
@@ -5,9 +5,6 @@
 #include "CoralKernel/Service.h"
 
 #define DEFINE_CORALSERVICE(type,name) \
-  DEFINE_EDM_PLUGIN (cond::CoralServicePluginFactory,type,name)
-
-#define DEFINE_CORALSERVICE(type,name) \
-  DEFINE_EDM_PLUGIN (cond::CoralServicePluginFactory,type,name)
+  DEFINE_EDM_PLUGIN (cond::CoralServicePluginFactory,cond::CoralServiceWrapper<type>,name)
 
 #endif

--- a/CondCore/CondDB/interface/CoralServiceWrapper.h
+++ b/CondCore/CondDB/interface/CoralServiceWrapper.h
@@ -1,0 +1,29 @@
+#ifndef CondCore_CondDB_CondServiceWrapper_h
+#define CondCore_CondDB_CondServiceWrapper_h
+
+namespace coral {
+  class Service;
+}
+
+/**
+ * The wrapper is used to allow edm::PluginFactory to change its
+ * return type to unique_ptr from a raw pointer. The unique_ptr does
+ * not work for coral::Service, because its destructor is protected
+ * and ownership is managed by intrusive reference counting.
+ */
+namespace cond {
+  struct CoralServiceWrapperBase {
+    virtual ~CoralServiceWrapperBase() = default;
+    virtual coral::Service* create(const std::string& componentname) const = 0;
+  };
+
+  template <typename T>
+  struct CoralServiceWrapper: public CoralServiceWrapperBase {
+    ~CoralServiceWrapper() override = default;
+    coral::Service* create(const std::string& componentname) const override {
+      return new T{componentname};
+    }
+  };
+}
+
+#endif

--- a/CondCore/CondDB/src/CoralServiceFactory.cc
+++ b/CondCore/CondDB/src/CoralServiceFactory.cc
@@ -20,14 +20,6 @@ cond::CoralServiceFactory::get() {
 
 coral::Service*
 cond::CoralServiceFactory::create(const std::string& componentname) const {
- coral::Service* sp=CoralServicePluginFactory::get()->create(componentname,componentname);
- if(sp==nullptr) {
-   throw cond::Exception("CoralServiceFactory")
-     << "CoralServiceFactory:\n"
-     << "Cannot find coral service: "
-     << componentname << "\n"
-     << "Perhaps the name is misspelled or is not a Plugin?\n"
-     << "Try running EdmPluginDump to obtain a list of available Plugins.";
- }
- return sp;
+  std::unique_ptr<cond::CoralServiceWrapperBase> sp{CoralServicePluginFactory::get()->create(componentname)};
+  return sp->create(componentname);
 }


### PR DESCRIPTION
`coral::Service` has its destructor declared as protected (ownership is managed by intrusive reference counts) which makes it impossible to manage it with `std::unique_ptr` (without a custom deleter). This PR allows `edm::PluginFactory` return type to be changed later to `std::unique_ptr` by adding a wrapper layer for the `coral::Service` plugin creation.

Tested in CMSSW_10_5_X_2019-01-14-1100, no changes expected.