### PR TITLE
Add MTD TimeCalibration (for the moment to remove time offset in BTL) [10_4_X backport of 25634]

### DIFF
--- a/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_cff.py
+++ b/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_cff.py
@@ -12,6 +12,7 @@ from RecoLocalFastTime.FTLRecProducers.mtdTrackingRecHits_cfi import mtdTracking
 from RecoLocalFastTime.FTLClusterizer.mtdClusters_cfi import mtdClusters
 
 from RecoLocalFastTime.FTLClusterizer.MTDCPEESProducers_cff import *
+from RecoLocalFastTime.FTLRecProducers.MTDTimeCalibESProducers_cff import *
 
 _phase2_timing_layer_fastTimingLocalReco = cms.Sequence(mtdUncalibratedRecHits*mtdRecHits*mtdClusters*mtdTrackingRecHits)
 

--- a/RecoLocalFastTime/FTLCommonAlgos/BuildFile.xml
+++ b/RecoLocalFastTime/FTLCommonAlgos/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="Geometry/HGCalGeometry"/>
 <use   name="Geometry/Records"/>
+<use   name="Geometry/MTDGeometryBuilder"/>
 <use   name="DataFormats/FTLRecHit"/>
 <use   name="clhep"/>
 <export>

--- a/RecoLocalFastTime/FTLCommonAlgos/interface/MTDTimeCalib.h
+++ b/RecoLocalFastTime/FTLCommonAlgos/interface/MTDTimeCalib.h
@@ -1,0 +1,32 @@
+#ifndef RecoLocalFastTime_FTLCommonAlgos_MTDTimeCalib_H
+#define RecoLocalFastTime_FTLCommonAlgos_MTDTimeCalib_H 1
+
+#include "DataFormats/ForwardDetId/interface/MTDDetId.h"
+
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class MTDTimeCalib
+{
+ public:
+  //constructor & destructor
+  MTDTimeCalib(edm::ParameterSet const& conf, const MTDGeometry* geom, const MTDTopology* topo);  
+  ~MTDTimeCalib() {};
+
+  //accessors
+  float getTimeCalib(const MTDDetId& id) const;
+
+ private:
+  const MTDGeometry* geom_;
+  const MTDTopology* topo_;
+  float btlTimeOffset_;
+  float etlTimeOffset_;
+
+  //specific paramters from BTL simulation
+  float btlLightCollTime_;
+  float btlLightCollSlope_;
+};
+
+#endif

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/BuildFile.xml
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="Geometry/CaloGeometry"/>
 <use   name="RecoLocalFastTime/FTLCommonAlgos"/>
+<use   name="RecoLocalFastTime/Records"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/HGCDigi"/>

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
@@ -1,5 +1,8 @@
 #include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDRecHitAlgoBase.h"
 
+#include "RecoLocalFastTime/Records/interface/MTDTimeCalibRecord.h"
+#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDTimeCalib.h"
+
 class MTDRecHitAlgo : public MTDRecHitAlgoBase {
  public:
   /// Constructor
@@ -14,15 +17,22 @@ class MTDRecHitAlgo : public MTDRecHitAlgoBase {
 
   /// get event and eventsetup information
   void getEvent(const edm::Event&) final {}
-  void getEventSetup(const edm::EventSetup&) final {}
+  void getEventSetup(const edm::EventSetup&) final;
 
   /// make the rec hit
   FTLRecHit makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32_t& flags ) const final;
 
- private:  
+private:  
   double thresholdToKeep_, calibration_;
+  const MTDTimeCalib* time_calib_;
 };
 
+void MTDRecHitAlgo::getEventSetup(const edm::EventSetup& es)
+{
+    edm::ESHandle<MTDTimeCalib> pTC;
+    es.get<MTDTimeCalibRecord>().get("MTDTimeCalib",pTC);
+    time_calib_ = pTC.product();
+}
 
 FTLRecHit 
 MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32_t& flags) const {
@@ -59,9 +69,12 @@ MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32_t& flags)
       break ;
     }
   }
-
+  
   // --- Energy calibration: for the time being this is just a conversion pC --> MeV
   energy *= calibration_;
+
+  // --- Time calibration: for the time being just removes a time offset in BTL
+  time += time_calib_->getTimeCalib( uRecHit.id() );
 
   FTLRecHit rh( uRecHit.id(), uRecHit.row(), uRecHit.column(), energy, time, timeError );
     

--- a/RecoLocalFastTime/FTLCommonAlgos/src/MTDTimeCalib.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/src/MTDTimeCalib.cc
@@ -1,0 +1,86 @@
+#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDTimeCalib.h"
+
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
+#include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
+#include "Geometry/MTDNumberingBuilder/interface/GeometricTimingDet.h"
+
+MTDTimeCalib::MTDTimeCalib(edm::ParameterSet const& conf, 
+			   const MTDGeometry* geom, const MTDTopology* topo):
+  geom_(geom),
+  topo_(topo),
+  btlTimeOffset_( conf.getParameter<double>("BTLTimeOffset") ),
+  etlTimeOffset_( conf.getParameter<double>("ETLTimeOffset") ),
+  btlLightCollTime_( conf.getParameter<double>("BTLLightCollTime") ),
+  btlLightCollSlope_( conf.getParameter<double>("BTLLightCollSlope") )
+{
+}
+ 
+
+float MTDTimeCalib::getTimeCalib(const MTDDetId& id) const
+{
+  if (id.subDetector() != MTDDetId::FastTime)
+    {
+      throw cms::Exception("MTDTimeCalib") << "MTDDetId: " << std::hex
+						      << id.rawId()
+						      << " is invalid!" << std::dec
+						      << std::endl;
+    }
+
+  float time_calib = 0.;
+
+  if ( id.mtdSubDetector() == MTDDetId::BTL )
+    {
+      time_calib += btlTimeOffset_;
+      BTLDetId hitId(id);
+      DetId geoId = hitId.geographicalId( (BTLDetId::CrysLayout) topo_->getMTDTopologyMode() ); //for BTL topology gives different layout id
+      const MTDGeomDet* thedet = geom_->idToDet(geoId);
+      
+      if( thedet == nullptr ) {
+	throw cms::Exception("MTDTimeCalib") << "GeographicalID: " << std::hex
+					      << geoId.rawId()
+						<< " (" << id.rawId()<< ") is invalid!" << std::dec
+						<< std::endl;
+      }
+      const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+      const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());    
+      
+      if ( topo_->getMTDTopologyMode() == (int) BTLDetId::CrysLayout::tile )
+	{
+	  time_calib -= btlLightCollTime_; //simply remove the offset introduced at sim level
+	}
+      else if ( topo_->getMTDTopologyMode() == (int) BTLDetId::CrysLayout::bar ||
+		topo_->getMTDTopologyMode() == (int) BTLDetId::CrysLayout::barphiflat 
+		)
+	{
+	  //for bars in phi
+	  time_calib -= 0.5*topo.pitch().first*btlLightCollSlope_; //time offset for bar time is L/2v 
+	}
+      else if ( topo_->getMTDTopologyMode() == (int) BTLDetId::CrysLayout::barzflat ) 
+	{
+	  //for bars in z
+	  time_calib -= 0.5*topo.pitch().second*btlLightCollSlope_; //time offset for bar time is L/2v 
+	}
+    }
+  else if ( id.mtdSubDetector() == MTDDetId::ETL )
+    {
+      time_calib += etlTimeOffset_;
+    }
+  else
+    {
+      throw cms::Exception("MTDTimeCalib") << "MTDDetId: " << std::hex
+						      << id.rawId()
+						      << " is invalid!" << std::dec
+						      << std::endl;
+    }
+
+  return time_calib;
+}
+
+#include "FWCore/Utilities/interface/typelookup.h"
+
+//--- Now use the Framework macros to set it all up:
+TYPELOOKUP_DATA_REG(MTDTimeCalib);

--- a/RecoLocalFastTime/FTLRecProducers/BuildFile.xml
+++ b/RecoLocalFastTime/FTLRecProducers/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Framework"/>
+<use   name="FWCore/Utilities"/>
 <use   name="Geometry/MTDGeometryBuilder"/>
 <use   name="DataFormats/TrackerRecHit2D"/>
 <export>

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDTimeCalibESProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDTimeCalibESProducer.cc
@@ -1,0 +1,77 @@
+#include "RecoLocalFastTime/Records/interface/MTDTimeCalibRecord.h"
+
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/Records/interface/MTDTopologyRcd.h"
+
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+
+#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDTimeCalib.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <string>
+#include <memory>
+
+using namespace edm;
+
+class  MTDTimeCalibESProducer: public edm::ESProducer
+{
+ public:
+  MTDTimeCalibESProducer(const edm::ParameterSet & p);
+  ~MTDTimeCalibESProducer() override = default; 
+
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+  std::unique_ptr<MTDTimeCalib> produce(const MTDTimeCalibRecord &);
+  
+ private:
+  edm::ParameterSet pset_;
+};
+
+
+MTDTimeCalibESProducer::MTDTimeCalibESProducer(const edm::ParameterSet & p) 
+{
+  pset_ = p;
+  setWhatProduced(this,"MTDTimeCalib");
+}
+
+// Configuration descriptions
+void
+MTDTimeCalibESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("BTLTimeOffset", 0.)->
+    setComment("Time offset (additive) to all the BTL RecHits [ns]");
+  desc.add<double>("ETLTimeOffset", 0.)->
+    setComment("Time offset (additive) to all the ETL RecHits [ns]");
+  desc.add<double>("BTLLightCollTime", 0.2)->
+    setComment("Light collection time for BTL tile geometry [ns]");
+  desc.add<double>("BTLLightCollSlope", 0.075)->
+    setComment("Light collection slope for bar for BTL bar tile geometry [ns/cm]");
+  descriptions.add("MTDTimeCalibESProducer", desc);
+}
+
+std::unique_ptr<MTDTimeCalib>
+MTDTimeCalibESProducer::produce(const MTDTimeCalibRecord & iRecord)
+{ 
+  edm::ESHandle<MTDGeometry> pDD;
+  iRecord.getRecord<MTDDigiGeometryRecord>().get( pDD );
+  
+  edm::ESHandle<MTDTopology> pTopo;
+  iRecord.getRecord<MTDTopologyRcd>().get( pTopo );
+  
+  return std::make_unique<MTDTimeCalib>(
+					    pset_,
+					    pDD.product(),
+					    pTopo.product()
+					    );
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_EVENTSETUP_MODULE(MTDTimeCalibESProducer);

--- a/RecoLocalFastTime/FTLRecProducers/python/MTDTimeCalibESProducers_cff.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/MTDTimeCalibESProducers_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoLocalFastTime.FTLRecProducers.MTDTimeCalibESProducer_cfi import *
+
+# the following numbers are obtained on single pions 0.7-10 GeV noPU
+# to have backpropagated time average at 0
+MTDTimeCalibESProducer.BTLTimeOffset = cms.double(0.0115)
+MTDTimeCalibESProducer.ETLTimeOffset = cms.double(0.0066)

--- a/RecoLocalFastTime/Records/interface/MTDTimeCalibRecord.h
+++ b/RecoLocalFastTime/Records/interface/MTDTimeCalibRecord.h
@@ -1,0 +1,14 @@
+#ifndef RecoLocalFastTime_Records_MTDTimeCalibRecord_h
+#define RecoLocalFastTime_Records_MTDTimeCalibRecord_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/Records/interface/MTDTopologyRcd.h"
+
+#include "boost/mpl/vector.hpp"
+
+class  MTDTimeCalibRecord: public edm::eventsetup::DependentRecordImplementation<MTDTimeCalibRecord,
+  boost::mpl::vector<MTDDigiGeometryRecord,MTDTopologyRcd> > {};
+
+#endif 

--- a/RecoLocalFastTime/Records/src/MTDTimeCalibRecord.cc
+++ b/RecoLocalFastTime/Records/src/MTDTimeCalibRecord.cc
@@ -1,0 +1,4 @@
+#include "RecoLocalFastTime/Records/interface/MTDTimeCalibRecord.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(MTDTimeCalibRecord);


### PR DESCRIPTION
Add MTD TimeCalibration (for the moment to remove time offset in BTL)

(cherry picked from commit a063fe65e8dd542f4a4bc2a12bd1dc5e88e795a5)

fixes exception names

(cherry picked from commit 84ba63c3bb133de38820b11f0dc003ec949f0b15)

addressing PR review comments

(cherry picked from commit 1862fbc6b0e14629bfee7c6012e4cffd660f2301)

code review & correct small offset measured on backpropagated tracks in BTL & ETL

(cherry picked from commit 4731039479ab63ef629dcee6dcf6c941ad6b6b34)

add description

(cherry picked from commit 5c146c7e0b5eec0aa0923cdce4bead5f5974a20d)

backport #25634 