### PR TITLE
Fix the signature of SiStripTrivialClusterSource::beginRun()

### DIFF
--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.cc
@@ -18,7 +18,7 @@ SiStripTrivialClusterSource::SiStripTrivialClusterSource(const edm::ParameterSet
 
 SiStripTrivialClusterSource::~SiStripTrivialClusterSource() {}
 
-void SiStripTrivialClusterSource::beginRun( edm::Run&, const edm::EventSetup& setup ) {  
+void SiStripTrivialClusterSource::beginRun(const edm::Run&, const edm::EventSetup& setup ) {
 
   setup.get<SiStripDetCablingRcd>().get(cabling_);
   cabling_->addAllDetectorsRawIds(detids_);
@@ -26,8 +26,6 @@ void SiStripTrivialClusterSource::beginRun( edm::Run&, const edm::EventSetup& se
     nstrips_+=cabling_->getConnections(detids_[i]).size()*256;
   }
 }
-
-void SiStripTrivialClusterSource::endJob() {}
 
 void SiStripTrivialClusterSource::produce(edm::Event& iEvent,const edm::EventSetup& iSetup) {
   

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.h
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.h
@@ -27,11 +27,10 @@ class SiStripTrivialClusterSource : public edm::EDProducer {
  public:
   
   SiStripTrivialClusterSource(const edm::ParameterSet&);
-  ~SiStripTrivialClusterSource();
+  ~SiStripTrivialClusterSource() override;
   
-  virtual void beginRun( edm::Run&, const edm::EventSetup& );
-  virtual void endJob();
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
  private: 
 


### PR DESCRIPTION
This means that earlier the `beginRun()` was not called by the framework, and as a knock-on effect the `produce()` didn't do much useful work.

Tested in CMSSW_10_5_X_2019-01-13-0000.