### PR TITLE
Adding IO rules to set PF cluster isolation in Ele/Phos: 104X

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -59,6 +59,9 @@
   <ioread sourceClass="pat::Electron"  targetClass="pat::Electron" version="[-28]" target="cachedIP_" source="std::vector<bool> cachedIP_" embed="false">
     <![CDATA[ cachedIP_ = onfile.cachedIP_[1] + 2*onfile.cachedIP_[2] + 4*onfile.cachedIP_[3] + 8*onfile.cachedIP_[4]; ]]>
   </ioread>
+  <ioread sourceClass="pat::Electron"  targetClass="pat::Electron" version="[-37]" target="" source="float ecalPFClusIso_;float hcalPFClusIso_">
+    <![CDATA[reco::GsfElectron::PflowIsolationVariables pfIsoVar = newObj->pfIsolationVariables();pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;newObj->setPfIsolationVariables(pfIsoVar);]]>
+  </ioread>
 
 
   <class name="pat::Muon"  ClassVersion="25">
@@ -233,6 +236,9 @@
   <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
   <ioread sourceClass="pat::Photon" targetClass="pat::Photon" version="[1-]" source="" target="superClusterRelinked_">
     <![CDATA[superClusterRelinked_.reset();]]>
+  </ioread>
+  <ioread sourceClass="pat::Photon"  targetClass="pat::Photon" version="[-20]" target="" source="float ecalPFClusIso_;float hcalPFClusIso_">
+    <![CDATA[reco::Photon::PflowIsolationVariables pfIsoVar = newObj->getPflowIsolationVariables();pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;newObj->setPflowIsolationVariables(pfIsoVar);]]>
   </ioread>
 
   <class name="pat::Jet"  ClassVersion="16">

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -60,7 +60,10 @@
     <![CDATA[ cachedIP_ = onfile.cachedIP_[1] + 2*onfile.cachedIP_[2] + 4*onfile.cachedIP_[3] + 8*onfile.cachedIP_[4]; ]]>
   </ioread>
   <ioread sourceClass="pat::Electron"  targetClass="pat::Electron" version="[-37]" target="" source="float ecalPFClusIso_;float hcalPFClusIso_">
-    <![CDATA[reco::GsfElectron::PflowIsolationVariables pfIsoVar = newObj->pfIsolationVariables();pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;newObj->setPfIsolationVariables(pfIsoVar);]]>
+    <![CDATA[reco::GsfElectron::PflowIsolationVariables pfIsoVar = newObj->pfIsolationVariables();
+             pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;
+             pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;
+             newObj->setPfIsolationVariables(pfIsoVar);]]>
   </ioread>
 
 
@@ -238,7 +241,10 @@
     <![CDATA[superClusterRelinked_.reset();]]>
   </ioread>
   <ioread sourceClass="pat::Photon"  targetClass="pat::Photon" version="[-20]" target="" source="float ecalPFClusIso_;float hcalPFClusIso_">
-    <![CDATA[reco::Photon::PflowIsolationVariables pfIsoVar = newObj->getPflowIsolationVariables();pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;newObj->setPflowIsolationVariables(pfIsoVar);]]>
+    <![CDATA[reco::Photon::PflowIsolationVariables pfIsoVar = newObj->getPflowIsolationVariables();
+             pfIsoVar.sumEcalClusterEt = onfile.ecalPFClusIso_;
+             pfIsoVar.sumHcalClusterEt = onfile.hcalPFClusIso_;
+             newObj->setPflowIsolationVariables(pfIsoVar);]]>
   </ioread>
 
   <class name="pat::Jet"  ClassVersion="16">


### PR DESCRIPTION
Dear All,

This is the backport of #25671 which is needed to fix a bug in reading the pf cluster isolation for pre-102X produced eles/phos in 102X+. Up to you if you want it for 104X, I would say so otherwise it would be surprising that it works for 102X and 105X but not 103X and 104X

Best,
Sam