### PR TITLE
Manage PluginFactory plugin with a unique_ptr in algorithm_plugin_test in DetectorDescription

### DIFF
--- a/DetectorDescription/RegressionTest/test/algorithm_plugin_test.cpp
+++ b/DetectorDescription/RegressionTest/test/algorithm_plugin_test.cpp
@@ -10,11 +10,10 @@
 
 int main(int, char **argv)
 {
-  DDAlgorithm * algo;
   DDCompactView cpv;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
   std::string name("test:DDTestAlgorithm");
-  algo = DDAlgorithmFactory::get()->create(name);
+  std::unique_ptr<DDAlgorithm> algo{DDAlgorithmFactory::get()->create(name)};
   if (algo) {
     const DDNumericArguments nArgs;
     const DDVectorArguments vArgs;


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-01-23-1100, no changes expected.