### PR TITLE
Delete an unused class rule

### DIFF
--- a/DataFormats/Math/src/classes_def.xml
+++ b/DataFormats/Math/src/classes_def.xml
@@ -2,9 +2,6 @@
 <selection>
   <class pattern="ROOT::Math::SMatrix<*>" />
   <class pattern="ROOT::Math::MatRepStd<*>" />
-  <class pattern="ROOT::Math::MatRepSym<*>" >
-    <field name="fOff" transient="true"/>
-  </class>
   <class pattern="ROOT::Math::RowOffsets<*>" />
   <class pattern="ROOT::Math::SVector<*>" />
   <class pattern="std::vector<ROOT::Math::*>" />


### PR DESCRIPTION
ROOT::Math::MatRepSym<*> was defined, but was never used in selection
files.