### PR TITLE
Added firstLuminosityBlockForEachRun to ProducerSourceBase

### DIFF
--- a/FWCore/Integration/test/ThingExtSource.cc
+++ b/FWCore/Integration/test/ThingExtSource.cc
@@ -97,6 +97,14 @@ namespace edmtest {
     r.put(std::move(result), "endRun");
   }
 
+  void
+  ThingExtSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.setComment("Creates ThingCollections from a file for testing.");
+    edm::ProducerSourceFromFiles::fillDescription(desc);
+    descriptions.add("source", desc);
+  }
+
 }
 using edmtest::ThingExtSource;
 DEFINE_FWK_INPUT_SOURCE(ThingExtSource);

--- a/FWCore/Integration/test/ThingExtSource.h
+++ b/FWCore/Integration/test/ThingExtSource.h
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Sources/interface/ProducerSourceFromFiles.h"
 #include "FWCore/Integration/test/ThingAlgorithm.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 namespace edmtest {
   class ThingExtSource : public edm::ProducerSourceFromFiles {
@@ -31,6 +32,7 @@ namespace edmtest {
 
     void beginLuminosityBlock(edm::LuminosityBlock& lb) override;
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
     //Not called by the framework, only used internally

--- a/FWCore/Integration/test/ThingSource.cc
+++ b/FWCore/Integration/test/ThingSource.cc
@@ -89,6 +89,16 @@ namespace edmtest {
     // Step D: Put outputs into event
     r.put(std::move(result), "endRun");
   }
+
+
+  void
+  ThingSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.setComment("Creates ThingCollections for testing.");
+    edm::ProducerSourceBase::fillDescription(desc);
+    descriptions.add("source", desc);
+  }
+
 }
 using edmtest::ThingSource;
 DEFINE_FWK_INPUT_SOURCE(ThingSource);

--- a/FWCore/Integration/test/ThingSource.h
+++ b/FWCore/Integration/test/ThingSource.h
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Integration/test/ThingAlgorithm.h"
 #include "FWCore/Sources/interface/ProducerSourceBase.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 namespace edmtest {
   class ThingSource : public edm::ProducerSourceBase {
@@ -31,6 +32,7 @@ namespace edmtest {
 
     void beginLuminosityBlock(edm::LuminosityBlock& lb) override;
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
     //called internally, not by the framework

--- a/FWCore/Integration/test/inputExtSourceTest_cfg.py
+++ b/FWCore/Integration/test/inputExtSourceTest_cfg.py
@@ -9,7 +9,6 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.source = cms.Source("ThingExtSource",
-    module_label = cms.untracked.string('Thing'),
     fileNames = cms.untracked.vstring('file:dummy')
 )
 

--- a/FWCore/Integration/test/inputSourceTest_cfg.py
+++ b/FWCore/Integration/test/inputSourceTest_cfg.py
@@ -8,8 +8,7 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(2)
 )
 
-process.source = cms.Source("ThingSource",
-    module_label = cms.untracked.string('Thing')
+process.source = cms.Source("ThingSource"
 )
 
 process.OtherThing = cms.EDProducer("OtherThingProducer",

--- a/FWCore/Modules/test/BuildFile.xml
+++ b/FWCore/Modules/test/BuildFile.xml
@@ -3,6 +3,7 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Modules/test FWCoreModulesTest.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <test name="TestFWCoreModulesEmptySourceLumiForRuns" command="cmsRun ${LOCALTOP}/src/FWCore/Modules/test/emptysource_firstLuminosityBlockForEachRun_cfg.py"/>
   <bin file="test_catch2_*.cc" name="TestFWCoreModulesTP">
     <use name="FWCore/TestProcessor"/>
     <use name="catch2"/>

--- a/FWCore/Modules/test/emptysource_firstLuminosityBlockForEachRun_cfg.py
+++ b/FWCore/Modules/test/emptysource_firstLuminosityBlockForEachRun_cfg.py
@@ -1,0 +1,52 @@
+# Configuration file for EmptySource
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(8*5)
+)
+
+runToLumi = ((2,1),(10,3),(20,7) )
+
+def findRunForLumi( lumi) :
+  lastRun = runToLumi[0][0]
+  for r,l in runToLumi:
+    if l > lumi:
+      break
+    lastRun = r
+  return lastRun
+
+process.source = cms.Source("EmptySource",
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(x,y) for x,y in runToLumi]),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(5),
+    firstTime = cms.untracked.uint64(1000),
+    timeBetweenEvents = cms.untracked.uint64(10)
+)
+
+ids = cms.VEventID()
+numberOfEventsInLumi = 0
+numberOfEventsPerLumi = process.source.numberEventsInLuminosityBlock.value()
+lumi = process.source.firstLuminosityBlock.value()
+event=0
+oldRun = 2
+for i in xrange(process.maxEvents.input.value()):
+   numberOfEventsInLumi +=1
+   event += 1
+   run = findRunForLumi(lumi)
+   if numberOfEventsInLumi > numberOfEventsPerLumi:
+      numberOfEventsInLumi=1
+      lumi += 1
+      run = findRunForLumi(lumi)
+      if run != oldRun:
+        event = 1
+        oldRun = run
+   ids.append(cms.EventID(run,lumi,event))
+process.check = cms.EDAnalyzer("EventIDChecker", eventSequence = cms.untracked(ids))
+process.print1 = cms.OutputModule("AsciiOutputModule")
+
+process.p = cms.EndPath(process.check+process.print1)

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -10,9 +10,11 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
 #include <memory>
+#include <vector>
 
 namespace edm {
   class ParameterSet;
@@ -55,7 +57,9 @@ namespace edm {
 
     void advanceToNext(EventID& eventID, TimeValue_t& time);
     void retreatToPrevious(EventID& eventID, TimeValue_t& time);
+    RunNumber_t runForLumi(LuminosityBlockNumber_t) const;
 
+    std::vector<edm::LuminosityBlockID> firstLumiForRuns_;
     unsigned int numberEventsInRun_;
     unsigned int numberEventsInLumi_;
     TimeValue_t presentTime_;

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -200,4 +200,12 @@ LHESource::readLuminosityBlockAuxiliary_() {
   return aux;
 }
 
+void
+LHESource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("A source which reads LHE files.");
+  edm::ProducerSourceFromFiles::fillDescription(desc);
+  descriptions.add("source", desc);
+}
+
 DEFINE_FWK_INPUT_SOURCE(LHESource);

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -9,6 +9,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.h"
 #include "FWCore/Sources/interface/ProducerSourceFromFiles.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/LesHouches.h"
 
@@ -35,6 +36,8 @@ public:
   explicit LHESource(const edm::ParameterSet &params,
                      const edm::InputSourceDescription &desc);
   ~LHESource() override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
 


### PR DESCRIPTION
Using firstLuminosityBlockForEachRun allows one to trigger a new Run with a specific Run number to be started if a LuminosityBlock of a certain LuminosityBlock number is generated.
This is intended to be used by the Run dependent MC.