### PR TITLE
Provide easier to use ::get and ::getHandle methods for Event, Run and LuminosityBlock

### DIFF
--- a/DataFormats/Common/interface/BasicHandle.h
+++ b/DataFormats/Common/interface/BasicHandle.h
@@ -42,60 +42,52 @@ namespace edm {
 
   class BasicHandle {
   public:
-    BasicHandle() :
-      product_(),
-      prov_(nullptr) {}
+    BasicHandle() = delete;
 
-    BasicHandle(BasicHandle const& h) :
-      product_(h.product_),
-      prov_(h.prov_),
-      whyFailedFactory_(h.whyFailedFactory_){}
+    BasicHandle(BasicHandle const& h) = default;
 
     BasicHandle(BasicHandle &&h) = default;
-    
-    BasicHandle(WrapperBase const* iProd, Provenance const* iProv) :
+
+    BasicHandle(WrapperBase const* iProd, Provenance const* iProv) noexcept(true):
       product_(iProd),
       prov_(iProv) {
     }
 
     ///Used when the attempt to get the data failed
-    BasicHandle(std::shared_ptr<HandleExceptionFactory> const& iWhyFailed):
+    BasicHandle(std::shared_ptr<HandleExceptionFactory> const& iWhyFailed) noexcept(true) : 
     product_(),
     prov_(nullptr),
     whyFailedFactory_(iWhyFailed) {}
 
-    ~BasicHandle() {}
+    ~BasicHandle() = default;
 
-    void swap(BasicHandle& other) {
+    void swap(BasicHandle& other) noexcept(true){
       using std::swap;
       swap(product_, other.product_);
       std::swap(prov_, other.prov_);
       swap(whyFailedFactory_,other.whyFailedFactory_);
     }
 
-    BasicHandle& operator=(BasicHandle const& rhs) {
-      BasicHandle temp(rhs);
-      this->swap(temp);
-      return *this;
-    }
+    BasicHandle& operator=(BasicHandle&& rhs) = default;
+    BasicHandle& operator=(BasicHandle const& rhs) = default;
 
-    bool isValid() const {
+    bool isValid() const noexcept(true) {
       return product_ && prov_;
     }
 
-    bool failedToGet() const {
+    bool failedToGet() const noexcept(true) {
       return bool(whyFailedFactory_);
     }
 
-    WrapperBase const* wrapper() const {
+    WrapperBase const* wrapper() const noexcept(true) {
       return product_;
     }
 
-    Provenance const* provenance() const {
+    Provenance const* provenance() const noexcept(true) {
       return prov_;
     }
 
-    ProductID id() const {
+    ProductID id() const noexcept(true) {
       return prov_->productID();
     }
 
@@ -103,21 +95,24 @@ namespace edm {
       return whyFailedFactory_->make();
     }
     
-    std::shared_ptr<HandleExceptionFactory> const& whyFailedFactory() const {
+    std::shared_ptr<HandleExceptionFactory> const& whyFailedFactory() const noexcept(true) {
       return whyFailedFactory_;
     }
     
-    std::shared_ptr<HandleExceptionFactory>& whyFailedFactory()  {
+    std::shared_ptr<HandleExceptionFactory>& whyFailedFactory()  noexcept(true) {
       return whyFailedFactory_;
     }
 
-    void clear() {
+    void clear() noexcept(true) {
       product_ = nullptr;
       prov_ = nullptr;
       whyFailedFactory_.reset();
     }
 
+    static BasicHandle makeInvalid() { return BasicHandle(true);}
   private:
+    //This is used to create a special invalid BasicHandle
+    explicit BasicHandle(bool):product_(nullptr) {}
     WrapperBase const* product_;
     Provenance const* prov_;
     std::shared_ptr<HandleExceptionFactory> whyFailedFactory_;
@@ -126,7 +121,7 @@ namespace edm {
   // Free swap function
   inline
   void
-  swap(BasicHandle& a, BasicHandle& b) {
+  swap(BasicHandle& a, BasicHandle& b) noexcept(true) {
     a.swap(b);
   }
 }

--- a/DataFormats/Common/interface/HandleBase.h
+++ b/DataFormats/Common/interface/HandleBase.h
@@ -113,6 +113,14 @@ namespace edm {
     std::shared_ptr<HandleExceptionFactory> const&
     whyFailedFactory() const { return whyFailedFactory_;}
 
+    explicit operator bool () const {
+      return isValid();
+    }
+    
+    bool operator!() const {
+      return not isValid();
+    }
+
   protected:
 
     void const* productStorage() const;

--- a/DataFormats/Common/src/ConvertHandle.cc
+++ b/DataFormats/Common/src/ConvertHandle.cc
@@ -1,13 +1,19 @@
 #include "DataFormats/Common/interface/ConvertHandle.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "DataFormats/Common/interface/FunctorHandleExceptionFactory.h"
 
 namespace edm {
   namespace handleimpl {
-    void throwInvalidReference() {
-      throw Exception(errors::InvalidReference, "NullPointer")
-        << "edm::BasicHandle has null pointer to Wrapper";
-    }
+    static std::shared_ptr<HandleExceptionFactory> s_invalidRefFactory = makeHandleExceptionFactory([]()->std::shared_ptr<cms::Exception> {
+      std::shared_ptr<cms::Exception> whyFailed = std::make_shared<edm::Exception>(errors::InvalidReference, "NullPointer");
+      *whyFailed << "Handle has null pointer to data product";
+      return whyFailed;
+    });
 
+    std::shared_ptr<HandleExceptionFactory> makeInvalidReferenceException() {
+      return s_invalidRefFactory;
+    }
+    
     void throwConvertTypeError(std::type_info const& expected, std::type_info const& actual) {
       throw Exception(errors::LogicError, "TypeMismatch")
         << "edm::BasicHandle contains a product of type " << actual.name() << ".\n"

--- a/FWCore/Common/interface/EventBase.h
+++ b/FWCore/Common/interface/EventBase.h
@@ -94,7 +94,7 @@ namespace edm {
    EventBase::getByLabel(InputTag const& tag, Handle<T>& result) const {
       result.clear();
       BasicHandle bh = this->getByLabelImpl(typeid(edm::Wrapper<T>), typeid(T), tag);
-     convert_handle(std::move(bh), result);  // throws on conversion error
+     result = convert_handle<T>(std::move(bh));
       if (result.failedToGet()) {
          return false;
       }
@@ -106,7 +106,7 @@ namespace edm {
    EventBase::get(ProductID const& pid, Handle<T>& result) const {
       result.clear();
       BasicHandle bh = this->getImpl(typeid(T), pid);
-      convert_handle(std::move(bh), result);  // throws on conversion error
+      result = convert_handle_check_type<T>(std::move(bh));
       if (result.failedToGet()) {
          return false;
       }

--- a/FWCore/Common/interface/LuminosityBlockBase.h
+++ b/FWCore/Common/interface/LuminosityBlockBase.h
@@ -73,7 +73,7 @@ namespace edm {
    LuminosityBlockBase::getByLabel(const InputTag& tag, Handle<T>& result) const {
       result.clear();
       BasicHandle bh = this->getByLabelImpl(typeid(Wrapper<T>), typeid(T), tag);
-      convert_handle(std::move(bh), result);  // throws on conversion error
+      result = convert_handle<T>(std::move(bh));
       if (result.failedToGet()) {
          return false;
       }

--- a/FWCore/Common/interface/RunBase.h
+++ b/FWCore/Common/interface/RunBase.h
@@ -60,7 +60,7 @@ namespace edm {
    RunBase::getByLabel(InputTag const& tag, Handle<T>& result) const {
       result.clear();
       BasicHandle bh = this->getByLabelImpl(typeid(Wrapper<T>), typeid(T), tag);
-      convert_handle(std::move(bh), result);  // throws on conversion error
+      result = convert_handle<T>(std::move(bh));
       if (result.failedToGet()) {
          return false;
       }

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -356,7 +356,7 @@ namespace edm {
   Event::get(ProductID const& oid, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = this->getByProductID_(oid);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle_check_type<PROD>(std::move(bh));  // throws on conversion error
     if(result.failedToGet()) {
       return false;
     }
@@ -371,13 +371,12 @@ namespace edm {
       BasicHandle bh = this->getByProductID_(oid);
 
       if(bh.failedToGet()) {
-          Handle<View<ELEMENT> > temp(makeHandleExceptionFactory([oid]()->std::shared_ptr<cms::Exception> {
+          result = Handle<View<ELEMENT> >(makeHandleExceptionFactory([oid]()->std::shared_ptr<cms::Exception> {
             std::shared_ptr<cms::Exception> whyFailed = std::make_shared<edm::Exception>(edm::errors::ProductNotFound);
             *whyFailed
             << "get View by ID failed: no product with ID = " << oid <<"\n";
             return whyFailed;
           }));
-          result.swap(temp);
           return false;
       }
 
@@ -535,7 +534,7 @@ namespace edm {
   Event::getByLabel(InputTag const& tag, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -550,7 +549,7 @@ namespace edm {
                     Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -579,7 +578,7 @@ namespace edm {
   Event::getByToken(EDGetToken token, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -592,7 +591,7 @@ namespace edm {
   Event::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -740,7 +740,7 @@ namespace edm {
   // Will throw an exception if the collection is not available.
 
   template <typename T>
-  T const& get(Event const& event, InputTag const& tag) {
+  T const& get(Event const& event, InputTag const& tag) noexcept(false) {
     Handle<T> handle;
     event.getByLabel(tag, handle);
     // throw if the handle is not valid
@@ -748,7 +748,7 @@ namespace edm {
   }
 
   template <typename T>
-  T const& get(Event const& event, EDGetToken const& token) {
+  T const& get(Event const& event, EDGetToken const& token) noexcept(false) {
     Handle<T> handle;
     event.getByToken(token, handle);
     // throw if the handle is not valid
@@ -756,11 +756,8 @@ namespace edm {
   }
 
   template <typename T>
-  T const& get(Event const& event, EDGetTokenT<T> const& token) {
-    Handle<T> handle;
-    event.getByToken(token, handle);
-    // throw if the handle is not valid
-    return * handle.product();
+  T const& get(Event const& event, EDGetTokenT<T> const& token) noexcept(false) {
+    return event.get(token);
   }
 
 }

--- a/FWCore/Framework/interface/GetterOfProducts.h
+++ b/FWCore/Framework/interface/GetterOfProducts.h
@@ -149,8 +149,7 @@ namespace edm {
             handles.reserve(tokens_->size());
             edm::Handle<T> handle;
             for (auto const& token : *tokens_) {
-               event.getByToken(token, handle);
-               if (handle.isValid()) {
+               if (auto handle = event.getHandle(token)) {
                   handles.push_back(handle);
                }
             }
@@ -161,10 +160,8 @@ namespace edm {
          handles.clear();
          if(branchType_ == edm::InLumi ) {
             handles.reserve(tokens_->size());
-            edm::Handle<T> handle;
             for (auto const& token : *tokens_) {
-               lumi.getByToken(token, handle);
-               if (handle.isValid()) {
+               if (auto handle = lumi.getHandle(token)) {
                   handles.push_back(handle);
                }
             }
@@ -175,10 +172,8 @@ namespace edm {
          handles.clear();
          if(branchType_ == edm::InRun) {
             handles.reserve(tokens_->size());
-            edm::Handle<T> handle;
             for (auto const& token : *tokens_) {
-               run.getByToken(token, handle);
-               if (handle.isValid()) {
+               if (auto handle = run.getHandle(token)) {
                   handles.push_back(handle);
                }
             }

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -303,7 +303,7 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -319,7 +319,7 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -334,7 +334,7 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -349,7 +349,7 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -97,6 +97,14 @@ namespace edm {
     bool
     getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
 
+    template<typename PROD>
+    Handle<PROD>
+    getHandle(EDGetTokenT<PROD> token) const;
+
+    template<typename PROD>
+    PROD const&
+    get(EDGetTokenT<PROD> token) const noexcept(false);
+
 
     template <typename PROD>
     void
@@ -356,6 +364,25 @@ namespace edm {
     return true;
   }
 
+  template<typename PROD>
+  Handle<PROD>
+  LuminosityBlock::getHandle(EDGetTokenT<PROD> token) const {
+    if UNLIKELY(!provRecorder_.checkIfComplete<PROD>()) {
+      principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
+    }
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    return convert_handle<PROD>(std::move(bh));
+  }
+
+  template<typename PROD>
+  PROD const&
+  LuminosityBlock::get(EDGetTokenT<PROD> token) const noexcept(false) {
+    if UNLIKELY(!provRecorder_.checkIfComplete<PROD>()) {
+      principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
+    }
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    return *convert_handle<PROD>(std::move(bh));
+  }
 
   template<typename PROD>
   void

--- a/FWCore/Framework/interface/OccurrenceForOutput.h
+++ b/FWCore/Framework/interface/OccurrenceForOutput.h
@@ -53,8 +53,8 @@ namespace edm {
 
     ProcessHistoryID const& processHistoryID() const;
 
-    bool
-    getByToken(EDGetToken token, TypeID const& typeID, BasicHandle& result) const;
+    BasicHandle
+    getByToken(EDGetToken token, TypeID const& typeID) const;
 
     template<typename PROD>
     bool
@@ -97,9 +97,8 @@ namespace edm {
     if(!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("RunOrLumi", TypeID(typeid(PROD)), token);
     }
-    result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -112,9 +111,8 @@ namespace edm {
     if(!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("RunOrLumi", TypeID(typeid(PROD)), token);
     }
-    result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }

--- a/FWCore/Framework/interface/OccurrenceForOutput.h
+++ b/FWCore/Framework/interface/OccurrenceForOutput.h
@@ -64,6 +64,10 @@ namespace edm {
     bool
     getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
 
+    template<typename PROD>
+    Handle<PROD>
+    getHandle(EDGetTokenT<PROD> token) const;
+
     Provenance
     getProvenance(BranchID const& theID) const;
 
@@ -117,6 +121,16 @@ namespace edm {
       return false;
     }
     return true;
+  }
+
+  template<typename PROD>
+  Handle<PROD>
+  OccurrenceForOutput::getHandle(EDGetTokenT<PROD> token) const {
+    if(!provRecorder_.checkIfComplete<PROD>()) {
+      principal_get_adapter_detail::throwOnPrematureRead("RunOrLumi", TypeID(typeid(PROD)), token);
+    }
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    return convert_handle<PROD>(std::move(bh));  // throws on conversion error
   }
 
 }

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -365,9 +365,7 @@ namespace edm {
     typename BasicHandleVec::iterator end = bhv.end();
 
     while (it != end) {
-      Handle<PROD> result;
-      convert_handle(std::move(*it), result);  // throws on conversion error
-      products.push_back(result);
+      products.push_back(convert_handle<PROD>(std::move(*it)));
       ++it;
     }
     results.swap(products);

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -105,6 +105,15 @@ namespace edm {
     bool
     getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const;
 
+    template<typename PROD>
+    Handle<PROD>
+    getHandle(EDGetTokenT<PROD> token) const;
+    
+    template<typename PROD>
+    PROD const&
+    get(EDGetTokenT<PROD> token) const noexcept(false);
+    
+
     template <typename PROD>
     void
     getManyByType(std::vector<Handle<PROD> >& results) const;
@@ -366,6 +375,26 @@ namespace edm {
       return false;
     }
     return true;
+  }
+
+  template<typename PROD>
+  Handle<PROD>
+  Run::getHandle(EDGetTokenT<PROD> token) const {
+    if(!provRecorder_.checkIfComplete<PROD>()) {
+      principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), token);
+    }
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    return convert_handle<PROD>(std::move(bh));
+  }
+
+  template<typename PROD>
+  PROD const&
+  Run::get(EDGetTokenT<PROD> token) const noexcept(false) {
+    if(!provRecorder_.checkIfComplete<PROD>()) {
+      principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), token);
+    }
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
+    return *convert_handle<PROD>(std::move(bh));
   }
 
   template <typename PROD>

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -315,7 +315,7 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -331,7 +331,7 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -346,7 +346,7 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }
@@ -361,7 +361,7 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(std::move(bh), result);  // throws on conversion error
+    result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
     if (result.failedToGet()) {
       return false;
     }

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -76,8 +76,7 @@ namespace edm {
   void ThinningProducer<Collection, Selector>::
   produce(Event& event, EventSetup const& eventSetup) {
 
-    edm::Handle<Collection> inputCollection;
-    event.getByToken(inputToken_, inputCollection);
+    auto inputCollection = event.getHandle(inputToken_);
 
     edm::Event const& constEvent = event;
     selector_->preChoose(inputCollection, constEvent, eventSetup);

--- a/FWCore/Framework/src/OccurrenceForOutput.cc
+++ b/FWCore/Framework/src/OccurrenceForOutput.cc
@@ -61,17 +61,16 @@ namespace edm {
     return provRecorder_.principal().size();
   }
 
-  bool
-  OccurrenceForOutput::getByToken(EDGetToken token, TypeID const& typeID, BasicHandle& result) const {
-    result.clear();
-    result = provRecorder_.getByToken_(typeID, PRODUCT_TYPE, token, moduleCallingContext_);
+  BasicHandle
+  OccurrenceForOutput::getByToken(EDGetToken token, TypeID const& typeID) const {
+    auto result = provRecorder_.getByToken_(typeID, PRODUCT_TYPE, token, moduleCallingContext_);
     if (result.failedToGet()) {
-      return false;
+      return result;
     }
     if(!provRecorder_.isComplete() && result.wrapper()->isMergeable()) {
       principal_get_adapter_detail::throwOnPrematureRead("RunOrLumi", typeID, token);
     }
-    return true;
+    return result;
   }
 }
 

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -606,11 +606,15 @@ namespace edm {
     auto resolution = productResolver->resolveProduct(*this, skipCurrentProcess, sra, mcc);
     if(resolution.isAmbiguous()) {
       ambiguous = true;
-      return BasicHandle();
+      //The caller is looking explicitly for this case
+      // and uses the extra data at the caller to setup the exception
+      return BasicHandle::makeInvalid();
     }
     auto productData = resolution.data();
     if(productData == nullptr) {
-      return BasicHandle();
+      //The caller is looking explicitly for this case
+      // and uses the extra data at the caller to setup the exception
+      return BasicHandle::makeInvalid();
     }
     return BasicHandle(productData->wrapper(), &(productData->provenance()));
   }

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -701,7 +701,7 @@ void testEvent::getByLabel() {
   }
 
   BasicHandle bh = principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "LATE",nullptr, nullptr, nullptr);
-  convert_handle(std::move(bh), h);
+  h = convert_handle<product_t>(std::move(bh));
   CPPUNIT_ASSERT(h->value == 100);
   BasicHandle bh2(principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "nomatch",nullptr, nullptr, nullptr));
   CPPUNIT_ASSERT(!bh2.isValid());

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -87,6 +87,8 @@ class testEvent: public CppUnit::TestFixture {
   CPPUNIT_TEST(emptyEvent);
   CPPUNIT_TEST(getByLabelFromEmpty);
   CPPUNIT_TEST(getByTokenFromEmpty);
+  CPPUNIT_TEST(getHandleFromEmpty);
+  CPPUNIT_TEST(getFromEmpty);
   CPPUNIT_TEST(putAnIntProduct);
   CPPUNIT_TEST(putAndGetAnIntProduct);
   CPPUNIT_TEST(putAndGetAnIntProductByToken);
@@ -95,6 +97,8 @@ class testEvent: public CppUnit::TestFixture {
   CPPUNIT_TEST(transaction);
   CPPUNIT_TEST(getByLabel);
   CPPUNIT_TEST(getByToken);
+  CPPUNIT_TEST(getHandle);
+  CPPUNIT_TEST(get_product);
   CPPUNIT_TEST(getManyByType);
   CPPUNIT_TEST(printHistory);
   CPPUNIT_TEST(deleteProduct);
@@ -108,6 +112,8 @@ class testEvent: public CppUnit::TestFixture {
   void emptyEvent();
   void getByLabelFromEmpty();
   void getByTokenFromEmpty();
+  void getHandleFromEmpty();
+  void getFromEmpty();
   void putAnIntProduct();
   void putAndGetAnIntProduct();
   void putAndGetAnIntProductByToken();
@@ -116,6 +122,8 @@ class testEvent: public CppUnit::TestFixture {
   void transaction();
   void getByLabel();
   void getByToken();
+  void getHandle();
+  void get_product();
   void getManyByType();
   void printHistory();
   void deleteProduct();
@@ -505,6 +513,30 @@ void testEvent::getByTokenFromEmpty() {
   CPPUNIT_ASSERT_THROW(*nonesuch, cms::Exception);
 }
 
+void testEvent::getHandleFromEmpty() {
+  InputTag inputTag("moduleLabel", "instanceName");
+  
+  IntConsumer consumer( std::vector<InputTag>{1,inputTag});
+  consumer.updateLookup(InEvent, principal_->productLookup(),false);
+  assert(1==consumer.m_tokens.size());
+  currentEvent_->setConsumer(&consumer);
+  Handle<int> nonesuch;
+  CPPUNIT_ASSERT(!(nonesuch=currentEvent_->getHandle(consumer.m_tokens[0])));
+  CPPUNIT_ASSERT(!nonesuch.isValid());
+  CPPUNIT_ASSERT(nonesuch.failedToGet());
+  CPPUNIT_ASSERT_THROW(*nonesuch, cms::Exception);
+}
+
+void testEvent::getFromEmpty() {
+  InputTag inputTag("moduleLabel", "instanceName");
+  
+  IntConsumer consumer( std::vector<InputTag>{1,inputTag});
+  consumer.updateLookup(InEvent, principal_->productLookup(),false);
+  assert(1==consumer.m_tokens.size());
+  currentEvent_->setConsumer(&consumer);
+  CPPUNIT_ASSERT_THROW( (void) currentEvent_->get(consumer.m_tokens[0]), cms::Exception);
+}
+
 void testEvent::putAnIntProduct() {
   
   auto p = putProduct(std::make_unique<edmtest::IntProduct>(3),"int1",false);
@@ -786,6 +818,153 @@ void testEvent::getByToken() {
   
   CPPUNIT_ASSERT(currentEvent_->getByToken(modOneToken, h));
   CPPUNIT_ASSERT(h->value == 4);
+  
+}
+
+void testEvent::getHandle() {
+  typedef edmtest::IntProduct product_t;
+  typedef std::unique_ptr<product_t> ap_t;
+  typedef Handle<product_t> handle_t;
+  
+  ap_t one(new product_t(1));
+  ap_t two(new product_t(2));
+  ap_t three(new product_t(3));
+  ap_t four(new product_t(4));
+  addProduct(std::move(one),   "int1_tag", "int1");
+  addProduct(std::move(two),   "int2_tag", "int2");
+  addProduct(std::move(three), "int3_tag");
+  addProduct(std::move(four),  "nolabel_tag");
+  
+  auto ap_vthing = std::make_unique<std::vector<edmtest::Thing>>();
+  addProduct(std::move(ap_vthing), "thing", "");
+  
+  ap_t oneHundred(new product_t(100));
+  addProduct(std::move(oneHundred), "int1_tag_late", "int1");
+  
+  auto twoHundred = std::make_unique<edmtest::IntProduct>(200);
+  putProduct(std::move(twoHundred), "int1");
+  
+  CPPUNIT_ASSERT(currentEvent_->size() == 7);
+  
+  IntProductConsumer consumer(std::vector<InputTag> {
+    InputTag("modMulti"),
+    InputTag("modMulti","int1"),
+    InputTag("modMulti", "nomatch"),
+    InputTag("modMulti", "int1", "EARLY"),
+    InputTag("modMulti", "int1", "LATE"),
+    InputTag("modMulti", "int1", "CURRENT"),
+    InputTag("modMulti", "int2", "EARLY"),
+    InputTag("modOne")
+  });
+  consumer.updateLookup(InEvent, principal_->productLookup(),false);
+  
+  currentEvent_->setConsumer(&consumer);
+  
+  const auto modMultiToken = consumer.m_tokens[0];
+  const auto modMultiInt1Token = consumer.m_tokens[1];
+  const auto modMultinomatchToken = consumer.m_tokens[2];
+  const auto modMultiInt1EarlyToken = consumer.m_tokens[3];
+  const auto modMultiInt1LateToken = consumer.m_tokens[4];
+  const auto modMultiInt1CurrentToken = consumer.m_tokens[5];
+  const auto modMultiInt2EarlyToken = consumer.m_tokens[6];
+  const auto modOneToken = consumer.m_tokens[7];
+  
+  handle_t h;
+  CPPUNIT_ASSERT(h=currentEvent_->getHandle(modMultiToken));
+  CPPUNIT_ASSERT(h->value == 3);
+  
+  CPPUNIT_ASSERT(h=currentEvent_->getHandle(modMultiInt1Token));
+  CPPUNIT_ASSERT(h->value == 200);
+  
+  CPPUNIT_ASSERT(!(h=currentEvent_->getHandle(modMultinomatchToken)));
+  CPPUNIT_ASSERT(!h.isValid());
+  CPPUNIT_ASSERT_THROW(*h, cms::Exception);
+  
+  CPPUNIT_ASSERT(h=currentEvent_->getHandle(modMultiInt1Token));
+  CPPUNIT_ASSERT(h->value == 200);
+  
+  CPPUNIT_ASSERT(h=currentEvent_->getHandle(modMultiInt1EarlyToken));
+  CPPUNIT_ASSERT(h->value == 1);
+  
+  CPPUNIT_ASSERT(h=currentEvent_->getHandle(modMultiInt1LateToken));
+  CPPUNIT_ASSERT(h->value == 100);
+  
+  CPPUNIT_ASSERT(h=currentEvent_->getHandle(modMultiInt1CurrentToken));
+  CPPUNIT_ASSERT(h->value == 200);
+  
+  CPPUNIT_ASSERT(h=currentEvent_->getHandle(modMultiInt2EarlyToken));
+  CPPUNIT_ASSERT(h->value == 2);
+  
+  CPPUNIT_ASSERT(h=currentEvent_->getHandle(modOneToken));
+  CPPUNIT_ASSERT(h->value == 4);
+  
+}
+
+void testEvent::get_product() {
+  typedef edmtest::IntProduct product_t;
+  typedef std::unique_ptr<product_t> ap_t;
+  typedef Handle<product_t> handle_t;
+  
+  ap_t one(new product_t(1));
+  ap_t two(new product_t(2));
+  ap_t three(new product_t(3));
+  ap_t four(new product_t(4));
+  addProduct(std::move(one),   "int1_tag", "int1");
+  addProduct(std::move(two),   "int2_tag", "int2");
+  addProduct(std::move(three), "int3_tag");
+  addProduct(std::move(four),  "nolabel_tag");
+  
+  auto ap_vthing = std::make_unique<std::vector<edmtest::Thing>>();
+  addProduct(std::move(ap_vthing), "thing", "");
+  
+  ap_t oneHundred(new product_t(100));
+  addProduct(std::move(oneHundred), "int1_tag_late", "int1");
+  
+  auto twoHundred = std::make_unique<edmtest::IntProduct>(200);
+  putProduct(std::move(twoHundred), "int1");
+  
+  CPPUNIT_ASSERT(currentEvent_->size() == 7);
+  
+  IntProductConsumer consumer(std::vector<InputTag> {
+    InputTag("modMulti"),
+    InputTag("modMulti","int1"),
+    InputTag("modMulti", "nomatch"),
+    InputTag("modMulti", "int1", "EARLY"),
+    InputTag("modMulti", "int1", "LATE"),
+    InputTag("modMulti", "int1", "CURRENT"),
+    InputTag("modMulti", "int2", "EARLY"),
+    InputTag("modOne")
+  });
+  consumer.updateLookup(InEvent, principal_->productLookup(),false);
+  
+  currentEvent_->setConsumer(&consumer);
+  
+  const auto modMultiToken = consumer.m_tokens[0];
+  const auto modMultiInt1Token = consumer.m_tokens[1];
+  const auto modMultinomatchToken = consumer.m_tokens[2];
+  const auto modMultiInt1EarlyToken = consumer.m_tokens[3];
+  const auto modMultiInt1LateToken = consumer.m_tokens[4];
+  const auto modMultiInt1CurrentToken = consumer.m_tokens[5];
+  const auto modMultiInt2EarlyToken = consumer.m_tokens[6];
+  const auto modOneToken = consumer.m_tokens[7];
+  
+  CPPUNIT_ASSERT(currentEvent_->get(modMultiToken).value==3);
+  
+  CPPUNIT_ASSERT(currentEvent_->get(modMultiInt1Token).value == 200);
+  
+  CPPUNIT_ASSERT_THROW(currentEvent_->get(modMultinomatchToken), cms::Exception);
+  
+  CPPUNIT_ASSERT(currentEvent_->get(modMultiInt1Token).value == 200);
+  
+  CPPUNIT_ASSERT(currentEvent_->get(modMultiInt1EarlyToken).value == 1);
+  
+  CPPUNIT_ASSERT(currentEvent_->get(modMultiInt1LateToken).value == 100);
+  
+  CPPUNIT_ASSERT(currentEvent_->get(modMultiInt1CurrentToken).value == 200);
+  
+  CPPUNIT_ASSERT(currentEvent_->get(modMultiInt2EarlyToken).value == 2);
+  
+  CPPUNIT_ASSERT(currentEvent_->get(modOneToken).value == 4);
   
 }
 

--- a/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.cc
@@ -55,9 +55,7 @@ namespace edmtest {
     }
 
     if(dumpTriggerResults_) {
-      edm::Handle<edm::TriggerResults> triggerResults;
-      event.getByToken(triggerResultsToken_, triggerResults);
-      if(triggerResults.isValid()) {
+      if( auto triggerResults=event.getHandle(triggerResultsToken_)) {
         edm::LogAbsolute("RunLumiEvent") << "TestFailuresAnalyzer dumping TriggerResults";
         edm::LogAbsolute("RunLumiEvent") << *triggerResults;
       } else {

--- a/FWCore/Framework/test/stubs/TestGetPathStatus.cc
+++ b/FWCore/Framework/test/stubs/TestGetPathStatus.cc
@@ -44,24 +44,20 @@ private:
   void
   TestGetPathStatus::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const&) const {
 
-    edm::Handle<edm::PathStatus> hPathStatus;
-    event.getByToken(tokenPathStatus_, hPathStatus);
-    *hPathStatus;
+    auto const& pathStatus = event.get(tokenPathStatus_);
 
     unsigned int eventID = event.id().event();
-    if (eventID < expectedStates_.size() && expectedStates_[eventID] != static_cast<int>(hPathStatus->state())) {
+    if (eventID < expectedStates_.size() && expectedStates_[eventID] != static_cast<int>(pathStatus.state())) {
       std::cerr << "TestGetPathStatus::analyze unexpected path status state" << std::endl;
       abort();
     }
     if (eventID < expectedIndexes_.size() &&
-        expectedIndexes_[eventID] != hPathStatus->index()) {
+        expectedIndexes_[eventID] != pathStatus.index()) {
       std::cerr << "TestGetPathStatus::analyze unexpected path status index " << std::endl;
       abort();
     }
 
-    edm::Handle<edm::EndPathStatus> hEndPathStatus;
-    event.getByToken(tokenEndPathStatus_, hEndPathStatus);
-    *hEndPathStatus;
+    (void) event.get(tokenEndPathStatus_);
   }
 }
 using edmtest::TestGetPathStatus;

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -84,9 +84,8 @@ namespace edmtest {
     }
     
     void analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const override {
-      edm::Handle<IntProduct> h;
       for(auto const& token: m_tokens) {
-        iEvent.getByToken(token,h);
+        (void) iEvent.getHandle(token);
       }
     }
     

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -346,9 +346,8 @@ namespace edmtest {
   void
   IntProducerFromTransient::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
-    edm::Handle<TransientIntProduct> result;
-    bool ok = e.getByToken(getToken_, result);
-    assert(ok);
+    auto result = e.getHandle(getToken_);
+    assert(result);
     e.emplace(putToken_,result.product()->value);
   }
 
@@ -405,9 +404,7 @@ namespace edmtest {
 
     if (onlyGetOnEvent_ == 0u || e.eventAuxiliary().event() == onlyGetOnEvent_) {
       for(auto const& token: tokens_) {
-        edm::Handle<IntProduct> anInt;
-        e.getByToken(token, anInt);
-        value += anInt->value;
+        value += e.get(token).value;
       }
     }
     e.emplace(putToken_,value);

--- a/FWCore/Framework/test/stubs/ToyRefProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyRefProducers.cc
@@ -64,8 +64,7 @@ namespace edmtest {
   IntVecRefVectorProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
     // Get our input:
-    edm::Handle<std::vector<int> > input;
-    e.getByToken(target_, input);
+    edm::Handle<std::vector<int> > input = e.getHandle(target_);
     assert(input.isValid());
 
     auto prod = std::make_unique<product_type>();
@@ -102,8 +101,7 @@ namespace edmtest {
   IntVecRefToBaseVectorProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
     // Get our input:
-    edm::Handle<edm::View<int> > input;
-    e.getByToken(target_, input);
+    edm::Handle<edm::View<int> > input = e.getHandle(target_);
     assert(input.isValid());
 
     edm::RefToBaseVector<int> refVector;
@@ -137,8 +135,7 @@ namespace edmtest {
   IntVecPtrVectorProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     // EventSetup is not used.
     // Get our input:
-    edm::Handle<edm::View<int> > input;
-    e.getByToken(target_, input);
+    edm::Handle<edm::View<int> > input = e.getHandle(target_);
     assert(input.isValid());
 
     auto prod = std::make_unique<product_type>();
@@ -173,8 +170,7 @@ namespace edmtest {
   IntVecStdVectorPtrProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const  {
     // EventSetup is not used.
     // Get our input:
-    edm::Handle<edm::View<int> > input;
-    e.getByToken(target_, input);
+    edm::Handle<edm::View<int> > input = e.getHandle(target_);
     assert(input.isValid());
 
     auto prod = std::make_unique<product_type>();

--- a/FWCore/Integration/test/AcquireIntFilter.cc
+++ b/FWCore/Integration/test/AcquireIntFilter.cc
@@ -85,9 +85,7 @@ namespace edmtest {
     streamCacheData->processed().clear();
 
     for(auto const& token: m_tokens) {
-      edm::Handle<IntProduct> handle;
-      event.getByToken(token, handle);
-      streamCacheData->retrieved().push_back(handle->value);
+      streamCacheData->retrieved().push_back(event.get(token).value);
     }
 
     m_server->requestValuesAsync(streamID, &streamCacheData->retrieved(), &streamCacheData->processed(), holder);
@@ -103,9 +101,7 @@ namespace edmtest {
     event.put(std::make_unique<IntProduct>(sum));
 
     // This part is here only for the Parentage test.
-    edm::Handle<IntProduct> handle;
-    event.getByToken(m_tokenForProduce, handle);
-    *handle;
+    (void) event.get(m_tokenForProduce);
 
     return true;
   }

--- a/FWCore/Integration/test/AcquireIntProducer.cc
+++ b/FWCore/Integration/test/AcquireIntProducer.cc
@@ -87,9 +87,7 @@ namespace edmtest {
     streamCacheData->processed().clear();
 
     for(auto const& token: m_tokens) {
-      edm::Handle<IntProduct> handle;
-      event.getByToken(token, handle);
-      streamCacheData->retrieved().push_back(handle->value);
+      streamCacheData->retrieved().push_back(event.get(token).value);
     }
     m_server->requestValuesAsync(streamID.value(),
                                  &streamCacheData->retrieved(),
@@ -109,9 +107,7 @@ namespace edmtest {
     event.put(std::make_unique<IntProduct>(sum));
 
     // This part is here only for the Parentage test.
-    edm::Handle<IntProduct> handle;
-    event.getByToken(m_tokenForProduce, handle);
-    *handle;
+    (void) event.get(m_tokenForProduce);
   }
 
   void AcquireIntProducer::endJob() {

--- a/FWCore/Integration/test/AcquireIntStreamFilter.cc
+++ b/FWCore/Integration/test/AcquireIntStreamFilter.cc
@@ -55,9 +55,7 @@ namespace edmtest {
     cache->processed().clear();
 
     for(auto const& token: m_getTokens) {
-      edm::Handle<IntProduct> handle;
-      event.getByToken(token, handle);
-      cache->retrieved().push_back(handle->value);
+      cache->retrieved().push_back(event.get(token).value);
     }
 
     edm::Service<test_acquire::WaitingService>()->requestValuesAsync(m_token,
@@ -76,9 +74,7 @@ namespace edmtest {
     event.put(std::make_unique<IntProduct>(sum));
 
     // This part is here only for the Parentage test.
-    edm::Handle<IntProduct> handle;
-    event.getByToken(m_tokenForProduce, handle);
-    *handle;
+    (void) event.get(m_tokenForProduce);
 
     return true;
   }

--- a/FWCore/Integration/test/AcquireIntStreamProducer.cc
+++ b/FWCore/Integration/test/AcquireIntStreamProducer.cc
@@ -55,9 +55,7 @@ namespace edmtest {
     cache->processed().clear();
 
     for(auto const& token: m_getTokens) {
-      edm::Handle<IntProduct> handle;
-      event.getByToken(token, handle);
-      cache->retrieved().push_back(handle->value);
+      cache->retrieved().push_back(event.get(token).value);
     }
 
     edm::Service<test_acquire::WaitingService>()->requestValuesAsync(m_token,
@@ -76,9 +74,7 @@ namespace edmtest {
     event.put(std::make_unique<IntProduct>(sum));
 
     // This part is here only for the Parentage test.
-    edm::Handle<IntProduct> handle;
-    event.getByToken(m_tokenForProduce, handle);
-    *handle;
+    (void) event.get(m_tokenForProduce);
   }
 }
 using edmtest::AcquireIntStreamProducer;

--- a/FWCore/Integration/test/AssociationMapAnalyzer.cc
+++ b/FWCore/Integration/test/AssociationMapAnalyzer.cc
@@ -71,20 +71,16 @@ namespace edmtest {
                                   edm::Event const& event,
                                   edm::EventSetup const&) const {
 
-    edm::Handle<std::vector<int> > inputCollection1;
-    event.getByToken(inputToken1_, inputCollection1);
+    edm::Handle<std::vector<int> > inputCollection1 = event.getHandle(inputToken1_);
 
-    edm::Handle<std::vector<int> > inputCollection2;
-    event.getByToken(inputToken2_, inputCollection2);
+    edm::Handle<std::vector<int> > inputCollection2 = event.getHandle(inputToken2_);
 
     // Readout some entries from some AssociationMaps and check that
     // we readout the same content as was was put in. We know the values
     // by looking at the hard coded values in AssociationMapProducer.
     // The particular values used are arbitrary and have no meaning.
 
-    edm::Handle<AssocOneToOne> hAssociationMap1;
-    event.getByToken(associationMapToken1_, hAssociationMap1);
-    AssocOneToOne const& associationMap1 = *hAssociationMap1;
+    AssocOneToOne const& associationMap1 =event.get(associationMapToken1_);
 
     if(*associationMap1[edm::Ref<std::vector<int> >(inputCollection1, 0)] != 22 ||
        *associationMap1[edm::Ref<std::vector<int> >(inputCollection1, 2)] != 24 ||
@@ -106,10 +102,7 @@ namespace edmtest {
     }
 
     // Case where handle arguments were used creating the AssociationMap
-
-    edm::Handle<AssocOneToOne> hAssociationMap2;
-    event.getByToken(associationMapToken2_, hAssociationMap2);
-    AssocOneToOne const& associationMap2 = *hAssociationMap2;
+    AssocOneToOne const& associationMap2 = event.get(associationMapToken2_);
 
     if(*associationMap2[edm::Ref<std::vector<int> >(inputCollection1, 0)] != 22 ||
        *associationMap2[edm::Ref<std::vector<int> >(inputCollection1, 2)] != 25 ||
@@ -126,9 +119,7 @@ namespace edmtest {
 
     // One to Value case
 
-    edm::Handle<AssocOneToValue> hAssociationMap3;
-    event.getByToken(associationMapToken3_, hAssociationMap3);
-    AssocOneToValue const& associationMap3 = *hAssociationMap3;
+    AssocOneToValue const& associationMap3 = event.get(associationMapToken3_);
 
     if(associationMap3[edm::Ref<std::vector<int> >(inputCollection1, 0)] != 11.0 ||
        associationMap3[edm::Ref<std::vector<int> >(inputCollection1, 2)] != 12.0 ||
@@ -144,9 +135,7 @@ namespace edmtest {
 
     // One to Value case with handle argument
 
-    edm::Handle<AssocOneToValue> hAssociationMap4;
-    event.getByToken(associationMapToken4_, hAssociationMap4);
-    AssocOneToValue const& associationMap4 = *hAssociationMap4;
+    AssocOneToValue const& associationMap4 =event.get(associationMapToken4_);
 
     if(associationMap4[edm::Ref<std::vector<int> >(inputCollection1, 0)] != 21.0 ||
        associationMap4[edm::Ref<std::vector<int> >(inputCollection1, 2)] != 22.0 ||
@@ -162,9 +151,7 @@ namespace edmtest {
 
     // One to Many
 
-    edm::Handle<AssocOneToMany> hAssociationMap5;
-    event.getByToken(associationMapToken5_, hAssociationMap5);
-    AssocOneToMany const& associationMap5 = *hAssociationMap5;
+    AssocOneToMany const& associationMap5 = event.get(associationMapToken5_);
 
     if(*associationMap5[edm::Ref<std::vector<int> >(inputCollection1, 0)].at(0) != 22 ||
        *associationMap5[edm::Ref<std::vector<int> >(inputCollection1, 2)].at(1) != 27 ||
@@ -180,9 +167,7 @@ namespace edmtest {
 
     // One to Many With Quality
 
-    edm::Handle<AssocOneToManyWithQuality> hAssociationMap6;
-    event.getByToken(associationMapToken6_, hAssociationMap6);
-    AssocOneToManyWithQuality const& associationMap6 = *hAssociationMap6;
+    AssocOneToManyWithQuality const& associationMap6 =event.get(associationMapToken6_);
     if(*associationMap6[edm::Ref<std::vector<int> >(inputCollection1, 0)].at(0).first != 22 ||
        *associationMap6[edm::Ref<std::vector<int> >(inputCollection1, 2)].at(1).first != 25 ||
        *associationMap6[edm::Ptr<int>(inputCollection1, 0)].at(0).first != 22 ||
@@ -203,39 +188,33 @@ namespace edmtest {
 
     // One to One View
 
-    edm::Handle<edm::View<int> > inputView1;
-    event.getByToken(inputToken1V_, inputView1);
+    edm::View<int> const& inputView1 = event.get(inputToken1V_);
 
-    edm::Handle<edm::View<int> > inputView2;
-    event.getByToken(inputToken2V_, inputView2);
+    edm::Handle<edm::View<int>> inputView2 = event.getHandle(inputToken2V_);
 
-    edm::Handle<AssocOneToOneView> hAssociationMap7;
-    event.getByToken(associationMapToken7_, hAssociationMap7);
-    AssocOneToOneView const& associationMap7 = *hAssociationMap7;
-    if(*associationMap7[inputView1->refAt(0)] != 24 ||
-       *associationMap7[inputView1->refAt(2)] != 25) {
+    AssocOneToOneView const& associationMap7 =event.get(associationMapToken7_);
+    if(*associationMap7[inputView1.refAt(0)] != 24 ||
+       *associationMap7[inputView1.refAt(2)] != 25) {
       throw cms::Exception("TestFailure") << "unexpected result after using AssociationMap 15";
     }
     AssocOneToOneView::const_iterator iter7 = associationMap7.begin();
     ++iter7;
     if(*iter7->val != 25 ||
-       iter7->key != inputView1->refAt(2)) {
+       iter7->key != inputView1.refAt(2)) {
       throw cms::Exception("TestFailure") << "unexpected result after using AssociationMap 16";
     }
 
     // One to One View built with 2 arguments constructor
 
-    edm::Handle<AssocOneToOneView> hAssociationMap8;
-    event.getByToken(associationMapToken8_, hAssociationMap8);
-    AssocOneToOneView const& associationMap8 = *hAssociationMap8;
-    if(*associationMap8[inputView1->refAt(0)] != 26 ||
-       *associationMap8[inputView1->refAt(2)] != 27) {
+    AssocOneToOneView const& associationMap8 = event.get(associationMapToken8_);
+    if(*associationMap8[inputView1.refAt(0)] != 26 ||
+       *associationMap8[inputView1.refAt(2)] != 27) {
       throw cms::Exception("TestFailure") << "unexpected result after using AssociationMap 17";
     }
     AssocOneToOneView::const_iterator iter8 = associationMap8.begin();
     ++iter8;
     if(*iter8->val != 27 ||
-       iter8->key != inputView1->refAt(2)) {
+       iter8->key != inputView1.refAt(2)) {
       throw cms::Exception("TestFailure") << "unexpected result after using AssociationMap 18";
     }
   }

--- a/FWCore/Integration/test/AssociationMapProducer.cc
+++ b/FWCore/Integration/test/AssociationMapProducer.cc
@@ -71,11 +71,9 @@ namespace edmtest {
 
   void AssociationMapProducer::produce(edm::Event& event, edm::EventSetup const&) {
 
-    edm::Handle<std::vector<int> > inputCollection1;
-    event.getByToken(inputToken1_, inputCollection1);
+    edm::Handle<std::vector<int> > inputCollection1 = event.getHandle(inputToken1_);
 
-    edm::Handle<std::vector<int> > inputCollection2;
-    event.getByToken(inputToken2_, inputCollection2);
+    edm::Handle<std::vector<int> > inputCollection2 = event.getHandle(inputToken2_);
 
     // insert some entries into some AssociationMaps, in another
     // module we will readout the contents and check that we readout
@@ -124,22 +122,20 @@ namespace edmtest {
                    AssocOneToManyWithQuality::data_type(edm::Ref<std::vector<int> >(inputCollection2, 7), 33.0));
     event.put(std::move(assoc6));
 
-    edm::Handle<edm::View<int> > inputView1;
-    event.getByToken(inputToken1V_, inputView1);
+    edm::View<int> const& inputView1 = event.get(inputToken1V_);
 
-    edm::Handle<edm::View<int> > inputView2;
-    event.getByToken(inputToken2V_, inputView2);
+    edm::Handle<edm::View<int> > inputView2 = event.getHandle(inputToken2V_);
 
     auto assoc7 = std::make_unique<AssocOneToOneView>(&event.productGetter());
-    assoc7->insert(inputView1->refAt(0), inputView2->refAt(3));
-    assoc7->insert(inputView1->refAt(2), inputView2->refAt(4));
+    assoc7->insert(inputView1.refAt(0), inputView2->refAt(3));
+    assoc7->insert(inputView1.refAt(2), inputView2->refAt(4));
     event.put(std::move(assoc7));
 
-    auto assoc8 = std::make_unique<AssocOneToOneView>(edm::makeRefToBaseProdFrom(inputView1->refAt(0), event),
+    auto assoc8 = std::make_unique<AssocOneToOneView>(edm::makeRefToBaseProdFrom(inputView1.refAt(0), event),
                                                       edm::makeRefToBaseProdFrom(inputView2->refAt(0), event));
 
-    assoc8->insert(inputView1->refAt(0), inputView2->refAt(5));
-    assoc8->insert(inputView1->refAt(2), inputView2->refAt(6));
+    assoc8->insert(inputView1.refAt(0), inputView2->refAt(5));
+    assoc8->insert(inputView1.refAt(2), inputView2->refAt(6));
     event.put(std::move(assoc8), "twoArg");
   }
 }

--- a/FWCore/Integration/test/OtherThingRefComparer.cc
+++ b/FWCore/Integration/test/OtherThingRefComparer.cc
@@ -34,16 +34,14 @@ namespace edmtest {
   }
 
   void OtherThingRefComparer::analyze(edm::Event const& e, edm::EventSetup const&) {
-    edm::Handle<OtherThingCollection> handle1_;
-    e.getByToken(token1_,handle1_);
-    edm::Handle<OtherThingCollection> handle2_;
-    e.getByToken(token2_,handle2_);
+    auto const& t1_ = e.get(token1_);
+    auto const& t2_ = e.get(token2_);
     
-    assert(handle1_->size() == handle2_->size());
+    assert(t1_.size() == t2_.size());
 
     {
-      auto iter2 = handle2_->begin();
-      for(auto const& o1: *handle1_) {
+      auto iter2 = t2_.begin();
+      for(auto const& o1: t1_) {
         if(o1.ref != iter2->ref) {
           throw cms::Exception("RefCompareFailure")<<"edm::Refs are not equal"<< o1.ref.id()<<" "<<iter2->ref.id();
         }
@@ -52,8 +50,8 @@ namespace edmtest {
     }
 
     {
-      auto iter2 = handle2_->begin();
-      for(auto const& o1: *handle1_) {
+      auto iter2 = t2_.begin();
+      for(auto const& o1: t1_) {
         if(o1.ptr != iter2->ptr) {
           throw cms::Exception("RefCompareFailure")<<"edm::Ptrs are not equal"<<o1.ptr.id()<<" "<<iter2->ptr.id();
         }

--- a/FWCore/Integration/test/TableTestModules.cc
+++ b/FWCore/Integration/test/TableTestModules.cc
@@ -104,8 +104,7 @@ namespace edmtest {
         BranchDescription const* branchDescription = product.first;
         TypeID const& tid = branchDescription->unwrappedTypeID();
         EDGetToken const& token = product.second;
-        BasicHandle bh;
-        e.getByToken(token, tid, bh);
+        BasicHandle bh = e.getByToken(token, tid);
         assert(bh.isValid());
         auto examiner = bh.wrapper()->tableExaminer();
         assert(examiner);

--- a/FWCore/Integration/test/TableTestModules.cc
+++ b/FWCore/Integration/test/TableTestModules.cc
@@ -53,16 +53,15 @@ namespace edmtest {
     }
     
     void analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const final {
-      edm::Handle<edmtest::TableTest> h;
-      iEvent.getByToken(tableToken_, h);
+      auto const& t = iEvent.get(tableToken_);
       
-      auto size = h->size();
+      auto size = t.size();
       if(size != anInts_.size()) {
         throw cms::Exception("RuntimeError")<<"Table size ("<<size<<") does not equal expected size ("<<anInts_.size()<<")";
       }
 
       unsigned int index=0;
-      for(auto const& row : *h) {
+      for(auto const& row : t) {
         if( anInts_[index] != row.get<edmtest::AnInt>() ) {
           throw cms::Exception("RuntimeError")<<"index "<<index<<" anInt ="<<row.get<edmtest::AnInt>()<<" expected "<<anInts_[index];
         }

--- a/FWCore/Integration/test/TestParentage.cc
+++ b/FWCore/Integration/test/TestParentage.cc
@@ -83,8 +83,7 @@ namespace edmtest {
   void
   TestParentage::analyze(edm::Event const& e, edm::EventSetup const&) {
 
-    edm::Handle<IntProduct> h;
-    e.getByToken(token_, h);
+    edm::Handle<IntProduct> h = e.getHandle(token_);
 
     edm::Provenance const* prov = h.provenance();
 

--- a/FWCore/Integration/test/ThingAnalyzer.cc
+++ b/FWCore/Integration/test/ThingAnalyzer.cc
@@ -77,32 +77,23 @@ namespace edmtest {
     
     auto const& run = lumi.getRun();
     
-    edm::Handle<ThingCollection> h;
-    run.getByToken(beginRun_,h);
-    *h;
+    (void) run.get(beginRun_);
     
-    run.getByToken(endRun_,h);
-    shouldBeInvalid(h);
+    shouldBeInvalid(run.getHandle(endRun_));
     
-    lumi.getByToken(beginLumi_,h);
-    *h;
+    (void) lumi.get(beginLumi_);
     
-    lumi.getByToken(endLumi_,h);
-    shouldBeInvalid(h);
+    shouldBeInvalid(lumi.getHandle(endLumi_));
 
-    iEvent.getByToken(event_,h);
-    *h;
+    (void) iEvent.get(event_);
   }
   
   std::shared_ptr<Empty>
   ThingAnalyzer::globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const
   {
-    edm::Handle<ThingCollection> h;
-    iRun.getByToken(beginRun_,h);
-    *h;
+    (void) iRun.get(beginRun_);
     
-    iRun.getByToken(endRun_,h);
-    shouldBeInvalid(h);
+    shouldBeInvalid(iRun.getHandle(endRun_));
     
     return std::shared_ptr<Empty>();
   }
@@ -110,12 +101,9 @@ namespace edmtest {
   void
   ThingAnalyzer::globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const
   {
-    edm::Handle<ThingCollection> h;
-    iRun.getByToken(beginRun_,h);
-    *h;
+    (void) iRun.get(beginRun_);
     
-    iRun.getByToken(endRun_,h);
-    *h;
+    (void) iRun.get(endRun_);
   }
   
   std::shared_ptr<Empty>
@@ -123,19 +111,13 @@ namespace edmtest {
   {
     auto const& run = iLumi.getRun();
     
-    edm::Handle<ThingCollection> h;
-    run.getByToken(beginRun_,h);
-    *h;
+    (void) run.get(beginRun_);
     
-    run.getByToken(endRun_,h);
-    shouldBeInvalid(h);
+    shouldBeInvalid(run.getHandle(endRun_));
 
-    iLumi.getByToken(beginLumi_,h);
-    *h;
+    (void) iLumi.get(beginLumi_);
     
-    iLumi.getByToken(endLumi_,h);
-    shouldBeInvalid(h);
-
+    shouldBeInvalid(iLumi.getHandle(endLumi_));
     
     return std::shared_ptr<Empty>();
   }
@@ -145,18 +127,13 @@ namespace edmtest {
   {
     auto const& run = iLumi.getRun();
     
-    edm::Handle<ThingCollection> h;
-    run.getByToken(beginRun_,h);
-    *h;
+    (void) run.get(beginRun_);
     
-    run.getByToken(endRun_,h);
-    shouldBeInvalid(h);
+    shouldBeInvalid(run.getHandle(endRun_));
     
-    iLumi.getByToken(beginLumi_,h);
-    *h;
+    (void) iLumi.get(beginLumi_);
     
-    iLumi.getByToken(endLumi_,h);
-    *h;
+    (void) iLumi.get(endLumi_);
     
   }
   

--- a/FWCore/Integration/test/ThinningTestAnalyzer.cc
+++ b/FWCore/Integration/test/ThinningTestAnalyzer.cc
@@ -92,17 +92,13 @@ namespace edmtest {
 
   void ThinningTestAnalyzer::analyze(edm::Event const& event, edm::EventSetup const&) {
 
-    edm::Handle<ThingCollection> parentCollection;
-    event.getByToken(parentToken_, parentCollection);
+    edm::Handle<ThingCollection> parentCollection = event.getHandle(parentToken_);
 
-    edm::Handle<ThingCollection> thinnedCollection;
-    event.getByToken(thinnedToken_, thinnedCollection);
+    edm::Handle<ThingCollection> thinnedCollection = event.getHandle(thinnedToken_);
 
-    edm::Handle<edm::ThinnedAssociation> associationCollection;
-    event.getByToken(associationToken_, associationCollection);
+    edm::Handle<edm::ThinnedAssociation> associationCollection = event.getHandle(associationToken_);
 
-    edm::Handle<TrackOfThingsCollection> trackCollection;
-    event.getByToken(trackToken_, trackCollection);
+    edm::Handle<TrackOfThingsCollection> trackCollection = event.getHandle(trackToken_);
 
     unsigned int i = 0;
     if(parentWasDropped_) {

--- a/FWCore/Integration/test/ThinningThingProducer.cc
+++ b/FWCore/Integration/test/ThinningThingProducer.cc
@@ -57,9 +57,7 @@ namespace edmtest {
   }
 
   void ThinningThingSelector::preChoose(edm::Handle<edmtest::ThingCollection> tc, edm::Event const& event, edm::EventSetup const& es) {
-    edm::Handle<TrackOfThingsCollection> trackCollection;
-    event.getByToken(trackToken_, trackCollection);
-    for (auto const& track : *trackCollection) {
+    for (auto const& track : event.get(trackToken_)) {
       keysToSave_.insert(track.ref1.key() - offsetToThinnedKey_);
       keysToSave_.insert(track.ref2.key() - offsetToThinnedKey_);
       keysToSave_.insert(track.ptr1.key() - offsetToThinnedKey_);

--- a/FWCore/Integration/test/TrackOfThingsProducer.cc
+++ b/FWCore/Integration/test/TrackOfThingsProducer.cc
@@ -51,8 +51,7 @@ namespace edmtest {
 
   void TrackOfThingsProducer::produce(edm::Event& event, edm::EventSetup const&) {
 
-    edm::Handle<ThingCollection> inputCollection;
-    event.getByToken(inputToken_, inputCollection);
+    edm::Handle<ThingCollection> inputCollection = event.getHandle(inputToken_);
 
     auto result = std::make_unique<TrackOfThingsCollection>();
 

--- a/FWCore/Integration/test/WaitingThreadIntProducer.cc
+++ b/FWCore/Integration/test/WaitingThreadIntProducer.cc
@@ -237,9 +237,7 @@ namespace edmtest {
     std::vector<int> retrieved;
     
     for(auto const& token: m_tokens) {
-      edm::Handle<IntProduct> handle;
-      e.getByToken(token, handle);
-      retrieved.push_back(handle->value);
+      retrieved.push_back(e.get(token).value);
     }
     
     std::vector<int> values;

--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -85,8 +85,7 @@ namespace edm {
        BranchDescription const* branchDescription = product.first;
        TypeID const& tid = branchDescription->unwrappedTypeID();
        EDGetToken const& token = product.second;
-       BasicHandle bh;
-       p.getByToken(token, tid, bh);
+       BasicHandle bh = p.getByToken(token, tid);
        if(nullptr != bh.provenance() && bh.provenance()->branchDescription().branchID() != branchDescription->branchID()) {
          throw cms::Exception("BranchIDMissMatch") << "While processing " << id << " getByToken request for " << branchDescription->moduleLabel()
             << " '" << branchDescription->productInstanceName() << "' " << branchDescription->processName()

--- a/FWCore/Modules/src/LogErrorFilter.cc
+++ b/FWCore/Modules/src/LogErrorFilter.cc
@@ -101,12 +101,8 @@ LogErrorFilter::~LogErrorFilter() {
 // ------------ method called on each new Event  ------------
 bool
 LogErrorFilter::filter(edm::Event& iEvent, edm::EventSetup const&) {
-  edm::Handle<std::vector<edm::ErrorSummaryEntry> > errorsAndWarnings;
-  iEvent.getByToken(harvesterToken_,errorsAndWarnings);
 
-  if(errorsAndWarnings.failedToGet()) {
-    return false;
-  } else {
+  if(auto errorsAndWarnings = iEvent.getHandle(harvesterToken_)) {
     if (useThresholdsPerKind_){
       unsigned int errorsBelowThreshold = 0;
       unsigned int warningsBelowThreshold = 0;

--- a/FWCore/Modules/src/PathStatusFilter.cc
+++ b/FWCore/Modules/src/PathStatusFilter.cc
@@ -112,9 +112,7 @@ namespace edm {
       }
 
       bool evaluate(Event const& event) const override {
-        Handle<PathStatus> handle;
-        event.getByToken(token_, handle);
-        return handle->accept();
+        return event.get(token_).accept();
       }
 
     private:

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -117,8 +117,7 @@ namespace edm {
         idToBranchDescriptions[branchID] = branchDescription;
         TypeID const& tid(branchDescription->unwrappedTypeID());
         EDGetToken const& token = product.second;
-        BasicHandle bh;
-        e.getByToken(token, tid, bh);
+        BasicHandle bh = e.getByToken(token, tid);
              bool cannotFindProductProvenance=false;
              if(!(bh.provenance() and bh.provenance()->productProvenance())) {
                 missingProductProvenance.insert(branchID);

--- a/FWCore/Modules/src/TimeStudyModules.cc
+++ b/FWCore/Modules/src/TimeStudyModules.cc
@@ -58,9 +58,8 @@ namespace timestudy {
 
       void
       getAndSleep(edm::Event const& e) const {
-        edm::Handle<int> h;
         for(auto const&t: tokens_) {
-          e.getByToken(t,h);
+          (void) e.getHandle(t);
         }
         //Event number minimum value is 1
         usleep( eventTimes_[ (e.id().event()-1) % eventTimes_.size()]);

--- a/FWCore/Skeletons/scripts/mkTemplates/EDAnalyzer/EDAnalyzer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDAnalyzer/EDAnalyzer.cc
@@ -107,20 +107,11 @@ __class__::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
    using namespace edm;
 
-    Handle<TrackCollection> tracks;
-    iEvent.getByToken(tracksToken_, tracks);
-    for(TrackCollection::const_iterator itTrack = tracks->begin();
-        itTrack != tracks->end();
-        ++itTrack) {
+   for(const auto& track : iEvent.get(tracksToken_) ) {
       // do something with track parameters, e.g, plot the charge.
-      // int charge = itTrack->charge();
-@example_histo       histo->Fill( itTrack->charge() );
-    }
-
-#ifdef THIS_IS_AN_EVENT_EXAMPLE
-   Handle<ExampleData> pIn;
-   iEvent.getByLabel("example",pIn);
-#endif
+      // int charge = track.charge();
+@example_histo       histo->Fill( track.charge() );
+   }
 
 #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
    ESHandle<SetupData> pSetup;

--- a/IOPool/Input/test/IOExerciser.cc
+++ b/IOPool/Input/test/IOExerciser.cc
@@ -150,9 +150,7 @@ IOExerciser::write(edm::EventForOutput const& e)
 
    for (auto const& product : products_to_use)
    {
-      edm::BasicHandle result;
-
-      e.getByToken(product.token(), product.type(), result);
+      edm::BasicHandle result = e.getByToken(product.token(), product.type());
       ctr++;
    }
    edm::LogInfo("IOExerciser") << "IOExerciser read out " << ctr << " products.";

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -725,11 +725,10 @@ namespace edm {
 
       WrapperBase const* product = nullptr;
       ProductProvenance const* productProvenance = nullptr;
-      BasicHandle result;
       if(getProd) {
-        bool found = occurrence.getByToken(item.token_, item.branchDescription_->unwrappedTypeID(), result);
+        BasicHandle result = occurrence.getByToken(item.token_, item.branchDescription_->unwrappedTypeID());
         product = result.wrapper();
-        if(found && keepProvenance) {
+        if(result.isValid() && keepProvenance) {
           productProvenance = result.provenance()->productProvenance();
         }
         if(product == nullptr) {

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -122,8 +122,7 @@ namespace edm {
                                                     nullptr,
                                                     nullptr);
     assert(bhandle.isValid());
-    Handle<edmtest::UInt64Product> handle;
-    convert_handle<edmtest::UInt64Product>(std::move(bhandle), handle);
+    Handle<edmtest::UInt64Product> handle = convert_handle<edmtest::UInt64Product>(std::move(bhandle));
     assert(static_cast<EventNumber_t>(handle->value) == en);
 
     // Check that primary source products are retrieved from the same event as the EventAuxiliary

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -150,8 +150,7 @@ namespace edm {
 
     for(auto const& selection : *selections_) {
       BranchDescription const& desc = *selection.first;
-      BasicHandle result;
-      event.getByToken(selection.second, desc.unwrappedTypeID(), result);
+      BasicHandle result = event.getByToken(selection.second, desc.unwrappedTypeID());
       if(!result.isValid()) {
         // No product with this ID was put in the event.
         // Create and write the provenance.

--- a/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
+++ b/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
@@ -43,7 +43,7 @@ public:
   bool
   getByLabel(edm::InputTag const& tag, edm::Handle<T>& result) const {
     edm::BasicHandle bh = principal_.getByLabel(edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), tag, nullptr, nullptr, mcc_);
-    convert_handle(std::move(bh), result);
+    result = edm::convert_handle<T>(std::move(bh));
     return result.isValid();
   }
 


### PR DESCRIPTION
By using an `edm::EDGetTokenT<T>` one can now do
```C++
auto const& tracks = event.get(tracksToken);
```
or if one needs the `edm::Handle`
```C++
auto hTracks = event.getHandle(tracksToken);
```