### PR TITLE
Fix clang warnings in RecoPixelVertexing/PixelTrackFitting

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackBuilder.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackBuilder.cc
@@ -110,6 +110,7 @@ namespace {
   }
 
 
+#ifdef DEBUG_STATE
   inline void checkState(const  BasicTrajectoryStateOnSurface & bstate, const MagneticField* mf, const GlobalPoint & origin)
   {
     TrajectoryStateOnSurface state(bstate.clone());
@@ -129,6 +130,7 @@ namespace {
     const FreeTrajectoryState& fs = tscp.theState();
     LogTrace("") << "CHECK-2 FTS: " << fs;
   }
+#endif
 
 }
 
@@ -187,7 +189,9 @@ reco::Track * PixelTrackBuilder::build(
   // use Base (to avoid a useless new)
   BasicTrajectoryStateOnSurface impactPointState( lpar , error, impPointPlane, mf);
 
-  //checkState(impactPointState,mf);
+#ifdef DEBUG_STATE
+  checkState(impactPointState,mf);
+#endif
   LogTrace("") << "constructed TSOS:\n" << print(impactPointState);
 
   int ndof = 2*hits.size()-5;


### PR DESCRIPTION
Clang warned about function `checkState()` being unused in `PixelTrackBuilder.cc`. The file had a commented call to it, so I enclosed both of them inside `#ifdef DEBUG_STATE ... #endif`.

Tested in CMSSW_10_5_X_2019-01-14-1100, no changes expected.