### PR TITLE
Actually run the SwitchProducer tests

### DIFF
--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -110,6 +110,10 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_ParameterSet.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="TestIntegration.cpp" name="TestIntegrationSwitchProducer">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_TestSwitchProducer.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
   <bin   file="TestIntegration.cpp" name="CatchStdExceptiontest">
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test CatchStdExceptiontest.sh"/>
     <use   name="FWCore/Utilities"/>


### PR DESCRIPTION
While doing something else I realized that in #25439 I forgot to enable running the `SwitchProducer` integration tests. This PR enables the tests.

Tested in CMSSW_10_5_X_2019-01-25-1100, no changes expected.