### PR TITLE
Using new Event::get and ::getHandle in PFProducers

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -170,8 +170,7 @@ class PFAlgo {
 				      double dptRel_DispVtx);
   
   //MIKEB : Parameters for the vertices..
-  void setPFVertexParameters(bool useVertex,
-			     const reco::VertexCollection*  primaryVertices);			   
+  void setPFVertexParameters(bool useVertex, reco::VertexCollection const&  primaryVertices);
   
   // FlorianB : Collection of e/g electrons
   void setEGElectronCollection(const reco::GsfElectronCollection & egelectrons);

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
@@ -120,9 +120,7 @@ class PFEGammaAlgo {
   //destructor
   ~PFEGammaAlgo(){ };
 
-  void setEEtoPSAssociation(const edm::Handle<EEtoPSAssociation>& eetops) {
-    eetops_ = eetops;
-  }
+  void setEEtoPSAssociation(EEtoPSAssociation const& eetops) { eetops_ = &eetops; }
 
   void setAlphaGamma_ESplanes_fromDB(const ESEEIntercalibConstants* esEEInterCalib){
     cfg_.thePFEnergyCalibration->initAlphaGamma_ESplanes_fromDB(esEEInterCalib);
@@ -159,7 +157,7 @@ private:
 
   // useful pre-cached mappings:
   // hopefully we get an enum that lets us just make an array in the future
-  edm::Handle<reco::PFCluster::EEtoPSAssociation> eetops_;
+  reco::PFCluster::EEtoPSAssociation const* eetops_;
   reco::PFBlockRef _currentblock;
   reco::PFBlock::LinkData _currentlinks;  
   // keep a map of pf indices to the splayed block for convenience

--- a/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h
@@ -79,7 +79,7 @@ class PFMuonAlgo {
   //Assign a different track to the muon
   void changeTrack(reco::PFCandidate&,const MuonTrackTypePair&);
   //PF Post cleaning algorithm
-  void setInputsForCleaning(const reco::VertexCollection*); 
+  void setInputsForCleaning(reco::VertexCollection const&); 
   void postClean(reco::PFCandidateCollection *);
   void addMissingMuons(edm::Handle<reco::MuonCollection>, reco::PFCandidateCollection* cands);
 

--- a/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
@@ -35,7 +35,7 @@ public:
 private:
   // input collection
   edm::InputTag srccandidates_;
-  edm::EDGetTokenT<edm::View<reco::PFCandidate> > candidates_token;
+  edm::EDGetTokenT<edm::View<reco::PFCandidate> > candidatesToken_;
   double minTrackPt_;
   double minRawCaloEnergy_;
 
@@ -44,7 +44,7 @@ private:
 ChargedHadronPFTrackIsolationProducer::ChargedHadronPFTrackIsolationProducer(const edm::ParameterSet& cfg)
 {
   srccandidates_ = cfg.getParameter<edm::InputTag>("src");
-  candidates_token = consumes<edm::View<reco::PFCandidate> >(srccandidates_);
+  candidatesToken_ = consumes<edm::View<reco::PFCandidate> >(srccandidates_);
   minTrackPt_ = cfg.getParameter<double>("minTrackPt");
   minRawCaloEnergy_ = cfg.getParameter<double>("minRawCaloEnergy");
   
@@ -54,9 +54,7 @@ ChargedHadronPFTrackIsolationProducer::ChargedHadronPFTrackIsolationProducer(con
 void ChargedHadronPFTrackIsolationProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const
 {
   // get a view of our candidates via the base candidates
-  typedef edm::View<reco::PFCandidate> PFCandidateView;
-  edm::Handle<PFCandidateView> candidates;
-  evt.getByToken(candidates_token, candidates);
+  auto candidates = evt.getHandle(candidatesToken_);
   
   std::vector<bool> values;
 

--- a/RecoParticleFlow/PFProducer/plugins/EFilter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/EFilter.cc
@@ -62,12 +62,11 @@ EFilter::filter(edm::Event& iEvent,
 
 
 
-  Handle<std::vector<reco::PFSimParticle> > particles;
-  iEvent.getByToken(inputTagParticles_, particles);
+  auto const& particles = iEvent.get(inputTagParticles_);
 
-  if( !particles->empty() ) {
+  if( !particles.empty() ) {
     // take first trajectory point of first particle (the mother)
-    const reco::PFTrajectoryPoint& tp = (*particles)[0].trajectoryPoint(0);
+    const reco::PFTrajectoryPoint& tp = particles[0].trajectoryPoint(0);
     
     const math::XYZTLorentzVector& mom = tp.momentum();
 

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
@@ -61,7 +61,7 @@ class PFEGammaProducer : public edm::stream::EDProducer<edm::GlobalCache<pfEGHel
 
   void setPFEGParameters(PFEGammaAlgo::PFEGConfigInfo&);
 
-  void setPFVertexParameters(const reco::VertexCollection*  primaryVertices);
+  void setPFVertexParameters(reco::VertexCollection const&  primaryVertices);
 
   void createSingleLegConversions(reco::PFCandidateEGammaExtraCollection &extras,
                                   reco::ConversionCollection &oneLegConversions,

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
@@ -66,27 +66,24 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   auto pfCandidates_p = std::make_unique<reco::PFCandidateCollection>();
 
-  edm::Handle<reco::GsfElectronCollection> gsfElectrons;
-  iEvent.getByToken(inputTagGsfElectrons_,gsfElectrons);
+  auto gsfElectrons = iEvent.getHandle(inputTagGsfElectrons_);
 
   std::map<reco::GsfElectronRef,reco::PFCandidatePtr> electronCandidateMap;
 
 
-  edm::Handle<reco::PhotonCollection> photons;
-  iEvent.getByToken(inputTagPhotons_,photons);
+  auto photons = iEvent.getHandle(inputTagPhotons_);
   std::map<reco::PhotonRef,reco::PFCandidatePtr> photonCandidateMap;
 
 
   edm::Handle<reco::MuonToMuonMap> muonMap;
   if(fillMuonRefs_)
-    iEvent.getByToken(inputTagMuonMap_,muonMap);
+    muonMap = iEvent.getHandle(inputTagMuonMap_);
   std::map<reco::MuonRef,reco::PFCandidatePtr> muonCandidateMap;
 
   unsigned nColPF=inputTagPFCandidates_.size();
 
-  edm::Handle<reco::PFCandidateCollection> pfCandidates;
   for(unsigned icol=0;icol<nColPF;++icol) {
-    iEvent.getByToken(inputTagPFCandidates_[icol],pfCandidates);
+    auto pfCandidates = iEvent.getHandle(inputTagPFCandidates_[icol]);
     unsigned ncand=pfCandidates->size();
 
     for( unsigned i=0; i<ncand; ++i) {
@@ -185,8 +182,7 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::ValueMap<reco::PFCandidatePtr> pfMapMuons;
 
   if(fillMuonRefs_){
-    edm::Handle<reco::MuonCollection> muons;
-    iEvent.getByToken(inputTagMuons_, muons);
+    auto muons = iEvent.getHandle(inputTagMuons_);
 
     pfMapMuons = fillValueMap<reco::MuonCollection>(iEvent,
 						    muonTag_.label(),

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -19,23 +19,17 @@ using namespace std;
 using namespace edm;
 
 
-PFProducer::PFProducer(const edm::ParameterSet& iConfig) {
-  
+PFProducer::PFProducer(const edm::ParameterSet& iConfig)
+{
   //--ab: get calibration factors for HF:
-  bool calibHF_use;
-  std::vector<double>  calibHF_eta_step;
-  std::vector<double>  calibHF_a_EMonly;
-  std::vector<double>  calibHF_b_HADonly;
-  std::vector<double>  calibHF_a_EMHAD;
-  std::vector<double>  calibHF_b_EMHAD;
-  calibHF_use =     iConfig.getParameter<bool>("calibHF_use");
-  calibHF_eta_step  = iConfig.getParameter<std::vector<double> >("calibHF_eta_step");
-  calibHF_a_EMonly  = iConfig.getParameter<std::vector<double> >("calibHF_a_EMonly");
-  calibHF_b_HADonly = iConfig.getParameter<std::vector<double> >("calibHF_b_HADonly");
-  calibHF_a_EMHAD   = iConfig.getParameter<std::vector<double> >("calibHF_a_EMHAD");
-  calibHF_b_EMHAD   = iConfig.getParameter<std::vector<double> >("calibHF_b_EMHAD");
-  std::shared_ptr<PFEnergyCalibrationHF>  
-    thepfEnergyCalibrationHF ( new PFEnergyCalibrationHF(calibHF_use,calibHF_eta_step,calibHF_a_EMonly,calibHF_b_HADonly,calibHF_a_EMHAD,calibHF_b_EMHAD) ) ;
+  auto thepfEnergyCalibrationHF = std::make_shared<PFEnergyCalibrationHF>(
+      iConfig.getParameter<bool>("calibHF_use"),
+      iConfig.getParameter<std::vector<double> >("calibHF_eta_step"),
+      iConfig.getParameter<std::vector<double> >("calibHF_a_EMonly"),
+      iConfig.getParameter<std::vector<double> >("calibHF_b_HADonly"),
+      iConfig.getParameter<std::vector<double> >("calibHF_a_EMHAD"),
+      iConfig.getParameter<std::vector<double> >("calibHF_b_EMHAD")
+  );
   //-----------------
 
   inputTagBlocks_ = consumes<reco::PFBlockCollection>(iConfig.getParameter<InputTag>("blocks"));
@@ -491,74 +485,28 @@ PFProducer::beginRun(const edm::Run & run,
 
 
 void 
-PFProducer::produce(Event& iEvent, 
-		    const EventSetup& iSetup) {
-  
-  LogDebug("PFProducer")<<"START event: "
-			<<iEvent.id().event()
-			<<" in run "<<iEvent.id().run()<<endl;
-  
-
-  // Get The vertices from the event
-  // and assign dynamic vertex parameters
-  edm::Handle<reco::VertexCollection> vertices;
-  bool gotVertices = iEvent.getByToken(vertices_,vertices);
-  if(!gotVertices) {
-    ostringstream err;
-    err<<"Cannot find vertices for this event.Continuing Without them ";
-    LogError("PFProducer")<<err.str()<<endl;
-  }
+PFProducer::produce(Event& iEvent, const EventSetup& iSetup)
+{
+  LogDebug("PFProducer")<<"START event: " <<iEvent.id().event() <<" in run "<<iEvent.id().run()<<endl;
 
   //Assign the PFAlgo Parameters
-  pfAlgo_->setPFVertexParameters(useVerticesForNeutral_,vertices.product());
+  pfAlgo_->setPFVertexParameters(useVerticesForNeutral_, iEvent.get(vertices_));
 
   // get the collection of blocks 
-
-  Handle< reco::PFBlockCollection > blocks;
-
-  iEvent.getByToken( inputTagBlocks_, blocks );  
+  auto blocks = iEvent.getHandle( inputTagBlocks_);
+  assert( blocks.isValid() );
 
   // get the collection of muons 
+  if ( postMuonCleaning_ ) pfAlgo_->setMuonHandle( iEvent.getHandle(inputTagMuons_) );
 
-  Handle< reco::MuonCollection > muons;
+  if (useEGammaElectrons_) pfAlgo_->setEGElectronCollection( iEvent.get(inputTagEgammaElectrons_) );
 
-  if ( postMuonCleaning_ ) {
-
-    iEvent.getByToken( inputTagMuons_, muons );  
-    pfAlgo_->setMuonHandle(muons);
-  }
-
-  if (useEGammaElectrons_) {
-    Handle < reco::GsfElectronCollection > egelectrons;
-    iEvent.getByToken( inputTagEgammaElectrons_, egelectrons );  
-    pfAlgo_->setEGElectronCollection(*egelectrons);
-  }
-
-  if(use_EGammaFilters_) {
-
-    // Read PFEGammaCandidates
-
-    edm::Handle<edm::View<reco::PFCandidate> > pfEgammaCandidates;
-    iEvent.getByToken(inputTagPFEGammaCandidates_,pfEgammaCandidates);
-
-    // Get the value maps
-    
-    edm::Handle<edm::ValueMap<reco::GsfElectronRef> > valueMapGedElectrons;
-    iEvent.getByToken(inputTagValueMapGedElectrons_,valueMapGedElectrons);
-
-    edm::Handle<edm::ValueMap<reco::PhotonRef> > valueMapGedPhotons;
-    iEvent.getByToken(inputTagValueMapGedPhotons_,valueMapGedPhotons);
-
-    pfAlgo_->setEGammaCollections(*pfEgammaCandidates,
-    				  *valueMapGedElectrons,
-    				  *valueMapGedPhotons);
-
-  }
+  if(use_EGammaFilters_) pfAlgo_->setEGammaCollections( iEvent.get(inputTagPFEGammaCandidates_),
+                                                        iEvent.get(inputTagValueMapGedElectrons_),
+                                                        iEvent.get(inputTagValueMapGedPhotons_));
 
 
   LogDebug("PFProducer")<<"particle flow is starting"<<endl;
-
-  assert( blocks.isValid() );
 
   pfAlgo_->reconstructParticles( blocks );
   
@@ -664,4 +612,3 @@ PFProducer::produce(Event& iEvent,
 
     }
 }
-

--- a/RecoParticleFlow/PFProducer/plugins/importers/EGPhotonImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/EGPhotonImporter.cc
@@ -68,8 +68,7 @@ void EGPhotonImporter::
 importToBlock( const edm::Event& e, 
 	       BlockElementImporterBase::ElementList& elems ) const {
   typedef BlockElementImporterBase::ElementList::value_type ElementType;  
-  edm::Handle<reco::PhotonCollection> photons;
-  e.getByToken(_src,photons);
+  auto photons = e.getHandle(_src);
   elems.reserve(elems.size()+photons->size());
   // setup our elements so that all the SCs are grouped together
   auto SCs_end = std::partition(elems.begin(),elems.end(),

--- a/RecoParticleFlow/PFProducer/plugins/importers/GSFTrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GSFTrackImporter.cc
@@ -35,13 +35,11 @@ DEFINE_EDM_PLUGIN(BlockElementImporterFactory,
 void GSFTrackImporter::
 importToBlock( const edm::Event& e, 
 	       BlockElementImporterBase::ElementList& elems ) const {
-  typedef BlockElementImporterBase::ElementList::value_type ElementType;  
-  edm::Handle<reco::GsfPFRecTrackCollection> gsftracks;
-  e.getByToken(_src,gsftracks);
+  auto gsftracks = e.getHandle(_src);
   elems.reserve(elems.size() + gsftracks->size());
   // setup our elements so that all the SCs are grouped together
   auto SCs_end = std::partition(elems.begin(),elems.end(),
-				[](const ElementType& a){
+				[](const auto& a){
 				  return a->type() == reco::PFBlockElement::SC;
 				});
   size_t SCs_end_position = std::distance(elems.begin(),SCs_end);
@@ -73,7 +71,7 @@ importToBlock( const edm::Event& e,
 	      new reco::PFBlockElementSuperCluster(scref);
 	    scbe->setFromGsfElectron(true);
 	    scbe->setFromPFSuperCluster(_superClustersArePF);
-	    SCs_end = elems.insert(SCs_end,ElementType(scbe));
+	    SCs_end = elems.emplace(SCs_end,scbe);
 	    ++SCs_end; // point to element *after* the new one
 	  }
 	} 		   

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -52,10 +52,8 @@ void GeneralTracksImporter::
 importToBlock( const edm::Event& e, 
 	       BlockElementImporterBase::ElementList& elems ) const {
   typedef BlockElementImporterBase::ElementList::value_type ElementType;  
-  edm::Handle<reco::PFRecTrackCollection> tracks;
-  e.getByToken(src_,tracks);
-   edm::Handle<reco::MuonCollection> muons;
-  e.getByToken(muons_,muons);
+  auto tracks = e.getHandle(src_);
+  auto muons = e.getHandle(muons_);
   elems.reserve(elems.size() + tracks->size());
   std::vector<bool> mask(tracks->size(),true);
   reco::MuonRef muonref;

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -53,17 +53,14 @@ void GeneralTracksImporterWithVeto::
 importToBlock( const edm::Event& e, 
 	       BlockElementImporterBase::ElementList& elems ) const {
   typedef BlockElementImporterBase::ElementList::value_type ElementType;  
-  edm::Handle<reco::PFRecTrackCollection> tracks;
-  e.getByToken(src_,tracks);
-  edm::Handle<reco::PFRecTrackCollection> vetosH;
-  e.getByToken(veto_,vetosH);
+  auto tracks = e.getHandle(src_);
+  auto vetosH = e.getHandle(veto_);
   const auto& vetos = *vetosH;
   std::unordered_set<unsigned> vetoed;
   for(unsigned i = 0; i < vetos.size(); ++i ) {
     vetoed.insert(vetos[i].trackRef().key());
   }
-  edm::Handle<reco::MuonCollection> muons;
-  e.getByToken(muons_,muons);
+  auto muons = e.getHandle(muons_);
   elems.reserve(elems.size() + tracks->size());
   std::vector<bool> mask(tracks->size(),true);
   reco::MuonRef muonref;

--- a/RecoParticleFlow/PFProducer/plugins/importers/GenericClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GenericClusterImporter.cc
@@ -24,8 +24,7 @@ DEFINE_EDM_PLUGIN(BlockElementImporterFactory,
 void GenericClusterImporter::
 importToBlock( const edm::Event& e, 
 	       BlockElementImporterBase::ElementList& elems ) const {
-  edm::Handle<reco::PFClusterCollection> clusters;
-  e.getByToken(_src,clusters);
+  auto clusters = e.getHandle(_src);
   auto cbegin = clusters->cbegin();
   auto cend   = clusters->cend(); 
   for( auto clus = cbegin; clus != cend; ++clus ) {

--- a/RecoParticleFlow/PFProducer/plugins/importers/SpecialClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/SpecialClusterImporter.cc
@@ -34,10 +34,8 @@ void SpecialClusterImporter<T>::
 importToBlock( const edm::Event& e, 
 	       BlockElementImporterBase::ElementList& elems ) const {
   BlockElementImporterBase::ElementList ecals;
-  edm::Handle<reco::PFClusterCollection> clusters;
-  edm::Handle<edm::ValueMap<reco::CaloClusterPtr> > assoc;
-  e.getByToken(_src,clusters);
-  e.getByToken(_assoc,assoc);
+  auto clusters = e.getHandle(_src);
+  auto assoc = e.getHandle(_assoc);
   auto bclus = clusters->cbegin();
   auto eclus = clusters->cend();
   // get all the SCs in the element list

--- a/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
@@ -65,18 +65,14 @@ updateEventSetup(const edm::EventSetup& es) {
 void SuperClusterImporter::
 importToBlock( const edm::Event& e, 
 	       BlockElementImporterBase::ElementList& elems ) const {
-  typedef BlockElementImporterBase::ElementList::value_type ElementType;  
-  edm::Handle<reco::SuperClusterCollection> eb_scs;
-  e.getByToken(_srcEB,eb_scs);
-  edm::Handle<reco::SuperClusterCollection> ee_scs;
-  e.getByToken(_srcEE,ee_scs);
-  edm::Handle<CaloTowerCollection> towers;
-  e.getByToken(_srcTowers,towers);
+  auto eb_scs = e.getHandle(_srcEB);
+  auto ee_scs = e.getHandle(_srcEE);
+  auto towers = e.getHandle(_srcTowers);
   _hadTower->setTowerCollection(towers.product());
   elems.reserve(elems.size()+eb_scs->size()+ee_scs->size());
   // setup our elements so that all the SCs are grouped together
   auto SCs_end = std::partition(elems.begin(),elems.end(),
-				[](const ElementType& a){
+				[](auto const& a){
 				  return a->type() == reco::PFBlockElement::SC;
 				});  
   // add eb superclusters
@@ -96,7 +92,7 @@ importToBlock( const edm::Event& e,
 	(scpT > _pTbyPass || HoverE < _maxHoverE) ) {	
       scbe = new reco::PFBlockElementSuperCluster(scref);      
       scbe->setFromPFSuperCluster(_superClustersArePF);
-      SCs_end = elems.insert(SCs_end,ElementType(scbe));
+      SCs_end = elems.emplace(SCs_end, scbe);
       ++SCs_end; // point to element *after* the new one
     }    
   }// loop on eb superclusters
@@ -115,7 +111,7 @@ importToBlock( const edm::Event& e,
 	(scpT > _pTbyPass || HoverE < _maxHoverE)) {	
       scbe = new reco::PFBlockElementSuperCluster(scref);  
       scbe->setFromPFSuperCluster(_superClustersArePF);
-      SCs_end = elems.insert(SCs_end,ElementType(scbe));
+      SCs_end = elems.emplace(SCs_end, scbe);
       ++SCs_end; // point to element *after* the new one
     }    
   }// loop on ee superclusters

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
@@ -48,8 +48,7 @@ namespace pflow {
       importToBlock( const edm::Event& e, 
 		     BlockElementImporterBase::ElementList& elems ) const {
       typedef BlockElementImporterBase::ElementList::value_type ElementType;  
-      edm::Handle<Collection> pfparents;
-      e.getByToken(_src,pfparents);
+      auto pfparents = e.getHandle(_src);
       elems.reserve(elems.size() + 2*pfparents->size());
       // setup our elements so that all the SCs are grouped together
       auto TKs_end = std::partition(elems.begin(),elems.end(),

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
@@ -44,18 +44,16 @@ importToBlock( const edm::Event& e,
 	       BlockElementImporterBase::ElementList& elems ) const {
   typedef BlockElementImporterBase::ElementList::value_type ElementType;  
   
-  edm::Handle<edm::ValueMap<float> > timeH, timeErrH, timeGsfH, timeErrGsfH;
-  
-  e.getByToken(srcTime_, timeH);
-  e.getByToken(srcTimeError_, timeErrH);
-  e.getByToken(srcTimeGsf_, timeGsfH);
-  e.getByToken(srcTimeErrorGsf_, timeErrGsfH);
+  auto const& time = e.get(srcTime_);
+  auto const& timeErr = e.get(srcTimeError_);
+  auto const& timeGsf = e.get(srcTimeGsf_);
+  auto const& timeErrGsf = e.get(srcTimeErrorGsf_);
   
   for( auto& elem : elems ) {
     if( reco::PFBlockElement::TRACK == elem->type() ) {
       const auto& ref = elem->trackRef();
-      if (timeH->contains(ref.id())) {
-	elem->setTime( (*timeH)[ref], (*timeErrH)[ref] );
+      if (time.contains(ref.id())) {
+	elem->setTime( time[ref], timeErr[ref] );
       }
       if( debug_ ) {
 	edm::LogInfo("TrackTimingImporter") 
@@ -64,8 +62,8 @@ importToBlock( const edm::Event& e,
       }
     } else if ( reco::PFBlockElement::GSF == elem->type() ) {
       const auto& ref = static_cast<const reco::PFBlockElementGsfTrack*>(elem.get())->GsftrackRef();
-      if (timeGsfH->contains(ref.id())) {
-	elem->setTime( (*timeGsfH)[ref], (*timeErrGsfH)[ref] );
+      if (timeGsf.contains(ref.id())) {
+	elem->setTime( timeGsf[ref], timeErrGsf[ref] );
       }
       if( debug_ ) {
 	edm::LogInfo("TrackTimingImporter") 

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -361,8 +361,8 @@ PFAlgo::setDisplacedVerticesParameters(bool rejectTracks_Bad,
 
 
 void
-PFAlgo::setPFVertexParameters(bool useVertex,
-			      const reco::VertexCollection*  primaryVertices) {
+PFAlgo::setPFVertexParameters(bool useVertex, reco::VertexCollection const&  primaryVertices)
+{
   useVertices_ = useVertex;
 
   //Set the vertices for muon cleaning
@@ -371,11 +371,11 @@ PFAlgo::setPFVertexParameters(bool useVertex,
 
   //Now find the primary vertex!
   bool primaryVertexFound = false;
-  nVtx_ = primaryVertices->size();
+  nVtx_ = primaryVertices.size();
   if(usePFPhotons_){
     pfpho_->setnPU(nVtx_);
   }
-  for(auto const& vertex : *primaryVertices)
+  for(auto const& vertex : primaryVertices)
     {
       if(vertex.isValid()&&(!vertex.isFake()))
 	{

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -1165,9 +1165,7 @@ PFMuonAlgo::tracksPointingAtMET(const std::vector<reco::Muon::MuonTrackTypePair>
   
 
   
-void PFMuonAlgo::setInputsForCleaning(const reco::VertexCollection*  vertices) {
-  vertices_ = vertices;
-}
+void PFMuonAlgo::setInputsForCleaning(reco::VertexCollection const&  vertices) { vertices_ = &vertices; }
 
 bool PFMuonAlgo::cleanPunchThroughAndFakes(reco::PFCandidate&pfc,reco::PFCandidateCollection* cands,unsigned int imu ){
   using namespace reco;


### PR DESCRIPTION
This PR builds on top of https://github.com/cms-sw/cmssw/pull/25707 to replace the occurrences of `getByToken` with the more modern `get` and `getHandle` in RecoParticleFlow/PFProducer.