### PR TITLE
Fixing the seed check in CA iterations of FastSim

### DIFF
--- a/FastSimulation/Tracking/src/SeedFinderSelector.cc
+++ b/FastSimulation/Tracking/src/SeedFinderSelector.cc
@@ -207,7 +207,7 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *>& hits
 	  for(auto& ntuplet : tripletresult)
 	    ntuplet.reserve(3);
 	  CAHitTriplGenerator_->hitNtuplets(ihd,tripletresult,*eventSetup_,*seedingLayer); //calling the function from the class, modifies tripletresult
-      	  return !tripletresult.empty();
+      	  return !tripletresult[0].empty();
 	}
     }
     //new for Phase1     
@@ -267,7 +267,7 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *>& hits
       for(auto& ntuplet : quadrupletresult)
 	ntuplet.reserve(4);
       CAHitQuadGenerator_->hitNtuplets(ihd,quadrupletresult,*eventSetup_,*seedingLayer); //calling the function from the class, modifies quadrupletresult
-      return !quadrupletresult.empty();  
+      return !quadrupletresult[0].empty();  
     }    
 
     return true;


### PR DESCRIPTION
CAHitNTupletGenerator::hitNtuplets() takes in empty std::vector of type 'OrderedHitSeeds' from the SeedFinderSelector and modifies its value depending upon whether hit combination has qualified for a seed or not. The size of the std::vector is fixed to be equal to the number of tracking regions in IntermediateHitDoublets. Therefore, the size of the elements inside this container should be checked rather than the size of the vector itself to see if seed candidate has passed. 
Attaching below a plot of tracking efficiency vs pT for the 'Out of the box' tracks which demonstrates the effect of this change. In the plot, red curve is current FastSim (without this fix), blue is FastSim after this fix in place and black is FullSim. As can be seen, agreement of FastSim with FullSim will become much better after this change which indicates the proper implementation of the seed check. 
![trackingeffvspt](https://user-images.githubusercontent.com/19993232/51668760-ea94ba00-1fe8-11e9-8972-0495194f4039.png)
