### PR TITLE
simulation - removing '//' from header include.

### DIFF
--- a/SimG4CMS/FP420/plugins/FP420Test.cc
+++ b/SimG4CMS/FP420/plugins/FP420Test.cc
@@ -16,8 +16,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 // to retreive hits
-#include "SimG4CMS/FP420/interface//FP420NumberingScheme.h"
-#include "SimG4CMS/FP420/interface//FP420G4HitCollection.h"
+#include "SimG4CMS/FP420/interface/FP420NumberingScheme.h"
+#include "SimG4CMS/FP420/interface/FP420G4HitCollection.h"
 #include "SimG4CMS/FP420/interface/FP420Test.h"
 
 // G4 stuff


### PR DESCRIPTION
The // is not needed in the include path and it gives problems for LXR indexing the file.