### PR TITLE
No more possibility to ignore exceptions in TagAndProbe

### DIFF
--- a/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
+++ b/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
@@ -185,9 +185,6 @@ class BaseTreeFiller : boost::noncopyable {
 	edm::EDGetTokenT<pat::METCollection>    pfmetTokenMiniAOD_;
 	edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupInfoToken_;
 
-        /// Ignore exceptions when evaluating variables
-        bool ignoreExceptions_;
-
         /// Add branches with run and lumisection number
         bool addRunLumiInfo_;
 

--- a/PhysicsTools/TagAndProbe/src/BaseTreeFiller.cc
+++ b/PhysicsTools/TagAndProbe/src/BaseTreeFiller.cc
@@ -115,9 +115,6 @@ tnp::BaseTreeFiller::BaseTreeFiller(const char *name, const edm::ParameterSet& i
       rhoToken_ = iC.consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
       tree_->Branch("event_rho"    ,&rho_   ,"rho/F");
     }
-    
-
-    ignoreExceptions_ = iConfig.existsAs<bool>("ignoreExceptions") ? iConfig.getParameter<bool>("ignoreExceptions") : false;
 }
 
 tnp::BaseTreeFiller::BaseTreeFiller(BaseTreeFiller &main, const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC, const std::string &branchNamePrefix) :
@@ -304,22 +301,10 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
 }
 
 void tnp::BaseTreeFiller::fill(const reco::CandidateBaseRef &probe) const {
-    for (std::vector<tnp::ProbeVariable>::const_iterator it = vars_.begin(), ed = vars_.end(); it != ed; ++it) {
-      if (ignoreExceptions_)  {
-            try{ it->fill(probe); } catch(cms::Exception &ex ){}
-        } else {
-	  
-            it->fill(probe);
-        }
-    }
 
-    for (std::vector<tnp::ProbeFlag>::const_iterator it = flags_.begin(), ed = flags_.end(); it != ed; ++it) {
-        if (ignoreExceptions_)  {
-            try{ it->fill(probe); } catch(cms::Exception &ex ){}
-        } else {
-            it->fill(probe);
-        }
-    }
+    for(auto const& var : vars_) var.fill(probe);
+    for(auto const& flag : flags_) flag.fill(probe);
+
     if (tree_) tree_->Fill();
 }
 void tnp::BaseTreeFiller::writeProvenance(const edm::ParameterSet &pset) const {

--- a/PhysicsTools/TagAndProbe/test/Electron_TagProbeTreeProducer_cfg.py
+++ b/PhysicsTools/TagAndProbe/test/Electron_TagProbeTreeProducer_cfg.py
@@ -926,7 +926,6 @@ TagVariablesToStore = cms.PSet(
 
 CommonStuffForGsfElectronProbe = cms.PSet(
     variables = cms.PSet(ProbeVariablesToStore),
-    ignoreExceptions =  cms.bool (False),
     addRunLumiInfo   =  cms.bool (True),
     addEventVariablesInfo   =  cms.bool (True),
     pairVariables =  cms.PSet(ZVariablesToStore),
@@ -1249,7 +1248,6 @@ process.WP95ToHLT = cms.EDAnalyzer("TagProbeFitTreeProducer",
       probe_gsfEle_isEE           = cms.string("isEE"),
       probe_gsfEle_isGap          = cms.string("isGap"),
     ),
-    ignoreExceptions =  cms.bool (False),
     addRunLumiInfo   =  cms.bool (False),
     addEventVariablesInfo   =  cms.bool (False),                                                        
     tagProbePairs = cms.InputTag("tagWP95"),

--- a/PhysicsTools/TagAndProbe/test/Photon_TagProbeTreeProducer_cfg.py
+++ b/PhysicsTools/TagAndProbe/test/Photon_TagProbeTreeProducer_cfg.py
@@ -385,7 +385,6 @@ ProbePhotonVariablesToStore = cms.PSet(
 
 CommonStuffForPhotonProbe = cms.PSet(
    variables = cms.PSet(ProbePhotonVariablesToStore),
-   ignoreExceptions =  cms.bool (False),
    #fillTagTree      =  cms.bool (True),
    addRunLumiInfo   =  cms.bool (True),
    addEventVariablesInfo   =  cms.bool (True),
@@ -505,7 +504,6 @@ process.photonIDsusydiphotonToHLT = cms.EDAnalyzer("TagProbeFitTreeProducer",
       probe_phi  = cms.string("phi"),
       probe_et  = cms.string("et"),
     ),
-    ignoreExceptions =  cms.bool (False),
     addRunLumiInfo   =  cms.bool (False),
     addEventVariablesInfo   =  cms.bool (False),                                                        
     tagProbePairs = cms.InputTag("tagphotonIDsusydiphoton"),


### PR DESCRIPTION
I was struck by some seemingly "random" differences in synchronizations of TagAndProbe studies with my colleague. It turns out the reason was that the TagProbeTreeProducer can silently ignore exceptions when filling branches. In our case, a ValueMap was not available anymore in newer CMSSW which went unnoticed for days due to the exception ignoring.

I suggest to remove this feature from CMSSW because I think it does more harm than good, and it's probably harder to convince all users to set `ignoreExceptions =  cms.bool (False)` than to just change it upstream.