### PR TITLE
Gentle EgammaElectronAlgo cleanups

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
@@ -1,50 +1,21 @@
-
 #ifndef EgAmbiguityTools_H
 #define EgAmbiguityTools_H
-
-class MultiTrajectoryStateTransform ;
-class MultiTrajectoryStateMode ;
-
-#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h"
-#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaRecHitIsolation.h"
-#include "RecoEgamma/EgammaIsolationAlgos/interface/ElectronTkIsolation.h"
-
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-
-#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/CaloTopology/interface/CaloTopology.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
-#include "DataFormats/TrackReco/interface/HitPattern.h"
-#include "DataFormats/Common/interface/ValueMap.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-
-#include <list>
 
 namespace EgAmbiguityTools
- {
+{
   // for clusters
-  float sharedEnergy
-   ( const reco::CaloCluster *, const reco::CaloCluster *,
-	   edm::Handle<EcalRecHitCollection> & barrelRecHits,
-	   edm::Handle<EcalRecHitCollection> & endcapRecHits ) ;
-  float sharedEnergy
-   ( const reco::SuperClusterRef &, const reco::SuperClusterRef &,
-	   edm::Handle<EcalRecHitCollection> & barrelRecHits,
-	   edm::Handle<EcalRecHitCollection> & endcapRecHits ) ;
+  float sharedEnergy( reco::CaloCluster const& clu1, reco::CaloCluster const& clu2,
+                      EcalRecHitCollection const& barrelRecHits,
+                      EcalRecHitCollection const& endcapRecHits ) ;
+  float sharedEnergy( reco::SuperClusterRef const& sc1, reco::SuperClusterRef const& sc2,
+                      EcalRecHitCollection const& barrelRecHits,
+                      EcalRecHitCollection const& endcapRecHits ) ;
 
   // for tracks
   int sharedHits( const reco::GsfTrackRef &, const reco::GsfTrackRef & ) ;
@@ -52,15 +23,8 @@ namespace EgAmbiguityTools
 
   // electrons comparison
   bool isBetter( const reco::GsfElectron *, const reco::GsfElectron * ) ;
-  struct isInnerMost
-   {
-  	edm::ESHandle<TrackerGeometry> trackerHandle_ ;
-	isInnerMost( edm::ESHandle<TrackerGeometry> & geom ) : trackerHandle_(geom) {}
-	bool operator()( const reco::GsfElectron *, const reco::GsfElectron * ) ;
-   } ;
+  bool isInnerMost( const reco::GsfElectron *, const reco::GsfElectron * ) ;
 
- }
+}
 
 #endif
-
-

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h
@@ -9,25 +9,6 @@
 
 
 //===============================================================
-// For an stl collection of pointers, enforce the deletion
-// of pointed objects in case of exception.
-//===============================================================
-
-template <typename StlColType>
-class ExceptionSafeStlPtrCol : public StlColType
- {
-  public :
-    ExceptionSafeStlPtrCol() : StlColType() {}
-    ~ExceptionSafeStlPtrCol()
-     {
-      typename StlColType::const_iterator it ;
-      for ( it = StlColType::begin() ; it != StlColType::end() ; it++ )
-       { delete (*it) ; }
-     }
- } ;
-
-
-//===============================================================
 // Normalization of angles
 //===============================================================
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -198,8 +198,6 @@ class GsfElectronAlgo {
       const EcalRecHitsConfiguration &,
       EcalClusterFunctionBaseClass * superClusterErrorFunction,
       EcalClusterFunctionBaseClass * crackCorrectionFunction,
-      const SoftElectronMVAEstimator::Configuration & mva_NIso_Cfg,
-      const ElectronMVAEstimator::Configuration & mva_Iso_Cfg,	
       const RegressionHelper::Configuration & regCfg,
       const edm::ParameterSet& tkIsol03Cfg,
       const edm::ParameterSet& tkIsol04Cfg

--- a/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
@@ -1,13 +1,10 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h"
-//#include "RecoEgamma/EgammaElectronAlgos/interface/ElectronHcalHelper.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "TrackingTools/GsfTools/interface/MultiTrajectoryStateTransform.h"
 
-#include <sstream>
 #include <algorithm>
 
 using namespace edm ;
@@ -20,29 +17,21 @@ namespace EgAmbiguityTools
 bool isBetter( const reco::GsfElectron * e1, const reco::GsfElectron * e2 )
  { return (std::abs(e1->eSuperClusterOverP()-1) < std::abs(e2->eSuperClusterOverP() - 1)) ; }
 
-bool isInnerMost::operator()(const reco::GsfElectron *e1, const reco::GsfElectron *e2)
+bool isInnerMost(const reco::GsfElectron *e1, const reco::GsfElectron *e2)
 {
     // retreive first valid hit
     int gsfHitCounter1 = 0 ;
-    trackingRecHit_iterator elHitsIt1 ;
-    for(elHitsIt1 = e1->gsfTrack()->recHitsBegin();
-            elHitsIt1 != e1->gsfTrack()->recHitsEnd();
-            elHitsIt1++, gsfHitCounter1++)
-    { 
-        if ((**elHitsIt1).isValid()){
-            break;
-        }
+    for(auto const& elHit : e1->gsfTrack()->recHits())
+    {
+        if (elHit->isValid()) break;
+        gsfHitCounter1++;
     }
 
     int gsfHitCounter2 = 0 ;
-    trackingRecHit_iterator elHitsIt2 ;
-    for(elHitsIt2 = e2->gsfTrack()->recHitsBegin();
-            elHitsIt2 != e2->gsfTrack()->recHitsEnd();
-            elHitsIt2++, gsfHitCounter2++ )
+    for(auto const& elHit : e2->gsfTrack()->recHits())
     {
-        if ((**elHitsIt2).isValid()){
-            break;
-        }
+        if (elHit->isValid()) break;
+        gsfHitCounter2++;
     }
 
     uint32_t gsfHit1 = e1->gsfTrack()->hitPattern().getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter1);
@@ -60,15 +49,15 @@ bool isInnerMost::operator()(const reco::GsfElectron *e1, const reco::GsfElectro
 int sharedHits(const GsfTrackRef & gsfTrackRef1, const GsfTrackRef & gsfTrackRef2 )
 {
   //get the Hit Pattern for the gsfTracks
-  const HitPattern &gsfHitPattern1 = gsfTrackRef1->hitPattern();
-  const HitPattern &gsfHitPattern2 = gsfTrackRef2->hitPattern();
+  HitPattern const& gsfHitPattern1 = gsfTrackRef1->hitPattern();
+  HitPattern const& gsfHitPattern2 = gsfTrackRef2->hitPattern();
 
   unsigned int shared = 0;
 
   int gsfHitCounter1 = 0;
   for(trackingRecHit_iterator elHitsIt1 = gsfTrackRef1->recHitsBegin();
           elHitsIt1 != gsfTrackRef1->recHitsEnd(); elHitsIt1++, gsfHitCounter1++) {
-      if(!(**elHitsIt1).isValid()){
+      if(!(*elHitsIt1)->isValid()){
           //count only valid Hits
           continue;
       }
@@ -97,7 +86,7 @@ int sharedHits(const GsfTrackRef & gsfTrackRef1, const GsfTrackRef & gsfTrackRef
                       || HitPattern::stripTIDHitFilter(gsfHit2))){
               continue;
           }
-          if((**elHitsIt1).sharesInput(&(**gsfHitsIt2), TrackingRecHit::some)) {
+          if((*elHitsIt1)->sharesInput(&(**gsfHitsIt2), TrackingRecHit::some)) {
               //if (comp.equals(&(**elHitsIt1),&(**gsfHitsIt2))) {
               ////std::cout << "found shared hit " << gsfHit2 << std::endl;
               shared++;
@@ -109,7 +98,7 @@ int sharedHits(const GsfTrackRef & gsfTrackRef1, const GsfTrackRef & gsfTrackRef
   return shared;
 }
 
-int sharedDets(const GsfTrackRef& gsfTrackRef1, const GsfTrackRef& gsfTrackRef2 ) 
+int sharedDets(const GsfTrackRef& gsfTrackRef1, const GsfTrackRef& gsfTrackRef2 )
 {
     //get the Hit Pattern for the gsfTracks
     const HitPattern &gsfHitPattern1 = gsfTrackRef1->hitPattern();
@@ -134,7 +123,7 @@ int sharedDets(const GsfTrackRef& gsfTrackRef1, const GsfTrackRef& gsfTrackRef2 
         {
             continue;
         }
-        
+
         int gsfHitsCounter2 = 0;
         for(trackingRecHit_iterator gsfHitsIt2 = gsfTrackRef2->recHitsBegin();
                 gsfHitsIt2 != gsfTrackRef2->recHitsEnd(); gsfHitsIt2++, gsfHitsCounter2++) {
@@ -160,31 +149,27 @@ int sharedDets(const GsfTrackRef& gsfTrackRef1, const GsfTrackRef& gsfTrackRef2 
 
 }
 
-float sharedEnergy(const CaloCluster *clu1, const CaloCluster *clu2,
-       edm::Handle<EcalRecHitCollection> & barrelRecHits,
-       edm::Handle<EcalRecHitCollection> & endcapRecHits ) {
+float sharedEnergy( CaloCluster const& clu1, CaloCluster const& clu2,
+                    EcalRecHitCollection const& barrelRecHits,
+                    EcalRecHitCollection const& endcapRecHits )
+{
 
   double fractionShared = 0;
 
-  std::vector< std::pair<DetId, float> > v_id1 = clu1->hitsAndFractions();
-  std::vector< std::pair<DetId, float> > v_id2 = clu2->hitsAndFractions();
-  std::vector< std::pair<DetId, float> >::iterator ih1;
-  std::vector< std::pair<DetId, float> >::iterator ih2;
+  for(auto const& h1 : clu1.hitsAndFractions()) {
 
-  for(ih1 = v_id1.begin();ih1 != v_id1.end(); ih1++) {
+    for(auto const& h2 : clu2.hitsAndFractions()) {
 
-    for(ih2 = v_id2.begin();ih2 != v_id2.end(); ih2++) {
-
-      if ( (*ih1).first != (*ih2).first ) continue;
+      if ( h1.first != h2.first ) continue;
 
       // here we have common Xtal id
       EcalRecHitCollection::const_iterator itt;
-      if ((*ih1).first.subdetId() == EcalBarrel) {
-	if ((itt=barrelRecHits->find((*ih1).first))!=barrelRecHits->end())
-	fractionShared += itt->energy();
-      } else if ((*ih1).first.subdetId() == EcalEndcap) {
-	if ((itt=endcapRecHits->find((*ih1).first))!=endcapRecHits->end())
-	fractionShared += itt->energy();
+      if (h1.first.subdetId() == EcalBarrel) {
+        if ((itt=barrelRecHits.find(h1.first))!=barrelRecHits.end())
+        fractionShared += itt->energy();
+      } else if (h1.first.subdetId() == EcalEndcap) {
+        if ((itt=endcapRecHits.find(h1.first))!=endcapRecHits.end())
+        fractionShared += itt->energy();
       }
 
     }
@@ -195,14 +180,14 @@ float sharedEnergy(const CaloCluster *clu1, const CaloCluster *clu2,
 
 }
 
-float sharedEnergy(const SuperClusterRef& sc1, const SuperClusterRef& sc2,
-       edm::Handle<EcalRecHitCollection> & barrelRecHits,
-       edm::Handle<EcalRecHitCollection> & endcapRecHits ) {
-
+float sharedEnergy( SuperClusterRef const& sc1, SuperClusterRef const& sc2,
+                    EcalRecHitCollection const& barrelRecHits,
+                    EcalRecHitCollection const& endcapRecHits )
+{
   double energyShared = 0;
   for(CaloCluster_iterator icl1=sc1->clustersBegin();icl1!=sc1->clustersEnd(); icl1++) {
     for(CaloCluster_iterator icl2=sc2->clustersBegin();icl2!=sc2->clustersEnd(); icl2++) {
-      energyShared += sharedEnergy(&(**icl1),&(**icl2),barrelRecHits,endcapRecHits );
+      energyShared += sharedEnergy(**icl1,**icl2,barrelRecHits,endcapRecHits );
     }
   }
   return energyShared;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1,4 +1,3 @@
-
 #include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronClassification.h"
@@ -74,8 +73,6 @@ struct GsfElectronAlgo::GeneralData
      const EcalRecHitsConfiguration &,
      EcalClusterFunctionBaseClass * superClusterErrorFunction,
      EcalClusterFunctionBaseClass * crackCorrectionFunction,
-     const SoftElectronMVAEstimator::Configuration & mva_NIso_Cfg ,
-     const ElectronMVAEstimator::Configuration & mva_Iso_Cfg ,
      const RegressionHelper::Configuration &) ;
   ~GeneralData() ;
 
@@ -91,8 +88,6 @@ struct GsfElectronAlgo::GeneralData
   ElectronHcalHelper * hcalHelper, * hcalHelperPflow ;
   EcalClusterFunctionBaseClass * superClusterErrorFunction ;
   EcalClusterFunctionBaseClass * crackCorrectionFunction ;
-  //SoftElectronMVAEstimator *sElectronMVAEstimator;
-  //ElectronMVAEstimator *iElectronMVAEstimator;
   const RegressionHelper::Configuration regCfg;
   RegressionHelper * regHelper;
  } ;
@@ -108,8 +103,6 @@ struct GsfElectronAlgo::GeneralData
    const EcalRecHitsConfiguration & recHitsConfig,
    EcalClusterFunctionBaseClass * superClusterErrorFunc,
    EcalClusterFunctionBaseClass * crackCorrectionFunc,
-   const SoftElectronMVAEstimator::Configuration & /*mva_NIso_Config*/,
-   const ElectronMVAEstimator::Configuration & /*mva_Iso_Config*/,
    const RegressionHelper::Configuration & regConfig
    )
  : inputCfg(inputConfig),
@@ -122,8 +115,6 @@ struct GsfElectronAlgo::GeneralData
    hcalHelperPflow(new ElectronHcalHelper(hcalConfigPflow)),
    superClusterErrorFunction(superClusterErrorFunc),
    crackCorrectionFunction(crackCorrectionFunc),
-   //sElectronMVAEstimator(new SoftElectronMVAEstimator(mva_NIso_Config)),
-   //iElectronMVAEstimator(new ElectronMVAEstimator(mva_Iso_Config)),
    regCfg(regConfig),
    regHelper(new RegressionHelper(regConfig))
   {}
@@ -132,8 +123,6 @@ GsfElectronAlgo::GeneralData::~GeneralData()
  {
   delete hcalHelper ;
   delete hcalHelperPflow ;
-  //delete sElectronMVAEstimator;
-  //delete iElectronMVAEstimator;
   delete regHelper;
  }
 
@@ -150,14 +139,12 @@ struct GsfElectronAlgo::EventSetupData
    unsigned long long cacheIDTopo ;
    unsigned long long cacheIDTDGeom ;
    unsigned long long cacheIDMagField ;
-   //unsigned long long cacheChStatus ;
    unsigned long long cacheSevLevel ;
 
    edm::ESHandle<MagneticField> magField ;
    edm::ESHandle<CaloGeometry> caloGeom ;
    edm::ESHandle<CaloTopology> caloTopo ;
    edm::ESHandle<TrackerGeometry> trackerHandle ;
-   //edm::ESHandle<EcalChannelStatus> chStatus ;
    edm::ESHandle<EcalSeverityLevelAlgo> sevLevel;
 
    const MultiTrajectoryStateTransform * mtsTransform ;
@@ -166,7 +153,7 @@ struct GsfElectronAlgo::EventSetupData
 } ;
 
 GsfElectronAlgo::EventSetupData::EventSetupData()
- : cacheIDGeom(0), cacheIDTopo(0), cacheIDTDGeom(0), cacheIDMagField(0),/*cacheChStatus(0),*/
+ : cacheIDGeom(0), cacheIDTopo(0), cacheIDTDGeom(0), cacheIDMagField(0),
    cacheSevLevel(0), mtsTransform(nullptr), constraintAtVtx(nullptr), mtsMode(new MultiTrajectoryStateMode)
  {}
 
@@ -745,14 +732,12 @@ GsfElectronAlgo::GsfElectronAlgo
    const EcalRecHitsConfiguration & recHitsCfg,
    EcalClusterFunctionBaseClass * superClusterErrorFunction,
    EcalClusterFunctionBaseClass * crackCorrectionFunction,
-   const SoftElectronMVAEstimator::Configuration & mva_NIso_Cfg,
-   const ElectronMVAEstimator::Configuration & mva_Iso_Cfg,
    const RegressionHelper::Configuration & regCfg,
    const edm::ParameterSet& tkIsol03Cfg,
    const edm::ParameterSet& tkIsol04Cfg
    
  )
-   : generalData_(new GeneralData(inputCfg,strategyCfg,cutsCfg,cutsCfgPflow,hcalCfg,hcalCfgPflow,isoCfg,recHitsCfg,superClusterErrorFunction,crackCorrectionFunction,mva_NIso_Cfg,mva_Iso_Cfg,regCfg)),
+   : generalData_(new GeneralData(inputCfg,strategyCfg,cutsCfg,cutsCfgPflow,hcalCfg,hcalCfgPflow,isoCfg,recHitsCfg,superClusterErrorFunction,crackCorrectionFunction,regCfg)),
    eventSetupData_(new EventSetupData),
    eventData_(nullptr), electronData_(nullptr),
    tkIsol03Calc_(tkIsol03Cfg),tkIsol04Calc_(tkIsol04Cfg)
@@ -1607,7 +1592,7 @@ void GsfElectronAlgo::setAmbiguityData( bool ignoreNotPreselected )
   if (generalData_->strategyCfg.ambSortingStrategy==0)
    { eventData_->electrons->sort(EgAmbiguityTools::isBetter) ; }
   else if (generalData_->strategyCfg.ambSortingStrategy==1)
-   { eventData_->electrons->sort(EgAmbiguityTools::isInnerMost(eventSetupData_->trackerHandle)) ; }
+   { eventData_->electrons->sort(EgAmbiguityTools::isInnerMost) ; }
   else
    { throw cms::Exception("GsfElectronAlgo|UnknownAmbiguitySortingStrategy")<<"value of generalData_->strategyCfg.ambSortingStrategy is : "<<generalData_->strategyCfg.ambSortingStrategy ; }
 
@@ -1692,10 +1677,10 @@ void GsfElectronAlgo::setAmbiguityData( bool ignoreNotPreselected )
           float eMin = 1. ;
           float threshold = eMin*cosh(EleRelPoint(scRef1->position(),eventData_->beamspot->position()).eta()) ;
           sameCluster =
-           ( (EgAmbiguityTools::sharedEnergy(&(*eleClu1),&(*eleClu2),eventData_->barrelRecHits,eventData_->endcapRecHits)>=threshold) ||
-             (EgAmbiguityTools::sharedEnergy(&(*scRef1->seed()),&(*eleClu2),eventData_->barrelRecHits,eventData_->endcapRecHits)>=threshold) ||
-             (EgAmbiguityTools::sharedEnergy(&(*eleClu1),&(*scRef2->seed()),eventData_->barrelRecHits,eventData_->endcapRecHits)>=threshold) ||
-             (EgAmbiguityTools::sharedEnergy(&(*scRef1->seed()),&(*scRef2->seed()),eventData_->barrelRecHits,eventData_->endcapRecHits)>=threshold) ) ;
+           ( (EgAmbiguityTools::sharedEnergy(*eleClu1,*eleClu2,*eventData_->barrelRecHits,*eventData_->endcapRecHits)>=threshold) ||
+             (EgAmbiguityTools::sharedEnergy(*scRef1->seed(),*eleClu2,*eventData_->barrelRecHits,*eventData_->endcapRecHits)>=threshold) ||
+             (EgAmbiguityTools::sharedEnergy(*eleClu1,*scRef2->seed(),*eventData_->barrelRecHits,*eventData_->endcapRecHits)>=threshold) ||
+             (EgAmbiguityTools::sharedEnergy(*scRef1->seed(),*scRef2->seed(),*eventData_->barrelRecHits,*eventData_->endcapRecHits)>=threshold) ) ;
          }
         else
          { throw cms::Exception("GsfElectronAlgo|UnknownAmbiguityClustersOverlapStrategy")<<"value of generalData_->strategyCfg.ambClustersOverlapStrategy is : "<<generalData_->strategyCfg.ambClustersOverlapStrategy ; }

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -315,9 +315,6 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg, 
   EcalClusterFunctionBaseClass * const crackCorrectionFunction =
       EcalClusterFunctionFactory::get()->create(cfg.getParameter<std::string>("crackCorrectionFunction"),cfg) ;
 
-  mva_NIso_Cfg_.vweightsfiles = cfg.getParameter<std::vector<std::string>>("SoftElecMVAFilesString");
-  mva_Iso_Cfg_.vweightsfiles  = cfg.getParameter<std::vector<std::string>>("ElecMVAFilesString");
-
   // create algo
   algo_ = new GsfElectronAlgo
    ( inputCfg_, strategyCfg_,
@@ -326,8 +323,6 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg, 
      isoCfg,recHitsCfg,
      superClusterErrorFunction,
      crackCorrectionFunction,
-     mva_NIso_Cfg_,
-     mva_Iso_Cfg_,
      regressionCfg,
      cfg.getParameter<edm::ParameterSet>("trkIsol03Cfg"),
      cfg.getParameter<edm::ParameterSet>("trkIsol04Cfg")

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -59,8 +59,6 @@ class GsfElectronBaseProducer : public edm::stream::EDProducer< edm::GlobalCache
     const GsfElectronAlgo::CutsConfiguration cutsCfgPflow_ ;
     ElectronHcalHelper::Configuration hcalCfg_ ;
     ElectronHcalHelper::Configuration hcalCfgPflow_ ;
-    SoftElectronMVAEstimator::Configuration mva_NIso_Cfg_ ;
-    ElectronMVAEstimator::Configuration mva_Iso_Cfg_ ;
   private :
 
     // check expected configuration of previous modules


### PR DESCRIPTION
* Removed unused `ExceptionSafeStlPtrCol`
* Cleaned up includes in `EgAmbiguityTools.h`
* Slightly different interfaces in ambiguity tools with more `const` references and less Handles
* `isInnerMost` is now a free function (it didn't need the tracker geometry as a member anyway)
* Use new `TrackingRecHitRange` in ambiguity tools
* Removed remnants of MVA in GsfElectronAlgo outside heavy object cache

* Changes interfere with no other PR
* Local matrix tests pass