### PR TITLE
Run2-alca149 Make year dependent thresholds for IsoTrackFilter

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
@@ -95,6 +95,7 @@ private:
   const double                   eIsolate_;
   const double                   hitEthrEB_, hitEthrEE0_, hitEthrEE1_;
   const double                   hitEthrEE2_, hitEthrEE3_;
+  const double                   hitEthrEELo_, hitEthrEEHi_;
   const double                   pTrackLow_, pTrackHigh_, pTrackH_;
   const int                      preScale_, preScaleH_;
   const std::string              theTrackQuality_;
@@ -144,6 +145,8 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
   hitEthrEE1_(iConfig.getParameter<double>("EEHitEnergyThreshold1") ),
   hitEthrEE2_(iConfig.getParameter<double>("EEHitEnergyThreshold2") ),
   hitEthrEE3_(iConfig.getParameter<double>("EEHitEnergyThreshold3") ),
+  hitEthrEELo_(iConfig.getParameter<double>("EEHitEnergyThresholdLow") ),
+  hitEthrEEHi_(iConfig.getParameter<double>("EEHitEnergyThresholdHigh") ),
   pTrackLow_(iConfig.getParameter<double>("momentumRangeLow")),
   pTrackHigh_(iConfig.getParameter<double>("momentumRangeHigh")),
   pTrackH_(iConfig.getParameter<double>("momentumHigh")),
@@ -364,8 +367,13 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
 	  for (unsigned int k=0; k<eIds.size(); ++k) {
 	    const GlobalPoint& pos = geo->getPosition(eIds[k]);
 	    double eta  = std::abs(pos.eta());
-	    double eThr = (eIds[k].subdetId() == EcalBarrel) ? hitEthrEB_ :
-	      (((eta*hitEthrEE3_+hitEthrEE2_)*eta+hitEthrEE1_)*eta+hitEthrEE0_);
+	    double eThr(hitEthrEB_);
+	    if (eIds[k].subdetId() != EcalBarrel) {
+	      eThr = (((eta*hitEthrEE3_+hitEthrEE2_)*eta+hitEthrEE1_)*eta+
+		      hitEthrEE0_);
+	      if      (eThr < hitEthrEELo_) eThr = hitEthrEELo_;
+	      else if (eThr > hitEthrEEHi_) eThr = hitEthrEEHi_;
+	    }
 	    if (eHit[k] > eThr) eMipDR += eHit[k];
 	  }
 	  double hmaxNearP = spr::chargeIsolationCone(nTracks,
@@ -473,11 +481,13 @@ void AlCaIsoTracksFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<double>("slopeTrackP",0.05090504066);
   desc.add<double>("isolationEnergy",10.0);
   // energy thershold for ECAL (from Egamma group)
-  desc.add<double>("EBHitEnergyThreshold",0.10);
-  desc.add<double>("EEHitEnergyThreshold0",-41.0664);
-  desc.add<double>("EEHitEnergyThreshold1",68.7950);
-  desc.add<double>("EEHitEnergyThreshold2",-38.1483);
-  desc.add<double>("EEHitEnergyThreshold3",7.04303);
+  desc.add<double>("EBHitEnergyThreshold",0.08);
+  desc.add<double>("EEHitEnergyThreshold0",0.30);
+  desc.add<double>("EEHitEnergyThreshold1",0.00);
+  desc.add<double>("EEHitEnergyThreshold2",0.00);
+  desc.add<double>("EEHitEnergyThreshold3",0.00);
+  desc.add<double>("EEHitEnergyThresholdLow",0.30);
+  desc.add<double>("EEHitEnergyThresholdHigh",0.30);
   // Prescale events only containing isolated tracks in the range
   desc.add<double>("momentumRangeLow",20.0);
   desc.add<double>("momentumRangeHigh",40.0);

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
@@ -206,7 +206,12 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
 			       <<"\t Precale factor "  << preScale_
 			       <<"\t in momentum range " << pTrackLow_
 			       <<":" << pTrackHigh_ << " and prescale factor "
-			       << preScaleH_ << " for p > " << pTrackH_;
+			       << preScaleH_ << " for p > " << pTrackH_
+			       <<" Threshold for EB " <<  hitEthrEB_ << " EE "
+			       << hitEthrEE0_ << ":" << hitEthrEE1_ << ":"
+			       << hitEthrEE2_ << ":" << hitEthrEE3_ << ":"
+			       << hitEthrEELo_ << ":" << hitEthrEEHi_;
+
   for (unsigned int k=0; k<trigNames_.size(); ++k)
     edm::LogInfo("HcalIsoTrack") << "Trigger[" << k << "] " << trigNames_[k];
 } // AlCaIsoTracksFilter::AlCaIsoTracksFilter  constructor

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
@@ -284,7 +284,6 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
       edm::LogWarning("HcalIsoTrack") << "Cannot access the collection " << labelGenTrack_;
       foundCollections = false;
     }
-    reco::TrackCollection::const_iterator trkItr;
 
     //Define the best vertex and the beamspot
     edm::Handle<reco::VertexCollection> recVtxs;

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilter_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilter_cff.py
@@ -10,7 +10,7 @@ ALCARECOHcalCalIsoTrkFilterHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLe
 
 )
 
-from Calibration.HcalAlCaRecoProducers.alcaIsoTracksFilter_cfi import *
+from Calibration.HcalAlCaRecoProducers.alcaIsoTracksFilter_cff import *
 
 import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
 TkAlIsoProdFilter = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone()

--- a/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cff.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+from Calibration.HcalAlCaRecoProducers.alcaIsoTracksFilter_cfi import *
+
+from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+
+run2_HCAL_2018.toModify(alcaIsoTracksFilter,
+  EBHitEnergyThreshold    = cms.double(0.10),
+  EEHitEnergyThreshold0   = cms.double(-41.0664),
+  EEHitEnergyThreshold1   = cms.double(68.795),
+  EEHitEnergyThreshold2   = cms.double(-38.1483),
+  EEHitEnergyThreshold3   = cms.double(7.04303),
+  EEHitEnergyThresholdLow = cms.double(0.11),
+  EEHitEnergyThresholdHigh= cms.double(15.4),
+)
+
+run2_HCAL_2017.toModify(alcaIsoTracksFilter,
+  EBHitEnergyThreshold    = cms.double(0.18),
+  EEHitEnergyThreshold0   = cms.double(-206.074),
+  EEHitEnergyThreshold1   = cms.double(357.671),
+  EEHitEnergyThreshold2   = cms.double(-204.978),
+  EEHitEnergyThreshold3   = cms.double(39.033),
+  EEHitEnergyThresholdLow = cms.double(1.25),
+  EEHitEnergyThresholdHigh= cms.double(10.0),
+)

--- a/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cff.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from Calibration.HcalAlCaRecoProducers.alcaIsoTracksFilter_cfi import *
 
-from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
+from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 
-run2_ECAL_2017.toModify(alcaIsoTracksFilter,
+run2_HCAL_2017.toModify(alcaIsoTracksFilter,
   EBHitEnergyThreshold    = cms.double(0.18),
   EEHitEnergyThreshold0   = cms.double(-206.074),
   EEHitEnergyThreshold1   = cms.double(357.671),

--- a/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cff.py
@@ -2,7 +2,18 @@ import FWCore.ParameterSet.Config as cms
 
 from Calibration.HcalAlCaRecoProducers.alcaIsoTracksFilter_cfi import *
 
-from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
+
+run2_ECAL_2017.toModify(alcaIsoTracksFilter,
+  EBHitEnergyThreshold    = cms.double(0.18),
+  EEHitEnergyThreshold0   = cms.double(-206.074),
+  EEHitEnergyThreshold1   = cms.double(357.671),
+  EEHitEnergyThreshold2   = cms.double(-204.978),
+  EEHitEnergyThreshold3   = cms.double(39.033),
+  EEHitEnergyThresholdLow = cms.double(1.25),
+  EEHitEnergyThresholdHigh= cms.double(10.0),
+)
+
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 
 run2_HCAL_2018.toModify(alcaIsoTracksFilter,
@@ -13,14 +24,4 @@ run2_HCAL_2018.toModify(alcaIsoTracksFilter,
   EEHitEnergyThreshold3   = cms.double(7.04303),
   EEHitEnergyThresholdLow = cms.double(0.11),
   EEHitEnergyThresholdHigh= cms.double(15.4),
-)
-
-run2_HCAL_2017.toModify(alcaIsoTracksFilter,
-  EBHitEnergyThreshold    = cms.double(0.18),
-  EEHitEnergyThreshold0   = cms.double(-206.074),
-  EEHitEnergyThreshold1   = cms.double(357.671),
-  EEHitEnergyThreshold2   = cms.double(-204.978),
-  EEHitEnergyThreshold3   = cms.double(39.033),
-  EEHitEnergyThresholdLow = cms.double(1.25),
-  EEHitEnergyThresholdHigh= cms.double(10.0),
 )

--- a/Calibration/HcalAlCaRecoProducers/test/AlCaIsoTrackFilterProducer_cfg.py
+++ b/Calibration/HcalAlCaRecoProducers/test/AlCaIsoTrackFilterProducer_cfg.py
@@ -13,6 +13,9 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag=autoCond['run2_mc']
 
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('HcalIsoTrack')
+
 process.options = cms.untracked.PSet(
     wantSummary = cms.untracked.bool(True)
 )

--- a/Calibration/HcalAlCaRecoProducers/test/AlCaIsoTrackFilterProducer_cfg.py
+++ b/Calibration/HcalAlCaRecoProducers/test/AlCaIsoTrackFilterProducer_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("ALCAISOTRACK")
+process = cms.Process("ALCAISOTRACK",eras.Run2_2017)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')


### PR DESCRIPTION
ECAL Thresholds for the 3 years 2016,17,18 are different. These are for legacy ReReco