### PR TITLE
Pixel Stuck TBM simulation: check conditions in digitizer initialization

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -132,6 +132,41 @@ void SiPixelDigitizerAlgorithm::init(const edm::EventSetup& es) {
     es.get<SiPixelStatusScenarioProbabilityRcd>().get(scenarioProbabilityHandle);
     es.get<SiPixelFEDChannelContainerESProducerRcd>().get(PixelFEDChannelCollectionMapHandle);
     quality_map = PixelFEDChannelCollectionMapHandle.product();
+
+    SiPixelQualityProbabilities:: probabilityMap m_probabilities = scenarioProbabilityHandle->getProbability_Map();    
+    std::vector<std::string> allScenarios;
+
+    std::transform(quality_map->begin(),
+		   quality_map->end(),
+		   std::back_inserter(allScenarios),
+		   [](const PixelFEDChannelCollectionMap::value_type &pair){return pair.first;});
+
+    std::vector<std::string> allScenariosInProb;
+
+    for(auto it = m_probabilities.begin(); it != m_probabilities.end() ; ++it){
+      //int PUbin = it->first;
+      for (const auto &entry : it->second){
+	auto scenario = entry.first;
+	auto probability = entry.second;
+	if(probability!=0){
+	  if(std::find(allScenariosInProb.begin(), allScenariosInProb.end(), scenario) == allScenariosInProb.end()) {
+	    allScenariosInProb.push_back(scenario);
+	  }
+	} // if prob!=0
+      } // loop on the scenarios for that PU bin
+    } // loop on PU bins
+    
+    std::vector<std::string> notFound;
+    std::copy_if(allScenariosInProb.begin(), allScenariosInProb.end(), std::back_inserter(notFound),
+		 [&allScenarios](const std::string& arg)
+		 { return (std::find(allScenarios.begin(),allScenarios.end(), arg) == allScenarios.end());});
+    
+    if(notFound.size()!=0){
+      for(const auto &entry : notFound){
+	edm::LogError("SiPixelFEDChannelContainer") <<"The requested scenario: " << entry <<" is not found in the map!!"<<std::endl; 
+      }
+      throw cms::Exception("SiPixelDigitizerAlgorithm")<< "Found: " << notFound.size()<< " missing scenario(s) in SiPixelStatusScenariosRcd while present in SiPixelStatusScenarioProbabilityRcd \n";
+    } 
   }
   
   // Read template files for charge reweighting

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -161,7 +161,7 @@ void SiPixelDigitizerAlgorithm::init(const edm::EventSetup& es) {
 		 [&allScenarios](const std::string& arg)
 		 { return (std::find(allScenarios.begin(),allScenarios.end(), arg) == allScenarios.end());});
     
-    if(notFound.size()!=0){
+    if(!notFound.empty()){
       for(const auto &entry : notFound){
 	edm::LogError("SiPixelFEDChannelContainer") <<"The requested scenario: " << entry <<" is not found in the map!!"<<std::endl; 
       }

--- a/SimTracker/SiPixelDigitizer/python/customiseStuckTBMSimulation.py
+++ b/SimTracker/SiPixelDigitizer/python/customiseStuckTBMSimulation.py
@@ -16,7 +16,7 @@ def activateStuckTBMSimulation2018NoPU(process):
                                                       tag = cms.string('SiPixelQualityProbabilities_2018_noPU_v0_mc'),
                                                       connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS')),
                                              cms.PSet(record = cms.string('SiPixelStatusScenariosRcd'),
-                                                      tag = cms.string('SiPixelFEDChannelContainer_StuckTBM_2018_v0_mc'),
+                                                      tag = cms.string('SiPixelFEDChannelContainer_StuckTBM_2018_v0_fixed_mc'),
                                                       connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS')
                                                       )
                                              )


### PR DESCRIPTION
As pointed out in https://github.com/cms-sw/cmssw/pull/25524#issuecomment-455207659, the conditions used for the stuck-TBM simulation tests (wf: 10824.7,10842.7) are inconsistent as there are some non-zero probabilities (in `SiPixelStatusScenarioProbabilityRcd`) assigned to certain scenarios which are not included in the scenario DB object (`SiPixelStatusScenariosRcd`).
The new payload proposed in eb2c2ec fixes this, while commit 986a13d takes care of throwing in case of  an inconsistent sets of conditions at the pixel digitizer initialization instead that starting the job and eventually failing later randomly.
Tested in CMSSW_10_5_X_2019-01-17-1100 (architecture: `slc7_amd64_gcc700`) via:
```
dasgoclient --query 'file dataset=/RelValZMM_13/CMSSW_10_3_0_pre5-103X_upgrade2018_realistic_v7-v1/GEN-SIM' > step1_dasquery.log 
cmsDriver.py step2 --conditions auto:phase1_2018_realistic -n 100 --era Run2_2018 --eventcontent FEVTDEBUGHLT -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2018 --datatier GEN-SIM-DIGI-RAW --customise SimTracker/SiPixelDigitizer/customiseStuckTBMSimulation.activateStuckTBMSimulation2018NoPU --geometry DB:Extended --filein filelist:step1_dasquery.log --fileout file:step2.root --nThreads 4
``` 

(as in the failing tests: [link](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc820/CMSSW_10_5_X_2019-01-16-2300/pyRelValMatrixLogs/run/10842.7_ZMM_13+ZMM_13TeV_TuneCUETP8M1_2018_GenSimFullINPUT+DigiFull_killStuckTBM_2018+RecoFull_2018+HARVESTFull_2018+ALCAFull_2018+NanoFull_2018/step2_ZMM_13+ZMM_13TeV_TuneCUETP8M1_2018_GenSimFullINPUT+DigiFull_killStuckTBM_2018+RecoFull_2018+HARVESTFull_2018+ALCAFull_2018+NanoFull_2018.log#/65-65) )