### PR TITLE
Adding IO rules to set PF cluster isolation in Ele/Phos

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -59,6 +59,9 @@
   <ioread sourceClass="pat::Electron"  targetClass="pat::Electron" version="[-28]" target="cachedIP_" source="std::vector<bool> cachedIP_" embed="false">
     <![CDATA[ cachedIP_ = onfile.cachedIP_[1] + 2*onfile.cachedIP_[2] + 4*onfile.cachedIP_[3] + 8*onfile.cachedIP_[4]; ]]>
   </ioread>
+  <ioread sourceClass="pat::Electron"  targetClass="pat::Electron" version="[-37]" target="" source="float ecalPFClusIso_;float hcalPFClusIso_">
+    <![CDATA[reco::GsfElectron::PflowIsolationVariables pfIsoVar = newObj->pfIsolationVariables();pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;newObj->setPfIsolationVariables(pfIsoVar);]]>
+  </ioread>
 
 
   <class name="pat::Muon"  ClassVersion="25">
@@ -233,6 +236,9 @@
   <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
   <ioread sourceClass="pat::Photon" targetClass="pat::Photon" version="[1-]" source="" target="superClusterRelinked_">
     <![CDATA[superClusterRelinked_.reset();]]>
+  </ioread>
+  <ioread sourceClass="pat::Photon"  targetClass="pat::Photon" version="[-20]" target="" source="float ecalPFClusIso_;float hcalPFClusIso_">
+    <![CDATA[reco::Photon::PflowIsolationVariables pfIsoVar = newObj->getPflowIsolationVariables();pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;newObj->setPflowIsolationVariables(pfIsoVar);]]>
   </ioread>
 
   <class name="pat::Jet"  ClassVersion="16">

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -60,7 +60,10 @@
     <![CDATA[ cachedIP_ = onfile.cachedIP_[1] + 2*onfile.cachedIP_[2] + 4*onfile.cachedIP_[3] + 8*onfile.cachedIP_[4]; ]]>
   </ioread>
   <ioread sourceClass="pat::Electron"  targetClass="pat::Electron" version="[-37]" target="" source="float ecalPFClusIso_;float hcalPFClusIso_">
-    <![CDATA[reco::GsfElectron::PflowIsolationVariables pfIsoVar = newObj->pfIsolationVariables();pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;newObj->setPfIsolationVariables(pfIsoVar);]]>
+    <![CDATA[reco::GsfElectron::PflowIsolationVariables pfIsoVar = newObj->pfIsolationVariables();
+             pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;
+             pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;
+             newObj->setPfIsolationVariables(pfIsoVar);]]>
   </ioread>
 
 
@@ -238,7 +241,10 @@
     <![CDATA[superClusterRelinked_.reset();]]>
   </ioread>
   <ioread sourceClass="pat::Photon"  targetClass="pat::Photon" version="[-20]" target="" source="float ecalPFClusIso_;float hcalPFClusIso_">
-    <![CDATA[reco::Photon::PflowIsolationVariables pfIsoVar = newObj->getPflowIsolationVariables();pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;newObj->setPflowIsolationVariables(pfIsoVar);]]>
+    <![CDATA[reco::Photon::PflowIsolationVariables pfIsoVar = newObj->getPflowIsolationVariables();
+             pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;
+             pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;
+             newObj->setPflowIsolationVariables(pfIsoVar);]]>
   </ioread>
 
   <class name="pat::Jet"  ClassVersion="16">


### PR DESCRIPTION
As reported by @aminnj  at https://github.com/cms-sw/cmssw/issues/25573, in 102X its not possible to read the pf cluster isolation in pat::Electrons/Photons for 94X (or earlier objects). This is because in 101X we moved the pf cluster isolation from the pat::Electron/pat::Photon to the reco::GsfElectron/reco::Photon.

This PR adds an IO rule which fixes this and now allows PF cluster isolation of 94X produced objects to be read in 10X. 

Note, I couldnt figure out a better way to do this, there wasnt a good example of how to fill a base class member variable from a derived class member variable so I stuck with this simple solution, improvements are welcome. 

Obviously this only works when reading pat::Electrons/pat::Photons, reco:GsfElectrons/reco::Photons do not have the member in 94X and therefore it cant be filled.

A backport is required for 102X which I'll submit when this is mostly done. 