### PR TITLE
Added nStreams and nConcurrentLumis options to cmsDriver.py

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -85,6 +85,8 @@ defaultOptions.runsScenarioForMC = None
 defaultOptions.runUnscheduled = False
 defaultOptions.timeoutOutput = False
 defaultOptions.nThreads = '1'
+defaultOptions.nStreams = '0'
+defaultOptions.nConcurrentLumis = '1'
 
 # some helper routines
 def dumpPython(process,name):
@@ -2220,7 +2222,8 @@ class ConfigBuilder(object):
             self.pythonCfgCode +="\n"
             self.pythonCfgCode +="#Setup FWK for multithreaded\n"
             self.pythonCfgCode +="process.options.numberOfThreads=cms.untracked.uint32("+self._options.nThreads+")\n"
-            self.pythonCfgCode +="process.options.numberOfStreams=cms.untracked.uint32(0)\n"
+            self.pythonCfgCode +="process.options.numberOfStreams=cms.untracked.uint32("+self._options.nStreams+")\n"
+            self.pythonCfgCode +="process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32("+self._options.nConcurrentLumis+")\n"
         #repacked version
         if self._options.isRepacked:
             self.pythonCfgCode +="\n"

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -388,3 +388,13 @@ expertSettings.add_option("--nThreads",
                           default="1",
                           dest='nThreads'
                           )
+expertSettings.add_option("--nStreams",
+                          help="How many streams should CMSSW use (default is 0 which makes it same as nThreads)",
+                          default="0",
+                          dest='nStreams'
+                          )
+expertSettings.add_option("--nConcurrentLumis",
+                          help="How many concurrent LuminosityBlocks should CMSSW use (default is 1)",
+                          default="1",
+                          dest='nConcurrentLumis'
+                          )


### PR DESCRIPTION
Gave more control for concurrency. The default values are what we were already using.