### PR TITLE
Adding time threshold compatibility to MTDThrehsoldClusterizer [10_4_X backport of 25644]

### DIFF
--- a/RecoLocalFastTime/FTLClusterizer/interface/MTDThresholdClusterizer.h
+++ b/RecoLocalFastTime/FTLClusterizer/interface/MTDThresholdClusterizer.h
@@ -71,6 +71,7 @@ class MTDThresholdClusterizer : public MTDClusterizerBase {
   float theHitThreshold;    // Hit threshold 
   float theSeedThreshold;     // MTD cluster seed 
   float theClusterThreshold;  // Cluster threshold 
+  float theTimeThreshold; // Time compatibility between new hit and seed
 
   //! Geometry-related information
   int  theNumOfRows;

--- a/RecoLocalFastTime/FTLClusterizer/plugins/MTDClusterProducer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/plugins/MTDClusterProducer.cc
@@ -106,9 +106,7 @@ MTDClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<std::string>("BarrelClusterName", "FTLBarrel");
   desc.add<std::string>("EndcapClusterName", "FTLEndcap");
   desc.add<std::string>("ClusterMode","MTDThresholdClusterizer");
-  desc.add<double>("HitThreshold", 0.);
-  desc.add<double>("SeedThreshold", 0.);
-  desc.add<double>("ClusterThreshold", 0.);
+  MTDThresholdClusterizer::fillDescriptions(desc);
   descriptions.add("mtdClusterProducer", desc);
 }
   

--- a/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
@@ -31,6 +31,7 @@ MTDThresholdClusterizer::MTDThresholdClusterizer
     theHitThreshold( conf.getParameter<double>("HitThreshold") ),
     theSeedThreshold( conf.getParameter<double>("SeedThreshold") ),
     theClusterThreshold( conf.getParameter<double>("ClusterThreshold") ),
+    theTimeThreshold( conf.getParameter<double>("TimeThreshold") ),
     theNumOfRows(0), theNumOfCols(0), theCurrentId(0), 
     theBuffer(theNumOfRows, theNumOfCols ),
     bufferAlreadySet(false)
@@ -46,6 +47,7 @@ MTDThresholdClusterizer::fillDescriptions(edm::ParameterSetDescription& desc) {
   desc.add<double>("HitThreshold", 0.);
   desc.add<double>("SeedThreshold", 0.);
   desc.add<double>("ClusterThreshold", 0.);
+  desc.add<double>("TimeThreshold", 10.);
 }
 
 //----------------------------------------------------------------------------
@@ -256,6 +258,8 @@ MTDThresholdClusterizer::make_cluster( const FTLCluster::FTLHitPos& hit )
       for ( auto c = std::max(0,int(acluster.y[curInd]-1)); c < std::min(int(acluster.y[curInd]+2),int(theBuffer.columns())) && !stopClus; ++c) {
 	  for ( auto r = std::max(0,int(acluster.x[curInd]-1)); r < std::min(int(acluster.x[curInd]+2),int(theBuffer.rows()))  && !stopClus; ++r)  {
 	  if ( theBuffer.energy(r,c) > theHitThreshold) {
+	    if (std::abs(theBuffer.time(r,c) - seed_time) > theTimeThreshold*sqrt( theBuffer.time_error(r,c)*theBuffer.time_error(r,c) + seed_time_error*seed_time_error))
+	      continue;
 	    FTLCluster::FTLHitPos newhit(r,c);
 	    if (!acluster.add( newhit, theBuffer.energy(r,c), theBuffer.time(r,c), theBuffer.time_error(r,c))) 
 	      {


### PR DESCRIPTION
adding time threshold compatibility to MTDThrehsoldClusterizer

(cherry picked from commit b995bc8649fdfa77505ef3d9d8471eb7c57a4e40)

consistent default threshold value

(cherry picked from commit 25168a7aad6637dcbeeccab611b26a6e188632b9)

use std::abs

(cherry picked from commit 00c9e349f4af53e4a7fbb212a7a2f3633812dfb3)

fillDescription

(cherry picked from commit 027f20eb5a913a0dda6b929c56abf24437aedee5)

backport #25644