### PR TITLE
Fix SwitchProducer sanity checks to allow more than one SwitchProducer in a job.

### DIFF
--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -291,13 +291,20 @@ namespace edm {
 
     void processSwitchProducers(ParameterSet const& proc_pset, std::string const& processName, ProductRegistry& preg) {
       // Update Switch BranchDescriptions for the chosen case
-      std::vector<BranchKey> chosenBranches;
-      std::map<std::string, std::vector<std::string> > allCasesMap;
+      struct BranchesCases {
+        BranchesCases(std::vector<std::string> cases): caseLabels{std::move(cases)} {}
+        std::vector<BranchKey> chosenBranches;
+        std::vector<std::string> caseLabels;
+      };
+      std::map<std::string, BranchesCases> switchMap;
       for(auto& prod: preg.productListUpdator()) {
         if(prod.second.isSwitchAlias()) {
-          if(allCasesMap.find(prod.second.moduleLabel()) == allCasesMap.end()) {
+          auto it = switchMap.find(prod.second.moduleLabel());
+          if(it == switchMap.end())  {
             auto const& switchPSet = proc_pset.getParameter<edm::ParameterSet>(prod.second.moduleLabel());
-            allCasesMap[prod.second.moduleLabel()] = switchPSet.getParameter<std::vector<std::string>>("@all_cases");
+            auto inserted = switchMap.emplace(prod.second.moduleLabel(), switchPSet.getParameter<std::vector<std::string>>("@all_cases"));
+            assert(inserted.second);
+            it = inserted.first;
           }
 
           for(auto const& item: preg.productList()) {
@@ -312,21 +319,25 @@ namespace edm {
                   << ". Module label is " << item.first.moduleLabel() << ".\nPlease contact a framework developer.";
               }
               prod.second.setSwitchAliasForBranch(item.second);
-              chosenBranches.push_back(prod.first); // with moduleLabel of the Switch
+              it->second.chosenBranches.push_back(prod.first); // with moduleLabel of the Switch
             }
           }
         }
       }
-      if(allCasesMap.empty())
+      if(switchMap.empty())
         return;
 
-      std::sort(chosenBranches.begin(), chosenBranches.end());
+      for(auto& elem: switchMap) {
+        std::sort(elem.second.chosenBranches.begin(), elem.second.chosenBranches.end());
+      }
 
       // Check that non-chosen cases declare exactly the same branches
-      auto foundBranches = std::vector<bool>(chosenBranches.size(), false);
-      for(auto const& switchItem: allCasesMap) {
+      std::vector<bool> foundBranches;
+      for(auto const& switchItem: switchMap) {
         auto const& switchLabel = switchItem.first;
-        auto const& caseLabels = switchItem.second;
+        auto const& chosenBranches = switchItem.second.chosenBranches;
+        auto const& caseLabels = switchItem.second.caseLabels;
+        foundBranches.resize(chosenBranches.size());
         for(auto const& caseLabel: caseLabels) {
           std::fill(foundBranches.begin(), foundBranches.end(), false);
           for(auto const& item: preg.productList()) {

--- a/FWCore/Integration/test/testSwitchProducerTask_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerTask_cfg.py
@@ -29,7 +29,8 @@ process.maxEvents = cms.untracked.PSet(
 process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testSwitchProducerTask%d.root' % (1 if enableTest2 else 2,)),
     outputCommands = cms.untracked.vstring(
-        'keep *_intProducer_*_*'
+        'keep *_intProducer_*_*',
+        'keep *_intProducerOther_*_*'
     )
 )
 
@@ -45,7 +46,13 @@ process.intProducer = SwitchProducerTest(
     test2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer2"))
 )
 
-process.t = cms.Task(process.intProducer, process.intProducer1, process.intProducer2)
+# Test also existence of another SwitchProducer here
+process.intProducerOther = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1")),
+    test2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer2"))
+)
+
+process.t = cms.Task(process.intProducer, process.intProducerOther, process.intProducer1, process.intProducer2)
 process.p = cms.Path(process.t)
 
 process.e = cms.EndPath(process.out)


### PR DESCRIPTION
The check for non-chosen cases to declare exactly the same products was flawed in a way preventing the job to have more than one SwitchProducers. In more detail, the check complained that the cases of SwitchProducer `foo` did not declare products of SwitchProducer `bar`. This PR fixes the check by limiting the check to limit the products-to-be-checked to a single `SwitchProducer`.

Tested in 10_5_0_pre1.