### PR TITLE
Fix for conddb command line tool

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -1999,8 +1999,16 @@ def delete(args):
 
         Tag = session.get_dbtype(conddb.Tag)
         IOV = session.get_dbtype(conddb.IOV)
+        TagLog = session.get_dbtype(conddb.TagLog)
+        TagMetadata = session.get_dbtype(conddb.TagMetadata)
         session.query(IOV).\
             filter(IOV.tag_name == name).\
+            delete()
+        session.query(TagLog).\
+            filter(TagLog.tag_name == name).\
+            delete()
+        session.query(TagMetadata).\
+            filter(TagMetadata.tag_name == name).\
             delete()
         session.query(Tag).\
             filter(Tag.name == name).\


### PR DESCRIPTION
This PR contains a fix for the delete function in the conddb command.
The fix extends the queries to the TAG_LOG and TAG_METADATA tables, allowing the remove of the TAG