### PR TITLE
Remove overwriting of genreflex flags in L1TObjects

### DIFF
--- a/CondFormats/L1TObjects/BuildFile.xml
+++ b/CondFormats/L1TObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="boost"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>


### PR DESCRIPTION
This line was squashing genreflex flag `--cxxmodule` and was causing
an error in https://github.com/cms-sw/cmsdist/pull/4646, because of the
inconsistency between the rest of CMSSW libraries which were compiled with
`--cxxmodule`.