### PR TITLE
Changed forward declaration to struct in DBSpecToDetUnit

### DIFF
--- a/CondFormats/RPCObjects/interface/DBSpecToDetUnit.h
+++ b/CondFormats/RPCObjects/interface/DBSpecToDetUnit.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 struct ChamberLocationSpec;
-class FebLocationSpec;
+struct FebLocationSpec;
 
 class DBSpecToDetUnit {
 public:


### PR DESCRIPTION
This fixes a clang warning.