### PR TITLE
Manage PluginFactory plugins with smart pointers in Fireworks

### DIFF
--- a/Fireworks/Core/interface/FWDetailViewManager.h
+++ b/Fireworks/Core/interface/FWDetailViewManager.h
@@ -18,6 +18,7 @@
 //         Created:  Wed Mar  5 09:13:43 EST 2008
 //
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -48,11 +49,15 @@ public:
    struct ViewFrame 
    {
       TEveCompositeFrameInMainFrame *m_eveFrame;
-      FWDetailViewBase              *m_detailView;
+      std::unique_ptr<FWDetailViewBase> m_detailView;
       TEveWindow                    *m_eveWindow;
 
-      ViewFrame(TEveCompositeFrameInMainFrame *f, FWDetailViewBase* v, TEveWindow* w):
-         m_eveFrame(f), m_detailView(v), m_eveWindow(w) {}
+      ViewFrame(TEveCompositeFrameInMainFrame *f, std::unique_ptr<FWDetailViewBase> v, TEveWindow* w);
+      ~ViewFrame();
+      ViewFrame(const ViewFrame&) = delete;
+      ViewFrame& operator=(const ViewFrame&) = delete;
+      ViewFrame(ViewFrame&&) = default;
+      ViewFrame& operator=(ViewFrame&&) = default;
    };
 
 protected:

--- a/Fireworks/Core/src/FWEveViewManager.cc
+++ b/Fireworks/Core/src/FWEveViewManager.cc
@@ -225,10 +225,10 @@ FWEveViewManager::newItem(const FWEventItem* iItem)
       std::string builderName = info.m_name;
       int builderViewBit =  info.m_viewBit;
       
-      FWProxyBuilderBase* builder = nullptr;
+      std::shared_ptr<FWProxyBuilderBase> builder;
       try
       {
-         builder = FWProxyBuilderFactory::get()->create(builderName);
+         builder = std::shared_ptr<FWProxyBuilderBase>{FWProxyBuilderFactory::get()->create(builderName)};
 
       }
       catch (std::exception& exc)
@@ -242,7 +242,6 @@ FWEveViewManager::newItem(const FWEventItem* iItem)
       // 2.
       // printf("FWEveViewManager::makeProxyBuilderFor NEW builder %s \n", builderName.c_str());
       
-      std::shared_ptr<FWProxyBuilderBase> pB(builder);
       builder->setItem(iItem);
       iItem->changed_.connect(boost::bind(&FWEveViewManager::modelChanges,this,_1));
       iItem->goingToBeDestroyed_.connect(boost::bind(&FWEveViewManager::removeItem,this,_1));
@@ -293,7 +292,7 @@ FWEveViewManager::newItem(const FWEventItem* iItem)
          }
       }
       
-      m_builders[builderViewBit].push_back(pB);
+      m_builders[builderViewBit].emplace_back(std::move(builder));
    } // loop views
 }
 


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-01-23-1100, no changes expected.