### PR TITLE
Manage PluginFactory plugins with unique_ptr in CalibMuon/DTCalibration

### DIFF
--- a/CalibMuon/DTCalibration/interface/DTTMax.h
+++ b/CalibMuon/DTCalibration/interface/DTTMax.h
@@ -37,7 +37,7 @@ class DTTMax {
   
   /// Constructor
   DTTMax(const std::vector<DTRecHit1D> & hits, const DTSuperLayer & isl, GlobalVector dir, 
-	 GlobalPoint pos, DTTTrigBaseSync* sync);
+	 GlobalPoint pos, const DTTTrigBaseSync& sync);
   
   /// Destructor
   virtual ~DTTMax();
@@ -60,7 +60,7 @@ class DTTMax {
   // All information on one of the layers crossed by the segment
   struct InfoLayer {
     InfoLayer(const DTRecHit1D& rh_, const DTSuperLayer & isl, GlobalVector dir, 
-	      GlobalPoint pos, DTTTrigBaseSync* sync);
+	      GlobalPoint pos, const DTTTrigBaseSync& sync);
     DTRecHit1D rh;
     DTWireId idWire;
     DTEnums::DTCellSide lr;

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.cc
@@ -27,18 +27,15 @@
 using namespace edm;
 using namespace std;
 
-DTT0Correction::DTT0Correction(const ParameterSet& pset){ 
-
+DTT0Correction::DTT0Correction(const ParameterSet& pset):
+  correctionAlgo_{DTT0CorrectionFactory::get()->create(pset.getParameter<string>("correctionAlgo"),
+                                                       pset.getParameter<ParameterSet>("correctionAlgoConfig"))}
+{
   LogVerbatim("Calibration") << "[DTT0Correction] Constructor called" << endl;
-
-  // Get the concrete algo from the factory
-  string theAlgoName = pset.getParameter<string>("correctionAlgo");
-  correctionAlgo_ = DTT0CorrectionFactory::get()->create(theAlgoName,pset.getParameter<ParameterSet>("correctionAlgoConfig"));
 }
 
 DTT0Correction::~DTT0Correction(){
   LogVerbatim("Calibration") << "[DTT0Correction] Destructor called" << endl;
-  delete correctionAlgo_;
 }
 
 void DTT0Correction::beginRun( const edm::Run& run, const edm::EventSetup& setup ) {

--- a/CalibMuon/DTCalibration/plugins/DTT0Correction.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0Correction.h
@@ -39,6 +39,6 @@ private:
   const DTT0* t0Map_;
   edm::ESHandle<DTGeometry> muonGeom_;
 
-  dtCalibration::DTT0BaseCorrection* correctionAlgo_;
+  std::unique_ptr<dtCalibration::DTT0BaseCorrection> correctionAlgo_;
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
@@ -36,7 +36,7 @@ private:
   TFile* rootFile_;
   //const DTT0* tZeroMap_;
   edm::ESHandle<DTGeometry> dtGeom_;
-  DTTTrigBaseSync* tTrigSync_;
+  std::unique_ptr<DTTTrigBaseSync> tTrigSync_;
 
   // Map of the t0 and sigma histos by layer
   std::map<DTWireId, int> nDigisPerWire_;
@@ -67,16 +67,15 @@ private:
 
 DTTPAnalyzer::DTTPAnalyzer(const edm::ParameterSet& pset):
   subtractT0_(pset.getParameter<bool>("subtractT0")),
-  digiLabel_(pset.getParameter<edm::InputTag>("digiLabel")),
-  tTrigSync_(nullptr) {
+  digiLabel_(pset.getParameter<edm::InputTag>("digiLabel")) {
 
   std::string rootFileName = pset.getUntrackedParameter<std::string>("rootFileName");
   rootFile_ = new TFile(rootFileName.c_str(), "RECREATE");
   rootFile_->cd();
 
   if(subtractT0_) 
-     tTrigSync_ = DTTTrigSyncFactory::get()->create(pset.getParameter<std::string>("tTrigMode"),
-                                                    pset.getParameter<edm::ParameterSet>("tTrigModeConfig"));
+    tTrigSync_ = std::unique_ptr<DTTTrigBaseSync>{DTTTrigSyncFactory::get()->create(pset.getParameter<std::string>("tTrigMode"),
+                                                                                    pset.getParameter<edm::ParameterSet>("tTrigModeConfig"))};
 
 }
  

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.cc
@@ -60,7 +60,7 @@ DTTTrigCalibration::DTTTrigCalibration(const edm::ParameterSet& pset) {
   string rootFileName = pset.getUntrackedParameter<string>("rootFileName");
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
   theFile->cd();
-  theFitter = new DTTimeBoxFitter();
+  theFitter = std::make_unique<DTTimeBoxFitter>();
   if(debug)
     theFitter->setVerbosity(1);
 
@@ -70,10 +70,8 @@ DTTTrigCalibration::DTTTrigCalibration(const edm::ParameterSet& pset) {
   doSubtractT0 = pset.getUntrackedParameter<bool>("doSubtractT0","false");
   // Get the synchronizer
   if(doSubtractT0) {
-    theSync = DTTTrigSyncFactory::get()->create(pset.getUntrackedParameter<string>("tTrigMode"),
-						pset.getUntrackedParameter<ParameterSet>("tTrigModeConfig"));
-  } else {
-    theSync = nullptr;
+    theSync = std::unique_ptr<DTTTrigBaseSync>{DTTTrigSyncFactory::get()->create(pset.getUntrackedParameter<string>("tTrigMode"),
+                                                                                 pset.getUntrackedParameter<ParameterSet>("tTrigModeConfig"))};
   }
 
   checkNoisyChannels = pset.getUntrackedParameter<bool>("checkNoisyChannels","false");
@@ -100,7 +98,6 @@ DTTTrigCalibration::~DTTTrigCalibration(){
   //   }
 
   theFile->Close();
-  delete theFitter;
 }
 
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.h
@@ -88,9 +88,9 @@ private:
   double kFactor;
 
   // The fitter
-  DTTimeBoxFitter *theFitter;
+  std::unique_ptr<DTTimeBoxFitter> theFitter;
   // The module for t0 subtraction
-  DTTTrigBaseSync *theSync;//FIXME: should be const
+  std::unique_ptr<DTTTrigBaseSync> theSync;//FIXME: should be const
 
 };
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.cc
@@ -33,18 +33,15 @@ using namespace edm;
 using namespace std;
 
 DTTTrigCorrection::DTTTrigCorrection(const ParameterSet& pset): 
-  dbLabel_( pset.getUntrackedParameter<string>("dbLabel", "") ) {
-
+  dbLabel_( pset.getUntrackedParameter<string>("dbLabel", "") ),
+  correctionAlgo_{DTTTrigCorrectionFactory::get()->create(pset.getParameter<string>("correctionAlgo"),
+                                                          pset.getParameter<ParameterSet>("correctionAlgoConfig"))}
+{
   LogVerbatim("Calibration") << "[DTTTrigCorrection] Constructor called" << endl;
-
-  // Get the concrete algo from the factory
-  string theAlgoName = pset.getParameter<string>("correctionAlgo");
-  correctionAlgo_ = DTTTrigCorrectionFactory::get()->create(theAlgoName,pset.getParameter<ParameterSet>("correctionAlgoConfig"));
 }
 
 DTTTrigCorrection::~DTTTrigCorrection(){
   LogVerbatim("Calibration") << "[DTTTrigCorrection] Destructor called" << endl;
-  delete correctionAlgo_;
 }
 
 void DTTTrigCorrection::beginRun( const edm::Run& run, const edm::EventSetup& setup ) {

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
@@ -43,7 +43,7 @@ private:
   const DTTtrig* tTrigMap_;
   edm::ESHandle<DTGeometry> muonGeom_;
 
-  dtCalibration::DTTTrigBaseCorrection* correctionAlgo_;
+  std::unique_ptr<dtCalibration::DTTTrigBaseCorrection> correctionAlgo_;
 };
 #endif
 

--- a/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.h
@@ -100,7 +100,7 @@ private:
   TFile *theFile;
 
   // The fitter
-  DTMeanTimerFitter *theFitter;
+  std::unique_ptr<DTMeanTimerFitter> theFitter;
 
   // Perform the vDrift and t0 evaluation or just fill the
   //  tMaxHists (if you read the dataset in different jobs)
@@ -116,7 +116,7 @@ private:
   //bool checkNoisyChannels;
 
   // The module for t0 subtraction
-  DTTTrigBaseSync *theSync;//FIXME: should be const
+  std::unique_ptr<DTTTrigBaseSync> theSync;//FIXME: should be const
 
   // parameter set for DTCalibrationMap constructor
   edm::ParameterSet theCalibFilePar;

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
@@ -31,22 +31,19 @@ using namespace std;
 using namespace edm;
 
 DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset):
-  granularity_( pset.getUntrackedParameter<string>("calibGranularity","bySL") ) {
+  granularity_( pset.getUntrackedParameter<string>("calibGranularity","bySL") ),
+  vDriftAlgo_{DTVDriftPluginFactory::get()->create(pset.getParameter<string>("vDriftAlgo"),
+                                                   pset.getParameter<ParameterSet>("vDriftAlgoConfig"))}
+ {
 
   LogVerbatim("Calibration") << "[DTVDriftWriter]Constructor called!";
 
   if(granularity_ != "bySL")
      throw cms::Exception("Configuration") << "[DTVDriftWriter] Check parameter calibGranularity: " << granularity_ << " option not available.";
-
-  // Get the concrete algo from the factory
-  string algoName = pset.getParameter<string>("vDriftAlgo");
-  ParameterSet algoPSet = pset.getParameter<ParameterSet>("vDriftAlgoConfig");
-  vDriftAlgo_ = DTVDriftPluginFactory::get()->create(algoName,algoPSet);
 }
 
 DTVDriftWriter::~DTVDriftWriter(){
   LogVerbatim("Calibration") << "[DTVDriftWriter]Destructor called!";
-  delete vDriftAlgo_;
 }
 
 void DTVDriftWriter::beginRun(const edm::Run& run, const edm::EventSetup& setup) {

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -37,7 +37,7 @@ private:
   const DTMtime* mTimeMap_;
   edm::ESHandle<DTGeometry> dtGeom_;
 
-  dtCalibration::DTVDriftBaseAlgo* vDriftAlgo_; 
+  std::unique_ptr<dtCalibration::DTVDriftBaseAlgo> vDriftAlgo_;
 };
 #endif
 

--- a/CalibMuon/DTCalibration/src/DTTMax.cc
+++ b/CalibMuon/DTCalibration/src/DTTMax.cc
@@ -19,7 +19,7 @@ using namespace dttmaxenums;
 using namespace DTEnums;
 
 DTTMax::InfoLayer::InfoLayer(const DTRecHit1D& rh_, const DTSuperLayer & isl, GlobalVector dir,
-			     GlobalPoint pos, DTTTrigBaseSync* sync):
+			     GlobalPoint pos, const DTTTrigBaseSync& sync):
   rh(rh_), idWire(rh.wireId()), lr(rh.lrSide()) {
     const DTLayer*  layer = isl.layer(idWire.layerId());
     LocalPoint wirePosInLayer(layer->specificTopology().wirePosition(idWire.wire()), 0, 0);
@@ -31,7 +31,7 @@ DTTMax::InfoLayer::InfoLayer(const DTRecHit1D& rh_, const DTSuperLayer & isl, Gl
     LocalPoint segPos = layer->toLocal(pos);
     LocalPoint segPosAtLayer = segPos + segDir*(-segPos.z())/cos(segDir.theta());
     LocalPoint hitPos(rh.localPosition().x() ,segPosAtLayer.y(),0.);
-    time = rh.digiTime() - sync->offset(layer, idWire, layer->toGlobal(hitPos));
+    time = rh.digiTime() - sync.offset(layer, idWire, layer->toGlobal(hitPos));
  
     if (time < 0. || time > 415.) {
       // FIXME introduce time window to reject "out-of-time" digis
@@ -41,7 +41,7 @@ DTTMax::InfoLayer::InfoLayer(const DTRecHit1D& rh_, const DTSuperLayer & isl, Gl
 
 
 DTTMax::DTTMax(const vector<DTRecHit1D>& hits, const DTSuperLayer & isl, GlobalVector dir, 
-	       GlobalPoint pos, DTTTrigBaseSync* sync):
+	       GlobalPoint pos, const DTTTrigBaseSync& sync):
   theInfoLayers(4,(InfoLayer*)nullptr), //FIXME
   theTMaxes(4,(TMax*)nullptr) 
 {

--- a/CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h
+++ b/CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h
@@ -38,11 +38,11 @@ public:
   /// the 3D hit position (globPos) 
   double offset(const DTLayer* layer,
 		const DTWireId& wireId,
-		const GlobalPoint& globalPos);
+		const GlobalPoint& globalPos) const;
 
   /// Time (ns) to be subtracted to the digi time.
   /// It does not take into account TOF and signal propagation along the wire
-  virtual double offset(const DTWireId& wireId) = 0 ;
+  virtual double offset(const DTWireId& wireId) const = 0 ;
 
 
   /// Time to be subtracted to the digi time,
@@ -58,12 +58,12 @@ public:
 			const GlobalPoint& globalPos,
 			double &tTrig,
 			double& wirePropCorr,
-			double& tofCorr) = 0;
+			double& tofCorr) const = 0;
 
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
   /// It does not take into account TOF and signal propagation along the wire
-  virtual double emulatorOffset(const DTWireId& wireId);
+  virtual double emulatorOffset(const DTWireId& wireId) const;
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
   /// It does not take into account TOF and signal propagation along the wire
@@ -72,7 +72,7 @@ public:
   ///     - t0cell is the t0 from pulses
   virtual double emulatorOffset(const DTWireId& wireId,
 				double &tTrig,
-				double &t0cell) = 0;
+				double &t0cell) const = 0;
   
 
 };

--- a/CalibMuon/DTDigiSync/src/DTTTrigBaseSync.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigBaseSync.cc
@@ -17,7 +17,7 @@ DTTTrigBaseSync::~DTTTrigBaseSync(){}
 
 double DTTTrigBaseSync::offset(const DTLayer* layer,
 			       const DTWireId& wireId,
-			       const GlobalPoint& globalPos) {
+			       const GlobalPoint& globalPos) const {
   double tTrig = 0;
   double wireProp = 0;
   double tof = 0;
@@ -26,7 +26,7 @@ double DTTTrigBaseSync::offset(const DTLayer* layer,
 
 
 
-double DTTTrigBaseSync::emulatorOffset(const DTWireId& wireId) {
+double DTTTrigBaseSync::emulatorOffset(const DTWireId& wireId) const {
 
   double tTrig = 0.;
   double t0cell = 0.;

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
@@ -75,7 +75,7 @@ double DTTTrigSyncFromDB::offset(const DTLayer* layer,
 				  const GlobalPoint& globPos,
 				  double& tTrig,
 				  double& wirePropCorr,
-				  double& tofCorr) {
+				  double& tofCorr) const {
   // Correction for the float to int conversion while writeing the ttrig in ns into an int variable
   // (half a bin on average)
   // FIXME: this should disappear as soon as the ttrig object will become a float
@@ -167,7 +167,7 @@ double DTTTrigSyncFromDB::offset(const DTLayer* layer,
     return tTrig + wirePropCorr - tofCorr;
 }
 
-double DTTTrigSyncFromDB::offset(const DTWireId& wireId) {
+double DTTTrigSyncFromDB::offset(const DTWireId& wireId) const {
   float t0 = 0;
   float t0rms = 0;
   if(doT0Correction)
@@ -200,7 +200,7 @@ double DTTTrigSyncFromDB::offset(const DTWireId& wireId) {
 
 double DTTTrigSyncFromDB::emulatorOffset(const DTWireId& wireId,
 					 double &tTrig,
-					 double &t0cell) {
+					 double &t0cell) const {
   float t0 = 0;
   float t0rms = 0;
   if(doT0Correction)

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.h
@@ -74,11 +74,11 @@ public:
 			const GlobalPoint& globPos,
 			double& tTrig,
 			double& wirePropCorr,
-			double& tofCorr) override;
+			double& tofCorr) const override;
 
   /// Time (ns) to be subtracted to the digi time.
   /// It does not take into account TOF and signal propagation along the wire
-  double offset(const DTWireId& wireId) override;
+  double offset(const DTWireId& wireId) const override;
 
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
@@ -88,7 +88,7 @@ public:
   ///     - t0cell is the t0 from pulses
   double emulatorOffset(const DTWireId& wireId,
 				double &tTrig,
-				double &t0cell) override;
+				double &t0cell) const override;
 
 
  private:

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.cc
@@ -49,7 +49,7 @@ double DTTTrigSyncT0Only::offset(const DTLayer* layer,
 				  const GlobalPoint& globPos,
 				  double& tTrig,
 				  double& wirePropCorr,
-				  double& tofCorr) {
+				  double& tofCorr) const {
   tTrig = offset(wireId);
   wirePropCorr = 0;
   tofCorr = 0;
@@ -66,7 +66,7 @@ double DTTTrigSyncT0Only::offset(const DTLayer* layer,
   return tTrig + wirePropCorr - tofCorr;
 }
 
-double DTTTrigSyncT0Only::offset(const DTWireId& wireId) {
+double DTTTrigSyncT0Only::offset(const DTWireId& wireId) const {
   float t0 = 0;
   float t0rms = 0;
   tZeroMap->get(wireId,
@@ -80,11 +80,8 @@ double DTTTrigSyncT0Only::offset(const DTWireId& wireId) {
 
 double DTTTrigSyncT0Only::emulatorOffset(const DTWireId& wireId,
 					 double &tTrig,
-					 double &t0cell) {
+					 double &t0cell) const {
   tTrig = 0.;
   t0cell = 0.;
   return 0.;
 }
-
-
-

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.h
@@ -44,15 +44,15 @@ public:
 			const GlobalPoint& globPos,
 			double& tTrig,
 			double& wirePropCorr,
-			double& tofCorr) override;
+			double& tofCorr) const override;
 
-  double offset(const DTWireId& wireId) override;
+  double offset(const DTWireId& wireId) const override;
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
   /// Returns just 0 in this implementation of the plugin
   double emulatorOffset(const DTWireId& wireId,
 				double &tTrig,
-				double &t0cell) override;
+				double &t0cell) const override;
 
 
  private:

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.cc
@@ -46,7 +46,7 @@ double DTTTrigSyncTOFCorr::offset(const DTLayer* layer,
 				  const GlobalPoint& globPos,
 				  double& tTrig,
 				  double& wirePropCorr,
-				  double& tofCorr) {
+				  double& tofCorr) const {
   tTrig = offset(wireId);
 
   //Compute the time spent in signal propagation along wire.
@@ -105,7 +105,7 @@ double DTTTrigSyncTOFCorr::offset(const DTLayer* layer,
   return tTrig + wirePropCorr - tofCorr;
 }
 
-double DTTTrigSyncTOFCorr::offset(const DTWireId& wireId) {
+double DTTTrigSyncTOFCorr::offset(const DTWireId& wireId) const {
   // Correction for the float to int conversion
   // (half a bin on average) in DTDigi constructor
   static const float f2i_convCorr = (25./64.); // ns
@@ -119,7 +119,7 @@ double DTTTrigSyncTOFCorr::offset(const DTWireId& wireId) {
 
 double DTTTrigSyncTOFCorr::emulatorOffset(const DTWireId& wireId,
 					 double &tTrig,
-					 double &t0cell) {
+					 double &t0cell) const {
   tTrig = theTTrig;
   t0cell = 0.;
 

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.h
@@ -74,9 +74,9 @@ public:
 			const GlobalPoint& globPos,
 			double& tTrig,
 			double& wirePropCorr,
-			double& tofCorr) override;
+			double& tofCorr) const override;
 
-  double offset(const DTWireId& wireId) override;
+  double offset(const DTWireId& wireId) const override;
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
   /// It does not take into account TOF and signal propagation along the wire
@@ -85,7 +85,7 @@ public:
   ///     - t0cell is the t0 from pulses (always 0 in this case)
   double emulatorOffset(const DTWireId& wireId,
 				double &tTrig,
-				double &t0cell) override;
+				double &t0cell) const override;
 
  private:
   // The fixed t_trig to be subtracted to digi time (ns)


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Also tidy up the interfaces a bit in an attempt to make `DTTTrigCalibration::theSync()` const as suggested in the comments (but didn't work out in the end).

Tested in CMSSW_10_5_X_2019-01-23-1100, no changes expected.