### PR TITLE
changing strips from 192 to 96

### DIFF
--- a/Geometry/RPCGeometryBuilder/data/2023/v1/RPCSpecs.xml
+++ b/Geometry/RPCGeometryBuilder/data/2023/v1/RPCSpecs.xml
@@ -132,11 +132,11 @@
       <!-- B1,2,3 -->
       <Parameter name="nStrips" value="32"/>
     </SpecPar>
-    <SpecPar name="nStrips192" eval="true">
+    <SpecPar name="nStrips96" eval="true">
       <!-- D1,2,3,4; G1,2; H1,2 -->
       <PartSelector path="//REG."/>
       <PartSelector path="//REH."/>
-      <Parameter name="nStrips" value="192"/>
+      <Parameter name="nStrips" value="96"/>
     </SpecPar>
   </SpecParSection>
 </DDDefinition>

--- a/Geometry/RPCGeometryBuilder/data/PhaseII/RPCSpecs.xml
+++ b/Geometry/RPCGeometryBuilder/data/PhaseII/RPCSpecs.xml
@@ -132,11 +132,11 @@
       <!-- B1,2,3 -->
       <Parameter name="nStrips" value="32"/>
     </SpecPar>
-    <SpecPar name="nStrips192" eval="true">
+    <SpecPar name="nStrips96" eval="true">
       <!-- D1,2,3,4; G1,2; H1,2 -->
       <PartSelector path="//REG."/>
       <PartSelector path="//REH."/>
-      <Parameter name="nStrips" value="192"/>
+      <Parameter name="nStrips" value="96"/>
     </SpecPar>
   </SpecParSection>
 </DDDefinition>


### PR DESCRIPTION
Changing the number of iRPC strips from 192 to 96. The number 192 has been used for studies, while 96 is the number included in the TDR  (page 165 , table 5.2) :  https://cds.cern.ch/record/2283189/files/CMS-TDR-016.pdf
