### PR TITLE
alca - removing '//' from header include.

### DIFF
--- a/CondFormats/DataRecord/src/DTRecoUncertaintiesRcd.cc
+++ b/CondFormats/DataRecord/src/DTRecoUncertaintiesRcd.cc
@@ -10,7 +10,7 @@
 // Created:     Wed Feb 23 11:26:01 CET 2011
 // $Id: DTRecoUncertaintiesRcd.cc,v 1.1 2011/02/25 14:20:28 cerminar Exp $
 
-#include "CondFormats/DataRecord//interface/DTRecoUncertaintiesRcd.h"
+#include "CondFormats/DataRecord/interface/DTRecoUncertaintiesRcd.h"
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 
 EVENTSETUP_RECORD_REG(DTRecoUncertaintiesRcd);

--- a/CondFormats/DataRecord/src/DropBoxMetadataRcd.cc
+++ b/CondFormats/DataRecord/src/DropBoxMetadataRcd.cc
@@ -10,7 +10,7 @@
 // Created:     Wed Feb 23 11:26:01 CET 2011
 // $Id$
 
-#include "CondFormats/DataRecord//interface/DropBoxMetadataRcd.h"
+#include "CondFormats/DataRecord/interface/DropBoxMetadataRcd.h"
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 
 EVENTSETUP_RECORD_REG(DropBoxMetadataRcd);


### PR DESCRIPTION
The // is not needed in the include path and it gives problems for LXR indexing the file.