### PR TITLE
Manage PluginFactory plugin with unique_ptr in HLTMuonIsoFilter

### DIFF
--- a/HLTrigger/Muon/plugins/HLTMuonIsoFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonIsoFilter.cc
@@ -37,7 +37,6 @@ HLTMuonIsoFilter::HLTMuonIsoFilter(const edm::ParameterSet& iConfig) : HLTFilter
    previousCandToken_ (consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)),
    depTag_  (iConfig.getParameter< std::vector< edm::InputTag > >("DepTag" ) ),
    depToken_(),
-   theDepositIsolator(nullptr),
    min_N_   (iConfig.getParameter<int> ("MinN"))
 {
   depToken_.reserve(depTag_.size());
@@ -59,7 +58,7 @@ HLTMuonIsoFilter::HLTMuonIsoFilter(const edm::ParameterSet& iConfig) : HLTFilter
   edm::ParameterSet isolatorPSet = iConfig.getParameter<edm::ParameterSet>("IsolatorPSet");
   if (not isolatorPSet.empty()) {
     std::string type = isolatorPSet.getParameter<std::string>("ComponentName");
-    theDepositIsolator = MuonIsolatorFactory::get()->create(type, isolatorPSet, consumesCollector());
+    theDepositIsolator = std::unique_ptr<muonisolation::MuIsoBaseIsolator>(MuonIsolatorFactory::get()->create(type, isolatorPSet, consumesCollector()));
   }
   
   if (theDepositIsolator) produces<edm::ValueMap<bool> >();

--- a/HLTrigger/Muon/plugins/HLTMuonIsoFilter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonIsoFilter.h
@@ -40,7 +40,7 @@ class HLTMuonIsoFilter : public HLTFilter {
       std::vector<edm::EDGetTokenT<edm::ValueMap<reco::IsoDeposit> > > depToken_; // tokens identifying deposit maps
       edm::EDGetTokenT<edm::ValueMap<bool> > decMapToken_; // bool decision map
 
-      const muonisolation::MuIsoBaseIsolator * theDepositIsolator;
+      std::unique_ptr<const muonisolation::MuIsoBaseIsolator> theDepositIsolator;
 
       int    min_N_;          // minimum number of muons to fire the trigger
 };


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-01-23-1100, no changes expected.