### PR TITLE
CondDB formats for PPS/Totem timing calibrations

### DIFF
--- a/CondCore/CTPPSPlugins/src/plugin.cc
+++ b/CondCore/CTPPSPlugins/src/plugin.cc
@@ -5,7 +5,11 @@
 #include "CondFormats/DataRecord/interface/CTPPSPixelAnalysisMaskRcd.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
 #include "CondFormats/DataRecord/interface/CTPPSPixelGainCalibrationsRcd.h"
- 
+#include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
+#include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
+
 REGISTER_PLUGIN(CTPPSPixelDAQMappingRcd,CTPPSPixelDAQMapping);
 REGISTER_PLUGIN(CTPPSPixelAnalysisMaskRcd,CTPPSPixelAnalysisMask);
 REGISTER_PLUGIN(CTPPSPixelGainCalibrationsRcd,CTPPSPixelGainCalibrations);
+REGISTER_PLUGIN(PPSTimingCalibrationRcd,PPSTimingCalibration);
+

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -266,6 +266,7 @@ namespace cond {
       IMPORT_PAYLOAD_CASE( PhysicsTGraphPayload )
       IMPORT_PAYLOAD_CASE( PhysicsTFormulaPayload )
       IMPORT_PAYLOAD_CASE( PhysicsTools::Calibration::HistogramD3D )
+      IMPORT_PAYLOAD_CASE( PPSTimingCalibration )
       IMPORT_PAYLOAD_CASE( QGLikelihoodCategory                     )
       IMPORT_PAYLOAD_CASE( QGLikelihoodObject               )
       IMPORT_PAYLOAD_CASE( QGLikelihoodSystematicsObject     )

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -29,6 +29,7 @@
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelDAQMapping.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelAnalysisMask.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
 #include "CondFormats/DTObjects/interface/DTCCBConfig.h"
 #include "CondFormats/DTObjects/interface/DTDeadFlag.h"
 #include "CondFormats/DTObjects/interface/DTHVStatus.h"

--- a/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
@@ -19,21 +19,21 @@ class PPSTimingCalibrationESSource;
 class PPSTimingCalibration
 {
   public:
-    /// Helper structure for storing calibration data
-    struct CalibrationKey
+    /// Helper structure for indexing calibration data
+    struct Key
     {
-      CalibrationKey( int db = -1, int sampic = -1, int channel = -1, int cell = -1 ) :
-        db( db ), sampic( sampic ), channel( channel ), cell( cell ) {}
-      /// Comparison operator
-      bool operator<( const CalibrationKey& rhs ) const;
-      friend std::ostream& operator<<( std::ostream& os, const CalibrationKey& key );
-
       int db, sampic, channel, cell;
+
+      /// Comparison operator
+      bool operator<( const Key& rhs ) const;
+      friend std::ostream& operator<<( std::ostream& os, const Key& key );
+
+      COND_SERIALIZABLE;
     };
     //--------------------------------------------------------------------------
 
-    typedef std::map<CalibrationKey,std::vector<double> > ParametersMap;
-    typedef std::map<CalibrationKey,std::pair<double,double> > TimingMap;
+    using ParametersMap = std::map<Key,std::vector<double> >;
+    using TimingMap = std::map<Key,std::pair<double,double> >;
 
     PPSTimingCalibration() = default;
     PPSTimingCalibration( const std::string& formula, const ParametersMap& params, const TimingMap& timeinfo ) :
@@ -54,7 +54,7 @@ class PPSTimingCalibration
     ParametersMap parameters_;
     TimingMap timeInfo_;
 
-    COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
@@ -15,7 +15,6 @@
 #include <map>
 #include <vector>
 
-class PPSTimingCalibrationESSource;
 class PPSTimingCalibration
 {
   public:
@@ -48,8 +47,6 @@ class PPSTimingCalibration
     friend std::ostream& operator<<( std::ostream& os, const PPSTimingCalibration& data );
 
   private:
-    friend PPSTimingCalibrationESSource;
-
     std::string formula_;
     ParametersMap parameters_;
     TimingMap timeInfo_;

--- a/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
@@ -22,24 +22,13 @@ class PPSTimingCalibration
     /// Helper structure for storing calibration data
     struct CalibrationKey
     {
-      int db, sampic, channel, cell;
+      CalibrationKey( int db = -1, int sampic = -1, int channel = -1, int cell = -1 ) :
+        db( db ), sampic( sampic ), channel( channel ), cell( cell ) {}
       /// Comparison operator
-      bool operator<(const CalibrationKey& rhs) const {
-        if (db == rhs.db) {
-          if (sampic == rhs.sampic) {
-            if (channel == rhs.channel)
-              return cell < rhs.cell;
-            return channel < rhs.channel;
-          }
-          return sampic < rhs.sampic;
-        }
-        return db < rhs.db;
-      }
-      CalibrationKey(int db = -1, int sampic = -1, int channel = -1, int cell = -1) :
-        db(db), sampic(sampic), channel(channel), cell(cell) {}
-      friend std::ostream& operator<<(std::ostream& os, const CalibrationKey& key) {
-        return os << key.db << " " << key.sampic << " " << key.channel << " " << key.cell;
-      }
+      bool operator<( const CalibrationKey& rhs ) const;
+      friend std::ostream& operator<<( std::ostream& os, const CalibrationKey& key );
+
+      int db, sampic, channel, cell;
     };
     //--------------------------------------------------------------------------
 
@@ -48,47 +37,15 @@ class PPSTimingCalibration
 
     PPSTimingCalibration() = default;
     PPSTimingCalibration( const std::string& formula, const ParametersMap& params, const TimingMap& timeinfo ) :
-      formula_(formula), parameters_(params), timeInfo_(timeinfo) {}
+      formula_( formula ), parameters_( params ), timeInfo_( timeinfo ) {}
     ~PPSTimingCalibration() = default;
 
-    inline std::vector<double> getParameters(int db, int sampic, int channel, int cell) const {
-      CalibrationKey key = CalibrationKey(db, sampic, channel, cell);
-      auto out = parameters_.find(key);
-      if (out == parameters_.end())
-        return {};
-      else
-        return out->second;
-    }
+    std::vector<double> getParameters( int db, int sampic, int channel, int cell ) const;
     inline const std::string& getFormula() const { return formula_; }
-    inline double getTimeOffset(int db, int sampic, int channel) const {
-      CalibrationKey key = CalibrationKey(db, sampic, channel);
-      auto out = timeInfo_.find(key);
-      if (out == timeInfo_.end())
-        return 0.;
-      else
-        return out->second.first;
-    }
-    inline double getTimePrecision(int db, int sampic, int channel) const {
-      CalibrationKey key = CalibrationKey(db, sampic, channel);
-      auto out = timeInfo_.find(key);
-      if (out == timeInfo_.end())
-        return 0.;
-      else
-        return out->second.second;
-    }
+    double getTimeOffset( int db, int sampic, int channel ) const;
+    double getTimePrecision( int db, int sampic, int channel ) const;
 
-    friend std::ostream& operator<<(std::ostream& os, const PPSTimingCalibration& data) {
-      os << "FORMULA: "<< data.formula_ << "\nDB SAMPIC CHANNEL CELL PARAMETERS TIME_OFFSET\n";
-      for (const auto& kv : data.parameters_) {
-        os << kv.first <<" [";
-        for (size_t i = 0; i < kv.second.size(); ++i)
-          os << (i > 0 ? ", " : "") << kv.second.at(i);
-        CalibrationKey k = kv.first;
-        k.cell = -1;
-        os << "] " << data.timeInfo_.at(k).first << " " <<  data.timeInfo_.at(k).second << "\n";
-      }
-      return os;
-    }
+    friend std::ostream& operator<<( std::ostream& os, const PPSTimingCalibration& data );
 
   private:
     friend PPSTimingCalibrationESSource;

--- a/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
@@ -39,10 +39,10 @@ class PPSTimingCalibration
       formula_( formula ), parameters_( params ), timeInfo_( timeinfo ) {}
     ~PPSTimingCalibration() = default;
 
-    std::vector<double> getParameters( int db, int sampic, int channel, int cell ) const;
-    inline const std::string& getFormula() const { return formula_; }
-    double getTimeOffset( int db, int sampic, int channel ) const;
-    double getTimePrecision( int db, int sampic, int channel ) const;
+    std::vector<double> parameters( int db, int sampic, int channel, int cell ) const;
+    inline const std::string& formula() const { return formula_; }
+    double timeOffset( int db, int sampic, int channel ) const;
+    double timePrecision( int db, int sampic, int channel ) const;
 
     friend std::ostream& operator<<( std::ostream& os, const PPSTimingCalibration& data );
 

--- a/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h
@@ -1,0 +1,104 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Filip Dej
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#ifndef CondFormats_CTPPSReadoutObjects_PPSTimingCalibration_h
+#define CondFormats_CTPPSReadoutObjects_PPSTimingCalibration_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <map>
+#include <vector>
+
+class PPSTimingCalibrationESSource;
+class PPSTimingCalibration
+{
+  public:
+    /// Helper structure for storing calibration data
+    struct CalibrationKey
+    {
+      int db, sampic, channel, cell;
+      /// Comparison operator
+      bool operator<(const CalibrationKey& rhs) const {
+        if (db == rhs.db) {
+          if (sampic == rhs.sampic) {
+            if (channel == rhs.channel)
+              return cell < rhs.cell;
+            return channel < rhs.channel;
+          }
+          return sampic < rhs.sampic;
+        }
+        return db < rhs.db;
+      }
+      CalibrationKey(int db = -1, int sampic = -1, int channel = -1, int cell = -1) :
+        db(db), sampic(sampic), channel(channel), cell(cell) {}
+      friend std::ostream& operator<<(std::ostream& os, const CalibrationKey& key) {
+        return os << key.db << " " << key.sampic << " " << key.channel << " " << key.cell;
+      }
+    };
+    //--------------------------------------------------------------------------
+
+    typedef std::map<CalibrationKey,std::vector<double> > ParametersMap;
+    typedef std::map<CalibrationKey,std::pair<double,double> > TimingMap;
+
+    PPSTimingCalibration() = default;
+    PPSTimingCalibration( const std::string& formula, const ParametersMap& params, const TimingMap& timeinfo ) :
+      formula_(formula), parameters_(params), timeInfo_(timeinfo) {}
+    ~PPSTimingCalibration() = default;
+
+    inline std::vector<double> getParameters(int db, int sampic, int channel, int cell) const {
+      CalibrationKey key = CalibrationKey(db, sampic, channel, cell);
+      auto out = parameters_.find(key);
+      if (out == parameters_.end())
+        return {};
+      else
+        return out->second;
+    }
+    inline const std::string& getFormula() const { return formula_; }
+    inline double getTimeOffset(int db, int sampic, int channel) const {
+      CalibrationKey key = CalibrationKey(db, sampic, channel);
+      auto out = timeInfo_.find(key);
+      if (out == timeInfo_.end())
+        return 0.;
+      else
+        return out->second.first;
+    }
+    inline double getTimePrecision(int db, int sampic, int channel) const {
+      CalibrationKey key = CalibrationKey(db, sampic, channel);
+      auto out = timeInfo_.find(key);
+      if (out == timeInfo_.end())
+        return 0.;
+      else
+        return out->second.second;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const PPSTimingCalibration& data) {
+      os << "FORMULA: "<< data.formula_ << "\nDB SAMPIC CHANNEL CELL PARAMETERS TIME_OFFSET\n";
+      for (const auto& kv : data.parameters_) {
+        os << kv.first <<" [";
+        for (size_t i = 0; i < kv.second.size(); ++i)
+          os << (i > 0 ? ", " : "") << kv.second.at(i);
+        CalibrationKey k = kv.first;
+        k.cell = -1;
+        os << "] " << data.timeInfo_.at(k).first << " " <<  data.timeInfo_.at(k).second << "\n";
+      }
+      return os;
+    }
+
+  private:
+    friend PPSTimingCalibrationESSource;
+
+    std::string formula_;
+    ParametersMap parameters_;
+    TimingMap timeInfo_;
+
+    COND_SERIALIZABLE;
+};
+
+#endif
+

--- a/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
@@ -1,0 +1,93 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Filip Dej
+ *   Laurent Forthomme
+ *
+ * NOTE:
+ *   Given implementation handles calibration files in JSON format,
+ *   which can be generated using dedicated python script.
+ *
+ ****************************************************************************/
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/SourceFactory.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+namespace pt = boost::property_tree;
+
+//------------------------------------------------------------------------------
+
+class PPSTimingCalibrationESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder
+{
+  public:
+    PPSTimingCalibrationESSource( const edm::ParameterSet& );
+    ~PPSTimingCalibrationESSource() override = default;
+
+  private:
+    edm::ESProducts<std::unique_ptr<PPSTimingCalibration> > produce();
+    /// Extracts calibration data from JSON file
+    void parseJsonFile();
+
+    const std::string filename_;
+    PPSTimingCalibration calib_;
+};
+
+//------------------------------------------------------------------------------
+
+PPSTimingCalibrationESSource::PPSTimingCalibrationESSource( const edm::ParameterSet& iConfig ) :
+  filename_( iConfig.getParameter<edm::FileInPath>( "filename" ).fullPath() )
+{
+  parseJsonFile();
+}
+
+//------------------------------------------------------------------------------
+
+void
+PPSTimingCalibrationESSource::parseJsonFile()
+{
+  pt::ptree node;
+  pt::read_json( filename_, node );
+
+  const std::string formula = node.get<std::string>( "formula" );
+  PPSTimingCalibration::ParametersMap params;
+  PPSTimingCalibration::TimingMap time_info;
+
+  for ( pt::ptree::value_type& par : node.get_child( "parameters" ) ) {
+    PPSTimingCalibration::CalibrationKey key;
+    key.db = (int)strtol( par.first.data(), nullptr, 10 );
+
+    for (pt::ptree::value_type &board : par.second) {
+      key.sampic = board.second.get<int>( "sampic" );
+      key.channel = board.second.get<int>( "channel" );
+      double timeOffset = board.second.get<double>( "time_offset" );
+      double timePrecision = board.second.get<double>( "time_precision" );
+      key.cell = -1;
+      time_info[key] = { timeOffset, timePrecision };
+
+      int cell_ct = 0;
+      for ( pt::ptree::value_type &cell : board.second.get_child( "cells" ) ) {
+        std::vector<double> values;
+        key.cell = cell_ct;
+
+        for ( pt::ptree::value_type& param : cell.second )
+          values.emplace_back( std::stod( param.second.data(), nullptr ) );
+        params[key] = values;
+        cell_ct++;
+      }
+    }
+  }
+  calib_ = PPSTimingCalibration( formula, params, time_info );
+}
+

--- a/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
@@ -69,8 +69,9 @@ PPSTimingCalibrationESSource::produce( const PPSTimingCalibrationRcd& )
 //------------------------------------------------------------------------------
 
 void
-PPSTimingCalibrationESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue&,
-                                           edm::ValidityInterval& oValidity )
+PPSTimingCalibrationESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+                                              const edm::IOVSyncValue&,
+                                              edm::ValidityInterval& oValidity )
 {
   oValidity = edm::ValidityInterval( edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime() );
 }

--- a/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
@@ -88,7 +88,7 @@ PPSTimingCalibrationESSource::parseJsonFile() const
   PPSTimingCalibration::TimingMap time_info;
 
   for ( pt::ptree::value_type& par : node.get_child( "parameters" ) ) {
-    PPSTimingCalibration::CalibrationKey key;
+    PPSTimingCalibration::Key key;
     key.db = (int)strtol( par.first.data(), nullptr, 10 );
 
     for (pt::ptree::value_type &board : par.second) {

--- a/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PPSTimingCalibrationESSource.cc
@@ -63,7 +63,7 @@ PPSTimingCalibrationESSource::PPSTimingCalibrationESSource( const edm::Parameter
 edm::ESProducts<std::unique_ptr<PPSTimingCalibration> >
 PPSTimingCalibrationESSource::produce( const PPSTimingCalibrationRcd& )
 {
-  return edm::es::products( std::move( parseJsonFile() ) );
+  return edm::es::products( parseJsonFile() );
 }
 
 //------------------------------------------------------------------------------

--- a/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
@@ -34,7 +34,7 @@ operator<<( std::ostream& os, const PPSTimingCalibration::Key& key )
 //--------------------------------------------------------------------------
 
 std::vector<double>
-PPSTimingCalibration::getParameters( int db, int sampic, int channel, int cell ) const
+PPSTimingCalibration::parameters( int db, int sampic, int channel, int cell ) const
 {
   Key key{ db, sampic, channel, cell };
   auto out = parameters_.find( key );
@@ -44,7 +44,7 @@ PPSTimingCalibration::getParameters( int db, int sampic, int channel, int cell )
 }
 
 double
-PPSTimingCalibration::getTimeOffset( int db, int sampic, int channel ) const
+PPSTimingCalibration::timeOffset( int db, int sampic, int channel ) const
 {
   Key key{ db, sampic, channel, -1 };
   auto out = timeInfo_.find( key );
@@ -54,7 +54,7 @@ PPSTimingCalibration::getTimeOffset( int db, int sampic, int channel ) const
 }
 
 double
-PPSTimingCalibration::getTimePrecision( int db, int sampic, int channel ) const
+PPSTimingCalibration::timePrecision( int db, int sampic, int channel ) const
 {
   Key key{ db, sampic, channel, -1 };
   auto out = timeInfo_.find( key );

--- a/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
@@ -12,7 +12,7 @@
 //--------------------------------------------------------------------------
 
 bool
-PPSTimingCalibration::CalibrationKey::operator<( const PPSTimingCalibration::CalibrationKey& rhs ) const
+PPSTimingCalibration::Key::operator<( const PPSTimingCalibration::Key& rhs ) const
 {
   if ( db == rhs.db ) {
     if ( sampic == rhs.sampic ) {
@@ -26,7 +26,7 @@ PPSTimingCalibration::CalibrationKey::operator<( const PPSTimingCalibration::Cal
 }
 
 std::ostream&
-operator<<( std::ostream& os, const PPSTimingCalibration::CalibrationKey& key )
+operator<<( std::ostream& os, const PPSTimingCalibration::Key& key )
 {
   return os << key.db << " " << key.sampic << " " << key.channel << " " << key.cell;
 }
@@ -36,7 +36,7 @@ operator<<( std::ostream& os, const PPSTimingCalibration::CalibrationKey& key )
 std::vector<double>
 PPSTimingCalibration::getParameters( int db, int sampic, int channel, int cell ) const
 {
-  CalibrationKey key( db, sampic, channel, cell );
+  Key key{ db, sampic, channel, cell };
   auto out = parameters_.find( key );
   if ( out == parameters_.end() )
     return {};
@@ -46,7 +46,7 @@ PPSTimingCalibration::getParameters( int db, int sampic, int channel, int cell )
 double
 PPSTimingCalibration::getTimeOffset( int db, int sampic, int channel ) const
 {
-  CalibrationKey key( db, sampic, channel );
+  Key key{ db, sampic, channel, -1 };
   auto out = timeInfo_.find( key );
   if ( out == timeInfo_.end() )
     return 0.;
@@ -56,7 +56,7 @@ PPSTimingCalibration::getTimeOffset( int db, int sampic, int channel ) const
 double
 PPSTimingCalibration::getTimePrecision( int db, int sampic, int channel ) const
 {
-  CalibrationKey key( db, sampic, channel );
+  Key key{ db, sampic, channel, -1 };
   auto out = timeInfo_.find( key );
   if ( out == timeInfo_.end() )
     return 0.;
@@ -71,9 +71,10 @@ operator<<( std::ostream& os, const PPSTimingCalibration& data )
     os << kv.first <<" [";
     for ( size_t i = 0; i < kv.second.size(); ++i )
       os << ( i > 0 ? ", " : "" ) << kv.second.at( i );
-    PPSTimingCalibration::CalibrationKey k = kv.first;
+    PPSTimingCalibration::Key k = kv.first;
     k.cell = -1;
-    os << "] " << data.timeInfo_.at( k ).first << " " <<  data.timeInfo_.at( k ).second << "\n";
+    const auto& time = data.timeInfo_.at( k );
+    os << "] " << time.first << " " <<  time.second << "\n";
   }
   return os;
 }

--- a/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/PPSTimingCalibration.cc
@@ -1,0 +1,80 @@
+/****************************************************************************
+ *
+ * This is a part of CTPPS offline software.
+ * Authors:
+ *   Filip Dej
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
+
+//--------------------------------------------------------------------------
+
+bool
+PPSTimingCalibration::CalibrationKey::operator<( const PPSTimingCalibration::CalibrationKey& rhs ) const
+{
+  if ( db == rhs.db ) {
+    if ( sampic == rhs.sampic ) {
+      if ( channel == rhs.channel )
+        return cell < rhs.cell;
+      return channel < rhs.channel;
+    }
+    return sampic < rhs.sampic;
+  }
+  return db < rhs.db;
+}
+
+std::ostream&
+operator<<( std::ostream& os, const PPSTimingCalibration::CalibrationKey& key )
+{
+  return os << key.db << " " << key.sampic << " " << key.channel << " " << key.cell;
+}
+
+//--------------------------------------------------------------------------
+
+std::vector<double>
+PPSTimingCalibration::getParameters( int db, int sampic, int channel, int cell ) const
+{
+  CalibrationKey key( db, sampic, channel, cell );
+  auto out = parameters_.find( key );
+  if ( out == parameters_.end() )
+    return {};
+  return out->second;
+}
+
+double
+PPSTimingCalibration::getTimeOffset( int db, int sampic, int channel ) const
+{
+  CalibrationKey key( db, sampic, channel );
+  auto out = timeInfo_.find( key );
+  if ( out == timeInfo_.end() )
+    return 0.;
+  return out->second.first;
+}
+
+double
+PPSTimingCalibration::getTimePrecision( int db, int sampic, int channel ) const
+{
+  CalibrationKey key( db, sampic, channel );
+  auto out = timeInfo_.find( key );
+  if ( out == timeInfo_.end() )
+    return 0.;
+  return out->second.second;
+}
+
+std::ostream&
+operator<<( std::ostream& os, const PPSTimingCalibration& data )
+{
+  os << "FORMULA: "<< data.formula_ << "\nDB SAMPIC CHANNEL CELL PARAMETERS TIME_OFFSET\n";
+  for ( const auto& kv : data.parameters_ ) {
+    os << kv.first <<" [";
+    for ( size_t i = 0; i < kv.second.size(); ++i )
+      os << ( i > 0 ? ", " : "" ) << kv.second.at( i );
+    PPSTimingCalibration::CalibrationKey k = kv.first;
+    k.cell = -1;
+    os << "] " << data.timeInfo_.at( k ).first << " " <<  data.timeInfo_.at( k ).second << "\n";
+  }
+  return os;
+}
+

--- a/CondFormats/CTPPSReadoutObjects/src/T_EventSetup_PPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/T_EventSetup_PPSTimingCalibration.cc
@@ -1,0 +1,5 @@
+#include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(PPSTimingCalibration);
+

--- a/CondFormats/CTPPSReadoutObjects/src/classes.h
+++ b/CondFormats/CTPPSReadoutObjects/src/classes.h
@@ -12,5 +12,6 @@ namespace CondFormats_CTPPSPixelObjects {
      std::map<PPSTimingCalibration::Key,std::pair<double,double> > tc_pm;
      std::pair<PPSTimingCalibration::Key,std::vector<double> > tc_v_tm;
      std::pair<PPSTimingCalibration::Key,std::pair<double,double> > tc_v_pm;
- };
+  };
 }
+

--- a/CondFormats/CTPPSReadoutObjects/src/classes.h
+++ b/CondFormats/CTPPSReadoutObjects/src/classes.h
@@ -2,10 +2,15 @@
 
 namespace CondFormats_CTPPSPixelObjects {
    struct dictionary {
-     std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> ROCMapping; 
+     std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> ROCMapping;
      std::map<uint32_t, CTPPSPixelROCAnalysisMask> analysisMask;
      std::vector< CTPPSPixelGainCalibration::DetRegistry >::iterator p3;
      std::vector< CTPPSPixelGainCalibration::DetRegistry >::const_iterator p4;
-     std::map<uint32_t,CTPPSPixelGainCalibration> mycalibmap; 
+     std::map<uint32_t,CTPPSPixelGainCalibration> mycalibmap;
+     //--- timing calibration parameters
+     std::map<PPSTimingCalibration::Key,std::vector<double> > tc_tm;
+     std::map<PPSTimingCalibration::Key,std::pair<double,double> > tc_pm;
+     std::pair<PPSTimingCalibration::Key,std::vector<double> > tc_v_tm;
+     std::pair<PPSTimingCalibration::Key,std::pair<double,double> > tc_v_pm;
  };
-}     
+}

--- a/CondFormats/CTPPSReadoutObjects/src/classes_def.xml
+++ b/CondFormats/CTPPSReadoutObjects/src/classes_def.xml
@@ -28,8 +28,8 @@
     <class name="std::pair<PPSTimingCalibration::Key,std::pair<double,double> >"/>
     <class name="PPSTimingCalibration" class_version="0">
       <field name="formula_"/>
-      <field name="parameters_" mapping="blob"/>
-      <field name="timeInfo_" mapping="blob"/>
+      <field name="parameters_"/>
+      <field name="timeInfo_"/>
     </class>
 </lcgdict>
 

--- a/CondFormats/CTPPSReadoutObjects/src/classes_def.xml
+++ b/CondFormats/CTPPSReadoutObjects/src/classes_def.xml
@@ -1,11 +1,11 @@
 <lcgdict>
     <class name="CTPPSPixelFramePosition"  class_version="0"/>
-    
+
     <class name="CTPPSPixelROCInfo"  class_version="0"/>
-    
+
     <class name="CTPPSPixelDAQMapping"  class_version="0"/>
     <class name="std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo>"/>
-    
+
     <class name="CTPPSPixelAnalysisMask"  class_version="0"/>
 
     <class name="CTPPSPixelROCAnalysisMask"  class_version="0"/>
@@ -20,4 +20,15 @@
     <class name="CTPPSPixelGainCalibration::DetRegistry"/>
     <class name="std::vector<CTPPSPixelGainCalibration::DetRegistry>"/>
     <class name="CTPPSPixelGainCalibrations" class_version="0"/>
+
+    <class name="PPSTimingCalibration::Key"/>
+    <class name="std::map<PPSTimingCalibration::Key,std::vector<double> >"/>
+    <class name="std::map<PPSTimingCalibration::Key,std::pair<double,double> >"/>
+    <class name="std::pair<PPSTimingCalibration::Key,std::vector<double> >"/>
+    <class name="std::pair<PPSTimingCalibration::Key,std::pair<double,double> >"/>
+    <class name="PPSTimingCalibration" class_version="0">
+      <field name="formula_"/>
+      <field name="parameters_" mapping="blob"/>
+      <field name="timeInfo_" mapping="blob"/>
+    </class>
 </lcgdict>

--- a/CondFormats/CTPPSReadoutObjects/src/classes_def.xml
+++ b/CondFormats/CTPPSReadoutObjects/src/classes_def.xml
@@ -32,3 +32,4 @@
       <field name="timeInfo_" mapping="blob"/>
     </class>
 </lcgdict>
+

--- a/CondFormats/CTPPSReadoutObjects/src/headers.h
+++ b/CondFormats/CTPPSReadoutObjects/src/headers.h
@@ -1,3 +1,5 @@
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelDAQMapping.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelAnalysisMask.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
+

--- a/CondFormats/CTPPSReadoutObjects/test/BuildFile.xml
+++ b/CondFormats/CTPPSReadoutObjects/test/BuildFile.xml
@@ -1,3 +1,4 @@
 <bin file="testSerializationPPSTimingCalibration.cc">
   <use name="CondFormats/CTPPSReadoutObjects"/>
 </bin>
+

--- a/CondFormats/CTPPSReadoutObjects/test/BuildFile.xml
+++ b/CondFormats/CTPPSReadoutObjects/test/BuildFile.xml
@@ -1,0 +1,3 @@
+<bin file="testSerializationPPSTimingCalibration.cc">
+  <use name="CondFormats/CTPPSReadoutObjects"/>
+</bin>

--- a/CondFormats/CTPPSReadoutObjects/test/testSerializationPPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/test/testSerializationPPSTimingCalibration.cc
@@ -4,6 +4,8 @@
 int main()
 {
   testSerialization<PPSTimingCalibration>();
-  return 0 ;
+  testSerialization<PPSTimingCalibration::Key>();
+  testSerialization<std::vector<PPSTimingCalibration> >();
+  return 0;
 }
 

--- a/CondFormats/CTPPSReadoutObjects/test/testSerializationPPSTimingCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/test/testSerializationPPSTimingCalibration.cc
@@ -1,0 +1,9 @@
+#include "CondFormats/Serialization/interface/Test.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
+
+int main()
+{
+  testSerialization<PPSTimingCalibration>();
+  return 0 ;
+}
+

--- a/CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h
+++ b/CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h
@@ -1,0 +1,18 @@
+/****************************************************************************
+*
+* This is a part of PPS offline software.
+* Author:
+*   Laurent Forthomme (laurent.forthomme@cern.ch)
+*
+****************************************************************************/
+
+#ifndef CondFormats_DataRecord_PPSTimingCalibrationRcd
+#define CondFormats_DataRecord_PPSTimingCalibrationRcd
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+/// EventSetup record for TOTEM/PPS timing calibration information.
+class PPSTimingCalibrationRcd : public edm::eventsetup::EventSetupRecordImplementation<PPSTimingCalibrationRcd> {};
+
+#endif
+

--- a/CondFormats/DataRecord/src/PPSTimingCalibrationRcd.cc
+++ b/CondFormats/DataRecord/src/PPSTimingCalibrationRcd.cc
@@ -1,0 +1,13 @@
+/****************************************************************************
+*
+* This is a part of TOTEM/PPS offline software.
+* Author:
+*   Laurent Forthomme (laurent.forthomme@cern.ch)
+*
+****************************************************************************/
+
+#include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(PPSTimingCalibrationRcd);
+

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM/PPS offline software.
+ * Author:
+ *   Laurent Forthomme (laurent.forthomme@cern.ch)
+ *
+ ****************************************************************************/
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+#include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
+#include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
+
+#include <memory>
+
+class PPSTimingCalibrationAnalyzer : public edm::one::EDAnalyzer<>
+{
+  public:
+    explicit PPSTimingCalibrationAnalyzer( const edm::ParameterSet& ) {}
+    ~PPSTimingCalibrationAnalyzer() = default;
+
+  private:
+    void beginJob() override {}
+    void analyze( const edm::Event&, const edm::EventSetup& ) override;
+    void endJob() override {}
+
+    edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
+};
+
+void
+PPSTimingCalibrationAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+  // get timing calibration parameters
+  edm::ESHandle<PPSTimingCalibration> hTimingCalib;
+  if ( calibWatcher_.check( iSetup ) ) {
+    iSetup.get<PPSTimingCalibrationRcd>().get( hTimingCalib );
+
+    edm::LogInfo("PPSTimingCalibrationAnalyzer")
+      << "Calibrations retrieved:\n"
+      << *hTimingCalib;
+  }
+}
+
+DEFINE_FWK_MODULE( PPSTimingCalibrationAnalyzer );

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
@@ -28,7 +28,6 @@ class PPSTimingCalibrationAnalyzer : public edm::one::EDAnalyzer<>
 {
   public:
     explicit PPSTimingCalibrationAnalyzer( const edm::ParameterSet& ) {}
-    ~PPSTimingCalibrationAnalyzer() = default;
 
   private:
     void beginJob() override {}

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationAnalyzer.cc
@@ -53,3 +53,4 @@ PPSTimingCalibrationAnalyzer::analyze( const edm::Event& iEvent, const edm::Even
 }
 
 DEFINE_FWK_MODULE( PPSTimingCalibrationAnalyzer );
+

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
@@ -1,0 +1,54 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM/PPS offline software.
+ * Author:
+ *   Laurent Forthomme (laurent.forthomme@cern.ch)
+ *
+ ****************************************************************************/
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+#include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
+#include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
+
+#include <memory>
+
+class PPSTimingCalibrationWriter : public edm::one::EDAnalyzer<>
+{
+  public:
+    explicit PPSTimingCalibrationWriter( const edm::ParameterSet& ) {}
+    ~PPSTimingCalibrationWriter() = default;
+
+  private:
+    void beginJob() override {}
+    void analyze( const edm::Event&, const edm::EventSetup& ) override;
+    void endJob() override {}
+};
+
+void
+PPSTimingCalibrationWriter::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+  // get timing calibration parameters
+  edm::ESHandle<PPSTimingCalibration> hTimingCalib;
+  iSetup.get<PPSTimingCalibrationRcd>().get( hTimingCalib );
+
+  // store the calibration into a DB object
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  if ( poolDbService.isAvailable() )
+    poolDbService->writeOne( hTimingCalib.product(), poolDbService->currentTime(), "PPSTimingCalibrationRcd" );
+  else
+    throw cms::Exception("PPSTimingCalibrationWriter") << "PoolDBService required.";
+}
+
+DEFINE_FWK_MODULE( PPSTimingCalibrationWriter );
+

--- a/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
+++ b/CondTools/CTPPS/plugins/PPSTimingCalibrationWriter.cc
@@ -27,7 +27,6 @@ class PPSTimingCalibrationWriter : public edm::one::EDAnalyzer<>
 {
   public:
     explicit PPSTimingCalibrationWriter( const edm::ParameterSet& ) {}
-    ~PPSTimingCalibrationWriter() = default;
 
   private:
     void beginJob() override {}

--- a/CondTools/CTPPS/test/ppsTimingCalibrationAnalyzer_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationAnalyzer_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('test')
 
-# minimum of logs
+# minimum logging
 process.MessageLogger = cms.Service('MessageLogger',
     statistics = cms.untracked.vstring(),
     destinations = cms.untracked.vstring('cout'),
@@ -20,8 +20,7 @@ process.source = cms.Source('EmptyIOVSource',
 
 # load calibrations from database
 process.load('CondCore.CondDB.CondDB_cfi')
-# SQLite input
-process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite'
+process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite' # SQLite input
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
@@ -29,8 +28,7 @@ process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('PPSTimingCalibrationRcd'),
-            tag = cms.string('TotemTimingCalibration'),
-            #label = cms.string('UFSD')
+            tag = cms.string('TotemTimingCalibration')
         )
     )
 )

--- a/CondTools/CTPPS/test/ppsTimingCalibrationAnalyzer_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationAnalyzer_cfg.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('test')
+
+# minimum of logs
+process.MessageLogger = cms.Service('MessageLogger',
+    statistics = cms.untracked.vstring(),
+    destinations = cms.untracked.vstring('cout'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    )
+)
+
+process.source = cms.Source('EmptyIOVSource',
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+# load calibrations from database
+process.load('CondCore.CondDB.CondDB_cfi')
+# SQLite input
+process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite'
+
+process.PoolDBESSource = cms.ESSource('PoolDBESSource',
+    process.CondDB,
+    DumpStats = cms.untracked.bool(True),
+    toGet = cms.VPSet(
+        cms.PSet(
+            record = cms.string('PPSTimingCalibrationRcd'),
+            tag = cms.string('TotemTimingCalibration'),
+            #label = cms.string('UFSD')
+        )
+    )
+)
+
+process.ppsTimingCalibrationAnalyzer = cms.EDAnalyzer('PPSTimingCalibrationAnalyzer')
+
+process.path = cms.Path(
+    process.ppsTimingCalibrationAnalyzer
+)
+

--- a/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
@@ -26,7 +26,6 @@ process.PoolDBOutputService = cms.Service('PoolDBOutputService',
         cms.PSet(
             record = cms.string('PPSTimingCalibrationRcd'),
             tag = cms.string('TotemTimingCalibration'),
-            label = cms.string('UFSD')
         )
     )
 )

--- a/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
@@ -15,8 +15,9 @@ process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('RecoCTPPS
 
 # output service for database
 process.load('CondCore.CondDB.CondDB_cfi')
-# SQLite output
-process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite'
+process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite' # SQLite output
+#process.CondDB.connect = 'oracle://cmsprep/TimingCalibration' # Oracle output
+#process.CondDB.connect = 'frontier://cmsfrontier.cern.ch:8000/FrontierPrep/TimingCalibration' # Frontier output
 
 process.PoolDBOutputService = cms.Service('PoolDBOutputService',
     process.CondDB,

--- a/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationWriter_cfg.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('test')
+
+process.source = cms.Source('EmptyIOVSource',
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+# load calibrations from JSON file
+process.load('CondFormats.CTPPSReadoutObjects.ppsTimingCalibrationESSource_cfi')
+process.ppsTimingCalibrationESSource.calibrationFile = cms.FileInPath('RecoCTPPS/TotemRPLocal/data/timing_offsets_ufsd_2018.dec18.cal.json')
+
+# output service for database
+process.load('CondCore.CondDB.CondDB_cfi')
+# SQLite output
+process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite'
+
+process.PoolDBOutputService = cms.Service('PoolDBOutputService',
+    process.CondDB,
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(
+        cms.PSet(
+            record = cms.string('PPSTimingCalibrationRcd'),
+            tag = cms.string('TotemTimingCalibration'),
+            label = cms.string('UFSD')
+        )
+    )
+)
+
+process.ppsTimingCalibrationWriter = cms.EDAnalyzer('PPSTimingCalibrationWriter')
+
+process.path = cms.Path(
+    process.ppsTimingCalibrationWriter
+)
+


### PR DESCRIPTION
Definition of the conditions data format for Totem vertical UFSD / PPS horizontal diamond detectors timing calibration.
In addition to a string calibration function formula, for each of the 192 channels of vertical UFSD detectors, the following attributes are stored:
- 6 calibration function parameters
- 1 timing precision
- 1 time offset

The typical IOV is era for Totem's, and LHC fill for PPS' timing detectors.

A [follow-up PR](https://github.com/forthommel/cmssw/compare/totemTimingReco_timingCalibESprod_noLR...forthommel:totemTimingReco_timingCalibESprod_LRonly) will make use of these payloads in the PPS/Totem local reconstruction code, as previously discussed in slide 4 of [this RECO/AT](https://indico.cern.ch/event/787904/contributions/3288450/) and slide 3 of [this AlCaDB](https://indico.cern.ch/event/793525/contributions/3296664/) status reports.

FYI: @malbouis, @clemencia, @wpcarvalho, @nminafra 