### PR TITLE
Remove std::move from SiStripRawProcessingFactory to allow better compiler optimization

### DIFF
--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingFactory.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingFactory.cc
@@ -16,10 +16,10 @@ SiStripRawProcessingFactory::create(const edm::ParameterSet& conf)
 {
   return std::unique_ptr<SiStripRawProcessingAlgorithms>(
       new SiStripRawProcessingAlgorithms(
-        std::move(create_SubtractorPed(conf)),
-        std::move(create_SubtractorCMN(conf)),
-        std::move(create_Suppressor(conf)),
-        std::move(create_Restorer(conf)),
+        create_SubtractorPed(conf),
+        create_SubtractorCMN(conf),
+        create_Suppressor(conf),
+        create_Restorer(conf),
         conf.getParameter<bool>("doAPVRestore"),
         conf.getParameter<bool>("useCMMeanMap")
       ));


### PR DESCRIPTION
Moving a temporary object was preventing the compiler from doing copy elision. This was found by clang.

Tested in CMSSW_10_5_X_2019-01-13-0000, no changes expected