### PR TITLE
Use unique_ptr constructor for PluginFactory plugins in FWCore

### DIFF
--- a/FWCore/Integration/test/PluginUsingProducer.cc
+++ b/FWCore/Integration/test/PluginUsingProducer.cc
@@ -76,7 +76,7 @@ namespace edmtest {
   putToken_{produces<int>()}
   {
     auto pluginPSet = pset.getParameter<edm::ParameterSet>("plugin");
-    maker_.reset( IntFactory::get()->create(pluginPSet.getParameter<std::string>("type"), pluginPSet));
+    maker_ = std::unique_ptr<IntMakerBase>{IntFactory::get()->create(pluginPSet.getParameter<std::string>("type"), pluginPSet)};
   }
 
   void PluginUsingProducer::produce(edm::StreamID, edm::Event& event, edm::EventSetup const&)  const{

--- a/FWCore/ParameterSet/bin/edmPluginHelp.cpp
+++ b/FWCore/ParameterSet/bin/edmPluginHelp.cpp
@@ -104,7 +104,7 @@ namespace {
     std::unique_ptr<edm::ParameterSetDescriptionFillerBase> filler;
 
     try {
-      filler.reset(factory->create(pluginInfo.name_));
+      filler = std::unique_ptr<edm::ParameterSetDescriptionFillerBase>{factory->create(pluginInfo.name_)};
     }
     catch(cms::Exception& e) {
       os << "\nSTART ERROR FROM edmPluginHelp\n";


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-01-23-1100, no changes expected.


