### PR TITLE
reconstruction - removing '//' from header include.

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -22,7 +22,7 @@
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-#include "DataFormats/EgammaReco/interface//ElectronSeed.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 //#include "DataFormats/EgammaReco/interface/SuperCluster.h"

--- a/RecoEgamma/EgammaTools/src/HGCalIsoCalculator.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalIsoCalculator.cc
@@ -6,7 +6,7 @@
  */
 
 #include "DataFormats/Math/interface/deltaR.h"
-#include "RecoEgamma/EgammaTools//interface/HGCalIsoCalculator.h"
+#include "RecoEgamma/EgammaTools/interface/HGCalIsoCalculator.h"
 
 HGCalIsoCalculator::HGCalIsoCalculator():dr2_(0.15*0.15),mindr2_(0),rechittools_(nullptr),debug_(false),nlayers_(30){
     setNRings(5);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerRatio.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerRatio.h
@@ -9,7 +9,7 @@
   */
 
 #include "RecoLocalCalo/EcalRecProducers/interface/EcalUncalibRecHitWorkerRunOneDigiBase.h"
-#include "RecoLocalCalo/EcalRecAlgos/interface//EcalUncalibRecHitRatioMethodAlgo.h"
+#include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
@@ -16,7 +16,7 @@
 
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 
-#include "CondFormats//HcalObjects/interface/HcalPFCorrs.h"
+#include "CondFormats/HcalObjects/interface/HcalPFCorrs.h"
 #include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "Geometry/CaloTopology/interface/CaloTowerConstituentsMap.h"

--- a/RecoTracker/SiTrackerMRHTools/interface/SimpleDAFHitCollector.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/SimpleDAFHitCollector.h
@@ -4,7 +4,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
-#include "RecoTracker/SiTrackerMRHTools/interface//SiTrackerMultiRecHitUpdator.h"
+#include "RecoTracker/SiTrackerMRHTools/interface/SiTrackerMultiRecHitUpdator.h"
 #include <Geometry/CommonDetUnit/interface/GeomDetType.h>
 #include <vector>
 #include <memory>

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
@@ -7,7 +7,7 @@
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
-#include "RecoLocalTracker/Records//interface/TrackerCPERecord.h"
+#include "RecoLocalTracker/Records/interface/TrackerCPERecord.h"
 
 #include <memory>
 


### PR DESCRIPTION
The // is not needed in the include path and it gives problems for LXR indexing the file.