### PR TITLE
FastSim memory fix in TrajectorSeedProducer

### DIFF
--- a/FastSimulation/Tracking/src/SeedFinderSelector.cc
+++ b/FastSimulation/Tracking/src/SeedFinderSelector.cc
@@ -168,40 +168,49 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *>& hits
 	  const TrackingRegion& tr_ = *trackingRegion_;
 	  auto filler = ihd.beginRegion(&tr_); 
 
-	  //Forming doublets for CA triplets from the allowed layer pair combinations:(0,1),(1,2)
-	  std::array<SeedingLayerSetsBuilder::SeedingLayerId,2> hitPair;
-	  for(int i=0; i<2; i++){
-	    SeedingLayerSetsHits::SeedingLayerSet pairCandidate;
-	    hitPair[0] = Layer_tuple(hits[i]);
-	    hitPair[1] = Layer_tuple(hits[i+1]);
+	  //forming the SeedingLayerId of the hits
+	  std::array<SeedingLayerSetsBuilder::SeedingLayerId,3> hitPair;
+          hitPair[0] = Layer_tuple(hits[0]);
+	  hitPair[1] = Layer_tuple(hits[1]);
+          hitPair[2] = Layer_tuple(hits[2]);
 
-	    bool found;
-	    for(SeedingLayerSetsHits::SeedingLayerSet ls : *seedingLayer){
-	      found = false;
-	      for(const auto p : layerPairs_){
-		pairCandidate = ls.slice(p,p+2);
-		if(hitPair[0] == seedingLayerIds[pairCandidate[0].index()] && hitPair[1] == seedingLayerIds[pairCandidate[1].index()]){
-		  found = true;
-		  break;
-		}
-	      }
-	      if(found)
-		break;
-	    }
-	    assert(found == true);
-	    const DetLayer * fLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[i]->det()->geographicalId());
-	    const DetLayer * sLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[i+1]->det()->geographicalId());
-	    std::vector<BaseTrackerRecHit const *> fHits{hits[i]};
-	    std::vector<BaseTrackerRecHit const *> sHits{hits[i+1]};
-	    
-	    //Important: doublets to be added to the cache
-	    auto& layerCache = filler.layerHitMapCache();
-	    const RecHitsSortedInPhi& firsthm = *layerCache.add(pairCandidate[0], std::make_unique<RecHitsSortedInPhi>(fHits, trackingRegion_->origin(),fLayer));
-	    const RecHitsSortedInPhi& secondhm = *layerCache.add(pairCandidate[1], std::make_unique<RecHitsSortedInPhi>(sHits, trackingRegion_->origin(),sLayer));
-	    HitDoublets res(firsthm,secondhm);
-	    HitPairGeneratorFromLayerPair::doublets(*trackingRegion_,*fLayer,*sLayer,firsthm,secondhm,*eventSetup_,0,res);
-	    filler.addDoublets(pairCandidate, std::move(res)); //fill the formed doublet
-	  }
+	  //extracting the DetLayer of the hits
+          const DetLayer * fLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[0]->det()->geographicalId());
+          const DetLayer * sLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[1]->det()->geographicalId());
+          const DetLayer * tLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[2]->det()->geographicalId());
+
+	  //converting FastTrackerRecHit hits to BaseTrackerRecHit
+	  std::vector<BaseTrackerRecHit const *> fHits{hits[0]};
+	  std::vector<BaseTrackerRecHit const *> sHits{hits[1]};
+	  std::vector<BaseTrackerRecHit const *> tHits{hits[2]};
+
+	  //forming the SeedingLayerSet for the hit doublets
+	  SeedingLayerSetsHits::SeedingLayerSet pairCandidate1, pairCandidate2;
+          for(SeedingLayerSetsHits::SeedingLayerSet ls : *seedingLayer){
+	    SeedingLayerSetsHits::SeedingLayerSet pairCandidate;
+            for(const auto p : layerPairs_){
+              pairCandidate = ls.slice(p,p+2);
+              if(p==0 && hitPair[0] == seedingLayerIds[pairCandidate[0].index()] && hitPair[1] == seedingLayerIds[pairCandidate[1].index()])
+                pairCandidate1=pairCandidate;
+              if(p==1 && hitPair[1] == seedingLayerIds[pairCandidate[0].index()] && hitPair[2] == seedingLayerIds[pairCandidate[1].index()])
+                pairCandidate2=pairCandidate;
+            }
+          }
+
+	  //Important: hits of the layer to be added to LayerHitMapCache
+	  auto& layerCache = filler.layerHitMapCache();
+
+	  //doublets for CA triplets from the allowed layer pair combinations:(0,1),(1,2) and storing in filler
+          const RecHitsSortedInPhi & firsthm = *layerCache.add(pairCandidate1[0], std::make_unique<RecHitsSortedInPhi>(fHits, trackingRegion_->origin(), fLayer));
+          const RecHitsSortedInPhi & secondhm = *layerCache.add(pairCandidate1[1], std::make_unique<RecHitsSortedInPhi>(sHits, trackingRegion_->origin(), sLayer));
+          HitDoublets res1(firsthm,secondhm);
+	  HitPairGeneratorFromLayerPair::doublets(*trackingRegion_,*fLayer,*sLayer,firsthm,secondhm,*eventSetup_,0,res1);
+          filler.addDoublets(pairCandidate1, std::move(res1));
+          const RecHitsSortedInPhi & thirdhm = *layerCache.add(pairCandidate2[1], std::make_unique<RecHitsSortedInPhi>(tHits, trackingRegion_->origin(), tLayer));
+          HitDoublets res2(secondhm,thirdhm);
+	  HitPairGeneratorFromLayerPair::doublets(*trackingRegion_,*sLayer,*tLayer,secondhm,thirdhm,*eventSetup_,0,res2);
+          filler.addDoublets(pairCandidate2, std::move(res2));
+
 	  std::vector<OrderedHitSeeds> tripletresult;                                
 	  tripletresult.resize(ihd.regionSize());
 	  for(auto& ntuplet : tripletresult)
@@ -227,40 +236,57 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *>& hits
       const TrackingRegion& tr_ = *trackingRegion_;
       auto filler = ihd.beginRegion(&tr_);
       
-      //Forming doublets for CA quadruplets from the allowed layer pair combinations:(0,1),(1,2),(2,3)
-      std::array<SeedingLayerSetsBuilder::SeedingLayerId,2> hitPair;
-      for(int i=0; i<3; i++){
-	SeedingLayerSetsHits::SeedingLayerSet pairCandidate;
-	hitPair[0] = Layer_tuple(hits[i]);
- 	hitPair[1] = Layer_tuple(hits[i+1]);
-       
-	bool found;
-        for(SeedingLayerSetsHits::SeedingLayerSet ls : *seedingLayer){
-	  found = false;
-	  for(const auto p : layerPairs_){
-	    pairCandidate = ls.slice(p,p+2);
-	    if(hitPair[0] == seedingLayerIds[pairCandidate[0].index()] && hitPair[1] == seedingLayerIds[pairCandidate[1].index()]){
-	      found = true;
-	      break;
-	    }
-	  }
-	  if(found)
-	    break;
-	}
-	assert(found == true);
-	const DetLayer * fLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[i]->det()->geographicalId());
-	const DetLayer * sLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[i+1]->det()->geographicalId());
-	std::vector<BaseTrackerRecHit const *> fHits{hits[i]};
-	std::vector<BaseTrackerRecHit const *> sHits{hits[i+1]};
+      //forming the SeedingLayerId of the hits
+      std::array<SeedingLayerSetsBuilder::SeedingLayerId,4> hitPair;
+      hitPair[0] = Layer_tuple(hits[0]);
+      hitPair[1] = Layer_tuple(hits[1]);
+      hitPair[2] = Layer_tuple(hits[2]);
+      hitPair[3] = Layer_tuple(hits[3]);
 
-	//Important: doublets to be added to the cache
-	auto& layerCache = filler.layerHitMapCache();
-	const RecHitsSortedInPhi& firsthm = *layerCache.add(pairCandidate[0], std::make_unique<RecHitsSortedInPhi>(fHits, trackingRegion_->origin(), fLayer));
-	const RecHitsSortedInPhi& secondhm = *layerCache.add(pairCandidate[1], std::make_unique<RecHitsSortedInPhi>(sHits, trackingRegion_->origin(), sLayer));
-	HitDoublets res(firsthm,secondhm);
-	HitPairGeneratorFromLayerPair::doublets(*trackingRegion_,*fLayer,*sLayer,firsthm,secondhm,*eventSetup_,0,res);
-	filler.addDoublets(pairCandidate, std::move(res)); //fill the formed doublet
+      //extracting the DetLayer of the hits
+      const DetLayer * fLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[0]->det()->geographicalId());
+      const DetLayer * sLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[1]->det()->geographicalId());
+      const DetLayer * tLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[2]->det()->geographicalId());
+      const DetLayer * frLayer = measurementTracker_->geometricSearchTracker()->detLayer(hits[3]->det()->geographicalId());
+
+      //converting FastTrackerRecHit hits to BaseTrackerRecHit
+      std::vector<BaseTrackerRecHit const *> fHits{hits[0]};
+      std::vector<BaseTrackerRecHit const *> sHits{hits[1]};
+      std::vector<BaseTrackerRecHit const *> tHits{hits[2]};
+      std::vector<BaseTrackerRecHit const *> frHits{hits[3]};
+
+      //forming the SeedingLayerSet for the hit doublets     
+      SeedingLayerSetsHits::SeedingLayerSet pairCandidate1, pairCandidate2, pairCandidate3;
+      for(SeedingLayerSetsHits::SeedingLayerSet ls : *seedingLayer){
+	SeedingLayerSetsHits::SeedingLayerSet pairCandidate;
+        for(const auto p : layerPairs_){
+          pairCandidate = ls.slice(p,p+2);
+	  if(p==0 && hitPair[0] == seedingLayerIds[pairCandidate[0].index()] && hitPair[1] == seedingLayerIds[pairCandidate[1].index()])
+            pairCandidate1=pairCandidate;
+          if(p==1 && hitPair[1] == seedingLayerIds[pairCandidate[0].index()] && hitPair[2] == seedingLayerIds[pairCandidate[1].index()])
+            pairCandidate2=pairCandidate;
+          if(p==2 && hitPair[2] == seedingLayerIds[pairCandidate[0].index()] && hitPair[3] == seedingLayerIds[pairCandidate[1].index()])
+            pairCandidate3=pairCandidate;
+        }
       }
+      
+      //Important: hits of the layer to be added to LayerHitMapCache
+      auto& layerCache = filler.layerHitMapCache();
+
+      //doublets for CA quadruplets from the allowed layer pair combinations:(0,1),(1,2),(2,3) and storing in filler 
+      const RecHitsSortedInPhi & firsthm = *layerCache.add(pairCandidate1[0], std::make_unique<RecHitsSortedInPhi>(fHits, trackingRegion_->origin(), fLayer));
+      const RecHitsSortedInPhi & secondhm = *layerCache.add(pairCandidate1[1], std::make_unique<RecHitsSortedInPhi>(sHits, trackingRegion_->origin(), sLayer));
+      HitDoublets res1(firsthm,secondhm);
+      HitPairGeneratorFromLayerPair::doublets(*trackingRegion_,*fLayer,*sLayer,firsthm,secondhm,*eventSetup_,0,res1);
+      filler.addDoublets(pairCandidate1, std::move(res1));
+      const RecHitsSortedInPhi & thirdhm = *layerCache.add(pairCandidate2[1], std::make_unique<RecHitsSortedInPhi>(tHits, trackingRegion_->origin(), tLayer));
+      HitDoublets res2(secondhm,thirdhm);
+      HitPairGeneratorFromLayerPair::doublets(*trackingRegion_,*sLayer,*tLayer,secondhm,thirdhm,*eventSetup_,0,res2);
+      filler.addDoublets(pairCandidate2, std::move(res2));
+      const RecHitsSortedInPhi & fourthhm = *layerCache.add(pairCandidate3[1], std::make_unique<RecHitsSortedInPhi>(frHits, trackingRegion_->origin(), frLayer));
+      HitDoublets res3(thirdhm, fourthhm);
+      HitPairGeneratorFromLayerPair::doublets(*trackingRegion_,*tLayer,*frLayer,thirdhm,fourthhm,*eventSetup_,0,res3);
+      filler.addDoublets(pairCandidate3, std::move(res3));
       
       std::vector<OrderedHitSeeds> quadrupletresult;
       quadrupletresult.resize(ihd.regionSize());


### PR DESCRIPTION
This is a fix for the issue https://github.com/cms-sw/cmssw/issues/25197 
The call to RecHitsSortedInPhi::add()  https://github.com/cms-sw/cmssw/blob/02d4198c0b6615287fd88e9a8ff650aea994412e/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h#L68 with the same layer parameter has to be avoided because it tends to override the hits associated with that layer, leaving a dangling pointer behind.