### PR TITLE
added rootgeom dependency to fix UBSAN IBs

### DIFF
--- a/DetectorDescription/DDCMS/BuildFile.xml
+++ b/DetectorDescription/DDCMS/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="dd4hep"/>
 <use   name="rootmath"/>
+<use   name="rootgeom"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
Added dependency on rootgeom to resolve errors seen in UBSAN IBs.
```
  tmp/slc7_amd64_gcc700/src/DetectorDescription/DDCMS/src/DetectorDescriptionDDCMS/DDNamespace.cc.o:(.data.rel+0x98): 
undefined reference to `typeinfo for TGeoShape'
```