### PR TITLE
Remove unused variable from SiStripMonitorDigi

### DIFF
--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -41,8 +41,7 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 /* mia: but is there not a smarter way ?!?!?! */
-const double NORBITS_PER_SECOND = 11223.;
-const double NORBITS_PER_LS     = 262144.;
+const double NORBITS_PER_LS     = 262144.; // per-second value would be 11223
 
 //--------------------------------------------------------------------------------------------
 SiStripMonitorDigi::SiStripMonitorDigi(const edm::ParameterSet& iConfig) :

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -41,7 +41,9 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 /* mia: but is there not a smarter way ?!?!?! */
-const double NORBITS_PER_LS     = 262144.; // per-second value would be 11223
+namespace {
+  const double NORBITS_PER_LS     = 262144.; // per-second value would be 11223
+}
 
 //--------------------------------------------------------------------------------------------
 SiStripMonitorDigi::SiStripMonitorDigi(const edm::ParameterSet& iConfig) :


### PR DESCRIPTION
Fixes a clang warning. I also moved the remaining global constant to anonymous namespace to avoid polluting the global namespace (luckily there were no name conflicts).