### PR TITLE
Remove CMS custom hacks for Oracle OCCI old C++ ABI compatibility

### DIFF
--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplOracle.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplOracle.cc
@@ -44,7 +44,7 @@ void ConfigurationDatabaseImplOracle::connect(const std::string& accessor) noexc
      env_ = oracle::occi::Environment::createEnvironment (oracle::occi::Environment::DEFAULT);
      conn_ = env_->createConnection (user, password, db);
    } catch (SQLException& e) {
-           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
    }
 
 
@@ -62,7 +62,7 @@ void ConfigurationDatabaseImplOracle::disconnect() {
         env_->terminateConnection(conn_);
         Environment::terminateEnvironment(env_);
    } catch (SQLException& e) {
-           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
    }
 
 
@@ -136,7 +136,7 @@ void ConfigurationDatabaseImplOracle::getLUTChecksums(const std::string& tag,
         //Always terminate statement
         conn_->terminateStatement(stmt);
    } catch (SQLException& e) {
-           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
    }
 
 }
@@ -220,7 +220,7 @@ void ConfigurationDatabaseImplOracle::getLUTs_real(const std::string& tag, int c
 	//Always terminate statement
 	conn_->terminateStatement(stmt);
    } catch (SQLException& e) {
-           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
    }
 
 }
@@ -288,7 +288,7 @@ void ConfigurationDatabaseImplOracle::getPatterns_real(const std::string& tag, i
         //Always terminate statement
         conn_->terminateStatement(stmt);
    } catch (SQLException& e) {
-           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
    }
 
 
@@ -397,7 +397,7 @@ void ConfigurationDatabaseImplOracle::getRBXdata(const std::string& tag, const s
         //Always terminate statement
         conn_->terminateStatement(stmt);
    } catch (SQLException& e) {
-           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
    }
 
 }
@@ -428,7 +428,7 @@ void ConfigurationDatabaseImplOracle::getZSThresholds(const std::string& tag, in
                 unsigned int fiber = rs->getInt(1);
                 unsigned int fc = rs->getInt(2);
                 unsigned int zs = rs->getInt(3);
-                std::string fpga = getOraString(rs,4);
+                std::string fpga = rs->getString(4);
                 int tb;
                 if (fpga=="top") tb = 1;
                 else tb = 0;
@@ -439,7 +439,7 @@ void ConfigurationDatabaseImplOracle::getZSThresholds(const std::string& tag, in
         //Always terminate statement
         conn_->terminateStatement(stmt);
    } catch (SQLException& e) {
-           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
    }
 
 }
@@ -479,7 +479,7 @@ void ConfigurationDatabaseImplOracle::getHLXMasks_real(const std::string& tag, i
         masks.clear();
         while (rs->next()) {
                 int islot = rs->getInt(1);
-                std::string fpga = getOraString(rs,2);
+                std::string fpga = rs->getString(2);
 
                 int ifpga;
                 if (fpga=="top") ifpga = 1;
@@ -498,7 +498,7 @@ void ConfigurationDatabaseImplOracle::getHLXMasks_real(const std::string& tag, i
         //Always terminate statement
         conn_->terminateStatement(stmt);
    } catch (SQLException& e) {
-           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+           XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
    }
 }
 

--- a/CaloOnlineTools/HcalOnlineDb/src/HCALConfigDB.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HCALConfigDB.cc
@@ -189,7 +189,7 @@ std::vector<unsigned int> HCALConfigDB::getOnlineLUT( std::string tag, uint32_t 
 	  _condition_data_set_id = _cdsi;
 	  _crate    = rs -> getInt(2);
 	  _slot     = rs -> getInt(3);
-	  std::string fpga_ = getOraString(rs,4);
+	  std::string fpga_ = rs -> getString(4);
 	  if ( fpga_ == "top" ) _fpga = hcal::ConfigurationDatabase::Top;
 	  else _fpga  = hcal::ConfigurationDatabase::Bottom;
 	  _fiber    = rs -> getInt(5);
@@ -207,7 +207,7 @@ std::vector<unsigned int> HCALConfigDB::getOnlineLUT( std::string tag, uint32_t 
     //Always terminate statement
     _connection -> terminateStatement(stmt);
   } catch (SQLException& e) {
-    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
   }
   return result;
 }
@@ -255,7 +255,7 @@ std::vector<unsigned int> HCALConfigDB::getOnlineLUTFromXML( std::string tag, ui
 	    _condition_data_set_id = _cdsi;
 	    _crate    = rs -> getInt(2);
 	    _slot     = rs -> getInt(3);
-	    std::string fpga_ = getOraString(rs, 4);
+	    std::string fpga_ = rs -> getString(4);
 	    if ( fpga_ == "top" ) _fpga = hcal::ConfigurationDatabase::Top;
 	    else _fpga  = hcal::ConfigurationDatabase::Bottom;
 	    _fiber    = rs -> getInt(5);
@@ -274,7 +274,7 @@ std::vector<unsigned int> HCALConfigDB::getOnlineLUTFromXML( std::string tag, ui
       _connection -> terminateStatement(stmt);
 
     } catch (SQLException& e) {
-      XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+      XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
     }
   }
   else{

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalAssistant.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalAssistant.cc
@@ -202,7 +202,7 @@ int HcalAssistant::getListOfChannelsFromDb(){
     while (rs->next()) {
       _n_channels++;
       int _rawid = rs->getInt(1);
-      int _geomId = getGeomId( getSubdetector(getOraString(rs,2)),
+      int _geomId = getGeomId( getSubdetector(rs->getString(2)),
 			       rs->getInt(3),
 			       rs->getInt(4),
 			       rs->getInt(5)
@@ -213,8 +213,8 @@ int HcalAssistant::getListOfChannelsFromDb(){
     listIsRead = true;
   }
   catch (SQLException& e) {
-    std::cerr << ::toolbox::toString("Oracle  exception : %s", getOraMessage(&e)) << std::endl;
-    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s", getOraMessage(&e)));
+    std::cerr << ::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()) << std::endl;
+    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
   }
   conn.disconnect();
   return _n_channels;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -1563,7 +1563,7 @@ std::map<int, std::shared_ptr<LutXml> > HcalLutManager::get_brickSet_from_oracle
     _connection -> terminateStatement(stmt);
     //std::cout << "Query line count: " << _lines.getCount() << std::endl;
   } catch (SQLException& e) {
-    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage()));
   }
 
   //std::cout << lut_map.size() << std::endl;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalQIEManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalQIEManager.cc
@@ -178,7 +178,7 @@ void HcalQIEManager::getTableFromDb( std::string query_file, std::string output_
 	  _id.eta = rs->getInt(1);
 	  _id.phi = rs->getInt(2);
 	  _id.depth = rs->getInt(3);
-	  _id.subdetector  = getOraString(rs, 4);
+	  _id.subdetector  = rs -> getString(4);
 	  for (int j=0; j!=32; j++){
 	    _caps.caps[j] = rs -> getDouble(j+5);
 	  }
@@ -205,7 +205,7 @@ void HcalQIEManager::getTableFromDb( std::string query_file, std::string output_
 	//std::cout << "Query count: " << count << std::endl;
 	cout << "Query line count: " << _lines.getCount() << std::endl;
       } catch (SQLException& e) {
-	XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+	XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
       }
     }
   }
@@ -358,8 +358,8 @@ int HcalQIEManager::getHfQieTable( std::string input_file, std::string output_fi
       _id.eta = rs->getInt(1);
       _id.phi = rs->getInt(2);
       _id.depth = rs->getInt(3);
-      _id.subdetector  = getOraString(rs, 4);
-      rbx = getOraString(rs,5);
+      _id.subdetector  = rs -> getString(4);
+      rbx = rs->getString(5);
       rm_slot = rs->getInt(6);
       qie_slot = rs->getInt(7);
       adc = rs->getInt(8);
@@ -421,7 +421,7 @@ int HcalQIEManager::getHfQieTable( std::string input_file, std::string output_fi
 	_connection -> terminateStatement(stmt2);
 	
       } catch (SQLException& e) {
-	XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+	XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
       }
     }
     //Always terminate statement
@@ -430,7 +430,7 @@ int HcalQIEManager::getHfQieTable( std::string input_file, std::string output_fi
     //std::cout << "Query count: " << count << std::endl;
     std::cout << "Query line count: " << _lines.getCount() << std::endl;
   } catch (SQLException& e) {
-    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",getOraMessage(&e)));
+    XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,::toolbox::toString("Oracle  exception : %s",e.getMessage().c_str()));
   }
   
   db -> disconnect();

--- a/OnlineDB/CSCCondDB/src/CSCCableRead.cc
+++ b/OnlineDB/CSCCondDB/src/CSCCableRead.cc
@@ -43,11 +43,11 @@ std::string *alct_rev, float *cfeb_tmb_skew_delay, float *cfeb_timing_corr)
 //
 //    stmt->execute(); //execute procedure
 //
-//    *chamber_label = getOraString(stmt,2);
+//    *chamber_label = stmt->getString(2);
 //    *cfeb_length = stmt->getInt(3);
-//    *cfeb_rev = getOraString(stmt,4);
+//    *cfeb_rev = stmt->getString(4);
 //    *alct_length = stmt->getInt(5);
-//    *alct_rev = getOraString(stmt,6);
+//    *alct_rev = stmt->getString(6);
 //    *cfeb_tmb_skew_delay = stmt->getInt(7);
 //    *cfeb_timing_corr = stmt->getInt(8);
 
@@ -63,11 +63,11 @@ std::string *alct_rev, float *cfeb_tmb_skew_delay, float *cfeb_timing_corr)
 
     stmt->execute(); //execute procedure
 
-    *chamber_label = getOraString(stmt,2);
+    *chamber_label = stmt->getString(2);
     *cfeb_length = stmt->getFloat(3);
-    *cfeb_rev = getOraString(stmt,4);
+    *cfeb_rev = stmt->getString(4);
     *alct_length = stmt->getFloat(5);
-    *alct_rev = getOraString(stmt,6);
+    *alct_rev = stmt->getString(6);
     *cfeb_tmb_skew_delay = stmt->getFloat(7);
     *cfeb_timing_corr = stmt->getFloat(8);
 

--- a/OnlineDB/CSCCondDB/src/CSCMap.cc
+++ b/OnlineDB/CSCCondDB/src/CSCMap.cc
@@ -43,7 +43,7 @@
 
     stmt->execute(); //execute procedure
 
-    *chamber_id = getOraString(stmt,3);
+    *chamber_id = stmt->getString(3);
     *chamber_num = stmt->getInt(4);
     *chamber_index = stmt->getInt(5);
     *first_strip_index = stmt->getInt(6);
@@ -71,7 +71,7 @@
 
     stmt->execute(); //execute procedure
 
-    *chamber_id = getOraString(stmt,3);
+    *chamber_id = stmt->getString(3);
     *chamber_num = stmt->getInt(4);
     *chamber_index = stmt->getInt(5);
     *first_strip_index = stmt->getInt(6);

--- a/OnlineDB/CSCCondDB/src/CSCMap1.cc
+++ b/OnlineDB/CSCCondDB/src/CSCMap1.cc
@@ -55,7 +55,7 @@
 
     stmt->execute(); //execute procedure
 
-    item->chamberLabel = getOraString(stmt,10);
+    item->chamberLabel = stmt->getString(10);
     item->chamberId = chamberid;
      int chamber = chamberid/10%100;
      int rest = (chamberid - chamber*10)/1000;
@@ -73,7 +73,7 @@
     item->anodeIndex = stmt->getInt(16);
     item->strips = stmt->getInt(11);
     item->anodes = stmt->getInt(12);
-    item->crateLabel = getOraString(stmt,2);
+    item->crateLabel = stmt->getString(2);
     item->crateid  = stmt->getInt(3);
     item->sector = stmt->getInt(8);
     item->trig_sector = stmt->getInt(9);
@@ -110,10 +110,10 @@
 
     item->fed_crate = stmt->getInt(3);
     item->ddu_slot = stmt->getInt(4);
-    item->dcc_fifo = getOraString(stmt,6);
+    item->dcc_fifo = stmt->getString(6);
     item->fiber_crate = stmt->getInt(8);
     item->fiber_pos = stmt->getInt(9);
-    item->fiber_socket = getOraString(stmt,10);
+    item->fiber_socket = stmt->getString(10);
 
     con->terminateStatement (stmt);
   } //end of chamber
@@ -144,7 +144,7 @@
 
     stmt->execute(); //execute procedure
 
-    item->chamberLabel = getOraString(stmt,3);
+    item->chamberLabel = stmt->getString(3);
     item->chamberId = stmt->getInt(4);
      int chamberid = item->chamberId;
      int chamber = chamberid/10%100;
@@ -163,7 +163,7 @@
     item->anodeIndex = stmt->getInt(17);
     item->strips = stmt->getInt(12);
     item->anodes = stmt->getInt(13);
-    item->crateLabel = getOraString(stmt,11);
+    item->crateLabel = stmt->getString(11);
     item->crateid  = stmt->getInt(9);
     item->sector = stmt->getInt(7);
     item->trig_sector = stmt->getInt(8);
@@ -200,10 +200,10 @@
 
     item->fed_crate = stmt->getInt(3);
     item->ddu_slot = stmt->getInt(4);
-    item->dcc_fifo = getOraString(stmt,6);
+    item->dcc_fifo = stmt->getString(6);
     item->fiber_crate = stmt->getInt(8);
     item->fiber_pos = stmt->getInt(9);
-    item->fiber_socket = getOraString(stmt,10);
+    item->fiber_socket = stmt->getString(10);
 
     con->terminateStatement (stmt);
   } //end of cratedmb
@@ -242,10 +242,10 @@
 
     item->fed_crate = stmt->getInt(3);
     item->ddu_slot = stmt->getInt(4);
-    item->dcc_fifo = getOraString(stmt,5);
+    item->dcc_fifo = stmt->getString(5);
     item->fiber_crate = stmt->getInt(7);
     item->fiber_pos = stmt->getInt(8);
-    item->fiber_socket = getOraString(stmt,9);
+    item->fiber_socket = stmt->getString(9);
     int chamberid = stmt->getInt(14);
 
     stmt->setSQL("begin cms_emu_cern.cscmap.chamberid_crate(:1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :11, :12, :13, :14, :15, :16, :17, :18, :19, :20); end;");
@@ -273,7 +273,7 @@
 
     stmt->execute(); //execute procedure
 
-    item->chamberLabel = getOraString(stmt,10);
+    item->chamberLabel = stmt->getString(10);
     item->chamberId = chamberid;
      int chamber = chamberid/10%100;
      int rest = (chamberid - chamber*10)/1000;
@@ -291,7 +291,7 @@
     item->anodeIndex = stmt->getInt(16);
     item->strips = stmt->getInt(11);
     item->anodes = stmt->getInt(12);
-    item->crateLabel = getOraString(stmt,2);
+    item->crateLabel = stmt->getString(2);
     item->crateid  = stmt->getInt(3);
     item->sector = stmt->getInt(8);
     item->trig_sector = stmt->getInt(9);

--- a/OnlineDB/CSCCondDB/src/CSCOnlineDB.cc
+++ b/OnlineDB/CSCCondDB/src/CSCOnlineDB.cc
@@ -111,7 +111,7 @@
     std::cout<<"Exception thrown for insertBind"<<std::endl;
     std::cout<<"Error number: "<<  ex.getErrorCode() << std::endl;
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    std::cout << getOraMessage(&ex) << std::endl;
+    std::cout << ex.getMessage() << std::endl;
 #endif
    }
   }

--- a/OnlineDB/EcalCondDB/interface/IODConfig.h
+++ b/OnlineDB/EcalCondDB/interface/IODConfig.h
@@ -144,7 +144,7 @@ void populateClob (Clob &clob, std::string fname, unsigned int bufsize) noexcept
 
 
   }catch (SQLException &e) {
-    throw(std::runtime_error(std::string("populateClob():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("populateClob():  ")+e.getMessage()));
   }
 
   std::cout << "Populating the Clob - Success" << std::endl;
@@ -172,7 +172,7 @@ unsigned char* readClob (Clob &clob, int size) noexcept(false)
     return  buffer;
 
   }catch (SQLException &e) {
-    throw(std::runtime_error(std::string("readClob():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("readClob():  ")+e.getMessage()));
   }
 
 }

--- a/OnlineDB/EcalCondDB/interface/ITimingDat.h
+++ b/OnlineDB/EcalCondDB/interface/ITimingDat.h
@@ -64,7 +64,7 @@ void prepareWrite() noexcept(false) override
 			"VALUES (:iov_id, :logic_id, "
 			":timing_mean, :timing_rms, :task_status )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ITimingDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ITimingDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -92,7 +92,7 @@ void prepareWrite() noexcept(false) override
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ITimingDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ITimingDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -181,7 +181,7 @@ void prepareWrite() noexcept(false) override
     delete [] st_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ITimingDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ITimingDat::writeArrayDB():  "+e.getMessage()));
   }
 }
 
@@ -215,12 +215,12 @@ void prepareWrite() noexcept(false) override
     std::pair< EcalLogicID, DATT > p;
     DATT dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setTimingMean( rset->getFloat(7) );
       dat.setTimingRMS( rset->getFloat(8) );
@@ -233,7 +233,7 @@ void prepareWrite() noexcept(false) override
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ITimingDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ITimingDat::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/CaliCrystalIntercalDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliCrystalIntercalDat.cc
@@ -41,7 +41,7 @@ void CaliCrystalIntercalDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliCrystalIntercalDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliCrystalIntercalDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -70,7 +70,7 @@ void CaliCrystalIntercalDat::writeDB(const EcalLogicID* ecid, const CaliCrystalI
     
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliCrystalIntercalDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliCrystalIntercalDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -102,12 +102,12 @@ void CaliCrystalIntercalDat::fetchData(std::map< EcalLogicID, CaliCrystalInterca
     std::pair< EcalLogicID, CaliCrystalIntercalDat > p;
     CaliCrystalIntercalDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       
       dat.setCali( rset->getFloat(7) );
       dat.setCaliRMS( rset->getFloat(8) );
@@ -118,7 +118,7 @@ void CaliCrystalIntercalDat::fetchData(std::map< EcalLogicID, CaliCrystalInterca
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliCrystalIntercalDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliCrystalIntercalDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -213,6 +213,6 @@ void CaliCrystalIntercalDat::writeArrayDB(const std::map< EcalLogicID, CaliCryst
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/CaliGainRatioDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliGainRatioDat.cc
@@ -40,7 +40,7 @@ void CaliGainRatioDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliGainRatioDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliGainRatioDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -68,7 +68,7 @@ void CaliGainRatioDat::writeDB(const EcalLogicID* ecid, const CaliGainRatioDat* 
     
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliGainRatioDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliGainRatioDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -100,12 +100,12 @@ void CaliGainRatioDat::fetchData(std::map< EcalLogicID, CaliGainRatioDat >* fill
     std::pair< EcalLogicID, CaliGainRatioDat > p;
     CaliGainRatioDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       
       dat.setG1G12( rset->getFloat(7) );
       dat.setG6G12( rset->getFloat(8) );
@@ -115,7 +115,7 @@ void CaliGainRatioDat::fetchData(std::map< EcalLogicID, CaliGainRatioDat >* fill
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliGainRatioDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliGainRatioDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -202,6 +202,6 @@ void CaliGainRatioDat::writeArrayDB(const std::map< EcalLogicID, CaliGainRatioDa
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliGainRatio::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliGainRatio::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/CaliGeneralDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliGeneralDat.cc
@@ -39,7 +39,7 @@ void CaliGeneralDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliGeneralDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliGeneralDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -66,7 +66,7 @@ void CaliGeneralDat::writeDB(const EcalLogicID* ecid, const CaliGeneralDat* item
     
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliGeneralDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliGeneralDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -98,20 +98,20 @@ void CaliGeneralDat::fetchData(std::map< EcalLogicID, CaliGeneralDat >* fillMap,
     std::pair< EcalLogicID, CaliGeneralDat > p;
     CaliGeneralDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       
       dat.setNumEvents( rset->getInt(7) );
-      dat.setComments( getOraString(rset,8) );
+      dat.setComments( rset->getString(8) );
       
       p.second = dat;
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliGeneralDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliGeneralDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/CaliHVScanRatioDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliHVScanRatioDat.cc
@@ -40,7 +40,7 @@ void CaliHVScanRatioDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliHVScanRatioDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliHVScanRatioDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -68,7 +68,7 @@ void CaliHVScanRatioDat::writeDB(const EcalLogicID* ecid, const CaliHVScanRatioD
     
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliHVScanRatioDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliHVScanRatioDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -100,12 +100,12 @@ void CaliHVScanRatioDat::fetchData(std::map< EcalLogicID, CaliHVScanRatioDat >* 
     std::pair< EcalLogicID, CaliHVScanRatioDat > p;
     CaliHVScanRatioDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       
       dat.setHVRatio( rset->getFloat(7) );
       dat.setHVRatioRMS( rset->getFloat(8) );
@@ -115,6 +115,6 @@ void CaliHVScanRatioDat::fetchData(std::map< EcalLogicID, CaliHVScanRatioDat >* 
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliHVScanRatioDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliHVScanRatioDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/CaliIOV.cc
+++ b/OnlineDB/EcalCondDB/src/CaliIOV.cc
@@ -117,7 +117,7 @@ int CaliIOV::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliIOV::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliIOV::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -156,7 +156,7 @@ void CaliIOV::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("CaliTag::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("CaliTag::setByID:  "+e.getMessage()));
    }
 }
 
@@ -199,7 +199,7 @@ int CaliIOV::writeDB()
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliIOV::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliIOV::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -254,6 +254,6 @@ void CaliIOV::setByTm(CaliTag* tag, const Tm& eventTm)
      
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliIOV::setByTm:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliIOV::setByTm:  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/CaliTag.cc
+++ b/OnlineDB/EcalCondDB/src/CaliTag.cc
@@ -149,7 +149,7 @@ int CaliTag::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliTag::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliTag::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -171,13 +171,13 @@ void CaliTag::setByID(int id)
 
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
-      m_genTag = getOraString(rset,1);
+      m_genTag = rset->getString(1);
       int locID = rset->getInt(2);
       m_locDef.setConnection(m_env, m_conn);
       m_locDef.setByID(locID);
-      m_method = getOraString(rset,3);
-      m_version = getOraString(rset,4);
-      m_dataType = getOraString(rset,5);
+      m_method = rset->getString(3);
+      m_version = rset->getString(4);
+      m_dataType = rset->getString(5);
 
       m_ID = id;
     } else {
@@ -186,7 +186,7 @@ void CaliTag::setByID(int id)
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("CaliTag::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("CaliTag::setByID:  "+e.getMessage()));
   }
 }
 
@@ -222,7 +222,7 @@ int CaliTag::writeDB()
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("CaliTag::writeDB:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("CaliTag::writeDB:  "+e.getMessage()));
   }
 
   // now get the tag_id
@@ -252,7 +252,7 @@ void CaliTag::fetchAllTags( std::vector<CaliTag>* fillVec)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliTag::fetchAllTags:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliTag::fetchAllTags:  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/CaliTempDat.cc
+++ b/OnlineDB/EcalCondDB/src/CaliTempDat.cc
@@ -41,7 +41,7 @@ void CaliTempDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliTempDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliTempDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -70,7 +70,7 @@ void CaliTempDat::writeDB(const EcalLogicID* ecid, const CaliTempDat* item, Cali
     
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliTempDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliTempDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -102,12 +102,12 @@ void CaliTempDat::fetchData(std::map< EcalLogicID, CaliTempDat >* fillMap, CaliI
     std::pair< EcalLogicID, CaliTempDat > p;
     CaliTempDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       
       dat.setBeta( rset->getFloat(7) );
       dat.setR25( rset->getFloat(8) );
@@ -118,7 +118,7 @@ void CaliTempDat::fetchData(std::map< EcalLogicID, CaliTempDat >* fillMap, CaliI
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("CaliTempDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("CaliTempDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -215,6 +215,6 @@ void CaliTempDat::writeArrayDB(const std::map< EcalLogicID, CaliTempDat >* data,
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCSPTMTempList.cc
+++ b/OnlineDB/EcalCondDB/src/DCSPTMTempList.cc
@@ -87,7 +87,7 @@ void DCSPTMTempList::fetchValuesForECID(const EcalLogicID& ecid)
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCSPTMTempList:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCSPTMTempList:  "+e.getMessage()));
   }
 
 
@@ -163,7 +163,7 @@ void DCSPTMTempList::fetchValuesForECIDAndTime(const EcalLogicID& ecid, const Tm
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCSPTMTempList:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCSPTMTempList:  "+e.getMessage()));
   }
 
 

--- a/OnlineDB/EcalCondDB/src/DCUCCSDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUCCSDat.cc
@@ -50,8 +50,8 @@ void DCUCCSDat::prepareWrite()
 			":m2_vinj, :m1_vcc, :m2_vcc, :m1_dcutemp, "
 			":m2_dcutemp, :ccstemplow, :ccstemphigh)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCCSDat::prepareWrite():  ") + 
-			     getOraMessage(&e)));
+    throw(std::runtime_error("DCUCCSDat::prepareWrite():  " + 
+			     e.getMessage()));
   }
 }
 
@@ -93,7 +93,7 @@ void DCUCCSDat::writeDB(const EcalLogicID* ecid, const DCUCCSDat* item,
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCCSDat::writeDB():  ") + getOraMessage(&e)));
+    throw(std::runtime_error("DCUCCSDat::writeDB():  " + e.getMessage()));
   }
 }
 
@@ -129,12 +129,12 @@ void DCUCCSDat::fetchData(std::map< EcalLogicID, DCUCCSDat >* fillMap,
     std::pair< EcalLogicID, DCUCCSDat > p;
     DCUCCSDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setVDD(rset->getFloat(7), rset->getFloat(9), rset->getFloat(8),
 		  rset->getFloat(10));
@@ -146,7 +146,7 @@ void DCUCCSDat::fetchData(std::map< EcalLogicID, DCUCCSDat >* fillMap,
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCCSDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUCCSDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -271,6 +271,6 @@ void DCUCCSDat::writeArrayDB(const std::map< EcalLogicID, DCUCCSDat >* data, DCU
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCCSDat::writeArrayDB():  ") + getOraMessage(&e)));
+    throw(std::runtime_error("DCUCCSDat::writeArrayDB():  " + e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCUCapsuleTempDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUCapsuleTempDat.cc
@@ -39,7 +39,7 @@ void DCUCapsuleTempDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":capsule_temp)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCapsuleTempDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUCapsuleTempDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -65,7 +65,7 @@ void DCUCapsuleTempDat::writeDB(const EcalLogicID* ecid, const DCUCapsuleTempDat
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCapsuleTempDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUCapsuleTempDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,12 +97,12 @@ void DCUCapsuleTempDat::fetchData(std::map< EcalLogicID, DCUCapsuleTempDat >* fi
     std::pair< EcalLogicID, DCUCapsuleTempDat > p;
     DCUCapsuleTempDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setCapsuleTemp( rset->getFloat(7) );
 
@@ -110,7 +110,7 @@ void DCUCapsuleTempDat::fetchData(std::map< EcalLogicID, DCUCapsuleTempDat >* fi
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCapsuleTempDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUCapsuleTempDat::fetchData():  "+e.getMessage()));
   }
 }
 void DCUCapsuleTempDat::writeArrayDB(const std::map< EcalLogicID, DCUCapsuleTempDat >* data, DCUIOV* iov)
@@ -178,6 +178,6 @@ void DCUCapsuleTempDat::writeArrayDB(const std::map< EcalLogicID, DCUCapsuleTemp
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCapsuleTempDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUCapsuleTempDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCUCapsuleTempRawDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUCapsuleTempRawDat.cc
@@ -40,7 +40,7 @@ void DCUCapsuleTempRawDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCapsuleTempRawDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUCapsuleTempRawDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -67,7 +67,7 @@ void DCUCapsuleTempRawDat::writeDB(const EcalLogicID* ecid, const DCUCapsuleTemp
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCapsuleTempRawDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUCapsuleTempRawDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -99,12 +99,12 @@ void DCUCapsuleTempRawDat::fetchData(std::map< EcalLogicID, DCUCapsuleTempRawDat
     std::pair< EcalLogicID, DCUCapsuleTempRawDat > p;
     DCUCapsuleTempRawDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setCapsuleTempADC( rset->getFloat(7) );
       dat.setCapsuleTempRMS( rset->getFloat(8) );
@@ -113,7 +113,7 @@ void DCUCapsuleTempRawDat::fetchData(std::map< EcalLogicID, DCUCapsuleTempRawDat
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCapsuleTempRawDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUCapsuleTempRawDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -189,6 +189,6 @@ void DCUCapsuleTempRawDat::writeArrayDB(const std::map< EcalLogicID, DCUCapsuleT
     delete [] y_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUCapsuleTempRawDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUCapsuleTempRawDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCUIDarkDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUIDarkDat.cc
@@ -39,7 +39,7 @@ void DCUIDarkDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":apd_idark)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIDarkDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIDarkDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -65,7 +65,7 @@ void DCUIDarkDat::writeDB(const EcalLogicID* ecid, const DCUIDarkDat* item, DCUI
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIDarkDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIDarkDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,12 +97,12 @@ void DCUIDarkDat::fetchData(std::map< EcalLogicID, DCUIDarkDat >* fillMap, DCUIO
     std::pair< EcalLogicID, DCUIDarkDat > p;
     DCUIDarkDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setAPDIDark( rset->getFloat(7) );
 
@@ -110,7 +110,7 @@ void DCUIDarkDat::fetchData(std::map< EcalLogicID, DCUIDarkDat >* fillMap, DCUIO
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIDarkDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIDarkDat::fetchData():  "+e.getMessage()));
   }
 }
 void DCUIDarkDat::writeArrayDB(const std::map< EcalLogicID, DCUIDarkDat >* data, DCUIOV* iov)
@@ -176,6 +176,6 @@ void DCUIDarkDat::writeArrayDB(const std::map< EcalLogicID, DCUIDarkDat >* data,
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIDarkDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIDarkDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCUIDarkPedDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUIDarkPedDat.cc
@@ -39,7 +39,7 @@ void DCUIDarkPedDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":ped)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIDarkPedDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIDarkPedDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -65,7 +65,7 @@ void DCUIDarkPedDat::writeDB(const EcalLogicID* ecid, const DCUIDarkPedDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIDarkPedDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIDarkPedDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,12 +97,12 @@ void DCUIDarkPedDat::fetchData(std::map< EcalLogicID, DCUIDarkPedDat >* fillMap,
     std::pair< EcalLogicID, DCUIDarkPedDat > p;
     DCUIDarkPedDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setPed( rset->getFloat(7) );
 
@@ -110,7 +110,7 @@ void DCUIDarkPedDat::fetchData(std::map< EcalLogicID, DCUIDarkPedDat >* fillMap,
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIDarkPedDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIDarkPedDat::fetchData():  "+e.getMessage()));
   }
 }
 void DCUIDarkPedDat::writeArrayDB(const std::map< EcalLogicID, DCUIDarkPedDat >* data, DCUIOV* iov)
@@ -178,6 +178,6 @@ void DCUIDarkPedDat::writeArrayDB(const std::map< EcalLogicID, DCUIDarkPedDat >*
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIDarkPedDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIDarkPedDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCUIOV.cc
+++ b/OnlineDB/EcalCondDB/src/DCUIOV.cc
@@ -116,7 +116,7 @@ int DCUIOV::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIOV::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIOV::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -155,7 +155,7 @@ void DCUIOV::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("DCUTag::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("DCUTag::setByID:  "+e.getMessage()));
    }
 }
 
@@ -198,7 +198,7 @@ int DCUIOV::writeDB()
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIOV::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIOV::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -253,6 +253,6 @@ void DCUIOV::setByTm(DCUTag* tag, const Tm& eventTm)
      
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUIOV::setByTm:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUIOV::setByTm:  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCULVRBTempsDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCULVRBTempsDat.cc
@@ -41,7 +41,7 @@ void DCULVRBTempsDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRBTempsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRBTempsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -69,7 +69,7 @@ void DCULVRBTempsDat::writeDB(const EcalLogicID* ecid, const DCULVRBTempsDat* it
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRBTempsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRBTempsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -101,12 +101,12 @@ void DCULVRBTempsDat::fetchData(std::map< EcalLogicID, DCULVRBTempsDat >* fillMa
     std::pair< EcalLogicID, DCULVRBTempsDat > p;
     DCULVRBTempsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setT1( rset->getFloat(7) );
       dat.setT2( rset->getFloat(8) );
@@ -116,7 +116,7 @@ void DCULVRBTempsDat::fetchData(std::map< EcalLogicID, DCULVRBTempsDat >* fillMa
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRBTempsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRBTempsDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -204,6 +204,6 @@ void DCULVRBTempsDat::writeArrayDB(const std::map< EcalLogicID, DCULVRBTempsDat 
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRBTempsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRBTempsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCULVRTempsDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCULVRTempsDat.cc
@@ -41,7 +41,7 @@ void DCULVRTempsDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRTempsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRTempsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -69,7 +69,7 @@ void DCULVRTempsDat::writeDB(const EcalLogicID* ecid, const DCULVRTempsDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRTempsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRTempsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -101,12 +101,12 @@ void DCULVRTempsDat::fetchData(std::map< EcalLogicID, DCULVRTempsDat >* fillMap,
     std::pair< EcalLogicID, DCULVRTempsDat > p;
     DCULVRTempsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setT1( rset->getFloat(7) );
       dat.setT2( rset->getFloat(8) );
@@ -116,6 +116,6 @@ void DCULVRTempsDat::fetchData(std::map< EcalLogicID, DCULVRTempsDat >* fillMap,
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRTempsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRTempsDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCULVRVoltagesDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCULVRVoltagesDat.cc
@@ -53,7 +53,7 @@ void DCULVRVoltagesDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9, :10, :11, :12, :13, :14, :15, :16, :17)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRVoltagesDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRVoltagesDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -93,7 +93,7 @@ void DCULVRVoltagesDat::writeDB(const EcalLogicID* ecid, const DCULVRVoltagesDat
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRVoltagesDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRVoltagesDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -125,12 +125,12 @@ void DCULVRVoltagesDat::fetchData(std::map< EcalLogicID, DCULVRVoltagesDat >* fi
     std::pair< EcalLogicID, DCULVRVoltagesDat > p;
     DCULVRVoltagesDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setVFE1_A( rset->getFloat(7) );
       dat.setVFE2_A( rset->getFloat(8) );
@@ -152,7 +152,7 @@ void DCULVRVoltagesDat::fetchData(std::map< EcalLogicID, DCULVRVoltagesDat >* fi
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRVoltagesDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRVoltagesDat::fetchData():  "+e.getMessage()));
   }
 }
 void DCULVRVoltagesDat::writeArrayDB(const std::map< EcalLogicID, DCULVRVoltagesDat >* data, DCUIOV* iov)
@@ -327,6 +327,6 @@ void DCULVRVoltagesDat::writeArrayDB(const std::map< EcalLogicID, DCULVRVoltages
     delete [] h_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCULVRVoltagesDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCULVRVoltagesDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/DCUTag.cc
+++ b/OnlineDB/EcalCondDB/src/DCUTag.cc
@@ -91,7 +91,7 @@ int DCUTag::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUTag::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUTag::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -112,7 +112,7 @@ void DCUTag::setByID(int id)
 
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
-      m_genTag = getOraString(rset,1);
+      m_genTag = rset->getString(1);
       int locID = rset->getInt(2);
 
       m_locDef.setConnection(m_env, m_conn);
@@ -125,7 +125,7 @@ void DCUTag::setByID(int id)
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("DCUTag::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("DCUTag::setByID:  "+e.getMessage()));
   }
 }
 
@@ -158,7 +158,7 @@ int DCUTag::writeDB()
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("DCUTag::writeDB:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("DCUTag::writeDB:  "+e.getMessage()));
   }
 
   // now get the tag_id
@@ -188,7 +188,7 @@ void DCUTag::fetchAllTags( std::vector<DCUTag>* fillVec)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUTag::fetchAllTags:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUTag::fetchAllTags:  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/DCUVFETempDat.cc
+++ b/OnlineDB/EcalCondDB/src/DCUVFETempDat.cc
@@ -39,7 +39,7 @@ void DCUVFETempDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":vfe_temp)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUVFETempDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUVFETempDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -65,7 +65,7 @@ void DCUVFETempDat::writeDB(const EcalLogicID* ecid, const DCUVFETempDat* item, 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUVFETempDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUVFETempDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,12 +97,12 @@ void DCUVFETempDat::fetchData(std::map< EcalLogicID, DCUVFETempDat >* fillMap, D
     std::pair< EcalLogicID, DCUVFETempDat > p;
     DCUVFETempDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setVFETemp( rset->getFloat(7) );
 
@@ -110,7 +110,7 @@ void DCUVFETempDat::fetchData(std::map< EcalLogicID, DCUVFETempDat >* fillMap, D
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUVFETempDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUVFETempDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -179,6 +179,6 @@ void DCUVFETempDat::writeArrayDB(const std::map< EcalLogicID, DCUVFETempDat >* d
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("DCUVFETempDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("DCUVFETempDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/EcalCondDBInterface.cc
+++ b/OnlineDB/EcalCondDB/src/EcalCondDBInterface.cc
@@ -81,7 +81,7 @@ EcalLogicID EcalCondDBInterface::getEcalLogicID( int logicID )
     ResultSet* rset = stmt->executeQuery();
 
     if (rset->next()) {
-      name = getOraString(rset,1);
+      name = rset->getString(1);
       logicID = rset->getInt(2);
       id1 = rset->getInt(3);
       if (rset->isNull(3)) { id1 = EcalLogicID::NULLID; }
@@ -89,7 +89,7 @@ EcalLogicID EcalCondDBInterface::getEcalLogicID( int logicID )
       if (rset->isNull(4)) { id2 = EcalLogicID::NULLID; }
       id3 = rset->getInt(5);
       if (rset->isNull(5)) { id3 = EcalLogicID::NULLID; }
-      mapsTo = getOraString(rset,6);
+      mapsTo = rset->getString(6);
     } else {
       stringstream msg;
       msg << "ERROR:  Cannot build EcalLogicID for logic_id " << logicID;
@@ -97,7 +97,7 @@ EcalLogicID EcalCondDBInterface::getEcalLogicID( int logicID )
     }
 
   } catch (SQLException &e) {    
-    throw(std::runtime_error(std::string("ERROR:  Failed to retrive ids:  ") + getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ERROR:  Failed to retrive ids:  ") + e.getMessage()));
   }
   
   return EcalLogicID( name, logicID, id1, id2, id3, mapsTo );  
@@ -192,7 +192,7 @@ EcalLogicID EcalCondDBInterface::getEcalLogicID( string name,
       throw(std::runtime_error(msg.str()));
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ERROR:  Failed to retrive logic_id:  ") + getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ERROR:  Failed to retrive logic_id:  ") + e.getMessage()));
   }
 
   // create and return the EcalLogicID object
@@ -269,7 +269,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDSet( string name,
     int id1, id2, id3, logicId;
 
     while (rset->next()) {
-      name = getOraString(rset,1);
+      name = rset->getString(1);
       logicId = rset->getInt(2);
       id1 = rset->getInt(3);
       if (rset->isNull(3)) { id1 = EcalLogicID::NULLID; }
@@ -277,7 +277,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDSet( string name,
       if (rset->isNull(4)) { id2 = EcalLogicID::NULLID; }
       id3 = rset->getInt(5);
       if (rset->isNull(5)) { id3 = EcalLogicID::NULLID; }
-      mapsTo = getOraString(rset,6);
+      mapsTo = rset->getString(6);
 
       EcalLogicID ecid = EcalLogicID( name, logicId, id1, id2, id3, mapsTo );
       result.push_back(ecid);
@@ -285,7 +285,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDSet( string name,
     stmt->setPrefetchRowCount(0);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ERROR:  Failure while getting EcalLogicID set:  ") + getOraMessage(&e)));    
+    throw(std::runtime_error(std::string("ERROR:  Failure while getting EcalLogicID set:  ") + e.getMessage()));    
   }
 
   return result;
@@ -372,7 +372,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDMappedTo(int lmr_log
     stmt->setPrefetchRowCount(0);
   }
   catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ERROR:  Failure while getting EcalLogicID set:  ") + getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ERROR:  Failure while getting EcalLogicID set:  ") + e.getMessage()));
   }
   return ret;
 }
@@ -491,7 +491,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDSetOrdered( string n
     int id1, id2, id3, logicId;
 
     while (rset->next()) {
-      name = getOraString(rset,1);
+      name = rset->getString(1);
       logicId = rset->getInt(2);
       id1 = rset->getInt(3);
       if (rset->isNull(3)) { id1 = EcalLogicID::NULLID; }
@@ -499,7 +499,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDSetOrdered( string n
       if (rset->isNull(4)) { id2 = EcalLogicID::NULLID; }
       id3 = rset->getInt(5);
       if (rset->isNull(5)) { id3 = EcalLogicID::NULLID; }
-      mapsTo = getOraString(rset,6);
+      mapsTo = rset->getString(6);
 
       EcalLogicID ecid = EcalLogicID( name, logicId, id1, id2, id3, mapsTo );
       result.push_back(ecid);
@@ -507,7 +507,7 @@ std::vector<EcalLogicID> EcalCondDBInterface::getEcalLogicIDSetOrdered( string n
     stmt->setPrefetchRowCount(0);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ERROR:  Failure while getting EcalLogicID set:  ") + getOraMessage(&e)));    
+    throw(std::runtime_error(std::string("ERROR:  Failure while getting EcalLogicID set:  ") + e.getMessage()));    
   }
 
   return result;

--- a/OnlineDB/EcalCondDB/src/EcalDBConnection.cc
+++ b/OnlineDB/EcalCondDB/src/EcalDBConnection.cc
@@ -28,7 +28,7 @@ EcalDBConnection::EcalDBConnection( string host,
     stmt = conn->createStatement();
   } catch (SQLException &e) {
     cout<< ss.str() << endl;
-    throw(std::runtime_error(std::string("ERROR:  Connection Failed:  ") + getOraMessage(&e)));
+    throw(std::runtime_error("ERROR:  Connection Failed:  " + e.getMessage() ));
   }
 
   this->host = host;
@@ -48,7 +48,7 @@ EcalDBConnection::EcalDBConnection( string sid,
     conn = env->createConnection(user, pass, sid);
     stmt = conn->createStatement();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ERROR:  Connection Failed:  ") + getOraMessage(&e)));
+    throw(std::runtime_error("ERROR:  Connection Failed:  " + e.getMessage() ));
   }
 
   this->host = "";
@@ -65,6 +65,6 @@ EcalDBConnection::~EcalDBConnection()  noexcept(false) {
     env->terminateConnection(conn);
     Environment::terminateEnvironment(env);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ERROR:  Destructor Failed:  ") + getOraMessage(&e)));
+    throw(std::runtime_error("ERROR:  Destructor Failed:  " + e.getMessage() ));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigBadStripDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadStripDat.cc
@@ -40,7 +40,7 @@ void FEConfigBadStripDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, tcc_id,fed_id, tt_id, st_id, status ) "
 			"VALUES (:1, :2, :3, :4, :5 ,:6 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadStripDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadStripDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -61,7 +61,7 @@ void FEConfigBadStripDat::writeDB(const FEConfigBadStripDat* item, FEConfigBadSt
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadStripDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadStripDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -98,7 +98,7 @@ void FEConfigBadStripDat::fetchData(std::vector< FEConfigBadStripDat >* p, FECon
 
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadStripDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadStripDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -179,6 +179,6 @@ void FEConfigBadStripDat::writeArrayDB(const std::vector< FEConfigBadStripDat >&
     delete [] st_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadStripDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadStripDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigBadStripInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadStripInfo.cc
@@ -50,7 +50,7 @@ int FEConfigBadStripInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadStripInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadStripInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -74,7 +74,7 @@ void FEConfigBadStripInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadStripInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadStripInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ void FEConfigBadStripInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadStripInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadStripInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -161,11 +161,11 @@ void FEConfigBadStripInfo::fetchData(FEConfigBadStripInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadStripInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadStripInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -195,7 +195,7 @@ int FEConfigBadStripInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadStripInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadStripInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/FEConfigBadTTDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadTTDat.cc
@@ -39,7 +39,7 @@ void FEConfigBadTTDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, tcc_id, fed_id, tt_id, status ) "
 			"VALUES (:1, :2, :3, :4, :5 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadTTDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadTTDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -59,7 +59,7 @@ void FEConfigBadTTDat::writeDB(const FEConfigBadTTDat* item, FEConfigBadTTInfo* 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadTTDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadTTDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,7 +95,7 @@ void FEConfigBadTTDat::fetchData(std::vector< FEConfigBadTTDat >* p, FEConfigBad
 
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadTTDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadTTDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -169,6 +169,6 @@ void FEConfigBadTTDat::writeArrayDB(const std::vector< FEConfigBadTTDat >& data,
     delete [] st_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadTTDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadTTDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigBadTTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadTTInfo.cc
@@ -50,7 +50,7 @@ int FEConfigBadTTInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadTTInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadTTInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -74,7 +74,7 @@ void FEConfigBadTTInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadTTInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadTTInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ void FEConfigBadTTInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadTTInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadTTInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -161,11 +161,11 @@ void FEConfigBadTTInfo::fetchData(FEConfigBadTTInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadTTInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadTTInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -195,7 +195,7 @@ int FEConfigBadTTInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadTTInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadTTInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/FEConfigBadXTDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadXTDat.cc
@@ -40,7 +40,7 @@ void FEConfigBadXTDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, tcc_id,fed_id, tt_id, CRY_id, status ) "
 			"VALUES (:1, :2, :3, :4, :5 ,:6 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadXTDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadXTDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -61,7 +61,7 @@ void FEConfigBadXTDat::writeDB(const FEConfigBadXTDat* item, FEConfigBadXTInfo* 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadXTDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadXTDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -98,7 +98,7 @@ void FEConfigBadXTDat::fetchData(std::vector< FEConfigBadXTDat >* p, FEConfigBad
 
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadXTDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadXTDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -179,6 +179,6 @@ void FEConfigBadXTDat::writeArrayDB(const std::vector< FEConfigBadXTDat >& data,
     delete [] st_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadXTDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigBadXTDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigBadXTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigBadXTInfo.cc
@@ -50,7 +50,7 @@ int FEConfigBadXTInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadXTInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadXTInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -74,7 +74,7 @@ void FEConfigBadXTInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadXTInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadXTInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ void FEConfigBadXTInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadXTInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadXTInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -161,11 +161,11 @@ void FEConfigBadXTInfo::fetchData(FEConfigBadXTInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadXTInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadXTInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -195,7 +195,7 @@ int FEConfigBadXTInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigBadXTInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigBadXTInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrDat.cc
@@ -39,7 +39,7 @@ void FEConfigFgrDat::prepareWrite()
 		      "VALUES (:fgr_conf_id, :logic_id, "
 		      ":group_id )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void FEConfigFgrDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,12 +95,12 @@ void FEConfigFgrDat::fetchData(map< EcalLogicID, FEConfigFgrDat >* fillMap, FECo
     std::pair< EcalLogicID, FEConfigFgrDat > p;
     FEConfigFgrDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setFgrGroupId( rset->getInt(7) );  
        
@@ -108,7 +108,7 @@ void FEConfigFgrDat::fetchData(map< EcalLogicID, FEConfigFgrDat >* fillMap, FECo
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -174,6 +174,6 @@ void FEConfigFgrDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFgrDat >*
     delete [] x_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrEEStripDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrEEStripDat.cc
@@ -40,7 +40,7 @@ void FEConfigFgrEEStripDat::prepareWrite()
 		      "VALUES (:fgr_conf_id, :logic_id, "
 		      ":threshold, :lut_fg )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrEEStripDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrEEStripDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -66,7 +66,7 @@ void FEConfigFgrEEStripDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrEE
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrEEStripDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrEEStripDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -98,12 +98,12 @@ void FEConfigFgrEEStripDat::fetchData(map< EcalLogicID, FEConfigFgrEEStripDat >*
     std::pair< EcalLogicID, FEConfigFgrEEStripDat > p;
     FEConfigFgrEEStripDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setThreshold( rset->getUInt(7) );  
       dat.setLutFg( rset->getUInt(8) );  
@@ -112,7 +112,7 @@ void FEConfigFgrEEStripDat::fetchData(map< EcalLogicID, FEConfigFgrEEStripDat >*
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrEEStripDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrEEStripDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -188,6 +188,6 @@ void FEConfigFgrEEStripDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFg
     delete [] y_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrEEStripDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrEEStripDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrEETowerDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrEETowerDat.cc
@@ -39,7 +39,7 @@ void FEConfigFgrEETowerDat::prepareWrite()
 		      "VALUES (:fgr_conf_id, :logic_id, "
 		      ":lut_value )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrEETowerDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrEETowerDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -64,7 +64,7 @@ void FEConfigFgrEETowerDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrEE
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrEETowerDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrEETowerDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -96,12 +96,12 @@ void FEConfigFgrEETowerDat::fetchData(map< EcalLogicID, FEConfigFgrEETowerDat >*
     std::pair< EcalLogicID, FEConfigFgrEETowerDat > p;
     FEConfigFgrEETowerDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setLutValue( rset->getInt(7) );  
 
@@ -109,7 +109,7 @@ void FEConfigFgrEETowerDat::fetchData(map< EcalLogicID, FEConfigFgrEETowerDat >*
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrEETowerDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrEETowerDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -177,6 +177,6 @@ void FEConfigFgrEETowerDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFg
     delete [] x_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrEETowerDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrEETowerDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrGroupDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrGroupDat.cc
@@ -44,7 +44,7 @@ void FEConfigFgrGroupDat::prepareWrite()
 		      "VALUES (:fgr_conf_id, :group_id, "
 		      ":3, :4, :5, :6, :7 )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrGroupDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrGroupDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -75,7 +75,7 @@ void FEConfigFgrGroupDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrGrou
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrGroupDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrGroupDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -121,7 +121,7 @@ void FEConfigFgrGroupDat::fetchData(map< EcalLogicID, FEConfigFgrGroupDat >* fil
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrGroupDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrGroupDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -227,6 +227,6 @@ void FEConfigFgrGroupDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFgrG
     delete [] t_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrGroupDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrGroupDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrInfo.cc
@@ -52,7 +52,7 @@ int FEConfigFgrInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigFgrInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -76,7 +76,7 @@ void FEConfigFgrInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigFgrInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -114,7 +114,7 @@ void FEConfigFgrInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigFgrInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -149,14 +149,14 @@ void FEConfigFgrInfo::fetchData(FEConfigFgrInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setNumberOfGroups(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigFgrInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -175,14 +175,14 @@ void FEConfigFgrInfo::fetchLastData(FEConfigFgrInfo * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setNumberOfGroups(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigFgrInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -212,7 +212,7 @@ int FEConfigFgrInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigFgrInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;
@@ -236,7 +236,7 @@ void FEConfigFgrInfo::setByID(int id)
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
        this->setId(rset->getInt(1));
-       this->setConfigTag(getOraString(rset,2));
+       this->setConfigTag(rset->getString(2));
        this->setVersion(rset->getInt(3));
        this->setNumberOfGroups(rset->getInt(4));
        Date dbdate = rset->getDate(5);
@@ -247,7 +247,7 @@ void FEConfigFgrInfo::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("FEConfigFgrInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error(std::string("FEConfigFgrInfo::setByID:  ")+e.getMessage()));
    }
 }
 

--- a/OnlineDB/EcalCondDB/src/FEConfigFgrParamDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigFgrParamDat.cc
@@ -42,7 +42,7 @@ void FEConfigFgrParamDat::prepareWrite()
 		      "VALUES (:fgr_conf_id, :logic_id, "
 		      " :fg_lowthresh, :fg_highthresh, :fg_lowratio, :fg_highratio )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrParamDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrParamDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -70,7 +70,7 @@ void FEConfigFgrParamDat::writeDB(const EcalLogicID* ecid, const FEConfigFgrPara
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrParamDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrParamDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -102,12 +102,12 @@ void FEConfigFgrParamDat::fetchData(map< EcalLogicID, FEConfigFgrParamDat >* fil
     std::pair< EcalLogicID, FEConfigFgrParamDat > p;
     FEConfigFgrParamDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setFGlowthresh( rset->getFloat(7) );  
       dat.setFGhighthresh(  rset->getFloat(8) );
@@ -118,7 +118,7 @@ void FEConfigFgrParamDat::fetchData(map< EcalLogicID, FEConfigFgrParamDat >* fil
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrParamDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrParamDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -209,6 +209,6 @@ void FEConfigFgrParamDat::writeArrayDB(const std::map< EcalLogicID, FEConfigFgrP
     delete [] st_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigFgrParamDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigFgrParamDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigLUTDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLUTDat.cc
@@ -39,7 +39,7 @@ void FEConfigLUTDat::prepareWrite()
 		      "VALUES (:lut_conf_id, :logic_id, "
 		      ":group_id )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLUTDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void FEConfigLUTDat::writeDB(const EcalLogicID* ecid, const FEConfigLUTDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLUTDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,12 +95,12 @@ void FEConfigLUTDat::fetchData(map< EcalLogicID, FEConfigLUTDat >* fillMap, FECo
     std::pair< EcalLogicID, FEConfigLUTDat > p;
     FEConfigLUTDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setLUTGroupId( rset->getInt(7) );  
        
@@ -108,7 +108,7 @@ void FEConfigLUTDat::fetchData(map< EcalLogicID, FEConfigLUTDat >* fillMap, FECo
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLUTDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -174,6 +174,6 @@ void FEConfigLUTDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLUTDat >*
     delete [] x_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLUTDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigLUTGroupDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLUTGroupDat.cc
@@ -42,7 +42,7 @@ void FEConfigLUTGroupDat::prepareWrite()
 		      "VALUES (:lut_conf_id, :group_id, "
 		      ":lut_id, :lut_value )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTGroupDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTGroupDat::prepareWrite():  ")+e.getMessage()));
   }
 }
 
@@ -116,7 +116,7 @@ void FEConfigLUTGroupDat::writeDB(const EcalLogicID* ecid, const FEConfigLUTGrou
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTGroupDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTGroupDat::writeArrayDB():  ")+e.getMessage()));
   }
 }
 
@@ -172,7 +172,7 @@ void FEConfigLUTGroupDat::fetchData(map< EcalLogicID, FEConfigLUTGroupDat >* fil
       }
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTGroupDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTGroupDat::fetchData:  ")+e.getMessage()));
   }
 }
 
@@ -264,6 +264,6 @@ void FEConfigLUTGroupDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLUTG
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTGroupDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTGroupDat::writeArrayDB():  ")+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigLUTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLUTInfo.cc
@@ -52,7 +52,7 @@ int FEConfigLUTInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -76,7 +76,7 @@ void FEConfigLUTInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -114,7 +114,7 @@ void FEConfigLUTInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -149,14 +149,14 @@ void FEConfigLUTInfo::fetchData(FEConfigLUTInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setNumberOfGroups(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -175,14 +175,14 @@ void FEConfigLUTInfo::fetchLastData(FEConfigLUTInfo * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setNumberOfGroups(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -212,7 +212,7 @@ int FEConfigLUTInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLUTInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;
@@ -236,7 +236,7 @@ void FEConfigLUTInfo::setByID(int id)
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
        this->setId(rset->getInt(1));
-       this->setConfigTag(getOraString(rset,2));
+       this->setConfigTag(rset->getString(2));
        this->setVersion(rset->getInt(3));
        this->setNumberOfGroups(rset->getInt(4));
        Date dbdate = rset->getDate(5);
@@ -247,7 +247,7 @@ void FEConfigLUTInfo::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("FEConfigLUTInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error(std::string("FEConfigLUTInfo::setByID:  ")+e.getMessage()));
    }
 }
 

--- a/OnlineDB/EcalCondDB/src/FEConfigLUTParamDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLUTParamDat.cc
@@ -41,7 +41,7 @@ void FEConfigLUTParamDat::prepareWrite()
 		      "VALUES (:lut_conf_id, :logic_id, "
 		      ":etsat, :ttthreshlow, :ttthreshhigh )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTParamDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLUTParamDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -68,7 +68,7 @@ void FEConfigLUTParamDat::writeDB(const EcalLogicID* ecid, const FEConfigLUTPara
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTParamDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLUTParamDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -100,12 +100,12 @@ void FEConfigLUTParamDat::fetchData(map< EcalLogicID, FEConfigLUTParamDat >* fil
     std::pair< EcalLogicID, FEConfigLUTParamDat > p;
     FEConfigLUTParamDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
 
 
@@ -117,7 +117,7 @@ void FEConfigLUTParamDat::fetchData(map< EcalLogicID, FEConfigLUTParamDat >* fil
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTParamDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLUTParamDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -201,6 +201,6 @@ void FEConfigLUTParamDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLUTP
     delete [] z_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLUTParamDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLUTParamDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigLinDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLinDat.cc
@@ -45,7 +45,7 @@ void FEConfigLinDat::prepareWrite()
 		      "VALUES (:lin_conf_id, :logic_id, "
 		      ":multx12, :multx6, :multx1, :shift12, :shift6, :shift1 )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLinDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -75,7 +75,7 @@ void FEConfigLinDat::writeDB(const EcalLogicID* ecid, const FEConfigLinDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLinDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -107,12 +107,12 @@ void FEConfigLinDat::fetchData(map< EcalLogicID, FEConfigLinDat >* fillMap, FECo
     std::pair< EcalLogicID, FEConfigLinDat > p;
     FEConfigLinDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setMultX12( rset->getInt(7) );  
       dat.setMultX6( rset->getInt(8) );  
@@ -125,7 +125,7 @@ void FEConfigLinDat::fetchData(map< EcalLogicID, FEConfigLinDat >* fillMap, FECo
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLinDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -231,6 +231,6 @@ void FEConfigLinDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLinDat >*
     delete [] s_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLinDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigLinInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLinInfo.cc
@@ -52,7 +52,7 @@ int FEConfigLinInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLinInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -76,7 +76,7 @@ void FEConfigLinInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLinInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -114,7 +114,7 @@ void FEConfigLinInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLinInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -149,14 +149,14 @@ void FEConfigLinInfo::fetchData(FEConfigLinInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setIOVId(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLinInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -175,14 +175,14 @@ void FEConfigLinInfo::fetchLastData(FEConfigLinInfo * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setIOVId(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLinInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -212,7 +212,7 @@ int FEConfigLinInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigLinInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;
@@ -236,7 +236,7 @@ void FEConfigLinInfo::setByID(int id)
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
        this->setId(rset->getInt(1));
-       this->setConfigTag(getOraString(rset,2));
+       this->setConfigTag(rset->getString(2));
        this->setVersion(rset->getInt(3));
        this->setIOVId(rset->getInt(4));
        Date dbdate = rset->getDate(5);
@@ -247,7 +247,7 @@ void FEConfigLinInfo::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("FEConfigLinInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error(std::string("FEConfigLinInfo::setByID:  ")+e.getMessage()));
    }
 }
 

--- a/OnlineDB/EcalCondDB/src/FEConfigLinParamDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLinParamDat.cc
@@ -38,7 +38,7 @@ void FEConfigLinParamDat::prepareWrite()
 		      "VALUES (:lin_conf_id, :logic_id, "
 		      ":etsat )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinParamDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLinParamDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void FEConfigLinParamDat::writeDB(const EcalLogicID* ecid, const FEConfigLinPara
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinParamDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLinParamDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,12 +95,12 @@ void FEConfigLinParamDat::fetchData(map< EcalLogicID, FEConfigLinParamDat >* fil
     std::pair< EcalLogicID, FEConfigLinParamDat > p;
     FEConfigLinParamDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
 
 
@@ -110,7 +110,7 @@ void FEConfigLinParamDat::fetchData(map< EcalLogicID, FEConfigLinParamDat >* fil
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinParamDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLinParamDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -174,6 +174,6 @@ void FEConfigLinParamDat::writeArrayDB(const std::map< EcalLogicID, FEConfigLinP
     delete [] x_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigLinParamDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigLinParamDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigMainInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigMainInfo.cc
@@ -62,7 +62,7 @@ int FEConfigMainInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigMainInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigMainInfo::fetchNextId():  "+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ int FEConfigMainInfo::fetchID()
     std::cout<<m_ID<<endl;
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigMainInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigMainInfo::fetchID:  "+e.getMessage()));
   }
   setByID(m_ID);
   return m_ID;
@@ -136,7 +136,7 @@ void FEConfigMainInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigMainInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigMainInfo::prepareWrite():  "+e.getMessage()));
   }
 
 }
@@ -172,7 +172,7 @@ void FEConfigMainInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigMainInfo::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigMainInfo::writeDB:  "+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -207,7 +207,7 @@ int FEConfigMainInfo::fetchIDLast()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigInfo::fetchIDLast:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigInfo::fetchIDLast:  "+e.getMessage()));
   }
 
   setByID(m_ID);
@@ -244,9 +244,9 @@ void FEConfigMainInfo::setByID(int id)
        setBxtId(       rset->getInt(10) );
        setBttId(       rset->getInt(11) );
        setBstId(       rset->getInt(12) );
-       setConfigTag(   getOraString(rset,13) );
+       setConfigTag(   rset->getString(13) );
        setVersion(     rset->getInt(14) );
-       setDescription(      getOraString(rset,15) );
+       setDescription(      rset->getString(15) );
        Date dbdate = rset->getDate(16);
        setDBTime( dh.dateToTm( dbdate ));
        m_ID = id;
@@ -255,7 +255,7 @@ void FEConfigMainInfo::setByID(int id)
      }
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("FEConfigMainInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("FEConfigMainInfo::setByID:  "+e.getMessage()));
    }
 }
 
@@ -302,14 +302,14 @@ void FEConfigMainInfo::fetchData(FEConfigMainInfo * result)
     setBttId(       rset->getInt(11) );
     setBstId(       rset->getInt(12) );
     
-    result->setConfigTag(         getOraString(rset,13) );
+    result->setConfigTag(         rset->getString(13) );
     result->setVersion(     rset->getInt(14) );
-    result->setDescription(      getOraString(rset,15) );
+    result->setDescription(      rset->getString(15) );
     Date dbdate = rset->getDate(16);
     result->setDBTime( dh.dateToTm( dbdate ));
  
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigMainInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigMainInfo::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/FEConfigParamDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigParamDat.cc
@@ -45,7 +45,7 @@ void FEConfigParamDat::prepareWrite()
 		      "VALUES (:lin_conf_id, :logic_id, "
 		      ":etsat, :ttthreshlow, :ttthreshhigh, :fg_lowthresh, :fg_highthresh, :fg_lowratio, :fg_highratio )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigParamDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigParamDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -76,7 +76,7 @@ void FEConfigParamDat::writeDB(const EcalLogicID* ecid, const FEConfigParamDat* 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigParamDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigParamDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -108,12 +108,12 @@ void FEConfigParamDat::fetchData(map< EcalLogicID, FEConfigParamDat >* fillMap, 
     std::pair< EcalLogicID, FEConfigParamDat > p;
     FEConfigParamDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
 
 
@@ -129,7 +129,7 @@ void FEConfigParamDat::fetchData(map< EcalLogicID, FEConfigParamDat >* fillMap, 
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigParamDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigParamDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -244,6 +244,6 @@ void FEConfigParamDat::writeArrayDB(const std::map< EcalLogicID, FEConfigParamDa
     delete [] st_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigParamDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigParamDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigPedDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigPedDat.cc
@@ -41,7 +41,7 @@ void FEConfigPedDat::prepareWrite()
 		      "VALUES (:ped_conf_id, :logic_id, "
 		      ":ped_mean_g12, :ped_mean_g6, :ped_mean_g1 )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigPedDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -67,7 +67,7 @@ void FEConfigPedDat::writeDB(const EcalLogicID* ecid, const FEConfigPedDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigPedDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -98,12 +98,12 @@ void FEConfigPedDat::fetchData(map< EcalLogicID, FEConfigPedDat >* fillMap, FECo
     std::pair< EcalLogicID, FEConfigPedDat > p;
     FEConfigPedDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setPedMeanG12( rset->getFloat(7) );  
       dat.setPedMeanG6( rset->getFloat(8) );
@@ -113,7 +113,7 @@ void FEConfigPedDat::fetchData(map< EcalLogicID, FEConfigPedDat >* fillMap, FECo
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigPedDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -196,6 +196,6 @@ void FEConfigPedDat::writeArrayDB(const std::map< EcalLogicID, FEConfigPedDat >*
     delete [] z_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigPedDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigPedInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigPedInfo.cc
@@ -52,7 +52,7 @@ int FEConfigPedInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigPedInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -76,7 +76,7 @@ void FEConfigPedInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigPedInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -114,7 +114,7 @@ void FEConfigPedInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigPedInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -149,14 +149,14 @@ void FEConfigPedInfo::fetchData(FEConfigPedInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setIOVId(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigPedInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -175,14 +175,14 @@ void FEConfigPedInfo::fetchLastData(FEConfigPedInfo * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setIOVId(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigPedInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -212,7 +212,7 @@ int FEConfigPedInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigPedInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigPedInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;
@@ -236,7 +236,7 @@ void FEConfigPedInfo::setByID(int id)
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
        this->setId(rset->getInt(1));
-       this->setConfigTag(getOraString(rset,2));
+       this->setConfigTag(rset->getString(2));
        this->setVersion(rset->getInt(3));
        this->setIOVId(rset->getInt(4));
        Date dbdate = rset->getDate(5);
@@ -247,7 +247,7 @@ void FEConfigPedInfo::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("FEConfigPedInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error(std::string("FEConfigPedInfo::setByID:  ")+e.getMessage()));
    }
 }
 

--- a/OnlineDB/EcalCondDB/src/FEConfigSlidingDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigSlidingDat.cc
@@ -39,7 +39,7 @@ void FEConfigSlidingDat::prepareWrite()
 		      "VALUES (:sli_conf_id, :logic_id, "
 		      ":sliding )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigSlidingDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -64,7 +64,7 @@ void FEConfigSlidingDat::writeDB(const EcalLogicID* ecid, const FEConfigSlidingD
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigSlidingDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -96,12 +96,12 @@ void FEConfigSlidingDat::fetchData(map< EcalLogicID, FEConfigSlidingDat >* fillM
     std::pair< EcalLogicID, FEConfigSlidingDat > p;
     FEConfigSlidingDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setSliding( rset->getFloat(7) );  
 
@@ -109,7 +109,7 @@ void FEConfigSlidingDat::fetchData(map< EcalLogicID, FEConfigSlidingDat >* fillM
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigSlidingDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -178,6 +178,6 @@ void FEConfigSlidingDat::writeArrayDB(const std::map< EcalLogicID, FEConfigSlidi
     delete [] x_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigSlidingDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigSlidingInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigSlidingInfo.cc
@@ -52,7 +52,7 @@ int FEConfigSlidingInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSlidingInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -76,7 +76,7 @@ void FEConfigSlidingInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSlidingInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -114,7 +114,7 @@ void FEConfigSlidingInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSlidingInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -149,14 +149,14 @@ void FEConfigSlidingInfo::fetchData(FEConfigSlidingInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setIOVId(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSlidingInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -175,14 +175,14 @@ void FEConfigSlidingInfo::fetchLastData(FEConfigSlidingInfo * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setIOVId(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSlidingInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -212,7 +212,7 @@ int FEConfigSlidingInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSlidingInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSlidingInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;
@@ -236,7 +236,7 @@ void FEConfigSlidingInfo::setByID(int id)
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
        this->setId(rset->getInt(1));
-       this->setConfigTag(getOraString(rset,2));
+       this->setConfigTag(rset->getString(2));
        this->setVersion(rset->getInt(3));
        this->setIOVId(rset->getInt(4));
        Date dbdate = rset->getDate(5);
@@ -247,7 +247,7 @@ void FEConfigSlidingInfo::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("FEConfigSlidingInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error(std::string("FEConfigSlidingInfo::setByID:  ")+e.getMessage()));
    }
 }
 

--- a/OnlineDB/EcalCondDB/src/FEConfigSpikeDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigSpikeDat.cc
@@ -39,7 +39,7 @@ void FEConfigSpikeDat::prepareWrite()
 		      "VALUES (:spi_conf_id, :logic_id, "
 		      ":spike_threshold )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigSpikeDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void FEConfigSpikeDat::writeDB(const EcalLogicID* ecid, const FEConfigSpikeDat* 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigSpikeDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -93,12 +93,12 @@ void FEConfigSpikeDat::fetchData(map< EcalLogicID, FEConfigSpikeDat >* fillMap, 
     std::pair< EcalLogicID, FEConfigSpikeDat > p;
     FEConfigSpikeDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setSpikeThreshold( rset->getInt(7) );  
        
@@ -106,7 +106,7 @@ void FEConfigSpikeDat::fetchData(map< EcalLogicID, FEConfigSpikeDat >* fillMap, 
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigSpikeDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -172,6 +172,6 @@ void FEConfigSpikeDat::writeArrayDB(const std::map< EcalLogicID, FEConfigSpikeDa
     delete [] x_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigSpikeDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigSpikeInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigSpikeInfo.cc
@@ -51,7 +51,7 @@ int FEConfigSpikeInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSpikeInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -75,7 +75,7 @@ void FEConfigSpikeInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSpikeInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -111,7 +111,7 @@ void FEConfigSpikeInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSpikeInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -146,13 +146,13 @@ void FEConfigSpikeInfo::fetchData(FEConfigSpikeInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     Date dbdate = rset->getDate(4);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSpikeInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -171,13 +171,13 @@ void FEConfigSpikeInfo::fetchLastData(FEConfigSpikeInfo * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     Date dbdate = rset->getDate(4);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSpikeInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -207,7 +207,7 @@ int FEConfigSpikeInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigSpikeInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigSpikeInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;
@@ -231,7 +231,7 @@ void FEConfigSpikeInfo::setByID(int id)
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
        this->setId(rset->getInt(1));
-       this->setConfigTag(getOraString(rset,2));
+       this->setConfigTag(rset->getString(2));
        this->setVersion(rset->getInt(3));
        Date dbdate = rset->getDate(4);
        this->setDBTime( dh.dateToTm( dbdate ));
@@ -241,7 +241,7 @@ void FEConfigSpikeInfo::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("FEConfigSpikeInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error(std::string("FEConfigSpikeInfo::setByID:  ")+e.getMessage()));
    }
 }
 

--- a/OnlineDB/EcalCondDB/src/FEConfigTimingDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigTimingDat.cc
@@ -38,7 +38,7 @@ void FEConfigTimingDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (tim_conf_id, logic_id, "
 		      "time_par1, time_par2 ) VALUES (:tim_conf_id, :logic_id, :time_par1, :time_par2 )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigTimingDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void FEConfigTimingDat::writeDB(const EcalLogicID* ecid, const FEConfigTimingDat
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigTimingDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -93,12 +93,12 @@ void FEConfigTimingDat::fetchData(map< EcalLogicID, FEConfigTimingDat >* fillMap
     std::pair< EcalLogicID, FEConfigTimingDat > p;
     FEConfigTimingDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setTimingPar1( rset->getInt(7) );  
       dat.setTimingPar2( rset->getInt(8) );  
@@ -107,7 +107,7 @@ void FEConfigTimingDat::fetchData(map< EcalLogicID, FEConfigTimingDat >* fillMap
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigTimingDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -180,6 +180,6 @@ void FEConfigTimingDat::writeArrayDB(const std::map< EcalLogicID, FEConfigTiming
     delete [] y_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigTimingDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigTimingInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigTimingInfo.cc
@@ -51,7 +51,7 @@ int FEConfigTimingInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigTimingInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -75,7 +75,7 @@ void FEConfigTimingInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigTimingInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -111,7 +111,7 @@ void FEConfigTimingInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigTimingInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -146,13 +146,13 @@ void FEConfigTimingInfo::fetchData(FEConfigTimingInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     Date dbdate = rset->getDate(4);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigTimingInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -171,13 +171,13 @@ void FEConfigTimingInfo::fetchLastData(FEConfigTimingInfo * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     Date dbdate = rset->getDate(4);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigTimingInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -207,7 +207,7 @@ int FEConfigTimingInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigTimingInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigTimingInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;
@@ -231,7 +231,7 @@ void FEConfigTimingInfo::setByID(int id)
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
        this->setId(rset->getInt(1));
-       this->setConfigTag(getOraString(rset,2));
+       this->setConfigTag(rset->getString(2));
        this->setVersion(rset->getInt(3));
        Date dbdate = rset->getDate(4);
        this->setDBTime( dh.dateToTm( dbdate ));
@@ -241,7 +241,7 @@ void FEConfigTimingInfo::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("FEConfigTimingInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error(std::string("FEConfigTimingInfo::setByID:  ")+e.getMessage()));
    }
 }
 

--- a/OnlineDB/EcalCondDB/src/FEConfigWeightDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigWeightDat.cc
@@ -39,7 +39,7 @@ void FEConfigWeightDat::prepareWrite()
 		      "VALUES (:wei_conf_id, :logic_id, "
 		      ":group_id )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigWeightDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void FEConfigWeightDat::writeDB(const EcalLogicID* ecid, const FEConfigWeightDat
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigWeightDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,12 +95,12 @@ void FEConfigWeightDat::fetchData(map< EcalLogicID, FEConfigWeightDat >* fillMap
     std::pair< EcalLogicID, FEConfigWeightDat > p;
     FEConfigWeightDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setWeightGroupId( rset->getInt(7) );  
        
@@ -108,7 +108,7 @@ void FEConfigWeightDat::fetchData(map< EcalLogicID, FEConfigWeightDat >* fillMap
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigWeightDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -174,6 +174,6 @@ void FEConfigWeightDat::writeArrayDB(const std::map< EcalLogicID, FEConfigWeight
     delete [] x_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigWeightDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigWeightGroupDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigWeightGroupDat.cc
@@ -44,7 +44,7 @@ void FEConfigWeightGroupDat::prepareWrite()
 		      "VALUES (:wei_conf_id, :group_id, "
 		      ":w0, :w1, :w2, :w3, :w4 )" );
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightGroupDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigWeightGroupDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -75,7 +75,7 @@ void FEConfigWeightGroupDat::writeDB(const EcalLogicID* ecid, const FEConfigWeig
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightGroupDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigWeightGroupDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -121,7 +121,7 @@ void FEConfigWeightGroupDat::fetchData(map< EcalLogicID, FEConfigWeightGroupDat 
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightGroupDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigWeightGroupDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -227,6 +227,6 @@ void FEConfigWeightGroupDat::writeArrayDB(const std::map< EcalLogicID, FEConfigW
     delete [] t_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightGroupDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("FEConfigWeightGroupDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/FEConfigWeightInfo.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigWeightInfo.cc
@@ -52,7 +52,7 @@ int FEConfigWeightInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigWeightInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -76,7 +76,7 @@ void FEConfigWeightInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigWeightInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -114,7 +114,7 @@ void FEConfigWeightInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigWeightInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -149,14 +149,14 @@ void FEConfigWeightInfo::fetchData(FEConfigWeightInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setNumberOfGroups(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigWeightInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -175,14 +175,14 @@ void FEConfigWeightInfo::fetchLastData(FEConfigWeightInfo * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
     result->setNumberOfGroups(rset->getInt(4));
     Date dbdate = rset->getDate(5);
     result->setDBTime( dh.dateToTm( dbdate ));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigWeightInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -212,7 +212,7 @@ int FEConfigWeightInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("FEConfigWeightInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("FEConfigWeightInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;
@@ -236,7 +236,7 @@ void FEConfigWeightInfo::setByID(int id)
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
        this->setId(rset->getInt(1));
-       this->setConfigTag(getOraString(rset,2));
+       this->setConfigTag(rset->getString(2));
        this->setVersion(rset->getInt(3));
        this->setNumberOfGroups(rset->getInt(4));
        Date dbdate = rset->getDate(5);
@@ -247,7 +247,7 @@ void FEConfigWeightInfo::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("FEConfigWeightInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error(std::string("FEConfigWeightInfo::setByID:  ")+e.getMessage()));
    }
 }
 

--- a/OnlineDB/EcalCondDB/src/LMFColor.cc
+++ b/OnlineDB/EcalCondDB/src/LMFColor.cc
@@ -94,8 +94,8 @@ std::string LMFColor::setByIDSql(Statement *stmt, int id) {
 
 void LMFColor::getParameters(ResultSet *rset) {
   setInt("color", rset->getInt(1));
-  setString("sname", getOraString(rset,2));
-  setString("lname", getOraString(rset,3));
+  setString("sname", rset->getString(2));
+  setString("lname", rset->getString(3));
 }
 
 bool LMFColor::isValid() {

--- a/OnlineDB/EcalCondDB/src/LMFCorrCoefDat.cc
+++ b/OnlineDB/EcalCondDB/src/LMFCorrCoefDat.cc
@@ -168,8 +168,8 @@ RunIOV LMFCorrCoefDat::fetchLastInsertedRun() {
     stmt->setSQL(sql);
   }
   catch (oracle::occi::SQLException &e) {
-    throw(std::runtime_error(std::string("[LMFCorrCoefDat::fetchLastInsertedRun]: ") +
-                             getOraMessage(&e)));
+    throw(std::runtime_error("[LMFCorrCoefDat::fetchLastInsertedRun]: " +
+                             e.getMessage()));
   }
   if (m_debug) {
     std::cout << "[LMFCorrCoefDat::fetchLastInsertedRun] executing query"
@@ -188,8 +188,8 @@ RunIOV LMFCorrCoefDat::fetchLastInsertedRun() {
     }
   }
   catch (oracle::occi::SQLException &e) {
-    throw(std::runtime_error(std::string("[LMFCorrCoefDat::fetchLastInsertedRun]: ") +
-                             getOraMessage(&e)));
+    throw(std::runtime_error("[LMFCorrCoefDat::fetchLastInsertedRun]: " +
+                             e.getMessage()));
   }
   if (iov_id > 0) {
     iov.setByID(iov_id);
@@ -488,8 +488,8 @@ LMFCorrCoefDat::getCorrections(const Tm &t, const Tm &t2, int max) {
     }
   }
   catch (oracle::occi::SQLException &e) {
-    throw(std::runtime_error(std::string("LMFCorrCoefDat::getCorrections: ") + 
-			     getOraMessage(&e)));
+    throw(std::runtime_error("LMFCorrCoefDat::getCorrections: " + 
+			     e.getMessage()));
   }
   if (m_debug) {
     std::cout << "[LMFCorrCoefDat::getCorrections] Map built" << std::endl

--- a/OnlineDB/EcalCondDB/src/LMFCorrVers.cc
+++ b/OnlineDB/EcalCondDB/src/LMFCorrVers.cc
@@ -41,7 +41,7 @@ std::string LMFCorrVers::setByIDSql(Statement *stmt, int id)
 }
 
 void LMFCorrVers::getParameters(ResultSet *rset) {
-  setString("description", getOraString(rset,1));
+  setString("description", rset->getString(1));
 }
 
 LMFUnique * LMFCorrVers::createObject() const {

--- a/OnlineDB/EcalCondDB/src/LMFDat.cc
+++ b/OnlineDB/EcalCondDB/src/LMFDat.cc
@@ -330,7 +330,7 @@ void LMFDat::fetch(int logic_id, const Tm *timestamp, int direction)
       m_conn->terminateStatement(stmt);
     }
     catch (oracle::occi::SQLException &e) {
-      throw(std::runtime_error(m_className + "::fetch: " + getOraMessage(&e)));
+      throw(std::runtime_error(m_className + "::fetch: " + e.getMessage()));
     }
     m_ID = m_data.size();
   }
@@ -386,7 +386,7 @@ std::map<int, std::vector<float> > LMFDat::fetchData()
     m_conn->terminateStatement(stmt);
   }
   catch (oracle::occi::SQLException &e) {
-    throw(std::runtime_error(m_className + "::fetchData:  "+getOraMessage(&e)));
+    throw(std::runtime_error(m_className + "::fetchData:  "+e.getMessage()));
   }
   if (m_debug) {
     cout << m_className << ":: data items to write = " 
@@ -528,7 +528,7 @@ int LMFDat::writeDB()
 	dump();
 	m_conn->rollback();
 	throw(std::runtime_error(m_className + "::writeDB: " + 
-				 getOraMessage(&e)));
+				 e.getMessage()));
       }
     } else {
       cout << m_className << "::writeDB: Cannot write because " << 
@@ -562,13 +562,13 @@ void LMFDat::getKeyTypes()
     stmt->setString(2, getIovIdFieldName());
     ResultSet *rset = stmt->executeQuery();
     while (rset->next() != 0) {
-      std::string name = getOraString(rset,1);
-      std::string t = getOraString(rset,2);
+      std::string name = rset->getString(1);
+      std::string t = rset->getString(2);
       m_type[m_keys[name]] = t;
     }
     m_conn->terminateStatement(stmt);
   } catch (oracle::occi::SQLException &e) {
-    throw(std::runtime_error(m_className + "::getKeyTypes: " + getOraMessage(&e) +
+    throw(std::runtime_error(m_className + "::getKeyTypes: " + e.getMessage() +
 			" [" + sql + "]"));
   }
 }

--- a/OnlineDB/EcalCondDB/src/LMFLmrSubIOV.cc
+++ b/OnlineDB/EcalCondDB/src/LMFLmrSubIOV.cc
@@ -217,7 +217,7 @@ std::list<int> LMFLmrSubIOV::getIOVIDsLaterThan(const Tm &tmin, const Tm &tmax,
     catch (oracle::occi::SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
       throw(std::runtime_error(m_className + "::getLmrSubIOVLaterThan: " +
-			       getOraMessage(&e)));
+			       e.getMessage()));
 #else
       throw(std::runtime_error(m_className + "::getLmrSubIOVLaterThan: error code " +
 			       std::to_string(e.getErrorCode())));

--- a/OnlineDB/EcalCondDB/src/LMFPrimVers.cc
+++ b/OnlineDB/EcalCondDB/src/LMFPrimVers.cc
@@ -38,7 +38,7 @@ std::string LMFPrimVers::setByIDSql(Statement *stmt, int id)
 }
 
 void LMFPrimVers::getParameters(ResultSet *rset) {
-  setString("description", getOraString(rset,1));
+  setString("description", rset->getString(1));
 }
 
 LMFUnique * LMFPrimVers::createObject() const {

--- a/OnlineDB/EcalCondDB/src/LMFRunIOV.cc
+++ b/OnlineDB/EcalCondDB/src/LMFRunIOV.cc
@@ -269,7 +269,7 @@ void LMFRunIOV::getParameters(ResultSet *rset) noexcept(false) {
   setString("subrun_start", dh.dateToTm(start).str());
   Date stop = rset->getDate(7);
   setString("subrun_end", dh.dateToTm(stop).str());
-  setString("subrun_type", getOraString(rset,8));
+  setString("subrun_type", rset->getString(8));
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
   setString("db_timestamp", rset->getTimestamp(9).toText("YYYY-MM-DD HH24:MI:SS", 0));
 #else
@@ -369,7 +369,7 @@ std::list<LMFRunIOV> LMFRunIOV::fetchBySequence(const vector<int>& par,
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
     throw(std::runtime_error(m_className + "::" + method + ": " +
-                             getOraMessage(&e)));
+                             e.getMessage()));
   }
   return l;
 }

--- a/OnlineDB/EcalCondDB/src/LMFRunTag.cc
+++ b/OnlineDB/EcalCondDB/src/LMFRunTag.cc
@@ -68,7 +68,7 @@ std::string LMFRunTag::setByIDSql(Statement *stmt, int id)
 }
 
 void LMFRunTag::getParameters(ResultSet *rset) {
-  setString("gen_tag", getOraString(rset,1));
+  setString("gen_tag", rset->getString(1));
   setInt("version", rset->getInt(2));
 }
 

--- a/OnlineDB/EcalCondDB/src/LMFSeqDat.cc
+++ b/OnlineDB/EcalCondDB/src/LMFSeqDat.cc
@@ -243,7 +243,7 @@ std::map<int, LMFSeqDat> LMFSeqDat::fetchByRunIOV(const std::vector<std::string>
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
     throw(std::runtime_error(m_className + "::" + method + ": " + 
-			     getOraMessage(&e)));
+			     e.getMessage()));
   }
   return l;
 }

--- a/OnlineDB/EcalCondDB/src/LMFSeqVers.cc
+++ b/OnlineDB/EcalCondDB/src/LMFSeqVers.cc
@@ -38,7 +38,7 @@ std::string LMFSeqVers::setByIDSql(Statement *stmt, int id)
 }
 
 void LMFSeqVers::getParameters(ResultSet *rset) {
-  setString("description", getOraString(rset,1));
+  setString("description", rset->getString(1));
 }
 
 LMFUnique * LMFSeqVers::createObject() const {

--- a/OnlineDB/EcalCondDB/src/LMFTrigType.cc
+++ b/OnlineDB/EcalCondDB/src/LMFTrigType.cc
@@ -56,8 +56,8 @@ std::string LMFTrigType::setByIDSql(Statement *stmt, int id)
 }   
 
 void LMFTrigType::getParameters(ResultSet *rset) {
-  setString("short_name", getOraString(rset,1));
-  setString("long_name", getOraString(rset,2));
+  setString("short_name", rset->getString(1));
+  setString("long_name", rset->getString(2));
 }
 
 LMFTrigType * LMFTrigType::createObject() const {

--- a/OnlineDB/EcalCondDB/src/LMFUnique.cc
+++ b/OnlineDB/EcalCondDB/src/LMFUnique.cc
@@ -101,7 +101,7 @@ boost::ptr_list<LMFUnique> LMFUnique::fetchAll() const
     m_conn->terminateStatement(stmt);
   }
   catch (SQLException &e) {
-    throw(std::runtime_error(m_className + "::fetchAll:  "+getOraMessage(&e)));
+    throw(std::runtime_error(m_className + "::fetchAll:  "+e.getMessage()));
   }
   if (m_debug) {
     cout << m_className << ": list size = " << l.size() << endl;
@@ -262,7 +262,7 @@ int LMFUnique::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(m_className + "::fetchID:  "+getOraMessage(&e)));
+    throw(std::runtime_error(m_className + "::fetchID:  "+e.getMessage()));
   }
   // given the ID of this object setup it completely
   if (m_ID > 0) {
@@ -316,7 +316,7 @@ void LMFUnique::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(m_className + "::setByID:  "+getOraMessage(&e)));
+   throw(std::runtime_error(m_className + "::setByID:  "+e.getMessage()));
   }
 }
 
@@ -368,7 +368,7 @@ int LMFUnique::writeDB()
     } catch (SQLException &e) {
       debug();
       dump();
-      throw(std::runtime_error(m_className + "::writeDB:  " + getOraMessage(&e) +
+      throw(std::runtime_error(m_className + "::writeDB:  " + e.getMessage() +
 			       " while executing query " + sql));
     }
     // now get the id

--- a/OnlineDB/EcalCondDB/src/LocationDef.cc
+++ b/OnlineDB/EcalCondDB/src/LocationDef.cc
@@ -65,7 +65,7 @@ int LocationDef::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("LocationDef::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("LocationDef::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -86,7 +86,7 @@ void LocationDef::setByID(int id)
 
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
-      m_loc = getOraString(rset,1);
+      m_loc = rset->getString(1);
       m_ID = id;
     } else {
       throw(std::runtime_error("LocationDef::setByID:  Given def_id is not in the database"));
@@ -94,7 +94,7 @@ void LocationDef::setByID(int id)
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("LocationDef::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("LocationDef::setByID:  "+e.getMessage()));
   }
 }
 
@@ -117,6 +117,6 @@ void LocationDef::fetchAllDefs( std::vector<LocationDef>* fillVec)
       fillVec->push_back( locationDef );
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("LocationDef::fetchAllDefs:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("LocationDef::fetchAllDefs:  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MODCCSFEDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODCCSFEDat.cc
@@ -38,7 +38,7 @@ void MODCCSFEDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":ccs_word)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODCCSFEDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODCCSFEDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void MODCCSFEDat::writeDB(const EcalLogicID* ecid, const MODCCSFEDat* item, MODR
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODCCSFEDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODCCSFEDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,12 +95,12 @@ void MODCCSFEDat::fetchData(std::map< EcalLogicID, MODCCSFEDat >* fillMap, MODRu
     std::pair< EcalLogicID, MODCCSFEDat > p;
     MODCCSFEDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setWord( rset->getInt(7) );
 
@@ -108,7 +108,7 @@ void MODCCSFEDat::fetchData(std::map< EcalLogicID, MODCCSFEDat >* fillMap, MODRu
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODCCSFEDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODCCSFEDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -176,6 +176,6 @@ void MODCCSFEDat::writeArrayDB(const std::map< EcalLogicID, MODCCSFEDat >* data,
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MODCCSHFDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODCCSHFDat.cc
@@ -39,7 +39,7 @@ void MODCCSHFDat::setFile(std::string x) {
   //try {
   std::cout<< "file is "<< m_file<<endl;
   // }catch (Exception &e) {
-  //throw(std::runtime_error(std::string("MODCCSHFDat::setFile():  ")+getOraMessage(&e)));
+  //throw(std::runtime_error(std::string("MODCCSHFDat::setFile():  ")+e.getMessage()));
   //} 
     // here we must open the file and read the CCS Clob
     std::cout << "Going to read CCS file: " << m_file << endl;
@@ -72,7 +72,7 @@ void MODCCSHFDat::prepareWrite()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODCCSHFDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("MODCCSHFDat::prepareWrite():  ")+e.getMessage()));
   }
 }
 
@@ -133,7 +133,7 @@ void MODCCSHFDat::writeDB(const EcalLogicID* ecid, const MODCCSHFDat* item, MODR
     m_writeStmt->closeResultSet (rset);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODCCSHFDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("MODCCSHFDat::writeDB():  ")+e.getMessage()));
   }
 }
 
@@ -165,20 +165,20 @@ void MODCCSHFDat::fetchData(std::map< EcalLogicID, MODCCSHFDat >* fillMap, MODRu
     std::pair< EcalLogicID, MODCCSHFDat > p;
     MODCCSHFDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       // to be corrected 
-      //      dat.setClob( getOraString(rset,7) );
+      //      dat.setClob( rset->getString(7) );
 
       p.second = dat;
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODCCSHFDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("MODCCSHFDat::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -249,7 +249,7 @@ void MODCCSHFDat::writeArrayDB(const std::map< EcalLogicID, MODCCSHFDat >* data,
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+e.getMessage()));
   }
 }
 
@@ -319,7 +319,7 @@ void MODCCSHFDat::populateClob (Clob &clob, std::string fname, unsigned int clob
 
 
   }catch (SQLException &e) {
-    throw(std::runtime_error(std::string("populateClob():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("populateClob():  ")+e.getMessage()));
   }
 
   cout << "Populating the Clob - Success" << endl;
@@ -348,7 +348,7 @@ unsigned char* MODCCSHFDat::readClob (oracle::occi::Clob &clob, int size)
     return  buffer;
 
   }catch (SQLException &e) {
-    throw(std::runtime_error(std::string("readClob():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("readClob():  ")+e.getMessage()));
   }
 
 }

--- a/OnlineDB/EcalCondDB/src/MODCCSTRDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODCCSTRDat.cc
@@ -38,7 +38,7 @@ void MODCCSTRDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":ccs_word)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODCCSTRDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODCCSTRDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void MODCCSTRDat::writeDB(const EcalLogicID* ecid, const MODCCSTRDat* item, MODR
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODCCSTRDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODCCSTRDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,12 +95,12 @@ void MODCCSTRDat::fetchData(std::map< EcalLogicID, MODCCSTRDat >* fillMap, MODRu
     std::pair< EcalLogicID, MODCCSTRDat > p;
     MODCCSTRDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setWord( rset->getInt(7) );
 
@@ -108,7 +108,7 @@ void MODCCSTRDat::fetchData(std::map< EcalLogicID, MODCCSTRDat >* fillMap, MODRu
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODCCSTRDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODCCSTRDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -176,6 +176,6 @@ void MODCCSTRDat::writeArrayDB(const std::map< EcalLogicID, MODCCSTRDat >* data,
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MODDCCDetailsDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODDCCDetailsDat.cc
@@ -52,7 +52,7 @@ void MODDCCDetailsDat::prepareWrite()
 			" VALUES (:iov_id, :logic_id, "
 			" :1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :11, :12 ) ");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODDCCDetailsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODDCCDetailsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -88,7 +88,7 @@ void MODDCCDetailsDat::writeDB(const EcalLogicID* ecid, const MODDCCDetailsDat* 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODDCCDetailsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODDCCDetailsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -120,12 +120,12 @@ void MODDCCDetailsDat::fetchData(std::map< EcalLogicID, MODDCCDetailsDat >* fill
     std::pair< EcalLogicID, MODDCCDetailsDat > p;
     MODDCCDetailsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setQPLL( rset->getInt(7) );
       dat.setOpticalLink( rset->getInt(8) );
@@ -144,7 +144,7 @@ void MODDCCDetailsDat::fetchData(std::map< EcalLogicID, MODDCCDetailsDat >* fill
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODDCCDetailsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODDCCDetailsDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -300,6 +300,6 @@ void MODDCCDetailsDat::writeArrayDB(const std::map< EcalLogicID, MODDCCDetailsDa
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MODDCCOperationDat.cc
+++ b/OnlineDB/EcalCondDB/src/MODDCCOperationDat.cc
@@ -38,7 +38,7 @@ void MODDCCOperationDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":1) ");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODDCCOperationDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODDCCOperationDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void MODDCCOperationDat::writeDB(const EcalLogicID* ecid, const MODDCCOperationD
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODDCCOperationDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODDCCOperationDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,20 +95,20 @@ void MODDCCOperationDat::fetchData(std::map< EcalLogicID, MODDCCOperationDat >* 
     std::pair< EcalLogicID, MODDCCOperationDat > p;
     MODDCCOperationDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
-      dat.setOperation( getOraString(rset,7) );
+      dat.setOperation( rset->getString(7) );
 
       p.second = dat;
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODDCCOperationDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODDCCOperationDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -176,6 +176,6 @@ void MODDCCOperationDat::writeArrayDB(const std::map< EcalLogicID, MODDCCOperati
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MODRunIOV.cc
+++ b/OnlineDB/EcalCondDB/src/MODRunIOV.cc
@@ -145,7 +145,7 @@ int MODRunIOV::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODRunIOV::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODRunIOV::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -186,7 +186,7 @@ void MODRunIOV::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("MODRunIOV::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("MODRunIOV::setByID:  "+e.getMessage()));
    }
 }
 
@@ -231,7 +231,7 @@ int MODRunIOV::writeDB()
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODRunIOV::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODRunIOV::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -298,7 +298,7 @@ void MODRunIOV::setByRun( RunIOV* runiov, subrun_t subrun)
      
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MODRunIOV::setByRun:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MODRunIOV::setByRun:  "+e.getMessage()));
   }
   
 }

--- a/OnlineDB/EcalCondDB/src/MonCrystalConsistencyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonCrystalConsistencyDat.cc
@@ -42,7 +42,7 @@ void MonCrystalConsistencyDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonCrystalConsistencyDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonCrystalConsistencyDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -72,7 +72,7 @@ void MonCrystalConsistencyDat::writeDB(const EcalLogicID* ecid, const MonCrystal
     m_writeStmt->setInt(8, item->getTaskStatus() );
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonCrystalConsistencyDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonCrystalConsistencyDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -102,12 +102,12 @@ void MonCrystalConsistencyDat::fetchData(std::map< EcalLogicID, MonCrystalConsis
     std::pair< EcalLogicID, MonCrystalConsistencyDat > p;
     MonCrystalConsistencyDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setProcessedEvents( rset->getInt(7) );
       dat.setProblematicEvents( rset->getInt(8) );
@@ -121,7 +121,7 @@ void MonCrystalConsistencyDat::fetchData(std::map< EcalLogicID, MonCrystalConsis
     }
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonCrystalConsistencyDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonCrystalConsistencyDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -232,6 +232,6 @@ void MonCrystalConsistencyDat::writeArrayDB(const std::map< EcalLogicID, MonCrys
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonCrystalConsistencyDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonCrystalConsistencyDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonDelaysTTDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonDelaysTTDat.cc
@@ -41,7 +41,7 @@ void MonDelaysTTDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":delay_mean, :delay_rms, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonDelaysTTDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonDelaysTTDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -69,7 +69,7 @@ void MonDelaysTTDat::writeDB(const EcalLogicID* ecid, const MonDelaysTTDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonDelaysTTDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonDelaysTTDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -101,12 +101,12 @@ void MonDelaysTTDat::fetchData(std::map< EcalLogicID, MonDelaysTTDat >* fillMap,
     std::pair< EcalLogicID, MonDelaysTTDat > p;
     MonDelaysTTDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setDelayMean( rset->getFloat(7) );
       dat.setDelayRMS( rset->getFloat(8) );
@@ -117,7 +117,7 @@ void MonDelaysTTDat::fetchData(std::map< EcalLogicID, MonDelaysTTDat >* fillMap,
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonDelaysTTDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonDelaysTTDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -204,6 +204,6 @@ void MonDelaysTTDat::writeArrayDB(const std::map< EcalLogicID, MonDelaysTTDat >*
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonDelaysTTDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonDelaysTTDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonH4TablePositionDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonH4TablePositionDat.cc
@@ -38,7 +38,7 @@ void MonH4TablePositionDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonH4TablePositionDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonH4TablePositionDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -65,7 +65,7 @@ void MonH4TablePositionDat::writeDB(const EcalLogicID* ecid, const MonH4TablePos
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonH4TablePositionDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonH4TablePositionDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,12 +97,12 @@ void MonH4TablePositionDat::fetchData(std::map< EcalLogicID, MonH4TablePositionD
     std::pair< EcalLogicID, MonH4TablePositionDat > p;
     MonH4TablePositionDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setTableX( rset->getFloat(7) );
       dat.setTableY( rset->getFloat(8) );
@@ -111,7 +111,7 @@ void MonH4TablePositionDat::fetchData(std::map< EcalLogicID, MonH4TablePositionD
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonH4TablePositionDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonH4TablePositionDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -185,6 +185,6 @@ void MonH4TablePositionDat::writeArrayDB(const std::map< EcalLogicID, MonH4Table
     delete [] y_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonH4TablePositionDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonH4TablePositionDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonLaserBlueDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserBlueDat.cc
@@ -42,7 +42,7 @@ void MonLaserBlueDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":apd_mean, :apd_rms, :apd_over_pn_mean, :apd_over_pn_rms, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserBlueDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserBlueDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -72,7 +72,7 @@ void MonLaserBlueDat::writeDB(const EcalLogicID* ecid, const MonLaserBlueDat* it
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserBlueDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserBlueDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -105,12 +105,12 @@ void MonLaserBlueDat::fetchData(std::map< EcalLogicID, MonLaserBlueDat >* fillMa
     std::pair< EcalLogicID, MonLaserBlueDat > p;
     MonLaserBlueDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setAPDMean( rset->getFloat(7) );
       dat.setAPDRMS( rset->getFloat(8) );
@@ -123,7 +123,7 @@ void MonLaserBlueDat::fetchData(std::map< EcalLogicID, MonLaserBlueDat >* fillMa
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserBlueDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserBlueDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -226,6 +226,6 @@ void MonLaserBlueDat::writeArrayDB(const std::map< EcalLogicID, MonLaserBlueDat 
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserBlueDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserBlueDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonLaserGreenDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserGreenDat.cc
@@ -42,7 +42,7 @@ void MonLaserGreenDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":apd_mean, :apd_rms, :apd_over_pn_mean, :apd_over_pn_rms, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserGreenDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserGreenDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -72,7 +72,7 @@ void MonLaserGreenDat::writeDB(const EcalLogicID* ecid, const MonLaserGreenDat* 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserGreenDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserGreenDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -105,12 +105,12 @@ void MonLaserGreenDat::fetchData(std::map< EcalLogicID, MonLaserGreenDat >* fill
     std::pair< EcalLogicID, MonLaserGreenDat > p;
     MonLaserGreenDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setAPDMean( rset->getFloat(7) );
       dat.setAPDRMS( rset->getFloat(8) );
@@ -123,7 +123,7 @@ void MonLaserGreenDat::fetchData(std::map< EcalLogicID, MonLaserGreenDat >* fill
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserGreenDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserGreenDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -226,6 +226,6 @@ void MonLaserGreenDat::writeArrayDB(const std::map< EcalLogicID, MonLaserGreenDa
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserGreenDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserGreenDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonLaserIRedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserIRedDat.cc
@@ -42,7 +42,7 @@ void MonLaserIRedDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":apd_mean, :apd_rms, :apd_over_pn_mean, :apd_over_pn_rms, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserIRedDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserIRedDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -72,7 +72,7 @@ void MonLaserIRedDat::writeDB(const EcalLogicID* ecid, const MonLaserIRedDat* it
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserIRedDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserIRedDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -105,12 +105,12 @@ void MonLaserIRedDat::fetchData(std::map< EcalLogicID, MonLaserIRedDat >* fillMa
     std::pair< EcalLogicID, MonLaserIRedDat > p;
     MonLaserIRedDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setAPDMean( rset->getFloat(7) );
       dat.setAPDRMS( rset->getFloat(8) );
@@ -123,7 +123,7 @@ void MonLaserIRedDat::fetchData(std::map< EcalLogicID, MonLaserIRedDat >* fillMa
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserIRedDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserIRedDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -226,6 +226,6 @@ void MonLaserIRedDat::writeArrayDB(const std::map< EcalLogicID, MonLaserIRedDat 
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserIRedDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserIRedDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonLaserPulseDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserPulseDat.cc
@@ -40,7 +40,7 @@ void MonLaserPulseDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserPulseDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserPulseDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -69,7 +69,7 @@ void MonLaserPulseDat::writeDB(const EcalLogicID* ecid, const MonLaserPulseDat* 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserPulseDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserPulseDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -101,12 +101,12 @@ void MonLaserPulseDat::fetchData(std::map< EcalLogicID, MonLaserPulseDat >* fill
     std::pair< EcalLogicID, MonLaserPulseDat > p;
     MonLaserPulseDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setPulseHeightMean( rset->getFloat(7) );
       dat.setPulseHeightRMS( rset->getFloat(8) );
@@ -117,7 +117,7 @@ void MonLaserPulseDat::fetchData(std::map< EcalLogicID, MonLaserPulseDat >* fill
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserPulseDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserPulseDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -212,6 +212,6 @@ void MonLaserPulseDat::writeArrayDB(const std::map< EcalLogicID, MonLaserPulseDa
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserPulseDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserPulseDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonLaserRedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserRedDat.cc
@@ -42,7 +42,7 @@ void MonLaserRedDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":apd_mean, :apd_rms, :apd_over_pn_mean, :apd_over_pn_rms, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserRedDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserRedDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -72,7 +72,7 @@ void MonLaserRedDat::writeDB(const EcalLogicID* ecid, const MonLaserRedDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserRedDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserRedDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -105,12 +105,12 @@ void MonLaserRedDat::fetchData(std::map< EcalLogicID, MonLaserRedDat >* fillMap,
     std::pair< EcalLogicID, MonLaserRedDat > p;
     MonLaserRedDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setAPDMean( rset->getFloat(7) );
       dat.setAPDRMS( rset->getFloat(8) );
@@ -123,7 +123,7 @@ void MonLaserRedDat::fetchData(std::map< EcalLogicID, MonLaserRedDat >* fillMap,
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserRedDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserRedDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -226,6 +226,6 @@ void MonLaserRedDat::writeArrayDB(const std::map< EcalLogicID, MonLaserRedDat >*
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserRedDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserRedDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonLaserStatusDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLaserStatusDat.cc
@@ -40,7 +40,7 @@ void MonLaserStatusDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserStatusDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserStatusDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -69,7 +69,7 @@ void MonLaserStatusDat::writeDB(const EcalLogicID* ecid, const MonLaserStatusDat
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserStatusDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserStatusDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -101,12 +101,12 @@ void MonLaserStatusDat::fetchData(std::map< EcalLogicID, MonLaserStatusDat >* fi
     std::pair< EcalLogicID, MonLaserStatusDat > p;
     MonLaserStatusDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setLaserPower( rset->getFloat(7) );
       dat.setLaserFilter( rset->getFloat(8) );
@@ -117,6 +117,6 @@ void MonLaserStatusDat::fetchData(std::map< EcalLogicID, MonLaserStatusDat >* fi
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLaserStatusDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLaserStatusDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonLed1Dat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLed1Dat.cc
@@ -42,7 +42,7 @@ void MonLed1Dat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":vpt_mean, :vpt_rms, :vpt_over_pn_mean, :vpt_over_pn_rms, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLed1Dat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLed1Dat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -72,7 +72,7 @@ void MonLed1Dat::writeDB(const EcalLogicID* ecid, const MonLed1Dat* item, MonRun
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLed1Dat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLed1Dat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -105,12 +105,12 @@ void MonLed1Dat::fetchData(std::map< EcalLogicID, MonLed1Dat >* fillMap, MonRunI
     std::pair< EcalLogicID, MonLed1Dat > p;
     MonLed1Dat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setVPTMean( rset->getFloat(7) );
       dat.setVPTRMS( rset->getFloat(8) );
@@ -123,7 +123,7 @@ void MonLed1Dat::fetchData(std::map< EcalLogicID, MonLed1Dat >* fillMap, MonRunI
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLed1Dat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLed1Dat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -226,6 +226,6 @@ void MonLed1Dat::writeArrayDB(const std::map< EcalLogicID, MonLed1Dat >* data, M
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLed1Dat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLed1Dat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonLed2Dat.cc
+++ b/OnlineDB/EcalCondDB/src/MonLed2Dat.cc
@@ -42,7 +42,7 @@ void MonLed2Dat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":vpt_mean, :vpt_rms, :vpt_over_pn_mean, :vpt_over_pn_rms, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLed2Dat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLed2Dat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -72,7 +72,7 @@ void MonLed2Dat::writeDB(const EcalLogicID* ecid, const MonLed2Dat* item, MonRun
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLed2Dat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLed2Dat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -105,12 +105,12 @@ void MonLed2Dat::fetchData(std::map< EcalLogicID, MonLed2Dat >* fillMap, MonRunI
     std::pair< EcalLogicID, MonLed2Dat > p;
     MonLed2Dat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setVPTMean( rset->getFloat(7) );
       dat.setVPTRMS( rset->getFloat(8) );
@@ -123,7 +123,7 @@ void MonLed2Dat::fetchData(std::map< EcalLogicID, MonLed2Dat >* fillMap, MonRunI
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLed2Dat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLed2Dat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -226,6 +226,6 @@ void MonLed2Dat::writeArrayDB(const std::map< EcalLogicID, MonLed2Dat >* data, M
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonLed2Dat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonLed2Dat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonMemChConsistencyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonMemChConsistencyDat.cc
@@ -42,7 +42,7 @@ void MonMemChConsistencyDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonMemChConsistencyDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonMemChConsistencyDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -72,7 +72,7 @@ void MonMemChConsistencyDat::writeDB(const EcalLogicID* ecid, const MonMemChCons
     m_writeStmt->setInt(8, item->getTaskStatus() );
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonMemChConsistencyDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonMemChConsistencyDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -104,12 +104,12 @@ void MonMemChConsistencyDat::fetchData(std::map< EcalLogicID, MonMemChConsistenc
     std::pair< EcalLogicID, MonMemChConsistencyDat > p;
     MonMemChConsistencyDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setProcessedEvents( rset->getInt(7) );
       dat.setProblematicEvents( rset->getInt(8) );
@@ -122,7 +122,7 @@ void MonMemChConsistencyDat::fetchData(std::map< EcalLogicID, MonMemChConsistenc
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonMemChConsistencyDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonMemChConsistencyDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -233,6 +233,6 @@ void MonMemChConsistencyDat::writeArrayDB(const std::map< EcalLogicID, MonMemChC
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonMemChConsistencyDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonMemChConsistencyDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonMemTTConsistencyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonMemTTConsistencyDat.cc
@@ -43,7 +43,7 @@ void MonMemTTConsistencyDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonMemTTConsistencyDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonMemTTConsistencyDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -74,7 +74,7 @@ void MonMemTTConsistencyDat::writeDB(const EcalLogicID* ecid, const MonMemTTCons
     m_writeStmt->setInt(9, item->getTaskStatus() );
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonMemTTConsistencyDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonMemTTConsistencyDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -106,12 +106,12 @@ void MonMemTTConsistencyDat::fetchData(std::map< EcalLogicID, MonMemTTConsistenc
     std::pair< EcalLogicID, MonMemTTConsistencyDat > p;
     MonMemTTConsistencyDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setProcessedEvents( rset->getInt(7) );
       dat.setProblematicEvents( rset->getInt(8) );
@@ -125,7 +125,7 @@ void MonMemTTConsistencyDat::fetchData(std::map< EcalLogicID, MonMemTTConsistenc
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonMemTTConsistencyDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonMemTTConsistencyDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -245,6 +245,6 @@ void MonMemTTConsistencyDat::writeArrayDB(const std::map< EcalLogicID, MonMemTTC
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonMemTTConsistencyDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonMemTTConsistencyDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonOccupancyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonOccupancyDat.cc
@@ -39,7 +39,7 @@ void MonOccupancyDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonOccupancyDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonOccupancyDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -67,7 +67,7 @@ void MonOccupancyDat::writeDB(const EcalLogicID* ecid, const MonOccupancyDat* it
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonOccupancyDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonOccupancyDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -99,12 +99,12 @@ void MonOccupancyDat::fetchData(std::map< EcalLogicID, MonOccupancyDat >* fillMa
     std::pair< EcalLogicID, MonOccupancyDat > p;
     MonOccupancyDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setEventsOverLowThreshold( rset->getInt(7) );
       dat.setEventsOverHighThreshold( rset->getInt(8) );
@@ -114,7 +114,7 @@ void MonOccupancyDat::fetchData(std::map< EcalLogicID, MonOccupancyDat >* fillMa
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonOccupancyDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonOccupancyDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -199,6 +199,6 @@ void MonOccupancyDat::writeArrayDB(const std::map< EcalLogicID, MonOccupancyDat 
     
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonOccupancyDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonOccupancyDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPNBlueDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNBlueDat.cc
@@ -47,7 +47,7 @@ void MonPNBlueDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9, :10, :11)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNBlueDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNBlueDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -81,7 +81,7 @@ void MonPNBlueDat::writeDB(const EcalLogicID* ecid, const MonPNBlueDat* item, Mo
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNBlueDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNBlueDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -113,12 +113,12 @@ void MonPNBlueDat::fetchData(std::map< EcalLogicID, MonPNBlueDat >* fillMap, Mon
     std::pair< EcalLogicID, MonPNBlueDat > p;
     MonPNBlueDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setADCMeanG1( rset->getFloat(7) );
       dat.setADCRMSG1( rset->getFloat(8) );
@@ -133,7 +133,7 @@ void MonPNBlueDat::fetchData(std::map< EcalLogicID, MonPNBlueDat >* fillMap, Mon
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNBlueDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNBlueDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -268,6 +268,6 @@ void MonPNBlueDat::writeArrayDB(const std::map< EcalLogicID, MonPNBlueDat >* dat
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNBlueDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNBlueDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPNGreenDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNGreenDat.cc
@@ -47,7 +47,7 @@ void MonPNGreenDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9, :10, :11)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNGreenDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNGreenDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -81,7 +81,7 @@ void MonPNGreenDat::writeDB(const EcalLogicID* ecid, const MonPNGreenDat* item, 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNGreenDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNGreenDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -113,12 +113,12 @@ void MonPNGreenDat::fetchData(std::map< EcalLogicID, MonPNGreenDat >* fillMap, M
     std::pair< EcalLogicID, MonPNGreenDat > p;
     MonPNGreenDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setADCMeanG1( rset->getFloat(7) );
       dat.setADCRMSG1( rset->getFloat(8) );
@@ -133,7 +133,7 @@ void MonPNGreenDat::fetchData(std::map< EcalLogicID, MonPNGreenDat >* fillMap, M
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNGreenDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNGreenDat::fetchData():  "+e.getMessage()));
   }
 }
 void MonPNGreenDat::writeArrayDB(const std::map< EcalLogicID, MonPNGreenDat >* data, MonRunIOV* iov)
@@ -267,6 +267,6 @@ void MonPNGreenDat::writeArrayDB(const std::map< EcalLogicID, MonPNGreenDat >* d
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNGreenDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNGreenDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPNIRedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNIRedDat.cc
@@ -47,7 +47,7 @@ void MonPNIRedDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9, :10, :11)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNIRedDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNIRedDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -81,7 +81,7 @@ void MonPNIRedDat::writeDB(const EcalLogicID* ecid, const MonPNIRedDat* item, Mo
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNIRedDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNIRedDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -113,12 +113,12 @@ void MonPNIRedDat::fetchData(std::map< EcalLogicID, MonPNIRedDat >* fillMap, Mon
     std::pair< EcalLogicID, MonPNIRedDat > p;
     MonPNIRedDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setADCMeanG1( rset->getFloat(7) );
       dat.setADCRMSG1( rset->getFloat(8) );
@@ -133,7 +133,7 @@ void MonPNIRedDat::fetchData(std::map< EcalLogicID, MonPNIRedDat >* fillMap, Mon
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNIRedDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNIRedDat::fetchData():  "+e.getMessage()));
   }
 }
 void MonPNIRedDat::writeArrayDB(const std::map< EcalLogicID, MonPNIRedDat >* data, MonRunIOV* iov)
@@ -267,6 +267,6 @@ void MonPNIRedDat::writeArrayDB(const std::map< EcalLogicID, MonPNIRedDat >* dat
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNIRedDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNIRedDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPNLed1Dat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNLed1Dat.cc
@@ -47,7 +47,7 @@ void MonPNLed1Dat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9, :10, :11)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNLed1Dat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNLed1Dat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -81,7 +81,7 @@ void MonPNLed1Dat::writeDB(const EcalLogicID* ecid, const MonPNLed1Dat* item, Mo
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNLed1Dat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNLed1Dat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -113,12 +113,12 @@ void MonPNLed1Dat::fetchData(std::map< EcalLogicID, MonPNLed1Dat >* fillMap, Mon
     std::pair< EcalLogicID, MonPNLed1Dat > p;
     MonPNLed1Dat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setADCMeanG1( rset->getFloat(7) );
       dat.setADCRMSG1( rset->getFloat(8) );
@@ -133,7 +133,7 @@ void MonPNLed1Dat::fetchData(std::map< EcalLogicID, MonPNLed1Dat >* fillMap, Mon
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNLed1Dat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNLed1Dat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -268,6 +268,6 @@ void MonPNLed1Dat::writeArrayDB(const std::map< EcalLogicID, MonPNLed1Dat >* dat
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNLed1Dat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNLed1Dat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPNLed2Dat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNLed2Dat.cc
@@ -47,7 +47,7 @@ void MonPNLed2Dat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9, :10, :11)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNLed2Dat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNLed2Dat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -81,7 +81,7 @@ void MonPNLed2Dat::writeDB(const EcalLogicID* ecid, const MonPNLed2Dat* item, Mo
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNLed2Dat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNLed2Dat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -113,12 +113,12 @@ void MonPNLed2Dat::fetchData(std::map< EcalLogicID, MonPNLed2Dat >* fillMap, Mon
     std::pair< EcalLogicID, MonPNLed2Dat > p;
     MonPNLed2Dat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id2
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setADCMeanG1( rset->getFloat(7) );
       dat.setADCRMSG1( rset->getFloat(8) );
@@ -133,7 +133,7 @@ void MonPNLed2Dat::fetchData(std::map< EcalLogicID, MonPNLed2Dat >* fillMap, Mon
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNLed2Dat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNLed2Dat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -268,6 +268,6 @@ void MonPNLed2Dat::writeArrayDB(const std::map< EcalLogicID, MonPNLed2Dat >* dat
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNLed2Dat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNLed2Dat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPNMGPADat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNMGPADat.cc
@@ -47,7 +47,7 @@ void MonPNMGPADat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9, :10, :11)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNMGPADat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNMGPADat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -81,7 +81,7 @@ void MonPNMGPADat::writeDB(const EcalLogicID* ecid, const MonPNMGPADat* item, Mo
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNMGPADat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNMGPADat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -113,12 +113,12 @@ void MonPNMGPADat::fetchData(std::map< EcalLogicID, MonPNMGPADat >* fillMap, Mon
     std::pair< EcalLogicID, MonPNMGPADat > p;
     MonPNMGPADat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setADCMeanG1( rset->getFloat(7) );
       dat.setADCRMSG1( rset->getFloat(8) );
@@ -133,7 +133,7 @@ void MonPNMGPADat::fetchData(std::map< EcalLogicID, MonPNMGPADat >* fillMap, Mon
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNMGPADat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNMGPADat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -268,6 +268,6 @@ void MonPNMGPADat::writeArrayDB(const std::map< EcalLogicID, MonPNMGPADat >* dat
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNMGPADat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNMGPADat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPNPedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNPedDat.cc
@@ -43,7 +43,7 @@ void MonPNPedDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNPedDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNPedDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -73,7 +73,7 @@ void MonPNPedDat::writeDB(const EcalLogicID* ecid, const MonPNPedDat* item, MonR
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNPedDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNPedDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -105,12 +105,12 @@ void MonPNPedDat::fetchData(std::map< EcalLogicID, MonPNPedDat >* fillMap, MonRu
     std::pair< EcalLogicID, MonPNPedDat > p;
     MonPNPedDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setPedMeanG1( rset->getFloat(7) );
       dat.setPedRMSG1( rset->getFloat(8) );
@@ -121,7 +121,7 @@ void MonPNPedDat::fetchData(std::map< EcalLogicID, MonPNPedDat >* fillMap, MonRu
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNPedDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNPedDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -229,6 +229,6 @@ void MonPNPedDat::writeArrayDB(const std::map< EcalLogicID, MonPNPedDat >* data,
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNPedDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNPedDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPNRedDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPNRedDat.cc
@@ -47,7 +47,7 @@ void MonPNRedDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9, :10, :11)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNRedDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNRedDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -81,7 +81,7 @@ void MonPNRedDat::writeDB(const EcalLogicID* ecid, const MonPNRedDat* item, MonR
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNRedDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNRedDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -113,12 +113,12 @@ void MonPNRedDat::fetchData(std::map< EcalLogicID, MonPNRedDat >* fillMap, MonRu
     std::pair< EcalLogicID, MonPNRedDat > p;
     MonPNRedDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setADCMeanG1( rset->getFloat(7) );
       dat.setADCRMSG1( rset->getFloat(8) );
@@ -133,7 +133,7 @@ void MonPNRedDat::fetchData(std::map< EcalLogicID, MonPNRedDat >* fillMap, MonRu
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNRedDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNRedDat::fetchData():  "+e.getMessage()));
   }
 }
 void MonPNRedDat::writeArrayDB(const std::map< EcalLogicID, MonPNRedDat >* data, MonRunIOV* iov)
@@ -267,6 +267,6 @@ void MonPNRedDat::writeArrayDB(const std::map< EcalLogicID, MonPNRedDat >* data,
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPNRedDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPNRedDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPedestalOffsetsDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPedestalOffsetsDat.cc
@@ -42,7 +42,7 @@ void MonPedestalOffsetsDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":dac_g1, :dac_g6, :dac_g12, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalOffsetsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalOffsetsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -70,7 +70,7 @@ void MonPedestalOffsetsDat::writeDB(const EcalLogicID* ecid, const MonPedestalOf
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalOffsetsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalOffsetsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -101,12 +101,12 @@ void MonPedestalOffsetsDat::fetchData(std::map< EcalLogicID, MonPedestalOffsetsD
     std::pair< EcalLogicID, MonPedestalOffsetsDat > p;
     MonPedestalOffsetsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setDACG1( rset->getInt(7) );
       dat.setDACG6( rset->getInt(8) );
@@ -117,7 +117,7 @@ void MonPedestalOffsetsDat::fetchData(std::map< EcalLogicID, MonPedestalOffsetsD
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalOffsetsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalOffsetsDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -211,6 +211,6 @@ void MonPedestalOffsetsDat::writeArrayDB(const std::map< EcalLogicID, MonPedesta
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalOffsetsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalOffsetsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPedestalsDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPedestalsDat.cc
@@ -46,7 +46,7 @@ void MonPedestalsDat::prepareWrite()
 		      ":ped_mean_g1, :ped_mean_g6, :ped_mean_g12, "
 		      ":ped_rms_g1, :ped_rms_g6, :ped_rms_g12, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -77,7 +77,7 @@ void MonPedestalsDat::writeDB(const EcalLogicID* ecid, const MonPedestalsDat* it
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -110,12 +110,12 @@ void MonPedestalsDat::fetchData(map< EcalLogicID, MonPedestalsDat >* fillMap, Mo
     std::pair< EcalLogicID, MonPedestalsDat > p;
     MonPedestalsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setPedMeanG1( rset->getFloat(7) );  
       dat.setPedMeanG6( rset->getFloat(8) );
@@ -129,7 +129,7 @@ void MonPedestalsDat::fetchData(map< EcalLogicID, MonPedestalsDat >* fillMap, Mo
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::fetchData:  "+e.getMessage()));
   }
 }
 
@@ -248,6 +248,6 @@ void MonPedestalsDat::writeArrayDB(const std::map< EcalLogicID, MonPedestalsDat 
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPedestalsOnlineDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPedestalsOnlineDat.cc
@@ -41,7 +41,7 @@ void MonPedestalsOnlineDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":adc_mean_g12, :adc_rms_g12, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsOnlineDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsOnlineDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -68,7 +68,7 @@ void MonPedestalsOnlineDat::writeDB(const EcalLogicID* ecid, const MonPedestalsO
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsOnlineDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsOnlineDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -100,12 +100,12 @@ void MonPedestalsOnlineDat::fetchData(std::map< EcalLogicID, MonPedestalsOnlineD
     std::pair< EcalLogicID, MonPedestalsOnlineDat > p;
     MonPedestalsOnlineDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setADCMeanG12( rset->getFloat(7) );
       dat.setADCRMSG12( rset->getFloat(8) );
@@ -115,7 +115,7 @@ void MonPedestalsOnlineDat::fetchData(std::map< EcalLogicID, MonPedestalsOnlineD
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsOnlineDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsOnlineDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -202,6 +202,6 @@ void MonPedestalsOnlineDat::writeArrayDB(const std::map< EcalLogicID, MonPedesta
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonPulseShapeDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonPulseShapeDat.cc
@@ -48,7 +48,7 @@ void MonPulseShapeDat::prepareWrite()
 			);
 			
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPulseShapeDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPulseShapeDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -81,9 +81,9 @@ void MonPulseShapeDat::writeDB(const EcalLogicID* ecid, const MonPulseShapeDat* 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPulseShapeDat::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPulseShapeDat::writeDB:  "+e.getMessage()));
   } catch (exception &e) {
-    throw(std::runtime_error(std::string("MonPulseShapeDat::writeDB:  ") + string(e.what())));
+    throw(std::runtime_error("MonPulseShapeDat::writeDB:  " + string(e.what())));
   }
 }
 
@@ -117,12 +117,12 @@ void MonPulseShapeDat::fetchData(std::map< EcalLogicID, MonPulseShapeDat >* fill
     std::pair< EcalLogicID, MonPulseShapeDat > p;
     MonPulseShapeDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       int gain[] = {1, 6, 12};
       std::vector<float> samples(10);
@@ -138,6 +138,6 @@ void MonPulseShapeDat::fetchData(std::map< EcalLogicID, MonPulseShapeDat >* fill
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPulseShapeDat::fetchData:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPulseShapeDat::fetchData:  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonRunDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunDat.cc
@@ -43,7 +43,7 @@ void MonRunDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":num_events, :run_outcome_id, :rootfile_name, :task_list, :task_outcome) ");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -77,7 +77,7 @@ void MonRunDat::writeDB(const EcalLogicID* ecid, const MonRunDat* item, MonRunIO
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -111,17 +111,17 @@ void MonRunDat::fetchData(map< EcalLogicID, MonRunDat >* fillMap, MonRunIOV* iov
     MonRunOutcomeDef outcomeDef;
     outcomeDef.setConnection(m_env, m_conn);
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setNumEvents( rset->getInt(7) );
       outcomeDef.setByID( rset->getInt(8) );
       dat.setMonRunOutcomeDef( outcomeDef );
-      dat.setRootfileName( getOraString(rset,9) );
+      dat.setRootfileName( rset->getString(9) );
       dat.setTaskList( rset->getInt(10) );
       dat.setTaskOutcome( rset->getInt(11) );
 
@@ -129,6 +129,6 @@ void MonRunDat::fetchData(map< EcalLogicID, MonRunDat >* fillMap, MonRunIOV* iov
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonRunIOV.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunIOV.cc
@@ -162,7 +162,7 @@ int MonRunIOV::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunIOV::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunIOV::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -207,7 +207,7 @@ void MonRunIOV::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("MonRunIOV::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("MonRunIOV::setByID:  "+e.getMessage()));
    }
 }
 
@@ -257,7 +257,7 @@ int MonRunIOV::writeDB()
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunIOV::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunIOV::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -337,7 +337,7 @@ void MonRunIOV::setByRun(MonRunTag* montag, RunIOV* runiov, subrun_t subrun)
      
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunIOV::setByRun:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunIOV::setByRun:  "+e.getMessage()));
   }
   
 }

--- a/OnlineDB/EcalCondDB/src/MonRunList.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunList.cc
@@ -140,7 +140,7 @@ void MonRunList::fetchRuns()
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunIOV::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunIOV::fetchID:  "+e.getMessage()));
   }
 
 
@@ -250,7 +250,7 @@ void MonRunList::fetchRuns(int min_run, int max_run)
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunIOV::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunIOV::fetchID:  "+e.getMessage()));
   }
 
 
@@ -343,7 +343,7 @@ void MonRunList::fetchLastNRuns( int max_run, int n_runs  )
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunList::fetchLastNRuns:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunList::fetchLastNRuns:  "+e.getMessage()));
   }
 
 

--- a/OnlineDB/EcalCondDB/src/MonRunOutcomeDef.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunOutcomeDef.cc
@@ -74,7 +74,7 @@ int MonRunOutcomeDef::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunOutcomeDef::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunOutcomeDef::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -95,8 +95,8 @@ void MonRunOutcomeDef::setByID(int id)
 
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
-      m_shortDesc = getOraString(rset,1);
-      m_longDesc = getOraString(rset,2);
+      m_shortDesc = rset->getString(1);
+      m_longDesc = rset->getString(2);
       m_ID = id;
     } else {
       throw(std::runtime_error("MonRunOutcomeDef::setByID:  Given def_id is not in the database"));
@@ -104,7 +104,7 @@ void MonRunOutcomeDef::setByID(int id)
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("MonRunOutcomeDef::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("MonRunOutcomeDef::setByID:  "+e.getMessage()));
   }
 }
 
@@ -127,6 +127,6 @@ void MonRunOutcomeDef::fetchAllDefs( std::vector<MonRunOutcomeDef>* fillVec)
       fillVec->push_back( def );
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunOutcomeDef::fetchAllDefs:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunOutcomeDef::fetchAllDefs:  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonRunTag.cc
+++ b/OnlineDB/EcalCondDB/src/MonRunTag.cc
@@ -89,7 +89,7 @@ int MonRunTag::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunTag::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunTag::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -110,7 +110,7 @@ void MonRunTag::setByID(int id)
 
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
-      m_genTag = getOraString(rset,1);
+      m_genTag = rset->getString(1);
       int verID = rset->getInt(2);
       m_monVersionDef.setByID(verID);
       m_ID = id;
@@ -120,7 +120,7 @@ void MonRunTag::setByID(int id)
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("MonRunTag::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("MonRunTag::setByID:  "+e.getMessage()));
   }
 }
 
@@ -153,7 +153,7 @@ int MonRunTag::writeDB()
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("MonRunTag::writeDB:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("MonRunTag::writeDB:  "+e.getMessage()));
   }
 
   // now get the tag_id
@@ -183,7 +183,7 @@ void MonRunTag::fetchAllTags( std::vector<MonRunTag>* fillVec)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonRunTag::fetchAllTags:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonRunTag::fetchAllTags:  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/MonShapeQualityDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonShapeQualityDat.cc
@@ -39,7 +39,7 @@ void MonShapeQualityDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":avg_chi2)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonShapeQualityDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonShapeQualityDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -65,7 +65,7 @@ void MonShapeQualityDat::writeDB(const EcalLogicID* ecid, const MonShapeQualityD
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonShapeQualityDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonShapeQualityDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,12 +97,12 @@ void MonShapeQualityDat::fetchData(std::map< EcalLogicID, MonShapeQualityDat >* 
     std::pair< EcalLogicID, MonShapeQualityDat > p;
     MonShapeQualityDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setAvgChi2( rset->getFloat(7) );
 
@@ -110,7 +110,7 @@ void MonShapeQualityDat::fetchData(std::map< EcalLogicID, MonShapeQualityDat >* 
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonShapeQualityDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonShapeQualityDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -178,6 +178,6 @@ void MonShapeQualityDat::writeArrayDB(const std::map< EcalLogicID, MonShapeQuali
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonPedestalsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonPedestalsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonTTConsistencyDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonTTConsistencyDat.cc
@@ -43,7 +43,7 @@ void MonTTConsistencyDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":3, :4, :5, :6, :7, :8, :9)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonTTConsistencyDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonTTConsistencyDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -74,7 +74,7 @@ void MonTTConsistencyDat::writeDB(const EcalLogicID* ecid, const MonTTConsistenc
     m_writeStmt->setInt(9, item->getTaskStatus() );
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonTTConsistencyDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonTTConsistencyDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -106,12 +106,12 @@ void MonTTConsistencyDat::fetchData(std::map< EcalLogicID, MonTTConsistencyDat >
     std::pair< EcalLogicID, MonTTConsistencyDat > p;
     MonTTConsistencyDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setProcessedEvents( rset->getInt(7) );
       dat.setProblematicEvents( rset->getInt(8) );
@@ -125,7 +125,7 @@ void MonTTConsistencyDat::fetchData(std::map< EcalLogicID, MonTTConsistencyDat >
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonTTConsistencyDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonTTConsistencyDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -244,6 +244,6 @@ void MonTTConsistencyDat::writeArrayDB(const std::map< EcalLogicID, MonTTConsist
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonTTConsistencyDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonTTConsistencyDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonTestPulseDat.cc
+++ b/OnlineDB/EcalCondDB/src/MonTestPulseDat.cc
@@ -45,7 +45,7 @@ void MonTestPulseDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":adc_mean_g1, :adc_rms_g1, :adc_rms_g6, :adc_rms_g6, :adc_mean_g12, :adc_rms_g12, :task_status)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonTestPulseDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonTestPulseDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -76,7 +76,7 @@ void MonTestPulseDat::writeDB(const EcalLogicID* ecid, const MonTestPulseDat* it
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonTestPulseDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonTestPulseDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -108,12 +108,12 @@ void MonTestPulseDat::fetchData(std::map< EcalLogicID, MonTestPulseDat >* fillMa
     std::pair< EcalLogicID, MonTestPulseDat > p;
     MonTestPulseDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setADCMeanG1( rset->getFloat(7) );
       dat.setADCRMSG1( rset->getFloat(8) );
@@ -127,7 +127,7 @@ void MonTestPulseDat::fetchData(std::map< EcalLogicID, MonTestPulseDat >* fillMa
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonTestPulseDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonTestPulseDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -246,6 +246,6 @@ void MonTestPulseDat::writeArrayDB(const std::map< EcalLogicID, MonTestPulseDat 
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonTestPulseDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonTestPulseDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/MonVersionDef.cc
+++ b/OnlineDB/EcalCondDB/src/MonVersionDef.cc
@@ -72,7 +72,7 @@ int MonVersionDef::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonVersionDef::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonVersionDef::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -93,15 +93,15 @@ void MonVersionDef::setByID(int id)
 
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
-      m_monVer = getOraString(rset,1);
-      m_desc = getOraString(rset,2);
+      m_monVer = rset->getString(1);
+      m_desc = rset->getString(2);
     } else {
       throw(std::runtime_error("MonVersionDef::setByID:  Given def_id is not in the database"));
     }
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("MonVersionDef::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("MonVersionDef::setByID:  "+e.getMessage()));
   }
 }
 
@@ -124,6 +124,6 @@ void MonVersionDef::fetchAllDefs( std::vector<MonVersionDef>* fillVec)
       fillVec->push_back( monVersionDef );
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("MonVersionDef::fetchAllDefs:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("MonVersionDef::fetchAllDefs:  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODBadTTDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODBadTTDat.cc
@@ -39,7 +39,7 @@ void ODBadTTDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, tr_id, fed_id, tt_id, status ) "
 			"VALUES (:1, :2, :3, :4, :5 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadTTDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODBadTTDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -59,7 +59,7 @@ void ODBadTTDat::writeDB(const ODBadTTDat* item, ODBadTTInfo* iov )
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadTTDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODBadTTDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,7 +95,7 @@ void ODBadTTDat::fetchData(std::vector< ODBadTTDat >* p, ODBadTTInfo* iov)
 
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadTTDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODBadTTDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -169,6 +169,6 @@ void ODBadTTDat::writeArrayDB(const std::vector< ODBadTTDat >& data, ODBadTTInfo
     delete [] st_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadTTDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODBadTTDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODBadTTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODBadTTInfo.cc
@@ -50,7 +50,7 @@ int ODBadTTInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadTTInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadTTInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -74,7 +74,7 @@ void ODBadTTInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadTTInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadTTInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ void ODBadTTInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadTTInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadTTInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -161,11 +161,11 @@ void ODBadTTInfo::fetchData(ODBadTTInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadTTInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadTTInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -195,7 +195,7 @@ int ODBadTTInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadTTInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadTTInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODBadXTDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODBadXTDat.cc
@@ -40,7 +40,7 @@ void ODBadXTDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, sm_id, fed_id, tt_id, xt_id, status ) "
 			"VALUES (:1, :2, :3, :4, :5 ,:6 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadXTDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODBadXTDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -61,7 +61,7 @@ void ODBadXTDat::writeDB(const ODBadXTDat* item, ODBadXTInfo* iov )
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadXTDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODBadXTDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -98,7 +98,7 @@ void ODBadXTDat::fetchData(std::vector< ODBadXTDat >* p, ODBadXTInfo* iov)
 
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadXTDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODBadXTDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -179,6 +179,6 @@ void ODBadXTDat::writeArrayDB(const std::vector< ODBadXTDat >& data, ODBadXTInfo
     delete [] st_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadXTDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODBadXTDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODBadXTInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODBadXTInfo.cc
@@ -50,7 +50,7 @@ int ODBadXTInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadXTInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadXTInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -74,7 +74,7 @@ void ODBadXTInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadXTInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadXTInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ void ODBadXTInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadXTInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadXTInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -161,11 +161,11 @@ void ODBadXTInfo::fetchData(ODBadXTInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadXTInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadXTInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -195,7 +195,7 @@ int ODBadXTInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODBadXTInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODBadXTInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODCCSConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODCCSConfig.cc
@@ -71,7 +71,7 @@ int ODCCSConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCCSConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -96,7 +96,7 @@ void ODCCSConfig::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCCSConfig::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -181,7 +181,7 @@ void ODCCSConfig::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCCSConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -215,19 +215,19 @@ void ODCCSConfig::fetchData(ODCCSConfig * result)
     // 1 is the id and 2 is the config tag
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
 
     result->setDaccal(       rset->getInt(3) );
     result->setDelay(        rset->getInt(4) );
-    result->setGain(         getOraString(rset,5) );
-    result->setMemGain(      getOraString(rset,6) );
+    result->setGain(         rset->getString(5) );
+    result->setMemGain(      rset->getString(6) );
     result->setOffsetHigh(   rset->getInt(7) );
     result->setOffsetLow(    rset->getInt(8) );
     result->setOffsetMid(    rset->getInt(9) );
-    result->setTrgMode(      getOraString(rset,10) );
-    result->setTrgFilter(    getOraString(rset,11) );
+    result->setTrgMode(      rset->getString(10) );
+    result->setTrgFilter(    rset->getString(11) );
     result->setClock(        rset->getInt(12) );
-    result->setBGOSource(      getOraString(rset,13) );
+    result->setBGOSource(      rset->getString(13) );
     result->setTTSMask(        rset->getInt(14) );
     result->setDAQBCIDPreset(        rset->getInt(15) );
     result->setTrgBCIDPreset(        rset->getInt(16) );
@@ -235,7 +235,7 @@ void ODCCSConfig::fetchData(ODCCSConfig * result)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCCSConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -265,7 +265,7 @@ int ODCCSConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCCSConfig::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODCCSCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODCCSCycle.cc
@@ -33,7 +33,7 @@ void ODCCSCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_CCS_Cycle (cycle_id, ccs_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODCCSCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODCCSCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODCCSCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODCCSCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODCCSCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODCCSCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODCCSCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODCCSCycle::fetchData(ODCCSCycle * result)
     result->setCCSConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCCSCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODCCSCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODCond2ConfInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODCond2ConfInfo.cc
@@ -59,7 +59,7 @@ int ODCond2ConfInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -83,7 +83,7 @@ void ODCond2ConfInfo::fetchParents()  noexcept(false) {
       
       
     } catch (SQLException &e) {
-      throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchParents():  ")+getOraMessage(&e)));
+      throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchParents():  ")+e.getMessage()));
     }
   }
   }
@@ -99,7 +99,7 @@ void ODCond2ConfInfo::fetchParents()  noexcept(false) {
       }
       m_conn->terminateStatement(m_readStmt);
     } catch (SQLException &e) {
-      throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchParents():  ")+getOraMessage(&e)));
+      throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchParents():  ")+e.getMessage()));
     }
   }
   }
@@ -130,7 +130,7 @@ void ODCond2ConfInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCond2ConfInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCond2ConfInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -174,7 +174,7 @@ void ODCond2ConfInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCond2ConfInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCond2ConfInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -216,18 +216,18 @@ void ODCond2ConfInfo::fetchData(ODCond2ConfInfo * result)
     //    result->setId(rset->getInt(1));
 
 
-    result->setType(getOraString(rset,2));
+    result->setType(rset->getString(2));
     Date startDate = rset->getDate(3);
-    result->setLocation(getOraString(rset,4));
+    result->setLocation(rset->getString(4));
     result->setRunNumber(rset->getInt(5));
-    result->setDescription(getOraString(rset,6));
+    result->setDescription(rset->getString(6));
     Date endDate = rset->getDate(7);
 
     m_rec_time = dh.dateToTm( startDate );
     m_db_time = dh.dateToTm( endDate );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -261,7 +261,7 @@ int ODCond2ConfInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODCond2ConfInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODDCCConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODDCCConfig.cc
@@ -48,7 +48,7 @@ int ODDCCConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCCConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -98,7 +98,7 @@ void ODDCCConfig::prepareWrite()
     
     
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCCConfig::prepareWrite():  ")+e.getMessage()));
   }
 
   std::cout<<"updating the clob 1 "<<std::endl;
@@ -180,7 +180,7 @@ void ODDCCConfig::writeDB()
     m_writeStmt->closeResultSet (rset);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCCConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -228,9 +228,9 @@ void ODDCCConfig::fetchData(ODDCCConfig * result)
     // 1 is the id and 2 is the config tag
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
-    result->setDCCConfigurationUrl(getOraString(rset,3));
-    result->setTestPatternFileUrl(getOraString(rset,4));
+    result->setConfigTag(rset->getString(2));
+    result->setDCCConfigurationUrl(rset->getString(3));
+    result->setTestPatternFileUrl(rset->getString(4));
     result->setNTestPatternsToLoad(rset->getInt(5));
     result->setSMHalf(rset->getInt(6));
 
@@ -256,11 +256,11 @@ void ODDCCConfig::fetchData(ODDCCConfig * result)
 
     */
     result->setDCCClob(buffer );
-    result->setDCCWeightsMode(getOraString(rset,8));
+    result->setDCCWeightsMode(rset->getString(8));
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCCConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -292,7 +292,7 @@ int ODDCCConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCCConfig::fetchID:  ")+e.getMessage()));
   }
   
   

--- a/OnlineDB/EcalCondDB/src/ODDCCCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODDCCCycle.cc
@@ -33,7 +33,7 @@ void ODDCCCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_DCC_Cycle (cycle_id, dcc_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCCCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODDCCCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCCCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODDCCCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCCCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODDCCCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCCCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODDCCCycle::fetchData(ODDCCCycle * result)
     result->setDCCConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCCCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODDCUConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODDCUConfig.cc
@@ -57,7 +57,7 @@ int ODDCUConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCUConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -78,7 +78,7 @@ void ODDCUConfig::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCUConfig::prepareWrite():  ")+e.getMessage()));
   }
 }
 
@@ -98,7 +98,7 @@ void ODDCUConfig::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCUConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -131,11 +131,11 @@ void ODDCUConfig::fetchData(ODDCUConfig * result)
     rset->next();
     // 1 is the id and 2 is the config tag
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCUConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -164,7 +164,7 @@ int ODDCUConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODDCUConfig::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODDCUCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODDCUCycle.cc
@@ -33,7 +33,7 @@ void ODDCUCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_DCU_Cycle (cycle_id, dcu_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCUCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODDCUCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCUCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODDCUCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCUCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODDCUCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCUCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODDCUCycle::fetchData(ODDCUCycle * result)
     result->setDCUConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCUCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCUCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODDelaysDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODDelaysDat.cc
@@ -39,7 +39,7 @@ void ODDelaysDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, sm_id, fed_id, tt_id, time_offset ) "
 			"VALUES (:1, :2, :3, :4, :5 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDelaysDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDelaysDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -59,7 +59,7 @@ void ODDelaysDat::writeDB(const ODDelaysDat* item, ODFEDelaysInfo* iov )
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDelaysDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDelaysDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -99,7 +99,7 @@ void ODDelaysDat::fetchData(std::vector< ODDelaysDat >* p, int iovID)
 
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDelaysDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDelaysDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -174,6 +174,6 @@ void ODDelaysDat::writeArrayDB(const std::vector< ODDelaysDat >& data, ODFEDelay
     delete [] st_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDelaysDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDelaysDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODEcalCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODEcalCycle.cc
@@ -227,7 +227,7 @@ int ODEcalCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODEcalCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODEcalCycle::fetchID:  "+e.getMessage()));
   }
   setByID(m_ID);
   return m_ID;
@@ -253,12 +253,12 @@ void ODEcalCycle::setByID(int id)
 
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
-       m_tag = getOraString(rset,1);
+       m_tag = rset->getString(1);
        m_version = rset->getInt(2);
        m_seq_num = rset->getInt(3);
        m_cycle_num = rset->getInt(4);
-       m_cycle_tag = getOraString(rset,5);
-       m_cycle_description = getOraString(rset,6);
+       m_cycle_tag = rset->getString(5);
+       m_cycle_description = rset->getString(6);
        m_ccs = rset->getInt(7);
        m_dcc = rset->getInt(8);
        m_laser = rset->getInt(9);
@@ -278,7 +278,7 @@ void ODEcalCycle::setByID(int id)
      }
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("ODEcalCycle::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("ODEcalCycle::setByID:  "+e.getMessage()));
    }
 }
 
@@ -328,12 +328,12 @@ void ODEcalCycle::fetchData(ODEcalCycle * result)
 
     rset->next();
 
-    result->setTag(          getOraString(rset,1) );
+    result->setTag(          rset->getString(1) );
     result->setVersion(      rset->getInt(2) );
     result->setSeqNum(       rset->getInt(3) );
     result->setCycleNum(     rset->getInt(4) );
-    result->setCycleTag(     getOraString(rset,5) );
-    result->setCycleDescription( getOraString(rset,6) );
+    result->setCycleTag(     rset->getString(5) );
+    result->setCycleDescription( rset->getString(6) );
     result->setCCSId(        rset->getInt(7) );
     result->setDCCId(        rset->getInt(8) );
     result->setLaserId(      rset->getInt(9) );
@@ -352,7 +352,7 @@ void ODEcalCycle::fetchData(ODEcalCycle * result)
     result->setTCCEEId(      rset->getInt(19) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODEcalCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODEcalCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODFEDAQConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODFEDAQConfig.cc
@@ -68,7 +68,7 @@ int ODFEDAQConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDAQConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDAQConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -89,7 +89,7 @@ void ODFEDAQConfig::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDAQConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDAQConfig::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -143,7 +143,7 @@ void ODFEDAQConfig::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDAQConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDAQConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -184,7 +184,7 @@ void ODFEDAQConfig::fetchData(ODFEDAQConfig * result)
       result->setVersion(new_version);
       
     } catch (SQLException &e) {
-      throw(std::runtime_error(std::string("ODFEDAQConfig::fetchData():  ")+getOraMessage(&e)));
+      throw(std::runtime_error(std::string("ODFEDAQConfig::fetchData():  ")+e.getMessage()));
     }
     
     
@@ -205,7 +205,7 @@ void ODFEDAQConfig::fetchData(ODFEDAQConfig * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
     result->setPedestalId(       getInt(rset,4) );
@@ -215,10 +215,10 @@ void ODFEDAQConfig::fetchData(ODFEDAQConfig * result)
     result->setBadTTId(          getInt(rset,8) );
     result->setTriggerBadXtId(   getInt(rset,9) );
     result->setTriggerBadTTId(   getInt(rset,10) );
-    result->setComment(          getOraString(rset,11) );
+    result->setComment(          rset->getString(11) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDAQConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDAQConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -248,7 +248,7 @@ int ODFEDAQConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDAQConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDAQConfig::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODFEDelaysInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODFEDelaysInfo.cc
@@ -52,7 +52,7 @@ int ODFEDelaysInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDelaysInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDelaysInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -76,7 +76,7 @@ void ODFEDelaysInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDelaysInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDelaysInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -112,7 +112,7 @@ void ODFEDelaysInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDelaysInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDelaysInfo::writeDB():  ")+e.getMessage()));
   }
 
   // Now get the ID
@@ -160,11 +160,11 @@ void ODFEDelaysInfo::fetchData(ODFEDelaysInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDelaysInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDelaysInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -194,7 +194,7 @@ int ODFEDelaysInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEDelaysInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEDelaysInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODFEPedestalOffsetInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODFEPedestalOffsetInfo.cc
@@ -51,7 +51,7 @@ int ODFEPedestalOffsetInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -75,7 +75,7 @@ void ODFEPedestalOffsetInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -111,7 +111,7 @@ void ODFEPedestalOffsetInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::writeDB():  ")+e.getMessage()));
   }
 
 
@@ -162,11 +162,11 @@ void ODFEPedestalOffsetInfo::fetchData(ODFEPedestalOffsetInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -184,11 +184,11 @@ void ODFEPedestalOffsetInfo::fetchLastData(ODFEPedestalOffsetInfo * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -218,7 +218,7 @@ int ODFEPedestalOffsetInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEPedestalOffsetInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODFEWeightsInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODFEWeightsInfo.cc
@@ -51,7 +51,7 @@ int ODFEWeightsInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEWeightsInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEWeightsInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -75,7 +75,7 @@ void ODFEWeightsInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEWeightsInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEWeightsInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ void ODFEWeightsInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEWeightsInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEWeightsInfo::writeDB():  ")+e.getMessage()));
   }
 
   // Now get the ID
@@ -160,11 +160,11 @@ void ODFEWeightsInfo::fetchData(ODFEWeightsInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEWeightsInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEWeightsInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -194,7 +194,7 @@ int ODFEWeightsInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODFEWeightsInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODFEWeightsInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODGolBiasCurrentDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODGolBiasCurrentDat.cc
@@ -41,7 +41,7 @@ void ODGolBiasCurrentDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, fed_id, tt_id, gol_id, gol_current, pll_current, status ) "
 			"VALUES (:1, :2, :3, :4, :5 , :6, :7)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODGolBiasCurrentDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODGolBiasCurrentDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -64,7 +64,7 @@ void ODGolBiasCurrentDat::writeDB(const ODGolBiasCurrentDat* item, ODGolBiasCurr
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODGolBiasCurrentDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODGolBiasCurrentDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -104,7 +104,7 @@ void ODGolBiasCurrentDat::fetchData(std::vector< ODGolBiasCurrentDat >* p, ODGol
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODGolBiasCurrentDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODGolBiasCurrentDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -194,6 +194,6 @@ void ODGolBiasCurrentDat::writeArrayDB(const std::vector< ODGolBiasCurrentDat >&
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODGolBiasCurrentDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODGolBiasCurrentDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODGolBiasCurrentInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODGolBiasCurrentInfo.cc
@@ -50,7 +50,7 @@ int ODGolBiasCurrentInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -74,7 +74,7 @@ void ODGolBiasCurrentInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ void ODGolBiasCurrentInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -172,11 +172,11 @@ void ODGolBiasCurrentInfo::fetchData(ODGolBiasCurrentInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -206,7 +206,7 @@ int ODGolBiasCurrentInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODGolBiasCurrentInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODJBH4Config.cc
+++ b/OnlineDB/EcalCondDB/src/ODJBH4Config.cc
@@ -54,7 +54,7 @@ int ODJBH4Config::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Config::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Config::fetchNextId():  "+e.getMessage()));
   }
 
 }
@@ -75,7 +75,7 @@ void ODJBH4Config::prepareWrite()
     m_writeStmt->setInt(1, next_id);
     m_ID=next_id;
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Config::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Config::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -105,7 +105,7 @@ void ODJBH4Config::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Config::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Config::writeDB():  "+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -135,19 +135,19 @@ void ODJBH4Config::fetchData(ODJBH4Config * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
 
     result->setUseBuffer(           rset->getInt(3) );
-    result->setHalModuleFile(        getOraString(rset,4) );
-    result->setHalAddressTableFile(         getOraString(rset,5) );
-    result->setHalStaticTableFile(    getOraString(rset,6) );
-    result->setCbd8210SerialNumber(        getOraString(rset,7) );
-    result->setCaenBridgeType(           getOraString(rset,8) );
+    result->setHalModuleFile(        rset->getString(4) );
+    result->setHalAddressTableFile(         rset->getString(5) );
+    result->setHalStaticTableFile(    rset->getString(6) );
+    result->setCbd8210SerialNumber(        rset->getString(7) );
+    result->setCaenBridgeType(           rset->getString(8) );
     result->setCaenLinkNumber(            rset->getInt(9) );
     result->setCaenBoardNumber(              rset->getInt(10) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Config::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Config::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -177,7 +177,7 @@ int ODJBH4Config::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Config::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Config::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODJBH4Cycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODJBH4Cycle.cc
@@ -33,7 +33,7 @@ void ODJBH4Cycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_JBH4_Cycle (cycle_id, jbh4_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Cycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Cycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODJBH4Cycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Cycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Cycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODJBH4Cycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Cycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Cycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODJBH4Cycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Cycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Cycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODJBH4Cycle::fetchData(ODJBH4Cycle * result)
     result->setJBH4ConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODJBH4Cycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODJBH4Cycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODLTCConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODLTCConfig.cc
@@ -47,7 +47,7 @@ int ODLTCConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTCConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -92,7 +92,7 @@ void ODLTCConfig::prepareWrite()
 
     
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTCConfig::prepareWrite():  ")+e.getMessage()));
   }
 
   std::cout<<"updating the clob 1 "<<std::endl;
@@ -176,7 +176,7 @@ void ODLTCConfig::writeDB()
     m_writeStmt->closeResultSet (rset);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTCConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -218,8 +218,8 @@ void ODLTCConfig::fetchData(ODLTCConfig * result)
     // 1 is the id and 2 is the config tag
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
-    result->setLTCConfigurationFile(getOraString(rset,3));
+    result->setConfigTag(rset->getString(2));
+    result->setLTCConfigurationFile(rset->getString(3));
   
 
     Clob clob = rset->getClob (4);
@@ -239,7 +239,7 @@ void ODLTCConfig::fetchData(ODLTCConfig * result)
     result->setLTCClob(buffer );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTCConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -270,7 +270,7 @@ int ODLTCConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTCConfig::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODLTCCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODLTCCycle.cc
@@ -33,7 +33,7 @@ void ODLTCCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_LTC_Cycle (cycle_id, ltc_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTCCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODLTCCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTCCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODLTCCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTCCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODLTCCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTCCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODLTCCycle::fetchData(ODLTCCycle * result)
     result->setLTCConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTCCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTCCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODLTSConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODLTSConfig.cc
@@ -66,7 +66,7 @@ int ODLTSConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTSConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -88,7 +88,7 @@ void ODLTSConfig::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTSConfig::prepareWrite():  ")+e.getMessage()));
   }
 }
 
@@ -112,7 +112,7 @@ void ODLTSConfig::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTSConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -145,16 +145,16 @@ void ODLTSConfig::fetchData(ODLTSConfig * result)
     rset->next();
     // 1 is the id and 2 is the config tag
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
 
-    result->setTriggerType(        getOraString(rset,3) );
+    result->setTriggerType(        rset->getString(3) );
     result->setNumberOfEvents(     rset->getInt(4) );
     result->setRate(               rset->getInt(5) );
     result->setTrigLocL1Delay(     rset->getInt(6) );
   
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTSConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -183,7 +183,7 @@ int ODLTSConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLTSConfig::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODLTSCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODLTSCycle.cc
@@ -33,7 +33,7 @@ void ODLTSCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_LTS_Cycle (cycle_id, lts_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTSCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODLTSCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTSCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODLTSCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTSCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODLTSCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTSCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODLTSCycle::fetchData(ODLTSCycle * result)
     result->setLTSConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLTSCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLTSCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODLaserConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODLaserConfig.cc
@@ -208,7 +208,7 @@ int ODLaserConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLaserConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -288,7 +288,7 @@ void ODLaserConfig::prepareWrite()
     m_writeStmt->setInt(1, next_id);
     m_ID=next_id;
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLaserConfig::prepareWrite():  ")+e.getMessage()));
   }
 }
 
@@ -394,7 +394,7 @@ void ODLaserConfig::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLaserConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -429,7 +429,7 @@ void ODLaserConfig::fetchData(ODLaserConfig * result)
     // start from 3 because of select * 
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
 
     result->setDebug(rset->getInt(  3  ));
     result->setDummy(rset->getInt(  4  ));
@@ -507,7 +507,7 @@ void ODLaserConfig::fetchData(ODLaserConfig * result)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLaserConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -535,7 +535,7 @@ int ODLaserConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODLaserConfig::fetchID:  ")+e.getMessage()));
   }
 
   fetchData(this);

--- a/OnlineDB/EcalCondDB/src/ODLaserCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODLaserCycle.cc
@@ -33,7 +33,7 @@ void ODLaserCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_Laser_Cycle (cycle_id, laser_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLaserCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODLaserCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLaserCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODLaserCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLaserCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODLaserCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLaserCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODLaserCycle::fetchData(ODLaserCycle * result)
     result->setLaserConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODLaserCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODLaserCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODPedestalOffsetsDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODPedestalOffsetsDat.cc
@@ -41,7 +41,7 @@ void ODPedestalOffsetsDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, sm_id, fed_id, tt_id, cry_id, low, mid, high) "
 			"VALUES (:1, :2, :3, :4, :5, :6, :7, :8 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODPedestalOffsetsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODPedestalOffsetsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -64,7 +64,7 @@ void ODPedestalOffsetsDat::writeDB(const ODPedestalOffsetsDat* item, ODFEPedesta
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODPedestalOffsetsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODPedestalOffsetsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -105,7 +105,7 @@ void ODPedestalOffsetsDat::fetchData(std::vector< ODPedestalOffsetsDat >* p, ODF
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODPedestalOffsetsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODPedestalOffsetsDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -200,6 +200,6 @@ void ODPedestalOffsetsDat::writeArrayDB(const std::vector< ODPedestalOffsetsDat 
     delete [] z1_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODPedestalOffsetsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODPedestalOffsetsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODRunConfigCycleInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODRunConfigCycleInfo.cc
@@ -48,7 +48,7 @@ void ODRunConfigCycleInfo::prepareWrite()
      "VALUES (:1, :2, :3 , :4 )");
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigCycleInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigCycleInfo::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -73,7 +73,7 @@ void ODRunConfigCycleInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigCycleInfo::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigCycleInfo::writeDB:  "+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -119,7 +119,7 @@ int ODRunConfigCycleInfo::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigCycleInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigCycleInfo::fetchID:  "+e.getMessage()));
   }
   setByID(m_ID);
 
@@ -148,7 +148,7 @@ int ODRunConfigCycleInfo::fetchIDLast()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigCycleInfo::fetchIDLast:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigCycleInfo::fetchIDLast:  "+e.getMessage()));
   }
 
   setByID(m_ID);
@@ -175,15 +175,15 @@ void ODRunConfigCycleInfo::setByID(int id)
      if (rset->next()) {
        m_sequence_id=rset->getInt(1);
        m_cycle_num=rset->getInt(2);
-       m_tag = getOraString(rset,3);
-       m_description= getOraString(rset,4);
+       m_tag = rset->getString(3);
+       m_description= rset->getString(4);
        m_ID = id;
      } else {
        throw(std::runtime_error("ODRunConfigCycleInfo::setByID:  Given cycle_id is not in the database"));
      }
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("ODRunConfigCycleInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("ODRunConfigCycleInfo::setByID:  "+e.getMessage()));
    }
 }
 
@@ -207,11 +207,11 @@ void ODRunConfigCycleInfo::fetchData(ODRunConfigCycleInfo * result)
 
     result->setSequenceID(       rset->getInt(1) );
     result->setCycleNumber(      rset->getInt(2) );
-    result->setTag(              getOraString(rset,3) );
-    result->setDescription(      getOraString(rset,4) );
+    result->setTag(              rset->getString(3) );
+    result->setDescription(      rset->getString(4) );
  
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigCycleInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigCycleInfo::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODRunConfigInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODRunConfigInfo.cc
@@ -67,7 +67,7 @@ int ODRunConfigInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODDCCConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODDCCConfig::fetchNextId():  "+e.getMessage()));
   }
 
 }
@@ -101,7 +101,7 @@ int ODRunConfigInfo::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigInfo::fetchID:  "+e.getMessage()));
   }
   setByID(m_ID);
   return m_ID;
@@ -129,7 +129,7 @@ int ODRunConfigInfo::fetchIDLast()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigInfo::fetchIDLast:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigInfo::fetchIDLast:  "+e.getMessage()));
   }
 
   setByID(m_ID);
@@ -163,14 +163,14 @@ void ODRunConfigInfo::setByID(int id)
      
      ResultSet* rset = stmt->executeQuery();
      if (rset->next()) {
-       m_tag= getOraString(rset,1);
+       m_tag= rset->getString(1);
        m_version= rset->getInt(2);
        int run_type_id=rset->getInt(3);
        int run_mode_id=rset->getInt(4);
        m_num_seq=rset->getInt(5);
-       m_description= getOraString(rset,6);
+       m_description= rset->getString(6);
        m_defaults= rset->getInt(7);
-       m_trigger_mode= getOraString(rset,8);
+       m_trigger_mode= rset->getString(8);
        m_num_events= rset->getInt(9);
        Date dbdate = rset->getDate(10);
        m_db_time = dh.dateToTm( dbdate );
@@ -179,13 +179,13 @@ void ODRunConfigInfo::setByID(int id)
        m_runModeDef.setByID(run_mode_id);
        m_runTypeDef.setConnection(m_env, m_conn);
        m_runTypeDef.setByID(run_type_id);
-       m_usage_status=getOraString(rset,11);
+       m_usage_status=rset->getString(11);
      } else {
        throw(std::runtime_error("ODRunConfigInfo::setByID:  Given config_id is not in the database"));
      }
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("ODRunConfigInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("ODRunConfigInfo::setByID:  "+e.getMessage()));
    }
 }
 
@@ -209,7 +209,7 @@ void ODRunConfigInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigInfo::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -249,7 +249,7 @@ void ODRunConfigInfo::writeDB()
     m_writeStmt->executeUpdate();
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigInfo::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigInfo::writeDB:  "+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -285,7 +285,7 @@ int ODRunConfigInfo::updateDefaultCycle()
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigInfo::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigInfo::writeDB:  "+e.getMessage()));
   }
   
   return m_ID;
@@ -321,23 +321,23 @@ void ODRunConfigInfo::fetchData(ODRunConfigInfo * result)
     rset->next();
 
     result->setId(               rset->getInt(1) );
-    result->setTag(              getOraString(rset,2) );
+    result->setTag(              rset->getString(2) );
     result->setVersion(          rset->getInt(3) );
     //    RunTypeDef myRunType = rset->getInt(4);
     //    result->setRunTypeDef( myRunType );
     //    RunModeDef myRunMode = rset->getInt(5);
     //    result->setRunModeDef( myRunMode );
     result->setNumberOfSequences(rset->getInt(6) );
-    result->setDescription(      getOraString(rset,7) );
+    result->setDescription(      rset->getString(7) );
     result->setDefaults(         rset->getInt(8) );
-    result->setTriggerMode(      getOraString(rset,9) );
+    result->setTriggerMode(      rset->getString(9) );
     result->setNumberOfEvents(   rset->getInt(10) );
     Date dbdate = rset->getDate(11);
     result->setDBTime(dh.dateToTm( dbdate ));
-    result->setUsageStatus(      getOraString(rset,12) );
+    result->setUsageStatus(      rset->getString(12) );
 
   } catch (SQLException &e) {
-    cout << " ODRunConfigInfo::fetchData():  " << getOraMessage(&e) << endl;
-    throw(std::runtime_error(std::string("ODRunConfigInfo::fetchData():  ")+getOraMessage(&e)));
+    cout << " ODRunConfigInfo::fetchData():  " << e.getMessage() << endl;
+    throw(std::runtime_error("ODRunConfigInfo::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODRunConfigSeqInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODRunConfigSeqInfo.cc
@@ -70,7 +70,7 @@ int ODRunConfigSeqInfo::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigSeqInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigSeqInfo::fetchID:  "+e.getMessage()));
   }
   setByID(m_ID);
   return m_ID;
@@ -98,7 +98,7 @@ int ODRunConfigSeqInfo::fetchIDLast()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigSeqInfo::fetchIDLast:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigSeqInfo::fetchIDLast:  "+e.getMessage()));
   }
 
   setByID(m_ID);
@@ -127,7 +127,7 @@ void ODRunConfigSeqInfo::setByID(int id)
        m_seq_num=rset->getInt(2);
        m_cycles=rset->getInt(3);
        int seq_def_id=rset->getInt(4);
-       m_description= getOraString(rset,5);
+       m_description= rset->getString(5);
        m_ID = id;
        m_run_seq.setConnection(m_env, m_conn);
        m_run_seq.setByID(seq_def_id);
@@ -136,7 +136,7 @@ void ODRunConfigSeqInfo::setByID(int id)
      }
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("ODRunConfigSeqInfo::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("ODRunConfigSeqInfo::setByID:  "+e.getMessage()));
    }
 }
 
@@ -151,7 +151,7 @@ void ODRunConfigSeqInfo::prepareWrite()
 			"sequence_num, num_of_cycles, sequence_type_def_id, description ) "
 			"VALUES (:1, :2, :3 , :4, :5 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigSeqInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigSeqInfo::prepareWrite():  "+e.getMessage()));
   }
 }
 void ODRunConfigSeqInfo::writeDB()
@@ -184,7 +184,7 @@ void ODRunConfigSeqInfo::writeDB()
     m_writeStmt->executeUpdate();
 
    } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigSeqInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigSeqInfo::writeDB():  "+e.getMessage()));
   }
   if (!this->fetchID()) {
     throw(std::runtime_error("ODRunConfigSeqInfo::writeDB:  Failed to write"));
@@ -231,10 +231,10 @@ void ODRunConfigSeqInfo::fetchData(ODRunConfigSeqInfo * result)
 
     m_run_seq.setConnection(m_env, m_conn);
     m_run_seq.setByID(seq_def_id);
-    result->setDescription(   getOraString(rset,5) );
+    result->setDescription(   rset->getString(5) );
     
     
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODRunConfigSeqInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODRunConfigSeqInfo::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODSRPConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODSRPConfig.cc
@@ -54,7 +54,7 @@ int ODSRPConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODSRPConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -155,7 +155,7 @@ void ODSRPConfig::prepareWrite()
 
     
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODSRPConfig::prepareWrite():  ")+e.getMessage()));
   }
 
   std::cout<<"updating the clob 1 "<<std::endl;
@@ -189,7 +189,7 @@ void ODSRPConfig::writeDB()
     m_writeStmt->closeResultSet (rset);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODSRPConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -223,14 +223,14 @@ void ODSRPConfig::fetchData(ODSRPConfig * result)
     // 1 is the id and 2 is the config tag
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
 
     result->setDebugMode(rset->getInt(3));
     result->setDummyMode(rset->getInt(4));
-    result->setPatternDirectory(getOraString(rset,5));
+    result->setPatternDirectory(rset->getString(5));
     result->setAutomaticMasks(rset->getInt(6));
     result->setSRP0BunchAdjustPosition(rset->getInt(7));
-    result->setConfigFile(getOraString(rset,8));
+    result->setConfigFile(rset->getString(8));
 
     Clob clob = rset->getClob(9);
     m_size = clob.length();
@@ -256,7 +256,7 @@ void ODSRPConfig::fetchData(ODSRPConfig * result)
     result->setAutomaticSrpSelect(rset->getInt(10));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODSRPConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -288,7 +288,7 @@ int ODSRPConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODSRPConfig::fetchID:  ")+e.getMessage()));
   }
 
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODSRPCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODSRPCycle.cc
@@ -33,7 +33,7 @@ void ODSRPCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_SRP_Cycle (cycle_id, srp_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODSRPCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODSRPCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODSRPCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODSRPCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODSRPCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODSRPCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODSRPCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODSRPCycle::fetchData(ODSRPCycle * result)
     result->setSRPConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODSRPCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODSRPCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODScanConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODScanConfig.cc
@@ -51,7 +51,7 @@ int ODScanConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODScanConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -91,7 +91,7 @@ void ODScanConfig::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODScanConfig::prepareWrite():  ")+e.getMessage()));
   }
 }
 
@@ -116,7 +116,7 @@ void ODScanConfig::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODScanConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -151,15 +151,15 @@ void ODScanConfig::fetchData(ODScanConfig * result)
 
     // id 1 is the scan_id 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setTypeId(           rset->getInt(3) );
-    result->setScanType(        getOraString(rset,4) );
+    result->setScanType(        rset->getString(4) );
     result->setFromVal(            rset->getInt(5) );
     result->setToVal(              rset->getInt(6) );
     result->setStep(              rset->getInt(7) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODScanConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -188,7 +188,7 @@ int ODScanConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODScanConfig::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODScanCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODScanCycle.cc
@@ -33,7 +33,7 @@ void ODScanCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_Scan_Cycle (cycle_id, scan_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODScanCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODScanCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODScanCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODScanCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODScanCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODScanCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODScanCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODScanCycle::fetchData(ODScanCycle * result)
     result->setScanConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODScanCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODScanCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODTCCConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODTCCConfig.cc
@@ -51,7 +51,7 @@ int ODTCCConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -127,7 +127,7 @@ void ODTCCConfig::prepareWrite()
 
     
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCConfig::prepareWrite():  ")+e.getMessage()));
   }
 
   std::cout<<"updating the clob 1 "<<std::endl;
@@ -162,7 +162,7 @@ void ODTCCConfig::writeDB()
     m_writeStmt->closeResultSet (rset);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -198,12 +198,12 @@ void ODTCCConfig::fetchData(ODTCCConfig * result)
     rset->next();
     // the first is the id 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
 
-    result->setTCCConfigurationFile(getOraString(rset,3));
-    result->setLUTConfigurationFile(getOraString(rset,4));
-    result->setSLBConfigurationFile(getOraString(rset,5));
-    result->setTestPatternFileUrl(getOraString(rset,6));
+    result->setTCCConfigurationFile(rset->getString(3));
+    result->setLUTConfigurationFile(rset->getString(4));
+    result->setSLBConfigurationFile(rset->getString(5));
+    result->setTestPatternFileUrl(rset->getString(6));
     result->setNTestPatternsToLoad(rset->getInt(7));
     //
 
@@ -247,7 +247,7 @@ void ODTCCConfig::fetchData(ODTCCConfig * result)
     result->setSLBClob(buffer3 );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -278,7 +278,7 @@ int ODTCCConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCConfig::fetchID:  ")+e.getMessage()));
   }
 
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODTCCCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODTCCCycle.cc
@@ -33,7 +33,7 @@ void ODTCCCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_TCC_Cycle (cycle_id, tcc_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODTCCCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODTCCCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODTCCCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODTCCCycle::fetchData(ODTCCCycle * result)
     result->setTCCConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODTCCEEConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODTCCEEConfig.cc
@@ -52,7 +52,7 @@ int ODTCCEEConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEEConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCEEConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -135,7 +135,7 @@ void ODTCCEEConfig::prepareWrite()
 
     
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEEConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCEEConfig::prepareWrite():  ")+e.getMessage()));
   }
 
   std::cout<<"updating the clob 1 "<<std::endl;
@@ -170,7 +170,7 @@ void ODTCCEEConfig::writeDB()
     m_writeStmt->closeResultSet (rset);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEEConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCEEConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -206,12 +206,12 @@ void ODTCCEEConfig::fetchData(ODTCCEEConfig * result)
     rset->next();
     // the first is the id 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
 
-    result->setTCCConfigurationFile(getOraString(rset,3));
-    result->setLUTConfigurationFile(getOraString(rset,4));
-    result->setSLBConfigurationFile(getOraString(rset,5));
-    result->setTestPatternFileUrl(getOraString(rset,6));
+    result->setTCCConfigurationFile(rset->getString(3));
+    result->setLUTConfigurationFile(rset->getString(4));
+    result->setSLBConfigurationFile(rset->getString(5));
+    result->setTestPatternFileUrl(rset->getString(6));
     result->setNTestPatternsToLoad(rset->getInt(7));
     result->setSLBLatency(rset->getInt(12));
     //
@@ -256,7 +256,7 @@ void ODTCCEEConfig::fetchData(ODTCCEEConfig * result)
     result->setSLBClob(buffer3 );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEEConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCEEConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -287,7 +287,7 @@ int ODTCCEEConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEEConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTCCEEConfig::fetchID:  ")+e.getMessage()));
   }
 
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODTCCEECycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODTCCEECycle.cc
@@ -33,7 +33,7 @@ void ODTCCEECycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_TCC_EE_Cycle (cycle_id, tcc_ee_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEECycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCEECycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODTCCEECycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEECycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCEECycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODTCCEECycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEECycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCEECycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODTCCEECycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEECycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCEECycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODTCCEECycle::fetchData(ODTCCEECycle * result)
     result->setTCCConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTCCEECycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTCCEECycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODTTCFConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODTTCFConfig.cc
@@ -49,7 +49,7 @@ int ODTTCFConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCFConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -94,7 +94,7 @@ void ODTTCFConfig::prepareWrite()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCFConfig::prepareWrite():  ")+e.getMessage()));
   }
 
   std::cout<<"updating the clob 1 "<<std::endl;
@@ -123,7 +123,7 @@ void ODTTCFConfig::writeDB()
     m_writeStmt->closeResultSet (rset);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCFConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -158,8 +158,8 @@ void ODTTCFConfig::fetchData(ODTTCFConfig * result)
     rset->next();
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
-    result->setTTCFConfigurationFile(getOraString(rset,3));
+    result->setConfigTag(rset->getString(2));
+    result->setTTCFConfigurationFile(rset->getString(3));
     Clob clob = rset->getClob (4);
     cout << "Opening the clob in Read only mode" << endl;
     clob.open (OCCI_LOB_READONLY);
@@ -171,7 +171,7 @@ void ODTTCFConfig::fetchData(ODTTCFConfig * result)
     result->setTTCFClob((unsigned char*) buffer );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCFConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -202,7 +202,7 @@ int ODTTCFConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCFConfig::fetchID:  ")+e.getMessage()));
   }
 
     return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODTTCFCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODTTCFCycle.cc
@@ -33,7 +33,7 @@ void ODTTCFCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_TTCF_Cycle (cycle_id, ttcf_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCFCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODTTCFCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCFCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODTTCFCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCFCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODTTCFCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCFCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODTTCFCycle::fetchData(ODTTCFCycle * result)
     result->setTTCFConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCFCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCFCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODTTCciConfig.cc
+++ b/OnlineDB/EcalCondDB/src/ODTTCciConfig.cc
@@ -56,7 +56,7 @@ int ODTTCciConfig::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciConfig::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCciConfig::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -103,7 +103,7 @@ void ODTTCciConfig::prepareWrite()
 
     
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciConfig::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCciConfig::prepareWrite():  ")+e.getMessage()));
   }
 
   std::cout<<"updating the clob 1 "<<std::endl;
@@ -190,7 +190,7 @@ void ODTTCciConfig::writeDB()
     m_writeStmt->closeResultSet (rset);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciConfig::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCciConfig::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -226,15 +226,15 @@ void ODTTCciConfig::fetchData(ODTTCciConfig * result)
     // 1 is the id and 2 is the config tag
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
 
 
-    result->setTTCciConfigurationFile(getOraString(rset,3));
-    result->setTrgMode(getOraString(rset,4));
+    result->setTTCciConfigurationFile(rset->getString(3));
+    result->setTrgMode(rset->getString(4));
     result->setTrgSleep(rset->getInt(5));
 
-    result->setConfigurationScript(getOraString(rset,7));
-    result->setConfigurationScriptParams(getOraString(rset,8));
+    result->setConfigurationScript(rset->getString(7));
+    result->setConfigurationScriptParams(rset->getString(8));
     
     Clob clob = rset->getClob (6);
     cout << "Opening the clob in Read only mode" << endl;
@@ -253,7 +253,7 @@ void ODTTCciConfig::fetchData(ODTTCciConfig * result)
     result->setTTCciClob(buffer );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciConfig::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCciConfig::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -284,7 +284,7 @@ int ODTTCciConfig::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciConfig::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTTCciConfig::fetchID:  ")+e.getMessage()));
   }
     return m_ID;
 }

--- a/OnlineDB/EcalCondDB/src/ODTTCciCycle.cc
+++ b/OnlineDB/EcalCondDB/src/ODTTCciCycle.cc
@@ -33,7 +33,7 @@ void ODTTCciCycle::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO ECAL_TTCci_Cycle (cycle_id, ttcci_configuration_id ) "
 		 "VALUES (:1, :2 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciCycle::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCciCycle::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -52,7 +52,7 @@ void ODTTCciCycle::writeDB()  noexcept(false)
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciCycle::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCciCycle::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -93,7 +93,7 @@ int ODTTCciCycle::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCciCycle::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -122,7 +122,7 @@ void ODTTCciCycle::setByID(int id)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciCycle::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCciCycle::fetchID:  "+e.getMessage()));
   }
 }
 
@@ -151,7 +151,7 @@ void ODTTCciCycle::fetchData(ODTTCciCycle * result)
     result->setTTCciConfigurationID(       rset->getInt(1) );
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTTCciCycle::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTTCciCycle::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/ODTowersToByPassDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODTowersToByPassDat.cc
@@ -41,7 +41,7 @@ void ODTowersToByPassDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, fed_id, tr_id, tt_id, time_corr, STATUS ) "
 			"VALUES (:1, :2, :3, :4, :5 , :6 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTowersToByPassDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTowersToByPassDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -62,7 +62,7 @@ void ODTowersToByPassDat::writeDB(const ODTowersToByPassDat* item, ODTowersToByP
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTowersToByPassDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTowersToByPassDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -101,7 +101,7 @@ void ODTowersToByPassDat::fetchData(std::vector< ODTowersToByPassDat >* p, ODTow
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTowersToByPassDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTowersToByPassDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -184,6 +184,6 @@ void ODTowersToByPassDat::writeArrayDB(const std::vector< ODTowersToByPassDat >&
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTowersToByPassDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODTowersToByPassDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODTowersToByPassInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODTowersToByPassInfo.cc
@@ -50,7 +50,7 @@ int ODTowersToByPassInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTowersToByPassInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTowersToByPassInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -74,7 +74,7 @@ void ODTowersToByPassInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTowersToByPassInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTowersToByPassInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ void ODTowersToByPassInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTowersToByPassInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTowersToByPassInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -172,11 +172,11 @@ void ODTowersToByPassInfo::fetchData(ODTowersToByPassInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTowersToByPassInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTowersToByPassInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -206,7 +206,7 @@ int ODTowersToByPassInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODTowersToByPassInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODTowersToByPassInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODVfeToRejectDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODVfeToRejectDat.cc
@@ -41,7 +41,7 @@ void ODVfeToRejectDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, fed_id, tt_id, vfe_id, GAIN, STATUS ) "
 			"VALUES (:1, :2, :3, :4, :5 , :6 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODVfeToRejectDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODVfeToRejectDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -62,7 +62,7 @@ void ODVfeToRejectDat::writeDB(const ODVfeToRejectDat* item, ODVfeToRejectInfo* 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODVfeToRejectDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODVfeToRejectDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -101,7 +101,7 @@ void ODVfeToRejectDat::fetchData(std::vector< ODVfeToRejectDat >* p, ODVfeToReje
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODVfeToRejectDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODVfeToRejectDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -184,6 +184,6 @@ void ODVfeToRejectDat::writeArrayDB(const std::vector< ODVfeToRejectDat >& data,
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODVfeToRejectDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODVfeToRejectDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODVfeToRejectInfo.cc
+++ b/OnlineDB/EcalCondDB/src/ODVfeToRejectInfo.cc
@@ -50,7 +50,7 @@ int ODVfeToRejectInfo::fetchNextId()  noexcept(false) {
     return result; 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODVfeToRejectInfo::fetchNextId():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODVfeToRejectInfo::fetchNextId():  ")+e.getMessage()));
   }
 
 }
@@ -74,7 +74,7 @@ void ODVfeToRejectInfo::prepareWrite()
     m_ID=next_id;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODVfeToRejectInfo::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODVfeToRejectInfo::prepareWrite():  ")+e.getMessage()));
   }
 
 }
@@ -110,7 +110,7 @@ void ODVfeToRejectInfo::writeDB()
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODVfeToRejectInfo::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODVfeToRejectInfo::writeDB():  ")+e.getMessage()));
   }
   // Now get the ID
   if (!this->fetchID()) {
@@ -172,11 +172,11 @@ void ODVfeToRejectInfo::fetchData(ODVfeToRejectInfo * result)
     // 1 is the id and 2 is the config tag and 3 is the version
 
     result->setId(rset->getInt(1));
-    result->setConfigTag(getOraString(rset,2));
+    result->setConfigTag(rset->getString(2));
     result->setVersion(rset->getInt(3));
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODVfeToRejectInfo::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODVfeToRejectInfo::fetchData():  ")+e.getMessage()));
   }
 }
 
@@ -206,7 +206,7 @@ int ODVfeToRejectInfo::fetchID()    noexcept(false)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODVfeToRejectInfo::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("ODVfeToRejectInfo::fetchID:  ")+e.getMessage()));
   }
 
   return m_ID;

--- a/OnlineDB/EcalCondDB/src/ODWeightsDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODWeightsDat.cc
@@ -51,7 +51,7 @@ void ODWeightsDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, sm_id, fed_id, tt_id, cry_id, wei0, wei1, wei2, wei3, wei4, wei5 ) "
 			"VALUES (:1, :2, :3, :4, :5, :6, :7, :8 , :9, :10, :11 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -78,7 +78,7 @@ void ODWeightsDat::writeDB(const ODWeightsDat* item, ODFEWeightsInfo* iov )
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -128,7 +128,7 @@ void ODWeightsDat::fetchData(std::vector< ODWeightsDat >* p, ODFEWeightsInfo* io
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -158,7 +158,7 @@ void ODWeightsDat::fetchData(ODWeightsDat * p)
     std::cout << " table " << getTable() << " total nb of rows " << row << std::endl;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -273,6 +273,6 @@ void ODWeightsDat::writeArrayDB(const std::vector< ODWeightsDat >& data, ODFEWei
     delete [] z2_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/ODWeightsSamplesDat.cc
+++ b/OnlineDB/EcalCondDB/src/ODWeightsSamplesDat.cc
@@ -40,7 +40,7 @@ void ODWeightsSamplesDat::prepareWrite()
     m_writeStmt->setSQL("INSERT INTO "+getTable()+" (rec_id, fed_id, sample_id, weight_number ) "
 			"VALUES (:1, :2, :3, :4 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsSamplesDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsSamplesDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -59,7 +59,7 @@ void ODWeightsSamplesDat::writeDB(const ODWeightsSamplesDat* item, ODFEWeightsIn
     
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsSamplesDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsSamplesDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,7 +95,7 @@ void ODWeightsSamplesDat::fetchData(std::vector< ODWeightsSamplesDat >* p, ODFEW
     }
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsSamplesDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsSamplesDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -117,7 +117,7 @@ void ODWeightsSamplesDat::fetchData(ODWeightsSamplesDat * p)
     }
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsSamplesDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsSamplesDat::fetchData():  "+e.getMessage()));
   }
 }
 
@@ -182,6 +182,6 @@ void ODWeightsSamplesDat::writeArrayDB(const std::vector< ODWeightsSamplesDat >&
     delete [] z_len;
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("ODWeightsSamplesDat::writeArrayDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("ODWeightsSamplesDat::writeArrayDB():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunCommentDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunCommentDat.cc
@@ -43,7 +43,7 @@ void RunCommentDat::prepareWrite()
 			"VALUES (:iov_id,  "
 			":source, :user_comment)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunCommentDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunCommentDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -65,7 +65,7 @@ void RunCommentDat::writeDB(const EcalLogicID* ecid, const RunCommentDat* item, 
     
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunCommentDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunCommentDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -103,8 +103,8 @@ void RunCommentDat::fetchData(map< EcalLogicID, RunCommentDat >* fillMap, RunIOV
 			     EcalLogicID::NULLID, EcalLogicID::NULLID,        // comment number
 			    "Comment_order");    
 
-      dat.setSource( getOraString(rset,2) );
-      dat.setComment( getOraString(rset,3) );
+      dat.setSource( rset->getString(2) );
+      dat.setComment( rset->getString(3) );
 
       Date startDate = rset->getDate(4);
       m_time = dh.dateToTm( startDate );
@@ -114,6 +114,6 @@ void RunCommentDat::fetchData(map< EcalLogicID, RunCommentDat >* fillMap, RunIOV
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunCommentDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunCommentDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunConfigDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunConfigDat.cc
@@ -39,7 +39,7 @@ void RunConfigDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":config_tag, :config_ver)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunConfigDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunConfigDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -65,7 +65,7 @@ void RunConfigDat::writeDB(const EcalLogicID* ecid, const RunConfigDat* item, Ru
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunConfigDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunConfigDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,20 +97,20 @@ void RunConfigDat::fetchData(map< EcalLogicID, RunConfigDat >* fillMap, RunIOV* 
     std::pair< EcalLogicID, RunConfigDat > p;
     RunConfigDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
-      dat.setConfigTag( getOraString(rset,7) );
+      dat.setConfigTag( rset->getString(7) );
       dat.setConfigVersion( rset->getInt(8) );
 
       p.second = dat;
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunConfigDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunConfigDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunCrystalErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunCrystalErrorsDat.cc
@@ -38,7 +38,7 @@ void RunCrystalErrorsDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			"to_number(:error_bits))");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunCrystalErrorsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunCrystalErrorsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -62,7 +62,7 @@ void RunCrystalErrorsDat::writeDB(const EcalLogicID* ecid, const RunCrystalError
     m_writeStmt->setString(3, std::to_string(item->getErrorBits()));
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunCrystalErrorsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunCrystalErrorsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,14 +95,14 @@ void RunCrystalErrorsDat::fetchData(map< EcalLogicID, RunCrystalErrorsDat >* fil
     std::pair< EcalLogicID, RunCrystalErrorsDat > p;
     RunCrystalErrorsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
-      dat.setErrorBits( boost::lexical_cast<uint64_t>(getOraString(rset,7)) );
+      dat.setErrorBits( boost::lexical_cast<uint64_t>(rset->getString(7)) );
 
       p.second = dat;
       fillMap->insert(p);
@@ -110,6 +110,6 @@ void RunCrystalErrorsDat::fetchData(map< EcalLogicID, RunCrystalErrorsDat >* fil
     m_conn->terminateStatement(stmt);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunCrystalErrorsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunCrystalErrorsDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunDCSHVDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSHVDat.cc
@@ -79,7 +79,7 @@ ResultSet *RunDCSHVDat::getBarrelRset(const Tm& timeStart) {
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + e.getMessage() + " " + query));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  error code ") + std::to_string(e.getErrorCode()) + " " + query));
 #endif
@@ -107,7 +107,7 @@ ResultSet *RunDCSHVDat::getEndcapAnodeRset(const Tm& timeStart) {
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + e.getMessage() + " " + query));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  error code ") + std::to_string(e.getErrorCode()) + " " + query));
 #endif
@@ -135,7 +135,7 @@ ResultSet *RunDCSHVDat::getEndcapDynodeRset(const Tm& timeStart) {
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + e.getMessage() + " " + query));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  error code ") + std::to_string(e.getErrorCode()) + " " + query));
 #endif
@@ -157,7 +157,7 @@ ResultSet *RunDCSHVDat::getBarrelRset() {
     rset = m_readStmt->executeQuery();
   }
   catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + e.getMessage() + " " + query));
   }
   return rset;
 }
@@ -176,7 +176,7 @@ ResultSet *RunDCSHVDat::getBarrelRset() {
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  ") + e.getMessage() + " " + query));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::getBarrelRset():  error code ") + std::to_string(e.getErrorCode()) + " " + query));
 #endif
@@ -197,7 +197,7 @@ ResultSet *RunDCSHVDat::getEndcapAnodeRset() {
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::getEndcapAnodeRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSHVDat::getEndcapAnodeRset():  ") + e.getMessage() + " " + query));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::getEndcapAnodeRset():  error code ") + std::to_string(e.getErrorCode()) + " " + query));
 #endif
@@ -218,7 +218,7 @@ ResultSet *RunDCSHVDat::getEndcapDynodeRset() {
   } 
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::getEndcapDynodeRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSHVDat::getEndcapDynodeRset():  ") + e.getMessage() + " " + query));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::getEndcapDynodeRset():  error code ") + std::to_string(e.getErrorCode()) + " " + query));
 #endif
@@ -237,12 +237,12 @@ void RunDCSHVDat::fillTheMap(ResultSet *rset,
 
   try {
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       
       dat.setHV(        rset->getFloat(7) );
       dat.setHVNominal( rset->getFloat(8) );
@@ -260,7 +260,7 @@ void RunDCSHVDat::fillTheMap(ResultSet *rset,
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  ")+e.getMessage()));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  error code ") + std::to_string(e.getErrorCode())));
 #endif
@@ -284,12 +284,12 @@ void RunDCSHVDat::fillTheMapByTime(ResultSet *rset,
   try {
     int count=-1;
     while(rset->next()) {
-      EcalLogicID ec = EcalLogicID( getOraString(rset,1),     // name
+      EcalLogicID ec = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       
 
       dat.setHV(        rset->getFloat(7) );
@@ -354,7 +354,7 @@ void RunDCSHVDat::fillTheMapByTime(ResultSet *rset,
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  ")+e.getMessage()));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  error code ") + std::to_string(e.getErrorCode())));
 #endif
@@ -434,7 +434,7 @@ void RunDCSHVDat::fetchLastData(map< EcalLogicID, RunDCSHVDat >* fillMap )
   } 
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  ")+e.getMessage()));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  error code ") + std::to_string(e.getErrorCode())));
 #endif
@@ -474,7 +474,7 @@ void RunDCSHVDat::fetchHistoricalData(std::list< std::pair<Tm, std::map< EcalLog
   } 
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  ")+e.getMessage()));
 #else
     throw(std::runtime_error(std::string("RunDCSHVDat::fetchData():  error code ") + std::to_string(e.getErrorCode())));
 #endif

--- a/OnlineDB/EcalCondDB/src/RunDCSLVDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSLVDat.cc
@@ -65,7 +65,7 @@ ResultSet *RunDCSLVDat::getBarrelRset() {
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSLVDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSLVDat::getBarrelRset():  ") + e.getMessage() + " " + query));
 #else
     throw(std::runtime_error(std::string("RunDCSLVDat::getBarrelRset():  error code ") + std::to_string(e.getErrorCode()) + " " + query));
 #endif
@@ -86,7 +86,7 @@ ResultSet *RunDCSLVDat::getEndcapRset() {
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSLVDat::getEndcapRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSLVDat::getEndcapRset():  ") + e.getMessage() + " " + query));
 #else
     throw(std::runtime_error(std::string("RunDCSLVDat::getEndcapRset():  error code ") + std::to_string(e.getErrorCode()) + " " + query));
 #endif
@@ -102,12 +102,12 @@ void RunDCSLVDat::fillTheMap(ResultSet *rset,
 
   try {
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       
       dat.setLV(        rset->getFloat(7) );
       dat.setLVNominal( rset->getFloat(8) );
@@ -125,7 +125,7 @@ void RunDCSLVDat::fillTheMap(ResultSet *rset,
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSLVDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunDCSLVDat::fetchData():  ")+e.getMessage()));
 #else
     throw(std::runtime_error(std::string("RunDCSLVDat::fetchData():  error code ") + std::to_string(e.getErrorCode())));
 #endif
@@ -201,7 +201,7 @@ void RunDCSLVDat::fetchLastData(map< EcalLogicID, RunDCSLVDat >* fillMap )
   } 
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSLVDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunDCSLVDat::fetchData():  ")+e.getMessage()));
 #else
     throw(std::runtime_error(std::string("RunDCSLVDat::fetchData():  error code ") + std::to_string(e.getErrorCode())));
 #endif

--- a/OnlineDB/EcalCondDB/src/RunDCSMagnetDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDCSMagnetDat.cc
@@ -86,7 +86,7 @@ ResultSet *RunDCSMagnetDat::getMagnetRset() {
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSMagnetDat::getBarrelRset():  ") + getOraMessage(&e) + " " + query));
+    throw(std::runtime_error(std::string("RunDCSMagnetDat::getBarrelRset():  ") + e.getMessage() + " " + query));
 #else
     throw(std::runtime_error(std::string("RunDCSMagnetDat::getBarrelRset():  error code ") + std::to_string(e.getErrorCode()) + " " + query));
 #endif
@@ -107,12 +107,12 @@ void RunDCSMagnetDat::fillTheMap(ResultSet *rset,
 
   try {
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
       
     std::cout<<"done the logic id"<<std::endl;
       dat.setMagnetCurrent( rset->getFloat(7) );
@@ -130,7 +130,7 @@ void RunDCSMagnetDat::fillTheMap(ResultSet *rset,
   }
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSMagnetDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunDCSMagnetDat::fetchData():  ")+e.getMessage()));
 #else
     throw(std::runtime_error(std::string("RunDCSMagnetDat::fetchData():  error code ") + std::to_string(e.getErrorCode())));
 #endif
@@ -178,7 +178,7 @@ void RunDCSMagnetDat::fetchLastData(map< EcalLogicID, RunDCSMagnetDat >* fillMap
   } 
   catch (SQLException &e) {
 #if defined(_GLIBCXX_USE_CXX11_ABI) && (_GLIBCXX_USE_CXX11_ABI == 0)
-    throw(std::runtime_error(std::string("RunDCSMagnetDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunDCSMagnetDat::fetchData():  ")+e.getMessage()));
 #else
     throw(std::runtime_error(std::string("RunDCSMagnetDat::fetchData():  error code ") + std::to_string(e.getErrorCode())));
 #endif

--- a/OnlineDB/EcalCondDB/src/RunDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunDat.cc
@@ -36,7 +36,7 @@ void RunDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":num_events)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -61,7 +61,7 @@ void RunDat::writeDB(const EcalLogicID* ecid, const RunDat* item, RunIOV* iov)
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -93,12 +93,12 @@ void RunDat::fetchData(map< EcalLogicID, RunDat >* fillMap, RunIOV* iov)
     std::pair< EcalLogicID, RunDat > p;
     RunDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setNumEvents( rset->getInt(7) );
 
@@ -107,6 +107,6 @@ void RunDat::fetchData(map< EcalLogicID, RunDat >* fillMap, RunIOV* iov)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunFEConfigDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunFEConfigDat.cc
@@ -39,7 +39,7 @@ void RunFEConfigDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":Config_id ) ");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunFEConfigDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunFEConfigDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -65,7 +65,7 @@ void RunFEConfigDat::writeDB(const EcalLogicID* ecid, const RunFEConfigDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunFEConfigDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunFEConfigDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -102,12 +102,12 @@ void RunFEConfigDat::fetchData(map< EcalLogicID, RunFEConfigDat >* fillMap, RunI
     std::pair< EcalLogicID, RunFEConfigDat > p;
     RunFEConfigDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setConfigId( rset->getInt(7) );
  
@@ -117,7 +117,7 @@ void RunFEConfigDat::fetchData(map< EcalLogicID, RunFEConfigDat >* fillMap, RunI
     //    terminateReadStatement();
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunFEConfigDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunFEConfigDat::fetchData():  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/RunH4TablePositionDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunH4TablePositionDat.cc
@@ -41,7 +41,7 @@ void RunH4TablePositionDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":table_x, :table_y, :number_of_spills, :number_of_events)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunH4TablePositionDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunH4TablePositionDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -69,7 +69,7 @@ void RunH4TablePositionDat::writeDB(const EcalLogicID* ecid, const RunH4TablePos
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunH4TablePositionDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunH4TablePositionDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -101,12 +101,12 @@ void RunH4TablePositionDat::fetchData(map< EcalLogicID, RunH4TablePositionDat >*
     std::pair< EcalLogicID, RunH4TablePositionDat > p;
     RunH4TablePositionDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setTableX( rset->getInt(7) );
       dat.setTableY( rset->getInt(8) );
@@ -118,6 +118,6 @@ void RunH4TablePositionDat::fetchData(map< EcalLogicID, RunH4TablePositionDat >*
     }
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunH4TablePositionDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunH4TablePositionDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunIOV.cc
+++ b/OnlineDB/EcalCondDB/src/RunIOV.cc
@@ -141,7 +141,7 @@ int RunIOV::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunIOV::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunIOV::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -181,7 +181,7 @@ void RunIOV::setByID(int id)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("RunIOV::setByID:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("RunIOV::setByID:  "+e.getMessage()));
    }
 }
 
@@ -225,7 +225,7 @@ int RunIOV::writeDB()
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunIOV::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunIOV::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -270,7 +270,7 @@ int RunIOV::updateEndTimeDB()
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunIOV::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunIOV::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -320,7 +320,7 @@ int RunIOV::fetchIDByRunAndTag()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunIOV::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunIOV::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -360,7 +360,7 @@ int RunIOV::updateStartTimeDB()
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunIOV::writeDB:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunIOV::writeDB:  "+e.getMessage()));
   }
 
   // Now get the ID
@@ -410,7 +410,7 @@ void RunIOV::setByRun(RunTag* tag, run_t run)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("RunIOV::setByRun:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("RunIOV::setByRun:  "+e.getMessage()));
    }
 }
 
@@ -451,7 +451,7 @@ void RunIOV::setByTime(std::string location, const Tm &t)
 
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("RunIOV::setByTime(loc, run):  ") + getOraMessage(&e)));
+     throw(std::runtime_error("RunIOV::setByTime(loc, run):  " + e.getMessage()));
    }
 }
 
@@ -488,7 +488,7 @@ void RunIOV::setByRun(std::string location, run_t run)
 
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("RunIOV::setByRun(loc, run):  ")+getOraMessage(&e)));
+     throw(std::runtime_error("RunIOV::setByRun(loc, run):  "+e.getMessage()));
    }
 }
 
@@ -534,7 +534,7 @@ void RunIOV::setByRecentData(std::string dataTable, RunTag* tag, run_t run)
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("RunIOV::setByRecentData:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("RunIOV::setByRecentData:  "+e.getMessage()));
    }
 }
 
@@ -576,7 +576,7 @@ void RunIOV::setByRecentData(std::string dataTable, std::string location, run_t 
      
      m_conn->terminateStatement(stmt);
    } catch (SQLException &e) {
-     throw(std::runtime_error(std::string("RunIOV::setByRecentData:  ")+getOraMessage(&e)));
+     throw(std::runtime_error("RunIOV::setByRecentData:  "+e.getMessage()));
    }
 }
 

--- a/OnlineDB/EcalCondDB/src/RunLaserRunDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunLaserRunDat.cc
@@ -37,7 +37,7 @@ void RunLaserRunDat::prepareWrite()
 			"VALUES (:1, :2, "
 			":3, :4 )");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunLaserRunDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunLaserRunDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void RunLaserRunDat::writeDB(const EcalLogicID* ecid, const RunLaserRunDat* item
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunLaserRunDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunLaserRunDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,21 +95,21 @@ void RunLaserRunDat::fetchData(map< EcalLogicID, RunLaserRunDat >* fillMap, RunI
     std::pair< EcalLogicID, RunLaserRunDat > p;
     RunLaserRunDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
-      dat.setLaserSequenceType( getOraString(rset,7));    // maps_to
-      dat.setLaserSequenceCond( getOraString(rset,8));    // maps_to
+      dat.setLaserSequenceType( rset->getString(7));    // maps_to
+      dat.setLaserSequenceCond( rset->getString(8));    // maps_to
 
       p.second = dat;
       fillMap->insert(p);
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunLaserRunDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunLaserRunDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunList.cc
+++ b/OnlineDB/EcalCondDB/src/RunList.cc
@@ -183,7 +183,7 @@ void RunList::fetchRuns(int min_run, int max_run, bool withTriggers,
     m_vec_runiov.resize(i);
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunList::fetchRuns:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunList::fetchRuns:  ")+e.getMessage()));
   }
 }
 
@@ -253,7 +253,7 @@ void RunList::fetchLastNRuns( int max_run, int n_runs  )
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunList::fetchLastNRuns:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunList::fetchLastNRuns:  ")+e.getMessage()));
   }
 
 
@@ -323,9 +323,9 @@ void RunList::fetchRunsByLocation (int min_run, int max_run, const LocationDef& 
        
        RunTag atag;
        atag.setLocationDef(locDef);
-       atag.setGeneralTag(getOraString(rset,7));
+       atag.setGeneralTag(rset->getString(7));
        RunTypeDef rundef;
-       rundef.setRunType(getOraString(rset,8));
+       rundef.setRunType(rset->getString(8));
        atag.setRunTypeDef(rundef);
 
        RunIOV r ;
@@ -344,7 +344,7 @@ void RunList::fetchRunsByLocation (int min_run, int max_run, const LocationDef& 
     m_conn->terminateStatement(stmt);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunList::fetchRunsByLocation:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunList::fetchRunsByLocation:  ")+e.getMessage()));
   }
 
 
@@ -414,9 +414,9 @@ void RunList::fetchGlobalRunsByLocation (int min_run, int max_run, const Locatio
        
        RunTag atag;
        atag.setLocationDef(locDef);
-       atag.setGeneralTag(getOraString(rset,7));
+       atag.setGeneralTag(rset->getString(7));
        RunTypeDef rundef;
-       rundef.setRunType(getOraString(rset,8));
+       rundef.setRunType(rset->getString(8));
        atag.setRunTypeDef(rundef);
 
        RunIOV r ;
@@ -435,7 +435,7 @@ void RunList::fetchGlobalRunsByLocation (int min_run, int max_run, const Locatio
     m_conn->terminateStatement(stmt);
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunList::fetchRunsByLocation:  ")+getOraMessage(&e)));
+    throw(std::runtime_error(std::string("RunList::fetchRunsByLocation:  ")+e.getMessage()));
   }
 
 

--- a/OnlineDB/EcalCondDB/src/RunMemChErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunMemChErrorsDat.cc
@@ -39,7 +39,7 @@ void RunMemChErrorsDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			"to_number(:error_bits))");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunMemChErrorsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunMemChErrorsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void RunMemChErrorsDat::writeDB(const EcalLogicID* ecid, const RunMemChErrorsDat
     m_writeStmt->setString(3, std::to_string(item->getErrorBits()));
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunMemChErrorsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunMemChErrorsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -96,14 +96,14 @@ void RunMemChErrorsDat::fetchData(map< EcalLogicID, RunMemChErrorsDat >* fillMap
     std::pair< EcalLogicID, RunMemChErrorsDat > p;
     RunMemChErrorsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
-      dat.setErrorBits( boost::lexical_cast<uint64_t>(getOraString(rset,7)) );
+      dat.setErrorBits( boost::lexical_cast<uint64_t>(rset->getString(7)) );
 
       p.second = dat;
       fillMap->insert(p);
@@ -111,6 +111,6 @@ void RunMemChErrorsDat::fetchData(map< EcalLogicID, RunMemChErrorsDat >* fillMap
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunMemChErrorsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunMemChErrorsDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunMemTTErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunMemTTErrorsDat.cc
@@ -40,7 +40,7 @@ void RunMemTTErrorsDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			"to_number(:error_bits))");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunMemTTErrorsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunMemTTErrorsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -64,7 +64,7 @@ void RunMemTTErrorsDat::writeDB(const EcalLogicID* ecid, const RunMemTTErrorsDat
     m_writeStmt->setString(3, std::to_string(item->getErrorBits()));
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunMemTTErrorsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunMemTTErrorsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,14 +97,14 @@ void RunMemTTErrorsDat::fetchData(map< EcalLogicID, RunMemTTErrorsDat >* fillMap
     std::pair< EcalLogicID, RunMemTTErrorsDat > p;
     RunMemTTErrorsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
-      dat.setErrorBits( boost::lexical_cast<uint64_t>(getOraString(rset,7)) );
+      dat.setErrorBits( boost::lexical_cast<uint64_t>(rset->getString(7)) );
 
       p.second = dat;
       fillMap->insert(p);
@@ -112,6 +112,6 @@ void RunMemTTErrorsDat::fetchData(map< EcalLogicID, RunMemTTErrorsDat >* fillMap
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunMemTTErrorsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunMemTTErrorsDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunModeDef.cc
+++ b/OnlineDB/EcalCondDB/src/RunModeDef.cc
@@ -69,7 +69,7 @@ int RunModeDef::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunModeDef::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunModeDef::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -90,14 +90,14 @@ void RunModeDef::setByID(int id)
 
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
-      m_runMode = getOraString(rset,1);
+      m_runMode = rset->getString(1);
     } else {
       throw(std::runtime_error("RunModeDef::setByID:  Given def_id is not in the database"));
     }
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("RunModeDef::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("RunModeDef::setByID:  "+e.getMessage()));
   }
 }
 
@@ -120,6 +120,6 @@ void RunModeDef::fetchAllDefs( std::vector<RunModeDef>* fillVec)
       fillVec->push_back( runModeDef );
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunModeDef::fetchAllDefs:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunModeDef::fetchAllDefs:  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunPNErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunPNErrorsDat.cc
@@ -40,7 +40,7 @@ void RunPNErrorsDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			"to_number(:error_bits))");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunPNErrorsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunPNErrorsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -64,7 +64,7 @@ void RunPNErrorsDat::writeDB(const EcalLogicID* ecid, const RunPNErrorsDat* item
     m_writeStmt->setString(3, std::to_string(item->getErrorBits()));
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunPNErrorsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunPNErrorsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,14 +97,14 @@ void RunPNErrorsDat::fetchData(map< EcalLogicID, RunPNErrorsDat >* fillMap, RunI
     std::pair< EcalLogicID, RunPNErrorsDat > p;
     RunPNErrorsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
-      dat.setErrorBits( boost::lexical_cast<uint64_t>(getOraString(rset,7)) );
+      dat.setErrorBits( boost::lexical_cast<uint64_t>(rset->getString(7)) );
 
       p.second = dat;
       fillMap->insert(p);
@@ -112,6 +112,6 @@ void RunPNErrorsDat::fetchData(map< EcalLogicID, RunPNErrorsDat >* fillMap, RunI
 
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunPNErrorsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunPNErrorsDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunPTMTempDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunPTMTempDat.cc
@@ -38,7 +38,7 @@ void RunPTMTempDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":temperature)");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunPTMTempDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunPTMTempDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -63,7 +63,7 @@ void RunPTMTempDat::writeDB(const EcalLogicID* ecid, const RunPTMTempDat* item, 
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunPTMTempDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunPTMTempDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -95,12 +95,12 @@ void RunPTMTempDat::fetchData(map< EcalLogicID, RunPTMTempDat >* fillMap, RunIOV
     std::pair< EcalLogicID, RunPTMTempDat > p;
     RunPTMTempDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
       dat.setTemperature( rset->getFloat(7) );
 
@@ -109,6 +109,6 @@ void RunPTMTempDat::fetchData(map< EcalLogicID, RunPTMTempDat >* fillMap, RunIOV
     }
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunPTMTempDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunPTMTempDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunSeqDef.cc
+++ b/OnlineDB/EcalCondDB/src/RunSeqDef.cc
@@ -75,7 +75,7 @@ int RunSeqDef::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunSeqDef::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunSeqDef::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -98,7 +98,7 @@ void RunSeqDef::setByID(int id)
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
       idruntype = rset->getInt(1);
-      m_runSeq = getOraString(rset,2);
+      m_runSeq = rset->getString(2);
     } else {
       throw(std::runtime_error("RunSeqDef::setByID:  Given def_id is not in the database"));
     }
@@ -109,7 +109,7 @@ void RunSeqDef::setByID(int id)
     m_runType.setByID(idruntype);
 
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("RunSeqDef::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("RunSeqDef::setByID:  "+e.getMessage()));
   }
 }
 
@@ -132,7 +132,7 @@ void RunSeqDef::fetchAllDefs( std::vector<RunSeqDef>* fillVec)
       fillVec->push_back( runSeqDef );
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunSeqDef::fetchAllDefs:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunSeqDef::fetchAllDefs:  "+e.getMessage()));
   }
 }
 
@@ -169,7 +169,7 @@ int RunSeqDef::writeDB()
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("RunSeqDef::writeDB:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("RunSeqDef::writeDB:  "+e.getMessage()));
   }
 
   // now get the tag_id

--- a/OnlineDB/EcalCondDB/src/RunTPGConfigDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunTPGConfigDat.cc
@@ -39,7 +39,7 @@ void RunTPGConfigDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			":Config_tag , :version ) ");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTPGConfigDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTPGConfigDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -66,7 +66,7 @@ void RunTPGConfigDat::writeDB(const EcalLogicID* ecid, const RunTPGConfigDat* it
 
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTPGConfigDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTPGConfigDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -98,14 +98,14 @@ void RunTPGConfigDat::fetchData(map< EcalLogicID, RunTPGConfigDat >* fillMap, Ru
     std::pair< EcalLogicID, RunTPGConfigDat > p;
     RunTPGConfigDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
-      dat.setConfigTag( getOraString(rset,7) );
+      dat.setConfigTag( rset->getString(7) );
       dat.setVersion( rset->getInt(8) );
  
 
@@ -113,6 +113,6 @@ void RunTPGConfigDat::fetchData(map< EcalLogicID, RunTPGConfigDat >* fillMap, Ru
       fillMap->insert(p);
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTPGConfigDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTPGConfigDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunTTErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunTTErrorsDat.cc
@@ -40,7 +40,7 @@ void RunTTErrorsDat::prepareWrite()
 			"VALUES (:iov_id, :logic_id, "
 			"to_number(:error_bits))");
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTTErrorsDat::prepareWrite():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTTErrorsDat::prepareWrite():  "+e.getMessage()));
   }
 }
 
@@ -64,7 +64,7 @@ void RunTTErrorsDat::writeDB(const EcalLogicID* ecid, const RunTTErrorsDat* item
     m_writeStmt->setString(3, std::to_string(item->getErrorBits()));
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTTErrorsDat::writeDB():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTTErrorsDat::writeDB():  "+e.getMessage()));
   }
 }
 
@@ -97,20 +97,20 @@ void RunTTErrorsDat::fetchData(map< EcalLogicID, RunTTErrorsDat >* fillMap, RunI
     std::pair< EcalLogicID, RunTTErrorsDat > p;
     RunTTErrorsDat dat;
     while(rset->next()) {
-      p.first = EcalLogicID( getOraString(rset,1),     // name
+      p.first = EcalLogicID( rset->getString(1),     // name
 			     rset->getInt(2),        // logic_id
 			     rset->getInt(3),        // id1
 			     rset->getInt(4),        // id2
 			     rset->getInt(5),        // id3
-			     getOraString(rset,6));    // maps_to
+			     rset->getString(6));    // maps_to
 
-      dat.setErrorBits( boost::lexical_cast<uint64_t>(getOraString(rset,7)) );
+      dat.setErrorBits( boost::lexical_cast<uint64_t>(rset->getString(7)) );
 
       p.second = dat;
       fillMap->insert(p);
     }
 
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTTErrorsDat::fetchData():  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTTErrorsDat::fetchData():  "+e.getMessage()));
   }
 }

--- a/OnlineDB/EcalCondDB/src/RunTag.cc
+++ b/OnlineDB/EcalCondDB/src/RunTag.cc
@@ -116,7 +116,7 @@ int RunTag::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTag::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTag::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -137,7 +137,7 @@ void RunTag::setByID(int id)
 
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
-      m_genTag = getOraString(rset,1);
+      m_genTag = rset->getString(1);
       int locID = rset->getInt(2);
       int runTypeID = rset->getInt(3);
 
@@ -154,7 +154,7 @@ void RunTag::setByID(int id)
 
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("RunTag::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("RunTag::setByID:  "+e.getMessage()));
   }
 }
 
@@ -188,7 +188,7 @@ int RunTag::writeDB()
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("RunTag::writeDB:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("RunTag::writeDB:  "+e.getMessage()));
   }
 
   // now get the tag_id
@@ -218,7 +218,7 @@ void RunTag::fetchAllTags( std::vector<RunTag>* fillVec)
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTag::fetchAllTags:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTag::fetchAllTags:  "+e.getMessage()));
   }
 }
 

--- a/OnlineDB/EcalCondDB/src/RunTypeDef.cc
+++ b/OnlineDB/EcalCondDB/src/RunTypeDef.cc
@@ -73,7 +73,7 @@ int RunTypeDef::fetchID()
     }
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTypeDef::fetchID:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTypeDef::fetchID:  "+e.getMessage()));
   }
 
   return m_ID;
@@ -94,15 +94,15 @@ void RunTypeDef::setByID(int id)
 
     ResultSet* rset = stmt->executeQuery();
     if (rset->next()) {
-      m_runType = getOraString(rset,1);
-      m_desc = getOraString(rset,2);
+      m_runType = rset->getString(1);
+      m_desc = rset->getString(2);
     } else {
       throw(std::runtime_error("RunTypeDef::setByID:  Given def_id is not in the database"));
     }
     
     m_conn->terminateStatement(stmt);
   } catch (SQLException &e) {
-   throw(std::runtime_error(std::string("RunTypeDef::setByID:  ")+getOraMessage(&e)));
+   throw(std::runtime_error("RunTypeDef::setByID:  "+e.getMessage()));
   }
 }
 
@@ -125,6 +125,6 @@ void RunTypeDef::fetchAllDefs( std::vector<RunTypeDef>* fillVec)
       fillVec->push_back( runTypeDef );
     }
   } catch (SQLException &e) {
-    throw(std::runtime_error(std::string("RunTypeDef::fetchAllDefs:  ")+getOraMessage(&e)));
+    throw(std::runtime_error("RunTypeDef::fetchAllDefs:  "+e.getMessage()));
   }
 }

--- a/OnlineDB/Oracle/test/test.cpp
+++ b/OnlineDB/Oracle/test/test.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]){
   }catch(oracle::occi::SQLException &e)
   {
     cout <<"Caught oracle::occi::SQLException exception with error code: "<<e.getErrorCode()<<endl;
-    cout <<"Exception Message:"<<getOraMessage(&e)<<endl;
+    cout <<"Exception Message:"<< e.getMessage()<<endl;
     if (e.getErrorCode()==errCode){
       cout << "OK: Expected exception found:" << errCode << endl;
     }

--- a/OnlineDB/SiStripConfigDb/src/SiStripConfigDb.cc
+++ b/OnlineDB/SiStripConfigDb/src/SiStripConfigDb.cc
@@ -195,7 +195,7 @@ void SiStripConfigDb::clearLocalCache() {
 DeviceFactory* const SiStripConfigDb::deviceFactory( std::string method_name ) const { 
   if ( factory_ ) { return factory_; }
   else { 
-    if ( !method_name.empty() ) { 
+    if ( method_name != "" ) { 
       stringstream ss;
       ss << "[SiStripConfigDb::" << __func__ << "]"
 	 << " NULL pointer to DeviceFactory requested by" 
@@ -211,7 +211,7 @@ DeviceFactory* const SiStripConfigDb::deviceFactory( std::string method_name ) c
 DbClient* const SiStripConfigDb::databaseCache( std::string method_name ) const { 
   if ( dbCache_ ) { return dbCache_; }
   else { 
-    if ( !method_name.empty() ) { 
+    if ( method_name != "" ) { 
       stringstream ss;
       ss << "[SiStripConfigDb::" << __func__ << "]"
 	 << " NULL pointer to DbClient requested by" 
@@ -231,7 +231,7 @@ void SiStripConfigDb::usingDatabase() {
   std::string passwd = "";
   std::string path = "";
   DbAccess::getDbConfiguration( user, passwd, path );
-  if ( !user.empty() && !passwd.empty() && !path.empty() ) {
+  if ( user != "" && passwd != "" && path != "" ) {
 
     std::stringstream ss;
     ss << "[SiStripConfigDb::" << __func__ << "]"
@@ -559,7 +559,7 @@ void SiStripConfigDb::usingXmlFiles() {
   for ( ; ip != jp; ++ip ) {
     
     // Input module.xml file
-    if ( ip->second.inputModuleXml().empty() ) {
+    if ( ip->second.inputModuleXml() == "" ) {
       edm::LogWarning(mlConfigDb_)
 	<< "[SiStripConfigDb::" << __func__ << "]"
 	<< " NULL path to input 'module.xml' file!";
@@ -582,7 +582,7 @@ void SiStripConfigDb::usingXmlFiles() {
     }
   
     // Input dcuinfo.xml file
-    if ( ip->second.inputDcuInfoXml().empty() ) {
+    if ( ip->second.inputDcuInfoXml() == "" ) {
       edm::LogWarning(mlConfigDb_)
 	<< "[SiStripConfigDb::" << __func__ << "]"
 	<< " NULL path to input 'dcuinfo.xml' file!";
@@ -612,7 +612,7 @@ void SiStripConfigDb::usingXmlFiles() {
     } else {
       std::vector<std::string>::iterator iter = ip->second.inputFecXml().begin();
       for ( ; iter != ip->second.inputFecXml().end(); iter++ ) {
-	if ( (*iter).empty() ) {
+	if ( *iter == "" ) {
 	  edm::LogWarning(mlConfigDb_)
 	    << "[SiStripConfigDb::" << __func__ << "]"
 	    << " NULL path to input 'fec.xml' file!";
@@ -642,7 +642,7 @@ void SiStripConfigDb::usingXmlFiles() {
     } else {
       std::vector<std::string>::iterator iter = ip->second.inputFedXml().begin();
       for ( ; iter != ip->second.inputFedXml().end(); iter++ ) {
-	if ( (*iter).empty() ) {
+	if ( *iter == "" ) {
 	  edm::LogWarning(mlConfigDb_) 
 	    << "[SiStripConfigDb::" << __func__ << "]"
 	    << " NULL path to input 'fed.xml' file!";
@@ -669,7 +669,7 @@ void SiStripConfigDb::usingXmlFiles() {
   }
 
   // Output module.xml file
-  if ( dbParams_.outputModuleXml().empty() ) { 
+  if ( dbParams_.outputModuleXml() == "" ) { 
     edm::LogWarning(mlConfigDb_) 
       << "[SiStripConfigDb::" << __func__ << "]"
       << " NULL path to output 'module.xml' file!"
@@ -685,7 +685,7 @@ void SiStripConfigDb::usingXmlFiles() {
   }
 
   // Output dcuinfo.xml file
-  if ( dbParams_.outputDcuInfoXml().empty() ) { 
+  if ( dbParams_.outputDcuInfoXml() == "" ) { 
     edm::LogWarning(mlConfigDb_) 
       << "[SiStripConfigDb::" << __func__ << "]"
       << " NULL path to output 'dcuinfo.xml' file!"
@@ -701,7 +701,7 @@ void SiStripConfigDb::usingXmlFiles() {
   }
 
   // Output fec.xml file
-  if ( dbParams_.outputFecXml().empty() ) {
+  if ( dbParams_.outputFecXml() == "" ) {
     edm::LogWarning(mlConfigDb_) 
       << "[SiStripConfigDb::" << __func__ << "]"
       << " NULL path to output 'fec.xml' file!"
@@ -717,7 +717,7 @@ void SiStripConfigDb::usingXmlFiles() {
   }
 
   // Output fed.xml file
-  if ( dbParams_.outputFedXml().empty() ) {
+  if ( dbParams_.outputFedXml() == "" ) {
     edm::LogWarning(mlConfigDb_) 
       << "[SiStripConfigDb::" << __func__ << "]"
       << " NULL path to output 'fed.xml' file!"
@@ -748,15 +748,15 @@ void SiStripConfigDb::handleException( const std::string& method_name,
     ss << " Caught cms::Exception in method "
        << method_name << " with message: " << std::endl 
        << e.what();
-    if ( !extra_info.empty() ) { ss << "Additional info: " << extra_info << std::endl; }
+    if ( extra_info != "" ) { ss << "Additional info: " << extra_info << std::endl; }
     //throw e; // rethrow cms::Exception
   }
   
-  catch ( oracle::occi::SQLException& e ) {
+  catch ( const oracle::occi::SQLException& e ) { 
     ss << " Caught oracle::occi::SQLException in method "
        << method_name << " with message: " << std::endl 
-       << getOraMessage(&e);
-    if ( !extra_info.empty() ) { ss << "Additional info: " << extra_info << std::endl; }
+       << e.getMessage();
+    if ( extra_info != "" ) { ss << "Additional info: " << extra_info << std::endl; }
     //throw cms::Exception(mlConfigDb_) << ss.str() << std::endl;
   }
 
@@ -764,7 +764,7 @@ void SiStripConfigDb::handleException( const std::string& method_name,
     ss << " Caught FecExceptionHandler exception in method "
        << method_name << " with message: " << std::endl 
        << const_cast<FecExceptionHandler&>(e).what();
-    if ( !extra_info.empty() ) { ss << "Additional info: " << extra_info << std::endl; }
+    if ( extra_info != "" ) { ss << "Additional info: " << extra_info << std::endl; }
     //throw cms::Exception(mlConfigDb_) << ss.str() << std::endl;
   }
 
@@ -780,7 +780,7 @@ void SiStripConfigDb::handleException( const std::string& method_name,
     ss << " Caught ICUtils::ICException in method "
        << method_name << " with message: " << std::endl 
        << e.what();
-    if ( !extra_info.empty() ) { ss << "Additional info: " << extra_info << std::endl; }
+    if ( extra_info != "" ) { ss << "Additional info: " << extra_info << std::endl; }
     //throw cms::Exception(mlConfigDb_) << ss.str() << std::endl;
   }
 
@@ -788,14 +788,14 @@ void SiStripConfigDb::handleException( const std::string& method_name,
     ss << " Caught std::exception in method "
        << method_name << " with message: " << std::endl 
        << e.what();
-    if ( !extra_info.empty() ) { ss << "Additional info: " << extra_info << std::endl; }
+    if ( extra_info != "" ) { ss << "Additional info: " << extra_info << std::endl; }
     //throw cms::Exception(mlConfigDb_) << ss.str() << std::endl;
   }
 
   catch (...) {
     ss << " Caught unknown exception in method "
        << method_name << " (No message) " << std::endl;
-    if ( !extra_info.empty() ) { ss << "Additional info: " << extra_info << std::endl; }
+    if ( extra_info != "" ) { ss << "Additional info: " << extra_info << std::endl; }
     //throw cms::Exception(mlConfigDb_) << ss.str() << std::endl;
   }
   
@@ -908,7 +908,7 @@ void SiStripConfigDb::runs( const SiStripConfigDb::Runs& in,
   Runs::const_iterator jj = in.end();
   for ( ; ii != jj; ++ii ) {
     // Check partition name
-    if ( ii->partition_ == optional_partition || optional_partition.empty() ) { 
+    if ( ii->partition_ == optional_partition || optional_partition == "" ) { 
       // Check run type
       if ( ii->type_ != sistrip::UNKNOWN_RUN_TYPE &&
 	   ii->type_ != sistrip::UNDEFINED_RUN_TYPE ) { 
@@ -964,7 +964,7 @@ void SiStripConfigDb::runs( const SiStripConfigDb::Runs& in,
   Runs::const_iterator jj = in.end();
   for ( ; ii != jj; ++ii ) {
     // Check partition name
-    if ( !ii->partition_.empty() ) {
+    if ( ii->partition_ != "" ) {
       // Check run type
       if ( ii->type_ == optional_type || optional_type == sistrip::UNDEFINED_RUN_TYPE ) { 
 	// Check run number


### PR DESCRIPTION
Removes custom oracle calls introduces in this commit 
https://github.com/cms-sw/cmssw/pull/22384/commits/03499f00f522994e3bb857938dc0435d7fbea077
and keeps the changes introduced in later commits.

Revert https://github.com/cms-sw/cmssw/pull/22384 commit 03499f00f52