### PR TITLE
Fix clang warnings in RecoLocalTracker/SiPixelRecHits

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -182,7 +182,7 @@ PixelCPEGeneric::localPosition(DetParam const & theDetParam, ClusterParam & theC
       float locBx = theDetParam.bx;
       //cout << "PixelCPEGeneric::localPosition(...) : locBz = " << locBz << endl;
       
-      theClusterParam.pixmx  = -999.9; // max pixel charge for truncation of 2-D cluster
+      theClusterParam.pixmx  = -999;   // max pixel charge for truncation of 2-D cluster
       theClusterParam.sigmay = -999.9; // CPE Generic y-error for multi-pixel cluster
       theClusterParam.deltay = -999.9; // CPE Generic y-bias for multi-pixel cluster
       theClusterParam.sigmax = -999.9; // CPE Generic x-error for multi-pixel cluster

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
@@ -35,7 +35,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #define LOGERROR(x) edm::LogError(x)
 #define LOGDEBUG(x) LogDebug(x)
-static const int theVerboseLevel = 2;
 #define ENDL " "
 #include "FWCore/Utilities/interface/Exception.h"
 #else


### PR DESCRIPTION
* Remove unused (global static const) variable
* Set `ClusterParamGeneric::pixmx` with proper type for the literal
   * The type was changed from `float` to `int` in #18457

Tested in CMSSW_10_5_X_2019-01-13-0000, no changes expected.