### PR TITLE
Remove redundant configuration settings for siPixelDigis

### DIFF
--- a/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
+++ b/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
@@ -2,21 +2,6 @@ import FWCore.ParameterSet.Config as cms
 import EventFilter.SiPixelRawToDigi.siPixelRawToDigi_cfi
 
 siPixelDigis = EventFilter.SiPixelRawToDigi.siPixelRawToDigi_cfi.siPixelRawToDigi.clone()
-siPixelDigis.Timing = cms.untracked.bool(False)
-siPixelDigis.IncludeErrors = cms.bool(True)
-siPixelDigis.InputLabel = cms.InputTag("siPixelRawData")
-siPixelDigis.UseQualityInfo = cms.bool(False)
-## ErrorList: list of error codes used by tracking to invalidate modules
-siPixelDigis.ErrorList = cms.vint32(29)
-## UserErrorList: list of error codes used by Pixel experts for investigation
-siPixelDigis.UserErrorList = cms.vint32(40)
-##  Use pilot blades
-siPixelDigis.UsePilotBlade = cms.bool(False)
-##  Use phase1
-siPixelDigis.UsePhase1 = cms.bool(False)
-## Empty Regions PSet means complete unpacking
-siPixelDigis.Regions = cms.PSet( ) 
-siPixelDigis.CablingMapLabel = cms.string("")
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(siPixelDigis, UsePhase1=True)


### PR DESCRIPTION
These are already set in `fillDescriptions()`, so there is no need to specify them again. This cleanup helps the Patatrack GPU work.

Tested in 10_5_0_pre1, no changes expected.