### PR TITLE
Make edm::EventSetup a facade

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
@@ -2,7 +2,6 @@
 
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 #include "Alignment/CommonAlignment/interface/Alignable.h"
@@ -32,8 +31,7 @@ AlignmentStats::AlignmentStats(const edm::ParameterSet &iConfig) :
   keepHitPopulation_(iConfig.getParameter<bool>("keepHitStats")),
   statsTreeName_(iConfig.getParameter<string>("TrkStatsFileName")),
   hitsTreeName_(iConfig.getParameter<string>("HitStatsFileName")),
-  prescale_(iConfig.getParameter<uint32_t>("TrkStatsPrescale")),
-  lastSetup_(nullptr)
+  prescale_(iConfig.getParameter<uint32_t>("TrkStatsPrescale"))
 {
 
   //sanity checks
@@ -75,7 +73,6 @@ void AlignmentStats::beginJob(){// const edm::EventSetup &iSetup
   */
 
   tmpPresc_=prescale_;
-  firstEvent_=true;
 
   //load the tracker geometry from the EventSetup
   //  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry_);
@@ -85,17 +82,15 @@ void AlignmentStats::beginJob(){// const edm::EventSetup &iSetup
 
 void AlignmentStats::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup){
 
-  lastSetup_ = &iSetup;
-
   //load list of detunits needed then in endJob
  
-  if(firstEvent_){
-    edm::ESHandle<TrackerGeometry> tmpTkGeometry;
-    iSetup.get<TrackerDigiGeometryRecord>().get(tmpTkGeometry);
-    trackerGeometry_=&(*tmpTkGeometry);
-    firstEvent_=false;
-  }
+  edm::ESHandle<TrackerGeometry> tmpTkGeometry;
+  iSetup.get<TrackerDigiGeometryRecord>().get(tmpTkGeometry);
+  trackerGeometry_=&(*tmpTkGeometry);
 
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  trackerTopology_ = tTopoHandle.product();
 
   //take trajectories and tracks to loop on
   // edm::Handle<TrajTrackAssociationCollection> TrackAssoMap;
@@ -307,12 +302,7 @@ void AlignmentStats::endJob(){
   hitstree->Branch("posPhi",  &posPhi,  "posPhi/F");
   */
 
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  lastSetup_->get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-
-  AlignableTracker* theAliTracker=new AlignableTracker(&(*trackerGeometry_), tTopo);
+  std::unique_ptr<AlignableTracker> theAliTracker=std::make_unique<AlignableTracker>(&(*trackerGeometry_), trackerTopology_);
   const auto& Detunitslist = theAliTracker->deepComponents();
   int ndetunits=Detunitslist.size();
   edm::LogInfo("AlignmentStats")<<"Number of DetUnits in the AlignableTracker: "<< ndetunits<<std::endl;
@@ -372,39 +362,39 @@ void AlignmentStats::endJob(){
    //get layers, petals, etc...
    if(subdet==PixelSubdetector::PixelBarrel){//PXB
      
-     layer=tTopo->pxbLayer(id);
+     layer=trackerTopology_->pxbLayer(id);
      is2D=true;
      isStereo=false;
    }
    else if(subdet==PixelSubdetector::PixelEndcap){
      
-     layer=tTopo->pxfDisk(id);
+     layer=trackerTopology_->pxfDisk(id);
      is2D=true;
      isStereo=false;
    }
    else if(subdet==SiStripDetId::TIB){
      
-     layer=tTopo->tibLayer(id);
-     is2D=tTopo->tibIsDoubleSide(id);
-     isStereo=tTopo->tibIsStereo(id);
+     layer=trackerTopology_->tibLayer(id);
+     is2D=trackerTopology_->tibIsDoubleSide(id);
+     isStereo=trackerTopology_->tibIsStereo(id);
    }
    else if(subdet==SiStripDetId::TID){
      
-     layer=tTopo->tidWheel(id);
-     is2D=tTopo->tidIsDoubleSide(id);
-     isStereo=tTopo->tidIsStereo(id);
+     layer=trackerTopology_->tidWheel(id);
+     is2D=trackerTopology_->tidIsDoubleSide(id);
+     isStereo=trackerTopology_->tidIsStereo(id);
    }
    else if(subdet==SiStripDetId::TOB){
      
-     layer=tTopo->tobLayer(id);
-     is2D=tTopo->tobIsDoubleSide(id);
-     isStereo=tTopo->tobIsStereo(id);
+     layer=trackerTopology_->tobLayer(id);
+     is2D=trackerTopology_->tobIsDoubleSide(id);
+     isStereo=trackerTopology_->tobIsStereo(id);
    }
    else if(subdet==SiStripDetId::TEC){
      
-     layer=tTopo->tecWheel(id);
-     is2D=tTopo->tecIsDoubleSide(id);
-     isStereo=tTopo->tecIsStereo(id);
+     layer=trackerTopology_->tecWheel(id);
+     is2D=trackerTopology_->tecIsDoubleSide(id);
+     isStereo=trackerTopology_->tecIsStereo(id);
    }
    else{
      edm::LogError("AlignmentStats")<<"Detector not belonging neither to pixels nor to strips! Skipping it. SubDet= "<<subdet;

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.h
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.h
@@ -11,6 +11,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 // #include <Riostream.h>
 #include <fstream>
@@ -46,7 +47,6 @@ class AlignmentStats: public edm::EDAnalyzer{
   uint32_t prescale_;
   //////
   uint32_t tmpPresc_;
-  bool firstEvent_;
 
   //Track stats
   TFile *treefile_;
@@ -64,8 +64,7 @@ class AlignmentStats: public edm::EDAnalyzer{
 
   //  edm::ESHandle<TrackerGeometry> trackerGeometry_;
   const TrackerGeometry* trackerGeometry_;
-
-  const edm::EventSetup *lastSetup_;
+  const TrackerTopology* trackerTopology_;
 
 };
 

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.h
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.h
@@ -22,6 +22,8 @@
 #include <memory>
 
 class TrackerTopology;
+class SiStripDetCabling;
+class TrackerGeometry;
 
 class SiStripGainCosmicCalculator : public ConditionDBWriter<SiStripApvGain> {
 public:
@@ -34,8 +36,8 @@ private:
   std::unique_ptr<SiStripApvGain> getNewObject() override;
 private:
   std::pair<double,double> getPeakOfLandau( TH1F * inputHisto );
-  double moduleWidth(const uint32_t detid, const edm::EventSetup* iSetup);
-  double moduleThickness(const uint32_t detid, const edm::EventSetup* iSetup);
+  double moduleWidth(const uint32_t detid);
+  double moduleThickness(const uint32_t detid);
 private:
   std::string TrackProducer;
   std::string TrackLabel;
@@ -47,7 +49,8 @@ private:
   std::map<uint32_t, double> thickness_map; // map of detector id to respective thickness
   std::vector<uint32_t> SelectedDetIds;
   std::vector<uint32_t> detModulesToBeExcluded;
-  const edm::EventSetup * eventSetupCopy_;
+  SiStripDetCabling const* siStripDetCabling = nullptr;
+  TrackerGeometry const* tkGeom = nullptr;
   unsigned int MinNrEntries;
   double MaxChi2OverNDF;
   bool outputHistogramsInRootFile;

--- a/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
+++ b/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
@@ -304,6 +304,13 @@ void SiStripCommissioningSource::analyze( const edm::Event& event,
   
   // Create commissioning task objects 
   if ( !tasksExist_ ) { createTask( summary.product(), setup ); }
+  else {
+    for(auto& v: tasks_) {
+      for(auto& t: v) {
+        t->eventSetup(&setup);
+      }
+    }
+  }
 
   // Retrieve raw digis with mode appropriate to task 
   edm::Handle< edm::DetSetVector<SiStripRawDigi> > raw;

--- a/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
+++ b/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
@@ -366,7 +366,7 @@ void SiStripCommissioningSource::analyze( const edm::Event& event,
   }
 
   // Check for NULL pointer to digi container
-  if ( &(*raw) == nullptr ) {
+  if ( not raw.isValid() ) {
     std::stringstream ss;
     ss << "[SiStripCommissioningSource::" << __func__ << "]" << std::endl
        << " NULL pointer to DetSetVector!" << std::endl
@@ -375,7 +375,7 @@ void SiStripCommissioningSource::analyze( const edm::Event& event,
     return;
   }
 
-  if(isSpy_ and  &(*rawAlt) == nullptr){
+  if(isSpy_ and  (not rawAlt.isValid())){
     std::stringstream ss;
     ss << "[SiStripCommissioningSource::" << __func__ << "]" << std::endl
        << " NULL pointer to DetSetVector!" << std::endl

--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -30,6 +30,10 @@
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/DependentRecordTag.h"
 
+//This is here only because too many modules depend no
+// getting this header from this file (before EventSetupImpl)
+#include "FWCore/Framework/interface/EventSetup.h"
+
 // forward declarations
 namespace edm {
 namespace eventsetup {

--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -26,7 +26,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupImpl.h"
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/DependentRecordTag.h"
 
@@ -51,7 +51,7 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
         typedef typename boost::mpl::find< ListT, DepRecordT>::type FoundItrT;
         static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
         try {
-          EventSetup const& eventSetupT = this->eventSetup();
+          EventSetupImpl const& eventSetupT = this->eventSetup();
           return eventSetupT.get<DepRecordT>();
         } catch(cms::Exception& e) {
           std::ostringstream sstrm;
@@ -67,7 +67,7 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
         typedef typename boost::mpl::end< ListT >::type EndItrT;
         typedef typename boost::mpl::find< ListT, DepRecordT>::type FoundItrT;
         static_assert(! std::is_same<FoundItrT, EndItrT>::value, "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
-        EventSetup const& eventSetupT = this->eventSetup();
+        EventSetupImpl const& eventSetupT = this->eventSetup();
         return eventSetupT.tryToGet<DepRecordT>();
       }
 

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -53,7 +53,7 @@ namespace edm {
     SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
     SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
   private:
-    bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+    bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     //Needed by Worker but not something supported
@@ -62,13 +62,13 @@ namespace edm {
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();
-    bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const* mcc);
-    bool doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    bool doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                   ModuleCallingContext const* mcc);
-    bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const* mcc);
-    bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                               ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -60,7 +60,7 @@ namespace edm {
     SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
     SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
   private:
-    bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+    bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     //Needed by WorkerT but not supported
@@ -69,13 +69,13 @@ namespace edm {
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();    
-    void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const* mcc);
-    void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                   ModuleCallingContext const* mcc);
-    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const* mcc);
-    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                               ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/EDLooperBase.h
+++ b/FWCore/Framework/interface/EDLooperBase.h
@@ -93,8 +93,9 @@ namespace edm {
       void doBeginLuminosityBlock(LuminosityBlockPrincipal&, EventSetupImpl const& , ProcessContext*);
       void doEndLuminosityBlock(LuminosityBlockPrincipal&, EventSetupImpl const& , ProcessContext*);
 
+      void beginOfJob(EventSetupImpl const& );
       //This interface is deprecated
-      virtual void beginOfJob(EventSetupImpl const& );
+      virtual void beginOfJob(EventSetup const& );
       virtual void beginOfJob();
 
       virtual void endOfJob();

--- a/FWCore/Framework/interface/EDLooperBase.h
+++ b/FWCore/Framework/interface/EDLooperBase.h
@@ -85,16 +85,16 @@ namespace edm {
       EDLooperBase& operator=(EDLooperBase const&) = delete; // Disallow copying and moving
 
       void doStartingNewLoop();
-      Status doDuringLoop(EventPrincipal& eventPrincipal, EventSetup const& es, ProcessingController&, StreamContext*);
-      Status doEndOfLoop(EventSetup const& es);
+      Status doDuringLoop(EventPrincipal& eventPrincipal, EventSetupImpl const&  es, ProcessingController&, StreamContext*);
+      Status doEndOfLoop(EventSetupImpl const&  es);
       void prepareForNextLoop(eventsetup::EventSetupProvider* esp);
-      void doBeginRun(RunPrincipal&, EventSetup const&, ProcessContext*);
-      void doEndRun(RunPrincipal&, EventSetup const&, ProcessContext*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal&, EventSetup const&, ProcessContext*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal&, EventSetup const&, ProcessContext*);
+      void doBeginRun(RunPrincipal&, EventSetupImpl const& , ProcessContext*);
+      void doEndRun(RunPrincipal&, EventSetupImpl const& , ProcessContext*);
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal&, EventSetupImpl const& , ProcessContext*);
+      void doEndLuminosityBlock(LuminosityBlockPrincipal&, EventSetupImpl const& , ProcessContext*);
 
       //This interface is deprecated
-      virtual void beginOfJob(EventSetup const&);
+      virtual void beginOfJob(EventSetupImpl const& );
       virtual void beginOfJob();
 
       virtual void endOfJob();

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -56,7 +56,7 @@ namespace edm {
     SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
     SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
   private:
-    bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+    bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     //Needed by WorkerT but not supported
@@ -65,13 +65,13 @@ namespace edm {
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();
-    void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const* mcc);
-    void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                   ModuleCallingContext const* mcc);
-    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const* mcc);
-    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                               ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -44,6 +44,7 @@ namespace edm {
    class ESInputTag;
    template <class T>
    class ESGetTokenT;
+   class PileUp;
 
    namespace eventsetup {
       class EventSetupProvider;
@@ -54,8 +55,8 @@ namespace edm {
 
   class EventSetup
   {
-    ///Only EventSetupProvider allowed to create a EventSetup
-    friend class eventsetup::EventSetupProvider;
+    ///Needed until a better solution can be found
+    friend class edm::PileUp;
     public:
 
       explicit EventSetup(EventSetupImpl const& iSetup):
@@ -115,8 +116,10 @@ namespace edm {
          return m_setup.recordIsProvidedByAModule(iKey);
       }
       // ---------- static member functions --------------------
-
+      
     private:
+      edm::EventSetupImpl const& impl() const {return m_setup;}
+
 
       // ---------- member data --------------------------------
      edm::EventSetupImpl const& m_setup;

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -30,6 +30,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Framework/interface/EventSetupImpl.h"
 #include "FWCore/Framework/interface/HCMethods.h"
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
@@ -56,8 +57,9 @@ namespace edm {
     ///Only EventSetupProvider allowed to create a EventSetup
     friend class eventsetup::EventSetupProvider;
     public:
-      virtual ~EventSetup();
 
+      explicit EventSetup(EventSetupImpl const& iSetup):
+      m_setup{iSetup} {}
       EventSetup(EventSetup const&) = delete;
       EventSetup& operator=(EventSetup const&) = delete;
 
@@ -66,37 +68,14 @@ namespace edm {
           a eventsetup::NoRecordException<T> is thrown */
       template< typename T>
          T get() const {
-           using namespace eventsetup;
-           using namespace eventsetup::heterocontainer;
-            //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-            //  HOWEVER the error message under gcc 3.x is awful
-            static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>, "Trying to get a class that is not a Record from EventSetup");
-
-           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
-           if(nullptr == temp) {
-             throw eventsetup::NoRecordException<T>(recordDoesExist(*this, eventsetup::EventSetupRecordKey::makeKey<T>()));
-           }
-           T returnValue;
-           returnValue.setImpl(temp);
-           return returnValue;
+           return m_setup.get<T>();
          }
 
       /** returns the Record of type T.  If no such record available
        a null pointer is returned */
       template< typename T>
         std::optional<T> tryToGet() const {
-           using namespace eventsetup;
-           using namespace eventsetup::heterocontainer;
-
-           //NOTE: this will catch the case where T does not inherit from EventSetupRecord
-           static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,"Trying to get a class that is not a Record from EventSetup");
-           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
-           if(temp != nullptr) {
-              T rec;
-              rec.setImpl(temp);
-              return rec;
-           }
-           return std::nullopt;
+           return m_setup.tryToGet<T>();
         }
 
       /** can directly access data if data_default_record_trait<> is defined for this data type **/
@@ -122,43 +101,25 @@ namespace edm {
         return getData(iToken.m_tag, iHolder);
       }
 
-      std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
-
-      ///clears the oToFill vector and then fills it with the keys for all available records
-      void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
-
-      ///returns true if the Record is provided by a Source or a Producer
-      /// a value of true does not mean this EventSetup object holds such a record
-      bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
-      // ---------- static member functions --------------------
-
-      friend class eventsetup::EventSetupRecordImpl;
-
-    protected:
-      //Only called by EventSetupProvider
-      void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
-        knownRecords_ = iSupplier;
+      std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey& iKey) const {
+         return m_setup.find(iKey);
       }
 
-      void add(const eventsetup::EventSetupRecordImpl& iRecord);
-
-      void clear();
+      ///clears the oToFill vector and then fills it with the keys for all available records
+      void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const {
+         m_setup.fillAvailableRecordKeys(oToFill);
+      }
+      ///returns true if the Record is provided by a Source or a Producer
+      /// a value of true does not mean this EventSetup object holds such a record
+      bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& iKey) const {
+         return m_setup.recordIsProvidedByAModule(iKey);
+      }
+      // ---------- static member functions --------------------
 
     private:
-      EventSetup(ActivityRegistry const*);
-
-      ActivityRegistry const* activityRegistry() const { return activityRegistry_; }
-      eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
-
-      void insert(const eventsetup::EventSetupRecordKey&,
-                  const eventsetup::EventSetupRecordImpl*);
 
       // ---------- member data --------------------------------
-
-      //NOTE: the records are not owned
-      std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const *> recordMap_;
-      eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
-      ActivityRegistry const* activityRegistry_;
+     edm::EventSetupImpl const& m_setup;
   };
 
   // Free functions to retrieve an object from the EventSetup.

--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -58,7 +58,7 @@ namespace edm {
     public:
       ~EventSetupImpl();
 
-      EventSetupImpl(EventSetup const&) = delete;
+      EventSetupImpl(EventSetupImpl const&) = delete;
       EventSetupImpl& operator=(EventSetupImpl const&) = delete;
 
       // ---------- const member functions ---------------------

--- a/FWCore/Framework/interface/EventSetupImpl.h
+++ b/FWCore/Framework/interface/EventSetupImpl.h
@@ -1,0 +1,166 @@
+#ifndef FWCore_Framework_EventSetupImpl_h
+#define FWCore_Framework_EventSetupImpl_h
+// -*- C++ -*-
+//
+// Package:     Framework
+// Class:      EventSetupImpl
+//
+/**\class EventSetupImpl EventSetupImpl.h FWCore/Framework/interface/EventSetupImpl.h
+
+ Description: Container for all Records dealing with non-RunState info
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Chris Jones
+// Created:     Thu Mar 24 13:50:04 EST 2005
+//
+
+// system include files
+#include <cassert>
+#include <map>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Framework/interface/HCMethods.h"
+#include "FWCore/Framework/interface/NoRecordException.h"
+#include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/data_default_record_trait.h"
+#include "FWCore/Utilities/interface/Transition.h"
+
+// forward declarations
+
+namespace edm {
+   class ActivityRegistry;
+   class ESInputTag;
+   template <class T>
+   class ESGetTokenT;
+
+   namespace eventsetup {
+      class EventSetupProvider;
+      class EventSetupRecord;
+      class EventSetupRecordImpl;
+      class EventSetupKnownRecordsSupplier;
+   }
+
+  class EventSetupImpl
+  {
+    ///Only EventSetupProvider allowed to create a EventSetup
+    friend class eventsetup::EventSetupProvider;
+    public:
+      ~EventSetupImpl();
+
+      EventSetupImpl(EventSetup const&) = delete;
+      EventSetupImpl& operator=(EventSetupImpl const&) = delete;
+
+      // ---------- const member functions ---------------------
+      /** returns the Record of type T.  If no such record available
+          a eventsetup::NoRecordException<T> is thrown */
+      template< typename T>
+         T get() const {
+           using namespace eventsetup;
+           using namespace eventsetup::heterocontainer;
+            //NOTE: this will catch the case where T does not inherit from EventSetupRecord
+            //  HOWEVER the error message under gcc 3.x is awful
+            static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>, "Trying to get a class that is not a Record from EventSetup");
+
+           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
+           if(nullptr == temp) {
+             throw eventsetup::NoRecordException<T>(recordDoesExist(*this, eventsetup::EventSetupRecordKey::makeKey<T>()));
+           }
+           T returnValue;
+           returnValue.setImpl(temp);
+           return returnValue;
+         }
+
+      /** returns the Record of type T.  If no such record available
+       a null pointer is returned */
+      template< typename T>
+        std::optional<T> tryToGet() const {
+           using namespace eventsetup;
+           using namespace eventsetup::heterocontainer;
+
+           //NOTE: this will catch the case where T does not inherit from EventSetupRecord
+           static_assert(std::is_base_of_v<edm::eventsetup::EventSetupRecord, T>,"Trying to get a class that is not a Record from EventSetup");
+           auto const temp = findImpl(makeKey<typename type_from_itemtype<eventsetup::EventSetupRecordKey,T>::Type,eventsetup::EventSetupRecordKey>());
+           if(temp != nullptr) {
+              T rec;
+              rec.setImpl(temp);
+              return rec;
+           }
+           return std::nullopt;
+        }
+
+      /** can directly access data if data_default_record_trait<> is defined for this data type **/
+      template< typename T>
+         bool getData(T& iHolder) const {
+            return getData(std::string{}, iHolder);
+         }
+
+      template< typename T>
+         bool getData(const std::string& iLabel, T& iHolder) const {
+            auto const& rec = this->get<eventsetup::default_record_t<T>>();
+            return rec.get(iLabel, iHolder);
+         }
+
+      template< typename T>
+        bool getData(const ESInputTag& iTag, T& iHolder) const {
+           auto const& rec = this->get<eventsetup::default_record_t<T>>();
+           return rec.get(iTag, iHolder);
+        }
+
+      template <typename T>
+      bool getData(const ESGetTokenT<T>& iToken, ESHandle<T>& iHolder) const {
+        return getData(iToken.m_tag, iHolder);
+      }
+
+      std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey&) const;
+
+      ///clears the oToFill vector and then fills it with the keys for all available records
+      void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
+
+      ///returns true if the Record is provided by a Source or a Producer
+      /// a value of true does not mean this EventSetup object holds such a record
+      bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
+      // ---------- static member functions --------------------
+
+      friend class eventsetup::EventSetupRecordImpl;
+
+    protected:
+      //Only called by EventSetupProvider
+      void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
+        knownRecords_ = iSupplier;
+      }
+
+      void add(const eventsetup::EventSetupRecordImpl& iRecord);
+
+      void clear();
+
+    private:
+      EventSetupImpl(ActivityRegistry const*);
+
+      ActivityRegistry const* activityRegistry() const { return activityRegistry_; }
+      eventsetup::EventSetupRecordImpl const* findImpl(const eventsetup::EventSetupRecordKey&) const;
+
+      void insert(const eventsetup::EventSetupRecordKey&,
+                  const eventsetup::EventSetupRecordImpl*);
+
+      // ---------- member data --------------------------------
+
+      //NOTE: the records are not owned
+      std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecordImpl const *> recordMap_;
+      eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
+      ActivityRegistry const* activityRegistry_;
+  };
+
+}
+
+#endif // FWCore_Framework_EventSetup_h

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -19,7 +19,7 @@
 //
 
 // user include files
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupImpl.h"
 #include "FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h"
 
 // system include files
@@ -68,9 +68,9 @@ class EventSetupProvider {
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
-      EventSetup const& eventSetupForInstance(IOVSyncValue const&);
+      EventSetupImpl const& eventSetupForInstance(IOVSyncValue const&);
 
-      EventSetup const& eventSetup() const {return eventSetup_;}
+      EventSetupImpl const& eventSetup() const {return eventSetup_;}
 
       //called by specializations of EventSetupRecordProviders
       void addRecordToEventSetup(EventSetupRecordImpl& iRecord);
@@ -119,7 +119,7 @@ class EventSetupProvider {
       void insert(EventSetupRecordKey const&, std::unique_ptr<EventSetupRecordProvider>);
 
       // ---------- member data --------------------------------
-      EventSetup eventSetup_;
+      EventSetupImpl eventSetup_;
       typedef std::map<EventSetupRecordKey, std::shared_ptr<EventSetupRecordProvider> > Providers;
       Providers providers_;
       std::unique_ptr<EventSetupKnownRecordsSupplier> knownRecordsSupplier_;

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -78,7 +78,7 @@ namespace edm {
    class ESHandle;
    class ESHandleExceptionFactory;
    class ESInputTag;
-   class EventSetup;
+   class EventSetupImpl;
 
    namespace eventsetup {
       struct ComponentDescription;
@@ -190,7 +190,7 @@ namespace edm {
 
          DataProxy const* find(DataKey const& aKey) const ;
 
-         EventSetup const& eventSetup() const {
+         EventSetupImpl const& eventSetup() const {
             return impl_->eventSetup();
          }
 

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -73,7 +73,7 @@ namespace cms {
 namespace edm {
    class ESHandleExceptionFactory;
    class ESInputTag;
-   class EventSetup;
+   class EventSetupImpl;
 
    namespace eventsetup {
       struct ComponentDescription;
@@ -136,7 +136,7 @@ namespace edm {
          bool transientReset() ;
 
          void set(ValidityInterval const&);
-         void setEventSetup(EventSetup const* iEventSetup) {eventSetup_ = iEventSetup; }
+         void setEventSetup(EventSetupImpl const* iEventSetup) {eventSetup_ = iEventSetup; }
 
          void getESProducers(std::vector<ComponentDescription const*>& esproducers);
          void fillReferencedDataKeys(std::map<DataKey, ComponentDescription const*>& referencedDataKeys);
@@ -145,7 +145,7 @@ namespace edm {
 
          DataProxy const* find(DataKey const& aKey) const ;
 
-        EventSetup const& eventSetup() const {
+        EventSetupImpl const& eventSetup() const {
           return *eventSetup_;
         }
 
@@ -190,7 +190,7 @@ namespace edm {
          EventSetupRecordKey key_;
          std::vector<DataKey> keysForProxies_;
          std::vector<DataProxy const*> proxies_;
-         EventSetup const* eventSetup_;
+         EventSetupImpl const* eventSetup_;
          unsigned long long cacheIdentifier_;
          mutable std::atomic<bool> transientAccessRequested_;
       };

--- a/FWCore/Framework/interface/Frameworkfwd.h
+++ b/FWCore/Framework/interface/Frameworkfwd.h
@@ -21,6 +21,7 @@ namespace edm {
   class EventForOutput;
   class EventPrincipal;
   class EventSetup;
+  class EventSetupImpl;
   class FileBlock;
   class InputSource;
   struct InputSourceDescription;

--- a/FWCore/Framework/interface/NoRecordException.h
+++ b/FWCore/Framework/interface/NoRecordException.h
@@ -36,11 +36,11 @@
 // forward declarations
 namespace edm {
    class IOVSyncValue;
-   class EventSetup;
+   class EventSetupImpl;
    namespace eventsetup {
       class EventSetupRecordKey;
       void no_record_exception_message_builder(cms::Exception&,const char*, bool iKnownRecord);
-     bool recordDoesExist( edm::EventSetup const& , edm::eventsetup::EventSetupRecordKey const&);
+     bool recordDoesExist( edm::EventSetupImpl const& , edm::eventsetup::EventSetupRecordKey const&);
 
 //NOTE: when EDM gets own exception hierarchy, will need to change inheritance
 template <class T>

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -118,19 +118,19 @@ namespace edm {
 
     void doBeginJob();
     void doEndJob();
-    bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+    bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
     //Needed by WorkerT but not supported
     void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
 
-    bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c,
                     ModuleCallingContext const* mcc);
-    bool doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c,
                   ModuleCallingContext const* mcc);
-    bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                                 ModuleCallingContext const* mcc);
-    bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                               ModuleCallingContext const* mcc);
 
     void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -97,7 +97,7 @@ namespace edm {
   }
   class ActivityRegistry;
   class BranchIDListHelper;
-  class EventSetup;
+  class EventSetupImpl;
   class ExceptionCollector;
   class MergeableRunProductMetadata;
   class OutputModuleCommunicator;
@@ -140,13 +140,13 @@ namespace edm {
     void processOneEventAsync(WaitingTaskHolder iTask,
                               unsigned int iStreamID,
                               EventPrincipal& principal,
-                              EventSetup const& eventSetup,
+                              EventSetupImpl const& eventSetup,
                               ServiceToken const& token);
 
     template <typename T>
     void processOneGlobalAsync(WaitingTaskHolder iTask,
                                typename T::MyPrincipal& principal,
-                               EventSetup const& eventSetup,
+                               EventSetupImpl const& eventSetup,
                                ServiceToken const& token,
                                bool cleaningUpAfterException = false);
 
@@ -154,7 +154,7 @@ namespace edm {
     void processOneStreamAsync(WaitingTaskHolder iTask,
                                unsigned int iStreamID,
                                typename T::MyPrincipal& principal,
-                               EventSetup const& eventSetup,
+                               EventSetupImpl const& eventSetup,
                                ServiceToken const& token,
                                bool cleaningUpAfterException = false);
 
@@ -313,7 +313,7 @@ namespace edm {
   void Schedule::processOneStreamAsync(WaitingTaskHolder iTaskHolder,
                                        unsigned int iStreamID,
                                        typename T::MyPrincipal& ep,
-                                       EventSetup const& es,
+                                       EventSetupImpl const& es,
                                        ServiceToken const& token,
                                        bool cleaningUpAfterException) {
     assert(iStreamID<streamSchedules_.size());
@@ -324,7 +324,7 @@ namespace edm {
   void
   Schedule::processOneGlobalAsync(WaitingTaskHolder iTaskHolder,
                                   typename T::MyPrincipal& ep,
-                                  EventSetup const& es,
+                                  EventSetupImpl const& es,
                                   ServiceToken const& token,
                                   bool cleaningUpAfterException) {
     globalSchedule_->processOneGlobalAsync<T>(iTaskHolder,ep,es,token,cleaningUpAfterException);

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -50,7 +50,7 @@ namespace edm {
       }
     }
     
-    void setEventSetup(EventSetup const& iSetup) {
+    void setEventSetup(EventSetupImpl const& iSetup) {
       aux_.setEventSetup(&iSetup);
     }
 
@@ -61,7 +61,7 @@ namespace edm {
     
     template <typename T, typename U>
     void runNowAsync(WaitingTask* task,
-                     typename T::MyPrincipal& p, EventSetup const& es,
+                     typename T::MyPrincipal& p, EventSetupImpl const& es,
                      ServiceToken const& token, StreamID streamID,
                      typename T::Context const* topContext, U const* context) const {
       //do nothing for event since we will run when requested
@@ -82,7 +82,7 @@ namespace edm {
     template <typename T>
     void runAccumulatorsAsync(WaitingTask* task,
                               typename T::MyPrincipal const& ep,
-                              EventSetup const& es,
+                              EventSetupImpl const& es,
                               ServiceToken const& token,
                               StreamID streamID,
                               ParentContext const& parentContext,

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -50,7 +50,7 @@ namespace edm {
 
     template <typename T, typename U>
       void processOneOccurrence(typename T::MyPrincipal& principal,
-                                EventSetup const& eventSetup,
+                                EventSetupImpl const& eventSetup,
                                 StreamID streamID,
                                 typename T::Context const* topContext,
                                 U const* context,
@@ -59,7 +59,7 @@ namespace edm {
     void processOneOccurrenceAsync(
                               WaitingTask* task,
                               typename T::MyPrincipal& principal,
-                              EventSetup const& eventSetup,
+                              EventSetupImpl const& eventSetup,
                               ServiceToken const& token,
                               StreamID streamID,
                               typename T::Context const* topContext,
@@ -68,13 +68,13 @@ namespace edm {
     template <typename T>
     void processAccumulatorsAsync(WaitingTask* task,
                                   typename T::MyPrincipal const& ep,
-                                  EventSetup const& es,
+                                  EventSetupImpl const& es,
                                   ServiceToken const& token,
                                   StreamID streamID,
                                   ParentContext const& parentContext,
                                   typename T::Context const* context);
 
-    void setupOnDemandSystem(Principal& principal, EventSetup const& es);
+    void setupOnDemandSystem(Principal& principal, EventSetupImpl const& es);
 
     void beginJob(ProductRegistry const& iRegistry);
     void endJob();
@@ -109,7 +109,7 @@ namespace edm {
   template <typename T, typename U>
   void
     WorkerManager::processOneOccurrence(typename T::MyPrincipal& ep,
-                                        EventSetup const& es,
+                                        EventSetupImpl const& es,
                                         StreamID streamID,
                                         typename T::Context const* topContext,
                                         U const* context,
@@ -140,7 +140,7 @@ namespace edm {
   void
   WorkerManager::processOneOccurrenceAsync(WaitingTask* task,
                                            typename T::MyPrincipal& ep,
-                                           EventSetup const& es,
+                                           EventSetupImpl const& es,
                                            ServiceToken const& token,
                                            StreamID streamID,
                                            typename T::Context const* topContext,
@@ -153,7 +153,7 @@ namespace edm {
   void
   WorkerManager::processAccumulatorsAsync(WaitingTask* task,
                                           typename T::MyPrincipal const& ep,
-                                          EventSetup const& es,
+                                          EventSetupImpl const& es,
                                           ServiceToken const& token,
                                           StreamID streamID,
                                           ParentContext const& parentContext,

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -71,7 +71,7 @@ namespace edm {
       }
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       //For now this is a placeholder
@@ -85,29 +85,29 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal const& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal const& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal const& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal const& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
 
       
-      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override
@@ -119,7 +119,7 @@ namespace edm {
       void registerProductsAndCallbacks(EDAnalyzerBase* module, ProductRegistry* reg);
       std::string workerType() const {return "WorkerT<EDAnalyzer>";}
       
-      virtual void analyze(StreamID, Event const& , EventSetup const&) const= 0;
+      virtual void analyze(StreamID, Event const& , EventSetup const& ) const= 0;
       virtual void beginJob() {}
       virtual void endJob(){}
       

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -70,10 +70,10 @@ namespace edm {
       virtual bool wantsStreamLuminosityBlocks() const =0;
 
     private:
-      bool doEvent(EventPrincipal const&, EventSetup const&,
+      bool doEvent(EventPrincipal const&, EventSetupImpl const& ,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
-      void doAcquire(EventPrincipal const&, EventSetup const&,
+      void doAcquire(EventPrincipal const&, EventSetupImpl const& ,
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);
@@ -88,29 +88,29 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal const& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal const& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal const& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal const& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
 
       
-      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -73,10 +73,10 @@ namespace edm {
       virtual bool wantsStreamLuminosityBlocks() const =0;
 
     private:
-      bool doEvent(EventPrincipal const&, EventSetup const&,
+      bool doEvent(EventPrincipal const&, EventSetupImpl const& ,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
-      void doAcquire(EventPrincipal const&, EventSetup const&,
+      void doAcquire(EventPrincipal const&, EventSetupImpl const& ,
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);
@@ -88,29 +88,29 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal const& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal const& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal const& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal const& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
 
       
-      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -125,34 +125,34 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
 
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
 
-      bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      bool doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      bool doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -77,7 +77,7 @@ namespace edm {
         return queue_;
       }
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       //For now this is a placeholder
@@ -91,29 +91,29 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal const& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal const& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal const& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal const& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
 
       
-      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -75,7 +75,7 @@ namespace edm {
         return queue_;
       }
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       //For now this is a placeholder
@@ -89,29 +89,29 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal const& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal const& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal const& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal const& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
 
       
-      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -78,7 +78,7 @@ namespace edm {
         return queue_;
       }
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
@@ -89,29 +89,29 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal const& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal const& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal const& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal const& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
 
       
-      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -130,34 +130,34 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
 
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
 
-      bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      bool doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      bool doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -73,7 +73,7 @@ namespace edm {
       void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       //For now this is a placeholder
@@ -84,13 +84,13 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
       
-      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -72,7 +72,7 @@ namespace edm {
       virtual SerialTaskQueue* globalLuminosityBlocksQueue();
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       //For now this is a placeholder
@@ -83,13 +83,13 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
       
-      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -72,7 +72,7 @@ namespace edm {
       virtual SerialTaskQueue* globalLuminosityBlocksQueue();
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
       //For now this is a placeholder
@@ -83,13 +83,13 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
 
-      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
 
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -131,16 +131,16 @@ namespace edm {
 
       void doBeginJob();
       void doEndJob();
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
-      bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                       ModuleCallingContext const*);
-      bool doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      bool doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                     ModuleCallingContext const*);
-      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                   ModuleCallingContext const*);
-      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                 ModuleCallingContext const*);
       
       void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h"
 #include "FWCore/Framework/interface/stream/callAbilities.h"
 #include "FWCore/Framework/interface/stream/dummy_helpers.h"
@@ -120,45 +121,48 @@ namespace edm {
       }
 
       void doBeginRun(RunPrincipal const& rp,
-                      EventSetup const& c,
+                      EventSetupImpl const&  ci,
                       ModuleCallingContext const* mcc) final {
-        if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache) {
+        if constexpr(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache) {
           Run r(rp, moduleDescription(), mcc, false);
           r.setConsumer(consumer());
           Run const& cnstR = r;
           RunIndex ri = rp.index();
+          const EventSetup c{ci};
           MyGlobalRun::beginRun(cnstR,c,m_global.get(),m_runs[ri]);
           typename T::RunContext rc(m_runs[ri].get(),m_global.get());
           MyGlobalRunSummary::beginRun(cnstR,c,&rc,m_runSummaries[ri]);
         }
       }
       void doEndRun(RunPrincipal const& rp,
-                    EventSetup const& c,
+                    EventSetupImpl const&  ci,
                     ModuleCallingContext const* mcc) final
       {
-        if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache) {
+        if constexpr(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache) {
           
           Run r(rp, moduleDescription(), mcc, true);
           r.setConsumer(consumer());
 
           RunIndex ri = rp.index();
           typename T::RunContext rc(m_runs[ri].get(),m_global.get());
+          const EventSetup c{ci};
           MyGlobalRunSummary::globalEndRun(r,c,&rc,m_runSummaries[ri].get());
           MyGlobalRun::endRun(r,c,&rc);
         }
       }
 
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetup const& c,
+                                  EventSetupImpl const&  ci,
                                   ModuleCallingContext const* mcc) final
       {
-        if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache) {
+        if constexpr(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache) {
           LuminosityBlock lb(lbp, moduleDescription(), mcc, false);
           lb.setConsumer(consumer());
           LuminosityBlock const& cnstLb = lb;
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::RunContext rc(m_runs[ri].get(),m_global.get());
+          const EventSetup c{ci};
           MyGlobalLuminosityBlock::beginLuminosityBlock(cnstLb,c,&rc,m_lumis[li]);
           typename T::LuminosityBlockContext lc(m_lumis[li].get(),m_runs[ri].get(),m_global.get());
           MyGlobalLuminosityBlockSummary::beginLuminosityBlock(cnstLb,c,&lc,m_lumiSummaries[li]);
@@ -166,9 +170,9 @@ namespace edm {
         
       }
       void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetup const& c,
+                                EventSetupImpl const&  ci,
                                 ModuleCallingContext const* mcc) final {
-        if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache) {
+        if constexpr(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache) {
           
           LuminosityBlock lb(lbp, moduleDescription(), mcc, true);
           lb.setConsumer(consumer());
@@ -176,6 +180,7 @@ namespace edm {
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::LuminosityBlockContext lc(m_lumis[li].get(),m_runs[ri].get(),m_global.get());
+          const EventSetup c{ci};
           MyGlobalLuminosityBlockSummary::globalEndLuminosityBlock(lb,c,&lc,m_lumiSummaries[li].get());
           MyGlobalLuminosityBlock::endLuminosityBlock(lb,c,&lc);
         }

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -113,7 +113,7 @@ namespace edm {
       
       const EDAnalyzerAdaptorBase& operator=(const EDAnalyzerAdaptorBase&) = delete; // stop default
       
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const& ep, EventSetupImpl const&  c,
                    ActivityRegistry*,
                    ModuleCallingContext const*) ;
       void doPreallocate(PreallocationConfiguration const&);
@@ -130,33 +130,33 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal const& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       virtual void setupRun(EDAnalyzerBase*, RunIndex) = 0;
       void doStreamEndRun(StreamID id,
                           RunPrincipal const& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       virtual void streamEndRunSummary(EDAnalyzerBase*,edm::Run const&, edm::EventSetup const&) = 0;
 
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal const& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       virtual void setupLuminosityBlock(EDAnalyzerBase*, LuminosityBlockIndex) = 0;
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal const& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
       virtual void streamEndLuminosityBlockSummary(EDAnalyzerBase*,edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
 
-      virtual void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      virtual void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                               ModuleCallingContext const*)=0;
-      virtual void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      virtual void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                             ModuleCallingContext const*)=0;
-      virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                           ModuleCallingContext const*)=0;
-      virtual void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      virtual void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  c,
                                         ModuleCallingContext const*)=0;
 
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
@@ -69,11 +69,11 @@ namespace edm {
       
       const EDFilterAdaptorBase& operator=(const EDFilterAdaptorBase&) =delete; // stop default
 
-      bool doEvent(EventPrincipal const&, EventSetup const&,
+      bool doEvent(EventPrincipal const&, EventSetupImpl const& ,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
 
-      void doAcquire(EventPrincipal const&, EventSetup const&,
+      void doAcquire(EventPrincipal const&, EventSetupImpl const& ,
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);

--- a/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
@@ -69,11 +69,11 @@ namespace edm {
       
       const EDProducerAdaptorBase& operator=(const EDProducerAdaptorBase&) =delete; // stop default
 
-      bool doEvent(EventPrincipal const&, EventSetup const&,
+      bool doEvent(EventPrincipal const&, EventSetupImpl const& ,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
 
-      void doAcquire(EventPrincipal const&, EventSetup const&,
+      void doAcquire(EventPrincipal const&, EventSetupImpl const& ,
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/stream/callAbilities.h"
 #include "FWCore/Framework/interface/stream/dummy_helpers.h"
 #include "FWCore/Framework/interface/stream/makeGlobal.h"
@@ -128,28 +129,29 @@ namespace edm {
       }
 
       void doBeginRun(RunPrincipal const& rp,
-                      EventSetup const& c,
+                      EventSetupImpl const&  ci,
                       ModuleCallingContext const* mcc) final {
-        if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kBeginRunProducer) {
+        if constexpr (T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kBeginRunProducer) {
           Run r(rp, this->moduleDescription(), mcc, false);
           r.setConsumer(this->consumer());
           r.setProducer(this->producer());
           Run const& cnstR = r;
           RunIndex ri = rp.index();
+          const EventSetup c{ci};
           MyGlobalRun::beginRun(cnstR,c,m_global.get(),m_runs[ri]);
           typename T::RunContext rc(m_runs[ri].get(),m_global.get());
           MyGlobalRunSummary::beginRun(cnstR,c,&rc,m_runSummaries[ri]);
-          if(T::HasAbility::kBeginRunProducer) {
+          if constexpr (T::HasAbility::kBeginRunProducer) {
             MyBeginRunProduce::produce(r,c,&rc);
             this->commit(r);
           }
         }
       }
       void doEndRun(RunPrincipal const& rp,
-                    EventSetup const& c,
+                    EventSetupImpl const&  ci,
                     ModuleCallingContext const* mcc) final
       {
-        if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kEndRunProducer) {
+        if constexpr (T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kEndRunProducer) {
           
           Run r(rp, this->moduleDescription(), mcc, true);
           r.setConsumer(this->consumer());
@@ -157,7 +159,8 @@ namespace edm {
 
           RunIndex ri = rp.index();
           typename T::RunContext rc(m_runs[ri].get(),m_global.get());
-          if(T::HasAbility::kEndRunProducer) {
+          const EventSetup c{ci};
+          if constexpr (T::HasAbility::kEndRunProducer) {
             MyEndRunProduce::produce(r,c,&rc,m_runSummaries[ri].get());
             this->commit(r);
           }
@@ -166,10 +169,10 @@ namespace edm {
         }
       }
 
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const&  ci,
                                   ModuleCallingContext const* mcc) final
       {
-        if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or T::HasAbility::kBeginLuminosityBlockProducer) {
+        if constexpr (T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or T::HasAbility::kBeginLuminosityBlockProducer) {
           LuminosityBlock lb(lbp, this->moduleDescription(), mcc, false);
           lb.setConsumer(this->consumer());
           lb.setProducer(this->producer());
@@ -177,10 +180,12 @@ namespace edm {
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::RunContext rc(m_runs[ri].get(),m_global.get());
+          const EventSetup c{ci};
+
           MyGlobalLuminosityBlock::beginLuminosityBlock(cnstLb,c,&rc,m_lumis[li]);
           typename T::LuminosityBlockContext lc(m_lumis[li].get(),m_runs[ri].get(),m_global.get());
           MyGlobalLuminosityBlockSummary::beginLuminosityBlock(cnstLb,c,&lc,m_lumiSummaries[li]);
-          if(T::HasAbility::kBeginLuminosityBlockProducer) {
+          if constexpr (T::HasAbility::kBeginLuminosityBlockProducer) {
             MyBeginLuminosityBlockProduce::produce(lb,c,&lc);
             this->commit(lb);
           }
@@ -188,9 +193,9 @@ namespace edm {
         
       }
       void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetup const& c,
+                                EventSetupImpl const&  ci,
                                 ModuleCallingContext const* mcc) final {
-        if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or T::HasAbility::kEndLuminosityBlockProducer) {
+        if constexpr (T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or T::HasAbility::kEndLuminosityBlockProducer) {
           
           LuminosityBlock lb(lbp, this->moduleDescription(), mcc, true);
           lb.setConsumer(this->consumer());
@@ -199,7 +204,8 @@ namespace edm {
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::LuminosityBlockContext lc(m_lumis[li].get(),m_runs[ri].get(),m_global.get());
-          if(T::HasAbility::kEndLuminosityBlockProducer) {
+          const EventSetup c{ci};
+          if constexpr (T::HasAbility::kEndLuminosityBlockProducer) {
             MyEndLuminosityBlockProduce::produce(lb,c,&lc,m_lumiSummaries[li].get());
             this->commit(lb);
           }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -151,36 +151,36 @@ namespace edm {
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID id,
                             RunPrincipal const& ep,
-                            EventSetup const& c,
+                            EventSetupImpl const&  c,
                             ModuleCallingContext const*);
       virtual void setupRun(T*, RunIndex) = 0;
       void doStreamEndRun(StreamID id,
                           RunPrincipal const& ep,
-                          EventSetup const& c,
+                          EventSetupImpl const&  c,
                           ModuleCallingContext const*);
       virtual void streamEndRunSummary(T*,edm::Run const&, edm::EventSetup const&) = 0;
 
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal const& ep,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*);
       virtual void setupLuminosityBlock(T*, LuminosityBlockIndex) = 0;
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal const& ep,
-                                      EventSetup const& c,
+                                      EventSetupImpl const&  c,
                                       ModuleCallingContext const*);
       virtual void streamEndLuminosityBlockSummary(T*,edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
       
       
-      virtual void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+      virtual void doBeginRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                               ModuleCallingContext const*)=0;
-      virtual void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+      virtual void doEndRun(RunPrincipal const& rp, EventSetupImpl const&  c,
                             ModuleCallingContext const*)=0;
       virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                          EventSetup const& c,
+                                          EventSetupImpl const&  c,
                                           ModuleCallingContext const*)=0;
       virtual void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                        EventSetup const& c,
+                                        EventSetupImpl const&  c,
                                         ModuleCallingContext const*)=0;
       
       //For now, the following are just dummy implemenations with no ability for users to override

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
@@ -30,13 +31,14 @@ namespace edm {
 
 
   bool
-  EDAnalyzer::doEvent(EventPrincipal const& ep, EventSetup const& c,
+  EDAnalyzer::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                       ActivityRegistry* act,
                       ModuleCallingContext const* mcc) {
     Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act,mcc);
+    const EventSetup c{ci};
     this->analyze(e, c);
     return true;
   }
@@ -55,37 +57,41 @@ namespace edm {
   }
 
   bool
-  EDAnalyzer::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+  EDAnalyzer::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                          ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc,false);
     r.setConsumer(this);
+    const EventSetup c{ci};
     this->beginRun(r, c);
     return true;
   }
 
   bool
-  EDAnalyzer::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+  EDAnalyzer::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                        ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc,true);
     r.setConsumer(this);
+    const EventSetup c{ci};
     this->endRun(r, c);
     return true;
   }
 
   bool
-  EDAnalyzer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  EDAnalyzer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                      ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc,false);
     lb.setConsumer(this);
+    const EventSetup c{ci};
     this->beginLuminosityBlock(lb, c);
     return true;
   }
 
   bool
-  EDAnalyzer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  EDAnalyzer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                    ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc,true);
     lb.setConsumer(this);
+    const EventSetup c{ci};
     this->endLuminosityBlock(lb, c);
     return true;
   }

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 
@@ -27,7 +28,7 @@ namespace edm {
   }
 
   bool
-  EDFilter::doEvent(EventPrincipal const& ep, EventSetup const& c,
+  EDFilter::doEvent(EventPrincipal const& ep, EventSetupImpl const& c,
                     ActivityRegistry* act,
                     ModuleCallingContext const* mcc) {
     bool rc = false;
@@ -36,7 +37,7 @@ namespace edm {
     e.setProducer(this,&previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act,mcc);
-    rc = this->filter(e, c);
+    rc = this->filter(e, EventSetup{c});
     commit_(e, &previousParentageId_);
     return rc;
   }
@@ -54,44 +55,44 @@ namespace edm {
   }
 
   void
-  EDFilter::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+  EDFilter::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c,
                        ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc,false);
     r.setConsumer(this);
     Run const& cnstR=r;
-    this->beginRun(cnstR, c);
+    this->beginRun(cnstR, EventSetup{c});
     commit_(r);
     return;
   }
 
   void
-  EDFilter::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+  EDFilter::doEndRun(RunPrincipal const& rp, EventSetupImpl const& c,
                      ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc,true);
     r.setConsumer(this);
     Run const& cnstR=r;
-    this->endRun(cnstR, c);
+    this->endRun(cnstR, EventSetup{c});
     commit_(r);
     return;
   }
 
   void
-  EDFilter::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  EDFilter::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                                    ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc,false);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
-    this->beginLuminosityBlock(cnstLb, c);
+    this->beginLuminosityBlock(cnstLb, EventSetup{c});
     commit_(lb);
   }
 
   void
-  EDFilter::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  EDFilter::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                                  ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc,true);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
-    this->endLuminosityBlock(cnstLb, c);
+    this->endLuminosityBlock(cnstLb, EventSetup{c});
     commit_(lb);
     return ;
   }

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -87,7 +87,8 @@ namespace edm {
                   esp, std::placeholders::_1));
   }
 
-  void EDLooperBase::beginOfJob(const edm::EventSetupImpl&) { beginOfJob();}
+  void EDLooperBase::beginOfJob(const edm::EventSetupImpl& iImpl) { beginOfJob(EventSetup{iImpl});}
+  void EDLooperBase::beginOfJob(const edm::EventSetup&) { beginOfJob();}
   void EDLooperBase::beginOfJob() { }
 
   void EDLooperBase::endOfJob() { }

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -15,6 +15,7 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/MessageLogger/interface/ExceptionMessages.h"
@@ -40,7 +41,7 @@ namespace edm {
   }
 
   EDLooperBase::Status
-  EDLooperBase::doDuringLoop(edm::EventPrincipal& eventPrincipal, const edm::EventSetup& es,
+  EDLooperBase::doDuringLoop(edm::EventPrincipal& eventPrincipal, const edm::EventSetupImpl& esi,
                              edm::ProcessingController& ioController, StreamContext* streamContext) {
 
     streamContext->setTransition(StreamContext::Transition::kEvent);
@@ -54,6 +55,7 @@ namespace edm {
 
     Status status = kContinue;
     try {
+      const EventSetup es{esi};
       status = duringLoop(event, es, ioController);
     }
     catch(cms::Exception& e) {
@@ -70,7 +72,8 @@ namespace edm {
   }
 
   EDLooperBase::Status
-  EDLooperBase::doEndOfLoop(const edm::EventSetup& es) {
+  EDLooperBase::doEndOfLoop(const edm::EventSetupImpl& esi) {
+    const EventSetup es{esi};
     return endOfLoop(es, iCounter_);
   }
 
@@ -84,12 +87,12 @@ namespace edm {
                   esp, std::placeholders::_1));
   }
 
-  void EDLooperBase::beginOfJob(const edm::EventSetup&) { beginOfJob();}
+  void EDLooperBase::beginOfJob(const edm::EventSetupImpl&) { beginOfJob();}
   void EDLooperBase::beginOfJob() { }
 
   void EDLooperBase::endOfJob() { }
 
-  void EDLooperBase::doBeginRun(RunPrincipal& iRP, EventSetup const& iES, ProcessContext* processContext) {
+  void EDLooperBase::doBeginRun(RunPrincipal& iRP, EventSetupImpl const& iES, ProcessContext* processContext) {
         GlobalContext globalContext(GlobalContext::Transition::kBeginRun,
                                     LuminosityBlockID(iRP.run(), 0),
                                     iRP.index(),
@@ -99,10 +102,11 @@ namespace edm {
         ParentContext parentContext(&globalContext);
         ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
         Run run(iRP, moduleDescription_, &moduleCallingContext_, false);
-        beginRun(run,iES);
+        const EventSetup es{iES};
+        beginRun(run,es);
   }
 
-  void EDLooperBase::doEndRun(RunPrincipal& iRP, EventSetup const& iES, ProcessContext* processContext){
+  void EDLooperBase::doEndRun(RunPrincipal& iRP, EventSetupImpl const& iES, ProcessContext* processContext){
         GlobalContext globalContext(GlobalContext::Transition::kEndRun,
                                     LuminosityBlockID(iRP.run(), 0),
                                     iRP.index(),
@@ -112,9 +116,10 @@ namespace edm {
         ParentContext parentContext(&globalContext);
         ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
         Run run(iRP, moduleDescription_, &moduleCallingContext_,true);
-        endRun(run,iES);
+        const EventSetup es{iES};
+        endRun(run,es);
   }
-  void EDLooperBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetup const& iES, ProcessContext* processContext){
+  void EDLooperBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetupImpl const& iES, ProcessContext* processContext){
     GlobalContext globalContext(GlobalContext::Transition::kBeginLuminosityBlock,
                                 iLB.id(),
                                 iLB.runPrincipal().index(),
@@ -124,9 +129,10 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     LuminosityBlock luminosityBlock(iLB, moduleDescription_, &moduleCallingContext_, false);
-    beginLuminosityBlock(luminosityBlock,iES);
+    const EventSetup es{iES};
+    beginLuminosityBlock(luminosityBlock,es);
   }
-  void EDLooperBase::doEndLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetup const& iES, ProcessContext* processContext){
+  void EDLooperBase::doEndLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetupImpl const& iES, ProcessContext* processContext){
     GlobalContext globalContext(GlobalContext::Transition::kEndLuminosityBlock,
                                 iLB.id(),
                                 iLB.runPrincipal().index(),
@@ -136,7 +142,8 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     LuminosityBlock luminosityBlock(iLB, moduleDescription_, &moduleCallingContext_, true);
-    endLuminosityBlock(luminosityBlock,iES);
+    const EventSetup es{iES};
+    endLuminosityBlock(luminosityBlock,es);
   }
 
   void EDLooperBase::beginRun(Run const&, EventSetup const&){}

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 
@@ -28,7 +29,7 @@ namespace edm {
   EDProducer::~EDProducer() { }
 
   bool
-  EDProducer::doEvent(EventPrincipal const& ep, EventSetup const& c,
+  EDProducer::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                       ActivityRegistry* act,
                       ModuleCallingContext const* mcc) {
     Event e(ep, moduleDescription_, mcc);
@@ -36,6 +37,7 @@ namespace edm {
     e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act,mcc);
+    const EventSetup c{ci};
     this->produce(e, c);
     commit_(e, &previousParentageId_);
     return true;
@@ -54,40 +56,44 @@ namespace edm {
   }
 
   void
-  EDProducer::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+  EDProducer::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                          ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc, false);
     r.setConsumer(this);
     Run const& cnstR = r;
+    const EventSetup c{ci};
     this->beginRun(cnstR, c);
     commit_(r);
   }
 
   void
-  EDProducer::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+  EDProducer::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                        ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc,true);
     r.setConsumer(this);
     Run const& cnstR = r;
+    const EventSetup c{ci};
     this->endRun(cnstR, c);
     commit_(r);
   }
 
   void
-  EDProducer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  EDProducer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                      ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc,false);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
+    const EventSetup c{ci};
     this->beginLuminosityBlock(cnstLb, c);
     commit_(lb);
   }
 
   void
-  EDProducer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  EDProducer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                    ModuleCallingContext const* mcc) {
     LuminosityBlock lb(lbp, moduleDescription_, mcc,true);
     lb.setConsumer(this);
+    const EventSetup c{ci};
     LuminosityBlock const& cnstLb = lb;
     this->endLuminosityBlock(cnstLb, c);
     commit_(lb);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -919,7 +919,7 @@ namespace edm {
       eventSetupForInstanceSucceeded = true;
       sentry.completedSuccessfully();
     }
-    EventSetup const& es = esp_->eventSetup();
+    auto const& es = esp_->eventSetup();
     if(looper_ && looperBeginJobRun_== false) {
       looper_->copyInfo(ScheduleInfo(schedule_.get()));
       looper_->beginOfJob(es);
@@ -1009,7 +1009,7 @@ namespace edm {
       espController_->eventSetupForInstance(ts);
       sentry.completedSuccessfully();
     }
-    EventSetup const& es = esp_->eventSetup();
+    auto const& es = esp_->eventSetup();
     if(globalBeginSucceeded){
       //To wait, the ref count has to be 1+#streams
       auto streamLoopWaitTask = make_empty_waiting_task();
@@ -1125,7 +1125,7 @@ namespace edm {
             } else {
 
               status->globalBeginDidSucceed();
-              EventSetup const& es = esp_->eventSetup();
+              auto const& es = esp_->eventSetup();
               if(looper_) {
                 try {
                   //make the services available
@@ -1166,7 +1166,7 @@ namespace edm {
           
           //task to start the global begin lumi
           WaitingTaskHolder beginStreamsHolder{beginStreamsTask};
-          EventSetup const& es = esp_->eventSetup();
+          auto const& es = esp_->eventSetup();
           {
             typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
             beginGlobalTransitionAsync<Traits>(beginStreamsHolder,
@@ -1244,7 +1244,7 @@ namespace edm {
           ServiceRegistry::Operate operate(serviceToken_);
           if(looper_) {
             auto& lp = *(status->lumiPrincipal());
-            EventSetup const& es = esp_->eventSetup();
+            auto const& es = esp_->eventSetup();
             looper_->doEndLuminosityBlock(lp, es, &processContext_);
           }
         }catch(...) {
@@ -1292,7 +1292,7 @@ namespace edm {
 
 
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
-    EventSetup const& es = esp_->eventSetup();
+    auto const& es = esp_->eventSetup();
 
     endGlobalTransitionAsync<Traits>(WaitingTaskHolder(writeT),
                                      *schedule_,
@@ -1334,7 +1334,7 @@ namespace edm {
       auto & lumiPrincipal = *iLumiStatus->lumiPrincipal();
       IOVSyncValue ts(EventID(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), EventID::maxEventNumber()),
                       lumiPrincipal.endTime());
-      EventSetup const& es = esp_->eventSetup();
+      auto const& es = esp_->eventSetup();
 
       bool cleaningUpAfterException = iLumiStatus->cleaningUpAfterException();
       

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -31,21 +31,11 @@ namespace edm {
 //
 // constructors and destructor
 //
-EventSetup::EventSetup(ActivityRegistry const* activityRegistry) :
-   recordMap_(),
-   activityRegistry_(activityRegistry)
-
-{
-}
 
 // EventSetup::EventSetup(EventSetup const& rhs)
 // {
 //    // do actual copying here;
 // }
-
-EventSetup::~EventSetup()
-{
-}
 
 //
 // assignment operators
@@ -62,66 +52,9 @@ EventSetup::~EventSetup()
 //
 // member functions
 //
-void
-EventSetup::insert(const eventsetup::EventSetupRecordKey& iKey,
-                const eventsetup::EventSetupRecordImpl* iRecord)
-{
-   recordMap_[iKey]= iRecord;
-}
-
-void
-EventSetup::clear()
-{
-   recordMap_.clear();
-}
-
-void
-EventSetup::add(const eventsetup::EventSetupRecordImpl& iRecord)
-{
-   insert(iRecord.key(), &iRecord);
-}
-
 //
 // const member functions
 //
-std::optional<eventsetup::EventSetupRecordGeneric>
-EventSetup::find(const eventsetup::EventSetupRecordKey& iKey) const
-{
-   auto itFind = recordMap_.find(iKey);
-   if(itFind == recordMap_.end()) {
-     return std::nullopt;
-   }
-  return eventsetup::EventSetupRecordGeneric(itFind->second);
-}
-
-eventsetup::EventSetupRecordImpl const*
-EventSetup::findImpl(const eventsetup::EventSetupRecordKey& iKey) const
-{
-  auto itFind = recordMap_.find(iKey);
-  if(itFind == recordMap_.end()) {
-    return nullptr;
-  }
-  return itFind->second;
-}
-
-void
-EventSetup::fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const
-{
-  oToFill.clear();
-  oToFill.reserve(recordMap_.size());
-
-  for(auto it = recordMap_.begin(), itEnd=recordMap_.end();
-      it != itEnd;
-      ++it) {
-    oToFill.push_back(it->first);
-  }
-}
-
-bool
-EventSetup::recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& iKey) const
-{
-  return knownRecords_->isKnown(iKey);
-}
 
 //
 // static member functions

--- a/FWCore/Framework/src/EventSetupImpl.cc
+++ b/FWCore/Framework/src/EventSetupImpl.cc
@@ -1,0 +1,129 @@
+// -*- C++ -*-
+//
+// Package:     Framework
+// Module:      EventSetup
+//
+// Description: <one line class summary>
+//
+// Implementation:
+//     <Notes on implementation>
+//
+// Author:      Chris Jones
+// Created:     Thu Mar 24 16:27:10 EST 2005
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/EventSetupImpl.h"
+#include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h"
+
+namespace edm {
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+EventSetupImpl::EventSetupImpl(ActivityRegistry const* activityRegistry) :
+   recordMap_(),
+   activityRegistry_(activityRegistry)
+
+{
+}
+
+// EventSetupImpl::EventSetupImpl(EventSetupImpl const& rhs)
+// {
+//    // do actual copying here;
+// }
+
+EventSetupImpl::~EventSetupImpl()
+{
+}
+
+//
+// assignment operators
+//
+// EventSetupImpl const& EventSetupImpl::operator=(EventSetupImpl const& rhs)
+// {
+//   //An exception safe implementation is
+//   EventSetupImpl temp(rhs);
+//   swap(rhs);
+//
+//   return *this;
+// }
+
+//
+// member functions
+//
+void
+EventSetupImpl::insert(const eventsetup::EventSetupRecordKey& iKey,
+                const eventsetup::EventSetupRecordImpl* iRecord)
+{
+   recordMap_[iKey]= iRecord;
+}
+
+void
+EventSetupImpl::clear()
+{
+   recordMap_.clear();
+}
+
+void
+EventSetupImpl::add(const eventsetup::EventSetupRecordImpl& iRecord)
+{
+   insert(iRecord.key(), &iRecord);
+}
+
+//
+// const member functions
+//
+std::optional<eventsetup::EventSetupRecordGeneric>
+EventSetupImpl::find(const eventsetup::EventSetupRecordKey& iKey) const
+{
+   auto itFind = recordMap_.find(iKey);
+   if(itFind == recordMap_.end()) {
+     return std::nullopt;
+   }
+  return eventsetup::EventSetupRecordGeneric(itFind->second);
+}
+
+eventsetup::EventSetupRecordImpl const*
+EventSetupImpl::findImpl(const eventsetup::EventSetupRecordKey& iKey) const
+{
+  auto itFind = recordMap_.find(iKey);
+  if(itFind == recordMap_.end()) {
+    return nullptr;
+  }
+  return itFind->second;
+}
+
+void
+EventSetupImpl::fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const
+{
+  oToFill.clear();
+  oToFill.reserve(recordMap_.size());
+
+  for(auto it = recordMap_.begin(), itEnd=recordMap_.end();
+      it != itEnd;
+      ++it) {
+    oToFill.push_back(it->first);
+  }
+}
+
+bool
+EventSetupImpl::recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& iKey) const
+{
+  return knownRecords_->isKnown(iKey);
+}
+
+//
+// static member functions
+//
+}

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -749,7 +749,7 @@ EventSetupProvider::insert(std::unique_ptr<EventSetupRecordProvider> iRecordProv
 //
 // const member functions
 //
-EventSetup const&
+EventSetupImpl const&
 EventSetupProvider::eventSetupForInstance(const IOVSyncValue& iValue)
 {
    eventSetup_.clear();

--- a/FWCore/Framework/src/EventSetupRecordImpl.cc
+++ b/FWCore/Framework/src/EventSetupRecordImpl.cc
@@ -17,7 +17,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordImpl.h"
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupImpl.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -63,7 +63,7 @@ namespace edm {
   }
 
   class ActivityRegistry;
-  class EventSetup;
+  class EventSetupImpl;
   class ExceptionCollector;
   class ProcessContext;
   class PreallocationConfiguration;
@@ -96,7 +96,7 @@ namespace edm {
     template <typename T>
     void processOneGlobalAsync(WaitingTaskHolder holder,
                                typename T::MyPrincipal& principal,
-                               EventSetup const& eventSetup,
+                               EventSetupImpl const& eventSetup,
                                ServiceToken const& token,
                                bool cleaningUpAfterException = false);
 
@@ -165,7 +165,7 @@ namespace edm {
   void
   GlobalSchedule::processOneGlobalAsync(WaitingTaskHolder iHolder,
                                         typename T::MyPrincipal& ep,
-                                        EventSetup const& es,
+                                        EventSetupImpl const& es,
                                         ServiceToken const& token,
                                         bool cleaningUpAfterException) {
     try {

--- a/FWCore/Framework/src/NoRecordException.cc
+++ b/FWCore/Framework/src/NoRecordException.cc
@@ -16,11 +16,11 @@
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupImpl.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 bool
-edm::eventsetup::recordDoesExist( EventSetup const& iES, EventSetupRecordKey const& iKey) {
+edm::eventsetup::recordDoesExist( EventSetupImpl const& iES, EventSetupRecordKey const& iKey) {
   return iES.recordIsProvidedByAModule(iKey);
 }
 

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -257,7 +257,7 @@ namespace edm {
 
   bool
   OutputModule::doEvent(EventPrincipal const& ep,
-                        EventSetup const&,
+                        EventSetupImpl const&,
                         ActivityRegistry* act,
                         ModuleCallingContext const* mcc) {
 
@@ -293,7 +293,7 @@ namespace edm {
 
   bool
   OutputModule::doBeginRun(RunPrincipal const& rp,
-                           EventSetup const&,
+                           EventSetupImpl const&,
                            ModuleCallingContext const* mcc) {
     FDEBUG(2) << "beginRun called\n";
     RunForOutput r(rp, moduleDescription_, mcc,false);
@@ -304,7 +304,7 @@ namespace edm {
 
   bool
   OutputModule::doEndRun(RunPrincipal const& rp,
-                         EventSetup const&,
+                         EventSetupImpl const&,
                          ModuleCallingContext const* mcc) {
     FDEBUG(2) << "endRun called\n";
     RunForOutput r(rp, moduleDescription_, mcc,true);
@@ -325,7 +325,7 @@ namespace edm {
 
   bool
   OutputModule::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                       EventSetup const&,
+                                       EventSetupImpl const&,
                                        ModuleCallingContext const* mcc) {
     FDEBUG(2) << "beginLuminosityBlock called\n";
     LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc,false);
@@ -336,7 +336,7 @@ namespace edm {
 
   bool
   OutputModule::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                     EventSetup const&,
+                                     EventSetupImpl const&,
                                      ModuleCallingContext const* mcc) {
     FDEBUG(2) << "endLuminosityBlock called\n";
     LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc,true);

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -208,7 +208,7 @@ namespace edm {
   void
   Path::processOneOccurrenceAsync(WaitingTask* iTask,
                                   EventPrincipal const& iEP,
-                                  EventSetup const& iES,
+                                  EventSetupImpl const& iES,
                                   ServiceToken const& iToken,
                                   StreamID const& iStreamID,
                                   StreamContext const* iStreamContext) {
@@ -233,7 +233,7 @@ namespace edm {
   void
   Path::workerFinished(std::exception_ptr const* iException,
                        unsigned int iModuleIndex,
-                       EventPrincipal const& iEP, EventSetup const& iES,
+                       EventPrincipal const& iEP, EventSetupImpl const& iES,
                        ServiceToken const& iToken,
                        StreamID const& iID, StreamContext const* iContext) {
     ServiceRegistry::Operate guard(iToken);
@@ -291,7 +291,7 @@ namespace edm {
   void
   Path::finished(int iModuleIndex, bool iSucceeded, std::exception_ptr iException, StreamContext const* iContext,
                  EventPrincipal const& iEP,
-                 EventSetup const& iES,
+                 EventSetupImpl const& iES,
                  StreamID const& streamID) {
     
     if(not iException) {
@@ -323,7 +323,7 @@ namespace edm {
   
   void
   Path::runNextWorkerAsync(unsigned int iNextModuleIndex,
-                           EventPrincipal const& iEP, EventSetup const& iES,
+                           EventPrincipal const& iEP, EventSetupImpl const& iES,
                            ServiceToken const& iToken,
                            StreamID const& iID, StreamContext const* iContext) {
     

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -31,7 +31,7 @@
 
 namespace edm {
   class EventPrincipal;
-  class EventSetup;
+  class EventSetupImpl;
   class ModuleDescription;
   class PathStatusInserter;
   class RunPrincipal;
@@ -63,12 +63,12 @@ namespace edm {
     template <typename T>
     void runAllModulesAsync(WaitingTask*,
                             typename T::MyPrincipal const&,
-                            EventSetup  const&,
+                            EventSetupImpl  const&,
                             ServiceToken const&,
                             StreamID const&,
                             typename T::Context const*);
 
-    void processOneOccurrenceAsync(WaitingTask*, EventPrincipal const&, EventSetup const&,
+    void processOneOccurrenceAsync(WaitingTask*, EventPrincipal const&, EventSetupImpl const&,
                                    ServiceToken const&, StreamID const&, StreamContext const*);
     
     int bitPosition() const { return bitpos_; }
@@ -145,7 +145,7 @@ namespace edm {
     void finished(int iModuleIndex, bool iSucceeded, std::exception_ptr,
                   StreamContext const*,
                   EventPrincipal const& iEP,
-                  EventSetup const& iES,
+                  EventSetupImpl const& iES,
                   StreamID const& streamID);
 
     void handleEarlyFinish(EventPrincipal const&);
@@ -155,11 +155,11 @@ namespace edm {
     //Handle asynchronous processing
     void workerFinished(std::exception_ptr const* iException,
                         unsigned int iModuleIndex,
-                        EventPrincipal const& iEP, EventSetup const& iES,
+                        EventPrincipal const& iEP, EventSetupImpl const& iES,
                         ServiceToken const& iToken,
                         StreamID const& iID, StreamContext const* iContext);
     void runNextWorkerAsync(unsigned int iNextModuleIndex,
-                            EventPrincipal const&, EventSetup const&,
+                            EventPrincipal const&, EventSetupImpl const&,
                             ServiceToken const&,
                             StreamID const&, StreamContext const*);
 
@@ -191,7 +191,7 @@ namespace edm {
   template <typename T>
   void Path::runAllModulesAsync(WaitingTask* task,
                                 typename T::MyPrincipal const& p,
-                                EventSetup  const& es,
+                                EventSetupImpl  const& es,
                                 ServiceToken const& token,
                                 StreamID const& streamID,
                                 typename T::Context const* context) {

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1130,7 +1130,7 @@ namespace edm {
   void Schedule::processOneEventAsync(WaitingTaskHolder iTask,
                                       unsigned int iStreamID,
                                       EventPrincipal& ep,
-                                      EventSetup const& es,
+                                      EventSetupImpl const& es,
                                       ServiceToken const& token) {
     assert(iStreamID<streamSchedules_.size());
     streamSchedules_[iStreamID]->processOneEventAsync(std::move(iTask),ep,es,token,pathStatusInserters_);

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -537,7 +537,7 @@ namespace edm {
   
   void StreamSchedule::processOneEventAsync(WaitingTaskHolder iTask,
                                             EventPrincipal& ep,
-                                            EventSetup const& es,
+                                            EventSetupImpl const& es,
                                             ServiceToken const& serviceToken,
                                             std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters) {
     try {
@@ -639,7 +639,7 @@ namespace edm {
   
   void
   StreamSchedule::finishedPaths(std::atomic<std::exception_ptr*>& iExcept, WaitingTaskHolder iWait, EventPrincipal& ep,
-                                EventSetup const& es) {
+                                EventSetupImpl const& es) {
     
     if(iExcept) {
       try {

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -98,7 +98,7 @@ namespace edm {
 
   class ActivityRegistry;
   class BranchIDListHelper;
-  class EventSetup;
+  class EventSetupImpl;
   class ExceptionCollector;
   class ExceptionToActionTable;
   class OutputModuleCommunicator;
@@ -178,14 +178,14 @@ namespace edm {
 
     void processOneEventAsync(WaitingTaskHolder iTask,
                               EventPrincipal& ep,
-                              EventSetup const& es,
+                              EventSetupImpl const& es,
                               ServiceToken const& token,
                               std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters);
 
     template <typename T>
     void processOneStreamAsync(WaitingTaskHolder iTask,
                                typename T::MyPrincipal& principal,
-                               EventSetup const& eventSetup,
+                               EventSetupImpl const& eventSetup,
                                ServiceToken const& token,
                                bool cleaningUpAfterException = false);
 
@@ -296,7 +296,7 @@ namespace edm {
     void resetAll();
 
     void finishedPaths(std::atomic<std::exception_ptr*>&, WaitingTaskHolder,
-                       EventPrincipal& ep, EventSetup const& es);
+                       EventPrincipal& ep, EventSetupImpl const& es);
     std::exception_ptr finishProcessOneEvent(std::exception_ptr);
     
     void reportSkipped(EventPrincipal const& ep) const;
@@ -385,7 +385,7 @@ namespace edm {
   template <typename T>
   void StreamSchedule::processOneStreamAsync(WaitingTaskHolder iHolder,
                                              typename T::MyPrincipal& ep,
-                                             EventSetup const& es,
+                                             EventSetupImpl const& es,
                                              ServiceToken const& token,
                                              bool cleaningUpAfterException) {
     T::setStreamContext(streamContext_, ep);

--- a/FWCore/Framework/src/UnscheduledAuxiliary.h
+++ b/FWCore/Framework/src/UnscheduledAuxiliary.h
@@ -26,7 +26,7 @@
 // forward declarations
 
 namespace edm {
-  class EventSetup;
+  class EventSetupImpl;
   class ModuleCallingContext;
   class StreamContext;
   
@@ -37,12 +37,12 @@ namespace edm {
     UnscheduledAuxiliary(): m_eventSetup(nullptr) {}
 
     // ---------- const member functions ---------------------
-    EventSetup const* eventSetup() const { return m_eventSetup;}
+    EventSetupImpl const* eventSetup() const { return m_eventSetup;}
     
     // ---------- static member functions --------------------
 
     // ---------- member functions ---------------------------
-    void setEventSetup( EventSetup const* iSetup) {
+    void setEventSetup( EventSetupImpl const* iSetup) {
       m_eventSetup = iSetup;
     }
 
@@ -51,7 +51,7 @@ namespace edm {
   private:
 
     // ---------- member data --------------------------------
-    EventSetup const * m_eventSetup;
+    EventSetupImpl const * m_eventSetup;
 
   };
 }

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -379,7 +379,7 @@ private:
   }
 
   void Worker::runAcquire(EventPrincipal const& ep,
-                          EventSetup const& es,
+                          EventSetupImpl const& es,
                           ParentContext const& parentContext,
                           WaitingTaskWithArenaHolder& holder) {
 
@@ -401,7 +401,7 @@ private:
 
   void Worker::runAcquireAfterAsyncPrefetch(std::exception_ptr const* iEPtr,
                                             EventPrincipal const& ep,
-                                            EventSetup const& es,
+                                            EventSetupImpl const& es,
                                             ParentContext const& parentContext,
                                             WaitingTaskWithArenaHolder holder) {
     ranAcquireWithoutException_ = false;

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -124,7 +124,7 @@ namespace edm {
     virtual SerialTaskQueue* globalLuminosityBlocksQueue() = 0;
 
     template <typename T>
-    bool doWork(typename T::MyPrincipal const&, EventSetup const& c,
+    bool doWork(typename T::MyPrincipal const&, EventSetupImpl const& c,
                 StreamID stream,
                 ParentContext const& parentContext,
                 typename T::Context const* context);
@@ -141,7 +141,7 @@ namespace edm {
 
     template <typename T>
     void doWorkAsync(WaitingTask* task,
-                     typename T::MyPrincipal const&, EventSetup const& c,
+                     typename T::MyPrincipal const&, EventSetupImpl const& c,
                      ServiceToken const& token, StreamID stream,
                      ParentContext const& parentContext,
                      typename T::Context const* context);
@@ -149,7 +149,7 @@ namespace edm {
     template <typename T>
     void doWorkNoPrefetchingAsync(WaitingTask* task,
                                   typename T::MyPrincipal const&,
-                                  EventSetup const& c,
+                                  EventSetupImpl const& c,
                                   ServiceToken const& token,
                                   StreamID stream,
                                   ParentContext const& parentContext,
@@ -157,7 +157,7 @@ namespace edm {
 
     template <typename T>
     std::exception_ptr runModuleDirectly(typename T::MyPrincipal const& ep,
-                                         EventSetup const& es,
+                                         EventSetupImpl const& es,
                                          StreamID streamID,
                                          ParentContext const& parentContext,
                                          typename T::Context const* context);
@@ -235,34 +235,34 @@ namespace edm {
   protected:
     template<typename O> friend class workerhelper::CallImpl;
     virtual std::string workerType() const = 0;
-    virtual bool implDo(EventPrincipal const&, EventSetup const& c,
+    virtual bool implDo(EventPrincipal const&, EventSetupImpl const& c,
                         ModuleCallingContext const* mcc) = 0;
 
     virtual void itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const = 0;
     virtual bool implNeedToRunSelection() const = 0;
 
-    virtual void implDoAcquire(EventPrincipal const&, EventSetup const& c,
+    virtual void implDoAcquire(EventPrincipal const&, EventSetupImpl const& c,
                                ModuleCallingContext const* mcc,
                                WaitingTaskWithArenaHolder& holder) = 0;
 
     virtual bool implDoPrePrefetchSelection(StreamID id,
                                             EventPrincipal const& ep,
                                             ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoBegin(RunPrincipal const& rp, EventSetup const& c,
+    virtual bool implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c,
                              ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetup const& c,
+    virtual bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
                                    ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetup const& c,
+    virtual bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
                                  ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoEnd(RunPrincipal const& rp, EventSetup const& c,
+    virtual bool implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c,
                            ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    virtual bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                              ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                                    ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                                  ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    virtual bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                            ModuleCallingContext const* mcc) = 0;
     virtual void implBeginJob() = 0;
     virtual void implEndJob() = 0;
@@ -276,7 +276,7 @@ namespace edm {
   private:
     
     template <typename T>
-    bool runModule(typename T::MyPrincipal const&, EventSetup const& c,
+    bool runModule(typename T::MyPrincipal const&, EventSetupImpl const& c,
                 StreamID stream,
                 ParentContext const& parentContext,
                 typename T::Context const* context);
@@ -373,19 +373,19 @@ namespace edm {
     template<typename T>
     std::exception_ptr runModuleAfterAsyncPrefetch(std::exception_ptr const * iEPtr,
                                                    typename T::MyPrincipal const& ep,
-                                                   EventSetup const& es,
+                                                   EventSetupImpl const& es,
                                                    StreamID streamID,
                                                    ParentContext const& parentContext,
                                                    typename T::Context const* context);
 
     void runAcquire(EventPrincipal const& ep,
-                    EventSetup const& es,
+                    EventSetupImpl const& es,
                     ParentContext const& parentContext,
                     WaitingTaskWithArenaHolder& holder);
 
     void runAcquireAfterAsyncPrefetch(std::exception_ptr const* iEPtr,
                                       EventPrincipal const& ep,
-                                      EventSetup const& es,
+                                      EventSetupImpl const& es,
                                       ParentContext const& parentContext,
                                       WaitingTaskWithArenaHolder holder);
 
@@ -397,7 +397,7 @@ namespace edm {
     public:
       RunModuleTask(Worker* worker,
                     typename T::MyPrincipal const& ep,
-                    EventSetup const& es,
+                    EventSetupImpl const& es,
                     ServiceToken const& token,
                     StreamID streamID,
                     ParentContext const& parentContext,
@@ -489,7 +489,7 @@ namespace edm {
     private:
       Worker* m_worker;
       typename T::MyPrincipal const& m_principal;
-      EventSetup const& m_es;
+      EventSetupImpl const& m_es;
       StreamID m_streamID;
       ParentContext const m_parentContext;
       typename T::Context const* m_context;
@@ -505,7 +505,7 @@ namespace edm {
     public:
       AcquireTask(Worker* worker,
                   typename T::MyPrincipal const& ep,
-                  EventSetup const& es,
+                  EventSetupImpl const& es,
                   ServiceToken const& token,
                   ParentContext const& parentContext,
                   WaitingTaskWithArenaHolder holder) {}
@@ -517,7 +517,7 @@ namespace edm {
     public:
       AcquireTask(Worker* worker,
                   EventPrincipal const& ep,
-                  EventSetup const& es,
+                  EventSetupImpl const& es,
                   ServiceToken const& token,
                   ParentContext const& parentContext,
                   WaitingTaskWithArenaHolder holder):
@@ -579,7 +579,7 @@ namespace edm {
     private:
       Worker* m_worker;
       EventPrincipal const& m_principal;
-      EventSetup const& m_es;
+      EventSetupImpl const& m_es;
       ParentContext const m_parentContext;
       WaitingTaskWithArenaHolder m_holder;
       ServiceToken m_serviceToken;
@@ -656,7 +656,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> Arg;
       static bool call(Worker* iWorker, StreamID,
-                       EventPrincipal const& ep, EventSetup const& es,
+                       EventPrincipal const& ep, EventSetupImpl const& es,
                        ActivityRegistry* /* actReg */,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* /* context*/) {
@@ -679,7 +679,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Arg;
       static bool call(Worker* iWorker,StreamID,
-                       RunPrincipal const& ep, EventSetup const& es,
+                       RunPrincipal const& ep, EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -701,7 +701,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Arg;
       static bool call(Worker* iWorker,StreamID id,
-                       RunPrincipal const & ep, EventSetup const& es,
+                       RunPrincipal const & ep, EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -723,7 +723,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Arg;
       static bool call(Worker* iWorker,StreamID,
-                       RunPrincipal const& ep, EventSetup const& es,
+                       RunPrincipal const& ep, EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -744,7 +744,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Arg;
       static bool call(Worker* iWorker,StreamID id,
-                       RunPrincipal const& ep, EventSetup const& es,
+                       RunPrincipal const& ep, EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -766,7 +766,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Arg;
       static bool call(Worker* iWorker,StreamID,
-                       LuminosityBlockPrincipal const& ep, EventSetup const& es,
+                       LuminosityBlockPrincipal const& ep, EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -787,7 +787,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Arg;
       static bool call(Worker* iWorker,StreamID id,
-                       LuminosityBlockPrincipal const& ep, EventSetup const& es,
+                       LuminosityBlockPrincipal const& ep, EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -809,7 +809,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Arg;
       static bool call(Worker* iWorker,StreamID,
-                       LuminosityBlockPrincipal const& ep, EventSetup const& es,
+                       LuminosityBlockPrincipal const& ep, EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -830,7 +830,7 @@ namespace edm {
     public:
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> Arg;
       static bool call(Worker* iWorker,StreamID id,
-                       LuminosityBlockPrincipal const& ep, EventSetup const& es,
+                       LuminosityBlockPrincipal const& ep, EventSetupImpl const& es,
                        ActivityRegistry* actReg,
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
@@ -851,7 +851,7 @@ namespace edm {
   template <typename T>
   void Worker::doWorkAsync(WaitingTask* task,
                            typename T::MyPrincipal const& ep,
-                           EventSetup const& es,
+                           EventSetupImpl const& es,
                            ServiceToken const& token,
                            StreamID streamID,
                            ParentContext const& parentContext,
@@ -924,7 +924,7 @@ namespace edm {
   template<typename T>
   std::exception_ptr Worker::runModuleAfterAsyncPrefetch(std::exception_ptr const* iEPtr,
                                                          typename T::MyPrincipal const& ep,
-                                                         EventSetup const& es,
+                                                         EventSetupImpl const& es,
                                                          StreamID streamID,
                                                          ParentContext const& parentContext,
                                                          typename T::Context const* context) {
@@ -953,7 +953,7 @@ namespace edm {
   template <typename T>
   void Worker::doWorkNoPrefetchingAsync(WaitingTask* task,
                            typename T::MyPrincipal const& principal,
-                           EventSetup const& es,
+                           EventSetupImpl const& es,
                            ServiceToken const& serviceToken,
                            StreamID streamID,
                            ParentContext const& parentContext,
@@ -993,7 +993,7 @@ namespace edm {
 
   template <typename T>
   bool Worker::doWork(typename T::MyPrincipal const& ep,
-                      EventSetup const& es,
+                      EventSetupImpl const& es,
                       StreamID streamID,
                       ParentContext const& parentContext,
                       typename T::Context const* context) {
@@ -1115,7 +1115,7 @@ namespace edm {
   
   template <typename T>
   bool Worker::runModule(typename T::MyPrincipal const& ep,
-                      EventSetup const& es,
+                      EventSetupImpl const& es,
                       StreamID streamID,
                       ParentContext const& parentContext,
                       typename T::Context const* context) {
@@ -1157,7 +1157,7 @@ namespace edm {
 
   template <typename T>
   std::exception_ptr Worker::runModuleDirectly(typename T::MyPrincipal const& ep,
-                                               EventSetup const& es,
+                                               EventSetupImpl const& es,
                                                StreamID streamID,
                                                ParentContext const& parentContext,
                                                typename T::Context const* context) {

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -30,7 +30,7 @@ namespace edm {
 
     template <typename T>
     void runWorkerAsync(WaitingTask* iTask,
-                        typename T::MyPrincipal const&, EventSetup const&,
+                        typename T::MyPrincipal const&, EventSetupImpl const&,
                         ServiceToken const&,
                         StreamID streamID,
                         typename T::Context const* context);
@@ -111,7 +111,7 @@ namespace edm {
 
   template <typename T>
   void WorkerInPath::runWorkerAsync(WaitingTask* iTask,
-                                    typename T::MyPrincipal const& ep, EventSetup const & es,
+                                    typename T::MyPrincipal const& ep, EventSetupImpl const & es,
                                     ServiceToken const& token,
                                     StreamID streamID,
                                     typename T::Context const* context) {

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -146,7 +146,7 @@ namespace edm {
   }
 
   void
-  WorkerManager::setupOnDemandSystem(Principal& ep, EventSetup const& es) {
+  WorkerManager::setupOnDemandSystem(Principal& ep, EventSetupImpl const& es) {
     this->resetAll();
     unscheduled_.setEventSetup(es);
     if(&ep != lastSetupEventPrincipal_) {

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -99,7 +99,7 @@ namespace edm{
     template<typename T, typename P>
     struct DoStreamBeginTrans {
       inline void operator() (WorkerT<T>* iWorker, StreamID id, P const& rp,
-                              EventSetup const& c,
+                              EventSetupImpl const& c,
                               ModuleCallingContext const* mcc) {
         iWorker->callWorkerStreamBegin(0,id,rp,c, mcc);
       }
@@ -108,7 +108,7 @@ namespace edm{
     template<typename T, typename P>
     struct DoStreamEndTrans {
       inline void operator() (WorkerT<T>* iWorker, StreamID id, P const& rp,
-                              EventSetup const& c,
+                              EventSetupImpl const& c,
                               ModuleCallingContext const* mcc) {
         iWorker->callWorkerStreamEnd(0,id,rp,c, mcc);
       }
@@ -226,7 +226,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDo(EventPrincipal const& ep, EventSetup const& c, ModuleCallingContext const* mcc) {
+  WorkerT<T>::implDo(EventPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
     std::shared_ptr<Worker> sentry(this,[&ep](Worker* obj) {obj->postDoEvent(ep);});
     return module_->doEvent(ep, c, activityRegistry(), mcc);
   }
@@ -234,7 +234,7 @@ namespace edm{
   template<typename T>
   inline
   void
-  WorkerT<T>::implDoAcquire(EventPrincipal const&, EventSetup const&,
+  WorkerT<T>::implDoAcquire(EventPrincipal const&, EventSetupImpl const&,
                             ModuleCallingContext const*,
                             WaitingTaskWithArenaHolder&) {
   }
@@ -242,7 +242,7 @@ namespace edm{
   template<>
   inline
   void
-  WorkerT<global::EDProducerBase>::implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+  WorkerT<global::EDProducerBase>::implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
                                                  ModuleCallingContext const* mcc,
                                                  WaitingTaskWithArenaHolder& holder) {
     module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
@@ -251,7 +251,7 @@ namespace edm{
   template<>
   inline
   void
-  WorkerT<global::EDFilterBase>::implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+  WorkerT<global::EDFilterBase>::implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
                                                ModuleCallingContext const* mcc,
                                                WaitingTaskWithArenaHolder& holder) {
     module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
@@ -260,7 +260,7 @@ namespace edm{
   template<>
   inline
   void
-  WorkerT<stream::EDProducerAdaptorBase>::implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+  WorkerT<stream::EDProducerAdaptorBase>::implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
                                                         ModuleCallingContext const* mcc,
                                                         WaitingTaskWithArenaHolder& holder) {
     module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
@@ -269,7 +269,7 @@ namespace edm{
   template<>
   inline
   void
-  WorkerT<stream::EDFilterAdaptorBase>::implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+  WorkerT<stream::EDFilterAdaptorBase>::implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
                                                       ModuleCallingContext const* mcc,
                                                       WaitingTaskWithArenaHolder& holder) {
     module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
@@ -374,7 +374,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoBegin(RunPrincipal const& rp, EventSetup const& c, ModuleCallingContext const* mcc) {
+  WorkerT<T>::implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
     module_->doBeginRun(rp, c, mcc);
     return true;
   }
@@ -383,7 +383,7 @@ namespace edm{
   template<typename D>
   void
   WorkerT<T>::callWorkerStreamBegin(D, StreamID id, RunPrincipal const& rp,
-                                    EventSetup const& c,
+                                    EventSetupImpl const& c,
                                     ModuleCallingContext const* mcc) {
     module_->doStreamBeginRun(id, rp, c, mcc);
   }
@@ -392,7 +392,7 @@ namespace edm{
   template<typename D>
   void
   WorkerT<T>::callWorkerStreamEnd(D, StreamID id, RunPrincipal const& rp,
-                                  EventSetup const& c,
+                                  EventSetupImpl const& c,
                                   ModuleCallingContext const* mcc) {
     module_->doStreamEndRun(id, rp, c, mcc);
   }
@@ -401,7 +401,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetup const& c,
+  WorkerT<T>::implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
                                 ModuleCallingContext const* mcc) {
     std::conditional_t<workerimpl::has_stream_functions<T>::value,
                        workerimpl::DoStreamBeginTrans<T,RunPrincipal const>,
@@ -413,7 +413,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetup const& c,
+  WorkerT<T>::implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
                               ModuleCallingContext const* mcc) {
     std::conditional_t<workerimpl::has_stream_functions<T>::value,
                        workerimpl::DoStreamEndTrans<T,RunPrincipal const>,
@@ -425,7 +425,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoEnd(RunPrincipal const& rp, EventSetup const& c,
+  WorkerT<T>::implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c,
                         ModuleCallingContext const* mcc) {
     module_->doEndRun(rp, c, mcc);
     return true;
@@ -434,7 +434,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  WorkerT<T>::implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                           ModuleCallingContext const* mcc) {
     module_->doBeginLuminosityBlock(lbp, c, mcc);
     return true;
@@ -444,7 +444,7 @@ namespace edm{
   template<typename D>
   void
   WorkerT<T>::callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal const& rp,
-                                    EventSetup const& c,
+                                    EventSetupImpl const& c,
                                     ModuleCallingContext const* mcc) {
     module_->doStreamBeginLuminosityBlock(id, rp, c, mcc);
   }
@@ -453,7 +453,7 @@ namespace edm{
   template<typename D>
   void
   WorkerT<T>::callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal const& rp,
-                                  EventSetup const& c,
+                                  EventSetupImpl const& c,
                                   ModuleCallingContext const* mcc) {
     module_->doStreamEndLuminosityBlock(id, rp, c, mcc);
   }
@@ -462,7 +462,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  WorkerT<T>::implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                                 ModuleCallingContext const* mcc) {
     std::conditional_t<workerimpl::has_stream_functions<T>::value,
                        workerimpl::DoStreamBeginTrans<T,LuminosityBlockPrincipal>,
@@ -474,7 +474,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  WorkerT<T>::implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                               ModuleCallingContext const* mcc) {
     std::conditional_t<workerimpl::has_stream_functions<T>::value,
                        workerimpl::DoStreamEndTrans<T,LuminosityBlockPrincipal>,
@@ -487,7 +487,7 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+  WorkerT<T>::implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                         ModuleCallingContext const* mcc) {
     module_->doEndLuminosityBlock(lbp, c, mcc);
     return true;

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -65,19 +65,19 @@ namespace edm {
     void callWorkerEndStream(D, StreamID);
     template<typename D>
     void callWorkerStreamBegin(D, StreamID id, RunPrincipal const& rp,
-                               EventSetup const& c,
+                               EventSetupImpl const& c,
                                ModuleCallingContext const* mcc);
     template<typename D>
     void callWorkerStreamEnd(D, StreamID id, RunPrincipal const& rp,
-                             EventSetup const& c,
+                             EventSetupImpl const& c,
                              ModuleCallingContext const* mcc);
     template<typename D>
     void callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal const& rp,
-                               EventSetup const& c,
+                               EventSetupImpl const& c,
                                ModuleCallingContext const* mcc);
     template<typename D>
     void callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal const& rp,
-                             EventSetup const& c,
+                             EventSetupImpl const& c,
                              ModuleCallingContext const* mcc);
     
   protected:
@@ -85,34 +85,34 @@ namespace edm {
     T const& module() const {return *module_;}
 
   private:
-    bool implDo(EventPrincipal const& ep, EventSetup const& c,
+    bool implDo(EventPrincipal const& ep, EventSetupImpl const& c,
                         ModuleCallingContext const* mcc) override;
 
     void itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const final;
     bool implNeedToRunSelection() const final;
 
-    void implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+    void implDoAcquire(EventPrincipal const& ep, EventSetupImpl const& c,
                        ModuleCallingContext const* mcc,
                        WaitingTaskWithArenaHolder& holder) final;
 
     bool implDoPrePrefetchSelection(StreamID id,
                                             EventPrincipal const& ep,
                                             ModuleCallingContext const* mcc) override;
-    bool implDoBegin(RunPrincipal const& rp, EventSetup const& c,
+    bool implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c,
                              ModuleCallingContext const* mcc) override;
-    bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetup const& c,
+    bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
                                    ModuleCallingContext const* mcc) override;
-    bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetup const& c,
+    bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetupImpl const& c,
                                  ModuleCallingContext const* mcc) override;
-    bool implDoEnd(RunPrincipal const& rp, EventSetup const& c,
+    bool implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c,
                            ModuleCallingContext const* mcc) override;
-    bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                              ModuleCallingContext const* mcc) override;
-    bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                                    ModuleCallingContext const* mcc) override;
-    bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                                  ModuleCallingContext const* mcc) override;
-    bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& c,
                            ModuleCallingContext const* mcc) override;
     void implBeginJob() override;
     void implEndJob() override;

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
@@ -51,12 +52,13 @@ namespace edm {
     }
     
     bool
-    EDAnalyzerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDAnalyzerBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       EventSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -79,42 +81,46 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                                ModuleCallingContext const* mcc) {
       
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
     
     void
-    EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doEndRunSummary_(r,c);
       this->doEndRun_(cnstR, c);
     }
     
     void
-    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
     }
     
     void
-    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doEndLuminosityBlockSummary_(cnstLb,c);
       this->doEndLuminosityBlock_(cnstLb, c);
     }
@@ -130,40 +136,44 @@ namespace edm {
     void
     EDAnalyzerBase::doStreamBeginRun(StreamID id,
                                      RunPrincipal const& rp,
-                                     EventSetup const& c,
+                                     EventSetupImpl const& ci,
                                      ModuleCallingContext const* mcc)
     {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamBeginRun_(id, r, c);
     }
     void
     EDAnalyzerBase::doStreamEndRun(StreamID id,
                                    RunPrincipal const& rp,
-                                   EventSetup const& c,
+                                   EventSetupImpl const& ci,
                                    ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
     void
     EDAnalyzerBase::doStreamBeginLuminosityBlock(StreamID id,
                                                  LuminosityBlockPrincipal const& lbp,
-                                                 EventSetup const& c,
+                                                 EventSetupImpl const& ci,
                                                  ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamBeginLuminosityBlock_(id,lb, c);
     }
     
     void
     EDAnalyzerBase::doStreamEndLuminosityBlock(StreamID id,
                                                LuminosityBlockPrincipal const& lbp,
-                                               EventSetup const& c,
+                                               EventSetupImpl const& ci,
                                                ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndLuminosityBlock_(id,lb, c);
       this->doStreamEndLuminosityBlockSummary_(id,lb, c);
     }

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -15,6 +15,7 @@
 // user include files
 #include "FWCore/Framework/interface/global/EDFilterBase.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
@@ -52,7 +53,7 @@ namespace edm {
     }
     
     bool
-    EDFilterBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDFilterBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                           ActivityRegistry* act,
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -62,13 +63,14 @@ namespace edm {
                     &previousParentages_[streamIndex],
                     hasAcquire() ? &gotBranchIDsFromAcquire_[streamIndex] : nullptr);
       EventSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
       return returnValue;
     }
     
     void
-    EDFilterBase::doAcquire(EventPrincipal const& ep, EventSetup const& c,
+    EDFilterBase::doAcquire(EventPrincipal const& ep, EventSetupImpl const& ci,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc,
                             WaitingTaskWithArenaHolder& holder) {
@@ -79,6 +81,7 @@ namespace edm {
                               nullptr,
                               gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
 
@@ -106,11 +109,12 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -119,12 +123,13 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                            ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doEndRunProduce_(r, c);
       this->doEndRunSummary_(r,c);
       this->doEndRun_(cnstR, c);
@@ -132,11 +137,12 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -145,12 +151,13 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                        ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       lb.setProducer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlockSummary_(cnstLb,c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -168,40 +175,44 @@ namespace edm {
     void
     EDFilterBase::doStreamBeginRun(StreamID id,
                                      RunPrincipal const& rp,
-                                     EventSetup const& c,
+                                     EventSetupImpl const& ci,
                                      ModuleCallingContext const* mcc)
     {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamBeginRun_(id, r, c);
     }
     void
     EDFilterBase::doStreamEndRun(StreamID id,
                                    RunPrincipal const& rp,
-                                   EventSetup const& c,
+                                   EventSetupImpl const& ci,
                                    ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
     void
     EDFilterBase::doStreamBeginLuminosityBlock(StreamID id,
                                                  LuminosityBlockPrincipal const& lbp,
-                                                 EventSetup const& c,
+                                                 EventSetupImpl const& ci,
                                                  ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false );
       lb.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamBeginLuminosityBlock_(id,lb, c);
     }
     
     void
     EDFilterBase::doStreamEndLuminosityBlock(StreamID id,
                                                LuminosityBlockPrincipal const& lbp,
-                                               EventSetup const& c,
+                                               EventSetupImpl const& ci,
                                                ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndLuminosityBlock_(id,lb, c);
       this->doStreamEndLuminosityBlockSummary_(id,lb, c);
     }

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -261,7 +261,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doEvent(EventPrincipal const& ep,
-                              EventSetup const&,
+                              EventSetupImpl const&,
                               ActivityRegistry* act,
                               ModuleCallingContext const* mcc) {
       
@@ -288,7 +288,7 @@ namespace edm {
 
     bool
     OutputModuleBase::doBeginRun(RunPrincipal const& rp,
-                                 EventSetup const&,
+                                 EventSetupImpl const&,
                                  ModuleCallingContext const* mcc) {
       RunForOutput r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
@@ -298,7 +298,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doEndRun(RunPrincipal const& rp,
-                               EventSetup const&,
+                               EventSetupImpl const&,
                                ModuleCallingContext const* mcc) {
       RunForOutput r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
@@ -317,7 +317,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                             EventSetup const&,
+                                             EventSetupImpl const&,
                                              ModuleCallingContext const* mcc) {
       LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
@@ -327,7 +327,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                           EventSetup const&,
+                                           EventSetupImpl const&,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);

--- a/FWCore/Framework/src/globalTransitionAsync.h
+++ b/FWCore/Framework/src/globalTransitionAsync.h
@@ -30,7 +30,7 @@
 
 namespace edm {
   class IOVSyncValue;
-  class EventSetup;
+  class EventSetupImpl;
   class LuminosityBlockPrincipal;
   class RunPrincipal;
   
@@ -56,7 +56,7 @@ namespace edm {
                                   Schedule& iSchedule,
                                   P& iPrincipal,
                                   IOVSyncValue const & iTS,
-                                  EventSetup const& iES,
+                                  EventSetupImpl const& iES,
                                   ServiceToken const& token,
                                   SC& iSubProcesses) {
 
@@ -89,7 +89,7 @@ namespace edm {
                                 Schedule& iSchedule,
                                 P& iPrincipal,
                                 IOVSyncValue const & iTS,
-                                EventSetup const& iES,
+                                EventSetupImpl const& iES,
                                 ServiceToken const& token,
                                 SC& iSubProcesses,
                                 bool cleaningUpAfterException)

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
@@ -52,12 +53,13 @@ namespace edm {
     }
     
     bool
-    EDAnalyzerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDAnalyzerBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       EventSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -80,42 +82,46 @@ namespace edm {
     }
     
     void
-    EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                                ModuleCallingContext const* mcc) {
       
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
     
     void
-    EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doEndRunSummary_(r,c);
       this->doEndRun_(cnstR, c);
     }
     
     void
-    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
     }
     
     void
-    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doEndLuminosityBlockSummary_(cnstLb,c);
       this->doEndLuminosityBlock_(cnstLb, c);
     }
@@ -131,40 +137,44 @@ namespace edm {
     void
     EDAnalyzerBase::doStreamBeginRun(StreamID id,
                                      RunPrincipal const& rp,
-                                     EventSetup const& c,
+                                     EventSetupImpl const& ci,
                                      ModuleCallingContext const* mcc)
     {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamBeginRun_(id, r, c);
     }
     void
     EDAnalyzerBase::doStreamEndRun(StreamID id,
                                    RunPrincipal const& rp,
-                                   EventSetup const& c,
+                                   EventSetupImpl const& ci,
                                    ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
     void
     EDAnalyzerBase::doStreamBeginLuminosityBlock(StreamID id,
                                                  LuminosityBlockPrincipal const& lbp,
-                                                 EventSetup const& c,
+                                                 EventSetupImpl const& ci,
                                                  ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamBeginLuminosityBlock_(id,lb, c);
     }
     
     void
     EDAnalyzerBase::doStreamEndLuminosityBlock(StreamID id,
                                                LuminosityBlockPrincipal const& lbp,
-                                               EventSetup const& c,
+                                               EventSetupImpl const& ci,
                                                ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndLuminosityBlock_(id,lb, c);
       this->doStreamEndLuminosityBlockSummary_(id,lb, c);
     }

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
@@ -49,13 +50,14 @@ namespace edm {
     }
     
     bool
-    EDFilterBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDFilterBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                           ActivityRegistry* act,
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       const auto streamIndex =e.streamID().value();
       e.setProducer(this, &previousParentages_[streamIndex]);
+      const EventSetup c{ci};
       EventSignalsSentry sentry(act,mcc);
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
@@ -83,11 +85,12 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -96,12 +99,13 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                            ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doEndRunProduce_(r, c);
       this->doEndRunSummary_(r,c);
       this->doEndRun_(cnstR, c);
@@ -109,11 +113,12 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -122,12 +127,13 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                        ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       lb.setProducer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlockSummary_(cnstLb,c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -145,29 +151,32 @@ namespace edm {
     void
     EDFilterBase::doStreamBeginRun(StreamID id,
                                      RunPrincipal const& rp,
-                                     EventSetup const& c,
+                                     EventSetupImpl const& ci,
                                      ModuleCallingContext const* mcc)
     {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamBeginRun_(id, r, c);
     }
     void
     EDFilterBase::doStreamEndRun(StreamID id,
                                    RunPrincipal const& rp,
-                                   EventSetup const& c,
+                                   EventSetupImpl const& ci,
                                    ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
     void
     EDFilterBase::doStreamBeginLuminosityBlock(StreamID id,
                                                  LuminosityBlockPrincipal const& lbp,
-                                                 EventSetup const& c,
+                                                 EventSetupImpl const& ci,
                                                  ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+      const EventSetup c{ci};
       lb.setConsumer(this);
       this->doStreamBeginLuminosityBlock_(id,lb, c);
     }
@@ -175,10 +184,11 @@ namespace edm {
     void
     EDFilterBase::doStreamEndLuminosityBlock(StreamID id,
                                                LuminosityBlockPrincipal const& lbp,
-                                               EventSetup const& c,
+                                               EventSetupImpl const& ci,
                                                ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndLuminosityBlock_(id,lb, c);
       this->doStreamEndLuminosityBlockSummary_(id,lb, c);
     }

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
@@ -49,7 +50,7 @@ namespace edm {
     }
     
     bool
-    EDProducerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDProducerBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -57,6 +58,7 @@ namespace edm {
       const auto streamIndex = e.streamID().value();
       e.setProducer(this,&previousParentages_[streamIndex]);
       EventSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       this->produce(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
       return true;
@@ -83,11 +85,12 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                                ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -96,12 +99,13 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    EDProducerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doEndRunProduce_(r, c);
       this->doEndRunSummary_(r,c);
       this->doEndRun_(cnstR, c);
@@ -109,11 +113,12 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -122,12 +127,13 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       lb.setProducer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlockSummary_(cnstLb,c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -145,40 +151,44 @@ namespace edm {
     void
     EDProducerBase::doStreamBeginRun(StreamID id,
                                      RunPrincipal const& rp,
-                                     EventSetup const& c,
+                                     EventSetupImpl const& ci,
                                      ModuleCallingContext const* mcc)
     {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamBeginRun_(id, r, c);
     }
     void
     EDProducerBase::doStreamEndRun(StreamID id,
                                    RunPrincipal const& rp,
-                                   EventSetup const& c,
+                                   EventSetupImpl const& ci,
                                    ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
     void
     EDProducerBase::doStreamBeginLuminosityBlock(StreamID id,
                                                  LuminosityBlockPrincipal const& lbp,
-                                                 EventSetup const& c,
+                                                 EventSetupImpl const& ci,
                                                  ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamBeginLuminosityBlock_(id,lb, c);
     }
     
     void
     EDProducerBase::doStreamEndLuminosityBlock(StreamID id,
                                                LuminosityBlockPrincipal const& lbp,
-                                               EventSetup const& c,
+                                               EventSetupImpl const& ci,
                                                ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
+      const EventSetup c{ci};
       this->doStreamEndLuminosityBlock_(id,lb, c);
       this->doStreamEndLuminosityBlockSummary_(id,lb, c);
     }

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -262,7 +262,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doEvent(EventPrincipal const& ep,
-                              EventSetup const&,
+                              EventSetupImpl const&,
                               ActivityRegistry* act,
                               ModuleCallingContext const* mcc) {
       
@@ -289,7 +289,7 @@ namespace edm {
 
     bool
     OutputModuleBase::doBeginRun(RunPrincipal const& rp,
-                                 EventSetup const&,
+                                 EventSetupImpl const&,
                                  ModuleCallingContext const* mcc) {
       RunForOutput r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
@@ -299,7 +299,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doEndRun(RunPrincipal const& rp,
-                               EventSetup const&,
+                               EventSetupImpl const&,
                                ModuleCallingContext const* mcc) {
       RunForOutput r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
@@ -318,7 +318,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                             EventSetup const&,
+                                             EventSetupImpl const&,
                                              ModuleCallingContext const* mcc) {
       LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
@@ -328,7 +328,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                           EventSetup const&,
+                                           EventSetupImpl const&,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
@@ -53,13 +54,14 @@ namespace edm {
     }
 
     bool
-    EDAnalyzerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDAnalyzerBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       this->analyze(e, c);
       return true;
     }
@@ -91,38 +93,42 @@ namespace edm {
     void EDAnalyzerBase::preallocLumis(unsigned int) {};
 
     void
-    EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                                ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doBeginRun_(cnstR, c);
     }
     
     void
-    EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doEndRun_(cnstR, c);
     }
     
     void
-    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doBeginLuminosityBlock_(cnstLb, c);
     }
     
     void
-    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doEndLuminosityBlock_(cnstLb, c);
     }
     

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
@@ -50,7 +51,7 @@ namespace edm {
     }
     
     bool
-    EDFilterBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDFilterBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                           ActivityRegistry* act,
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -59,6 +60,7 @@ namespace edm {
       bool returnValue =true;
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       returnValue = this->filter(e, c);
       commit_(e, &previousParentageId_);
       return returnValue;
@@ -93,11 +95,12 @@ namespace edm {
     void EDFilterBase::preallocLumis(unsigned int) {};
 
     void
-    EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r,c);
@@ -105,11 +108,12 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                            ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doEndRun_(cnstR, c);
       r.setProducer(this);
       this->doEndRunProduce_(r, c);
@@ -117,11 +121,12 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doBeginLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
       this->doBeginLuminosityBlockProduce_(lb, c);
@@ -129,11 +134,12 @@ namespace edm {
     }
     
     void
-    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                        ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doEndLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
       this->doEndLuminosityBlockProduce_(lb, c);

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
@@ -49,7 +50,7 @@ namespace edm {
     }
     
     bool
-    EDProducerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDProducerBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                             ActivityRegistry* act,
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
@@ -57,6 +58,7 @@ namespace edm {
       e.setProducer(this, &previousParentage_);
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       this->produce(e, c);
       commit_(e, &previousParentageId_);
       return true;
@@ -93,11 +95,12 @@ namespace edm {
 
    
     void
-    EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+    EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                                ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
+      const EventSetup c{ci};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r,c);
@@ -105,23 +108,25 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+    EDProducerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci,
                              ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
       r.setProducer(this);
+      const EventSetup c{ci};
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
       commit_(r);
     }
     
     void
-    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
+      const EventSetup c{ci};
       this->doBeginLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
       this->doBeginLuminosityBlockProduce_(lb, c);
@@ -129,11 +134,12 @@ namespace edm {
     }
     
     void
-    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetupImpl const& ci,
                                          ModuleCallingContext const* mcc) {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       lb.setProducer(this);
+      const EventSetup c{ci};
       this->doEndLuminosityBlockProduce_(lb, c);
       LuminosityBlock const& cnstLb = lb;
       this->doEndLuminosityBlock_(cnstLb, c);

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -256,7 +256,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doEvent(EventPrincipal const& ep,
-                              EventSetup const&,
+                              EventSetupImpl const&,
                               ActivityRegistry* act,
                               ModuleCallingContext const* mcc) {
       
@@ -274,7 +274,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doBeginRun(RunPrincipal const& rp,
-                                 EventSetup const&,
+                                 EventSetupImpl const&,
                                  ModuleCallingContext const* mcc) {
       RunForOutput r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
@@ -284,7 +284,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doEndRun(RunPrincipal const& rp,
-                               EventSetup const&,
+                               EventSetupImpl const&,
                                ModuleCallingContext const* mcc) {
       RunForOutput r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
@@ -303,7 +303,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                             EventSetup const&,
+                                             EventSetupImpl const&,
                                              ModuleCallingContext const* mcc) {
       LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(this);
@@ -313,7 +313,7 @@ namespace edm {
     
     bool
     OutputModuleBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                           EventSetup const&,
+                                           EventSetupImpl const&,
                                            ModuleCallingContext const* mcc) {
       LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(this);

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
@@ -138,13 +139,14 @@ EDAnalyzerAdaptorBase::consumesInfo() const {
 }
 
 bool
-EDAnalyzerAdaptorBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+EDAnalyzerAdaptorBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                                ActivityRegistry* act,
                                ModuleCallingContext const* mcc) {
   assert(ep.streamID()<m_streamModules.size());
   auto mod = m_streamModules[ep.streamID()];
   Event e(ep, moduleDescription_, mcc);
   e.setConsumer(mod);
+  const EventSetup c{ci};
   EventSignalsSentry sentry(act,mcc);
   mod->analyze(e, c);
   return true;
@@ -166,13 +168,14 @@ EDAnalyzerAdaptorBase::doEndStream(StreamID id) {
 void
 EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
                                         RunPrincipal const& rp,
-                                        EventSetup const& c,
+                                        EventSetupImpl const& ci,
                                         ModuleCallingContext const* mcc)
 {
   auto mod = m_streamModules[id];
   setupRun(mod, rp.index());
   
   Run r(rp, moduleDescription_, mcc, false);
+  const EventSetup c{ci};
   r.setConsumer(mod);
   mod->beginRun(r, c);
 
@@ -181,12 +184,13 @@ EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
 void
 EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
                     RunPrincipal const& rp,
-                    EventSetup const& c,
+                    EventSetupImpl const& ci,
                     ModuleCallingContext const* mcc)
 {
   auto mod = m_streamModules[id];
   Run r(rp, moduleDescription_, mcc, true);
   r.setConsumer(mod);
+  const EventSetup c{ci};
   mod->endRun(r, c);
   streamEndRunSummary(mod,r,c);
 }
@@ -194,24 +198,26 @@ EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
 void
 EDAnalyzerAdaptorBase::doStreamBeginLuminosityBlock(StreamID id,
                                                     LuminosityBlockPrincipal const& lbp,
-                                                    EventSetup const& c,
+                                                    EventSetupImpl const& ci,
                                                     ModuleCallingContext const* mcc) {
   auto mod = m_streamModules[id];
   setupLuminosityBlock(mod,lbp.index());
   
   LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
   lb.setConsumer(mod);
+  const EventSetup c{ci};
   mod->beginLuminosityBlock(lb, c);
 }
 void
 EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
                                 LuminosityBlockPrincipal const& lbp,
-                                EventSetup const& c,
+                                EventSetupImpl const& ci,
                                 ModuleCallingContext const* mcc)
 {
   auto mod = m_streamModules[id];
   LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
   lb.setConsumer(mod);
+  const EventSetup c{ci};
   mod->endLuminosityBlock(lb, c);
   streamEndLuminosityBlockSummary(mod,lb, c);
 

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
@@ -47,7 +48,7 @@ namespace edm {
     }
     
     bool
-    EDFilterAdaptorBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDFilterAdaptorBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                                  ActivityRegistry* act,
                                  ModuleCallingContext const* mcc) {
       assert(ep.streamID()<m_streamModules.size());
@@ -58,13 +59,14 @@ namespace edm {
                     &mod->previousParentage_,
                     &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       bool result = mod->filter(e, c);
       commit(e, &mod->previousParentageId_);
       return result;
     }
     
     void
-    EDFilterAdaptorBase::doAcquire(EventPrincipal const& ep, EventSetup const& c,
+    EDFilterAdaptorBase::doAcquire(EventPrincipal const& ep, EventSetupImpl const& ci,
                                    ActivityRegistry* act,
                                    ModuleCallingContext const* mcc,
                                    WaitingTaskWithArenaHolder& holder) {
@@ -76,6 +78,7 @@ namespace edm {
                               nullptr,
                               mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/EventAcquireSignalsSentry.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc"
@@ -47,7 +48,7 @@ namespace edm {
     }
     
     bool
-    EDProducerAdaptorBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+    EDProducerAdaptorBase::doEvent(EventPrincipal const& ep, EventSetupImpl const& ci,
                                    ActivityRegistry* act,
                                    ModuleCallingContext const* mcc) {
       assert(ep.streamID()<m_streamModules.size());
@@ -58,13 +59,14 @@ namespace edm {
                     &mod->previousParentage_,
                     &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       mod->produce(e, c);
       commit(e, &mod->previousParentageId_);
       return true;
     }
 
     void
-    EDProducerAdaptorBase::doAcquire(EventPrincipal const& ep, EventSetup const& c,
+    EDProducerAdaptorBase::doAcquire(EventPrincipal const& ep, EventSetupImpl const& ci,
                                      ActivityRegistry* act,
                                      ModuleCallingContext const* mcc,
                                      WaitingTaskWithArenaHolder& holder) {
@@ -76,6 +78,7 @@ namespace edm {
                               nullptr,
                               mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act,mcc);
+      const EventSetup c{ci};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 
@@ -179,7 +180,7 @@ namespace edm {
     void
     ProducingModuleAdaptorBase<T>::doStreamBeginRun(StreamID id,
                                                     RunPrincipal const& rp,
-                                                    EventSetup const& c,
+                                                    EventSetupImpl const& ci,
                                                     ModuleCallingContext const* mcc)
     {
       auto mod = m_streamModules[id];
@@ -187,6 +188,7 @@ namespace edm {
       
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(mod);
+      const EventSetup c{ci};
       mod->beginRun(r, c);
       
     }    
@@ -194,12 +196,13 @@ namespace edm {
     void
     ProducingModuleAdaptorBase<T>::doStreamEndRun(StreamID id,
                                                   RunPrincipal const& rp,
-                                                  EventSetup const& c,
+                                                  EventSetupImpl const& ci,
                                                   ModuleCallingContext const* mcc)
     {
       auto mod = m_streamModules[id];
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(mod);
+      const EventSetup c{ci};
       mod->endRun(r, c);
       streamEndRunSummary(mod,r,c);
     }
@@ -208,13 +211,14 @@ namespace edm {
     void
     ProducingModuleAdaptorBase<T>::doStreamBeginLuminosityBlock(StreamID id,
                                                                 LuminosityBlockPrincipal const& lbp,
-                                                                EventSetup const& c,
+                                                                EventSetupImpl const& ci,
                                                                 ModuleCallingContext const* mcc) {
       auto mod = m_streamModules[id];
       setupLuminosityBlock(mod,lbp.index());
       
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(mod);
+      const EventSetup c{ci};
       mod->beginLuminosityBlock(lb, c);
     }
     
@@ -222,12 +226,13 @@ namespace edm {
     void
     ProducingModuleAdaptorBase<T>::doStreamEndLuminosityBlock(StreamID id,
                                                               LuminosityBlockPrincipal const& lbp,
-                                                              EventSetup const& c,
+                                                              EventSetupImpl const& ci,
                                                               ModuleCallingContext const* mcc)
     {
       auto mod = m_streamModules[id];
       LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
       lb.setConsumer(mod);
+      const EventSetup c{ci};
       mod->endLuminosityBlock(lb, c);
       streamEndLuminosityBlockSummary(mod,lb, c);
     }

--- a/FWCore/Framework/src/streamTransitionAsync.h
+++ b/FWCore/Framework/src/streamTransitionAsync.h
@@ -30,7 +30,7 @@
 
 namespace edm {
   class IOVSyncValue;
-  class EventSetup;
+  class EventSetupImpl;
   class LuminosityBlockPrincipal;
   class RunPrincipal;
   
@@ -58,7 +58,7 @@ namespace edm {
                                   unsigned int iStreamIndex,
                                   P& iPrincipal,
                                   IOVSyncValue const & iTS,
-                                  EventSetup const& iES,
+                                  EventSetupImpl const& iES,
                                   ServiceToken const& token,
                                   SC& iSubProcesses) {
     //When we are done processing the stream for this process,
@@ -93,7 +93,7 @@ namespace edm {
                                   unsigned int iNStreams,
                                   P& iPrincipal,
                                   IOVSyncValue const & iTS,
-                                  EventSetup const& iES,
+                                  EventSetupImpl const& iES,
                                   ServiceToken const& token,
                                   SC& iSubProcesses)
   {
@@ -109,7 +109,7 @@ namespace edm {
                                 unsigned int iStreamIndex,
                                 P& iPrincipal,
                                 IOVSyncValue const & iTS,
-                                EventSetup const& iES,
+                                EventSetupImpl const& iES,
                                 ServiceToken const& token,
                                 SC& iSubProcesses,
                                 bool cleaningUpAfterException)
@@ -144,7 +144,7 @@ namespace edm {
                                  unsigned int iNStreams,
                                  P& iPrincipal,
                                  IOVSyncValue const & iTS,
-                                 EventSetup const& iES,
+                                 EventSetupImpl const& iES,
                                  ServiceToken const& iToken,
                                  SC& iSubProcesses,
                                  bool cleaningUpAfterException)

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -518,29 +518,29 @@ void testdependentrecord::timeAndRunTest()
 						    edm::IOVSyncValue(edm::Timestamp( 5))));
      provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
      {
-       const edm::EventSetup& eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
+       const auto&  eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
        long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
        
 
-       const edm::EventSetup& eventSetup2 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
+       const auto&  eventSetup2 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
        long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
        CPPUNIT_ASSERT(id1 == id2);
 
-       const edm::EventSetup& eventSetup3 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
+       const auto&  eventSetup3 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
        long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
        CPPUNIT_ASSERT(id1 == id3);
 
        dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 6)), 
 						       edm::IOVSyncValue(edm::Timestamp( 10))));
 
-       const edm::EventSetup& eventSetup4 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
+       const auto&  eventSetup4 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
        long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
        CPPUNIT_ASSERT(id1 != id4);
 
        dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), 
 						      edm::IOVSyncValue(edm::EventID(1, 1, 10))));
 
-       const edm::EventSetup& eventSetup5 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
+       const auto&  eventSetup5 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
        long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
        CPPUNIT_ASSERT(id4 != id5);
      }
@@ -566,29 +566,29 @@ void testdependentrecord::timeAndRunTest()
                                                       edm::IOVSyncValue::invalidIOVSyncValue()));
       provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
       {
-         const edm::EventSetup& eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
+         const auto&  eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
          long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
          
          
-         const edm::EventSetup& eventSetup2 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
+         const auto&  eventSetup2 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
          long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id1 == id2);
          
-         const edm::EventSetup& eventSetup3 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
+         const auto&  eventSetup3 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
          long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id1 == id3);
          
          dummy2Finder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp( 6)), 
                                                          edm::IOVSyncValue::invalidIOVSyncValue()));
          
-         const edm::EventSetup& eventSetup4 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
+         const auto&  eventSetup4 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
          long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id1 != id4);
          
          dummyFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), 
                                                         edm::IOVSyncValue::invalidIOVSyncValue()));
          
-         const edm::EventSetup& eventSetup5 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
+         const auto&  eventSetup5 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
          long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id4 != id5);
       }
@@ -629,7 +629,7 @@ void testdependentrecord::getTest()
    std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepRecordProxyProvider>();
    provider.add(depProv);
    {
-      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
+      const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
       const DepRecord& depRecord = eventSetup.get<DepRecord>();
 
       depRecord.getRecord<DummyRecord>();
@@ -638,7 +638,7 @@ void testdependentrecord::getTest()
       CPPUNIT_ASSERT(dr.has_value());
    }
    {
-      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4)));
+      const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4)));
       CPPUNIT_ASSERT_THROW(eventSetup.get<DepRecord>(),edm::eventsetup::NoRecordException<DepRecord>);
    }
    
@@ -658,7 +658,7 @@ void testdependentrecord::oneOfTwoRecordTest()
   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepOn2RecordProxyProvider>();
   provider.add(depProv);
   {
-    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
+    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
     const DepOn2Record& depRecord = eventSetup.get<DepOn2Record>();
     
     depRecord.getRecord<DummyRecord>();
@@ -688,7 +688,7 @@ void testdependentrecord::resetTest()
   std::shared_ptr<edm::eventsetup::DataProxyProvider> depProv = std::make_shared<DepRecordProxyProvider>();
   provider.add(depProv);
   {
-    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
+    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
     const DepRecord& depRecord = eventSetup.get<DepRecord>();
     unsigned long long depCacheID = depRecord.cacheIdentifier();
     const DummyRecord& dummyRecord = depRecord.getRecord<DummyRecord>();
@@ -840,13 +840,13 @@ void testdependentrecord::extendIOVTest()
                                                    edm::IOVSyncValue{edm::EventID{1, 1, 6}}});
    provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
    {
-      const edm::EventSetup& eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
+      const auto&  eventSetup1 = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
       unsigned long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == eventSetup1.get<DummyRecord>().cacheIdentifier());
       CPPUNIT_ASSERT(id1 == eventSetup1.get<Dummy2Record>().cacheIdentifier());
       
       {
-         const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(2)));
+         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(2)));
          unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id1 == id);
          CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -856,7 +856,7 @@ void testdependentrecord::extendIOVTest()
       dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, 
                                                      edm::IOVSyncValue{edm::EventID{1, 1, 7}}});
       {
-         const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 6), edm::Timestamp(7)));
+         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 6), edm::Timestamp(7)));
          unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id1 == id);
          CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -868,7 +868,7 @@ void testdependentrecord::extendIOVTest()
          edm::IOVSyncValue{edm::EventID{1, 1, 7}}});
 
       {
-         const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(7)));
+         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(7)));
          unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id1 == id);
          CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -881,7 +881,7 @@ void testdependentrecord::extendIOVTest()
       dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, 
          edm::IOVSyncValue{edm::EventID{1, 1, 8}}});
       {
-         const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 8), edm::Timestamp(7)));
+         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 8), edm::Timestamp(7)));
          unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id1 == id);
          CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -894,7 +894,7 @@ void testdependentrecord::extendIOVTest()
       dummyFinder->setInterval(edm::ValidityInterval{edm::IOVSyncValue{edm::EventID{1, 1, 9}}, 
                                                      edm::IOVSyncValue{edm::EventID{1, 1, 9}}});
       {
-         const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 9), edm::Timestamp(7)));
+         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 9), edm::Timestamp(7)));
          unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id1+1 == id);
          CPPUNIT_ASSERT(id1+1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -908,7 +908,7 @@ void testdependentrecord::extendIOVTest()
                                                      edm::IOVSyncValue{edm::EventID{1, 1, 10}} });
       
       {
-         const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 10), edm::Timestamp(7)));
+         const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 10), edm::Timestamp(7)));
          unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
          CPPUNIT_ASSERT(id1+2 == id);
          CPPUNIT_ASSERT(id1+1 == eventSetup.get<DummyRecord>().cacheIdentifier());

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -183,7 +183,7 @@ void testEsproducer::getFromTest()
   for(int iTime=1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -204,7 +204,7 @@ void testEsproducer::getfromShareTest()
   for(int iTime=1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -225,7 +225,7 @@ void testEsproducer::getfromUniqueTest()
   for(int iTime=1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -244,7 +244,7 @@ void testEsproducer::getfromOptionalTest()
   for(int iTime=1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -266,7 +266,7 @@ void testEsproducer::labelTest()
     for(int iTime=1; iTime != 6; ++iTime) {
       const edm::Timestamp time(iTime);
       pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-      const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+      const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get("foo",pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
@@ -326,7 +326,7 @@ void testEsproducer::decoratorTest()
   for(int iTime=1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
-    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
 
     CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_pre);
@@ -374,7 +374,7 @@ void testEsproducer::dependsOnTest()
   for(int iTime=1; iTime != 6; ++iTime) {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
-    const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+    const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
     edm::ESHandle<DummyData> pDummy;
 
     eventSetup.get<DepRecord>().get(pDummy);
@@ -398,7 +398,7 @@ void testEsproducer::forceCacheClearTest()
 
   const edm::Timestamp time(1);
   pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time) , edm::IOVSyncValue(time)));
-  const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
+  const auto&  eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
   {
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);

--- a/FWCore/Framework/test/eventsetup_dataget_check_compile_time_error_t.cpp
+++ b/FWCore/Framework/test/eventsetup_dataget_check_compile_time_error_t.cpp
@@ -16,7 +16,7 @@ class DataWithNoDefaultRecord {};
 
 int main() {
    eventsetup::EventSetupProvider provider;
-   EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(0));
+   auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(0));
    //This should cause a compile time failure since DataWithNoDefaultRecord
    /// does not have a default record assigned
    ESHandle<DataWithNoDefaultRecord> pData;

--- a/FWCore/Framework/test/eventsetup_get_check_compile_time_error_t.cpp
+++ b/FWCore/Framework/test/eventsetup_get_check_compile_time_error_t.cpp
@@ -16,7 +16,7 @@ class NotAGoodRecord {};
 
 int main() {
    eventsetup::EventSetupProvider provider;
-   EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(0));
+   auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(0));
    //This should cause a compile time failure since NotAGoodRecord
    /// does not inherit from edm::eventsetup::EventSetupRecord
    eventSetup.get<NotAGoodRecord>();

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -106,14 +106,14 @@ void testEventsetup::constructTest()
   eventsetup::EventSetupProvider provider(&activityRegistry);
   const Timestamp time(1);
   const IOVSyncValue timestamp(time);
-  EventSetup const& eventSetup = provider.eventSetupForInstance(timestamp);
+  auto const& eventSetup = provider.eventSetupForInstance(timestamp);
   CPPUNIT_ASSERT(non_null(&eventSetup));
 }
 
 void testEventsetup::getTest()
 {
   eventsetup::EventSetupProvider provider(&activityRegistry);
-  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   CPPUNIT_ASSERT(non_null(&eventSetup));
 
   eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
@@ -126,7 +126,7 @@ void testEventsetup::getTest()
 void testEventsetup::tryToGetTest()
 {
   eventsetup::EventSetupProvider provider(&activityRegistry);
-  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   CPPUNIT_ASSERT(non_null(&eventSetup));
 
   eventsetup::EventSetupRecordImpl dummyRecord{ eventsetup::EventSetupRecordKey::makeKey<DummyRecord>() };
@@ -139,7 +139,7 @@ void testEventsetup::tryToGetTest()
 void testEventsetup::getExcTest()
 {
   eventsetup::EventSetupProvider provider(&activityRegistry);
-  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   CPPUNIT_ASSERT(non_null(&eventSetup));
   eventSetup.get<DummyRecord>();
 }
@@ -167,7 +167,7 @@ void testEventsetup::recordProviderTest()
   //       Since the EventSetup::get<> will only retrieve a Record if its
   //       interval of validity is 'valid' for the present 'instance'
   //       this is a 'hack' to have the 'get' succeed
-  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
   CPPUNIT_ASSERT(non_null(&gottenRecord));
 }
@@ -215,15 +215,15 @@ void testEventsetup::recordValidityTest()
   const Timestamp time_2(2);
   finder->setInterval(ValidityInterval(IOVSyncValue(time_2), IOVSyncValue(Timestamp(3))));
   {
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(time_2));
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(time_2));
     eventSetup.get<DummyRecord>();
   }
   {
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
     eventSetup.get<DummyRecord>();
   }
   {
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
     eventSetup.get<DummyRecord>();
   }
 
@@ -240,7 +240,7 @@ void testEventsetup::recordValidityExcTest()
   provider.insert(std::move(dummyRecordProvider));
 
   {
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(1)));
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(Timestamp(1)));
     eventSetup.get<DummyRecord>();
   }
 
@@ -269,7 +269,7 @@ void testEventsetup::proxyProviderTest()
   eventsetup::EventSetupProvider provider(&activityRegistry);
   provider.add(std::make_shared<DummyProxyProvider>());
 
-  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
   CPPUNIT_ASSERT(non_null(&gottenRecord));
 }
@@ -290,7 +290,7 @@ void testEventsetup::producerConflictTest()
     provider.add(dummyProv);
   }
   //checking for conflicts is now delayed until first time EventSetup is requested
-  /*EventSetup const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  /*auto const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
 
 }
 void testEventsetup::sourceConflictTest()
@@ -309,7 +309,7 @@ void testEventsetup::sourceConflictTest()
     provider.add(dummyProv);
   }
   //checking for conflicts is now delayed until first time EventSetup is requested
-  /*EventSetup const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  /*auto const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
 
 }
 //#define TEST_EXCLUDE_DEF
@@ -334,7 +334,7 @@ void testEventsetup::twoSourceTest()
     provider.add(finderPtr);
   }
   //checking for conflicts is now delayed until first time EventSetup is requested
-  /*EventSetup const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  /*auto const& eventSetup = */ provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
 
 }
 void testEventsetup::provenanceTest()
@@ -366,7 +366,7 @@ void testEventsetup::provenanceTest()
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -409,7 +409,7 @@ void testEventsetup::getDataWithLabelTest()
       dummyProv->setAppendToDataLabel(ps);
       provider.add(dummyProv);
     }
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     edm::ESHandle<DummyData> data;
     eventSetup.getData("blah",data);
     CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -452,7 +452,7 @@ void testEventsetup::getDataWithESInputTagTest()
       dummyProv->setAppendToDataLabel(ps);
       provider.add(dummyProv);
     }
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     {
       edm::ESHandle<DummyData> data;
       edm::ESInputTag blahTag("","blah");
@@ -521,7 +521,7 @@ void testEventsetup::sourceProducerResolutionTest()
     //       Since the EventSetup::get<> will only retrieve a Record if its
     //       interval of validity is 'valid' for the present 'instance'
     //       this is a 'hack' to have the 'get' succeed
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -547,7 +547,7 @@ void testEventsetup::sourceProducerResolutionTest()
     //       Since the EventSetup::get<> will only retrieve a Record if its
     //       interval of validity is 'valid' for the present 'instance'
     //       this is a 'hack' to have the 'get' succeed
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -589,7 +589,7 @@ void testEventsetup::preferTest()
       //       Since the EventSetup::get<> will only retrieve a Record if its
       //       interval of validity is 'valid' for the present 'instance'
       //       this is a 'hack' to have the 'get' succeed
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+      auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -620,7 +620,7 @@ void testEventsetup::preferTest()
       //       Since the EventSetup::get<> will only retrieve a Record if its
       //       interval of validity is 'valid' for the present 'instance'
       //       this is a 'hack' to have the 'get' succeed
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+      auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -652,7 +652,7 @@ void testEventsetup::preferTest()
       //       Since the EventSetup::get<> will only retrieve a Record if its
       //       interval of validity is 'valid' for the present 'instance'
       //       this is a 'hack' to have the 'get' succeed
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+      auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_==data->value_);
@@ -693,7 +693,7 @@ void testEventsetup::introspectionTest()
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
 
     std::vector<edm::eventsetup::EventSetupRecordKey> recordKeys;
     eventSetup.fillAvailableRecordKeys(recordKeys);
@@ -720,25 +720,25 @@ void testEventsetup::iovExtentionTest()
   const Timestamp time_2(2);
   finder->setInterval(ValidityInterval(IOVSyncValue{time_2}, IOVSyncValue{Timestamp{3}}));
   {
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{time_2});
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{time_2});
     CPPUNIT_ASSERT(2==eventSetup.get<DummyRecord>().cacheIdentifier());
   }
   {
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{Timestamp{3}});
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{Timestamp{3}});
     eventSetup.get<DummyRecord>();
     CPPUNIT_ASSERT(2==eventSetup.get<DummyRecord>().cacheIdentifier());
   }
   //extending the IOV should not cause the cache to be reset
   finder->setInterval(ValidityInterval(IOVSyncValue{time_2}, IOVSyncValue{Timestamp{4}}));
   {
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{Timestamp{4}});
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{Timestamp{4}});
     CPPUNIT_ASSERT(2==eventSetup.get<DummyRecord>().cacheIdentifier());
   }
 
   //this is a new IOV so should get cache reset
   finder->setInterval(ValidityInterval(IOVSyncValue{Timestamp{5}}, IOVSyncValue{Timestamp{6}}));
   {
-    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{Timestamp{5}});
+    auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue{Timestamp{5}});
     CPPUNIT_ASSERT(3==eventSetup.get<DummyRecord>().cacheIdentifier());
   }
 

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -59,7 +59,7 @@ void testfullChain::getfromDataproxyproviderTest()
    pFinder->setInterval(ValidityInterval(sync_1, IOVSyncValue(Timestamp(5))));
    for(unsigned int iTime=1; iTime != 6; ++iTime) {
       const Timestamp time(iTime);
-      EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(time));
+      auto const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(time));
       ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -100,7 +100,7 @@ private:
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
   std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
-  edm::EventSetup* m_es = nullptr;
+  edm::EventSetupImpl* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   
   template<typename T>

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -82,7 +82,7 @@ private:
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
   std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
-  edm::EventSetup* m_es = nullptr;
+  edm::EventSetupImpl* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::WorkerParams m_params;
   

--- a/FWCore/Framework/test/limited_module_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_module_t.cppunit.cc
@@ -110,7 +110,7 @@ private:
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
   std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
-  edm::EventSetup* m_es = nullptr;
+  edm::EventSetupImpl* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   
   template<typename T>

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -82,7 +82,7 @@ private:
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
   std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
-  edm::EventSetup* m_es = nullptr;
+  edm::EventSetupImpl* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::WorkerParams m_params;
   

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -89,7 +89,7 @@ private:
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
   std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
-  edm::EventSetup* m_es = nullptr;
+  edm::EventSetupImpl* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   edm::WorkerParams m_params;
   

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -98,7 +98,7 @@ private:
   std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
   std::shared_ptr<edm::RunPrincipal> m_rp;
   std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
-  edm::EventSetup* m_es = nullptr;
+  edm::EventSetupImpl* m_es = nullptr;
   edm::ModuleDescription m_desc = {"Dummy","dummy"};
   
   template<typename T, typename U>

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -298,7 +298,7 @@ TestProcessor::beginRun() {
                   runPrincipal.beginTime());
   espController_->eventSetupForInstance(ts);
   
-  EventSetup const& es = esp_->eventSetup();
+  auto const& es = esp_->eventSetup();
 
   std::vector<edm::SubProcess> emptyList;
   {
@@ -354,7 +354,7 @@ TestProcessor::beginLuminosityBlock() {
                   lumiPrincipal_->beginTime());
   espController_->eventSetupForInstance(ts);
   
-  EventSetup const& es = esp_->eventSetup();
+  auto const& es = esp_->eventSetup();
   
   std::vector<edm::SubProcess> emptyList;
   {
@@ -448,7 +448,7 @@ TestProcessor::endLuminosityBlock() {
                     lumiPrincipal->endTime());
     espController_->eventSetupForInstance(ts);
     
-    EventSetup const& es = esp_->eventSetup();
+    auto const& es = esp_->eventSetup();
 
     std::vector<edm::SubProcess> emptyList;
 
@@ -507,7 +507,7 @@ TestProcessor::endRun() {
                     runPrincipal.endTime());
     espController_->eventSetupForInstance(ts);
     
-    EventSetup const& es = esp_->eventSetup();
+    auto const& es = esp_->eventSetup();
     
     std::vector<edm::SubProcess> emptyList;
     

--- a/FWCore/Utilities/interface/ESGetToken.h
+++ b/FWCore/Utilities/interface/ESGetToken.h
@@ -21,6 +21,7 @@ namespace edm {
   class ESProducer;
   class ESConsumesCollector;
   class EventSetup;
+  class EventSetupImpl;
   namespace eventsetup {
     class EventSetupRecord;
   }
@@ -33,6 +34,7 @@ namespace edm {
     friend class ESProducer;
     friend class ESConsumesCollector;
     friend class EventSetup;
+    friend class EventSetupImpl;
     friend class eventsetup::EventSetupRecord;
 
   public:

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -197,7 +197,7 @@ namespace edm {
     if (provider_.get() != nullptr) {
       auto aux = std::make_shared<RunAuxiliary>(run.runAuxiliary());
       runPrincipal_.reset(new RunPrincipal(aux, productRegistry_, *processConfiguration_, nullptr, 0));
-      provider_->beginRun(*runPrincipal_, setup, run.moduleCallingContext(), *streamContext_);
+      provider_->beginRun(*runPrincipal_, setup.impl(), run.moduleCallingContext(), *streamContext_);
     }
   }
   void PileUp::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup) {
@@ -205,18 +205,18 @@ namespace edm {
       lumiPrincipal_.reset(new LuminosityBlockPrincipal(productRegistry_, *processConfiguration_, nullptr, 0));
       lumiPrincipal_->setAux(lumi.luminosityBlockAuxiliary());
       lumiPrincipal_->setRunPrincipal(runPrincipal_);
-      provider_->beginLuminosityBlock(*lumiPrincipal_, setup, lumi.moduleCallingContext(), *streamContext_);
+      provider_->beginLuminosityBlock(*lumiPrincipal_, setup.impl(), lumi.moduleCallingContext(), *streamContext_);
     }
   }
 
   void PileUp::endRun(const edm::Run& run, const edm::EventSetup& setup) {
     if (provider_.get() != nullptr) {
-      provider_->endRun(*runPrincipal_, setup, run.moduleCallingContext(), *streamContext_);
+      provider_->endRun(*runPrincipal_, setup.impl(), run.moduleCallingContext(), *streamContext_);
     }
   }
   void PileUp::endLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup) {
     if (provider_.get() != nullptr) {
-      provider_->endLuminosityBlock(*lumiPrincipal_, setup, lumi.moduleCallingContext(), *streamContext_);
+      provider_->endLuminosityBlock(*lumiPrincipal_, setup.impl(), lumi.moduleCallingContext(), *streamContext_);
     }
   }
 
@@ -225,7 +225,7 @@ namespace edm {
       // note:  run and lumi numbers must be modified to match lumiPrincipal_
       eventPrincipal_->setLuminosityBlockPrincipal(lumiPrincipal_.get());
       eventPrincipal_->setRunAndLumiNumber(lumiPrincipal_->run(), lumiPrincipal_->luminosityBlock());
-      provider_->setupPileUpEvent(*eventPrincipal_, setup, *streamContext_);
+      provider_->setupPileUpEvent(*eventPrincipal_, setup.impl(), *streamContext_);
     }
   }
 

--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -30,35 +30,35 @@ namespace edm {
 
   //NOTE: When the Stream interfaces are propagated to the modules, this code must be updated
   // to also send the stream based transitions
-  void SecondaryEventProvider::beginRun(RunPrincipal& run, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
+  void SecondaryEventProvider::beginRun(RunPrincipal& run, const EventSetupImpl& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> >(run, setup, StreamID::invalidStreamID(),
                                                                                                   nullptr, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> >(run, setup, sContext.streamID(),
                                                                                                   &sContext, mcc);
   }
 
-  void SecondaryEventProvider::beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
+  void SecondaryEventProvider::beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetupImpl& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> >(lumi, setup, StreamID::invalidStreamID(),
                                                                                                               nullptr, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> >(lumi, setup, sContext.streamID(),
                                                                                                               &sContext, mcc);
   }
 
-  void SecondaryEventProvider::endRun(RunPrincipal& run, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
+  void SecondaryEventProvider::endRun(RunPrincipal& run, const EventSetupImpl& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> >(run, setup, sContext.streamID(),
                                                                                                 &sContext, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> >(run, setup, StreamID::invalidStreamID(),
                                                                                                 nullptr, mcc);
   }
 
-  void SecondaryEventProvider::endLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
+  void SecondaryEventProvider::endLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetupImpl& setup, ModuleCallingContext const* mcc, StreamContext& sContext) {
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> >(lumi, setup, sContext.streamID(),
                                                                                                             &sContext, mcc);
     workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> >(lumi, setup, StreamID::invalidStreamID(),
                                                                                                             nullptr, mcc);
   }
 
-  void SecondaryEventProvider::setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup, StreamContext& sContext) {
+  void SecondaryEventProvider::setupPileUpEvent(EventPrincipal& ep, const EventSetupImpl& setup, StreamContext& sContext) {
     workerManager_.setupOnDemandSystem(ep, setup);
   }
   void SecondaryEventProvider::beginStream(edm::StreamID iID, StreamContext& sContext) {

--- a/Mixing/Base/src/SecondaryEventProvider.h
+++ b/Mixing/Base/src/SecondaryEventProvider.h
@@ -17,13 +17,13 @@ namespace edm {
              ProductRegistry& pregistry,
              std::shared_ptr<ProcessConfiguration> processConfiguration);
 
-    void beginRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*, StreamContext& sContext);
-    void beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup, ModuleCallingContext const*, StreamContext& sContext);
+    void beginRun(RunPrincipal& run, const edm::EventSetupImpl& setup, ModuleCallingContext const*, StreamContext& sContext);
+    void beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetupImpl& setup, ModuleCallingContext const*, StreamContext& sContext);
 
-    void endRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*, StreamContext& sContext);
-    void endLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup, ModuleCallingContext const*, StreamContext& sContext);
+    void endRun(RunPrincipal& run, const edm::EventSetupImpl& setup, ModuleCallingContext const*, StreamContext& sContext);
+    void endLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetupImpl& setup, ModuleCallingContext const*, StreamContext& sContext);
 
-    void setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup, StreamContext& sContext);
+    void setupPileUpEvent(EventPrincipal& ep, const EventSetupImpl& setup, StreamContext& sContext);
 
     void beginJob(ProductRegistry const& iRegistry) {workerManager_.beginJob(iRegistry);}
     void endJob() {workerManager_.endJob();}

--- a/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
@@ -41,8 +41,6 @@ class PhotonProducer : public edm::stream::EDProducer<> {
   PhotonProducer (const edm::ParameterSet& ps);
   ~PhotonProducer() override;
 
-  void beginRun (edm::Run const& r, edm::EventSetup const & es) final;
-  void endRun(edm::Run const&,  edm::EventSetup const&) final;
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
  private:

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -38,6 +38,7 @@
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EGHcalRecHitSelector.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -35,7 +35,6 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h" 
 #include "CondFormats/EcalObjects/interface/EcalFunctionParameters.h" 
-#include "RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EGHcalRecHitSelector.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -155,19 +155,6 @@ PhotonProducer::~PhotonProducer()
   //delete energyCorrectionF;
 }
 
-
-
-void  PhotonProducer::beginRun (edm::Run const& r, edm::EventSetup const & theEventSetup) {
-
-
-
-    thePhotonEnergyCorrector_ -> init(theEventSetup);
-}
-
-void  PhotonProducer::endRun (edm::Run const& r, edm::EventSetup const & theEventSetup) {
-}
-
-
 void PhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
 
   using namespace edm;
@@ -292,6 +279,7 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
   std::vector<double> preselCutValues;
   float minR9=0;
 
+  thePhotonEnergyCorrector_ -> init(es);
 
   std::vector<int> flags_, severitiesexcl_;
 

--- a/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
@@ -46,7 +46,6 @@
 #include "DataFormats/METReco/interface/CaloMETCollection.h"
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-#include "CalibCalorimetry/EcalTPGTools/interface/EcalTPGScale.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
@@ -140,8 +139,6 @@ private:
   edm::ESHandle<CaloGeometry>       geometry;
 
   edm::ESHandle<EcalTrigTowerConstituentsMap> ttMap_;
-
-  EcalTPGScale ecalScale_;
 
   const int maskedEcalChannelStatusThreshold_;
   const int chnStatusToBeEvaluated_;
@@ -271,7 +268,6 @@ void EcalDeadCellDeltaRFilter::envSet(const edm::EventSetup& iSetup) {
 
   if (debug_) std::cout << "***envSet***" << std::endl;
 
-  ecalScale_.setEventSetup( iSetup );
   iSetup.get<IdealGeometryRecord>().get(ttMap_);
 
   iSetup.get<EcalChannelStatusRcd> ().get(ecalStatus);

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedGenerator.cc
@@ -241,6 +241,7 @@ RPCSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     // Start from filling layers to filling seeds
     LayerFinder.fill();
+    Overlapper.setEventSetup(iSetup);
     Overlapper.run();
 
     // Save seeds to event

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalShapeBase.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalShapeBase.h
@@ -48,7 +48,7 @@ class EcalShapeBase : public CaloVShape
 
       unsigned int timeIndex( double aTime ) const ;
 
-      void buildMe() ;
+      void buildMe(const edm::EventSetup* = nullptr ) ;
 
       virtual void   fillShape(float &time_interval, double &m_thresh, EcalShapeBase::DVec& aVec, const edm::EventSetup* es) const = 0 ;
       bool         m_useDBShape;
@@ -67,7 +67,6 @@ class EcalShapeBase : public CaloVShape
       unsigned int m_arraySize;
       unsigned int m_denseArraySize;   
       double m_qNSecPerBin;
-      const edm::EventSetup *m_es;
 };
   
 

--- a/SimCalorimetry/EcalSimAlgos/src/EcalShapeBase.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalShapeBase.cc
@@ -16,12 +16,11 @@ EcalShapeBase::EcalShapeBase(bool useDBShape) :
    m_firstTimeOverThreshold  ( 0.0 ) ,
    m_indexOfMax              ( 0   ) ,
    m_timeOfMax               ( 0.0 ) , 
-   m_thresh                  ( 0.0 ) , 
-   m_es                      ( nullptr )
+   m_thresh                  ( 0.0 )
 {
 }
 
-void EcalShapeBase::setEventSetup( const edm::EventSetup & evtSetup ){ m_es = &evtSetup;  buildMe();} 
+void EcalShapeBase::setEventSetup( const edm::EventSetup & evtSetup ){ buildMe( &evtSetup );} 
 
 
 double 
@@ -51,12 +50,12 @@ EcalShapeBase::threshold()  const
 
 
 void
-EcalShapeBase::buildMe()
+EcalShapeBase::buildMe(const edm::EventSetup* evtSetup )
 {
    DVec shapeArray;
 
    float time_interval = 0;
-   fillShape(time_interval, m_thresh, shapeArray, m_es) ; // pure virtual function, implementation may vary for EB/EE/APD ...
+   fillShape(time_interval, m_thresh, shapeArray, evtSetup) ; // pure virtual function, implementation may vary for EB/EE/APD ...
    m_arraySize = shapeArray.size();  // original data
   
    m_denseArraySize    = 10*m_arraySize; // dense array with interpolation between data 


### PR DESCRIPTION
edm::EventSetup is now just a wrapper around the new edm::EventSetupImpl. The latter has all the functionality of the previous edm::EventSetup. This now matches the pattern used elsewhere, such as edm::Event and edm::EventPrincipal.

This will allow additional upcoming changes.