### PR TITLE
Removed unused lambda capture in CSCGeometryESModule

### DIFF
--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
@@ -124,7 +124,7 @@ void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record, st
   if ( useDDD_ ) {
 
     host->ifRecordChanges<MuonNumberingRecord>(record,
-                                               [this, &host, &record](auto const& rec) {
+                                               [&host, &record](auto const& rec) {
       host->clear();
       edm::ESTransientHandle<DDCompactView> cpv;
       edm::ESHandle<MuonDDDConstants> mdc;


### PR DESCRIPTION
This fixes a clang warning.