### PR TITLE
Remove EventSetup from PixelFitterBase-derived classes

### DIFF
--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -123,7 +123,7 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 	TripletHits[i] = &(*aSeedingRecHit);
       
       // fitting the triplet
-      std::unique_ptr<reco::Track> track = fitter.run(TripletHits, region);
+      std::unique_ptr<reco::Track> track = fitter.run(TripletHits, region, es);
       
       // decide if track should be skipped according to filter 
       if ( ! theFilter(track.get(), TripletHits) ) {

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h
@@ -17,13 +17,13 @@ class MagneticField;
 class TrackFitter : public PixelFitterBase
 {
 public:
-  TrackFitter(const edm::EventSetup *es, const TrackerGeometry *tracker,
+  TrackFitter(const TrackerGeometry *tracker,
               const MagneticField *field, const TransientTrackingRecHitBuilder *ttrhBuilder):
-    theES(es), theTracker(tracker), theField(field), theTTRecHitBuilder(ttrhBuilder)
+    theTracker(tracker), theField(field), theTTRecHitBuilder(ttrhBuilder)
   {}
   ~TrackFitter() override { }
 
-  std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region) const override;
+  std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region, const edm::EventSetup& setup) const override;
 
 private:
   float getCotThetaAndUpdateZip
@@ -35,7 +35,6 @@ private:
   void getErrTipAndErrZip(float pt, float eta,
                           float & errZip, float & errTip) const;
 
-  const edm::EventSetup *theES;
   const TrackerGeometry * theTracker;
   const MagneticField * theField;
   const TransientTrackingRecHitBuilder * theTTRecHitBuilder;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackFitterProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackFitterProducer.cc
@@ -58,8 +58,7 @@ void TrackFitterProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::
   edm::ESHandle<TransientTrackingRecHitBuilder> ttrhbESH;
   iSetup.get<TransientRecHitRecord>().get(theTTRHBuilderName, ttrhbESH);
 
-  auto impl = std::make_unique<TrackFitter>(&iSetup,
-                                            trackerESH.product(),
+  auto impl = std::make_unique<TrackFitter>(trackerESH.product(),
                                             fieldESH.product(),
                                             ttrhbESH.product());
   auto prod = std::make_unique<PixelFitter>(std::move(impl));

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/TrackFitter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/TrackFitter.cc
@@ -41,7 +41,8 @@ int getCharge
 /*****************************************************************************/
 std::unique_ptr<reco::Track> TrackFitter::run
   (const std::vector<const TrackingRecHit *> & hits,
-   const TrackingRegion & region) const
+   const TrackingRegion & region,
+   const edm::EventSetup& setup) const
 {
   std::unique_ptr<reco::Track> ret;
 
@@ -70,7 +71,7 @@ std::unique_ptr<reco::Track> TrackFitter::run
   float curvature = circle.curvature();
 
   // pt
-  float invPt = PixelRecoUtilities::inversePt(curvature, *theES);
+  float invPt = PixelRecoUtilities::inversePt(curvature, setup);
   float valPt = (invPt > 1.e-4) ? 1./invPt : 1.e4;
   float errPt = 0.055*valPt + 0.017*valPt*valPt;
 

--- a/RecoPixelVertexing/PixelTrackFitting/interface/KFBasedPixelFitter.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/KFBasedPixelFitter.h
@@ -21,13 +21,13 @@ class Propagator;
 
 class KFBasedPixelFitter : public PixelFitterBase {
 public:
-  KFBasedPixelFitter(const edm::EventSetup *es, const Propagator *propagator, const Propagator *opropagator,
+  KFBasedPixelFitter(const Propagator *propagator, const Propagator *opropagator,
                      const TransientTrackingRecHitBuilder *ttrhBuilder,
                      const TrackerGeometry *tracker, const MagneticField *field,
                      const reco::BeamSpot *beamSpot);
   ~KFBasedPixelFitter() override {}
 
-  std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region) const override;
+  std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region, const edm::EventSetup& setup) const override;
 
 private:
 
@@ -58,7 +58,6 @@ private:
     MyBeamSpotHit * clone() const override { return new MyBeamSpotHit(*this); }
   };
 
-  const edm::EventSetup *theES;
   const Propagator *thePropagator;
   const Propagator *theOPropagator;
   const TransientTrackingRecHitBuilder *theTTRHBuilder;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitter.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitter.h
@@ -12,8 +12,8 @@ public:
 
   void swap(PixelFitter& o) { std::swap(fitter_, o.fitter_); }
 
-  std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region) const {
-    return fitter_->run(hits, region);
+  std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region, const edm::EventSetup& setup) const {
+    return fitter_->run(hits, region, setup);
   }
 
 private:

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterBase.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterBase.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <memory>
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {class EventSetup;}
 class TrackingRegion;
 class TrackingRecHit;
 
@@ -16,17 +16,6 @@ public:
   virtual ~PixelFitterBase(){}
 
   virtual std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
-                                           const TrackingRegion& region) const { return std::unique_ptr<reco::Track>(); }
-
-  virtual reco::Track* run(
-      const edm::EventSetup& es,
-      const std::vector<const TrackingRecHit *>& hits,
-      const TrackingRegion& region) const { return nullptr;}
-
-  virtual reco::Track* run(
-      const edm::Event& ev,
-      const edm::EventSetup& es,
-      const std::vector<const TrackingRecHit *>& hits,
-      const TrackingRegion& region) const { return run(es,hits,region); }
+                                           const TrackingRegion& region) const = 0;
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterBase.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterBase.h
@@ -16,6 +16,7 @@ public:
   virtual ~PixelFitterBase(){}
 
   virtual std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
-                                           const TrackingRegion& region) const = 0;
+                                           const TrackingRegion& region,
+                                           const edm::EventSetup& setup) const = 0;
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByConformalMappingAndLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByConformalMappingAndLine.h
@@ -13,12 +13,12 @@ class TransientTrackingRecHitBuilder;
 
 class PixelFitterByConformalMappingAndLine : public PixelFitterBase {
 public:
-  explicit PixelFitterByConformalMappingAndLine(const edm::EventSetup *es, const TransientTrackingRecHitBuilder *ttrhBuilder, const TrackerGeometry *tracker, const MagneticField *field, double fixImpactParameter, bool useFixImpactParameter);
+  explicit PixelFitterByConformalMappingAndLine(const TransientTrackingRecHitBuilder *ttrhBuilder, const TrackerGeometry *tracker, const MagneticField *field, double fixImpactParameter, bool useFixImpactParameter);
   ~PixelFitterByConformalMappingAndLine() override { }
   std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
-                                           const TrackingRegion& region) const override;
+                                   const TrackingRegion& region,
+                                   const edm::EventSetup& setup) const override;
 private:
-  const edm::EventSetup *theES;
   const TransientTrackingRecHitBuilder *theTTRHBuilder;
   const TrackerGeometry *theTracker;
   const MagneticField *theField;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -18,10 +18,10 @@ public:
                                          bool scaleErrorsForBPix1, float scaleFactor);
   ~PixelFitterByHelixProjections() override {}
   std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
-                                           const TrackingRegion& region) const override;
+                                   const TrackingRegion& region,
+                                   const edm::EventSetup& setup) const override;
 
 private:
-  const edm::EventSetup *theES;
   const MagneticField *theField;
   const bool thescaleErrorsForBPix1;
   const float thescaleFactor;

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/KFBasedPixelFitterProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/KFBasedPixelFitterProducer.cc
@@ -83,8 +83,7 @@ void KFBasedPixelFitterProducer::produce(edm::StreamID, edm::Event& iEvent, cons
     beamspot = hbs.product();
   }
 
-  auto impl = std::make_unique<KFBasedPixelFitter>(&iSetup,
-                                                   propagator.product(),
+  auto impl = std::make_unique<KFBasedPixelFitter>(propagator.product(),
                                                    opropagator.product(),
                                                    ttrhb.product(),
                                                    tracker.product(),

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByConformalMappingAndLineProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByConformalMappingAndLineProducer.cc
@@ -61,8 +61,7 @@ void PixelFitterByConformalMappingAndLineProducer::produce(edm::StreamID, edm::E
   edm::ESHandle<MagneticField> field;
   iSetup.get<IdealMagneticFieldRecord>().get(field);
 
-  auto impl = std::make_unique<PixelFitterByConformalMappingAndLine>(&iSetup,
-                                                                     ttrhBuilder.product(),
+  auto impl = std::make_unique<PixelFitterByConformalMappingAndLine>(ttrhBuilder.product(),
                                                                      tracker.product(),
                                                                      field.product(),
                                                                      theFixImpactParameter,

--- a/RecoPixelVertexing/PixelTrackFitting/src/KFBasedPixelFitter.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/KFBasedPixelFitter.cc
@@ -75,15 +75,15 @@ AlgebraicMatrix KFBasedPixelFitter::MyBeamSpotHit::projectionMatrix() const
 }
 
 
-KFBasedPixelFitter::KFBasedPixelFitter(const edm::EventSetup *es, const Propagator *propagator, const Propagator *opropagator,
+KFBasedPixelFitter::KFBasedPixelFitter(const Propagator *propagator, const Propagator *opropagator,
                                        const TransientTrackingRecHitBuilder *ttrhBuilder,
                                        const TrackerGeometry *tracker, const MagneticField *field,
                                        const reco::BeamSpot *beamSpot):
-  theES(es), thePropagator(propagator), theOPropagator(opropagator), theTTRHBuilder(ttrhBuilder),
+  thePropagator(propagator), theOPropagator(opropagator), theTTRHBuilder(ttrhBuilder),
   theTracker(tracker), theField(field), theBeamSpot(beamSpot)
 {}
 
-std::unique_ptr<reco::Track> KFBasedPixelFitter::run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region) const {
+std::unique_ptr<reco::Track> KFBasedPixelFitter::run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region, const edm::EventSetup& setup) const {
   std::unique_ptr<reco::Track> ret;
 
   int nhits = hits.size();
@@ -108,7 +108,7 @@ std::unique_ptr<reco::Track> KFBasedPixelFitter::run(const std::vector<const Tra
   float theta;
   CircleFromThreePoints circle(points[0], points[1], points[2]);
   if (circle.curvature() > 1.e-4) {
-    float invPt = PixelRecoUtilities::inversePt( circle.curvature(), *theES);
+    float invPt = PixelRecoUtilities::inversePt( circle.curvature(), setup);
     float valPt = 1.f/invPt;
     float chargeTmp =    (points[1].x()-points[0].x())*(points[2].y()-points[1].y())
                        - (points[1].y()-points[0].y())*(points[2].x()-points[1].x()); 

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -94,10 +94,10 @@ namespace {
 }
   
 PixelFitterByHelixProjections::PixelFitterByHelixProjections(const edm::EventSetup *es,
-							     const MagneticField *field,
+                                                             const MagneticField *field,
                                                              bool scaleErrorsForBPix1,
                                                              float scaleFactor):
-  theES(es), theField(field),
+  theField(field),
   thescaleErrorsForBPix1(scaleErrorsForBPix1), thescaleFactor(scaleFactor)
 {
   //Retrieve tracker topology from geometry
@@ -108,7 +108,8 @@ PixelFitterByHelixProjections::PixelFitterByHelixProjections(const edm::EventSet
 
 std::unique_ptr<reco::Track> PixelFitterByHelixProjections::run(
     const std::vector<const TrackingRecHit * > & hits,
-    const TrackingRegion & region) const
+    const TrackingRegion & region,
+    const edm::EventSetup& setup) const
 {
   std::unique_ptr<reco::Track> ret;
 
@@ -136,8 +137,8 @@ std::unique_ptr<reco::Track> PixelFitterByHelixProjections::run(
   float curvature = circle.curvature();
 
   if ((curvature > 1.e-4)&&
-	(LIKELY(PixelRecoUtilities::fieldInInvGev(*theES)>0.01))) {
-    float invPt = PixelRecoUtilities::inversePt( circle.curvature(), *theES);
+	(LIKELY(PixelRecoUtilities::fieldInInvGev(setup)>0.01))) {
+    float invPt = PixelRecoUtilities::inversePt( circle.curvature(), setup);
     valPt = (invPt > 1.e-4f) ? 1.f/invPt : 1.e4f;
     CircleFromThreePoints::Vector2D center = circle.center();
     valTip = iCharge * (center.mag()-1.f/curvature);

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
@@ -70,7 +70,7 @@ void PixelTrackReconstruction::run(TracksWithTTRHs& tracks, edm::Event& ev, cons
       for (unsigned int iHit = 0; iHit < nHits; ++iHit) hits[iHit] = tuplet[iHit];
 
       // fitting
-      std::unique_ptr<reco::Track> track = fitter.run(hits, region);
+      std::unique_ptr<reco::Track> track = fitter.run(hits, region, es);
       if (!track) continue;
 
       if (filter) {


### PR DESCRIPTION
Pass the `EventSetup` via `run()` arguments instead.

Tested in 10_5_0_pre1, no changes expected.

@Dr15Jones 
