### PR TITLE
Removed unused function from writeInt.cc

### DIFF
--- a/CondCore/DBOutputService/test/stubs/writeInt.cc
+++ b/CondCore/DBOutputService/test/stubs/writeInt.cc
@@ -12,17 +12,6 @@
 typedef std::vector<int> Payload;
 
 
-namespace {
-
-  inline std::string toa(int i) {
-    std::ostringstream ss;
-    ss << i;
-    return ss.str();
-
-  }
-
-}
-
 class writeInt : public edm::EDAnalyzer {
  public:
   explicit writeInt(const edm::ParameterSet& iConfig );


### PR DESCRIPTION
This fixes a clang warning.