### PR TITLE
DD4hep: Muon Numbering

### DIFF
--- a/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
-    <debug_shapes/>
+    <!--debug_shapes/>
     <debug_includes/>
-    <!-- debug_rotations/>
-    <debug_includes/-->
+    <debug_rotations/>
+    <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/-->
+    <debug_materials/>
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
-    <!-- debug_materials/>
-    <debug_visattr/ -->
-    <debug_specpars/>
+    <debug_materials/>
+    <debug_visattr/>
+    <debug_specpars/-->
   </debug>
   
   <open_geometry/>
@@ -57,6 +57,7 @@
     <Include ref='Geometry/MuonCommonData/data/csc/2015/v2/csc.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mfshield/2015/v1/mfshield.xml'/>
     <Include ref='Geometry/MuonCommonData/data/muonNumbering/2015/v2/muonNumbering.xml'/>
+    <Include ref='Geometry/DTGeometryBuilder/data/dtSpecsFilter.xml'/>
     <Include ref='DetectorDescription/DDCMS/data/trackerParameters.xml'/>
   </IncludeSection>
   

--- a/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
-    <debug_shapes/>
+    <!-- debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
+    <debug_materials/>
     <debug_namespaces/>
     <debug_placements/>
-    <debug_algorithms/>
+    <debug_algorithms/-->
 
 <!-- 
     <debug_materials/>

--- a/DetectorDescription/DDCMS/interface/DDDetector.h
+++ b/DetectorDescription/DDCMS/interface/DDDetector.h
@@ -16,6 +16,7 @@ namespace cms  {
     DDVectorsMap vectors;
     DDPartSelectionMap partsels;
     DDSpecParRegistry specpars;
+    int value = 0;
   };
 }
 

--- a/DetectorDescription/DDCMS/interface/DDDetector.h
+++ b/DetectorDescription/DDCMS/interface/DDDetector.h
@@ -16,7 +16,6 @@ namespace cms  {
     DDVectorsMap vectors;
     DDPartSelectionMap partsels;
     DDSpecParRegistry specpars;
-    int value = 0;
   };
 }
 

--- a/DetectorDescription/DDCMS/interface/DDDetector.h
+++ b/DetectorDescription/DDCMS/interface/DDDetector.h
@@ -2,20 +2,48 @@
 #define DETECTOR_DESCRIPTION_DD_DETECTOR_H
 
 #include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
+#include <string>
 
 namespace dd4hep {
   class Detector;
 }
 
 namespace cms  {
-  struct DDDetector {
-
+  class DDDetector {
+  public:
     using Detector = dd4hep::Detector;
 
-    Detector* description = nullptr;
-    DDVectorsMap vectors;
-    DDPartSelectionMap partsels;
-    DDSpecParRegistry specpars;
+    explicit DDDetector(const std::string&, const std::string&);
+    DDDetector() = delete;
+    
+    ~DDDetector();
+
+    // FIXME: remove the need for it
+    Detector const* description() const {
+      return m_description;
+    }
+    
+    DDVectorsMap const& vectors() const {
+      return m_vectors;
+    }
+
+    DDPartSelectionMap const& partsels() const {
+      return m_partsels;
+    }
+    
+    DDSpecParRegistry const& specpars() const {
+      return m_specpars;
+    }
+
+  private:
+
+    void process(const std::string&);
+    
+    Detector* m_description = nullptr;
+    DDVectorsMap m_vectors;
+    DDPartSelectionMap m_partsels;
+    DDSpecParRegistry m_specpars;
+    const std::string m_tag;
   };
 }
 

--- a/DetectorDescription/DDCMS/interface/MuonGeometryRcd.h
+++ b/DetectorDescription/DDCMS/interface/MuonGeometryRcd.h
@@ -1,0 +1,18 @@
+#ifndef GEOMETRY_RECORDS_MUON_GEOMETRY_RCD_H
+#define GEOMETRY_RECORDS_MUON_GEOMETRY_RCD_H
+
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"
+#include "DetectorDescription/DDCMS/interface/DDSpecParRegistryRcd.h"
+#include "DetectorDescription/DDCMS/interface/MuonNumberingRcd.h"
+#include "Geometry/Records/interface/DTRecoGeometryRcd.h"
+#include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h"
+#include "boost/mpl/vector.hpp"
+
+class MuonGeometryRcd : public edm::eventsetup::DependentRecordImplementation<
+MuonGeometryRcd, boost::mpl::vector<MuonNumberingRcd, DDSpecParRegistryRcd, DetectorDescriptionRcd,
+  GlobalPositionRcd, DTAlignmentRcd, DTAlignmentErrorRcd, DTAlignmentErrorExtendedRcd, DTRecoGeometryRcd>> {};
+#endif

--- a/DetectorDescription/DDCMS/interface/MuonNumbering.h
+++ b/DetectorDescription/DDCMS/interface/MuonNumbering.h
@@ -1,0 +1,14 @@
+#ifndef DETECTOR_DESCRIPTION_MUON_NUMBERING_H
+#define DETECTOR_DESCRIPTION_MUON_NUMBERING_H
+
+#include <string>
+#include "tbb/concurrent_unordered_map.h"
+
+namespace cms {
+
+  struct MuonNumbering {
+    tbb::concurrent_unordered_map<std::string, int> values;
+  };
+}
+
+#endif

--- a/DetectorDescription/DDCMS/interface/MuonNumberingRcd.h
+++ b/DetectorDescription/DDCMS/interface/MuonNumberingRcd.h
@@ -1,0 +1,11 @@
+#ifndef GEOMETRY_RECORDS_MUON_NUMBERING_RCD_H
+#define GEOMETRY_RECORDS_MUON_NUMBERING_RCD_H
+
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"
+#include "DetectorDescription/DDCMS/interface/DDSpecParRegistryRcd.h"
+#include "boost/mpl/vector.hpp"
+
+class MuonNumberingRcd : public edm::eventsetup::DependentRecordImplementation<
+MuonNumberingRcd, boost::mpl::vector<DDSpecParRegistryRcd, DetectorDescriptionRcd>> {};
+#endif

--- a/DetectorDescription/DDCMS/interface/MuonSubDetector.h
+++ b/DetectorDescription/DDCMS/interface/MuonSubDetector.h
@@ -18,7 +18,7 @@ namespace cms {
       { gem, "MuonGEMHits" },
       { me0, "MuonME0Hits" },
       { nodef, "" }};
-  }
+  };
 }
 
 #endif

--- a/DetectorDescription/DDCMS/interface/MuonSubDetector.h
+++ b/DetectorDescription/DDCMS/interface/MuonSubDetector.h
@@ -1,0 +1,24 @@
+#ifndef DETECTOR_DESCRIPTION_MUON_SUB_DETECTOR_H
+#define DETECTOR_DESCRIPTION_MUON_SUB_DETECTOR_H
+
+#include <string>
+#include <map>
+
+namespace cms {
+  struct MuonSubDetector {
+    
+    enum class SubDetector {
+      barrel = 1, endcap = 2,
+      rpc = 3, gem = 4, me0 = 5, nodef };
+      
+    const std::map<SubDetector, std::string> subDetMap {
+      { barrel, "MuonDTHits" },
+      { endcap, "MuonCSCHits"},
+      { rpc,"MuonRPCHits" },
+      { gem, "MuonGEMHits" },
+      { me0, "MuonME0Hits" },
+      { nodef, "" }};
+  }
+}
+
+#endif

--- a/DetectorDescription/DDCMS/plugins/BuildFile.xml
+++ b/DetectorDescription/DDCMS/plugins/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="dd4hep"/>
 <use name="DetectorDescription/DDCMS"/>
 
-<library name="DetectorDescriptionTestPlugins" file="DDTestVectors.cc,DDTestSpecPars.cc,DDTestDumpFile.cc,DDTestDumpGeometry.cc,DDTestNavigateGeometry.cc,DDTestMuonNumbering.cc" >
+<library name="DetectorDescriptionTestPlugins" file="DDTestVectors.cc,DDTestSpecPars.cc,DDTestSpecParsFilter.cc,DDTestDumpFile.cc,DDTestDumpGeometry.cc,DDTestNavigateGeometry.cc,DDTestMuonNumbering.cc" >
   <lib name="Geom"/>
   <flags EDM_PLUGIN="1"/>
 </library>
@@ -13,9 +13,11 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 <library name="DetectorDescriptionDD4HepPlugins" file="*.cc" >
+  <flags SKIP_FILE="DTGeometryESProducer.cc"/>
   <flags SKIP_FILE="DDCMSDetector.cc"/>
   <flags SKIP_FILE="DDTestVector.cc"/>
   <flags SKIP_FILE="DDTestSpecPars.cc"/>
+  <flags SKIP_FILE="DDTestSpecParsFilter.cc"/>
   <flags SKIP_FILE="DDTestDumpFile.cc"/>
   <flags SKIP_FILE="DDTestDumpGeometry.cc"/>
   <flags SKIP_FILE="DDTestNavigateGeometry.cc"/>

--- a/DetectorDescription/DDCMS/plugins/BuildFile.xml
+++ b/DetectorDescription/DDCMS/plugins/BuildFile.xml
@@ -4,11 +4,11 @@
 <use name="dd4hep"/>
 <use name="DetectorDescription/DDCMS"/>
 
-<library name="DetectorDescriptionTestPlugins" file="DDTestVectors.cc,DDTestSpecPars.cc,DDTestDumpFile.cc,DDTestDumpGeometry.cc,DDTestNavigateGeometry.cc" >
+<library name="DetectorDescriptionTestPlugins" file="DDTestVectors.cc,DDTestSpecPars.cc,DDTestDumpFile.cc,DDTestDumpGeometry.cc,DDTestNavigateGeometry.cc,DDTestMuonNumbering.cc" >
   <lib name="Geom"/>
   <flags EDM_PLUGIN="1"/>
 </library>
-<library name="DetectorDescriptionPlugins" file="DDCMSDetector.cc,DDDetectorESProducer.cc,DDVectorRegistryESProducer.cc,DDSpecParRegistryESProducer.cc" >
+<library name="DetectorDescriptionPlugins" file="DDCMSDetector.cc,DDDetectorESProducer.cc,DDVectorRegistryESProducer.cc,DDSpecParRegistryESProducer.cc,MuonNumberingESProducer.cc" >
   <lib name="Geom"/>
   <flags EDM_PLUGIN="1"/>
 </library>
@@ -19,9 +19,11 @@
   <flags SKIP_FILE="DDTestDumpFile.cc"/>
   <flags SKIP_FILE="DDTestDumpGeometry.cc"/>
   <flags SKIP_FILE="DDTestNavigateGeometry.cc"/>
+  <flags SKIP_FILE="DDTestMuonNumbering.cc"/>
   <flags SKIP_FILE="DDDetectorESProducer.cc"/>
   <flags SKIP_FILE="DDVectorRegistryESProducer.cc"/>
   <flags SKIP_FILE="DDSpecParRegistryESProducer.cc"/>
+  <flags SKIP_FILE="MuonNumberingESProducer.cc"/>
   <use name="rootgeom"/>
   <flags DD4HEP_PLUGIN="1"/>
 </library>

--- a/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
+++ b/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
@@ -25,49 +25,37 @@ public:
   void analyze( edm::Event const& iEvent, edm::EventSetup const& ) override;
   void endJob() override;
 
-private:
-  
-  std::string m_confGeomXMLFiles;
-  std::vector< std::string > m_relFiles;
-  std::vector< std::string > m_files;
+private:  
+  string m_label;
 };
 
-DDCMSDetector::DDCMSDetector( const edm::ParameterSet& iConfig )
-{
-  m_confGeomXMLFiles = edm::FileInPath( iConfig.getParameter<std::string>( "confGeomXMLFiles" )).fullPath();
-  
-  m_relFiles = iConfig.getParameter<std::vector<std::string> >( "geomXMLFiles" );
-  for( const auto& it : m_relFiles ) {
-    edm::FileInPath fp( it );
-    m_files.emplace_back( fp.fullPath());
-  }
-}
+DDCMSDetector::DDCMSDetector(const edm::ParameterSet& iConfig)
+  : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", ""))
+{}
 
 void
 DDCMSDetector::analyze( const edm::Event&, const edm::EventSetup& iEventSetup)
 {
   edm::ESTransientHandle<DDDetector> det;
-  iEventSetup.get<DetectorDescriptionRcd>().get(det);
+  iEventSetup.get<DetectorDescriptionRcd>().get(m_label, det);
 
-  edm::ESTransientHandle<DDVectorRegistry> registry;
-  iEventSetup.get<DDVectorRegistryRcd>().get(registry);
-
-  for( const auto& it : m_files )
-    std::cout << it << std::endl;
-
-  std::cout << "DD Vector Registry size: " << registry->vectors.size() << "\n";
-  for( const auto& p: registry->vectors ) {
-    std::cout << " " << p.first << " => ";
-    for( const auto& i : p.second )
-      std::cout << i << ", ";
-    std::cout << '\n';
-  }
-  std::cout << "Iterate over the detectors:\n";
+  cout << "Iterate over the detectors:\n";
   for( auto const& it : det->description->detectors()) {
     dd4hep::DetElement det(it.second);
-    std::cout << it.first << ": " << det.path() << "\n";
+    cout << it.first << ": " << det.path() << "\n";
   }
-  std::cout << "..done!\n";
+  cout << "..done!\n";
+  
+  edm::ESTransientHandle<DDVectorRegistry> registry;
+  iEventSetup.get<DDVectorRegistryRcd>().get(m_label, registry);
+
+  cout << "DD Vector Registry size: " << registry->vectors.size() << "\n";
+  for( const auto& p: registry->vectors ) {
+    cout << " " << p.first << " => ";
+    for( const auto& i : p.second )
+      cout << i << ", ";
+    cout << '\n';
+  }
 }
 
 void

--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -21,7 +21,6 @@
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/ESProducts.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"

--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -37,7 +37,8 @@ public:
   ~DDDetectorESProducer() override;
   
   using ReturnType = unique_ptr<cms::DDDetector>;
-  
+  using Detector = dd4hep::Detector;
+
   ReturnType produce(const DetectorDescriptionRcd&);
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
@@ -60,6 +61,7 @@ DDDetectorESProducer::DDDetectorESProducer(const edm::ParameterSet& iConfig)
 
 DDDetectorESProducer::~DDDetectorESProducer()
 {
+  Detector::destroyInstance(m_label);
 }
 
 void
@@ -82,7 +84,6 @@ DDDetectorESProducer::ReturnType
 DDDetectorESProducer::produce(const DetectorDescriptionRcd& iRecord)
 {
   cout << "DDDetectorESProducer::Produce " << m_label << "\n";
-  using Detector = dd4hep::Detector;
   auto product = make_unique<DDDetector>();
   
   product->description = &Detector::getInstance(m_label);

--- a/DetectorDescription/DDCMS/plugins/DDSpecParRegistryESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDSpecParRegistryESProducer.cc
@@ -44,11 +44,15 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
   
   ReturnType produce(const DDSpecParRegistryRcd&);
+
+private:
+  string m_label;
 };
 
-DDSpecParRegistryESProducer::DDSpecParRegistryESProducer(const edm::ParameterSet&)
+DDSpecParRegistryESProducer::DDSpecParRegistryESProducer(const edm::ParameterSet& iConfig)
+  : m_label(iConfig.getParameter<std::string>("label"))
 {
-  setWhatProduced(this);
+  setWhatProduced(this, m_label);
 }
 
 DDSpecParRegistryESProducer::~DDSpecParRegistryESProducer()
@@ -59,6 +63,7 @@ void
 DDSpecParRegistryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
 {
   edm::ParameterSetDescription desc;
+  desc.add<string>("label");
   descriptions.addDefault(desc);
 }
 
@@ -66,7 +71,7 @@ DDSpecParRegistryESProducer::ReturnType
 DDSpecParRegistryESProducer::produce(const DDSpecParRegistryRcd& iRecord)
 {  
   edm::ESHandle<DDDetector> det;
-  iRecord.getRecord<DetectorDescriptionRcd>().get(det);
+  iRecord.getRecord<DetectorDescriptionRcd>().get(m_label, det);
 
   DDSpecParRegistry* registry = det->description->extension<DDSpecParRegistry>();
   auto product = std::make_unique<DDSpecParRegistry>();

--- a/DetectorDescription/DDCMS/plugins/DDSpecParRegistryESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDSpecParRegistryESProducer.cc
@@ -46,13 +46,13 @@ public:
   ReturnType produce(const DDSpecParRegistryRcd&);
 
 private:
-  string m_label;
+  const string m_label;
 };
 
 DDSpecParRegistryESProducer::DDSpecParRegistryESProducer(const edm::ParameterSet& iConfig)
-  : m_label(iConfig.getParameter<std::string>("label"))
+  : m_label(iConfig.getParameter<std::string>("appendToDataLabel"))
 {
-  setWhatProduced(this, m_label);
+  setWhatProduced(this);
 }
 
 DDSpecParRegistryESProducer::~DDSpecParRegistryESProducer()
@@ -63,7 +63,6 @@ void
 DDSpecParRegistryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
 {
   edm::ParameterSetDescription desc;
-  desc.add<string>("label");
   descriptions.addDefault(desc);
 }
 
@@ -73,7 +72,7 @@ DDSpecParRegistryESProducer::produce(const DDSpecParRegistryRcd& iRecord)
   edm::ESHandle<DDDetector> det;
   iRecord.getRecord<DetectorDescriptionRcd>().get(m_label, det);
 
-  DDSpecParRegistry* registry = det->description->extension<DDSpecParRegistry>();
+  const DDSpecParRegistry* registry = det->description()->extension<DDSpecParRegistry>();
   auto product = std::make_unique<DDSpecParRegistry>();
   product->specpars.insert(registry->specpars.begin(), registry->specpars.end());
   return product;

--- a/DetectorDescription/DDCMS/plugins/DDTestDumpFile.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestDumpFile.cc
@@ -16,46 +16,48 @@
 
 using namespace std;
 using namespace cms;
+using namespace edm;
 using namespace dd4hep;
 
-class DDTestDumpFile : public edm::one::EDAnalyzer<> {
+class DDTestDumpFile : public one::EDAnalyzer<> {
 public:
-  explicit DDTestDumpFile( const edm::ParameterSet& );
+  explicit DDTestDumpFile(const ParameterSet&);
 
   void beginJob() override {}
-  void analyze( edm::Event const& iEvent, edm::EventSetup const& ) override;
+  void analyze(Event const& iEvent, EventSetup const&) override;
   void endJob() override {}
 
 private:
-  std::string m_tag;
-  std::string m_outputFileName;
+  string m_tag;
+  string m_outputFileName;
+  string m_label;
 };
 
-DDTestDumpFile::DDTestDumpFile(const edm::ParameterSet& iConfig)
-{
-  m_tag =  iConfig.getUntrackedParameter<std::string>( "tag", "unknown" );
-  m_outputFileName = iConfig.getUntrackedParameter<std::string>( "outputFileName", "cmsDD4HepGeom.root" );
-}
+DDTestDumpFile::DDTestDumpFile(const ParameterSet& iConfig)
+  : m_tag(iConfig.getUntrackedParameter<string>("tag", "unknown")),
+    m_outputFileName(iConfig.getUntrackedParameter<string>("outputFileName", "cmsDD4HepGeom.root")),
+    m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", ""))
+{}
 
 void
-DDTestDumpFile::analyze(const edm::Event&, const edm::EventSetup& iEventSetup)
+DDTestDumpFile::analyze(const Event&, const EventSetup& iEventSetup)
 {
-  std::cout << "DDTestDumpFile::analyze:\n";
-  edm::ESTransientHandle<DDDetector> det;
-  iEventSetup.get<DetectorDescriptionRcd>().get(det);
+  cout << "DDTestDumpFile::analyze: " << m_label << "\n";
+  ESTransientHandle<DDDetector> det;
+  iEventSetup.get<DetectorDescriptionRcd>().get(m_label, det);
 
   TGeoManager& geom = det->description->manager();
   
   int level = 1 + geom.GetTopVolume()->CountNodes( 100, 3 );
   
-  std::cout << "In the DDTestDumpFile::analyze method...obtained main geometry, level="
-  	    << level << std::endl;
+  cout << "In the DDTestDumpFile::analyze method...obtained main geometry, level="
+       << level << "\n";
 
-  TFile file( m_outputFileName.c_str(), "RECREATE" );
-  file.WriteTObject( &geom );
-  file.WriteTObject( new TNamed( "CMSSW_VERSION", gSystem->Getenv( "CMSSW_VERSION" )));
-  file.WriteTObject( new TNamed( "tag", m_tag.c_str()));
+  TFile file(m_outputFileName.c_str(), "RECREATE");
+  file.WriteTObject(&geom );
+  file.WriteTObject(new TNamed("CMSSW_VERSION", gSystem->Getenv("CMSSW_VERSION")));
+  file.WriteTObject(new TNamed("tag", m_tag.c_str()));
   file.Close();
 }
 
-DEFINE_FWK_MODULE( DDTestDumpFile );
+DEFINE_FWK_MODULE(DDTestDumpFile);

--- a/DetectorDescription/DDCMS/plugins/DDTestDumpFile.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestDumpFile.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
 #include "DD4hep/Detector.h"
@@ -28,30 +29,30 @@ public:
   void endJob() override {}
 
 private:
-  string m_tag;
-  string m_outputFileName;
-  string m_label;
+  const string m_tag;
+  const string m_outputFileName;
+  const ESInputTag m_label;
 };
 
 DDTestDumpFile::DDTestDumpFile(const ParameterSet& iConfig)
   : m_tag(iConfig.getUntrackedParameter<string>("tag", "unknown")),
     m_outputFileName(iConfig.getUntrackedParameter<string>("outputFileName", "cmsDD4HepGeom.root")),
-    m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", ""))
+    m_label(iConfig.getParameter<ESInputTag>("DDDetector"))
 {}
 
 void
 DDTestDumpFile::analyze(const Event&, const EventSetup& iEventSetup)
 {
-  cout << "DDTestDumpFile::analyze: " << m_label << "\n";
+  LogVerbatim("Geometry") << "DDTestDumpFile::analyze: " << m_label;
   ESTransientHandle<DDDetector> det;
-  iEventSetup.get<DetectorDescriptionRcd>().get(m_label, det);
+  iEventSetup.get<DetectorDescriptionRcd>().get(m_label.module(), det);
 
-  TGeoManager& geom = det->description->manager();
+  TGeoManager& geom = det->description()->manager();
   
   int level = 1 + geom.GetTopVolume()->CountNodes( 100, 3 );
   
-  cout << "In the DDTestDumpFile::analyze method...obtained main geometry, level="
-       << level << "\n";
+  LogVerbatim("Geometry") << "In the DDTestDumpFile::analyze method...obtained main geometry, level="
+       << level;
 
   TFile file(m_outputFileName.c_str(), "RECREATE");
   file.WriteTObject(&geom );

--- a/DetectorDescription/DDCMS/plugins/DDTestDumpGeometry.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestDumpGeometry.cc
@@ -16,25 +16,30 @@
 
 using namespace std;
 using namespace cms;
+using namespace edm;
 
-class DDTestDumpGeometry : public edm::one::EDAnalyzer<> {
+class DDTestDumpGeometry : public one::EDAnalyzer<> {
 public:
-  explicit DDTestDumpGeometry(const edm::ParameterSet&);
+  explicit DDTestDumpGeometry(const ParameterSet&);
 
   void beginJob() override {}
-  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void analyze(Event const& iEvent, EventSetup const&) override;
   void endJob() override {}
+
+private:  
+  string m_label;
 };
 
-DDTestDumpGeometry::DDTestDumpGeometry(const edm::ParameterSet& iConfig)
+DDTestDumpGeometry::DDTestDumpGeometry(const ParameterSet& iConfig)
+  : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", ""))
 {}
 
 void
-DDTestDumpGeometry::analyze(const edm::Event&, const edm::EventSetup& iEventSetup)
+DDTestDumpGeometry::analyze(const Event&, const EventSetup& iEventSetup)
 {
-  cout << "DDTestDumpGeometry::analyze:\n";
-  edm::ESTransientHandle<DDDetector> det;
-  iEventSetup.get<DetectorDescriptionRcd>().get(det);
+  cout << "DDTestDumpGeometry::analyze: " << m_label << "\n";
+  ESTransientHandle<DDDetector> det;
+  iEventSetup.get<DetectorDescriptionRcd>().get(m_label, det);
 
   TGeoManager& geom = det->description->manager();
 

--- a/DetectorDescription/DDCMS/plugins/DDTestDumpGeometry.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestDumpGeometry.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
 #include "DD4hep/Detector.h"
@@ -27,29 +28,29 @@ public:
   void endJob() override {}
 
 private:  
-  string m_label;
+  const ESInputTag m_tag;
 };
 
 DDTestDumpGeometry::DDTestDumpGeometry(const ParameterSet& iConfig)
-  : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", ""))
+  : m_tag(iConfig.getParameter<ESInputTag>("DDDetector"))
 {}
 
 void
 DDTestDumpGeometry::analyze(const Event&, const EventSetup& iEventSetup)
 {
-  cout << "DDTestDumpGeometry::analyze: " << m_label << "\n";
+  LogVerbatim("Geometry") << "DDTestDumpGeometry::analyze: " << m_tag;
   ESTransientHandle<DDDetector> det;
-  iEventSetup.get<DetectorDescriptionRcd>().get(m_label, det);
+  iEventSetup.get<DetectorDescriptionRcd>().get(m_tag.module(), det);
 
-  TGeoManager& geom = det->description->manager();
+  TGeoManager& geom = det->description()->manager();
 
   TGeoIterator next(geom.GetTopVolume());
   TGeoNode *node;
   TString path;
   while(( node = next())) {
     next.GetPath( path );
-    cout << path << ": "<< node->GetVolume()->GetName() << "\n";
+    LogVerbatim("Geometry") << path << ": "<< node->GetVolume()->GetName();
   }
 }
 
-DEFINE_FWK_MODULE( DDTestDumpGeometry );
+DEFINE_FWK_MODULE(DDTestDumpGeometry);

--- a/DetectorDescription/DDCMS/plugins/DDTestDumpGeometry.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestDumpGeometry.cc
@@ -42,7 +42,7 @@ DDTestDumpGeometry::analyze(const Event&, const EventSetup& iEventSetup)
   ESTransientHandle<DDDetector> det;
   iEventSetup.get<DetectorDescriptionRcd>().get(m_tag.module(), det);
 
-  TGeoManager& geom = det->description()->manager();
+  TGeoManager const& geom = det->description()->manager();
 
   TGeoIterator next(geom.GetTopVolume());
   TGeoNode *node;

--- a/DetectorDescription/DDCMS/plugins/DDTestMuonNumbering.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestMuonNumbering.cc
@@ -1,0 +1,37 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DetectorDescription/DDCMS/interface/MuonNumberingRcd.h"
+#include "DetectorDescription/DDCMS/interface/MuonNumbering.h"
+
+#include <iostream>
+
+using namespace std;
+using namespace cms;
+using namespace edm;
+
+class DDTestMuonNumbering : public one::EDAnalyzer<> {
+public:
+  explicit DDTestMuonNumbering(const ParameterSet&){}
+
+  void beginJob() override {}
+  void analyze(Event const& iEvent, EventSetup const&) override;
+  void endJob() override {}
+};
+
+void
+DDTestMuonNumbering::analyze(const Event&, const EventSetup& iEventSetup)
+{
+  cout << "DDTestMuonNumbering::analyze\n";
+  ESTransientHandle<MuonNumbering> numbering;
+  iEventSetup.get<MuonNumberingRcd>().get(numbering);
+
+  cout << "MuonNumbering size: " << numbering->values.size() << "\n";
+  for(const auto& i: numbering->values) {
+    cout << " " << i.first << " = " << i.second;
+    cout << '\n';
+  }
+}
+
+DEFINE_FWK_MODULE(DDTestMuonNumbering);

--- a/DetectorDescription/DDCMS/plugins/DDTestMuonNumbering.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestMuonNumbering.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DetectorDescription/DDCMS/interface/MuonNumberingRcd.h"
 #include "DetectorDescription/DDCMS/interface/MuonNumbering.h"
 
@@ -23,15 +24,17 @@ public:
 void
 DDTestMuonNumbering::analyze(const Event&, const EventSetup& iEventSetup)
 {
-  cout << "DDTestMuonNumbering::analyze\n";
+  LogVerbatim("Geometry") << "DDTestMuonNumbering::analyze";
   ESTransientHandle<MuonNumbering> numbering;
   iEventSetup.get<MuonNumberingRcd>().get(numbering);
 
-  cout << "MuonNumbering size: " << numbering->values.size() << "\n";
-  for(const auto& i: numbering->values) {
-    cout << " " << i.first << " = " << i.second;
-    cout << '\n';
-  }
+  LogVerbatim("Geometry") << "MuonNumbering size: " << numbering->values.size();
+  LogVerbatim("Geometry").log([&numbering](auto& log) {
+      for(const auto& i: numbering->values) {
+	log << " " << i.first << " = " << i.second;
+	log << '\n';
+      }
+    });
 }
 
 DEFINE_FWK_MODULE(DDTestMuonNumbering);

--- a/DetectorDescription/DDCMS/plugins/DDTestNavigateGeometry.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestNavigateGeometry.cc
@@ -16,6 +16,7 @@
 
 using namespace std;
 using namespace cms;
+using namespace edm;
 using namespace dd4hep;
 
 namespace {
@@ -52,37 +53,41 @@ namespace {
   };
 }
 
-class DDTestNavigateGeometry : public edm::one::EDAnalyzer<> {
+class DDTestNavigateGeometry : public one::EDAnalyzer<> {
 public:
-  explicit DDTestNavigateGeometry(const edm::ParameterSet&);
+  explicit DDTestNavigateGeometry(const ParameterSet&);
 
   void beginJob() override {}
-  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void analyze(Event const& iEvent, EventSetup const&) override;
   void endJob() override {}
+
+private:  
+  string m_label;
 };
 
-DDTestNavigateGeometry::DDTestNavigateGeometry(const edm::ParameterSet& iConfig)
+DDTestNavigateGeometry::DDTestNavigateGeometry(const ParameterSet& iConfig)
+  : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", ""))
 {}
 
 void
-DDTestNavigateGeometry::analyze(const edm::Event&, const edm::EventSetup& iEventSetup)
+DDTestNavigateGeometry::analyze(const Event&, const EventSetup& iEventSetup)
 {
-  cout << "DDTestNavigateGeometry::analyze:\n";
+  cout << "DDTestNavigateGeometry::analyze: " << m_label << "\n";
 
   const DDVectorRegistryRcd& regRecord = iEventSetup.get<DDVectorRegistryRcd>();
-  edm::ESTransientHandle<DDVectorRegistry> reg;
-  regRecord.get(reg);
+  ESTransientHandle<DDVectorRegistry> reg;
+  regRecord.get(m_label, reg);
 
-  for( const auto& p: reg->vectors ) {
-    std::cout << " " << p.first << " => ";
-    for( const auto& i : p.second )
-      std::cout << i << ", ";
-    std::cout << '\n';
+  for(const auto& p: reg->vectors) {
+    cout << " " << p.first << " => ";
+    for(const auto& i : p.second)
+      cout << i << ", ";
+    cout << '\n';
   }
   
   const DetectorDescriptionRcd& ddRecord = iEventSetup.get<DetectorDescriptionRcd>();
-  edm::ESTransientHandle<DDDetector> ddd;
-  ddRecord.get(ddd);
+  ESTransientHandle<DDDetector> ddd;
+  ddRecord.get(m_label, ddd);
     
   dd4hep::Detector& detector = *ddd->description;
 

--- a/DetectorDescription/DDCMS/plugins/DDTestSpecPars.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestSpecPars.cc
@@ -9,22 +9,27 @@
 
 using namespace std;
 using namespace cms;
+using namespace edm;
 
-class DDTestSpecPars : public edm::one::EDAnalyzer<> {
+class DDTestSpecPars : public one::EDAnalyzer<> {
 public:
-  explicit DDTestSpecPars(const edm::ParameterSet&) {}
+  explicit DDTestSpecPars(const ParameterSet& iConfig)
+    : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", "")) {}
 
   void beginJob() override {}
-  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void analyze(Event const& iEvent, EventSetup const&) override;
   void endJob() override {}
+
+private:  
+  string m_label;
 };
 
 void
-DDTestSpecPars::analyze(const edm::Event&, const edm::EventSetup& iEventSetup)
+DDTestSpecPars::analyze(const Event&, const EventSetup& iEventSetup)
 {
-  cout << "DDTestSpecPars::analyze:\n";
-  edm::ESTransientHandle<DDSpecParRegistry> registry;
-  iEventSetup.get<DDSpecParRegistryRcd>().get(registry);
+  cout << "DDTestSpecPars::analyze: " << m_label << "\n";
+  ESTransientHandle<DDSpecParRegistry> registry;
+  iEventSetup.get<DDSpecParRegistryRcd>().get(m_label, registry);
 
   cout << "DD SpecPar Registry size: " << registry->specpars.size() << "\n";
   for(const auto& i: registry->specpars) {

--- a/DetectorDescription/DDCMS/plugins/DDTestSpecParsFilter.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestSpecParsFilter.cc
@@ -1,0 +1,76 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DetectorDescription/DDCMS/interface/DDSpecParRegistryRcd.h"
+#include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
+
+#include <iostream>
+
+using namespace std;
+using namespace cms;
+using namespace edm;
+
+class DDTestSpecParsFilter : public one::EDAnalyzer<> {
+public:
+  explicit DDTestSpecParsFilter(const ParameterSet& iConfig)
+    : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")),
+      m_attribute(iConfig.getUntrackedParameter<string>("attribute", "")),
+      m_value(iConfig.getUntrackedParameter<string>("value", ""))
+  {}
+
+  void beginJob() override {}
+  void analyze(Event const& iEvent, EventSetup const&) override;
+  void endJob() override {}
+
+private:  
+  const ESInputTag m_tag;
+  const string m_attribute;
+  const string m_value;
+};
+
+void
+DDTestSpecParsFilter::analyze(const Event&, const EventSetup& iEventSetup)
+{
+  LogVerbatim("Geometry") << "DDTestSpecParsFilter::analyze: " << m_tag;
+  ESTransientHandle<DDSpecParRegistry> registry;
+  iEventSetup.get<DDSpecParRegistryRcd>().get(m_tag.module(), registry);
+
+  LogVerbatim("Geometry") << "DDTestSpecParsFilter::analyze: " << m_tag.module() << " for attribute " << m_attribute << " and value " << m_value;
+  LogVerbatim("Geometry") << "DD SpecPar Registry size: " << registry->specpars.size();
+
+  DDSpecParRegistry myReg;
+  bool found(false);
+  for(const auto& i: registry->specpars) {
+    found = false;
+    for(const auto& l : i.second.spars) {
+      if(l.first == m_attribute) {
+	for(const auto& il : l.second) {
+	  if(il == m_value) {
+	    found = true;
+	  }
+	}
+      }
+    }
+    if(found) {
+      myReg.specpars.emplace(i);
+    }
+  }
+  LogVerbatim("Geometry").log([&myReg](auto& log) {
+      log << "Filtered DD SpecPar Registry size: " << myReg.specpars.size();
+      for(const auto& t: myReg.specpars) {
+	log << " " << t.first << " => ";
+	for(const auto& ki : t.second.paths)
+	  log << ki << ", ";
+	for(const auto& kl : t.second.spars) {
+	  log << kl.first << " => ";
+	  for(const auto& kil : kl.second) {
+	    log << kil << ", ";
+	  }
+	}
+      }
+    });
+}
+
+DEFINE_FWK_MODULE(DDTestSpecParsFilter);

--- a/DetectorDescription/DDCMS/plugins/DDTestVectors.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestVectors.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DetectorDescription/DDCMS/interface/DDVectorRegistryRcd.h"
 #include "DetectorDescription/DDCMS/interface/DDVectorRegistry.h"
 
@@ -14,7 +15,7 @@ using namespace edm;
 class DDTestVectors : public one::EDAnalyzer<> {
 public:
   explicit DDTestVectors(const ParameterSet& iConfig)
-    : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", ""))
+    : m_tag(iConfig.getParameter<ESInputTag>("DDDetector"))
   {}
 
   void beginJob() override {}
@@ -22,23 +23,24 @@ public:
   void endJob() override {}
 
 private:  
-  string m_label;
+  const ESInputTag m_tag;
 };
 
 void
 DDTestVectors::analyze( const Event&, const EventSetup& iEventSetup)
 {
-  cout << "DDTestVectors::analyze: " << m_label << "\n";
+  LogVerbatim("Geometry") << "DDTestVectors::analyze: " << m_tag;
   ESTransientHandle<DDVectorRegistry> registry;
-  iEventSetup.get<DDVectorRegistryRcd>().get(m_label, registry);
+  iEventSetup.get<DDVectorRegistryRcd>().get(m_tag.module(), registry);
 
-  cout << "DD Vector Registry size: " << registry->vectors.size() << "\n";
-  for(const auto& p: registry->vectors) {
-    cout << " " << p.first << " => ";
-    for(const auto& i : p.second)
-      cout << i << ", ";
-    cout << '\n';
-  }
+  LogVerbatim("Geometry").log([&registry](auto& log) {
+      log << "DD Vector Registry size: " << registry->vectors.size();
+      for(const auto& p: registry->vectors) {
+	log << " " << p.first << " => ";
+	for(const auto& i : p.second)
+	  log << i << ", ";
+      }
+    });
 }
 
 DEFINE_FWK_MODULE(DDTestVectors);

--- a/DetectorDescription/DDCMS/plugins/DDTestVectors.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestVectors.cc
@@ -9,29 +9,35 @@
 
 using namespace std;
 using namespace cms;
+using namespace edm;
 
-class DDTestVectors : public edm::one::EDAnalyzer<> {
+class DDTestVectors : public one::EDAnalyzer<> {
 public:
-  explicit DDTestVectors(const edm::ParameterSet& ) {}
+  explicit DDTestVectors(const ParameterSet& iConfig)
+    : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", ""))
+  {}
 
   void beginJob() override {}
-  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void analyze(Event const& iEvent, EventSetup const&) override;
   void endJob() override {}
+
+private:  
+  string m_label;
 };
 
 void
-DDTestVectors::analyze( const edm::Event&, const edm::EventSetup& iEventSetup)
+DDTestVectors::analyze( const Event&, const EventSetup& iEventSetup)
 {
-  std::cout << "DDTestVectors::analyze:\n";
-  edm::ESTransientHandle<DDVectorRegistry> registry;
-  iEventSetup.get<DDVectorRegistryRcd>().get(registry);
+  cout << "DDTestVectors::analyze: " << m_label << "\n";
+  ESTransientHandle<DDVectorRegistry> registry;
+  iEventSetup.get<DDVectorRegistryRcd>().get(m_label, registry);
 
-  std::cout << "DD Vector Registry size: " << registry->vectors.size() << "\n";
-  for( const auto& p: registry->vectors ) {
-    std::cout << " " << p.first << " => ";
-    for( const auto& i : p.second )
-      std::cout << i << ", ";
-    std::cout << '\n';
+  cout << "DD Vector Registry size: " << registry->vectors.size() << "\n";
+  for(const auto& p: registry->vectors) {
+    cout << " " << p.first << " => ";
+    for(const auto& i : p.second)
+      cout << i << ", ";
+    cout << '\n';
   }
 }
 

--- a/DetectorDescription/DDCMS/plugins/DDVectorRegistryESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDVectorRegistryESProducer.cc
@@ -44,11 +44,16 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
   
   ReturnType produce(const DDVectorRegistryRcd&);
+  
+private:
+  string m_label;
 };
 
-DDVectorRegistryESProducer::DDVectorRegistryESProducer(const edm::ParameterSet&)
+DDVectorRegistryESProducer::DDVectorRegistryESProducer(const edm::ParameterSet& iConfig)
+   : m_label(iConfig.getParameter<std::string>("label"))
 {
-  setWhatProduced(this);
+  setWhatProduced(this, m_label);
+  isUsingRecord(edm::eventsetup::EventSetupRecordKey::makeKey<DetectorDescriptionRcd>());
 }
 
 DDVectorRegistryESProducer::~DDVectorRegistryESProducer()
@@ -59,14 +64,16 @@ void
 DDVectorRegistryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
 {
   edm::ParameterSetDescription desc;
+  desc.add<string>("label");
   descriptions.addDefault(desc);
 }
 
 DDVectorRegistryESProducer::ReturnType
 DDVectorRegistryESProducer::produce(const DDVectorRegistryRcd& iRecord)
-{  
+{
+  cout << "DDVectorRegistryESProducer::produce\n";
   edm::ESHandle<DDDetector> det;
-  iRecord.getRecord<DetectorDescriptionRcd>().get(det);
+  iRecord.getRecord<DetectorDescriptionRcd>().get(m_label, det);
 
   DDVectorsMap* registry = det->description->extension<DDVectorsMap>();
 

--- a/DetectorDescription/DDCMS/plugins/DDVectorRegistryESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDVectorRegistryESProducer.cc
@@ -50,7 +50,7 @@ private:
 };
 
 DDVectorRegistryESProducer::DDVectorRegistryESProducer(const edm::ParameterSet& iConfig)
-   : m_label(iConfig.getParameter<std::string>("label"))
+  : m_label(iConfig.getParameter<std::string>("label"))
 {
   setWhatProduced(this, m_label);
   isUsingRecord(edm::eventsetup::EventSetupRecordKey::makeKey<DetectorDescriptionRcd>());

--- a/DetectorDescription/DDCMS/plugins/MuonNumberingESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/MuonNumberingESProducer.cc
@@ -66,11 +66,13 @@ MuonNumberingESProducer::produce(const MuonNumberingRcd& iRecord)
   ESHandle<DDSpecParRegistry> registry;
   iRecord.getRecord<DDSpecParRegistryRcd>().get(m_label, registry);
   auto it = registry->specpars.find(m_key);
-  for(const auto& l : it->second.spars) {
-    if(l.first == "OnlyForMuonNumbering") {
-      for(const auto& k : it->second.numpars) {
-	for(const auto& ik : k.second) {
-	  product->values.emplace(k.first, (int)ik); 
+  if(it != end(registry->specpars)) {
+    for(const auto& l : it->second.spars) {
+      if(l.first == "OnlyForMuonNumbering") {
+	for(const auto& k : it->second.numpars) {
+	  for(const auto& ik : k.second) {
+	    product->values.emplace(k.first, static_cast<int>(ik)); 
+	  }
 	}
       }
     }

--- a/DetectorDescription/DDCMS/plugins/MuonNumberingESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/MuonNumberingESProducer.cc
@@ -34,7 +34,7 @@ using namespace edm;
 class MuonNumberingESProducer : public ESProducer {
 public:
   MuonNumberingESProducer(const ParameterSet&);
-  ~MuonNumberingESProducer();
+  ~MuonNumberingESProducer() override;
   
   using ReturnType = unique_ptr<MuonNumbering>;
   

--- a/DetectorDescription/DDCMS/plugins/MuonNumberingESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/MuonNumberingESProducer.cc
@@ -1,0 +1,80 @@
+// -*- C++ -*-
+//
+// Package:    DetectorDescription/MuonNumberingESProducer
+// Class:      MuonNumberingESProducer
+// 
+/**\class MuonNumberingESProducer
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Ianna Osborne
+//         Created:  Tue, 15 Jan 2019 09:10:32 GMT
+//
+//
+
+#include <memory>
+#include <iostream>
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DetectorDescription/DDCMS/interface/MuonNumberingRcd.h"
+#include "DetectorDescription/DDCMS/interface/MuonNumbering.h"
+#include "DetectorDescription/DDCMS/interface/DDSpecParRegistryRcd.h"
+#include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
+
+using namespace std;
+using namespace cms;
+using namespace edm;
+
+class MuonNumberingESProducer : public ESProducer {
+public:
+  MuonNumberingESProducer(const ParameterSet&);
+  ~MuonNumberingESProducer();
+  
+  using ReturnType = unique_ptr<MuonNumbering>;
+  
+  ReturnType produce(const MuonNumberingRcd&);
+
+private:
+  string m_label;
+  string m_key;
+};
+
+MuonNumberingESProducer::MuonNumberingESProducer(const ParameterSet& iConfig)
+  : m_label(iConfig.getParameter<std::string>("label")),
+    m_key(iConfig.getParameter<std::string>("key"))
+
+{
+  setWhatProduced(this);
+}
+
+MuonNumberingESProducer::~MuonNumberingESProducer()
+{}
+
+MuonNumberingESProducer::ReturnType
+MuonNumberingESProducer::produce(const MuonNumberingRcd& iRecord)
+{
+  cout << "MuonNumberingESProducer::produce from " << m_label << " with " << m_key << "\n";
+  auto product = make_unique<MuonNumbering>();
+
+  ESHandle<DDSpecParRegistry> registry;
+  iRecord.getRecord<DDSpecParRegistryRcd>().get(m_label, registry);
+  auto it = registry->specpars.find(m_key);
+  for(const auto& l : it->second.spars) {
+    if(l.first == "OnlyForMuonNumbering") {
+      for(const auto& k : it->second.numpars) {
+	for(const auto& ik : k.second) {
+	  product->values.emplace(k.first, (int)ik); 
+	}
+      }
+    }
+  }
+  return product;
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(MuonNumberingESProducer);

--- a/DetectorDescription/DDCMS/plugins/MuonNumberingESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/MuonNumberingESProducer.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DetectorDescription/DDCMS/interface/MuonNumberingRcd.h"
 #include "DetectorDescription/DDCMS/interface/MuonNumbering.h"
 #include "DetectorDescription/DDCMS/interface/DDSpecParRegistryRcd.h"
@@ -41,8 +42,8 @@ public:
   ReturnType produce(const MuonNumberingRcd&);
 
 private:
-  string m_label;
-  string m_key;
+  const string m_label;
+  const string m_key;
 };
 
 MuonNumberingESProducer::MuonNumberingESProducer(const ParameterSet& iConfig)
@@ -59,7 +60,7 @@ MuonNumberingESProducer::~MuonNumberingESProducer()
 MuonNumberingESProducer::ReturnType
 MuonNumberingESProducer::produce(const MuonNumberingRcd& iRecord)
 {
-  cout << "MuonNumberingESProducer::produce from " << m_label << " with " << m_key << "\n";
+  LogDebug("Geometry") << "MuonNumberingESProducer::produce from " << m_label << " with " << m_key;
   auto product = make_unique<MuonNumbering>();
 
   ESHandle<DDSpecParRegistry> registry;

--- a/DetectorDescription/DDCMS/src/DDDetector.cc
+++ b/DetectorDescription/DDCMS/src/DDDetector.cc
@@ -1,0 +1,30 @@
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "DD4hep/Detector.h"
+
+#include <iostream>
+ 
+using namespace cms;
+using namespace std;
+
+DDDetector::DDDetector(const string& tag, const string& fileName)
+  : m_tag(tag)
+{
+  m_description = &dd4hep::Detector::getInstance(tag);
+  m_description->addExtension<DDVectorsMap>(&m_vectors);
+  m_description->addExtension<DDPartSelectionMap>(&m_partsels);
+  m_description->addExtension<DDSpecParRegistry>(&m_specpars);
+  process(fileName);
+}
+
+DDDetector::~DDDetector()
+{
+  Detector::destroyInstance(m_tag);
+}
+
+void
+DDDetector::process(const string& fileName)
+{
+  std::string name("DD4hep_CompactLoader");
+  const char* files[] = { fileName.c_str(), nullptr };
+  m_description->apply( name.c_str(), 2, (char**)files );
+}

--- a/DetectorDescription/DDCMS/src/ES_DDDetector.cc
+++ b/DetectorDescription/DDCMS/src/ES_DDDetector.cc
@@ -5,6 +5,8 @@
 #include "DetectorDescription/DDCMS/interface/DDVectorRegistry.h"
 #include "DetectorDescription/DDCMS/interface/DDVectorRegistryRcd.h"
 #include "DetectorDescription/DDCMS/interface/DetectorDescriptionRcd.h"
+#include "DetectorDescription/DDCMS/interface/MuonNumbering.h"
+#include "DetectorDescription/DDCMS/interface/MuonNumberingRcd.h"
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 #include "FWCore/Framework/interface/data_default_record_trait.h"
 
@@ -13,8 +15,10 @@ using namespace cms;
 TYPELOOKUP_DATA_REG(DDDetector);
 TYPELOOKUP_DATA_REG(DDSpecParRegistry);
 TYPELOOKUP_DATA_REG(DDVectorRegistry);
+TYPELOOKUP_DATA_REG(MuonNumbering);
 
 EVENTSETUP_RECORD_REG(DetectorDescriptionRcd);
 EVENTSETUP_DATA_DEFAULT_RECORD(DDDetector, DetectorDescriptionRcd);
 EVENTSETUP_RECORD_REG(DDSpecParRegistryRcd);
 EVENTSETUP_RECORD_REG(DDVectorRegistryRcd);
+EVENTSETUP_RECORD_REG(MuonNumberingRcd);

--- a/DetectorDescription/DDCMS/test/python/dump.py
+++ b/DetectorDescription/DDCMS/test/python/dump.py
@@ -8,33 +8,23 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-tracker.xml')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-tracker.xml'),
+                                            label = cms.string('CMS')
                                             )
-process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer")
+
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    label = cms.string('CMS'))
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              geomXMLFiles = cms.vstring('Geometry/CMSCommonData/data/materials.xml',
-                                                         'Geometry/CMSCommonData/data/rotations.xml',
-                                                         'Geometry/TrackerCommonData/data/pixbarmaterial.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarladder.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarladderfull.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarladderhalf.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarlayer.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarlayer0.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarlayer1.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarlayer2.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbar.xml', 
-                                                         'Geometry/TrackerCommonData/data/trackerpixbar.xml', 
-                                                         'Geometry/TrackerCommonData/data/tracker.xml',
-                                                         'Geometry/TrackerCommonData/data/trackermaterial.xml',
-                                                         'Geometry/TrackerCommonData/data/pixfwdMaterials.xml',
-                                                         'Geometry/CMSCommonData/data/cmsMother.xml',
-                                                         'Geometry/CMSCommonData/data/normal/cmsextent.xml', 
-                                                         'Geometry/CMSCommonData/data/cms.xml'),
-                              confGeomXMLFiles = cms.string('DetectorDescription/DDCMS/data/cms-tracker.xml')
+                              fromDataLabel = cms.untracked.string('CMS')
                               )
 
-process.testVectors = cms.EDAnalyzer("DDTestVectors")
-process.testDump = cms.EDAnalyzer("DDTestDumpFile")
+process.testVectors = cms.EDAnalyzer("DDTestVectors",
+                                     fromDataLabel = cms.untracked.string('CMS')
+                                     )
+
+process.testDump = cms.EDAnalyzer("DDTestDumpFile",
+                                  fromDataLabel = cms.untracked.string('CMS')
+                                  )
 
 process.p = cms.Path(process.test+process.testVectors+process.testDump)

--- a/DetectorDescription/DDCMS/test/python/dump.py
+++ b/DetectorDescription/DDCMS/test/python/dump.py
@@ -9,22 +9,23 @@ process.maxEvents = cms.untracked.PSet(
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-tracker.xml'),
-                                            label = cms.string('CMS')
+                                            appendToDataLabel = cms.string('CMS')
                                             )
 
 process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
-                                                    label = cms.string('CMS'))
+                                                    appendToDataLabel = cms.string('CMS')
+                                                    )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              fromDataLabel = cms.untracked.string('CMS')
+                              DDDetector = cms.ESInputTag('CMS')
                               )
 
 process.testVectors = cms.EDAnalyzer("DDTestVectors",
-                                     fromDataLabel = cms.untracked.string('CMS')
+                                     DDDetector = cms.ESInputTag('CMS')
                                      )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  fromDataLabel = cms.untracked.string('CMS')
+                                  DDDetector = cms.ESInputTag('CMS')
                                   )
 
 process.p = cms.Path(process.test+process.testVectors+process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testDDAngularAlgorithm.py
+++ b/DetectorDescription/DDCMS/test/python/testDDAngularAlgorithm.py
@@ -9,11 +9,11 @@ process.maxEvents = cms.untracked.PSet(
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-test-ddangular-algorithm.xml'),
-                                            label = cms.string('TestAngular')
+                                            appendToDataLabel = cms.string('TestAngular')
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  fromDataLabel = cms.untracked.string('TestAngular')
+                                  DDDetector = cms.ESInputTag('TestAngular')
                                   )
 
 process.p = cms.Path(process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testDDAngularAlgorithm.py
+++ b/DetectorDescription/DDCMS/test/python/testDDAngularAlgorithm.py
@@ -8,9 +8,12 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-test-ddangular-algorithm.xml')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-test-ddangular-algorithm.xml'),
+                                            label = cms.string('TestAngular')
                                             )
 
-process.testDump = cms.EDAnalyzer("DDTestDumpFile")
+process.testDump = cms.EDAnalyzer("DDTestDumpFile",
+                                  fromDataLabel = cms.untracked.string('TestAngular')
+                                  )
 
 process.p = cms.Path(process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
+++ b/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
@@ -7,17 +7,48 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    statistics = cms.untracked.vstring('cout', 'geometry'),
+    categories = cms.untracked.vstring('Geometry'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING'),
+        noLineBreaks = cms.untracked.bool(True)
+        ),
+    geometry = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        noLineBreaks = cms.untracked.bool(True),
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        WARNING = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        ERROR = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        threshold = cms.untracked.string('INFO'),
+        Geometry = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            )
+        ),
+    destinations = cms.untracked.vstring('cout',
+                                         'geometry')
+    )
+
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
-                                            label = cms.string('MUON')
+                                            appendToDataLabel = cms.string('MUON')
                                             )
 
 process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
-                                                    label = cms.string('MUON')
+                                                    appendToDataLabel = cms.string('MUON')
                                                     )
 
 process.test = cms.EDAnalyzer("DDTestNavigateGeometry",
-                              fromDataLabel = cms.untracked.string('MUON')
+                              DDDetector = cms.ESInputTag('MUON')
                               )
 
 process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
+++ b/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
@@ -8,11 +8,16 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
+                                            label = cms.string('MUON')
                                             )
 
-process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer")
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    label = cms.string('MUON')
+                                                    )
 
-process.test = cms.EDAnalyzer("DDTestNavigateGeometry")
+process.test = cms.EDAnalyzer("DDTestNavigateGeometry",
+                              fromDataLabel = cms.untracked.string('MUON')
+                              )
 
 process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testDDSpecPars.py
+++ b/DetectorDescription/DDCMS/test/python/testDDSpecPars.py
@@ -8,11 +8,16 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
+                                            label = cms.string('MUON')
                                             )
 
-process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer")
+process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
+                                                     label = cms.string('MUON')
+                                                     )
 
-process.test = cms.EDAnalyzer("DDTestSpecPars")
+process.test = cms.EDAnalyzer("DDTestSpecPars",
+                              fromDataLabel = cms.untracked.string('MUON')
+                              )
 
 process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testDDSpecParsFilter.py
+++ b/DetectorDescription/DDCMS/test/python/testDDSpecParsFilter.py
@@ -16,8 +16,10 @@ process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProduce
                                                      appendToDataLabel = cms.string('MUON')
                                                      )
 
-process.test = cms.EDAnalyzer("DDTestSpecPars",
-                              DDDetector = cms.ESInputTag('MUON')
+process.test = cms.EDAnalyzer("DDTestSpecParsFilter",
+                              DDDetector = cms.ESInputTag('MUON'),
+                              attribute = cms.untracked.string('MuStructure'),
+                              value = cms.untracked.string('MuonBarrelDT')
                               )
 
 process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testDDVectors.py
+++ b/DetectorDescription/DDCMS/test/python/testDDVectors.py
@@ -8,11 +8,15 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            label = cms.string('CMS'),
                                             confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml')
                                             )
 
-process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer")
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    label = cms.string('CMS'))
 
-process.test = cms.EDAnalyzer("DDTestVectors")
+process.test = cms.EDAnalyzer("DDTestVectors",
+                              fromDataLabel = cms.untracked.string('CMS')
+                              )
 
 process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testDDVectors.py
+++ b/DetectorDescription/DDCMS/test/python/testDDVectors.py
@@ -8,15 +8,15 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            label = cms.string('CMS'),
+                                            appendToDataLabel = cms.string('CMS'),
                                             confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml')
                                             )
 
 process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
-                                                    label = cms.string('CMS'))
+                                                    appendToDataLabel = cms.string('CMS'))
 
 process.test = cms.EDAnalyzer("DDTestVectors",
-                              fromDataLabel = cms.untracked.string('CMS')
+                              DDDetector = cms.ESInputTag('CMS')
                               )
 
 process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testMFGeometry.py
+++ b/DetectorDescription/DDCMS/test/python/testMFGeometry.py
@@ -9,11 +9,11 @@ process.maxEvents = cms.untracked.PSet(
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-mf-geometry.xml'),
-                                            label = cms.string('MagneticField')
+                                            appendToDataLabel = cms.string('MagneticField')
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  fromDataLabel = cms.untracked.string('MagneticField')
+                                  DDDetector = cms.ESInputTag('MagneticField')
                                   )
 
 process.p = cms.Path(process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testMFGeometry.py
+++ b/DetectorDescription/DDCMS/test/python/testMFGeometry.py
@@ -8,9 +8,12 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-mf-geometry.xml')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-mf-geometry.xml'),
+                                            label = cms.string('MagneticField')
                                             )
 
-process.testDump = cms.EDAnalyzer("DDTestDumpFile")
+process.testDump = cms.EDAnalyzer("DDTestDumpFile",
+                                  fromDataLabel = cms.untracked.string('MagneticField')
+                                  )
 
 process.p = cms.Path(process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testMuonGeometry.py
+++ b/DetectorDescription/DDCMS/test/python/testMuonGeometry.py
@@ -8,29 +8,39 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
+                                            label = cms.string('CMS')
                                             )
-##process.DDDetectorESProducer2 = cms.ESSource("DDDetectorESProducer",
-##                                            confGeomXMLFiles = cms.string('DetectorDescription/DDCMS/data/cms-mf-geometry.xml')
-##                                            )
+process.DDDetectorESProducer2 = cms.ESSource("DDDetectorESProducer",
+                                             confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-mf-geometry.xml'),
+                                             label = cms.string('MagneticField')
+                                             )
+process.DDDetectorESProducer3 = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
+                                            label = cms.string('')
+                                            )
 
-process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer")
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    label = cms.string('CMS'))
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              geomXMLFiles = cms.vstring('Geometry/CMSCommonData/data/normal/cmsextent.xml', 
-                                                         'Geometry/CMSCommonData/data/cms.xml', 
-                                                         'DetectorDescription/DDCMS/data/cmsMagneticField.xml', 
-                                                         'MagneticField/GeomBuilder/data/MagneticFieldVolumes_160812_1.xml',
-                                                         'MagneticField/GeomBuilder/data/MagneticFieldVolumes_160812_2.xml',
-                                                         'Geometry/CMSCommonData/data/materials.xml'),
-                              confGeomXMLFiles = cms.string('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml')
+                              fromDataLabel = cms.untracked.string('CMS')
+                              )
+process.DDVectorRegistryESProducer2 = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    label = cms.string('MagneticField'))
+process.test2 = cms.EDAnalyzer("DDCMSDetector",
+                              fromDataLabel = cms.untracked.string('MagneticField')
                               )
 
-##process.testVectors = cms.EDAnalyzer("DDTestVectors")
+process.testVectors = cms.EDAnalyzer("DDTestVectors",
+                                     fromDataLabel = cms.untracked.string('CMS')
+                                     )
 process.testDump = cms.EDAnalyzer("DDTestDumpFile")
 process.testGeoIter = cms.EDAnalyzer("DDTestDumpGeometry")
 
 process.p = cms.Path(
     process.test
-    ##+process.testVectors+process.testDump
+    +process.test2
+    +process.testVectors
+    ##+process.testDump
     +process.testGeoIter)

--- a/DetectorDescription/DDCMS/test/python/testMuonGeometry.py
+++ b/DetectorDescription/DDCMS/test/python/testMuonGeometry.py
@@ -9,34 +9,41 @@ process.maxEvents = cms.untracked.PSet(
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
-                                            label = cms.string('CMS')
+                                            appendToDataLabel = cms.string('CMS')
                                             )
 process.DDDetectorESProducer2 = cms.ESSource("DDDetectorESProducer",
                                              confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-mf-geometry.xml'),
-                                             label = cms.string('MagneticField')
+                                             appendToDataLabel = cms.string('MagneticField')
                                              )
 process.DDDetectorESProducer3 = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
-                                            label = cms.string('')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml')
                                             )
 
 process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
-                                                    label = cms.string('CMS'))
+                                                    appendToDataLabel = cms.string('CMS')
+                                                    )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              fromDataLabel = cms.untracked.string('CMS')
-                              )
-process.DDVectorRegistryESProducer2 = cms.ESProducer("DDVectorRegistryESProducer",
-                                                    label = cms.string('MagneticField'))
-process.test2 = cms.EDAnalyzer("DDCMSDetector",
-                              fromDataLabel = cms.untracked.string('MagneticField')
+                              DDDetector = cms.ESInputTag('CMS')
                               )
 
+process.DDVectorRegistryESProducer2 = cms.ESProducer("DDVectorRegistryESProducer",
+                                                     appendToDataLabel = cms.string('MagneticField')
+                                                     )
+
+process.test2 = cms.EDAnalyzer("DDCMSDetector",
+                               DDDetector = cms.ESInputTag('MagneticField')
+                               )
+
 process.testVectors = cms.EDAnalyzer("DDTestVectors",
-                                     fromDataLabel = cms.untracked.string('CMS')
+                                     DDDetector = cms.ESInputTag('CMS')
                                      )
+
 process.testDump = cms.EDAnalyzer("DDTestDumpFile")
-process.testGeoIter = cms.EDAnalyzer("DDTestDumpGeometry")
+
+process.testGeoIter = cms.EDAnalyzer("DDTestDumpGeometry",
+                                     DDDetector = cms.ESInputTag('CMS')
+                                     )
 
 process.p = cms.Path(
     process.test

--- a/DetectorDescription/DDCMS/test/python/testMuonNumbering.py
+++ b/DetectorDescription/DDCMS/test/python/testMuonNumbering.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MuonNumberingTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
+                                            label = cms.string('MUON')
+                                            )
+
+process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
+                                                     label = cms.string('MUON')
+                                                     )
+
+process.MuonNumberingESProducer = cms.ESProducer("MuonNumberingESProducer",
+                                                 label = cms.string('MUON'),
+                                                 key = cms.string('MuonCommonNumbering')
+                                                 )
+
+process.test = cms.EDAnalyzer("DDTestMuonNumbering")
+
+process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testShapes.py
+++ b/DetectorDescription/DDCMS/test/python/testShapes.py
@@ -9,23 +9,23 @@ process.maxEvents = cms.untracked.PSet(
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-test-shapes.xml'),
-                                            label = cms.string('TestShapes')
+                                            appendToDataLabel = cms.string('TestShapes')
                                             )
 
 process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
-                                                    label = cms.string('TestShapes')
+                                                    appendToDataLabel = cms.string('TestShapes')
                                                     )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              fromDataLabel = cms.untracked.string('TestShapes')
+                              DDDetector = cms.ESInputTag('TestShapes')
                               )
 
 process.testVectors = cms.EDAnalyzer("DDTestVectors",
-                                     fromDataLabel = cms.untracked.string('TestShapes')
+                                     DDDetector = cms.ESInputTag('TestShapes')
                                      )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  fromDataLabel = cms.untracked.string('TestShapes')
+                                  DDDetector = cms.ESInputTag('TestShapes')
                                   )
 
 process.p = cms.Path(process.test+process.testVectors+process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testShapes.py
+++ b/DetectorDescription/DDCMS/test/python/testShapes.py
@@ -8,34 +8,24 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-test-shapes.xml')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-test-shapes.xml'),
+                                            label = cms.string('TestShapes')
                                             )
 
-process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer")
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    label = cms.string('TestShapes')
+                                                    )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              geomXMLFiles = cms.vstring('Geometry/CMSCommonData/data/materials.xml',
-                                                         'Geometry/CMSCommonData/data/rotations.xml',
-                                                         'Geometry/TrackerCommonData/data/pixbarmaterial.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarladder.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarladderfull.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarladderhalf.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarlayer.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarlayer0.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarlayer1.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbarlayer2.xml', 
-                                                         'Geometry/TrackerCommonData/data/pixbar.xml', 
-                                                         'Geometry/TrackerCommonData/data/trackerpixbar.xml', 
-                                                         'Geometry/TrackerCommonData/data/tracker.xml',
-                                                         'Geometry/TrackerCommonData/data/trackermaterial.xml',
-                                                         'Geometry/TrackerCommonData/data/pixfwdMaterials.xml',
-                                                         'Geometry/CMSCommonData/data/cmsMother.xml',
-                                                         'Geometry/CMSCommonData/data/normal/cmsextent.xml', 
-                                                         'Geometry/CMSCommonData/data/cms.xml'),
-                              confGeomXMLFiles = cms.string('DetectorDescription/DDCMS/data/cms-test-shapes.xml')
+                              fromDataLabel = cms.untracked.string('TestShapes')
                               )
 
-process.testVectors = cms.EDAnalyzer("DDTestVectors")
-process.testDump = cms.EDAnalyzer("DDTestDumpFile")
+process.testVectors = cms.EDAnalyzer("DDTestVectors",
+                                     fromDataLabel = cms.untracked.string('TestShapes')
+                                     )
+
+process.testDump = cms.EDAnalyzer("DDTestDumpFile",
+                                  fromDataLabel = cms.untracked.string('TestShapes')
+                                  )
 
 process.p = cms.Path(process.test+process.testVectors+process.testDump)


### PR DESCRIPTION
* MuonNumbering record will replace MuonDDDConstants
* The MuonNumberingRcd producer consumes a labeled DDSpecParRegistry
* Add test and its configuration:
```
cmsRun DetectorDescription/DDCMS/test/python/testMuonNumbering.py
``` 
