### PR TITLE
Add a mechanism to adjust the pileup distribution in PreMixingModule

### DIFF
--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -82,7 +82,7 @@ namespace sistrip {
     size_t fileNameHash = 0U;
     //add spy events to the map until there are none left
     source_->loopOverEvents(*eventPrincipal_,fileNameHash,std::numeric_limits<size_t>::max(),
-                            [this](auto const& iE, auto const&){ this->addNextEventToMap(iE); },
+                            [this](auto const& iE, auto const&){ this->addNextEventToMap(iE); return true; },
                             nullptr,nullptr,false);
     //debug
     std::ostringstream ss;

--- a/FWCore/Sources/interface/VectorInputSource.h
+++ b/FWCore/Sources/interface/VectorInputSource.h
@@ -72,11 +72,12 @@ namespace edm {
   template<typename T>
   size_t VectorInputSource::loopOverEvents(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator, CLHEP::HepRandomEngine* engine, EventID const* id, bool recycleFiles) {
     size_t i = 0U;
-    for(; i < number; ++i) {
+    while(i < number) {
       clearEventPrincipal(cache);
       bool found = readOneEvent(cache, fileNameHash, engine, id, recycleFiles);
       if(!found) break;
-      eventOperator(cache, fileNameHash);
+      bool used = eventOperator(cache, fileNameHash);
+      if(used) ++i;
     }
     return i;
   }

--- a/FWCore/Sources/src/VectorInputSource.cc
+++ b/FWCore/Sources/src/VectorInputSource.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Sources/interface/VectorInputSource.h"
 #include "FWCore/Sources/interface/VectorInputSourceDescription.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 namespace edm {
 
@@ -10,7 +11,8 @@ namespace edm {
 
   VectorInputSource::VectorInputSource(ParameterSet const& pset, VectorInputSourceDescription const& desc) : 
       productRegistry_(desc.productRegistry_),
-      processHistoryRegistry_(new ProcessHistoryRegistry) {
+      processHistoryRegistry_(new ProcessHistoryRegistry),
+      consecutiveRejectionsLimit_(pset.getUntrackedParameter<unsigned int>("consecutiveRejectionsLimit", 100)) {
   }
 
   VectorInputSource::~VectorInputSource() {}
@@ -33,6 +35,14 @@ namespace edm {
   void
   VectorInputSource::doEndJob() {
     this->endJob();
+  }
+
+  void VectorInputSource::throwIfOverLimit(unsigned int consecutiveRejections) const {
+    if(consecutiveRejections >= consecutiveRejectionsLimit_) {
+      throw cms::Exception("LogicError") << "VectorInputSource::loopOverEvents() read " << consecutiveRejections << " consecutive pileup events that were rejected by the eventOperator. "
+                                         << "This is likely a sign of misconfiguration (of e.g. the adjusted-to pileup probability profile). "
+                                         << "If you know what you're doing, this exception can be turned off by setting consecutiveRejectionsLimit=0.";
+    }
   }
 
 }

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -108,7 +108,7 @@ namespace edm {
     }
   }
 
-  void SecondaryProducer::processOneEvent(EventPrincipal const& eventPrincipal, Event& e) {
+  bool SecondaryProducer::processOneEvent(EventPrincipal const& eventPrincipal, Event& e) {
     typedef edmtest::ThingCollection TC;
     typedef Wrapper<TC> WTC;
 
@@ -158,6 +158,8 @@ namespace edm {
     }
     assert (expectedEventNumber_ == en);
     ++expectedEventNumber_;
+
+    return true;
   }
 
   std::shared_ptr<VectorInputSource> SecondaryProducer::makeSecInput(ParameterSet const& ps) {

--- a/IOPool/SecondaryInput/test/SecondaryProducer.h
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.h
@@ -31,7 +31,7 @@ namespace edm {
     /**Accumulates the pileup events into this event*/
     virtual void produce(Event& e1, EventSetup const& c);
 
-    void processOneEvent(EventPrincipal const& eventPrincipal, Event& e);
+    bool processOneEvent(EventPrincipal const& eventPrincipal, Event& e);
 
   private:
     virtual void put(Event &) {}

--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -153,11 +153,15 @@ namespace edm {
     int eventCount ;
   public:
     RecordEventID(std::vector<edm::SecondaryEventIDAndFileInfo>& ids, T& eventOperator)
-      : ids_(ids), eventOperator_(eventOperator), eventCount(0) {
+      : ids_(ids), eventOperator_(eventOperator), eventCount(1) {
     }
-    void operator()(EventPrincipal const& eventPrincipal, size_t fileNameHash) {
-      ids_.emplace_back(eventPrincipal.id(), fileNameHash);
-      eventOperator_(eventPrincipal, ++eventCount);
+    bool operator()(EventPrincipal const& eventPrincipal, size_t fileNameHash) {
+      bool used = eventOperator_(eventPrincipal, eventCount);
+      if(used) {
+        ++eventCount;
+        ids_.emplace_back(eventPrincipal.id(), fileNameHash);
+      }
+      return used;
     }
   };
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -307,7 +307,7 @@ namespace edm
   
 
 
-  void DataMixingModule::pileWorker(const EventPrincipal &ep, int bcr, int eventNr, const edm::EventSetup& ES, edm::ModuleCallingContext const* mcc) {  
+  bool DataMixingModule::pileWorker(const EventPrincipal &ep, int bcr, int eventNr, const edm::EventSetup& ES, edm::ModuleCallingContext const* mcc) {  
 
     InternalContext internalContext(ep.id(), mcc);
     ParentContext parentContext(&internalContext);
@@ -359,6 +359,8 @@ namespace edm
     // SiPixels
     //whoops this should be for the MC worker ????? SiPixelWorker_->setPileupInfo(ps,bunchSpacing);
     SiPixelWorker_->addSiPixelPileups(bcr, &ep, eventNr, &moduleCallingContext);
+
+    return true;
   }
 
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -61,7 +61,7 @@ namespace edm {
 
       void initializeEvent(edm::Event const& e, edm::EventSetup const& eventSetup) override;
       void beginRun(edm::Run const& run, edm::EventSetup const& eventSetup) override;
-      void pileWorker(const edm::EventPrincipal&, int bcr, int EventId,const edm::EventSetup& ES, ModuleCallingContext const*);
+      bool pileWorker(const edm::EventPrincipal&, int bcr, int EventId,const edm::EventSetup& ES, ModuleCallingContext const*);
       //virtual void beginJob();
       //virtual void endJob();
       void beginLuminosityBlock(LuminosityBlock const& l1, EventSetup const& c) override;

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -320,7 +320,7 @@ namespace edm {
     }
   }
 
-  void MixingModule::pileAllWorkers(EventPrincipal const& eventPrincipal,
+  bool MixingModule::pileAllWorkers(EventPrincipal const& eventPrincipal,
                                     ModuleCallingContext const* mcc,
                                     int bunchCrossing, int eventId,
                                     int& vertexOffset,
@@ -346,6 +346,8 @@ namespace edm {
 
       worker->addPileups(eventPrincipal, &moduleCallingContext, eventId);
     }
+
+    return true;
   }
 
   void MixingModule::doPileUp(edm::Event &e, const edm::EventSetup& setup) {

--- a/SimGeneral/MixingModule/plugins/MixingModule.h
+++ b/SimGeneral/MixingModule/plugins/MixingModule.h
@@ -83,7 +83,7 @@ namespace edm {
       void checkSignal(const edm::Event &e) override;
       void addSignals(const edm::Event &e, const edm::EventSetup& es) override; 
       void doPileUp(edm::Event &e, const edm::EventSetup& es) override;
-      void pileAllWorkers(EventPrincipal const& ep, ModuleCallingContext const*, int bcr, int id, int& offset,
+      bool pileAllWorkers(EventPrincipal const& ep, ModuleCallingContext const*, int bcr, int id, int& offset,
 			  const edm::EventSetup& setup, edm::StreamID const&);
       void createDigiAccumulators(const edm::ParameterSet& mixingPSet, edm::ConsumesCollector& iC);
 

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -125,7 +125,7 @@ SecSourceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 	     << " bunch." << std::endl;
 }
 
-void  SecSourceAnalyzer::getBranches(EventPrincipal const &ep,
+bool  SecSourceAnalyzer::getBranches(EventPrincipal const &ep,
                                      ModuleCallingContext const* mcc)
   { 
     InternalContext internalContext(ep.id(), mcc);
@@ -168,6 +168,7 @@ void  SecSourceAnalyzer::getBranches(EventPrincipal const &ep,
 	
     }
  
+    return true;
   }
 
 

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.h
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.h
@@ -43,9 +43,9 @@ namespace edm {
     explicit SecSourceAnalyzer(const edm::ParameterSet&);
     ~SecSourceAnalyzer() override;
 
-    virtual void getBranches(EventPrincipal const& ep,
-                             ModuleCallingContext const*);
-    virtual void dummyFunction(EventPrincipal const& ep) {}
+    bool getBranches(EventPrincipal const& ep,
+                     ModuleCallingContext const*);
+    bool dummyFunction(EventPrincipal const& ep) { return true; }
 
   private:
     void beginJob() override ;

--- a/SimGeneral/PileupInformation/plugins/PileupInformation.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupInformation.cc
@@ -104,56 +104,42 @@ void PileupInformation::produce(edm::Event &event, const edm::EventSetup & setup
 
   int bunchSpacing;
 
+  // extract information - way easier than counting vertices
   const PileupMixingContent* MixInfo = MixingPileup.product();
+  const std::vector<int>& bunchCrossing = MixInfo->getMix_bunchCrossing();
+  const std::vector<int>& interactions = MixInfo->getMix_Ninteractions();
+  const std::vector<float>& TrueInteractions = MixInfo->getMix_TrueInteractions();
+  const std::vector<edm::EventID> eventInfoList= MixInfo->getMix_eventInfo();
 
-  if(MixInfo) {  // extract information - way easier than counting vertices
+  bunchSpacing = MixInfo->getMix_bunchSpacing();
+  unsigned int totalIntPU=0;
 
-    const std::vector<int>& bunchCrossing = MixInfo->getMix_bunchCrossing();
-    const std::vector<int>& interactions = MixInfo->getMix_Ninteractions();
-    const std::vector<float>& TrueInteractions = MixInfo->getMix_TrueInteractions();
-    const std::vector<edm::EventID> eventInfoList= MixInfo->getMix_eventInfo();
+  for(int ib=0; ib<(int)bunchCrossing.size(); ++ib){
+    //      std::cout << " bcr, nint " << bunchCrossing[ib] << " " << interactions[ib] << std::endl;
+    BunchCrossings.push_back(bunchCrossing[ib]);
+    Interactions_Xing.push_back(interactions[ib]);
+    TrueInteractions_Xing.push_back(TrueInteractions[ib]);
 
-    bunchSpacing = MixInfo->getMix_bunchSpacing();
-    unsigned int totalIntPU=0;
-
-    for(int ib=0; ib<(int)bunchCrossing.size(); ++ib){
-      //      std::cout << " bcr, nint " << bunchCrossing[ib] << " " << interactions[ib] << std::endl;
-      BunchCrossings.push_back(bunchCrossing[ib]);
-      Interactions_Xing.push_back(interactions[ib]);
-      TrueInteractions_Xing.push_back(TrueInteractions[ib]);
-      
-      std::vector<edm::EventID> eventInfos;
-      eventInfos.reserve( interactions[ib] );
-      for ( int pu=0; pu< interactions[ib]; pu++) {
-	eventInfos.push_back(eventInfoList[totalIntPU+pu]);
-      }
-      totalIntPU+=(interactions[ib]);
-      eventInfoList_Xing.push_back(eventInfos);
-
+    std::vector<edm::EventID> eventInfos;
+    eventInfos.reserve( interactions[ib] );
+    for ( int pu=0; pu< interactions[ib]; pu++) {
+      eventInfos.push_back(eventInfoList[totalIntPU+pu]);
     }
-  }
-  else{ // have to throw an exception..
-
-    throw cms::Exception("PileupInformation") << " PileupMixingContent is missing from the event.\n" 
-                                                 "There must be some breakdown in the Simulation Chain.\n"
-                                                 "You must run the MixingModule before calling this routine."; 
+    totalIntPU+=(interactions[ib]);
+    eventInfoList_Xing.push_back(eventInfos);
 
   }
   
   // store information from pileup vertices, if it's in the event. Have to loop on interactions again.
-
-  edm::Handle< PileupVertexContent > MixingPileupVtx;  // Get True pileup information from MixingModule
-  event.getByToken(PileupVtxLabel_, MixingPileupVtx);
-
-  const PileupVertexContent* MixVtxInfo = MixingPileupVtx.product();
-
   std::vector< std::vector<float> > ptHatList_Xing;
   std::vector< std::vector<float> > zPosList_Xing;
   std::vector< std::vector<float> > tPosList_Xing;
 
   bool Have_pThats = false;
 
-  if(MixVtxInfo) {  // extract information - way easier than counting vertices
+  edm::Handle< PileupVertexContent > MixingPileupVtx;  // Get True pileup information from MixingModule
+  if(event.getByToken(PileupVtxLabel_, MixingPileupVtx)) {  // extract information - way easier than counting vertices
+    const PileupVertexContent* MixVtxInfo = MixingPileupVtx.product();
 
 
     Have_pThats = true;

--- a/SimGeneral/PreMixingModule/plugins/BuildFile.xml
+++ b/SimGeneral/PreMixingModule/plugins/BuildFile.xml
@@ -9,6 +9,7 @@
 <use   name="SimDataFormats/PileupSummaryInfo"/>
 <use   name="SimGeneral/MixingModule"/>
 <use   name="SimGeneral/PreMixingModule"/>
+<use   name="clhep"/>
 <library   file="*.cc" name="SimGeneralPreMixingModulePlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
@@ -50,7 +50,7 @@ namespace edm {
     void endRun(const edm::Run& r, const edm::EventSetup& setup) override;
 
   private:
-    void pileWorker(const edm::EventPrincipal&, int bcr, int EventId,const edm::EventSetup& ES, ModuleCallingContext const*);
+    bool pileWorker(const edm::EventPrincipal&, int bcr, int EventId,const edm::EventSetup& ES, ModuleCallingContext const*);
 
     PreMixingPileupCopy puWorker_;
     bool addedPileup_ = false;
@@ -129,7 +129,7 @@ namespace edm {
     addedPileup_ = false; 
   }
 
-  void PreMixingModule::pileWorker(const EventPrincipal &ep, int bcr, int eventNr, const edm::EventSetup& ES, edm::ModuleCallingContext const* mcc) {  
+  bool PreMixingModule::pileWorker(const EventPrincipal &ep, int bcr, int eventNr, const edm::EventSetup& ES, edm::ModuleCallingContext const* mcc) {  
     InternalContext internalContext(ep.id(), mcc);
     ParentContext parentContext(&internalContext);
     ModuleCallingContext moduleCallingContext(&moduleDescription());
@@ -155,6 +155,8 @@ namespace edm {
     for(auto& w: workers_) {
       w->addPileups(pep, ES);
     }
+
+    return true;
   }
   
   void PreMixingModule::doPileUp(edm::Event &e, const edm::EventSetup& ES)

--- a/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
@@ -14,9 +14,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/transform.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/ServiceRegistry/interface/InternalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
 
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h"
@@ -26,6 +30,8 @@
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
 #include "PreMixingPileupCopy.h"
+
+#include <CLHEP/Random/RandomEngine.h>
 
 #include <functional>
 #include <vector>
@@ -50,18 +56,67 @@ namespace edm {
     void endRun(const edm::Run& r, const edm::EventSetup& setup) override;
 
   private:
-    bool pileWorker(const edm::EventPrincipal&, int bcr, int EventId,const edm::EventSetup& ES, ModuleCallingContext const*);
+    class AdjustPileupDistribution {
+    public:
+      AdjustPileupDistribution(const edm::ParameterSet& ps):
+        firstRun_(ps.getParameter<unsigned int>("firstRun")),
+        firstBinPileup_(ps.getParameter<unsigned int>("firstBinPileup")),
+        pileupProbabilities_(ps.getParameter<std::vector<double>>("pileupProbabilities"))
+      {
+        for(double p: pileupProbabilities_) {
+          if(p < 0. or p > 1.) {
+            throw cms::Exception("Configuration") << "Invalid probability value " << p << " for firstRun " << firstRun_ << ". The probability must be >= 0. and <= 1.";
+          }
+        }
+      }
+
+      edm::RunNumber_t firstRun() const { return firstRun_; }
+      double probability(float pileup, unsigned int& outOfBoundsCount, const unsigned int outOfBoundsLimit) const {
+        unsigned int bin = static_cast<unsigned int>(pileup);
+        if(bin < firstBinPileup_ or bin >= firstBinPileup_+pileupProbabilities_.size()) {
+          if(outOfBoundsLimit > 0) {
+            ++outOfBoundsCount;
+            if(outOfBoundsCount >= outOfBoundsLimit) {
+              throw cms::Exception("LogicError") << "Read " << outOfBoundsCount << " consecutive pileup events with true pileup outside of the configured pileup adjustment bounds. "
+                                                 << "The last one had true pileup " << pileup << " , while the bounds are [" << firstBinPileup_ << ", " << firstBinPileup_+pileupProbabilities_.size()-1 << "]. "
+                                                 << "If you know what you're doing, this exception can be turned off by setting adjustPileupOutOfBoundsLimit=0.";
+            }
+          }
+          return 0.;
+        }
+        outOfBoundsCount = 0;
+        return pileupProbabilities_[bin-firstBinPileup_];
+      }
+
+    private:
+      edm::RunNumber_t firstRun_;
+      unsigned int firstBinPileup_;
+      std::vector<double> pileupProbabilities_;
+    };
+
+    bool pileWorker(const edm::EventPrincipal&, int bcr, int EventId,const edm::EventSetup& ES, ModuleCallingContext const*, AdjustPileupDistribution const* pileupAdjuster);
 
     PreMixingPileupCopy puWorker_;
     bool addedPileup_ = false;
+    unsigned int pileupAdjustmentOutOfBoundsCount_ = 0;
+    unsigned int pileupAdjustmentOutOfBoundsLimit_;
 
+    std::vector<AdjustPileupDistribution> pileupAdjusters_;
     std::vector<std::unique_ptr<PreMixingWorker> > workers_;
   };
 
   PreMixingModule::PreMixingModule(const edm::ParameterSet& ps, MixingCache::Config const* globalConf):
     BMixingModule(ps, globalConf),
-    puWorker_(ps.getParameter<edm::ParameterSet>("workers").getParameter<edm::ParameterSet>("pileup"), *this, consumesCollector())
+    puWorker_(ps.getParameter<edm::ParameterSet>("workers").getParameter<edm::ParameterSet>("pileup"), *this, consumesCollector()),
+    pileupAdjustmentOutOfBoundsLimit_(ps.getUntrackedParameter<unsigned int>("adjustPileupOutOfBoundsLimit")),
+    pileupAdjusters_(edm::vector_transform(ps.getParameter<std::vector<edm::ParameterSet> >("adjustPileupDistribution"),
+                                           [](const auto& ps) { return AdjustPileupDistribution(ps); }))
   {  
+    std::sort(pileupAdjusters_.begin(), pileupAdjusters_.end(),
+              [](const auto& a, const auto& b) {
+                return a.firstRun() < b.firstRun();
+              });
+
     const auto& workers = ps.getParameter<edm::ParameterSet>("workers");
     std::vector<std::string> names = workers.getParameterNames();
 
@@ -129,13 +184,27 @@ namespace edm {
     addedPileup_ = false; 
   }
 
-  bool PreMixingModule::pileWorker(const EventPrincipal &ep, int bcr, int eventNr, const edm::EventSetup& ES, edm::ModuleCallingContext const* mcc) {  
+  bool PreMixingModule::pileWorker(const EventPrincipal &ep, int bcr, int eventNr, const edm::EventSetup& ES, edm::ModuleCallingContext const* mcc,
+                                   AdjustPileupDistribution const* pileupAdjuster) {
     InternalContext internalContext(ep.id(), mcc);
     ParentContext parentContext(&internalContext);
     ModuleCallingContext moduleCallingContext(&moduleDescription());
     ModuleContextSentry moduleContextSentry(&moduleCallingContext, parentContext);
 
     PileUpEventPrincipal pep(ep, &moduleCallingContext, bcr);
+
+    if(pileupAdjuster) {
+      float trueNumInteractions = puWorker_.getTrueNumInteractions(pep);
+      double prob = pileupAdjuster->probability(static_cast<unsigned int>(trueNumInteractions), pileupAdjustmentOutOfBoundsCount_, pileupAdjustmentOutOfBoundsLimit_);
+      edm::Service<edm::RandomNumberGenerator> rng;
+      CLHEP::HepRandomEngine& engine = rng->getEngine(ep.streamID());
+      if(engine.flat() > prob) {
+        // engine.flat() should give a double in ]0,1[ range
+        // the choice above means that "prob = 1-ulp" is treatead as 1
+        return false;
+      }
+    }
+
 
     LogDebug("PreMixingModule") <<"\n===============> adding pileups from event  "<<ep.id()<<" for bunchcrossing "<<bcr;
 
@@ -169,6 +238,22 @@ namespace edm {
 
     ModuleCallingContext const* mcc = e.moduleCallingContext();
 
+    AdjustPileupDistribution const* pileupAdjuster = nullptr;
+    if(not pileupAdjusters_.empty()) {
+      // Find the adjustment settings for the run of the signal event
+      // the container should be small-enough to not really gain
+      // anything with binary search
+      auto it = std::find_if(pileupAdjusters_.rbegin(), pileupAdjusters_.rend(),
+                             [iRun=e.id().run()](const auto& elem) {
+                               return elem.firstRun() <= iRun;
+                             });
+      if(it == pileupAdjusters_.rend()) {
+        throw cms::Exception("LogicError") << "Encountered run " << e.id().run() << ", but the first run available in the pileup adjustment configuration is "
+                                           << pileupAdjusters_.front().firstRun() << ". Please fix the configuration.";
+      }
+      pileupAdjuster = &*it;
+    }
+
     for (int bunchCrossing=minBunch_;bunchCrossing<=maxBunch_;++bunchCrossing) {
       for (unsigned int isource=0;isource<maxNbSources_;++isource) {
         std::shared_ptr<PileUp> source = inputSources_[isource];
@@ -194,7 +279,7 @@ namespace edm {
                 e.id(),
                 recordEventID,
                 std::bind(&PreMixingModule::pileWorker, std::ref(*this),
-			  _1, bunchCrossing, _2, std::cref(ES), mcc),
+			  _1, bunchCrossing, _2, std::cref(ES), mcc, pileupAdjuster),
 		NumPU_Events,
                 e.streamID()
 			   );

--- a/SimGeneral/PreMixingModule/plugins/PreMixingPileupCopy.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingPileupCopy.cc
@@ -25,6 +25,21 @@ namespace edm {
       producer.produces<std::vector<reco::GenParticle> >(tag.label());
     }
   }
+
+  float PreMixingPileupCopy::getTrueNumInteractions(PileUpEventPrincipal const& pep) const {
+    edm::Handle<std::vector<PileupSummaryInfo>> pileupInfoHandle;
+    pep.getByLabel(pileupInfoInputTag_, pileupInfoHandle);
+
+    auto it = std::find_if(pileupInfoHandle->begin(), pileupInfoHandle->end(),
+                           [](const auto& s) {
+                             return s.getBunchCrossing() == 0;
+                           });
+    if(it == pileupInfoHandle->end()) {
+      throw cms::Exception("LogicError") << "Did not find PileupSummaryInfo in bunch crossing 0";
+    }
+
+    return it->getTrueNumInteractions();
+  }
 	       
   void PreMixingPileupCopy::addPileupInfo(const PileUpEventPrincipal& pep) {
   

--- a/SimGeneral/PreMixingModule/plugins/PreMixingPileupCopy.h
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingPileupCopy.h
@@ -35,6 +35,8 @@ namespace edm {
     PreMixingPileupCopy(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector && iC);
     ~PreMixingPileupCopy() = default;
 
+    float getTrueNumInteractions(PileUpEventPrincipal const& pep) const;
+
     void addPileupInfo(PileUpEventPrincipal const& pep);
     const std::vector<PileupSummaryInfo>& getPileupSummaryInfo() const { return pileupSummaryStorage_; }
     int getBunchSpacing() const { return bsStorage_; }

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -33,6 +33,9 @@ mixData = cms.EDProducer("PreMixingModule",
     maxBunch = cms.int32(0),
     mixProdStep1 = cms.bool(False),
     mixProdStep2 = cms.bool(False),
+    # Optionally adjust the pileup distribution
+    adjustPileupDistribution = cms.VPSet(),
+    adjustPileupOutOfBoundsLimit = cms.untracked.uint32(10), # 10 is an initial guess for a good value
     # Workers
     workers = cms.PSet(
         pileup = cms.PSet(

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -25,7 +25,8 @@ mixData = cms.EDProducer("PreMixingModule",
         seed = cms.int32(1234567),
         type = cms.string('fixed'),
         sequential = cms.untracked.bool(False), # set to true for sequential reading of pileup
-        fileNames = cms.untracked.vstring('file:DMPreProcess_RAW2DIGI.root')
+        fileNames = cms.untracked.vstring('file:DMPreProcess_RAW2DIGI.root'),
+        consecutiveRejectionsLimit = cms.untracked.uint32(100) # should be sufficiently large to allow enough tails
     ),
     # Mixing Module parameters
     bunchspace = cms.int32(25),
@@ -35,7 +36,6 @@ mixData = cms.EDProducer("PreMixingModule",
     mixProdStep2 = cms.bool(False),
     # Optionally adjust the pileup distribution
     adjustPileupDistribution = cms.VPSet(),
-    adjustPileupOutOfBoundsLimit = cms.untracked.uint32(10), # 10 is an initial guess for a good value
     # Workers
     workers = cms.PSet(
         pileup = cms.PSet(

--- a/SimGeneral/PreMixingModule/test/BuildFile.xml
+++ b/SimGeneral/PreMixingModule/test/BuildFile.xml
@@ -4,7 +4,7 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
-  <use nam="SimDataFormats/PileupSummaryInfo"/>
+  <use name="SimDataFormats/PileupSummaryInfo"/>
 </library>
 
 <bin file="runtestSimGeneralPreMixingModule.cpp" name="runtestSimGeneralPreMixingModule">

--- a/SimGeneral/PreMixingModule/test/BuildFile.xml
+++ b/SimGeneral/PreMixingModule/test/BuildFile.xml
@@ -1,0 +1,13 @@
+<library file="TestPreMixingPileupAnalyzer.cc" name="SimGeneralPreMixingModuleTestPlugins">
+  <flags EDM_PLUGIN="1"/>
+  <use name="DataFormats/Common"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <use nam="SimDataFormats/PileupSummaryInfo"/>
+</library>
+
+<bin file="runtestSimGeneralPreMixingModule.cpp" name="runtestSimGeneralPreMixingModule">
+  <flags   TEST_RUNNER_ARGS=" /bin/bash SimGeneral/PreMixingModule/test run_testPremixPileupAdjustment.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>

--- a/SimGeneral/PreMixingModule/test/TestPreMixingPileupAnalyzer.cc
+++ b/SimGeneral/PreMixingModule/test/TestPreMixingPileupAnalyzer.cc
@@ -1,0 +1,53 @@
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+
+#include <algorithm>
+#include <vector>
+
+class TestPreMixingPileupAnalyzer: public edm::global::EDAnalyzer<> {
+public:
+public:
+  explicit TestPreMixingPileupAnalyzer(edm::ParameterSet const& iConfig);
+  void analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const& iSetup) const override;
+
+private:
+  edm::EDGetTokenT<std::vector<PileupSummaryInfo>> inputToken_;
+  std::vector<unsigned int> allowedPileups_;
+};
+
+TestPreMixingPileupAnalyzer::TestPreMixingPileupAnalyzer(edm::ParameterSet const& iConfig):
+  inputToken_(consumes<std::vector<PileupSummaryInfo>>(iConfig.getUntrackedParameter<edm::InputTag>("src"))),
+  allowedPileups_(iConfig.getUntrackedParameter<std::vector<unsigned int>>("allowedPileups"))
+{}
+
+
+void TestPreMixingPileupAnalyzer::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const& iSetup) const {
+  edm::Handle<std::vector<PileupSummaryInfo>> h;
+  iEvent.getByToken(inputToken_, h);
+  const auto& summary = *h;
+
+  auto it = std::find_if(summary.begin(), summary.end(), [](const auto& s) { return s.getBunchCrossing() == 0; });
+  if(it == summary.end()) {
+    throw cms::Exception("LogicError") << "Did not find PileupSummaryInfo in bunch crossing 0";
+  }
+
+  float trueNumInteractions = it->getTrueNumInteractions();
+  auto pubin = static_cast<unsigned int>(trueNumInteractions);
+  auto it2 = std::find(allowedPileups_.begin(), allowedPileups_.end(), pubin);
+  if(it2 == allowedPileups_.end()) {
+    cms::Exception ex{"LogicError"};
+    ex << "Got event with true number of interactions " << trueNumInteractions << ", pileup bin is thus " << pubin << ", that is not in the list of allowed values:";
+    for(auto v: allowedPileups_) {
+      ex << " " << v;
+    }
+    throw ex;
+  }
+}
+
+DEFINE_FWK_MODULE(TestPreMixingPileupAnalyzer);

--- a/SimGeneral/PreMixingModule/test/fakeminbias_cfg.py
+++ b/SimGeneral/PreMixingModule/test/fakeminbias_cfg.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MinBias")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+     input = cms.untracked.int32(10)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSwitchProducerTask%d.root' % (1 if enableTest2 else 2,)),
+    outputCommands = cms.untracked.vstring(
+        'keep *_intProducer_*_*'
+    )
+)

--- a/SimGeneral/PreMixingModule/test/run_testPremixPileupAdjustment.sh
+++ b/SimGeneral/PreMixingModule/test/run_testPremixPileupAdjustment.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+  echo "*************************************************"
+  echo "Produce a fake MinBias event library"
+  cmsRun ${LOCAL_TEST_DIR}/testFakeMinBias_cfg.py || die "cmsRun testFakeMinBias_cfg.py" $?
+
+  echo "*************************************************"
+  echo "Produce a fake pileup library (premix stage1)"
+  cmsRun ${LOCAL_TEST_DIR}/testPremixStage1_cfg.py || die "cmsRun testPremixStage1_cfg.py" $?
+
+  echo "*************************************************"
+  echo "Test premixing by adjusting the pileup"
+  cmsRun ${LOCAL_TEST_DIR}/testPremixStage2_cfg.py || die "cmsRun testPremixStage2_cfg.py" $?
+
+popd
+
+exit 0

--- a/SimGeneral/PreMixingModule/test/runtestSimGeneralPreMixingModule.cpp
+++ b/SimGeneral/PreMixingModule/test/runtestSimGeneralPreMixingModule.cpp
@@ -1,0 +1,3 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+
+RUNTEST()

--- a/SimGeneral/PreMixingModule/test/testFakeMinBias_cfg.py
+++ b/SimGeneral/PreMixingModule/test/testFakeMinBias_cfg.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MinBias")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+     input = cms.untracked.int32(10)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testFakeMinBias.root'),
+)
+
+process.e = cms.EndPath(process.out)

--- a/SimGeneral/PreMixingModule/test/testPremixStage1_cfg.py
+++ b/SimGeneral/PreMixingModule/test/testPremixStage1_cfg.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PremixStage1")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+     input = cms.untracked.int32(10)
+)
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+
+from SimGeneral.MixingModule.mix_flat_0_10_cfi import mix as _mix
+process.mix = _mix.clone(
+    input = dict(
+        nbPileupEvents = dict(
+            probFunctionVariable = [0,1,2,3],
+            probValue = [0.25, 0.25, 0.25, 0.25]
+        ),
+        fileNames = ["file:testFakeMinBias.root"]
+    ),
+    digitizers = cms.PSet(),
+    mixObjects = cms.PSet(),
+    minBunch = -1,
+    maxBunch = 1,
+)
+
+process.load("SimGeneral.PileupInformation.AddPileupSummary_cfi")
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testPremixStage1.root'),
+)
+
+process.t = cms.Task(
+    process.mix,
+    process.addPileupInfo
+)
+process.p = cms.Path(process.t)
+process.e = cms.EndPath(process.out)

--- a/SimGeneral/PreMixingModule/test/testPremixStage2_cfg.py
+++ b/SimGeneral/PreMixingModule/test/testPremixStage2_cfg.py
@@ -1,0 +1,53 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PremixStage1")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+     input = cms.untracked.int32(3)
+)
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+
+from SimGeneral.PreMixingModule.mixOne_premix_on_sim_cfi import mixData as _mixData
+process.mixData1 = _mixData.clone(
+    input = dict(fileNames = ["file:testPremixStage1.root"]),
+    workers = cms.PSet(
+        pileup = _mixData.workers.pileup.clone(
+            GenPUProtonsInputTags = []
+        )
+    ),
+    adjustPileupDistribution = [
+        cms.PSet(
+            firstRun = cms.uint32(1),
+            firstBinPileup = cms.uint32(0),
+            pileupProbabilities = cms.vdouble(0,1,1,0)
+        ),
+    ],
+    minBunch = -1,
+    maxBunch = 1,
+)
+process.RandomNumberGeneratorService.mixData1 = process.RandomNumberGeneratorService.mixData.clone()
+process.testMixData1 = cms.EDAnalyzer("TestPreMixingPileupAnalyzer",
+    src = cms.untracked.InputTag("mixData1"),
+    allowedPileups = cms.untracked.vuint32(1,2)
+)
+
+process.mixData2 = process.mixData1.clone(
+    adjustPileupDistribution = {0: dict(pileupProbabilities = [0.8,0,0,0.5])}
+)
+process.RandomNumberGeneratorService.mixData2 = process.RandomNumberGeneratorService.mixData.clone()
+process.testMixData2 = process.testMixData1.clone(
+    src = "mixData2",
+    allowedPileups = [0,3]
+)
+
+process.t = cms.Task(
+    process.mixData1,
+    process.mixData2,
+)
+process.s = cms.Sequence(
+    process.testMixData1+
+    process.testMixData2
+)
+process.p = cms.Path(process.s, process.t)


### PR DESCRIPTION
This PR adds a mechanism to adjust the pileup distribution of the premixed pileup library in premixing stage2 (pileup overlay). The mechanism (that is off by default) is the following
* For each true pileup value, a probability is defined in the configuration (see example below)
* When `PreMixingModule` reads an event from the  pileup library
  1. read the true pileup value from the pileup event
  2. generate a (0,1) random number
  3. if "number > prob(true pileup)", discard the pileup event and continue on i., otherwise use the pileup event as usual

If a pileup event is encountered with a true pileup value outside of the range in configuration, the probability is considered to be 0. Naively this would lead to an infinite loop on misconfiguration (if the configured pileup range would not cover at all the generated pileup), so a following protection is included: an exception is thrown if N consecutive pileup events landing outside of the configured pileup range are encountered (N is configurable, the exception can also be disabled).

This mechanism required adding a way to skip events in `VectorInputSource`.

Example configuration
```python
mixData = cms.EDProducer("PreMixingModule",
    ...
    adjustPileupDistribution = cms.VPSet(
        cms.PSet(
            firstRun = cms.uint32(1), # first run of which this snippet is active
            firstBinPileup = cms.uint32(10), # pileup of the first probability bin
            pileupProbabilities = cms.vdouble(0.1, 0.5, 1.0, 0.4) # probabilities for pileups 10,11,12,14
        ),
        cms.PSet(
            firstRun = cms.uint32(2),
            firstBinPileup = cms.uint32(10),
            pileupProbabilities = cms.vdouble(0.2, 0.3, 0.5, 1.0)
        ),
    ),
    ...
)
```
Tested in 10_4_0, no changes expected.