### PR TITLE
keep phase2_timing_layer functional

### DIFF
--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -186,7 +186,8 @@ _addTiming.append( cms.PSet( importerName = cms.string("TrackTimingImporter"),
                              ) 
                    )
 
-from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
+from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
 _addTimingLayer = particleFlowBlock.elementImporters.copy()
 _addTimingLayer.append( cms.PSet( importerName = cms.string("TrackTimingImporter"),
                              timeValueMap = cms.InputTag("tofPID:t0"),
@@ -204,7 +205,7 @@ phase2_timing.toModify(
     elementImporters = _addTiming
 )
 
-phase2_timing_layer.toModify(
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toModify(
     particleFlowBlock,
     elementImporters = _addTimingLayer
 )

--- a/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
@@ -25,8 +25,9 @@ phase2_timing.toModify(
     gsfTrackTimeErrorMap = cms.InputTag("gsfTrackTimeValueMapProducer:electronGsfTracksConfigurableFlatResolutionModelResolution"),
 )
 
-from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
-phase2_timing_layer.toModify(
+from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
+from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toModify(
     simPFProducer,
     trackTimeValueMap = cms.InputTag("tofPID:t0"),
     trackTimeErrorMap = cms.InputTag("tofPID:sigmat0"),

--- a/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
@@ -28,7 +28,8 @@ RecoVertexAOD = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
-from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
+from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
 
 _phase2_tktiming_RecoVertexEventContent = [ 'keep *_offlinePrimaryVertices4D__*',
                                             'keep *_offlinePrimaryVertices4DWithBS__*',
@@ -50,7 +51,7 @@ _phase2_tktiming_AddNewContent(RecoVertexAOD)
 
 def _phase2_tktiming_layer_AddNewContent(mod):
     temp = mod.outputCommands + _phase2_tktiming_layer_RecoVertexEventContent
-    phase2_timing_layer.toModify( mod, outputCommands = temp )
+    (phase2_timing_layer_tile | phase2_timing_layer_bar).toModify( mod, outputCommands = temp )
 
 _phase2_tktiming_layer_AddNewContent(RecoVertexFEVT)
 _phase2_tktiming_layer_AddNewContent(RecoVertexRECO)

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -85,10 +85,11 @@ _phase2_tktiming_layer_vertexrecoTask = cms.Task( _phase2_tktiming_vertexrecoTas
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toReplaceWith(vertexrecoTask, _phase2_tktiming_vertexrecoTask)
 
-from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
-phase2_timing_layer.toReplaceWith(vertexrecoTask, _phase2_tktiming_layer_vertexrecoTask)
-phase2_timing_layer.toReplaceWith(unsortedOfflinePrimaryVertices4D, unsortedOfflinePrimaryVertices4DwithPID.clone())
-phase2_timing_layer.toReplaceWith(offlinePrimaryVertices4D, offlinePrimaryVertices4DwithPID.clone())
-phase2_timing_layer.toReplaceWith(offlinePrimaryVertices4DWithBS, offlinePrimaryVertices4DwithPIDWithBS.clone())
-phase2_timing_layer.toModify(offlinePrimaryVertices4D, vertices = "unsortedOfflinePrimaryVertices4D", particles = "trackRefsForJetsBeforeSorting4D")
-phase2_timing_layer.toModify(offlinePrimaryVertices4DWithBS, vertices = "unsortedOfflinePrimaryVertices4D:WithBS", particles = "trackRefsForJetsBeforeSorting4D")
+from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
+from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(vertexrecoTask, _phase2_tktiming_layer_vertexrecoTask)
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(unsortedOfflinePrimaryVertices4D, unsortedOfflinePrimaryVertices4DwithPID.clone())
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(offlinePrimaryVertices4D, offlinePrimaryVertices4DwithPID.clone())
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(offlinePrimaryVertices4DWithBS, offlinePrimaryVertices4DwithPIDWithBS.clone())
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toModify(offlinePrimaryVertices4D, vertices = "unsortedOfflinePrimaryVertices4D", particles = "trackRefsForJetsBeforeSorting4D")
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toModify(offlinePrimaryVertices4DWithBS, vertices = "unsortedOfflinePrimaryVertices4D:WithBS", particles = "trackRefsForJetsBeforeSorting4D")

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -781,8 +781,8 @@ tracksValidationLite = cms.Sequence(
 ## customization for timing
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 phase2_timing_layer.toModify( generalTracksFromPV, 
-                              timesTag  = cms.InputTag('tofPID:t0'), 
-                              timeResosTag = cms.InputTag('tofPID:sigmat0'), 
+                              timesTag  = cms.InputTag('trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModel'), 
+                              timeResosTag = cms.InputTag('trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModelResolution'), 
                               nSigmaDtVertex = cms.double(3) )
 phase2_timing_layer.toModify( trackValidatorStandalone,
                               label_vertex = cms.untracked.InputTag('offlinePrimaryVertices4D') )
@@ -794,3 +794,9 @@ phase2_timing_layer.toModify( trackValidatorConversionStandalone,
                               label_vertex = cms.untracked.InputTag('offlinePrimaryVertices4D') )
 phase2_timing_layer.toModify( trackValidatorGsfTracks,
                               label_vertex = cms.untracked.InputTag('offlinePrimaryVertices4D') )
+
+from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
+from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toModify( generalTracksFromPV, 
+                              timesTag  = cms.InputTag('tofPID:t0'), 
+                              timeResosTag = cms.InputTag('tofPID:sigmat0') )


### PR DESCRIPTION
phase2_timing_layer era when used without phase2_timing_layer_tile or phase_2_timing_layer_bar does not include mtd global reco, and therefore the downstream changes to the 4d vertex reconstruction, etc to use fullsim inputs should not be activated in this case. 