### PR TITLE
Remove std::move from FastSim TrackingLayer to allow better compiler optimization

### DIFF
--- a/FastSimulation/Tracking/src/TrackingLayer.cc
+++ b/FastSimulation/Tracking/src/TrackingLayer.cc
@@ -279,13 +279,13 @@ std::string TrackingLayer::toString() const
             break;
     }
     
-    return std::move(ss.str());
+    return ss.str();
 }
 
 std::string TrackingLayer::toIdString() const
 {
     std::stringstream ss;
     ss<<getSubDetNumber()<<":"<<getLayerNumber()<<":"<<getSideNumber();
-    return std::move(ss.str());
+    return ss.str();
 }
 


### PR DESCRIPTION
Moving a temporary object was preventing the compiler from doing copy
elision. This was found by clang.

Tested in CMSSW_10_5_X_2019-01-13-0000, no changes expected.