### PR TITLE
Removed unused variable from HLTV32DB

### DIFF
--- a/RecoLuminosity/LumiProducer/plugins/HLTV32DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/HLTV32DB.cc
@@ -411,7 +411,6 @@ namespace lumi{
 			HltResult::iterator hltItEnd,
 			HltPathMap& hltpathmap,
 			unsigned int commitintv){
-   HltResult::iterator hltIt;
    unsigned int totalcmsls=std::distance(hltItBeg,hltItEnd);
    std::cout<<"inserting totalcmsls "<<totalcmsls<<std::endl;
    coral::AttributeList lshltData;


### PR DESCRIPTION
This fixes a clang warning.