### PR TITLE
Some more use of new TrackingRecHitRange

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
@@ -145,9 +145,8 @@ void AlignmentStats::analyze(const edm::Event &iEvent, const edm::EventSetup &iS
     int nhit=0;
     //loop on tracking rechits
     //std::cout << "   loop on hits of track #" << (itt - tracks->begin()) << std::endl;
-    for (trackingRecHit_iterator ith = ittrk->recHitsBegin(), edh = ittrk->recHitsEnd(); ith != edh; ++ith) {
-
-      const TrackingRecHit *hit = *ith; // ith is an iterator on edm::Ref to rechit
+    for (auto const& hit : ittrk->recHits())
+    {
       if(! hit->isValid())continue;
       DetId detid = hit->geographicalId();
       int subDet = detid.subdetId();

--- a/Alignment/CommonAlignmentMonitor/plugins/TrackerToMuonPropagator.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/TrackerToMuonPropagator.cc
@@ -209,8 +209,8 @@ TrackerToMuonPropagator::produce(edm::Event& iEvent, const edm::EventSetup& iSet
       // loop over the muon hits, keeping track of the successful extrapolations
       edm::OwnVector<TrackingRecHit> muonHits;
       std::vector<TrajectoryStateOnSurface> TSOSes;
-      for (trackingRecHit_iterator hit = globalMuon->combinedMuon()->recHitsBegin();  hit != globalMuon->combinedMuon()->recHitsEnd();  ++hit) {
-	 DetId id = (*hit)->geographicalId();
+      for(auto const& hit : globalMuon->combinedMuon()->recHits()) {
+	 DetId id = hit->geographicalId();
 
 	 TrajectoryStateOnSurface extrapolation;
 	 bool extrapolated = false;
@@ -224,7 +224,7 @@ TrackerToMuonPropagator::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 	 }
 	 
 	 if (extrapolated  &&  extrapolation.isValid()) {
-	    muonHits.push_back((*hit)->clone());
+	    muonHits.push_back(hit->clone());
 	    TSOSes.push_back(extrapolation);
 	 }
       } // end loop over standAloneMuon hits

--- a/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
@@ -2918,9 +2918,7 @@ GlobalTrackerMuonAlignment::trackFitter(reco::TrackRef alongTr, reco::TransientT
 
   edm::OwnVector<TrackingRecHit> recHit;
   DetId trackDetId = DetId(alongTr->innerDetId());
-  for (trackingRecHit_iterator i=alongTr->recHitsBegin();i!=alongTr->recHitsEnd(); i++) {
-    recHit.push_back((*i)->clone());
-  }
+  for(auto const& hit : alongTr->recHits()) recHit.push_back(hit->clone());
   if(direction != alongMomentum)
     {
       edm::OwnVector<TrackingRecHit> recHitAlong = recHit;
@@ -2935,12 +2933,7 @@ GlobalTrackerMuonAlignment::trackFitter(reco::TrackRef alongTr, reco::TransientT
 
   //MuonTransientTrackingRecHitBuilder::ConstRecHitContainer recHitTrack;
   TransientTrackingRecHit::RecHitContainer recHitTrack;
-  for (trackingRecHit_iterator i=alongTr->recHitsBegin();i!=alongTr->recHitsEnd(); i++) {
-    if((*i)->isValid()){
-      recHitTrack.push_back(TTRHBuilder->build(&**i ));} 
-    else{
-      recHitTrack.push_back(TTRHBuilder->build(&**i ));}  
-  }
+  for(auto const& hit : alongTr->recHits()) recHitTrack.push_back(TTRHBuilder->build(hit));
   
   if(info)
     std::cout<<" ... recHitTrack.size() "<<recHit.size()<<" "<<trackDetId.rawId()
@@ -2949,7 +2942,7 @@ GlobalTrackerMuonAlignment::trackFitter(reco::TrackRef alongTr, reco::TransientT
   MuonTransientTrackingRecHitBuilder::ConstRecHitContainer recHitMu = recHitTrack;
   /*
     MuonTransientTrackingRecHitBuilder::ConstRecHitContainer recHitMu =
-    MuRHBuilder->build(alongTTr.recHitsBegin(), alongTTr.recHitsEnd());
+    MuRHBuilder->build(alongTTr.recHits().begin(), alongTTr.recHits().end());
   */
   if(info)
     std::cout<<" ...along.... recHitMu.size() "<<recHitMu.size()<<std::endl;
@@ -3031,9 +3024,7 @@ GlobalTrackerMuonAlignment::muonFitter(reco::TrackRef alongTr, reco::TransientTr
 
   edm::OwnVector<TrackingRecHit> recHit;
   DetId trackDetId = DetId(alongTr->innerDetId());
-  for (trackingRecHit_iterator i=alongTr->recHitsBegin();i!=alongTr->recHitsEnd(); i++) {
-    recHit.push_back((*i)->clone());
-  }
+  for(auto const& hit : alongTr->recHits()) recHit.push_back(hit->clone());
   if(direction != alongMomentum)
     {
       edm::OwnVector<TrackingRecHit> recHitAlong = recHit;
@@ -3115,9 +3106,8 @@ void GlobalTrackerMuonAlignment::debugTrackHit(const std::string title, Transien
 {
   std::cout<<" ------- "<<title<<" --------"<<std::endl;
   int nHit = 1;
-  TransientTrackingRecHit::RecHitContainer recHit;
   for (trackingRecHit_iterator i=alongTr.recHitsBegin();i!=alongTr.recHitsEnd(); i++) {
-    std::cout<<" Hit "<<nHit++<<" DetId "<<(*i)->geographicalId().det();
+    std::cout<<" Hit "<<nHit++<<" DetId "<< (*i)->geographicalId().det();
     if( (*i)->geographicalId().det() == DetId::Tracker ) std::cout<<" Tracker ";
     else if ( (*i)->geographicalId().det() == DetId::Muon ) std::cout<<" Muon "; 
     else std::cout<<" Unknown ";
@@ -3132,13 +3122,12 @@ void GlobalTrackerMuonAlignment::debugTrackHit(const std::string title, reco::Tr
 {
   std::cout<<" ------- "<<title<<" --------"<<std::endl;
   int nHit = 1;
-  TransientTrackingRecHit::RecHitContainer recHit;
-  for (trackingRecHit_iterator i=alongTr->recHitsBegin();i!=alongTr->recHitsEnd(); i++) {
-    std::cout<<" Hit "<<nHit++<<" DetId "<<(*i)->geographicalId().det();
-    if( (*i)->geographicalId().det() == DetId::Tracker ) std::cout<<" Tracker ";
-    else if ( (*i)->geographicalId().det() == DetId::Muon ) std::cout<<" Muon "; 
+  for(auto const& hit : alongTr->recHits()) {
+    std::cout<<" Hit "<<nHit++<<" DetId "<< hit->geographicalId().det();
+    if( hit->geographicalId().det() == DetId::Tracker ) std::cout<<" Tracker ";
+    else if ( hit->geographicalId().det() == DetId::Muon ) std::cout<<" Muon "; 
     else std::cout<<" Unknown ";
-    if(!(*i)->isValid()) std::cout<<" not valid "<<std::endl;  
+    if(!hit->isValid()) std::cout<<" not valid "<<std::endl;  
     else std::cout<<std::endl;
   }
 }

--- a/Alignment/CommonAlignmentProducer/src/AlignmentCSCBeamHaloSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentCSCBeamHaloSelector.cc
@@ -29,11 +29,11 @@ AlignmentCSCBeamHaloSelector::Tracks
 AlignmentCSCBeamHaloSelector::select(const Tracks &tracks, const edm::Event &iEvent) const {
    Tracks result;
 
-   for (Tracks::const_iterator track = tracks.begin();  track != tracks.end();  ++track) {
+   for(auto const& track : tracks) {
       std::map<int, unsigned int> station_map;
 
-      for (trackingRecHit_iterator hit = (*track)->recHitsBegin();  hit != (*track)->recHitsEnd();  ++hit) {
-	 DetId id = (*hit)->geographicalId();
+      for(auto const& hit : track->recHits()) {
+	 DetId id = hit->geographicalId();
 	 if (id.det() == DetId::Muon  &&  id.subdetId() == MuonSubdetId::CSC) {
 	    CSCDetId cscid(id.rawId());
 	    int station = (cscid.endcap() == 1 ? 1 : -1) * cscid.station();
@@ -51,7 +51,7 @@ AlignmentCSCBeamHaloSelector::select(const Tracks &tracks, const edm::Event &iEv
 	 if (station_iter->second > m_minHitsPerStation) stations++;
       }
       if (stations >= m_minStations) {
-	 result.push_back(*track);
+	 result.push_back(track);
       }
    } // end loop over tracks
 

--- a/Alignment/CommonAlignmentProducer/src/AlignmentCSCOverlapSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentCSCOverlapSelector.cc
@@ -35,7 +35,7 @@ AlignmentCSCOverlapSelector::Tracks
 AlignmentCSCOverlapSelector::select(const Tracks &tracks, const edm::Event &iEvent) const {
    Tracks result;
 
-   for (Tracks::const_iterator track = tracks.begin();  track != tracks.end();  ++track) {
+   for(auto const& track : tracks) {
       unsigned int MEminus4_even = 0;
       unsigned int MEminus4_odd = 0;
       unsigned int MEminus3_even = 0;
@@ -54,8 +54,8 @@ AlignmentCSCOverlapSelector::select(const Tracks &tracks, const edm::Event &iEve
       unsigned int MEplus4_even = 0;
       unsigned int MEplus4_odd = 0;
 
-      for (trackingRecHit_iterator hit = (*track)->recHitsBegin();  hit != (*track)->recHitsEnd();  ++hit) {
-	 DetId id = (*hit)->geographicalId();
+      for(auto const& hit : track->recHits()) {
+	 DetId id = hit->geographicalId();
 	 if (id.det() == DetId::Muon  &&  id.subdetId() == MuonSubdetId::CSC) {
 	    CSCDetId cscid(id.rawId());
 	    int station = (cscid.endcap() == 1 ? 1 : -1) * cscid.station();
@@ -98,28 +98,28 @@ AlignmentCSCOverlapSelector::select(const Tracks &tracks, const edm::Event &iEve
       } // end loop over hits
 
       if ((m_station == 0  ||  m_station == -4)  &&
-	  (MEminus4_even >= m_minHitsPerChamber)  &&  (MEminus4_odd >= m_minHitsPerChamber)) result.push_back(*track);
+	  (MEminus4_even >= m_minHitsPerChamber)  &&  (MEminus4_odd >= m_minHitsPerChamber)) result.push_back(track);
 
       else if ((m_station == 0  ||  m_station == -3)  &&
-	       (MEminus3_even >= m_minHitsPerChamber)  &&  (MEminus3_odd >= m_minHitsPerChamber)) result.push_back(*track);
+	       (MEminus3_even >= m_minHitsPerChamber)  &&  (MEminus3_odd >= m_minHitsPerChamber)) result.push_back(track);
 
       else if ((m_station == 0  ||  m_station == -2)  &&
-	       (MEminus2_even >= m_minHitsPerChamber)  &&  (MEminus2_odd >= m_minHitsPerChamber)) result.push_back(*track);
+	       (MEminus2_even >= m_minHitsPerChamber)  &&  (MEminus2_odd >= m_minHitsPerChamber)) result.push_back(track);
 
       else if ((m_station == 0  ||  m_station == -1)  &&
-	       (MEminus1_even >= m_minHitsPerChamber)  &&  (MEminus1_odd >= m_minHitsPerChamber)) result.push_back(*track);
+	       (MEminus1_even >= m_minHitsPerChamber)  &&  (MEminus1_odd >= m_minHitsPerChamber)) result.push_back(track);
 
       else if ((m_station == 0  ||  m_station == 1)  &&
-	       (MEplus1_even >= m_minHitsPerChamber)  &&  (MEplus1_odd >= m_minHitsPerChamber)) result.push_back(*track);
+	       (MEplus1_even >= m_minHitsPerChamber)  &&  (MEplus1_odd >= m_minHitsPerChamber)) result.push_back(track);
 
       else if ((m_station == 0  ||  m_station == 2)  &&
-	       (MEplus2_even >= m_minHitsPerChamber)  &&  (MEplus2_odd >= m_minHitsPerChamber)) result.push_back(*track);
+	       (MEplus2_even >= m_minHitsPerChamber)  &&  (MEplus2_odd >= m_minHitsPerChamber)) result.push_back(track);
 
       else if ((m_station == 0  ||  m_station == 3)  &&
-	       (MEplus3_even >= m_minHitsPerChamber)  &&  (MEplus3_odd >= m_minHitsPerChamber)) result.push_back(*track);
+	       (MEplus3_even >= m_minHitsPerChamber)  &&  (MEplus3_odd >= m_minHitsPerChamber)) result.push_back(track);
 
       else if ((m_station == 0  ||  m_station == 4)  &&
-	       (MEplus4_even >= m_minHitsPerChamber)  &&  (MEplus4_odd >= m_minHitsPerChamber)) result.push_back(*track);
+	       (MEplus4_even >= m_minHitsPerChamber)  &&  (MEplus4_odd >= m_minHitsPerChamber)) result.push_back(track);
 
    } // end loop over tracks
   

--- a/Alignment/CommonAlignmentProducer/src/AlignmentCSCTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentCSCTrackSelector.cc
@@ -35,12 +35,12 @@ AlignmentCSCTrackSelector::select(const Tracks& tracks, const edm::Event& evt) c
 {
    Tracks result;
 
-   for (Tracks::const_iterator track = tracks.begin();  track != tracks.end();  ++track) {
+   for(auto const& track : tracks) {
       int hitsOnStationA = 0;
       int hitsOnStationB = 0;
 
-      for (trackingRecHit_iterator hit = (*track)->recHitsBegin();  hit != (*track)->recHitsEnd();  ++hit) {
-	 DetId id = (*hit)->geographicalId();
+      for(auto const& hit : track->recHits()) {
+	 DetId id = hit->geographicalId();
 
 	 if (id.det() == DetId::Muon  &&  id.subdetId() == MuonSubdetId::DT) {
 	    if (m_stationA == 0) hitsOnStationA++;
@@ -65,7 +65,7 @@ AlignmentCSCTrackSelector::select(const Tracks& tracks, const edm::Event& evt) c
       else stationBokay = (m_minHitsPerStation <= hitsOnStationB  &&  hitsOnStationB <= m_maxHitsPerStation);
 
       if (stationAokay  &&  stationBokay) {
-	 result.push_back(*track);
+	 result.push_back(track);
       }
    } // end loop over tracks
   

--- a/Alignment/LaserAlignment/test/RecoAnalyzerTC.cc
+++ b/Alignment/LaserAlignment/test/RecoAnalyzerTC.cc
@@ -62,15 +62,15 @@ void RecoAnalyzer::trackerTC(edm::Event const& theEvent, edm::EventSetup const& 
 
   int nTracks = 0;
   std::cout << " Number of Tracks in this event: " << theTrackCollection->size() << std::endl;
-  for( reco::TrackCollection::const_iterator i = theTrackCollection->begin(); i != theTrackCollection->end(); ++i )
+  for(auto const& track : *theTrackCollection)
   {
     nTracks++;
     std::cout << " Hits in Track " << nTracks << ": " << std::endl;
-    for(  trackingRecHit_iterator j = (*i).recHitsBegin(); j != (*i).recHitsEnd(); ++j )
+    for(auto const& hit : track->recHits())
     {
-        if ( (*j)->isValid() )
+        if ( hit->isValid() )
         {
-          GlobalPoint HitPosition = theTracker.idToDet((*j)->geographicalId())->surface().toGlobal((*j)->localPosition());
+          GlobalPoint HitPosition = theTracker.idToDet(hit->geographicalId())->surface().toGlobal(hit->localPosition());
 
           std::cout << "   HitPosition in Track (x, y, z, R, phi) = " << HitPosition.x() << " " << HitPosition.y() << " " << HitPosition.z() << " " 
             << HitPosition.perp() << " " << HitPosition.phi() << std::endl;

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
@@ -571,12 +571,12 @@ void MillePedeMonitor::fillTrack(const reco::Track *track, std::vector<TH1*> &tr
   int nhitinTECplus = 0, nhitinTECminus = 0;
   unsigned int thishit = 0;
 
-  for (trackingRecHit_iterator iHit = track->recHitsBegin(); iHit != track->recHitsEnd(); ++iHit) {
+  for(auto const& hit : track->recHits()) {
     thishit++;
-    const DetId detId((*iHit)->geographicalId());
+    const DetId detId(hit->geographicalId());
     const int subdetId = detId.subdetId(); 
 
-    if (!(*iHit)->isValid()) continue; // only real hits count as in track->numberOfValidHits()
+    if (!hit->isValid()) continue; // only real hits count as in track->numberOfValidHits()
     if (detId.det() != DetId::Tracker) {
       edm::LogError("DetectorMismatch") << "@SUB=MillePedeMonitor::fillTrack"
                                         << "DetId.det() != DetId::Tracker (=" << DetId::Tracker

--- a/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsTrackPreparation.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsTrackPreparation.cc
@@ -140,11 +140,11 @@ CSCOverlapsTrackPreparation::produce(edm::Event& iEvent, const edm::EventSetup& 
     std::vector<TrajectoryMeasurement::ConstRecHitPointer> transHits;
     std::vector<TrajectoryStateOnSurface> TSOSes;
 
-    for (trackingRecHit_iterator hit = track->recHitsBegin();  hit != track->recHitsEnd();  ++hit) {
-      DetId id = (*hit)->geographicalId();
+    for(auto const& hit : track->recHits()) {
+      DetId id = hit->geographicalId();
       if (id.det() == DetId::Muon  &&  id.subdetId() == MuonSubdetId::CSC) {
 	const Surface &layerSurface = cscGeometry->idToDet(id)->surface();
-	TrajectoryMeasurement::ConstRecHitPointer hitPtr(muonTransBuilder.build(&**hit, globalGeometry));
+	TrajectoryMeasurement::ConstRecHitPointer hitPtr(muonTransBuilder.build(hit, globalGeometry));
 
 	AlgebraicVector5 params;   // meaningless, CSCOverlapsAlignmentAlgorithm does the fit internally
 	params[0] = 1.;  // straight-forward direction
@@ -156,7 +156,7 @@ CSCOverlapsTrackPreparation::produce(edm::Event& iEvent, const edm::EventSetup& 
 	LocalTrajectoryError localTrajectoryError(0.001, 0.001, 0.001, 0.001, 0.001);
 
 	// these must be in lock-step
-	clonedHits.push_back((*hit)->clone());
+	clonedHits.push_back(hit->clone());
 	transHits.push_back(hitPtr);
 	TSOSes.push_back(TrajectoryStateOnSurface(localTrajectoryParameters, localTrajectoryError, layerSurface, &*magneticField));
       } // end if CSC

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentPreFilter.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentPreFilter.cc
@@ -86,9 +86,9 @@ MuonAlignmentPreFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
     if (track->pt() < m_minTrackPt || track->p() < m_minTrackP) continue;
     if (track->eta() < m_minTrackEta || track->eta() > m_maxTrackEta ) continue;
     
-    for (trackingRecHit_iterator hit = track->recHitsBegin(); hit != track->recHitsEnd();  ++hit)
+    for(auto const& hit : track->recHits())
     {
-      DetId id = (*hit)->geographicalId();        
+      DetId id = hit->geographicalId();        
       if (id.det() == DetId::Tracker) 
       {
         tracker_numHits++;

--- a/Alignment/MuonAlignmentAlgorithms/src/MuonResidualsFromTrack.cc
+++ b/Alignment/MuonAlignmentAlgorithms/src/MuonResidualsFromTrack.cc
@@ -46,21 +46,21 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(const edm::EventSetup& iSetup,
     reco::TransientTrack track( *m_recoTrack, &*magneticField, globalGeometry );
     TransientTrackingRecHit::ConstRecHitContainer recHitsForRefit;
     int iT = 0, iM = 0;
-    for (trackingRecHit_iterator hit = m_recoTrack->recHitsBegin(); hit != m_recoTrack->recHitsEnd(); ++hit) {
-        if((*hit)->isValid()) {
-            DetId hitId  = (*hit)->geographicalId();
+    for(auto const& hit : m_recoTrack->recHits()) {
+        if(hit->isValid()) {
+            DetId hitId  = hit->geographicalId();
             if ( hitId.det() == DetId::Tracker ) {
                 iT++;
-                if (m_debug) std::cout << "Tracker Hit " << iT << " is found. Add to refit. Dimension: " << (*hit)->dimension() << std::endl;
+                if (m_debug) std::cout << "Tracker Hit " << iT << " is found. Add to refit. Dimension: " << hit->dimension() << std::endl;
 
-                recHitsForRefit.push_back( theTrackerRecHitBuilder->build(&**hit) );
+                recHitsForRefit.push_back( theTrackerRecHitBuilder->build(&*hit) );
             } else if ( hitId.det() == DetId::Muon ){
-                //        if ( (*hit)->geographicalId().subdetId() == 3 && !theRPCInTheFit ) {
+                //        if ( hit->geographicalId().subdetId() == 3 && !theRPCInTheFit ) {
                 //          LogTrace("Reco|TrackingTools|TrackTransformer") << "RPC Rec Hit discarged"; 
                 //          continue;
                 //        }
                 iM++;
-                if (m_debug) std::cout << "Muon Hit " << iM << " is found. We do not add muon hits to refit. Dimension: " << (*hit)->dimension() << std::endl;
+                if (m_debug) std::cout << "Muon Hit " << iM << " is found. We do not add muon hits to refit. Dimension: " << hit->dimension() << std::endl;
                 if ( hitId.subdetId() == MuonSubdetId::DT ) {
                     const DTChamberId chamberId(hitId.rawId());
                     if (m_debug) std::cout << "Muon Hit in DT wheel " << chamberId.wheel() << " station " << chamberId.station() << " sector " << chamberId.sector() << "." << std::endl;
@@ -72,7 +72,7 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(const edm::EventSetup& iSetup,
                 } else {
                     if (m_debug) std::cout << "Warning! Muon Hit not in DT or CSC or RPC" << std::endl;
                 }
-                //        recHitsForRefit.push_back(theMuonRecHitBuilder->build(&**hit));
+                //        recHitsForRefit.push_back(theMuonRecHitBuilder->build(&*hit));
             }
         }
     }
@@ -296,9 +296,9 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(const edm::EventSetup& iSetup,
 
 
     int iT2 = 0, iM2 = 0;
-    for (trackingRecHit_iterator hit2 = m_recoTrack->recHitsBegin(); hit2 != m_recoTrack->recHitsEnd(); ++hit2) {
-        if((*hit2)->isValid()) {
-            DetId hitId2  = (*hit2)->geographicalId();
+    for(auto const& hit2 : m_recoTrack->recHits()) {
+        if(hit2->isValid()) {
+            DetId hitId2  = hit2->geographicalId();
             if ( hitId2.det() == DetId::Tracker ) {
                 iT2++;
                 if (m_debug) std::cout << "Tracker Hit " << iT2 << " is found. We don't calcualte Tsos for it" << std::endl;
@@ -308,7 +308,7 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(const edm::EventSetup& iSetup,
                 //          continue;
                 //        }
                 iM2++;
-                if (m_debug) std::cout << "Muon Hit " << iM2 << " is found. Dimension: " << (*hit2)->dimension() << std::endl;
+                if (m_debug) std::cout << "Muon Hit " << iM2 << " is found. Dimension: " << hit2->dimension() << std::endl;
                 if ( hitId2.subdetId() == MuonSubdetId::DT ) {
                     const DTChamberId chamberId(hitId2.rawId());
                     if (m_debug) std::cout << "Muon Hit in DT wheel " << chamberId.wheel() << " station " << chamberId.station() << " sector " << chamberId.sector() << std::endl;
@@ -319,9 +319,9 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(const edm::EventSetup& iSetup,
 
 
 
-                    if ( (*hit2)->dimension() > 1 ) {
-                        // std::vector<const TrackingRecHit*> vDTSeg2D = (*hit2)->recHits();
-                        std::vector<TrackingRecHit*> vDTSeg2D = (*hit2)->recHits();
+                    if ( hit2->dimension() > 1 ) {
+                        // std::vector<const TrackingRecHit*> vDTSeg2D = hit2->recHits();
+                        std::vector<TrackingRecHit*> vDTSeg2D = hit2->recHits();
 
                         if (m_debug) std::cout << "          vDTSeg2D size: " << vDTSeg2D.size() << std::endl;
 
@@ -418,9 +418,9 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(const edm::EventSetup& iSetup,
                         //            
                         //            if ( chamberId2.wheel() == 0 && chamberId2.station() == 2 && chamberId2.sector() == 7 ) {
                         //            
-                        //            double hitX2 = (*hit2)->localPosition().x();
-                        //          double hitY2 = (*hit2)->localPosition().y();
-                        //          double hitZ2 = (*hit2)->localPosition().z();
+                        //            double hitX2 = hit2->localPosition().x();
+                        //          double hitY2 = hit2->localPosition().y();
+                        //          double hitZ2 = hit2->localPosition().z();
                         //          
                         //          double tsosX2 = extrapolation.localPosition().x();
                         //          double tsosY2 = extrapolation.localPosition().y();
@@ -440,9 +440,9 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(const edm::EventSetup& iSetup,
                         if (m_debug) std::cout << "Muon hit in CSC endcap " << cscDetId2.endcap() << " station " << cscDetId2.station() << " ring " << cscDetId2.ring() << " chamber " << cscDetId2.chamber() << "." << std::endl;
 
 
-                        if ( (*hit2)->dimension() == 4 ) {
-                            // std::vector<const TrackingRecHit*> vCSCHits2D = (*hit2)->recHits();
-                            std::vector<TrackingRecHit*> vCSCHits2D = (*hit2)->recHits();
+                        if ( hit2->dimension() == 4 ) {
+                            // std::vector<const TrackingRecHit*> vCSCHits2D = hit2->recHits();
+                            std::vector<TrackingRecHit*> vCSCHits2D = hit2->recHits();
                             if (m_debug) std::cout << "          vCSCHits2D size: " << vCSCHits2D.size() << std::endl;
                             if ( vCSCHits2D.size() >= 5 ) {
                                 // for ( std::vector<const TrackingRecHit*>::const_iterator itCSCHits2D =  vCSCHits2D.begin();
@@ -560,9 +560,9 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(const edm::EventSetup& iSetup,
                 m_tracker_numHits = m_tracker_numHits > 0 ? m_tracker_numHits : 0 ;
 
                 /*
-                   for (trackingRecHit_iterator hit = m_recoMuon->innerTrack()->recHitsBegin();  hit != m_recoMuon->innerTrack()->recHitsEnd();  ++hit)
+                   for(auto const& hit : m_recoMuon->innerTrack()->recHits())
                    {
-                   DetId id = (*hit)->geographicalId();
+                   DetId id = hit->geographicalId();
                    if (id.det() == DetId::Tracker)
                    {
                    m_tracker_numHits++;

--- a/Alignment/OfflineValidation/plugins/CosmicSplitterValidation.cc
+++ b/Alignment/OfflineValidation/plugins/CosmicSplitterValidation.cc
@@ -401,13 +401,13 @@ void CosmicSplitterValidation::analyze(const edm::Event& iEvent, const edm::Even
                         int nhitinTEC1 =0;
                         int nhitinBPIX1 =0;
                         int nhitinFPIX1 =0;
-                        for (trackingRecHit_iterator iHit = track1.recHitsBegin(); iHit != track1.recHitsEnd(); ++iHit) {
+                        for(auto const& hit : track1.recHits()) {
 
-                                if((*iHit)->isValid()) {
+                                if(hit->isValid()) {
 
                                         Nrechits1++;
 
-                                        int type =(*iHit)->geographicalId().subdetId();
+                                        int type = hit->geographicalId().subdetId();
 
                                         if(type==int(StripSubdetector::TIB)){++nhitinTIB1;}
                                         if(type==int(StripSubdetector::TOB)){++nhitinTOB1;}
@@ -434,13 +434,13 @@ void CosmicSplitterValidation::analyze(const edm::Event& iEvent, const edm::Even
                         int nhitinTEC2 =0;
                         int nhitinBPIX2 =0;
                         int nhitinFPIX2 =0;
-                        for (trackingRecHit_iterator iHit = track2.recHitsBegin(); iHit != track2.recHitsEnd(); ++iHit) {
+                        for(auto const& hit : track2.recHits()) {
 
-                                if((*iHit)->isValid()) {
+                                if(hit->isValid()) {
 
                                         Nrechits2++;
 
-                                        int type =(*iHit)->geographicalId().subdetId();
+                                        int type = hit->geographicalId().subdetId();
 
                                         if(type==int(StripSubdetector::TIB)){++nhitinTIB2;}
                                         if(type==int(StripSubdetector::TOB)){++nhitinTOB2;}
@@ -481,13 +481,13 @@ void CosmicSplitterValidation::analyze(const edm::Event& iEvent, const edm::Even
                         int nhitinTECorg =0;
                         int nhitinBPIXorg =0;
                         int nhitinFPIXorg =0;
-                        for (trackingRecHit_iterator iHit = origTrack.recHitsBegin(); iHit != origTrack.recHitsEnd(); ++iHit) {
+                        for(auto const& hit : origTrack.recHits()) {
 
-                                if((*iHit)->isValid()) {
+                                if(hit->isValid()) {
 
                                         Nrechitsorg++;
 
-                                        int type =(*iHit)->geographicalId().subdetId();
+                                        int type = hit->geographicalId().subdetId();
 
                                         if(type==int(StripSubdetector::TIB)){++nhitinTIBorg;}
                                         if(type==int(StripSubdetector::TOB)){++nhitinTOBorg;}

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -615,7 +615,6 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	int nhitinTEC  = hits.numberOfValidStripTECHits();
 	int nhitinBPIX = hits.numberOfValidPixelBarrelHits();
 	int nhitinFPIX = hits.numberOfValidPixelEndcapHits();
-	
 	for (trackingRecHit_iterator iHit = theTTrack.recHitsBegin(); iHit != theTTrack.recHitsEnd(); ++iHit) {
 	  if((*iHit)->isValid()) {	
 	    
@@ -820,11 +819,11 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	      int module_num = -1.;
 	      int L1BPixHitCount = 0;
 
-	      for (trackingRecHit_iterator iHit = theTrack.recHitsBegin(); iHit != theTrack.recHitsEnd(); ++iHit) {
-		const DetId& detId = (*iHit)->geographicalId();
+          for(auto const& hit : theTrack.recHits()) {
+		const DetId& detId = hit->geographicalId();
 		unsigned int subid = detId.subdetId();
 		
-		if((*iHit)->isValid() && ( subid == PixelSubdetector::PixelBarrel ) ) {
+		if(hit->isValid() && ( subid == PixelSubdetector::PixelBarrel ) ) {
 		  int layer = tTopo->pxbLayer(detId);
 		  if(layer==1){
 		    L1BPixHitCount+=1;
@@ -2819,12 +2818,12 @@ void PrimaryVertexValidation::fillTrackHistos(std::map<std::string, TH1*> & h, c
   
   //
   int longesthit=0, nbarrel=0;
-  for(trackingRecHit_iterator hit=tt->track().recHitsBegin(); hit!=tt->track().recHitsEnd(); hit++){
-    if ((**hit).isValid() && (**hit).geographicalId().det() == DetId::Tracker ){
-      bool barrel = DetId((**hit).geographicalId()).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-      //bool endcap = DetId::DetId((**hit).geographicalId()).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  for(auto const& hit : tt->track().recHits()) {
+    if (hit->isValid() && hit->geographicalId().det() == DetId::Tracker ){
+      bool barrel = DetId(hit->geographicalId()).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+      //bool endcap = DetId::DetId(hit->geographicalId()).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
       if (barrel){
-	const SiPixelRecHit *pixhit = dynamic_cast<const SiPixelRecHit*>( &(**hit));
+	const SiPixelRecHit *pixhit = dynamic_cast<const SiPixelRecHit*>( &(*hit));
 	edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> const& clust = (*pixhit).cluster();
 	if (clust.isNonnull()) {
 	  nbarrel++;

--- a/Alignment/OfflineValidation/plugins/ResidualRefitting.h
+++ b/Alignment/OfflineValidation/plugins/ResidualRefitting.h
@@ -306,7 +306,7 @@ class ResidualRefitting : public edm::EDAnalyzer{
 	  ResidualRefitting::storage_trackExtrap& trackExtrap);
 	int MatchTrackWithRecHits(reco::TrackCollection::const_iterator trackIt, edm::Handle<reco::TrackCollection> ref);
 	
-	bool IsSameHit(trackingRecHit_iterator hit1, trackingRecHit_iterator hit2);
+	bool IsSameHit(TrackingRecHit const& hit1, TrackingRecHit const& hit2);
 
 
 	void trkExtrap(const DetId& detid, int iTrkLink, int iTrk, int iRec,

--- a/Alignment/TrackerAlignment/plugins/AlignmentPrescaler.cc
+++ b/Alignment/TrackerAlignment/plugins/AlignmentPrescaler.cc
@@ -98,8 +98,7 @@ void AlignmentPrescaler::produce(edm::Event &iEvent, const edm::EventSetup &iSet
     int ntakenhits=0;
     bool firstTakenHit=false;
 
-    for (trackingRecHit_iterator ith = ittrk->recHitsBegin(), edh = ittrk->recHitsEnd(); ith != edh; ++ith) {
-      const TrackingRecHit *hit = *ith; // ith is an iterator on edm::Ref to rechit
+    for(auto const& hit : ittrk->recHits()) {
       if(! hit->isValid()){
        	nhit++;
 	continue;

--- a/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
+++ b/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
@@ -269,12 +269,12 @@ CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       int nhitinTIDplus = 0;
       int countHit 	= 0;
 
-      for(trackingRecHit_iterator iHit1 = itTrack1->recHitsBegin(); iHit1 != itTrack1->recHitsEnd(); ++iHit1)
+      for(auto const& hit1 : itTrack1->recHits())
       {
 
-         const DetId detId1((*iHit1)->geographicalId());
+         const DetId detId1(hit1->geographicalId());
          const int subdetId1 = detId1.subdetId();
-         if (!(*iHit1)->isValid()) continue; // only real hits count as in itTrack1->numberOfValidHits()
+         if (!hit1->isValid()) continue; // only real hits count as in itTrack1->numberOfValidHits()
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // 			 Hit information in PixelBarrel                          		 //

--- a/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
+++ b/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
@@ -114,7 +114,7 @@ void TkAlCaOverlapTagger::produce(edm::Event &iEvent, const edm::EventSetup &iSe
       const TrackingRecHit *hit=&(* hitpointer);
       if(!hit->isValid())continue;
 
-      //std::cout << "         hit number " << (ith - itt->recHitsBegin()) << std::endl;
+      //std::cout << "         hit number " << (ith - itt->recHits().begin()) << std::endl;
       DetId detid = hit->geographicalId();
       int layer(layerFromId(detid, tTopo));//layer 1-4=TIB, layer 5-10=TOB
       int subDet = detid.subdetId();

--- a/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
+++ b/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
@@ -37,19 +37,18 @@ void TrackInfoProducerAlgorithm::run(const edm::Ref<std::vector<Trajectory> > tr
       nhit++;
       unsigned int detid=ttrh->hit()->geographicalId().rawId();
       
-      trackingRecHit_iterator thehit;
       TrackingRecHitRef thehitref;
       TrackingRecHit const * thehitptr=nullptr;
       int i=0,j=0;
 
-      for (thehit=track->recHitsBegin();thehit!=track->recHitsEnd();thehit++){
+      for(auto const& thehit : track->recHits()) {
 	i++;
 	LocalPoint hitpos;
-	if ((*thehit)->isValid())hitpos=(*thehit)->localPosition();
-	if((*thehit)->geographicalId().rawId()==detid&&
+	if (thehit->isValid())hitpos=thehit->localPosition();
+	if(thehit->geographicalId().rawId()==detid&&
 	   (hitpos - pos).mag() < 1e-4)
 	  {
-	    thehitptr=(*thehit);
+	    thehitptr= thehit;
             thehitref = track->extra()->recHitRef(i-1);
 	    j++;
 	    break;

--- a/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
+++ b/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
@@ -1,4 +1,3 @@
-
 // Package:          SiPixelErrorEstimation
 // Class:            SiPixelErrorEstimation
 // Original Author:  Gavril Giurgiu (JHU)
@@ -1372,11 +1371,10 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
 	  for ( tciter=tracks->begin(); tciter!=tracks->end(); ++tciter)
 	    {
 	      // First loop on hits: find matched hits
-	      for ( trackingRecHit_iterator it = tciter->recHitsBegin(); it != tciter->recHitsEnd(); ++it) 
+          for(auto const hit : tciter->recHits())
 		{
-		  const TrackingRecHit &trk_rec_hit = **it;
 		  // Is it a matched hit?
-		  const SiPixelRecHit* matchedhit = dynamic_cast<const SiPixelRecHit*>(&trk_rec_hit);
+		  const SiPixelRecHit* matchedhit = dynamic_cast<const SiPixelRecHit*>(hit);
 		  
 		  if ( matchedhit ) 
 		    {
@@ -1439,8 +1437,8 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
 		      pixel_clst_err_x = -9999.9;
 		      pixel_clst_err_y = -9999.9;
 		      
-		      position = (*it)->localPosition();
-		      error = (*it)->localPositionError();
+		      position = hit->localPosition();
+		      error = hit->localPositionError();
 		      
 		      rechitx = position.x();
 		      rechity = position.y();
@@ -1521,7 +1519,7 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
 			  //  // cout << "evt = " << evt << endl;
 			  //}
 			  
-			  DetId detId = (*it)->geographicalId();
+			  DetId detId = hit->geographicalId();
 
 			  const PixelGeomDetUnit* theGeomDet =
 			    dynamic_cast<const PixelGeomDetUnit*> ((*tracker).idToDet(detId) );

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
@@ -172,8 +172,7 @@ void SiStripQualityHotStripIdentifier::algoAnalyze(const edm::Event& e, const ed
 	<<"\n\t\touter PT "<< track->outerPt()<<std::endl;
 
       //Loop on rechits
-      for (trackingRecHit_iterator it = track->recHitsBegin();  it != track->recHitsEnd(); ++it){
-	const TrackingRecHit* recHit = &(**it);
+      for(auto const& recHit : track->recHits()) {
 	
 	if (!recHit->isValid()){
 	  LogTrace("SiStripQualityHotStripIdentifier") <<"\t\t Invalid Hit "<<std::endl;

--- a/Calibration/IsolatedParticles/src/MatchingSimTrack.cc
+++ b/Calibration/IsolatedParticles/src/MatchingSimTrack.cc
@@ -24,10 +24,9 @@ namespace spr{
     //Get the vector of PsimHits associated to TrackerRecHits and select the 
     //matching SimTrack on the basis of maximum occurance of trackIds
     std::vector<unsigned int> trkId, trkOcc;
-    int i=0;
-    for (trackingRecHit_iterator iTrkHit = pTrack->recHitsBegin(); iTrkHit != pTrack->recHitsEnd(); ++iTrkHit, ++i) {
+    for(auto const& trkHit : pTrack->recHits()) {
     
-      std::vector<PSimHit> matchedSimIds = associate.associateHit((**iTrkHit));
+      std::vector<PSimHit> matchedSimIds = associate.associateHit(*trkHit);
       for (unsigned int isim=0; isim<matchedSimIds.size(); isim++) {
 	unsigned tkId = matchedSimIds[isim].trackId();
 	bool found = false;

--- a/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorFromDetIdList.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorFromDetIdList.cc
@@ -95,8 +95,7 @@ void CalibrationTrackSelectorFromDetIdList::produce(edm::Event& iEvent, const ed
    
     bool saveTrack(false);
 
-    for (trackingRecHit_iterator ith = trk.recHitsBegin(), edh = trk.recHitsEnd(); ith != edh; ++ith) {
-      const TrackingRecHit * hit = (*ith); // ith is an iterator on edm::Ref to rechit
+    for(auto const& hit : trk.recHits()) {
       DetId detid = hit->geographicalId();
       
       for (const auto &detidsel : detidsels_){

--- a/Calibration/TkAlCaRecoProducers/src/CalibrationTrackSelector.cc
+++ b/Calibration/TkAlCaRecoProducers/src/CalibrationTrackSelector.cc
@@ -176,10 +176,10 @@ bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp, cons
     unsigned int nHit2D = 0;
     unsigned int thishit = 0;
 
-    for (trackingRecHit_iterator iHit = trackp->recHitsBegin(); iHit != trackp->recHitsEnd(); ++iHit) {
+    for(auto const& hit : trackp->recHits()) {
 
       thishit++;
-      int type = (*iHit)->geographicalId().subdetId(); 
+      int type = hit->geographicalId().subdetId(); 
 
       // *** thishit == 1 means last hit in CTF *** 
       // (FIXME: assumption might change or not be valid for all tracking algorthms)
@@ -190,16 +190,15 @@ bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp, cons
 
       if (seedOnlyFromAbove_ == 2 && thishit == 1 && type == int(StripSubdetector::TIB)) return false;  
 
-      if (!(*iHit)->isValid()) continue; // only real hits count as in trackp->numberOfValidHits()
-      const DetId detId((*iHit)->geographicalId());
+      if (!hit->isValid()) continue; // only real hits count as in trackp->numberOfValidHits()
+      const DetId detId(hit->geographicalId());
       if (detId.det() != DetId::Tracker) {
         edm::LogError("DetectorMismatch") << "@SUB=CalibrationTrackSelector::detailedHitsCheck"
                                           << "DetId.det() != DetId::Tracker (=" << DetId::Tracker
                                           << "), but " << detId.det() << ".";
       }
-      const TrackingRecHit* therechit = (*iHit);
-      if (chargeCheck_ && !(this->isOkCharge(therechit))) return false;
-      if (applyIsolation_ && (!this->isIsolated(therechit, evt))) return false;
+      if (chargeCheck_ && !(this->isOkCharge(hit))) return false;
+      if (applyIsolation_ && (!this->isIsolated(hit, evt))) return false;
       if      (StripSubdetector::TIB == detId.subdetId()) ++nhitinTIB;
       else if (StripSubdetector::TOB == detId.subdetId()) ++nhitinTOB;
       else if (StripSubdetector::TID == detId.subdetId()) ++nhitinTID;
@@ -207,7 +206,7 @@ bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp, cons
       else if (                kBPIX == detId.subdetId()) ++nhitinBPIX;
       else if (                kFPIX == detId.subdetId()) ++nhitinFPIX;
       // Do not call isHit2D(..) if already enough 2D hits for performance reason:
-      if (nHit2D < nHitMin2D_ && this->isHit2D(**iHit)) ++nHit2D;
+      if (nHit2D < nHitMin2D_ && this->isHit2D(*hit)) ++nHit2D;
     } // end loop on hits
     return (nhitinTIB >= minHitsinTIB_ && nhitinTOB >= minHitsinTOB_ 
             && nhitinTID >= minHitsinTID_ && nhitinTEC >= minHitsinTEC_ 

--- a/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
+++ b/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
@@ -61,16 +61,13 @@ namespace helper {
 						  trk.innerStateCovariance(), trk.innerDetId(),
 						  trk.seedDirection() ) );
 	  selGsfTrackExtras_->push_back( GsfTrackExtra( *(trk.gsfExtra()) ) );
-  	  TrackExtra & tx = selTrackExtras_->back();
-          unsigned int nHitsToAdd = 0;
-	  for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
-	    selHits_->push_back( (*hit)->clone() );
-            ++nHitsToAdd;
-	  }
-          tx.setHits( rHits, hidx, nHitsToAdd );
-          tx.setTrajParams(trk.extra()->trajParams(),trk.extra()->chi2sX5());
-          assert(tx.trajParams().size()==tx.recHitsSize());
-          hidx += nHitsToAdd;
+      TrackExtra & tx = selTrackExtras_->back();
+      unsigned int nHitsToAdd = trk.recHitsSize();
+      for(auto const& hit : trk.recHits()) selHits_->push_back( hit->clone() );
+      tx.setHits( rHits, hidx, nHitsToAdd );
+      tx.setTrajParams(trk.extra()->trajParams(),trk.extra()->chi2sX5());
+      assert(tx.trajParams().size()==tx.recHitsSize());
+      hidx += nHitsToAdd;
  	  trk.setGsfExtra( GsfTrackExtraRef( rGsfTrackExtras, tidx ) ); 
  	  trk.setExtra( TrackExtraRef( rTrackExtras, tidx ++ ) ); 
 	} 

--- a/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
+++ b/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
@@ -61,15 +61,15 @@ namespace helper {
 						  trk.innerStateCovariance(), trk.innerDetId(),
 						  trk.seedDirection() ) );
 	  selGsfTrackExtras_->push_back( GsfTrackExtra( *(trk.gsfExtra()) ) );
-      TrackExtra & tx = selTrackExtras_->back();
-      unsigned int nHitsToAdd = trk.recHitsSize();
-      for(auto const& hit : trk.recHits()) selHits_->push_back( hit->clone() );
-      tx.setHits( rHits, hidx, nHitsToAdd );
-      tx.setTrajParams(trk.extra()->trajParams(),trk.extra()->chi2sX5());
-      assert(tx.trajParams().size()==tx.recHitsSize());
-      hidx += nHitsToAdd;
- 	  trk.setGsfExtra( GsfTrackExtraRef( rGsfTrackExtras, tidx ) ); 
- 	  trk.setExtra( TrackExtraRef( rTrackExtras, tidx ++ ) ); 
+	  TrackExtra & tx = selTrackExtras_->back();
+	  unsigned int nHitsToAdd = trk.recHitsSize();
+	  for(auto const& hit : trk.recHits()) selHits_->push_back( hit->clone() );
+	  tx.setHits( rHits, hidx, nHitsToAdd );
+	  tx.setTrajParams(trk.extra()->trajParams(),trk.extra()->chi2sX5());
+	  assert(tx.trajParams().size()==tx.recHitsSize());
+	  hidx += nHitsToAdd;
+	  trk.setGsfExtra( GsfTrackExtraRef( rGsfTrackExtras, tidx ) ); 
+	  trk.setExtra( TrackExtraRef( rTrackExtras, tidx ++ ) ); 
 	} 
       }
     }

--- a/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
@@ -102,9 +102,7 @@ private:
           TrackExtra & tx = selTrackExtras_->back();
           // TrackingRecHits
           auto const firstHitIndex = selHits_->size();
-          for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
-              selHits_->push_back( (*hit)->clone() );
-          }
+          for(auto const& hit : trk.recHits()) selHits_->push_back( hit->clone() );
           tx.setHits( rHits, firstHitIndex, selHits_->size() - firstHitIndex );
           tx.setTrajParams(trk.extra()->trajParams(),trk.extra()->chi2sX5());
           assert(tx.trajParams().size()==tx.recHitsSize());

--- a/FWCore/Utilities/interface/Range.h
+++ b/FWCore/Utilities/interface/Range.h
@@ -17,6 +17,8 @@ namespace edm
          T begin() const { return begin_; }
          T end() const { return end_; }
 
+         bool empty() const { return begin_ == end_; }
+
        private:
          const T begin_;
          const T end_;

--- a/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronAssociator.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronAssociator.cc
@@ -99,11 +99,11 @@ SiStripElectronAssociator::produce(edm::Event& iEvent, const edm::EventSetup& iS
       // of hits are assigned to electrons.)  So let's look at one hit.
 
       // But first, make sure the track's hit list is not empty.
-      if (trackPtr->recHitsBegin() == trackPtr->recHitsEnd()) { continue; }
+      if (trackPtr->recHits().empty()) { continue; }
 
       // Detector id is not enough to completely specify a hit
-      uint32_t id = (*trackPtr->recHitsBegin())->geographicalId().rawId();
-      LocalPoint pos = (*trackPtr->recHitsBegin())->localPosition();
+      uint32_t id = trackPtr->recHit(0)->geographicalId().rawId();
+      LocalPoint pos = trackPtr->recHit(0)->localPosition();
       
       LogDebug("SiStripElectronAssociator") << " New Track Candidate " << i
                                             << " DetId " << id

--- a/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronAssociator.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/SiStripElectronAssociator.cc
@@ -102,8 +102,8 @@ SiStripElectronAssociator::produce(edm::Event& iEvent, const edm::EventSetup& iS
       if (trackPtr->recHits().empty()) { continue; }
 
       // Detector id is not enough to completely specify a hit
-      uint32_t id = trackPtr->recHit(0)->geographicalId().rawId();
-      LocalPoint pos = trackPtr->recHit(0)->localPosition();
+      uint32_t id = (*trackPtr->recHits().begin())->geographicalId().rawId();
+      LocalPoint pos = (*trackPtr->recHits().begin())->localPosition();
       
       LogDebug("SiStripElectronAssociator") << " New Track Candidate " << i
                                             << " DetId " << id

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionHitChecker.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionHitChecker.cc
@@ -16,7 +16,7 @@ std::pair<uint8_t,Measurement1DFloat> ConversionHitChecker::nHitsBeforeVtx(const
 
   //iterate inside out, when distance to vertex starts increasing, we are at the closest hit
   // the first (and last, btw) hit is always valid... (apparntly not..., conversion is different????)
-  TrackingRecHit const* recHit = nullptr;
+  TrackingRecHit const* recHit = *track.recHits().begin();
   unsigned int closest = 0;
   for(auto const& hit : track.recHits()) {
     if (hit->isValid()) {
@@ -25,7 +25,6 @@ std::pair<uint8_t,Measurement1DFloat> ConversionHitChecker::nHitsBeforeVtx(const
     }
     ++closest;
   }
-  if(recHit == nullptr) throw cms::Exception("No valid RecHit found in track!");
   auto globalPosition = recHit->surface()->toGlobal(trajParams[0].position());
   auto distance2 = (vtxPos - globalPosition).mag2();
   int nhits = 1;

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionHitChecker.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionHitChecker.cc
@@ -16,7 +16,7 @@ std::pair<uint8_t,Measurement1DFloat> ConversionHitChecker::nHitsBeforeVtx(const
 
   //iterate inside out, when distance to vertex starts increasing, we are at the closest hit
   // the first (and last, btw) hit is always valid... (apparntly not..., conversion is different????)
-  TrackingRecHit const* recHit;
+  TrackingRecHit const* recHit = nullptr;
   unsigned int closest = 0;
   for(auto const& hit : track.recHits()) {
     if (hit->isValid()) {
@@ -25,6 +25,7 @@ std::pair<uint8_t,Measurement1DFloat> ConversionHitChecker::nHitsBeforeVtx(const
     }
     ++closest;
   }
+  if(recHit == nullptr) throw cms::Exception("No valid RecHit found in track!");
   auto globalPosition = recHit->surface()->toGlobal(trajParams[0].position());
   auto distance2 = (vtxPos - globalPosition).mag2();
   int nhits = 1;


### PR DESCRIPTION
This was originally meant to be part of https://github.com/cms-sw/cmssw/pull/25591, but I decided to split it up the new interface and it's usage in different PRs to not touch too many packages at once.

This PR cleans up some packages from the now deprecated `recHitsBegin()` and `recHitsEnd()`.