### PR TITLE
Removed unused variable from ME0SegAlgoRU

### DIFF
--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
@@ -426,7 +426,6 @@ void ME0SegAlgoRU::compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit,
 	const HitAndPosition * old_hit = nullptr;
 	HitAndPositionPtrContainer new_proto_segment = current_proto_segment;
 
-	HitAndPositionPtrContainer::const_iterator it;
 	for (auto it = new_proto_segment.begin(); it != new_proto_segment.end();) {
 		if ((*it)->layer == new_hit.layer) {
 			old_hit = *it;


### PR DESCRIPTION
This fixes a clang warning.