### PR TITLE
Phase2-hgx177 Two new methods to carry out trigger imulation for scintillators

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -61,6 +61,8 @@ public:
   HGCalParameters::hgtrap getModule(unsigned int k, bool hexType, bool reco) const;
   std::vector<HGCalParameters::hgtrap> getModules() const; 
   const HGCalParameters* getParameter() const {return hgpar_;}
+  int                 getPhiBins(int lay) const;
+  std::pair<int,int>  getREtaRange(int lay) const;
   HGCalParameters::hgtrform getTrForm(unsigned int k) const {return hgpar_->getTrForm(k);}
   unsigned int        getTrFormN() const {return hgpar_->trformIndex_.size();}
   std::vector<HGCalParameters::hgtrform> getTrForms() const ;

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -412,19 +412,14 @@ std::vector<HGCalParameters::hgtrap> HGCalDDDConstants::getModules() const {
 }
 
 int HGCalDDDConstants::getPhiBins(int lay) const {
-  int nphi(0);
-  if (mode_ == HGCalGeometryMode::Trapezoid) {
-    int type  = hgpar_->scintType(lay);
-    nphi      = hgpar_->nPhiBinBH_[type];
-  }
-  return nphi;
+  return ((mode_ == HGCalGeometryMode::Trapezoid) ? hgpar_->scintCells(lay) : 0);
 }
 
 std::pair<int,int> HGCalDDDConstants::getREtaRange(int lay) const {
   int irmin(0), irmax(0);
   if (mode_ == HGCalGeometryMode::Trapezoid) {
     int indx = layerIndex(lay,false);
-    if ((indx >=0) && (indx < (int)(hgpar_->iradMinBH_.size()))) {
+    if ((indx >=0) && (indx < static_cast<int>(hgpar_->iradMinBH_.size()))) {
       irmin = hgpar_->iradMinBH_[indx];
       irmax = hgpar_->iradMaxBH_[indx];
     }

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -411,6 +411,27 @@ std::vector<HGCalParameters::hgtrap> HGCalDDDConstants::getModules() const {
   return mytrs;
 }
 
+int HGCalDDDConstants::getPhiBins(int lay) const {
+  int nphi(0);
+  if (mode_ == HGCalGeometryMode::Trapezoid) {
+    int type  = hgpar_->scintType(lay);
+    nphi      = hgpar_->nPhiBinBH_[type];
+  }
+  return nphi;
+}
+
+std::pair<int,int> HGCalDDDConstants::getREtaRange(int lay) const {
+  int irmin(0), irmax(0);
+  if (mode_ == HGCalGeometryMode::Trapezoid) {
+    int indx = layerIndex(lay,false);
+    if ((indx >=0) && (indx < (int)(hgpar_->iradMinBH_.size()))) {
+      irmin = hgpar_->iradMinBH_[indx];
+      irmax = hgpar_->iradMaxBH_[indx];
+    }
+  }
+  return std::make_pair(irmin,irmax);
+}
+
 std::vector<HGCalParameters::hgtrform> HGCalDDDConstants::getTrForms() const {
 
   std::vector<HGCalParameters::hgtrform> mytrs;

--- a/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
@@ -214,6 +214,18 @@ void HGCalNumberingTester::analyze( const edm::Event& iEvent, const edm::EventSe
       ++kk;
     }
   }
+
+  //For scintillators
+  if (hgdc.geomMode() == HGCalGeometryMode::Trapezoid) {
+    unsigned int kk(0);
+    for (auto const& lay : hgdc.getParameter()->layer_) {
+      auto rRange = hgdc.getREtaRange(lay);
+      std::cout << "[" << kk << "] Layer " << lay << " R/Eta " << rRange.first
+		<< ":" << rRange.second << " nPhi " << hgdc.getPhiBins(lay)
+		<< std::endl;
+      ++kk;
+    }
+  }
 }
 
 


### PR DESCRIPTION
2 new methods: int getPhiBins(int lay) and std::pair<int,int> getREtaRange(int lay) are introduced to provide # of phi bins and minimum/maximum r/eta index for a given layer