### PR TITLE
Use unique_ptr constructor for PluginFactory plugins in AttachSD

### DIFF
--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -28,18 +28,16 @@ AttachSD::create(const DDCompactView & cpv,
     std::string className = clg.className(rname);
     std::unique_ptr<SensitiveDetectorMakerBase> temp{SensitiveDetectorPluginFactory::get()->create(className)};
 
-    SensitiveDetector* sd = temp->make(rname,cpv,clg,p,man,reg);
+    std::unique_ptr<SensitiveDetector> sd{temp->make(rname,cpv,clg,p,man,reg)};
     
     std::stringstream ss;
     ss << " AttachSD: created a " << className << " with name " << rname;
  
     if(sd->isCaloSD()) {
-      SensitiveCaloDetector* caloDet = (SensitiveCaloDetector*)(sd);
-      detList.second.push_back(caloDet);
+      detList.second.push_back(static_cast<SensitiveCaloDetector*>(sd.release()));
       ss << " + calo SD"; 
     } else {
-      SensitiveTkDetector* tkDet = (SensitiveTkDetector*)(sd);
-      detList.first.push_back(tkDet);
+      detList.first.push_back(static_cast<SensitiveTkDetector*>(sd.release()));
       ss << " + tracking SD"; 
     }
     edm::LogVerbatim("SimG4CoreSensitiveDetector") << ss.str();

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -24,12 +24,11 @@ AttachSD::create(const DDCompactView & cpv,
   const std::vector<std::string>& rouNames = clg.readoutNames();
   edm::LogVerbatim("SimG4CoreSensitiveDetector") 
     << " AttachSD: Initialising " << rouNames.size() << " SDs";
-  std::unique_ptr<SensitiveDetectorMakerBase> temp; 
   for (auto & rname : rouNames) {
     std::string className = clg.className(rname);
-    temp.reset(SensitiveDetectorPluginFactory::get()->create(className));
+    std::unique_ptr<SensitiveDetectorMakerBase> temp{SensitiveDetectorPluginFactory::get()->create(className)};
 
-    SensitiveDetector* sd = temp.get()->make(rname,cpv,clg,p,man,reg);
+    SensitiveDetector* sd = temp->make(rname,cpv,clg,p,man,reg);
     
     std::stringstream ss;
     ss << " AttachSD: created a " << className << " with name " << rname;


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`. On the same go I also changed the management of `SensitiveDetector` object from raw pointer to `unique_ptr` (within `AttachSD::create()`, ~~likely the return type could be changed to use `unique_ptr` as well but I'd leave that out from this PR~~).

Tested in CMSSW_10_5_X_2019-01-23-1100, no changes expected.

