### PR TITLE
Use unique_ptr constructor for PluginFactory plugins in RecoLocalCalo/HGCalRecProducers

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitProducer.cc
@@ -48,13 +48,12 @@ HGCalRecHitProducer::HGCalRecHitProducer(const edm::ParameterSet& ps) :
   hebUncalibRecHitCollection_( consumes<HGChebUncalibratedRecHitCollection>( ps.getParameter<edm::InputTag>("HGCHEBuncalibRecHitCollection") ) ),
   eeRechitCollection_( ps.getParameter<std::string>("HGCEErechitCollection") ),
   hefRechitCollection_( ps.getParameter<std::string>("HGCHEFrechitCollection") ),
-  hebRechitCollection_( ps.getParameter<std::string>("HGCHEBrechitCollection") ) {  
+  hebRechitCollection_( ps.getParameter<std::string>("HGCHEBrechitCollection") ),
+  worker_{ HGCalRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps) }
+{
   produces< HGCeeRecHitCollection >(eeRechitCollection_);
   produces< HGChefRecHitCollection >(hefRechitCollection_);
   produces< HGChebRecHitCollection >(hebRechitCollection_);
-  
-  const std::string& componentType = ps.getParameter<std::string>("algo");
-  worker_.reset( HGCalRecHitWorkerFactory::get()->create(componentType, ps) );
 }
 
 HGCalRecHitProducer::~HGCalRecHitProducer() {

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
@@ -15,15 +15,13 @@ HGCalUncalibRecHitProducer::HGCalUncalibRecHitProducer(const edm::ParameterSet& 
   hebDigiCollection_( consumes<HGCalDigiCollection>( ps.getParameter<edm::InputTag>("HGCHEBdigiCollection") ) ),
   eeHitCollection_( ps.getParameter<std::string>("HGCEEhitCollection") ),
   hefHitCollection_( ps.getParameter<std::string>("HGCHEFhitCollection") ),
-  hebHitCollection_( ps.getParameter<std::string>("HGCHEBhitCollection") )
+  hebHitCollection_( ps.getParameter<std::string>("HGCHEBhitCollection") ),
+  worker_{ HGCalUncalibRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps) }
 {
 
   produces< HGCeeUncalibratedRecHitCollection >(eeHitCollection_);
   produces< HGChefUncalibratedRecHitCollection >(hefHitCollection_);
   produces< HGChebUncalibratedRecHitCollection >(hebHitCollection_);
-  
-  const std::string& componentType = ps.getParameter<std::string>("algo");
-  worker_.reset( HGCalUncalibRecHitWorkerFactory::get()->create(componentType, ps) );
 
 }
 


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-01-23-1100, no changes expected.