### PR TITLE
Added an edm::ValidHandle type

### DIFF
--- a/DataFormats/Common/interface/Handle.h
+++ b/DataFormats/Common/interface/Handle.h
@@ -24,30 +24,25 @@ If failedToGet() returns false but isValid() is also false then no attempt
   to get data has occurred
 
 ----------------------------------------------------------------------*/
-#include <typeinfo>
 
 #include "DataFormats/Common/interface/HandleBase.h"
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 namespace edm {
 
   template <typename T>
   class Handle : public HandleBase {
   public:
-    typedef T element_type;
+    using element_type = T;
 
     // Default constructed handles are invalid.
     Handle();
 
     Handle(T const* prod, Provenance const* prov);
     
-#if defined( __GXX_EXPERIMENTAL_CXX0X__)
     Handle(std::shared_ptr<HandleExceptionFactory> &&);
     Handle(Handle const&) = default;
-    
     Handle& operator=(Handle&&) = default;
     Handle& operator=(Handle const&) = default;
-#endif
     
     ~Handle();
 
@@ -66,12 +61,10 @@ namespace edm {
   Handle<T>::Handle(T const* prod, Provenance const* prov) : HandleBase(prod, prov) { 
   }
 
-#if defined( __GXX_EXPERIMENTAL_CXX0X__)
   template <class T>
   Handle<T>::Handle(std::shared_ptr<edm::HandleExceptionFactory> && iWhyFailed) :
   HandleBase(std::move(iWhyFailed))
   { }
-#endif
 
   template <class T>
   Handle<T>::~Handle() {}

--- a/DataFormats/Common/interface/ValidHandle.h
+++ b/DataFormats/Common/interface/ValidHandle.h
@@ -1,0 +1,66 @@
+#ifndef DataFormats_Common_ValidHandle_h
+#define DataFormats_Common_ValidHandle_h
+
+/*----------------------------------------------------------------------
+  
+Handle: Non-owning "smart pointer" for reference to products and
+their provenances.
+
+The data product is always guaranteed to be valid for this handle type.
+----------------------------------------------------------------------*/
+
+#include <utility>
+#include "DataFormats/Provenance/interface/ProductID.h"
+
+namespace edm {
+  namespace vhhelper {
+    void throwIfNotValid(const void*) noexcept(false);
+  }
+  template<typename T>
+  class ValidHandle {
+  public:
+    using element_type = T;
+    
+    ValidHandle() = delete;
+    ValidHandle(T const* prod, ProductID id) noexcept(false) :
+    product_(prod), id_(std::move(id)) {
+      vhhelper::throwIfNotValid(prod);
+    }
+    
+    //NOTE: C++ disallows references to null
+    ValidHandle(T const& prod, ProductID id) noexcept(true):
+    product_(&prod), id_(std::move(id)) {
+    }
+    ValidHandle( const ValidHandle<T>& ) = default;
+    ValidHandle<T>& operator=(ValidHandle<T> const& rhs) = default;
+    ~ValidHandle() = default;
+    
+
+    ProductID const&  id() const noexcept(true) { return id_; }
+
+    T const* product() const noexcept(true) {
+      return product_;
+    }
+    
+    T const* operator->() const noexcept(true) { return product();}
+    T const& operator*() const noexcept(true) { return *product();}
+    
+  private:
+    T const* product_;
+    ProductID id_;
+  };
+  
+  /** Take a handle (e.g. edm::Handle<T> or edm::OrphanHandle<T> and
+   create a edm::ValidHandle<T>. If the argument is an invalid handle,
+   an exception will be thrown.
+   */
+  template<typename U>
+  auto
+  makeValid(const U& iOtherHandleType) noexcept(false) {
+    vhhelper::throwIfNotValid(iOtherHandleType.product());
+    //because of the check, we know this is valid and do not have to check again
+    return ValidHandle<typename U::element_type>(*iOtherHandleType.product(), iOtherHandleType.id());
+  }
+}
+
+#endif

--- a/DataFormats/Common/src/ValidHandle.cc
+++ b/DataFormats/Common/src/ValidHandle.cc
@@ -1,0 +1,11 @@
+#include "DataFormats/Common/interface/ValidHandle.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace edm::vhhelper {
+  void
+  throwIfNotValid(const void* iProduct) noexcept(false) {
+    if(nullptr == iProduct) {
+      throw cms::Exception("Invalid Product")<<"Attempted to fill a edm::ValidHandle with an invalid product";
+    }
+  }
+}

--- a/DataFormats/Common/test/BuildFile.xml
+++ b/DataFormats/Common/test/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="boost"/>
 <use   name="cppunit"/>
 <use   name="DataFormats/Common"/>
-<bin   name="testDataFormatsCommon" file="testRunner.cpp,testOwnVector.cc,testOneToOneAssociation.cc,testValueMap.cc,testOneToManyAssociation.cc,testAssociationVector.cc,testAssociationNew.cc,testValueMapNew.cc,testSortedCollection.cc,testRangeMap.cc,testIDVectorMap.cc,ref_t.cppunit.cc,DetSetRefVector_t.cppunit.cc,reftobase_t.cppunit.cc,reftobasevector_t.cppunit.cc,cloningptr_t.cppunit.cc,ptr_t.cppunit.cc,ptrvector_t.cppunit.cc,containermask_t.cppunit.cc,reftobaseprod_t.cppunit.cc">
+<bin   name="testDataFormatsCommon" file="testRunner.cpp,testOwnVector.cc,testOneToOneAssociation.cc,testValueMap.cc,testOneToManyAssociation.cc,testAssociationVector.cc,testAssociationNew.cc,testValueMapNew.cc,testSortedCollection.cc,testRangeMap.cc,testIDVectorMap.cc,ref_t.cppunit.cc,DetSetRefVector_t.cppunit.cc,reftobase_t.cppunit.cc,reftobasevector_t.cppunit.cc,cloningptr_t.cppunit.cc,ptr_t.cppunit.cc,ptrvector_t.cppunit.cc,containermask_t.cppunit.cc,reftobaseprod_t.cppunit.cc,handle_t.cppunit.cc">
 </bin>
 <bin   file="DetSetVector_t.cpp">
 </bin>


### PR DESCRIPTION
A `edm::ValidHandle<>` is more efficient to use in different functions than a `edm::Handle<>` since the latter always checks to see if it is valid or not.