### PR TITLE
Allow calculation of muon ID bitset from const reference to muon

### DIFF
--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -119,8 +119,8 @@ namespace muon {
    int sharedSegments( const reco::Muon& muon1, const reco::Muon& muon2, 
                        unsigned int segmentArbitrationMask = reco::MuonSegmentMatch::BestInChamberByDR ) ;
 
-   void setCutBasedSelectorFlags(reco::Muon& muon,
-				 const reco::Vertex* vertex=nullptr,
-				 bool run2016_hip_mitigation=false);
+   reco::Muon::Selector makeSelectorBitset( reco::Muon const& muon,
+                                            reco::Vertex const* vertex=nullptr,
+                                            bool run2016_hip_mitigation=false );
 }
 #endif

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -999,9 +999,9 @@ bool outOfTimeMuon(const reco::Muon& muon){
 }
 
 
-void muon::setCutBasedSelectorFlags(reco::Muon& muon, 
-				    const reco::Vertex* vertex,
-				    bool run2016_hip_mitigation)
+reco::Muon::Selector muon::makeSelectorBitset( reco::Muon const& muon, 
+                                               reco::Vertex const* vertex,
+                                               bool run2016_hip_mitigation )
 {
   // https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideMuonIdRun2
   unsigned int selectors = muon.selectors();
@@ -1048,5 +1048,5 @@ void muon::setCutBasedSelectorFlags(reco::Muon& muon,
   // Timing
   if (!outOfTimeMuon(muon))     selectors |= reco::Muon::InTimeMuon;
 
-  muon.setSelectors(selectors);
+  return static_cast<reco::Muon::Selector>(selectors);
 }

--- a/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
@@ -107,7 +107,7 @@ namespace pat {
 
   template<>
   void LeptonUpdater<pat::Muon>::recomputeMuonBasicSelectors(pat::Muon & lep, const reco::Vertex & pv, const bool do_hip_mitigation_2016) const {
-    muon::setCutBasedSelectorFlags(lep, &pv, do_hip_mitigation_2016);
+    lep.setSelectors(muon::makeSelectorBitset(lep, &pv, do_hip_mitigation_2016));
   }
 
 } // namespace

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -645,7 +645,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
     if (recomputeBasicSelectors_){
       muon.setSelectors(0);
       bool isRun2016BCDEF = (272728 <= iEvent.run() && iEvent.run() <= 278808);
-      muon::setCutBasedSelectorFlags(muon, pv, isRun2016BCDEF);
+      muon.setSelectors(muon::makeSelectorBitset(muon, pv, isRun2016BCDEF));
     }
     double miniIsoValue = -1;
     if (computeMiniIso_){

--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
@@ -444,7 +444,7 @@ void MuonProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
      if (computeStandardSelectors_){
        outMuon.setSelectors(0); // reset flags
        bool isRun2016BCDEF = (272728 <= event.run() && event.run() <= 278808);
-       muon::setCutBasedSelectorFlags(outMuon, vertex, isRun2016BCDEF);
+       outMuon.setSelectors(muon::makeSelectorBitset(outMuon, vertex, isRun2016BCDEF));
      }
 
      outputMuons->push_back(outMuon); 


### PR DESCRIPTION
The POG recommendation for muon IDs is to use this muon ID bitset [1] for 94X and up. In my analysis framework, I would like to recompute this bitset to get all the IDs in the same way, even when the sample was older or does not have all the IDs set yet. In the current CMSSW code, you can't compute the ID bitset without setting the bitset of the muon. That's inconvenient if all you (want to) have are `const` references to the muons, so I made this little commit in my analysis branch.

Maybe this change can also be done in master so other analyzers might profit as well? Thanks!

[1] https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonIdRun2#Muon_selectors_Since_9_4_X