### PR TITLE
Remove empty endJob() functions from AlcaBeamMonitorClient and BeamMonitorBx

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
@@ -341,8 +341,4 @@ void AlcaBeamMonitorClient::endRun(const Run& iRun, const EventSetup& context) {
   /**/
 }
 
-//----------------------------------------------------------------------------------------------------------------------
-void AlcaBeamMonitorClient::endJob(const LuminosityBlock& iLumi,
-                                   const EventSetup& iSetup) {}
-
 DEFINE_FWK_MODULE(AlcaBeamMonitorClient);

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
@@ -33,7 +33,6 @@ class AlcaBeamMonitorClient : public edm::EDAnalyzer {
   void analyze  	   (const edm::Event& iEvent, 	       const edm::EventSetup& iSetup) override;
   void endLuminosityBlock  (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void endRun		   (const edm::Run& iRun,              const edm::EventSetup& iSetup) override;
-  void endJob		   (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup);
   
  private:
   //                x,y,z,sigmax(y,z)... [run,lumi]          Histo name      

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
@@ -562,9 +562,4 @@ void BeamMonitorBx::endRun(const Run& r, const EventSetup& context){
 
 }
 
-//--------------------------------------------------------
-void BeamMonitorBx::endJob(const LuminosityBlock& lumiSeg,
-			   const EventSetup& iSetup){
-}
-
 DEFINE_FWK_MODULE(BeamMonitorBx);

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
@@ -53,7 +53,7 @@ BeamMonitorBx::BeamMonitorBx( const ParameterSet& ps ) :
 
   dbe_            = Service<DQMStore>().operator->();
 
-  if (monitorName_ != "" ) monitorName_ = monitorName_+"/" ;
+  if (!monitorName_.empty() ) monitorName_ = monitorName_+"/" ;
 
   theBeamFitter = new BeamFitter(parameters_, consumesCollector());
   theBeamFitter->resetTrkVector();
@@ -456,7 +456,7 @@ void BeamMonitorBx::FillTables(int nthbx,int nthbin_,
   for (std::map<std::string,std::string>::const_iterator varName = vMap.begin();
        varName != vMap.end(); ++varName) {
     TString tmpName = varName->first;
-    if (suffix_ != "") tmpName += TString("_"+suffix_);
+    if (!suffix_.empty()) tmpName += TString("_"+suffix_);
     hs[tmpName]->setBinContent(1,nthbin_,nthbx);
     hs[tmpName]->setBinContent(2,nthbin_,val_[varName->first].first);
     hs[tmpName]->setBinContent(3,nthbin_,val_[varName->first].second);

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.h
@@ -49,8 +49,6 @@ class BeamMonitorBx : public edm::EDAnalyzer {
 			  const edm::EventSetup& c) override;
   // EndRun
   void endRun(const edm::Run& r, const edm::EventSetup& c) override;
-  // Endjob
-  void endJob(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c);
   
  private:
 


### PR DESCRIPTION
These `endJob()` functions were hiding an overloaded virtual function (caught by clang). As the implementations were empty, it was simplest to just remove them.

Tested in CMSSW_10_5_X_2019-01-27-0000, no changes expected.