### PR TITLE
Update CSC RU segment builder

### DIFF
--- a/RecoLocalMuon/CSCSegment/python/CSCSegmentAlgorithmRU_cfi.py
+++ b/RecoLocalMuon/CSCSegment/python/CSCSegmentAlgorithmRU_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 RU_ME1A = cms.PSet(
     doCollisions = cms.bool(True),
+    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(35),
     chi2_str = cms.double(50.0),
     chi2Max = cms.double(100.0),
@@ -14,6 +15,7 @@ RU_ME1A = cms.PSet(
 )
 RU_ME1B = cms.PSet(
     doCollisions = cms.bool(True),
+    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(35),
     chi2_str = cms.double(50.0),
     chi2Max = cms.double(100.0),
@@ -26,6 +28,7 @@ RU_ME1B = cms.PSet(
 )
 RU_ME12 = cms.PSet(
     doCollisions = cms.bool(True),
+    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(35),
     chi2_str = cms.double(50.0),
     chi2Max = cms.double(100.0),
@@ -38,6 +41,7 @@ RU_ME12 = cms.PSet(
 )
 RU_ME13 = cms.PSet(
     doCollisions = cms.bool(True),
+    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(20),
     chi2_str = cms.double(30.0),
     chi2Max = cms.double(60.0),
@@ -50,6 +54,7 @@ RU_ME13 = cms.PSet(
 )
 RU_MEX1 = cms.PSet(
     doCollisions = cms.bool(True),
+    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(60),
     chi2_str = cms.double(80.0),
     chi2Max = cms.double(180.0),
@@ -62,6 +67,7 @@ RU_MEX1 = cms.PSet(
 )
 RU_MEX2 = cms.PSet(
     doCollisions = cms.bool(True),
+    enlarge = cms.bool(False),
     chi2Norm_2D_ = cms.double(35),
     chi2_str = cms.double(50.0),
     chi2Max = cms.double(100.0),

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
@@ -565,7 +565,6 @@ float CSCSegAlgoRU::fit_r_phi(const AlgoState& aState, const SVector6& points, i
 
 void CSCSegAlgoRU::baseline(AlgoState& aState, int n_seg_min) const {
   int nhits = aState.proto_segment.size();
-  ChamberHitContainer::const_iterator iRH_worst;
   //initialise vectors for strip position and error within strip
   SVector6 sp;
   SVector6 se;

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
@@ -114,8 +114,10 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber, 
   for (int ipass = 0; ipass < npass; ++ipass) {
     if(aState.windowScale >1.){
       iadd = 1;
-      aState.strip_iadd = 2;
-      aState.chi2D_iadd = 2;
+      aState.chi2Max = 2*aState.chi2Max;    
+      aState.strip_iadd = 4;
+      aState.chi2D_iadd = 4;
+      if(rechits.size() <= 12) iadd = 0;//allow 3 hit segments for low hit multiplicity chambers	    
     }
     int used_rh = 0;
     for (ChamberHitContainerCIt i1 = ib; i1 != ie; ++i1) {
@@ -126,13 +128,13 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber, 
     if(aState.doCollisions && search_disp && int(rechits.size()-used_rh)>2){//check if there are enough recHits left to build a segment from displaced vertices
       aState.doCollisions = false;
       aState.windowScale = 1.; // scale factor for cuts
-      aState.dRMax = 2.0;
-      aState.dPhiMax = 2*aState.dPhiMax;
-      aState.dRIntMax = 2*aState.dRIntMax;
-      aState.dPhiIntMax = 2*aState.dPhiIntMax;
-      aState.chi2Norm_2D_ = 5*aState.chi2Norm_2D_;
-      aState.chi2_str_ = 100;
-      aState.chi2Max = 2*aState.chi2Max;
+      aState.dRMax = 4.0;
+      aState.dPhiMax = 4*aState.dPhiMax;
+      aState.dRIntMax = 4*aState.dRIntMax;
+      aState.dPhiIntMax = 4*aState.dPhiIntMax;
+      aState.chi2Norm_2D_ = 10*aState.chi2Norm_2D_;
+      aState.chi2_str_ = 200;
+      aState.chi2Max = 4*aState.chi2Max;
     }else{
       search_disp = false;//make sure the flag is off
     }
@@ -255,12 +257,12 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber, 
       search_disp = false;
       aState.doCollisions = true;
       aState.dRMax = 2.0;
-      aState.dPhiMax = aState.dPhiMax/2;
-      aState.dRIntMax = aState.dRIntMax/2;
-      aState.dPhiIntMax = aState.dPhiIntMax/2;
-      aState.chi2Norm_2D_ = aState.chi2Norm_2D_/5;
+      aState.dPhiMax = 0.25*aState.dPhiMax;
+      aState.dRIntMax = 0.25*aState.dRIntMax;
+      aState.dPhiIntMax = 0.25*aState.dPhiIntMax;
+      aState.chi2Norm_2D_ = 0.1*aState.chi2Norm_2D_;
       aState.chi2_str_ = 100;
-      aState.chi2Max = aState.chi2Max/2;
+      aState.chi2Max = 0.25*aState.chi2Max;
     }
 
     std::vector<CSCSegment>::iterator it =segments.begin();
@@ -389,7 +391,7 @@ bool CSCSegAlgoRU::areHitsCloseInR(const AlgoState& aState, const CSCRecHit2D* h
     h1z = 1;
     h2z = 1;
   }
-  if (gp2.perp() > ((gp1.perp() - aState.dRMax*maxWG_width[iStn])*h2z)/h1z && gp2.perp() < ((gp1.perp() + aState.dRMax*maxWG_width[iStn])*h2z)/h1z){
+  if (gp2.perp() > ((gp1.perp() - aState.dRMax*aState.strip_iadd*maxWG_width[iStn])*h2z)/h1z && gp2.perp() < ((gp1.perp() + aState.dRMax*aState.strip_iadd*maxWG_width[iStn])*h2z)/h1z){
     return true;
   }
   else{
@@ -476,7 +478,7 @@ bool CSCSegAlgoRU::isHitNearSegment(const AlgoState& aState, const CSCRecHit2D* 
       maxWG_width[1] = 10.75;
     }
   }
-  return (fabs(phidif) < aState.dPhiIntMax*aState.strip_iadd*pos_str+dphi_incr && fabs(dr) < aState.dRIntMax*maxWG_width[iStn])? true:false;
+  return (fabs(phidif) < aState.dPhiIntMax*aState.strip_iadd*pos_str+dphi_incr && fabs(dr) < aState.dRIntMax*aState.strip_iadd*maxWG_width[iStn])? true:false;
 }
 
 float CSCSegAlgoRU::phiAtZ(const AlgoState& aState, float z) const {
@@ -495,11 +497,14 @@ float CSCSegAlgoRU::phiAtZ(const AlgoState& aState, float z) const {
 bool CSCSegAlgoRU::isSegmentGood(const AlgoState& aState,  const ChamberHitContainer& rechitsInChamber) const {
   // If the chamber has 20 hits or fewer, require at least 3 hits on segment
   // If the chamber has >20 hits require at least 4 hits
+  // If it's the second cycle of the builder and there are <= 12 hits in chamber, require at least 3 hits on segment
   //@@ THESE VALUES SHOULD BECOME PARAMETERS?
   bool ok = false;
   unsigned int iadd = ( rechitsInChamber.size() > 20)? 1 : 0;
-  if (aState.windowScale > 1.)
+  if (aState.windowScale > 1.) {
     iadd = 1;
+    if (  rechitsInChamber.size() <= 12 ) iadd = 0;
+  }	  
   if (aState.proto_segment.size() >= 3+iadd)
     ok = true;
   return ok;

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
@@ -114,10 +114,15 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber, 
   for (int ipass = 0; ipass < npass; ++ipass) {
     if(aState.windowScale >1.){
       iadd = 1;
-      aState.chi2Max = 2*aState.chi2Max;    
-      aState.strip_iadd = 4;
-      aState.chi2D_iadd = 4;
-      if(rechits.size() <= 12) iadd = 0;//allow 3 hit segments for low hit multiplicity chambers	    
+      if(enlarge){
+       aState.chi2Max = 2*aState.chi2Max;    
+       aState.strip_iadd = 4;
+       aState.chi2D_iadd = 4;
+       if(rechits.size() <= 12) iadd = 0;//allow 3 hit segments for low hit multiplicity chambers	    
+      } else {
+       aState.strip_iadd = 2;
+       aState.chi2D_iadd = 2;
+      }
     }
     int used_rh = 0;
     for (ChamberHitContainerCIt i1 = ib; i1 != ie; ++i1) {
@@ -128,13 +133,23 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber, 
     if(aState.doCollisions && search_disp && int(rechits.size()-used_rh)>2){//check if there are enough recHits left to build a segment from displaced vertices
       aState.doCollisions = false;
       aState.windowScale = 1.; // scale factor for cuts
-      aState.dRMax = 4.0;
-      aState.dPhiMax = 4*aState.dPhiMax;
-      aState.dRIntMax = 4*aState.dRIntMax;
-      aState.dPhiIntMax = 4*aState.dPhiIntMax;
-      aState.chi2Norm_2D_ = 10*aState.chi2Norm_2D_;
-      aState.chi2_str_ = 200;
-      aState.chi2Max = 4*aState.chi2Max;
+      if(enlarge){ 
+	aState.dRMax = 4.0;
+	aState.dPhiMax = 4*aState.dPhiMax;
+        aState.dRIntMax = 4*aState.dRIntMax;
+        aState.dPhiIntMax = 4*aState.dPhiIntMax;
+        aState.chi2Norm_2D_ = 10*aState.chi2Norm_2D_;
+        aState.chi2_str_ = 200;
+        aState.chi2Max = 4*aState.chi2Max;
+      } else {
+        aState.dRMax = 2.0;
+	aState.dPhiMax = 2*aState.dPhiMax;
+        aState.dRIntMax = 2*aState.dRIntMax;
+        aState.dPhiIntMax = 2*aState.dPhiIntMax;
+        aState.chi2Norm_2D_ = 5*aState.chi2Norm_2D_;
+        aState.chi2_str_ = 100;
+        aState.chi2Max = 2*aState.chi2Max;
+      }
     }else{
       search_disp = false;//make sure the flag is off
     }
@@ -257,12 +272,20 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber, 
       search_disp = false;
       aState.doCollisions = true;
       aState.dRMax = 2.0;
-      aState.dPhiMax = 0.25*aState.dPhiMax;
-      aState.dRIntMax = 0.25*aState.dRIntMax;
-      aState.dPhiIntMax = 0.25*aState.dPhiIntMax;
-      aState.chi2Norm_2D_ = 0.1*aState.chi2Norm_2D_;
       aState.chi2_str_ = 100;
-      aState.chi2Max = 0.25*aState.chi2Max;
+      if(enlarge){	   
+        aState.dPhiMax = 0.25*aState.dPhiMax;
+        aState.dRIntMax = 0.25*aState.dRIntMax;
+        aState.dPhiIntMax = 0.25*aState.dPhiIntMax;
+        aState.chi2Norm_2D_ = 0.1*aState.chi2Norm_2D_;
+        aState.chi2Max = 0.25*aState.chi2Max;
+      } else {
+        aState.dPhiMax = 0.5*aState.dPhiMax;
+        aState.dRIntMax = 0.5*aState.dRIntMax;
+        aState.dPhiIntMax = 0.5*aState.dPhiIntMax;
+        aState.chi2Norm_2D_ = 0.2*aState.chi2Norm_2D_;
+        aState.chi2Max = 0.5*aState.chi2Max;
+      }
     }
 
     std::vector<CSCSegment>::iterator it =segments.begin();
@@ -391,11 +414,10 @@ bool CSCSegAlgoRU::areHitsCloseInR(const AlgoState& aState, const CSCRecHit2D* h
     h1z = 1;
     h2z = 1;
   }
-  if (gp2.perp() > ((gp1.perp() - aState.dRMax*aState.strip_iadd*maxWG_width[iStn])*h2z)/h1z && gp2.perp() < ((gp1.perp() + aState.dRMax*aState.strip_iadd*maxWG_width[iStn])*h2z)/h1z){
-    return true;
-  }
-  else{
-    return false;
+  if(enlarge) {
+    return (gp2.perp() > ((gp1.perp() - aState.dRMax*aState.strip_iadd*maxWG_width[iStn])*h2z)/h1z && gp2.perp() < ((gp1.perp() + aState.dRMax*aState.strip_iadd*maxWG_width[iStn])*h2z)/h1z)? true:false;
+  }else{
+    return (gp2.perp() > ((gp1.perp() - aState.dRMax*maxWG_width[iStn])*h2z)/h1z && gp2.perp() < ((gp1.perp() + aState.dRMax*maxWG_width[iStn])*h2z)/h1z)? true:false;
   }
 }
 
@@ -478,7 +500,11 @@ bool CSCSegAlgoRU::isHitNearSegment(const AlgoState& aState, const CSCRecHit2D* 
       maxWG_width[1] = 10.75;
     }
   }
-  return (fabs(phidif) < aState.dPhiIntMax*aState.strip_iadd*pos_str+dphi_incr && fabs(dr) < aState.dRIntMax*aState.strip_iadd*maxWG_width[iStn])? true:false;
+  if(enlarge) {
+    return (fabs(phidif) < aState.dPhiIntMax*aState.strip_iadd*pos_str+dphi_incr && fabs(dr) < aState.dRIntMax*aState.strip_iadd*maxWG_width[iStn])? true:false;
+  }else{
+    return (fabs(phidif) < aState.dPhiIntMax*aState.strip_iadd*pos_str+dphi_incr && fabs(dr) < aState.dRIntMax*maxWG_width[iStn])? true:false;
+  }
 }
 
 float CSCSegAlgoRU::phiAtZ(const AlgoState& aState, float z) const {
@@ -503,7 +529,7 @@ bool CSCSegAlgoRU::isSegmentGood(const AlgoState& aState,  const ChamberHitConta
   unsigned int iadd = ( rechitsInChamber.size() > 20)? 1 : 0;
   if (aState.windowScale > 1.) {
     iadd = 1;
-    if (  rechitsInChamber.size() <= 12 ) iadd = 0;
+    if( rechitsInChamber.size() <= 12 && enlarge) iadd = 0;
   }	  
   if (aState.proto_segment.size() >= 3+iadd)
     ok = true;

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.h
@@ -162,7 +162,7 @@ private:
     float wideSeg;
     int minLayersApart;
     bool debugInfo;
-
+    bool enlarge = false;
 };
 
 #endif

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.h
@@ -91,6 +91,7 @@ private:
 
       //adjustable configuration
       bool doCollisions;
+      bool enlarge;
       float dRMax ;
       float dPhiMax;
       float dRIntMax;
@@ -162,7 +163,7 @@ private:
     float wideSeg;
     int minLayersApart;
     bool debugInfo;
-    bool enlarge = false;
+    bool enlarge;
 };
 
 #endif


### PR DESCRIPTION
The RU builder thresholds are made looser on second and third iterations of the builder in order to increase the efficiency of the segment reconstruction for cases with "soft" muons, when the trajectory bends on a scale of a CSC detector. Related presentation can be found here https://indico.cern.ch/event/784929/contributions/3265299/attachments/1777781/2890942/19_01_11-Voytishin_Palichik-CSCSegBuilder_proposal_RECO_meeting.pdf