### PR TITLE
Drop L1 from FastSim premixing stage1

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -985,7 +985,7 @@ steps["FS_PREMIXUP15_PU25"] = merge([
         {"cfg":"SingleNuE10_cfi",
          "--fast":"",
          "--conditions":"auto:run2_mc",
-         "-s":"GEN,SIM,RECOBEFMIX,DIGI,L1,DIGI2RAW",
+         "-s":"GEN,SIM,RECOBEFMIX,DIGI,DIGI2RAW",
          "--eventcontent":"PREMIX",
          "--datatier":"GEN-SIM-DIGI-RAW",
          "--procModifiers":"premix_stage1",


### PR DESCRIPTION
To suppress warning messages as requested in
https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/3507/1/1.html

Partial back-port of the first commit of #24184 (limiting to L1, anything beyond would require full backport of #24184).

Tested in CMSSW_10_2_9, no changes expected.