### PR TITLE
analysis - removing '//' from header include.

### DIFF
--- a/PhysicsTools/TagAndProbe/interface/TriggerCandProducer.h
+++ b/PhysicsTools/TagAndProbe/interface/TriggerCandProducer.h
@@ -58,5 +58,5 @@ class TriggerCandProducer : public edm::EDProducer
   bool skipEvent_;
   bool matchUnprescaledTriggerOnly_;
 };
-#include "PhysicsTools/TagAndProbe//src/TriggerCandProducer.icc"
+#include "PhysicsTools/TagAndProbe/src/TriggerCandProducer.icc"
 #endif


### PR DESCRIPTION
The // is not needed in the include path and it gives problems for LXR indexing the file.