### PR TITLE
Manage PluginFactory plugin with unique_ptr in ExternalDecayDriver

### DIFF
--- a/GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h
+++ b/GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h
@@ -49,9 +49,9 @@ namespace gen {
 
       private:
 	 bool                     fIsInitialized;
-	 TauolaInterfaceBase*     fTauolaInterface;
-	 EvtGenInterfaceBase*     fEvtGenInterface;
-	 PhotosInterfaceBase*     fPhotosInterface;
+	 std::unique_ptr<TauolaInterfaceBase>     fTauolaInterface;
+	 std::unique_ptr<EvtGenInterfaceBase>     fEvtGenInterface;
+	 std::unique_ptr<PhotosInterfaceBase>     fPhotosInterface;
 	 std::vector<int>         fPDGs;
 	 std::vector<std::string> fSpecialSettings;
 


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-01-23-1100, no changes expected.