### PR TITLE
Fix Include Path Typo

### DIFF
--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -1,6 +1,6 @@
 #include "SimG4CMS/Muon/interface/MuonSensitiveDetector.h"
 #include "SimG4CMS/Muon/interface/MuonSlaveSD.h"
-#include "SimG4CMS/Muon//interface/MuonEndcapFrameRotation.h"
+#include "SimG4CMS/Muon/interface/MuonEndcapFrameRotation.h"
 #include "SimG4CMS/Muon/interface/MuonRPCFrameRotation.h"
 #include "SimG4CMS/Muon/interface/MuonGEMFrameRotation.h"
 #include "SimG4CMS/Muon/interface/MuonME0FrameRotation.h"


### PR DESCRIPTION
* The ```//``` is not needed in the include path and it gives problems for LXR indexing the file

@smuzaffar - FYI