### PR TITLE
Pixel simulated bad channel info packed into FED raw data

### DIFF
--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -40,6 +40,7 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h"
 #include "FWCore/Utilities/interface/typedefs.h"
+#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 
 #include <vector>
 #include <map>
@@ -64,6 +65,8 @@ public:
   typedef std::pair<DetDigis::const_iterator, DetDigis::const_iterator> Range; 
   typedef std::vector<SiPixelRawDataError> DetErrors;
   typedef std::map<cms_uint32_t, DetErrors> Errors;
+  typedef std::vector<PixelFEDChannel> DetBadChannels;
+  typedef std::map<cms_uint32_t, DetBadChannels> BadChannels;
 
   typedef cms_uint32_t Word32;
   typedef cms_uint64_t Word64;
@@ -80,7 +83,7 @@ public:
 
   void interpretRawData(bool& errorsInEvent, int fedId,  const FEDRawData & data, Collection & digis, Errors & errors);
 
-  void formatRawData( unsigned int lvl1_ID, RawData & fedRawData, const Digis & digis);
+  void formatRawData( unsigned int lvl1_ID, RawData & fedRawData, const Digis & digis, const BadChannels & badChannels);
 
   cms_uint32_t linkId(cms_uint32_t word32) { return (word32 >> LINK_shift) & LINK_mask; }
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -65,7 +65,7 @@ public:
 
 private:
 
-  mutable std::atomic_flag lock_{ ATOMIC_FLAG_INIT };
+  mutable std::atomic_flag lock_ = ATOMIC_FLAG_INIT;
   CMS_THREAD_GUARD(lock_) mutable edm::ESWatcher<SiPixelFedCablingMapRcd> recordWatcher;
   CMS_THREAD_GUARD(lock_) mutable std::shared_ptr<pr::Cache> previousCache_;
   const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi; 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -30,6 +30,8 @@
 #include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
 #include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
 
+#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
+
 #include <atomic>
 #include <memory>
 
@@ -67,6 +69,7 @@ private:
   CMS_THREAD_GUARD(lock_) mutable edm::ESWatcher<SiPixelFedCablingMapRcd> recordWatcher;
   CMS_THREAD_GUARD(lock_) mutable std::shared_ptr<pr::Cache> previousCache_;
   const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi; 
+  const edm::EDGetTokenT<PixelFEDChannelCollection> theBadPixelFEDChannelsToken;
   const edm::EDPutTokenT<FEDRawDataCollection> putToken_;
   const bool usePilotBlade = false;  // I am not yet sure we need it here?
   const bool usePhase1;
@@ -76,6 +79,7 @@ using namespace std;
 
 SiPixelDigiToRaw::SiPixelDigiToRaw( const edm::ParameterSet& pset ) :
   tPixelDigi{ consumes<edm::DetSetVector<PixelDigi> >(pset.getParameter<edm::InputTag>("InputLabel")) },
+  theBadPixelFEDChannelsToken{ consumes<PixelFEDChannelCollection>(pset.getParameter<edm::InputTag>("InputLabel")) },
   putToken_{produces<FEDRawDataCollection>()},
   usePhase1{ pset.getParameter<bool> ("UsePhase1") }
 {
@@ -130,6 +134,25 @@ void SiPixelDigiToRaw::produce( edm::StreamID, edm::Event& ev,
 
   LogDebug("SiPixelDigiToRaw") << cache->cablingTree_->version();
 
+  PixelDataFormatter::BadChannels badChannels;
+  edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
+  if (ev.getByToken(theBadPixelFEDChannelsToken, pixelFEDChannelCollectionHandle)){
+    for (auto const& fedChannels: *pixelFEDChannelCollectionHandle) {
+      PixelDataFormatter::DetBadChannels detBadChannels;
+      for(const auto& fedChannel: fedChannels) {
+	sipixelobjects::CablingPathToDetUnit path={fedChannel.fed, fedChannel.link, 1};
+	if (cache->cablingTree_->findItem(path)!=nullptr) {
+	  detBadChannels.push_back(fedChannel);
+	} else {
+	  edm::LogError("SiPixelDigiToRaw")
+            <<" FED "<<fedChannel.fed<<" Link "<<fedChannel.link<<" for module "<<fedChannels.detId()
+            <<" marked bad, but this channel does not exist in the cabling map" <<endl;
+	}
+      } // channels reading a module
+      if (!detBadChannels.empty()) badChannels.insert({fedChannels.detId(), std::move(detBadChannels)});
+    } // loop on detId-s
+  }
+
   //PixelDataFormatter formatter(cablingTree_.get());
   PixelDataFormatter formatter(cache->cablingTree_.get(), usePhase1);
 
@@ -139,7 +162,7 @@ void SiPixelDigiToRaw::produce( edm::StreamID, edm::Event& ev,
   FEDRawDataCollection buffers;
 
   // convert data to raw
-  formatter.formatRawData( ev.id().event(), rawdata, digis );
+  formatter.formatRawData( ev.id().event(), rawdata, digis, badChannels);
 
   // pack raw data into collection
   for (auto const* fed: cache->cablingTree_->fedList()) {

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -58,7 +58,6 @@ SiPixelRawToDigi::SiPixelRawToDigi( const edm::ParameterSet& conf )
     usererrorlist = config_.getParameter<std::vector<int> > ("UserErrorList");
   }
   tFEDRawDataCollection = consumes <FEDRawDataCollection> (config_.getParameter<edm::InputTag>("InputLabel"));
-  theBadPixelFEDChannelsLabel = consumes<PixelFEDChannelCollection>(config_.getParameter<edm::InputTag>("BadPixelFEDChannelsInputLabel"));
   
   //start counters
   ndigis = 0;
@@ -153,7 +152,6 @@ SiPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
   desc.add<bool>("UsePhase1",false)->setComment("##  Use phase1");
   desc.add<std::string>("CablingMapLabel","")->setComment("CablingMap label"); //Tav
   desc.addOptional<bool>("CheckPixelOrder");  // never used, kept for back-compatibility
-  desc.add<edm::InputTag>("BadPixelFEDChannelsInputLabel",edm::InputTag("mix"));  
   descriptions.add("siPixelRawToDigi",desc);
   
 }
@@ -317,29 +315,12 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
     hDigi->Fill(formatter.nDigis());
   }
   
-
-  //------------------------------------
-  //send digis and errors back to framework 
-
-  edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
-  std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ = nullptr;  
-  if (ev.getByToken(theBadPixelFEDChannelsLabel, pixelFEDChannelCollectionHandle)){
-    
-    const PixelFEDChannelCollection * pfcc= pixelFEDChannelCollectionHandle.product();
-    PixelFEDChannelCollection_ = std::make_unique<PixelFEDChannelCollection>(*pfcc);
-  }
-  
   ev.put(std::move(collection));
   if(includeErrors){
     ev.put(std::move(errorcollection));
     ev.put(std::move(tkerror_detidcollection));
     ev.put(std::move(usererror_detidcollection), "UserErrorModules");      
-    if (PixelFEDChannelCollection_  == nullptr){
-      ev.put(std::move(disabled_channelcollection));
-    }
-    else{
-      ev.put(std::move(PixelFEDChannelCollection_));
-    }
+    ev.put(std::move(disabled_channelcollection));
   }
 }
 // declare this as a framework plugin

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -16,7 +16,6 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/CPUTimer.h"
-#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 
 class SiPixelFedCablingTree;
 class SiPixelFedCabling;
@@ -45,7 +44,6 @@ private:
   const SiPixelQuality* badPixelInfo_;
   PixelUnpackingRegions* regions_;
   edm::EDGetTokenT<FEDRawDataCollection> tFEDRawDataCollection; 
-  edm::EDGetTokenT<PixelFEDChannelCollection>  theBadPixelFEDChannelsLabel;
   TH1D *hCPU, *hDigi;
   std::unique_ptr<edm::CPUTimer> theTimer;
   bool includeErrors;

--- a/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
+++ b/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
@@ -20,5 +20,3 @@ siPixelDigis.CablingMapLabel = cms.string("")
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(siPixelDigis, UsePhase1=True)
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(siPixelDigis, BadPixelFEDChannelsInputLabel = "mixData")


### PR DESCRIPTION
This is the follow-up of the PR:
https://github.com/cms-sw/cmssw/pull/25466
in which simulation of bad components grouped by FED channels, randomly chosen from a collision data-driven set of configurations, were introduced.

Reminder: the killing of digis happens in the digitizer during simulation. The digitizer places a list of killed channels into the event in order for the tracking to be able to inactivate rechits in the empty modules. In real collisions, the FED FW generates an error code 25 associated to the channel from which no response is received upon a trigger (e.g. the module is turned off or the TBM gets stuck). The RawToDigi module unpacks these errors and places a list of bad channels into the event for tracking. In PR25466, the RawToDigi step replaced the default empty channel list output with the list from the digitizer.

In this PR, the channel list prepared by the digitizer is packed into the simulated FEDRawData, so that the unpacker do not need to handle simulation differently from data. By default, the bad channel simulation is turned off (in the digitizer config), no FED error 25 is simulated, and the unpacker produces an empty bad channel list.

Validation was done to check that the channel list produced by the unpacker agrees with the one from the digitizer, and running the same events before and after this modification to 10_4_0 with the feature turned on, the same number of clusters are created.

@mmusich @tsusa 