### PR TITLE
Some modernization for SiPixelClusterProducer

### DIFF
--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -33,6 +34,8 @@ class SiPixelGainCalibrationServiceBase {
 
   SiPixelGainCalibrationServiceBase(){};
   virtual ~SiPixelGainCalibrationServiceBase(){};
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
   
   // default inplementation from PixelThresholdClusterizer 
   virtual void calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron);

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -47,11 +47,18 @@ def customiseFor2017DtUnpacking(process):
 
     return process
 
+def customiseFor25811(process):
+    for prod in producers_by_type(process, "SiPixelClusterProducer"):
+        if hasattr(prod, "MissCalibrate") and not prod.MissCalibrate.isTracked():
+            prod.MissCalibrate = cms.bool(prod.MissCalibrate.value())
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    process = customiseFor25811(process)
 
     return process

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -69,10 +69,7 @@ PixelThresholdClusterizer::~PixelThresholdClusterizer() {}
 
 // Configuration descriptions
 void
-PixelThresholdClusterizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // siPixelClusters
-  edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src", edm::InputTag("siPixelDigis"));
+PixelThresholdClusterizer::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<int>("ChannelThreshold", 1000);
   desc.addUntracked<bool>("MissCalibrate", true);
   desc.add<bool>("SplitClusters", false);
@@ -80,17 +77,14 @@ PixelThresholdClusterizer::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<int>("VCaltoElectronGain_L1", 65);
   desc.add<int>("VCaltoElectronOffset", -414);
   desc.add<int>("VCaltoElectronOffset_L1", -414);
-  desc.add<std::string>("payloadType", "Offline");
   desc.add<int>("SeedThreshold", 1000);
   desc.add<int>("ClusterThreshold_L1", 4000);
   desc.add<int>("ClusterThreshold", 4000);
-  desc.add<int>("maxNumberOfClusters", -1);
   desc.add<double>("ElectronPerADCGain", 135.);
   desc.add<bool>("Phase2Calibration", false);
   desc.add<int>("Phase2ReadoutMode", -1);
   desc.add<double>("Phase2DigiBaseline", 1200.);
   desc.add<int>("Phase2KinkADC", 8);
-  descriptions.add("siClustersFromPixelThresholdClusterizer", desc);
 }
 
 //----------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -58,7 +58,7 @@ PixelThresholdClusterizer::PixelThresholdClusterizer
     thePhase2KinkADC( conf.getParameter<int>("Phase2KinkADC") ),
     theNumOfRows(0), theNumOfCols(0), theDetid(0),
     // Get the constants for the miss-calibration studies
-    doMissCalibrate( conf.getUntrackedParameter<bool>("MissCalibrate",true) ),
+    doMissCalibrate( conf.getParameter<bool>("MissCalibrate") ),
     doSplitClusters( conf.getParameter<bool>("SplitClusters") )
 {
   theBuffer.setSize( theNumOfRows, theNumOfCols );
@@ -71,7 +71,7 @@ PixelThresholdClusterizer::~PixelThresholdClusterizer() {}
 void
 PixelThresholdClusterizer::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<int>("ChannelThreshold", 1000);
-  desc.addUntracked<bool>("MissCalibrate", true);
+  desc.add<bool>("MissCalibrate", true);
   desc.add<bool>("SplitClusters", false);
   desc.add<int>("VCaltoElectronGain", 65);
   desc.add<int>("VCaltoElectronGain_L1", 65);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -50,7 +50,6 @@
 // Parameter Set:
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include <vector>
@@ -74,7 +73,7 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
                           const std::vector<short>& badChannels,
                           edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) override { clusterizeDetUnitT(input, pixDet, tTopo, badChannels, output); }
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
  private:
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -32,6 +32,7 @@
 // Framework
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 // STL
 #include <vector>
@@ -48,7 +49,7 @@
   //---------------------------------------------------------------------------
   SiPixelClusterProducer::SiPixelClusterProducer(edm::ParameterSet const& conf) 
     : 
-    clusterMode_( conf.getUntrackedParameter<std::string>("ClusterMode","PixelThresholdClusterizer") ),
+    clusterMode_( conf.getParameter<std::string>("ClusterMode") ),
     maxTotalClusters_( conf.getParameter<int32_t>( "maxNumberOfClusters" ) )
   {
     if ( clusterMode_ == "PixelThresholdReclusterizer" )
@@ -74,6 +75,20 @@
 
   // Destructor
 SiPixelClusterProducer::~SiPixelClusterProducer() = default;
+
+void SiPixelClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("src", edm::InputTag("siPixelDigis"));
+  desc.add<std::string>("ClusterMode", "PixelThresholdClusterizer");
+  desc.add<int>("maxNumberOfClusters", -1)->setComment("-1 means no limit");
+  desc.add<std::string>("payloadType", "Offline")->setComment("Options: HLT - column granularity, Offline - gain:col/ped:pix");
+
+  PixelThresholdClusterizer::fillPSetDescription(desc);
+  SiPixelGainCalibrationServiceBase::fillPSetDescription(desc); // no-op, but in principle the structures are there...
+
+  descriptions.add("SiPixelClusterizerDefault", desc);
+}
 
   
   //---------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -49,6 +49,7 @@
   //---------------------------------------------------------------------------
   SiPixelClusterProducer::SiPixelClusterProducer(edm::ParameterSet const& conf) 
     : 
+    tPutPixelClusters(produces<SiPixelClusterCollectionNew>()),
     clusterMode_( conf.getParameter<std::string>("ClusterMode") ),
     maxTotalClusters_( conf.getParameter<int32_t>( "maxNumberOfClusters" ) )
   {
@@ -56,8 +57,6 @@
       tPixelClusters = consumes<SiPixelClusterCollectionNew>( conf.getParameter<edm::InputTag>("src") );
     else
       tPixelDigi = consumes<edm::DetSetVector<PixelDigi>>( conf.getParameter<edm::InputTag>("src") );
-    //--- Declare to the EDM what kind of collections we will be making.
-    produces<SiPixelClusterCollectionNew>(); 
 
     const auto& payloadType = conf.getParameter<std::string>( "payloadType" );
     if (payloadType == "HLT")
@@ -129,7 +128,7 @@ void SiPixelClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& de
 
     // Step D: write output to file
     output->shrink_to_fit();
-    e.put(std::move(output));
+    e.put(tPutPixelClusters, std::move(output));
 
   }
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -49,7 +49,6 @@
   SiPixelClusterProducer::SiPixelClusterProducer(edm::ParameterSet const& conf) 
     : 
     clusterMode_( conf.getUntrackedParameter<std::string>("ClusterMode","PixelThresholdClusterizer") ),
-    readyToCluster_(false),   // since we obviously aren't
     maxTotalClusters_( conf.getParameter<int32_t>( "maxNumberOfClusters" ) )
   {
     if ( clusterMode_ == "PixelThresholdReclusterizer" )
@@ -129,14 +128,12 @@ SiPixelClusterProducer::~SiPixelClusterProducer() = default;
     if ( clusterMode_ == "PixelThresholdReclusterizer" || clusterMode_ == "PixelThresholdClusterizer" ) {
       clusterizer_ = std::make_unique<PixelThresholdClusterizer>(conf);
       clusterizer_->setSiPixelGainCalibrationService(theSiPixelGainCalibration_.get());
-      readyToCluster_ = true;
     } 
     else {
-      edm::LogError("SiPixelClusterProducer") << "[SiPixelClusterProducer]:"
+      throw cms::Exception("Configuration") << "[SiPixelClusterProducer]:"
 		<<" choice " << clusterMode_ << " is invalid.\n"
 		<< "Possible choices:\n" 
 		<< "    PixelThresholdClusterizer";
-      readyToCluster_ = false;
     }
   }
 
@@ -148,13 +145,6 @@ SiPixelClusterProducer::~SiPixelClusterProducer() = default;
   void SiPixelClusterProducer::run(const T                              & input, 
                                    const edm::ESHandle<TrackerGeometry> & geom,
                                    edmNew::DetSetVector<SiPixelCluster> & output) {
-    if ( ! readyToCluster_ ) {
-      edm::LogError("SiPixelClusterProducer")
-		<<" at least one clusterizer is not ready -- can't run!" ;
-      // TO DO: throw an exception here?  The user may want to know...
-      return;   // clusterizer is invalid, bail out
-    }
-
     int numberOfDetUnits = 0;
     int numberOfClusters = 0;
  

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -47,6 +47,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
   class dso_hidden SiPixelClusterProducer final : public edm::stream::EDProducer<> {
@@ -54,6 +55,8 @@
     //--- Constructor, virtual destructor (just in case)
     explicit SiPixelClusterProducer(const edm::ParameterSet& conf);
     ~SiPixelClusterProducer() override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     void setupClusterizer(const edm::ParameterSet& conf);
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -72,6 +72,7 @@
   private:
     edm::EDGetTokenT<SiPixelClusterCollectionNew>  tPixelClusters;
     edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
+    edm::EDPutTokenT<SiPixelClusterCollectionNew>  tPutPixelClusters;
     // TO DO: maybe allow a map of pointers?
     std::unique_ptr<SiPixelGainCalibrationServiceBase> theSiPixelGainCalibration_;
     const std::string clusterMode_;         // user's choice of the clusterizer

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -73,7 +73,6 @@
     std::unique_ptr<SiPixelGainCalibrationServiceBase> theSiPixelGainCalibration_;
     const std::string clusterMode_;         // user's choice of the clusterizer
     std::unique_ptr<PixelClusterizerBase> clusterizer_;    // what we got (for now, one ptr to base class)
-    bool readyToCluster_;                   // needed clusterizers valid => good to go!
     const TrackerTopology* tTopo_;          // needed to get correct layer number
 
     //! Optional limit on the total number of clusters

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -70,16 +70,14 @@
     edm::EDGetTokenT<SiPixelClusterCollectionNew>  tPixelClusters;
     edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
     // TO DO: maybe allow a map of pointers?
-    SiPixelGainCalibrationServiceBase * theSiPixelGainCalibration_;
+    std::unique_ptr<SiPixelGainCalibrationServiceBase> theSiPixelGainCalibration_;
     const std::string clusterMode_;         // user's choice of the clusterizer
-    PixelClusterizerBase * clusterizer_;    // what we got (for now, one ptr to base class)
+    std::unique_ptr<PixelClusterizerBase> clusterizer_;    // what we got (for now, one ptr to base class)
     bool readyToCluster_;                   // needed clusterizers valid => good to go!
     const TrackerTopology* tTopo_;          // needed to get correct layer number
 
     //! Optional limit on the total number of clusters
     const int32_t maxTotalClusters_;
-
-    const std::string payloadType_;
   };
 
 

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -1,61 +1,32 @@
 
 import FWCore.ParameterSet.Config as cms
 
-#
-from CondTools.SiPixel.SiPixelGainCalibrationService_cfi import *
-siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
-    SiPixelGainCalibrationServiceParameters,
-    src = cms.InputTag("siPixelDigis"),
-    ChannelThreshold = cms.int32(1000),
-    MissCalibrate = cms.untracked.bool(True),
-    SplitClusters = cms.bool(False),
-    VCaltoElectronGain    = cms.int32(65),
-    VCaltoElectronGain_L1 = cms.int32(65),
-    VCaltoElectronOffset    = cms.int32(-414),  
-    VCaltoElectronOffset_L1 = cms.int32(-414),  
-    # **************************************
-    # ****  payLoadType Options         ****
-    # ****  HLT - column granularity    ****
-    # ****  Offline - gain:col/ped:pix  ****
-    # **************************************
-    payloadType = cms.string('Offline'),
-    #payloadType = cms.string('Full'),
-    SeedThreshold = cms.int32(1000),
-    ClusterThreshold    = cms.int32(4000),
-    ClusterThreshold_L1 = cms.int32(4000),
-    # **************************************
-    maxNumberOfClusters = cms.int32(-1), # -1 means no limit.
-    ElectronPerADCGain = cms.double(135.0),
-    Phase2Calibration = cms.bool(False),
-    Phase2ReadoutMode = cms.int32(-1),
-    Phase2DigiBaseline = cms.double(1200.),
-    Phase2KinkADC = cms.int32(8),
-)
+from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerDefault_cfi import SiPixelClusterizerDefault as _SiPixelClusterizerDefault
+siPixelClusters = _SiPixelClusterizerDefault.clone()
 
 # phase1 pixel
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(siPixelClusters,
-  VCaltoElectronGain      = cms.int32(47),   # L2-4: 47 +- 4.7
-  VCaltoElectronGain_L1   = cms.int32(50),   # L1:   49.6 +- 2.6
-  VCaltoElectronOffset    = cms.int32(-60),  # L2-4: -60 +- 130
-  VCaltoElectronOffset_L1 = cms.int32(-670), # L1:   -670 +- 220
-  ChannelThreshold        = cms.int32(10),
-  SeedThreshold           = cms.int32(1000),
-  ClusterThreshold        = cms.int32(4000),
-  ClusterThreshold_L1     = cms.int32(2000)
-
+  VCaltoElectronGain      = 47,   # L2-4: 47 +- 4.7
+  VCaltoElectronGain_L1   = 50,   # L1:   49.6 +- 2.6
+  VCaltoElectronOffset    = -60,  # L2-4: -60 +- 130
+  VCaltoElectronOffset_L1 = -670, # L1:   -670 +- 220
+  ChannelThreshold        = 10,
+  SeedThreshold           = 1000,
+  ClusterThreshold        = 4000,
+  ClusterThreshold_L1     = 2000
 )
 
 # Need these until phase2 pixel templates are used
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(siPixelClusters, # FIXME
-  src = cms.InputTag('simSiPixelDigis', "Pixel"),
+  src = 'simSiPixelDigis:Pixel',
   MissCalibrate = False,
-  Phase2Calibration = cms.bool(True),
-  Phase2ReadoutMode = cms.int32(-1), # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction
-  Phase2DigiBaseline = cms.double(1200.), 
-  Phase2KinkADC = cms.int32(8),
-  ElectronPerADCGain = cms.double(600.) # it can be changed to something else (e.g. 135e) if needed
+  Phase2Calibration = True,
+  Phase2ReadoutMode = -1, # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction
+  Phase2DigiBaseline = 1200.,
+  Phase2KinkADC = 8,
+  ElectronPerADCGain = 600. # it can be changed to something else (e.g. 135e) if needed
 )
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 (premix_stage2 & phase2_tracker).toModify(siPixelClusters,


### PR DESCRIPTION
This PR contains following changes of which some help the Patatrack GPU work
* Use unique_ptr
* Throw an exception for incorrect configuration
* Implement `fillDescriptions()`
* Use `edm::EDPutTokenT`

Tested in CMSSW_10_5_0_pre1, no changes expected.