### PR TITLE
Disable Rivet beam check

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -37,7 +37,7 @@ private:
   reco::Particle::Point genVertex_;
   
   Rivet::RivetAnalysis* rivetAnalysis_;
-	Rivet::AnalysisHandler analysisHandler_;
+  Rivet::AnalysisHandler analysisHandler_;
 
 };
 

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -33,6 +33,7 @@ ParticleLevelProducer::ParticleLevelProducer(const edm::ParameterSet& pset):
   produces<reco::GenParticleCollection>("tags");
   produces<reco::METCollection>("mets");
   
+  analysisHandler_.setIgnoreBeams(true);
   analysisHandler_.addAnalysis(rivetAnalysis_);
 }
 


### PR DESCRIPTION
Disable beam check to work for heavy ions and non-standard generators (LPAIR)