### PR TITLE
Fixed header problems in PhysicsTools/Utilities

### DIFF
--- a/PhysicsTools/Utilities/interface/Derivative.h
+++ b/PhysicsTools/Utilities/interface/Derivative.h
@@ -3,7 +3,7 @@
 
 #include "PhysicsTools/Utilities/interface/Functions.h"
 #include "PhysicsTools/Utilities/interface/Fraction.h"
-#include <boost/type_traits.hpp>
+#include <type_traits>
 
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
 
@@ -20,7 +20,7 @@ namespace funct {
   }
 
   TEMPL(XT1) struct Independent : 
-    public ::boost::is_same<DERIV(X, A), NUM(0)> { };
+    public ::std::is_same<DERIV(X, A), NUM(0)> { };
   
   // dx / dx = 1 
   DERIV_RULE(TYPX, X, NUM(1), num<1>());

--- a/PhysicsTools/Utilities/interface/Factorize.h
+++ b/PhysicsTools/Utilities/interface/Factorize.h
@@ -6,6 +6,7 @@
 #include "PhysicsTools/Utilities/interface/DecomposePower.h"
 #include "PhysicsTools/Utilities/interface/DecomposeProduct.h"
 #include <boost/type_traits.hpp>
+#include <boost/integer/common_factor.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/not.hpp>
 #include <boost/mpl/int.hpp>
@@ -83,7 +84,7 @@ namespace funct {
   }
   
   TEMPL(N2) struct Divides<NUM(n), NUM(m)> { 
-    enum { gcd = boost::math::static_gcd<tmpl::abs<n>::value, tmpl::abs<m>::value>::value };
+    enum { gcd = boost::integer::static_gcd<tmpl::abs<n>::value, tmpl::abs<m>::value>::value };
     static const bool value = (gcd != 1);
     typedef NUM(n) arg;
     typedef NUM(gcd) type;

--- a/PhysicsTools/Utilities/interface/Fraction.h
+++ b/PhysicsTools/Utilities/interface/Fraction.h
@@ -3,8 +3,7 @@
 
 #include "PhysicsTools/Utilities/interface/Numerical.h"
 #include "PhysicsTools/Utilities/interface/Operations.h"
-#include <boost/math/common_factor.hpp>
-#include <boost/static_assert.hpp>
+#include <boost/integer/common_factor.hpp>
 
 namespace funct {
 
@@ -18,7 +17,7 @@ namespace funct {
     double operator()(double, double) const { return double(n) / double (m); }
   };
   
-  template<int n, int m, unsigned gcd = boost::math::static_gcd<n, m>::value,
+  template<int n, int m, unsigned gcd = boost::integer::static_gcd<n, m>::value,
     int num = n / gcd, int den = m / gcd>
   struct PositiveFraction {
     typedef FractionStruct<num, den> type;

--- a/PhysicsTools/Utilities/interface/Primitive.h
+++ b/PhysicsTools/Utilities/interface/Primitive.h
@@ -6,7 +6,7 @@
 #include "PhysicsTools/Utilities/interface/Derivative.h"
 #include "PhysicsTools/Utilities/interface/Parameter.h"
 #include "PhysicsTools/Utilities/interface/Identity.h"
-#include <boost/type_traits.hpp>
+#include <type_traits>
 
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
 
@@ -156,8 +156,8 @@ namespace funct {
   //  /
   
   template <TYPXT2,
-    bool bint = not ::boost::is_same<PRIMIT(X, B), UndefinedIntegral>::value,
-    bool aint = not ::boost::is_same<PRIMIT(X, A), UndefinedIntegral>::value>
+    bool bint = not ::std::is_same<PRIMIT(X, B), UndefinedIntegral>::value,
+    bool aint = not ::std::is_same<PRIMIT(X, A), UndefinedIntegral>::value>
     struct PartIntegral {
       typedef UndefinedIntegral type;
       GET(PROD_S(A, B), type());
@@ -217,8 +217,8 @@ namespace funct {
   //  /
   
   template <TYPXT2,
-    bool bint = not ::boost::is_same<PRIMIT(X, RATIO(NUM(1), B)), UndefinedIntegral>::value,
-    bool aint = not ::boost::is_same<PRIMIT(X, A), UndefinedIntegral>::value>
+    bool bint = not ::std::is_same<PRIMIT(X, RATIO(NUM(1), B)), UndefinedIntegral>::value,
+    bool aint = not ::std::is_same<PRIMIT(X, A), UndefinedIntegral>::value>
     struct PartIntegral2 {
       typedef UndefinedIntegral type;
       GET(RATIO_S(A, B), type());

--- a/PhysicsTools/Utilities/interface/SimplifyProduct.h
+++ b/PhysicsTools/Utilities/interface/SimplifyProduct.h
@@ -6,6 +6,7 @@
 #include "PhysicsTools/Utilities/interface/DecomposePower.h"
 #include "PhysicsTools/Utilities/interface/ParametricTrait.h"
 #include <boost/mpl/if.hpp>
+#include <type_traits>
 
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
 
@@ -193,7 +194,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return f; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return g; }
-      enum { value = not ::boost::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     struct prod2 { 
       typedef G A; typedef H B; typedef F C;
@@ -202,7 +203,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return g; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return f; }
-      enum { value = not ::boost::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     
     typedef typename 

--- a/PhysicsTools/Utilities/interface/SimplifyRatio.h
+++ b/PhysicsTools/Utilities/interface/SimplifyRatio.h
@@ -12,6 +12,7 @@
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
 
 #include <boost/mpl/if.hpp>
+#include <type_traits>
 
 namespace funct {
 
@@ -188,7 +189,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return f; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return g; }
-      enum { value = not ::boost::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     struct prod2 { 
       typedef G A; typedef H B; typedef F C;
@@ -197,7 +198,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return g; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return f; }
-      enum { value = not ::boost::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     
     typedef typename 
@@ -255,7 +256,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return f; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return g; }
-      enum { value = not ::boost::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     struct prod2 { 
       typedef G A; typedef H B; typedef F C;
@@ -264,7 +265,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return g; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return f; }
-      enum { value = not ::boost::is_same<AB, base>::value };
+      enum { value = not ::std::is_same<AB, base>::value };
     };
     
     typedef typename 
@@ -313,12 +314,12 @@ namespace funct {
     struct ratio1 { 
       typedef RATIO_S(A, C) base;
       typedef RATIO(A, C) type;
-      enum { value = not ::boost::is_same<type, base>::value };
+      enum { value = not ::std::is_same<type, base>::value };
     };
     struct ratio2 { 
       typedef RATIO_S(B, C) base;
       typedef RATIO(B, C) type;
-      enum { value = not ::boost::is_same<type, base>::value };
+      enum { value = not ::std::is_same<type, base>::value };
     };
     typedef AuxSumRatio<A, B, C, ratio1::value or ratio2::value> aux;
     typedef typename aux::type type;

--- a/PhysicsTools/Utilities/interface/SimplifySum.h
+++ b/PhysicsTools/Utilities/interface/SimplifySum.h
@@ -7,7 +7,7 @@
 #include "PhysicsTools/Utilities/interface/Numerical.h"
 #include "PhysicsTools/Utilities/interface/DecomposeProduct.h"
 #include "PhysicsTools/Utilities/interface/ParametricTrait.h"
-#include <boost/type_traits.hpp>
+#include <type_traits>
 #include <boost/mpl/if.hpp>
 
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
@@ -149,7 +149,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return f; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return g; }
-      enum { value = not ::boost::is_same< AB, base >::value };
+      enum { value = not ::std::is_same< AB, base >::value };
     };
     struct prod2 { 
       typedef G A; typedef H B; typedef F C;
@@ -158,7 +158,7 @@ namespace funct {
       inline static const A& a(const F& f, const G& g, const H& h) { return g; }
       inline static const B& b(const F& f, const G& g, const H& h) { return h; }
       inline static const C& c(const F& f, const G& g, const H& h) { return f; }
-      enum { value = not ::boost::is_same< AB, base >::value };
+      enum { value = not ::std::is_same< AB, base >::value };
     };
     
     typedef typename 


### PR DESCRIPTION
- Boost had moved a header from /math to /integer
- There were includes missing in SimplifyProduct.h