### PR TITLE
Phase2-hgx179 Extend HGCScintillatorDetId to cover both detector and trigger cells

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
@@ -50,15 +50,15 @@ public:
   int layer() const { return (id_>>kHGCalLayerOffset)&kHGCalLayerMask; }
 
   /// get the eta index
-  int iradiusAbs() const { return (id_>>kHGCalRadiusOffset)&kHGCalRadiusMask; }
+  int iradiusAbs() const;
   int iradius()    const { return zside()*iradiusAbs(); }
-  int ietaAbs()    const { return (id_>>kHGCalRadiusOffset)&kHGCalRadiusMask; }
+  int ietaAbs()    const { return iradiusAbs(); }
   int ieta()       const { return zside()*ietaAbs(); }
   int iradiusTriggerAbs() const;
   int iradiusTrigger() const { return zside()*iradiusTriggerAbs(); }
 
   /// get the phi index
-  int iphi() const { return (id_>>kHGCalPhiOffset)&kHGCalPhiMask; }
+  int iphi() const;
   std::pair<int,int> ietaphi() const { return std::pair<int,int>(ieta(),iphi()); }
   std::pair<int,int> iradiusphi() const { return std::pair<int,int>(iradius(),iphi()); }
   int iphiTrigger() const;  

--- a/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
@@ -54,19 +54,17 @@ public:
   int iradius()    const { return zside()*iradiusAbs(); }
   int ietaAbs()    const { return iradiusAbs(); }
   int ieta()       const { return zside()*ietaAbs(); }
-  int iradiusTriggerAbs() const;
-  int iradiusTrigger() const { return zside()*iradiusTriggerAbs(); }
 
   /// get the phi index
   int iphi() const;
   std::pair<int,int> ietaphi() const { return std::pair<int,int>(ieta(),iphi()); }
   std::pair<int,int> iradiusphi() const { return std::pair<int,int>(iradius(),iphi()); }
-  int iphiTrigger() const;  
 
   /// trigger or detector cell
   std::vector<HGCScintillatorDetId> detectorCells() const;
   bool trigger() const { 
-    return ((((id_>>kHGCalTriggerOffset)&kHGCalTriggerMask) == 1) ? true : false); }
+    return (((id_>>kHGCalTriggerOffset)&kHGCalTriggerMask) == 1);
+  }
   HGCScintillatorDetId triggerCell() const;
 
   /// consistency check : no bits left => no overhead
@@ -90,6 +88,10 @@ public:
   static const int kHGCalZsideMask      = 0x1;
   static const int kHGCalTypeOffset     = 26;
   static const int kHGCalTypeMask       = 0x3;
+
+  int iradiusTriggerAbs() const;
+  int iradiusTrigger() const { return zside()*iradiusTriggerAbs(); }
+  int iphiTrigger() const;  
 };
 
 std::ostream& operator<<(std::ostream&,const HGCScintillatorDetId& id);

--- a/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
@@ -2,6 +2,7 @@
 #define DataFormats_ForwardDetId_HGCScintillatorDetId_H 1
 
 #include <iosfwd>
+#include <vector>
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 
@@ -9,7 +10,8 @@
    [0:8]   iphi index wrt x-axis on +z side
    [9:16]  |radius| index (starting from a minimum radius depending on type)
    [17:21] Layer #
-   [22:24] Reserved for future extension
+   [22]    Trigger(1)/Detector(0) cell
+   [23:24] Reserved for future extension
    [25:25] z-side (0 for +z; 1 for -z)
    [26:27] Type (0 fine divisions of scintillators;
                  1 coarse divisions of scintillators)
@@ -25,14 +27,15 @@ public:
   /** Create cellid from raw id (0=invalid tower id) */
   HGCScintillatorDetId(uint32_t rawid);
   /** Constructor from subdetector, zplus, layer, module, cell numbers */
-  HGCScintillatorDetId(int type, int layer, int iradius, int iphi);
+  HGCScintillatorDetId(int type, int layer, int iradius, int iphi, 
+		       bool trigger=false);
   /** Constructor from a generic cell id */
   HGCScintillatorDetId(const DetId& id);
   /** Assignment from a generic cell id */
   HGCScintillatorDetId& operator=(const DetId& id);
   
   /** Converter for a geometry cell id */
-  HGCScintillatorDetId geometryCell () const {return HGCScintillatorDetId (0, layer(), iradius(), iphi());}
+  HGCScintillatorDetId geometryCell () const;
 
   /// get the subdetector
   DetId::Detector subdet() const { return det(); }
@@ -51,11 +54,20 @@ public:
   int iradius()    const { return zside()*iradiusAbs(); }
   int ietaAbs()    const { return (id_>>kHGCalRadiusOffset)&kHGCalRadiusMask; }
   int ieta()       const { return zside()*ietaAbs(); }
+  int iradiusTriggerAbs() const;
+  int iradiusTrigger() const { return zside()*iradiusTriggerAbs(); }
 
   /// get the phi index
   int iphi() const { return (id_>>kHGCalPhiOffset)&kHGCalPhiMask; }
   std::pair<int,int> ietaphi() const { return std::pair<int,int>(ieta(),iphi()); }
   std::pair<int,int> iradiusphi() const { return std::pair<int,int>(iradius(),iphi()); }
+  int iphiTrigger() const;  
+
+  /// trigger or detector cell
+  std::vector<HGCScintillatorDetId> detectorCells() const;
+  bool trigger() const { 
+    return ((((id_>>kHGCalTriggerOffset)&kHGCalTriggerMask) == 1) ? true : false); }
+  HGCScintillatorDetId triggerCell() const;
 
   /// consistency check : no bits left => no overhead
   bool isEE()      const { return false; }
@@ -72,6 +84,8 @@ public:
   static const int kHGCalRadiusMask     = 0xFF;
   static const int kHGCalLayerOffset    = 17;
   static const int kHGCalLayerMask      = 0x1F;
+  static const int kHGCalTriggerOffset  = 22;
+  static const int kHGCalTriggerMask    = 0x1;
   static const int kHGCalZsideOffset    = 25;
   static const int kHGCalZsideMask      = 0x1;
   static const int kHGCalTypeOffset     = 26;

--- a/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
@@ -3,7 +3,7 @@
 #include <ostream>
 #include <iostream>
 
-const HGCScintillatorDetId HGCScintillatorDetId::Undefined(0,0,0,0);
+const HGCScintillatorDetId HGCScintillatorDetId::Undefined(0,0,0,0, false);
 
 HGCScintillatorDetId::HGCScintillatorDetId() : DetId() {
 }
@@ -12,12 +12,14 @@ HGCScintillatorDetId::HGCScintillatorDetId(uint32_t rawid) : DetId(rawid) {
 }
 
 HGCScintillatorDetId::HGCScintillatorDetId(int type, int layer, int radius,
-					   int phi) : DetId(HGCalHSc,ForwardEmpty) {
+					   int phi, bool trigger) : DetId(HGCalHSc,ForwardEmpty) {
 
   int zside      = (radius < 0) ? 1 : 0;
+  int itrig      = trigger ? 1 : 0;
   int radiusAbs  = std::abs(radius);
   id_ |= (((type&kHGCalTypeMask)<<kHGCalTypeOffset) | 
 	  ((zside&kHGCalZsideMask)<<kHGCalZsideOffset) |
+	  ((itrig&kHGCalTriggerMask)<<kHGCalTriggerOffset) |
 	  ((layer&kHGCalLayerMask)<<kHGCalLayerOffset) |
 	  ((radiusAbs&kHGCalRadiusMask)<<kHGCalRadiusOffset) |
 	  ((phi&kHGCalPhiMask)<<kHGCalPhiOffset));
@@ -42,8 +44,64 @@ HGCScintillatorDetId& HGCScintillatorDetId::operator=(const DetId& gen) {
   return (*this);
 }
 
+int HGCScintillatorDetId::iradiusTriggerAbs() const {
+
+  if (trigger()) return ((iradiusAbs()+1)/2);
+  else           return iradiusAbs();
+}
+
+int HGCScintillatorDetId::iphiTrigger() const {
+
+  if (trigger()) return ((iphi()+1)/2);
+  else           return iphi();
+}
+
+std::vector<HGCScintillatorDetId> HGCScintillatorDetId::detectorCells() const {
+
+  std::vector<HGCScintillatorDetId> cells;
+  int irad = iradiusAbs();
+  int ifi  = iphi();
+  int iz   = zside();
+  if (trigger()) {
+    cells.emplace_back(HGCScintillatorDetId(type(), layer(), (2*irad-1)*iz, 
+					    2*ifi-1, false));
+    cells.emplace_back(HGCScintillatorDetId(type(), layer(), 2*irad*iz, 
+					    2*ifi-1, false));
+    cells.emplace_back(HGCScintillatorDetId(type(), layer(), (2*irad-1)*iz, 
+					    2*ifi, false));
+    cells.emplace_back(HGCScintillatorDetId(type(), layer(), 2*irad*iz, 
+					    2*ifi, false));
+  } else {
+    cells.emplace_back(HGCScintillatorDetId(type(), layer(), irad*iz, ifi,
+					    false));
+
+  }
+  return cells;
+}
+
+HGCScintillatorDetId HGCScintillatorDetId::geometryCell() const {
+
+  if (trigger()) {
+    return HGCScintillatorDetId (type(), layer(), iradiusTrigger(), 
+				 iphiTrigger(), false);
+  } else {
+    return HGCScintillatorDetId (type(), layer(), iradius(), iphi(), false);
+  }
+}
+
+HGCScintillatorDetId HGCScintillatorDetId::triggerCell() const {
+
+  if (trigger()) 
+    return HGCScintillatorDetId (type(), layer(), iradius(), iphi(), true);
+  else
+    return HGCScintillatorDetId (type(), layer(), iradiusTrigger(), 
+				 iphiTrigger(), true);
+}
+
 std::ostream& operator<<(std::ostream& s,const HGCScintillatorDetId& id) {
   return s << " HGCScintillatorDetId::EE:HE= " << id.isEE() << ":" << id.isHE()
-	   << " type= " << id.type()  << " layer= " << id.layer() 
-	   << " radius= "  << id.iradius() << " phi= " << id.iphi();
+	   << " trigger= " << id.trigger() << " type= " << id.type()
+	   << " layer= " << id.layer() << " radius= "  << id.iradius()
+	   << ":" << id.iradiusTrigger() << " phi= " << id.iphi() << ":"
+	   << id.iphiTrigger();
 }

--- a/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
@@ -44,14 +44,22 @@ HGCScintillatorDetId& HGCScintillatorDetId::operator=(const DetId& gen) {
   return (*this);
 }
 
-int HGCScintillatorDetId::iradiusTriggerAbs() const {
+int HGCScintillatorDetId::iradiusAbs() const {
+  if (trigger()) return (2*((id_>>kHGCalRadiusOffset)&kHGCalRadiusMask));
+  else return           ((id_>>kHGCalRadiusOffset)&kHGCalRadiusMask);
+}
 
+int HGCScintillatorDetId::iradiusTriggerAbs() const {
   if (trigger()) return ((iradiusAbs()+1)/2);
   else           return iradiusAbs();
 }
 
-int HGCScintillatorDetId::iphiTrigger() const {
+int HGCScintillatorDetId::iphi() const {
+  if (trigger()) return (2*((id_>>kHGCalPhiOffset)&kHGCalPhiMask));
+  else           return ((id_>>kHGCalPhiOffset)&kHGCalPhiMask);
+}
 
+int HGCScintillatorDetId::iphiTrigger() const {
   if (trigger()) return ((iphi()+1)/2);
   else           return iphi();
 }

--- a/DataFormats/ForwardDetId/test/testHGCDetId.cc
+++ b/DataFormats/ForwardDetId/test/testHGCDetId.cc
@@ -102,7 +102,7 @@ void testScint(int layer) {
     for (int phi=1; phi<=phimax; ++phi) {
       for (int zp=0; zp<2; ++zp) {
 	int eta = (2*zp-1)*ieta;
-	HGCScintillatorDetId id(type,layer,eta,phi);
+	HGCScintillatorDetId id(type,layer,eta,phi,false);
 	std::cout << "Input " << type << ":" << layer << ":" << eta << ":"
 		  << phi << " ID " << id;
 	if ((id.ieta() != eta) || (id.iphi() != phi) || 


### PR DESCRIPTION
One additional bit used to distinguish between detector and trigger cells. Accordingly several methods are used to convert one to other