### PR TITLE
Removed struct dictionary from classes.h in TBDataFormats

### DIFF
--- a/TBDataFormats/EcalTBObjects/src/classes.h
+++ b/TBDataFormats/EcalTBObjects/src/classes.h
@@ -5,33 +5,4 @@
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopeRecInfo.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace TBDataFormats_EcalTBObjects {
-  struct dictionary {
-    std::vector<EcalTBTDCSample> vTDC_;
-    std::vector<EcalTBHodoscopePlaneRawHits> vHplaneRawHits_;
-    
-    EcalTBEventHeader EHw_;
- 
-    EcalTBEventHeader::magnetsMeasurement aMagnetMeasurement_;
-    //    EcalTBEventHeader::magnetsMeasurement_t aMagnetMeasurement_t;
-
-    std::vector< EcalTBEventHeader::magnetsMeasurement > aVMagnetMeasurement_;
-    //    std::vector< EcalTBEventHeader::magnetsMeasurement_t > aVMagnetMeasurement_t;
-
-    EcalTBTDCRawInfo TDCw_;
-    EcalTBTDCRecInfo RecTDCw_;
-
-    EcalTBHodoscopeRawInfo Hodow_;
-    EcalTBHodoscopeRecInfo RecHodow_;
-
-    edm::Wrapper<EcalTBEventHeader> theEHw_;
-
-    edm::Wrapper<EcalTBTDCRawInfo> theTDCw_;
-    edm::Wrapper<EcalTBTDCRecInfo> theRecTDCw_;
-
-    edm::Wrapper<EcalTBHodoscopeRawInfo> theHodow_;
-    edm::Wrapper<EcalTBHodoscopeRecInfo> theRecHodow_;
-
- };
-}
 

--- a/TBDataFormats/HcalTBObjects/src/classes.h
+++ b/TBDataFormats/HcalTBObjects/src/classes.h
@@ -6,16 +6,4 @@
 #include "TBDataFormats/HcalTBObjects/interface/HcalTBParticleId.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace TBDataFormats_HcalTBObjects {
-  struct dictionary {
-
-    edm::Wrapper<HcalTBTriggerData>   theTriggerData_;
-    edm::Wrapper<HcalTBRunData>       theRunData_;
-    edm::Wrapper<HcalTBEventPosition> theEvtPosData_;
-    edm::Wrapper<HcalTBTiming>        theTimingData_;
-    edm::Wrapper<HcalTBBeamCounters>  theBeamCountersData_;
-    edm::Wrapper<HcalTBParticleId>    theParticleId_;
-
- };
-}
 


### PR DESCRIPTION
ROOT no longer requires forcing the instantiation of templates
in the .h file. The declaration in classes_def.xml is sufficient.