### PR TITLE
fixed a memory issue caused by ME1a half strip value 

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.h
@@ -67,6 +67,8 @@ public:
 protected:
 
   virtual const CSCGEMMotherboardLUT* getLUT() const=0;
+  // check wether wiregroup corss strip or not. ME11 case would redefine this function
+  virtual bool doesWiregroupCrossStrip(int key_wg, int key_strip) const {return true;}
 
   // check if a GEMDetId is valid
   bool isGEMDetId(unsigned int) const;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -430,6 +430,11 @@ bool CSCGEMMotherboardME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLC
   return cscTmbLUT_->doesALCTCrossCLCT(a, c, theEndcap, gangedME1a_);
 }
 
+bool CSCGEMMotherboardME11::doesWiregroupCrossStrip(int key_wg, int key_strip) const
+{
+  return cscTmbLUT_->doesWiregroupCrossStrip(key_wg, key_strip, theEndcap, gangedME1a_);
+}
+
 
 void CSCGEMMotherboardME11::correlateLCTsGEM(const CSCALCTDigi& bALCT,
                                              const CSCALCTDigi& sALCT,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -325,20 +325,20 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
 
 std::vector<CSCCorrelatedLCTDigi> CSCGEMMotherboardME11::readoutLCTs1a() const
 {
-  return readoutLCTs(ME1A);
+  return readoutLCTsME11(ME1A);
 }
 
 
 std::vector<CSCCorrelatedLCTDigi> CSCGEMMotherboardME11::readoutLCTs1b() const
 {
-  return readoutLCTs(ME1B);
+  return readoutLCTsME11(ME1B);
 }
 
 
 // Returns vector of read-out correlated LCTs, if any.  Starts with
 // the vector of all found LCTs and selects the ones in the read-out
 // time window.
-std::vector<CSCCorrelatedLCTDigi> CSCGEMMotherboardME11::readoutLCTs(enum CSCPart me1ab) const
+std::vector<CSCCorrelatedLCTDigi> CSCGEMMotherboardME11::readoutLCTsME11(enum CSCPart me1ab) const
 {
   std::vector<CSCCorrelatedLCTDigi> tmpV;
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.h
@@ -46,7 +46,7 @@ class CSCGEMMotherboardME11 : public CSCGEMMotherboard
   std::unique_ptr<CSCMotherboardLUTME11> cscTmbLUT_;
 
   /* readout the LCTs in a sector of ME11 */
-  std::vector<CSCCorrelatedLCTDigi> readoutLCTs(enum CSCPart me1ab) const;
+  std::vector<CSCCorrelatedLCTDigi> readoutLCTsME11(enum CSCPart me1ab) const;
 
   /** Methods to sort the LCTs */
   void sortLCTs(std::vector<CSCCorrelatedLCTDigi>&, int bx,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.h
@@ -57,6 +57,9 @@ class CSCGEMMotherboardME11 : public CSCGEMMotherboard
   /* check if an ALCT cross a CLCT in an ME11 sector */
   bool doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c) const;
 
+  /* does wiregroup cross halfstrip or not */
+  bool doesWiregroupCrossStrip(int key_wg, int key_hs) const override;
+
   /* correlate a pair of ALCTs and a pair of CLCTs with matched pads or copads
      the output is up to two LCTs in a sector of ME11 */
   void correlateLCTsGEM(const CSCALCTDigi& bestALCT,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.h
@@ -43,6 +43,9 @@ class CSCGEMMotherboardME21 : public CSCGEMMotherboard
   const CSCGEMMotherboardLUTME21* getLUT() const override {return tmbLUT_.get();}
   std::unique_ptr<CSCGEMMotherboardLUTME21> tmbLUT_;
 
+  /* does wiregroup cross halfstrip or not */
+  bool doesWiregroupCrossStrip(int key_wg, int key_strip) const {return true;}
+
   /* correlate a pair of ALCTs and a pair of CLCTs with matched pads or copads
      the output is up to two LCTs in a sector of ME21 */
   void correlateLCTsGEM(const CSCALCTDigi& bestALCT,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.h
@@ -44,7 +44,7 @@ class CSCGEMMotherboardME21 : public CSCGEMMotherboard
   std::unique_ptr<CSCGEMMotherboardLUTME21> tmbLUT_;
 
   /* does wiregroup cross halfstrip or not */
-  bool doesWiregroupCrossStrip(int key_wg, int key_strip) const {return true;}
+  bool doesWiregroupCrossStrip(int key_wg, int key_strip) const override {return true;}
 
   /* correlate a pair of ALCTs and a pair of CLCTs with matched pads or copads
      the output is up to two LCTs in a sector of ME21 */

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.cc
@@ -52,6 +52,14 @@ CSCMotherboardLUTME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi
    if ( !c.isValid() || !a.isValid() ) return false;
    int key_hs = c.getKeyStrip();
    int key_wg = a.getKeyWG();
+   return doesWiregroupCrossStrip(key_wg, key_hs, theEndcap, gangedME1a);
+ }
+
+
+bool
+CSCMotherboardLUTME11::doesWiregroupCrossStrip(int key_wg, int key_hs,
+                                         int theEndcap, bool gangedME1a) const
+ {
    // ME1/a half-strip starts at 128
    if ( key_hs > CSCConstants::MAX_HALF_STRIP_ME1B )
      {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboardLUT.h
@@ -19,6 +19,8 @@ class CSCMotherboardLUTME11
   ~CSCMotherboardLUTME11() {}
   bool doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c,
                          int theEndcap, bool gangedME1a = false) const;
+  bool doesWiregroupCrossStrip(int wg, int keystrip, int theEndcap, bool gangedME1a = false) const;
+
  private:
   // LUT for which ME1/1 wire group can cross which ME1/a halfstrip
   // 1st index: WG number


### PR DESCRIPTION
 CLCT halfstrip from ME1a is from 128-223 while a LUT using halfstrip expects that halfstrip of ME1a is from 0-95. this bug caused the memory issue in #25709 