### PR TITLE
Move lowPtGsfElectronSequence back to highlevelreco (102X)

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -50,6 +50,9 @@ from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 # Cosmic During Collisions
 from RecoTracker.SpecialSeedGenerators.cosmicDC_cff import *
 
+# Low pT electrons
+from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronSequence_cff import *
+
 localreco = cms.Sequence(bunchSpacingProducer+trackerlocalreco+muonlocalreco+calolocalreco+castorreco)
 localreco_HcalNZS = cms.Sequence(bunchSpacingProducer+trackerlocalreco+muonlocalreco+calolocalrecoNZS+castorreco)
 
@@ -146,7 +149,8 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
                              recoPFMET*
                              PFTau*
                              reducedRecHits*
-                             cosmicDCTracksSeq
+                             cosmicDCTracksSeq*
+                             lowPtGsfElectronSequence
                              )
 
 # XeXe data with pp reco


### PR DESCRIPTION
This PR has been made in response to [this](https://github.com/cms-sw/cmssw/pull/25595#issuecomment-457664271) request. 

This PR is the back port of #25773.

While Slava suggests to remove the dependence on ```rho``` and use instead ```nPV``` or similar, we note that the BDT models used by the ```LowPtGsfElectronSeedProducer``` use ```rho``` as an input variable. So removing this dependence would mean a retraining is mandatory. Given the very tight timescales, it is very unlikely that we will be able to retrain the models in time and we expect to rely on the existing models already merged into cms-data. It _may_ be possible for the 10_5_X cycle, but almost certainly not the 10_2_X cycle, which need for data processing ~now. 

@perrotta @slava77 @mverzett @nancymarinelli 
