### PR TITLE
Remove unnecessary explicit template instantiations from DQM/SiStripCommissioningSummary

### DIFF
--- a/DQM/SiStripCommissioningSummary/src/CommissioningSummaryFactory.cc
+++ b/DQM/SiStripCommissioningSummary/src/CommissioningSummaryFactory.cc
@@ -38,7 +38,3 @@ void SummaryPlotFactory<CommissioningAnalysis*>::fill( TH1& summary_histo ) {
   format();
   
 } 
-
-// -----------------------------------------------------------------------------
-//
-template class SummaryPlotFactory<CommissioningAnalysis*>;

--- a/DQM/SiStripCommissioningSummary/src/FedCablingSummaryFactory.cc
+++ b/DQM/SiStripCommissioningSummary/src/FedCablingSummaryFactory.cc
@@ -70,8 +70,3 @@ void SummaryPlotFactory<FedCablingAnalysis*>::fill( TH1& summary_histo ) {
   } 
   
 }
-
-// -----------------------------------------------------------------------------
-//
-template class SummaryPlotFactory<FedCablingAnalysis*>;
-

--- a/DQM/SiStripCommissioningSummary/src/FedTimingSummaryFactory.cc
+++ b/DQM/SiStripCommissioningSummary/src/FedTimingSummaryFactory.cc
@@ -145,8 +145,3 @@ void SummaryHistogramFactory<FedTimingAnalysis>::fill( TH1& summary_histo ) {
   generator_->format( sistrip::FED_TIMING, mon_, pres_, view_, level_, gran_, summary_histo );
   
 }
-
-// -----------------------------------------------------------------------------
-//
-template class SummaryHistogramFactory<FedTimingAnalysis>;
-


### PR DESCRIPTION
Found by clang.

Tested in CMSSW_10_5_X_2019-01-13-0000, no changes expected.