### PR TITLE
Continue migration of Geometry code to user-defined literals

### DIFF
--- a/Geometry/CSCGeometry/src/CSCLayerGeometry.cc
+++ b/Geometry/CSCGeometry/src/CSCLayerGeometry.cc
@@ -10,11 +10,14 @@
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include "DetectorDescription/Core/interface/DDUnits.h"
 
 #include <algorithm>
 #include <iostream>
-#include <cmath> // for M_PI_2 via math.h, as long as appropriate compiler flag switched on to allow acces
+
+using namespace dd;
+using namespace dd::operators;
+
 
 // Complicated initialization list since the chamber Bounds passed in must have its thickness reset to that of the layer
 // Note for half-widths, t + b = 2w and the TPB only has accessors for t and w so b = 2w - t
@@ -49,11 +52,11 @@ CSCLayerGeometry::CSCLayerGeometry( const CSCGeometry* geom, int iChamberType,
 
   if ( ! geom->realWireGeometry() ) {
     // Approximate ORCA_8_8_0 and earlier calculated geometry...
-    float wangler = wireAngleInDegrees*degree; // convert angle to radians
+    float wangler = wireAngleInDegrees * 1.0_deg; // convert angle to radians
     float wireCos = cos(wangler);
     float wireSin = sin(wangler);
     float y2 = apothem * wireCos + hBottomEdge * fabs(wireSin);
-    float wireSpacing = wg.wireSpacing/10.; // in cm
+    float wireSpacing = CONVERT_TO( wg.wireSpacing, cm );
     float wireOffset = -y2 + wireSpacing/2.;
     yOfFirstWire = wireOffset/wireCos;
   }
@@ -151,7 +154,7 @@ float CSCLayerGeometry::stripAngle(int strip) const
   // We want angle at centre of strip (strip N covers
   // *float* range N-1 to N-epsilon)
 
-  return M_PI_2 - theStripTopology->stripAngle(strip-0.5);
+  return 0.5_pi - theStripTopology->stripAngle(strip - 0.5);
 }
 
 LocalPoint CSCLayerGeometry::localCenterOfWireGroup( int wireGroup ) const {

--- a/Geometry/CSCGeometry/src/CSCWireTopology.cc
+++ b/Geometry/CSCGeometry/src/CSCWireTopology.cc
@@ -6,9 +6,12 @@
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include "DetectorDescription/Core/interface/DDUnits.h"
 
 #include <cmath>
+
+using namespace dd;
+using namespace dd::operators;
 
 CSCWireTopology::~CSCWireTopology() { 
   delete theWireGrouping;
@@ -31,13 +34,13 @@ CSCWireTopology::CSCWireTopology(
 
   const float zeroprecision = 1.E-06; // blur zero a bit, for comparisons
 
-  float wireAngleInRadians = wireAngleInDegrees*degree;
+  float wireAngleInRadians = wireAngleInDegrees * 1._deg;
 
   //@@ Conversion from mm to cm
-  float wireSpacing = wg.wireSpacing   / 10.; // in cm
-  float nw = wg.narrowWidthOfWirePlane / 10.; // in cm
-  float ww = wg.wideWidthOfWirePlane   / 10.; // in cm
-  float lw = wg.lengthOfWirePlane      / 10.; // in cm
+  float wireSpacing = CONVERT_TO( wg.wireSpacing,            cm );
+  float nw =          CONVERT_TO( wg.narrowWidthOfWirePlane, cm );
+  float ww =          CONVERT_TO( wg.wideWidthOfWirePlane,   cm );
+  float lw =          CONVERT_TO( wg.lengthOfWirePlane,      cm );
 
    LogTrace("CSCWireTopology|CSC") <<  
        "CSCWireTopology constructing CSCWireGeometry with:\n" <<

--- a/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
+++ b/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
@@ -9,6 +9,8 @@
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
+#include "DetectorDescription/Core/interface/DDUnits.h"
+
 #include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -29,10 +31,13 @@
 #include <fstream>
 #include <iomanip>
 #include <iterator>
-#include "CLHEP/Units/GlobalSystemOfUnits.h"  
 #include "TH1.h"
 #include "TH1D.h"
 #include "TProfile.h"
+
+using namespace dd;
+using namespace dd::operators;
+
 
 class CaloGeometryAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
   enum CenterOrCorner { kCenter , kCorner } ;
@@ -343,17 +348,19 @@ CaloGeometryAnalyzer::ovrTst( const CaloGeometry* cg      ,
       auto cell ( geom->getGeometry(id) ) ;
       const CaloSubdetectorGeometry* bar(cg->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
       const EcalEndcapGeometry::OrderedListOfEBDetId* ol ( eeG->getClosestBarrelCells( id ) ) ;
-      assert ( nullptr != ol ) ;
-      for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
-      {
-	 fOvr << "           " << i << "  " << (*ol)[i] ;
-	 auto  other ( bar->getGeometry((*ol)[i]) ) ;
-	 const GlobalVector cv ( cell->getPosition()-origin ) ;
-	 const GlobalVector ov ( other->getPosition()-origin ) ;
-	 const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
-	 const double angle ( 180.*acos( fabs(cosang)<1?cosang: 1 )/M_PI ) ;
-	 fOvr << ", angle = "<<angle<< std::endl ;
-      }
+      // assert ( nullptr != ol ) ;
+			if (ol != nullptr) {
+				for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
+				{
+				 fOvr << "           " << i << "  " << (*ol)[i] ;
+				 auto  other ( bar->getGeometry((*ol)[i]) ) ;
+				 const GlobalVector cv ( cell->getPosition()-origin ) ;
+				 const GlobalVector ov ( other->getPosition()-origin ) ;
+				 const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
+				 const double angle ( CONVERT_TO( acos( std::abs(cosang) < 1. ? cosang : 1. ), deg) ) ;
+				 fOvr << ", angle = "<<angle<< std::endl ;
+				}
+			}
    }
 }
 
@@ -372,17 +379,19 @@ CaloGeometryAnalyzer::ovrTst( const CaloGeometry* cg      ,
       const CaloSubdetectorGeometry* ecap(cg->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
       fOvr << "Endcap Neighbors of Barrel id = " << id << std::endl ;
       const EcalBarrelGeometry::OrderedListOfEEDetId* ol ( ebG->getClosestEndcapCells( id ) ) ;
-      assert ( nullptr != ol ) ;
-      for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
-      {
-	 fOvr << "           " << i << "  " << (*ol)[i] ;
-	 auto  other ( ecap->getGeometry((*ol)[i]) ) ;
-	 const GlobalVector cv ( cell->getPosition()-origin ) ;
-	 const GlobalVector ov ( other->getPosition()-origin ) ;
-	 const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
-	 const double angle ( 180.*acos( fabs(cosang)<1?cosang: 1 )/M_PI ) ;
-	 fOvr << ", angle = "<<angle<< std::endl ;
-      }
+      // assert ( nullptr != ol ) ;
+			if (ol != nullptr) {
+				for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
+				{
+				 fOvr << "           " << i << "  " << (*ol)[i] ;
+				 auto  other ( ecap->getGeometry((*ol)[i]) ) ;
+				 const GlobalVector cv ( cell->getPosition()-origin ) ;
+				 const GlobalVector ov ( other->getPosition()-origin ) ;
+				 const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
+				 const double angle ( CONVERT_TO( acos( std::abs(cosang) < 1. ? cosang : 1. ), deg) ) ;
+				 fOvr << ", angle = "<<angle<< std::endl ;
+				}
+			} else { fOvr << "endcap ecal ptr is null " << std::endl; }
    }      
 }
 
@@ -697,11 +706,11 @@ CaloGeometryAnalyzer::buildHcal( const CaloGeometry*       cg      ,
 	// test getCells against base class version every so often
 	if( 0 == ht.detId2denseId(closestCell)%30)
 	{
-	    cmpset( geom, gp,  2*deg ) ;
-	    cmpset( geom, gp,  5*deg ) ;
-	    cmpset( geom, gp,  7*deg ) ;
-	    cmpset( geom, gp, 25*deg ) ;
-	    cmpset( geom, gp, 45*deg ) ;
+	    cmpset( geom, gp,  2._deg ) ;
+	    cmpset( geom, gp,  5._deg ) ;
+	    cmpset( geom, gp,  7._deg ) ;
+	    cmpset( geom, gp, 25._deg ) ;
+	    cmpset( geom, gp, 45._deg ) ;
 	}
     
 	if (det == DetId::Hcal && subdetn==HcalForward) 
@@ -866,10 +875,10 @@ CaloGeometryAnalyzer::build( const CaloGeometry* cg      ,
 	    // test getCells against base class version every so often
 	    if( 0 == closestCell.hashedIndex()%100 )
 	    {
-	       cmpset( geom, gp,  2*deg ) ;
-	       cmpset( geom, gp,  5*deg ) ;
-	       cmpset( geom, gp, 25*deg ) ;
-	       cmpset( geom, gp, 45*deg ) ;
+	       cmpset( geom, gp,  2._deg ) ;
+	       cmpset( geom, gp,  5._deg ) ;
+	       cmpset( geom, gp, 25._deg ) ;
+	       cmpset( geom, gp, 45._deg ) ;
 	    }
 
 	    ovrTst( cg, geom, EBDetId(i) , fOvr ) ;
@@ -908,10 +917,10 @@ CaloGeometryAnalyzer::build( const CaloGeometry* cg      ,
 	    // test getCells against base class version every so often
 	    if( 0 == closestCell.hashedIndex()%10 )
 	    {
-	       cmpset( geom, gp,  2*deg ) ;
-	       cmpset( geom, gp,  5*deg ) ;
-	       cmpset( geom, gp, 25*deg ) ;
-	       cmpset( geom, gp, 45*deg ) ;
+	       cmpset( geom, gp,  2._deg ) ;
+	       cmpset( geom, gp,  5._deg ) ;
+	       cmpset( geom, gp, 25._deg ) ;
+	       cmpset( geom, gp, 45._deg ) ;
 	    }
 
 	    const GlobalVector xx ( 2.5,   0, 0 ) ;
@@ -1042,11 +1051,11 @@ CaloGeometryAnalyzer::build( const CaloGeometry* cg      ,
 	 // test getCells against base class version every so often
 	 if( 0 == ht.detId2denseId(closestCell)%30)
 	 {
-	    cmpset( geom, gp,  2*deg ) ;
-	    cmpset( geom, gp,  5*deg ) ;
-	    cmpset( geom, gp,  7*deg ) ;
-	    cmpset( geom, gp, 25*deg ) ;
-	    cmpset( geom, gp, 45*deg ) ;
+	    cmpset( geom, gp,  2._deg ) ;
+	    cmpset( geom, gp,  5._deg ) ;
+	    cmpset( geom, gp,  7._deg ) ;
+	    cmpset( geom, gp, 25._deg ) ;
+	    cmpset( geom, gp, 45._deg ) ;
 	 }
       }
       else if (det == DetId::Calo &&
@@ -1079,11 +1088,11 @@ CaloGeometryAnalyzer::build( const CaloGeometry* cg      ,
 	 // test getCells against base class version every so often
 	 // if( 0 == closestCell.denseIndex()%30 )
 	 {
-	    cmpset( geom, gp,  2*deg ) ;
-	    cmpset( geom, gp,  5*deg ) ;
-	    cmpset( geom, gp,  7*deg ) ;
-	    cmpset( geom, gp, 25*deg ) ;
-	    cmpset( geom, gp, 45*deg ) ;
+	    cmpset( geom, gp,  2._deg ) ;
+	    cmpset( geom, gp,  5._deg ) ;
+	    cmpset( geom, gp,  7._deg ) ;
+	    cmpset( geom, gp, 25._deg ) ;
+	    cmpset( geom, gp, 45._deg ) ;
 	 }
       }
       else if (det == DetId::Calo &&
@@ -1116,11 +1125,11 @@ CaloGeometryAnalyzer::build( const CaloGeometry* cg      ,
 	 // test getCells against base class version every so often
 	 // if( 0 == closestCell.denseIndex()%30 )
 	 {
-	    cmpset( geom, gp,  2*deg ) ;
-	    cmpset( geom, gp,  5*deg ) ;
-	    cmpset( geom, gp,  7*deg ) ;
-	    cmpset( geom, gp, 25*deg ) ;
-	    cmpset( geom, gp, 45*deg ) ;
+	    cmpset( geom, gp,  2._deg ) ;
+	    cmpset( geom, gp,  5._deg ) ;
+	    cmpset( geom, gp,  7._deg ) ;
+	    cmpset( geom, gp, 25._deg ) ;
+	    cmpset( geom, gp, 45._deg ) ;
 	 }
       }
     

--- a/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
+++ b/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
@@ -349,18 +349,18 @@ CaloGeometryAnalyzer::ovrTst( const CaloGeometry* cg      ,
       const CaloSubdetectorGeometry* bar(cg->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
       const EcalEndcapGeometry::OrderedListOfEBDetId* ol ( eeG->getClosestBarrelCells( id ) ) ;
       // assert ( nullptr != ol ) ;
-			if (ol != nullptr) {
-				for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
-				{
-				 fOvr << "           " << i << "  " << (*ol)[i] ;
-				 auto  other ( bar->getGeometry((*ol)[i]) ) ;
-				 const GlobalVector cv ( cell->getPosition()-origin ) ;
-				 const GlobalVector ov ( other->getPosition()-origin ) ;
-				 const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
-				 const double angle ( CONVERT_TO( acos( std::abs(cosang) < 1. ? cosang : 1. ), deg) ) ;
-				 fOvr << ", angle = "<<angle<< std::endl ;
-				}
-			}
+      if (ol != nullptr) {
+        for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
+        {
+         fOvr << "           " << i << "  " << (*ol)[i] ;
+         auto  other ( bar->getGeometry((*ol)[i]) ) ;
+         const GlobalVector cv ( cell->getPosition()-origin ) ;
+         const GlobalVector ov ( other->getPosition()-origin ) ;
+         const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
+         const double angle ( CONVERT_TO( acos( std::abs(cosang) < 1. ? cosang : 1. ), deg) ) ;
+         fOvr << ", angle = "<<angle<< std::endl ;
+        }
+      }
    }
 }
 
@@ -380,18 +380,18 @@ CaloGeometryAnalyzer::ovrTst( const CaloGeometry* cg      ,
       fOvr << "Endcap Neighbors of Barrel id = " << id << std::endl ;
       const EcalBarrelGeometry::OrderedListOfEEDetId* ol ( ebG->getClosestEndcapCells( id ) ) ;
       // assert ( nullptr != ol ) ;
-			if (ol != nullptr) {
-				for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
-				{
-				 fOvr << "           " << i << "  " << (*ol)[i] ;
-				 auto  other ( ecap->getGeometry((*ol)[i]) ) ;
-				 const GlobalVector cv ( cell->getPosition()-origin ) ;
-				 const GlobalVector ov ( other->getPosition()-origin ) ;
-				 const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
-				 const double angle ( CONVERT_TO( acos( std::abs(cosang) < 1. ? cosang : 1. ), deg) ) ;
-				 fOvr << ", angle = "<<angle<< std::endl ;
-				}
-			} else { fOvr << "endcap ecal ptr is null " << std::endl; }
+      if (ol != nullptr) {
+        for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
+        {
+         fOvr << "           " << i << "  " << (*ol)[i] ;
+         auto  other ( ecap->getGeometry((*ol)[i]) ) ;
+         const GlobalVector cv ( cell->getPosition()-origin ) ;
+         const GlobalVector ov ( other->getPosition()-origin ) ;
+         const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
+         const double angle ( CONVERT_TO( acos( std::abs(cosang) < 1. ? cosang : 1. ), deg) ) ;
+         fOvr << ", angle = "<<angle<< std::endl ;
+        }
+      } else { fOvr << "endcap ecal ptr is null " << std::endl; }
    }      
 }
 

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -811,21 +811,21 @@ int HcalTopology::nPhiBins(int etaRing) const {
   else if (etaRing >= firstHEDoublePhiRing())                                  lastPhiBin=doublePhiBins_;
   if (hcons_ && etaRing >= hcons_->getEtaRange(1).first && 
 	etaRing <= hcons_->getEtaRange(1).second)  {
-			return nPhiBins(HcalBarrel, etaRing);
+		return nPhiBins(HcalBarrel, etaRing);
   }
   return lastPhiBin;
 }
 
 int HcalTopology::nPhiBins(HcalSubdetector bc, int etaRing) const {
-	double phiTableVal;
+  double phiTableVal;
   if (bc == HcalForward) {
-		phiTableVal = dPhiTableHF[etaRing-firstHFRing_];
+    phiTableVal = dPhiTableHF[etaRing-firstHFRing_];
   } else {
-		phiTableVal = dPhiTable[etaRing-firstHBRing_];
-	}
-	int lastPhiBin = 0;
-	if (phiTableVal != 0.0)
-		lastPhiBin = static_cast<int>((2._pi / phiTableVal) + 0.001);
+    phiTableVal = dPhiTable[etaRing-firstHBRing_];
+  }
+  int lastPhiBin = 0;
+  if (phiTableVal != 0.0)
+    lastPhiBin = static_cast<int>((2._pi / phiTableVal) + 0.001);
   return lastPhiBin;
 }
 

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -7,7 +7,10 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalCalibDetId.h"
-#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "DetectorDescription/Core/interface/DDUnits.h"
+
+using namespace dd;
+using namespace dd::operators;
 
 static const int IPHI_MAX=72;
 
@@ -38,7 +41,7 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons,
   for (auto & i : etaBinsHE_) {
     if (firstHERing_ > i.ieta) firstHERing_ = i.ieta;
     if (lastHERing_  < i.ieta) lastHERing_  = i.ieta;
-    int unit = (int)((i.dphi+0.01)/(5.0*CLHEP::deg));
+    int unit = static_cast<int>((i.dphi / 5.0_deg) + 0.01);
     if (unit == 2 && firstHEDoublePhiRing_ > i.ieta)
       firstHEDoublePhiRing_ = i.ieta;
     if (unit == 4 && firstHEQuadPhiRing_ > i.ieta)
@@ -98,7 +101,7 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons,
       break;
     }
   }
-  const double fiveDegInRad = 2*M_PI/72;
+  const double fiveDegInRad = 5.0_deg;
   for (double k : dPhiTable) {
     int units = (int)(k/fiveDegInRad+0.5);
     unitPhi.emplace_back(units);
@@ -804,25 +807,25 @@ bool HcalTopology::decrementDepth(HcalDetId & detId) const {
 
 int HcalTopology::nPhiBins(int etaRing) const {
   int lastPhiBin=singlePhiBins_;
-  if      (etaRing>= firstHFQuadPhiRing())   lastPhiBin=doublePhiBins_/2;
-  else if (etaRing>= firstHEQuadPhiRing())   lastPhiBin=doublePhiBins_/2;
-  else if (etaRing>= firstHEDoublePhiRing()) lastPhiBin=doublePhiBins_;
-  if (hcons_) {
-    if (etaRing>=hcons_->getEtaRange(1).first && 
-	etaRing<=hcons_->getEtaRange(1).second)
-      lastPhiBin = (int)((2*M_PI+0.001)/dPhiTable[etaRing-firstHBRing_]);
+  if      (etaRing >= firstHFQuadPhiRing() || etaRing >= firstHEQuadPhiRing()) lastPhiBin=doublePhiBins_/2;
+  else if (etaRing >= firstHEDoublePhiRing())                                  lastPhiBin=doublePhiBins_;
+  if (hcons_ && etaRing >= hcons_->getEtaRange(1).first && 
+	etaRing <= hcons_->getEtaRange(1).second)  {
+			return nPhiBins(HcalBarrel, etaRing);
   }
   return lastPhiBin;
 }
 
 int HcalTopology::nPhiBins(HcalSubdetector bc, int etaRing) const {
-  static const double twopi = M_PI+M_PI;
-  int lastPhiBin;
+	double phiTableVal;
   if (bc == HcalForward) {
-    lastPhiBin = (int)((twopi+0.001)/dPhiTableHF[etaRing-firstHFRing_]);
+		phiTableVal = dPhiTableHF[etaRing-firstHFRing_];
   } else {
-    lastPhiBin = (int)((twopi+0.001)/dPhiTable[etaRing-firstHBRing_]);
-  }
+		phiTableVal = dPhiTable[etaRing-firstHBRing_];
+	}
+	int lastPhiBin = 0;
+	if (phiTableVal != 0.0)
+		lastPhiBin = static_cast<int>((2._pi / phiTableVal) + 0.001);
   return lastPhiBin;
 }
 
@@ -856,7 +859,6 @@ int HcalTopology::etaRing(HcalSubdetector bc, double abseta) const {
 }
 
 int HcalTopology::phiBin(HcalSubdetector bc, int etaring, double phi) const {
-  static const double twopi = M_PI+M_PI;
   //put phi in correct range (0->2pi)
   int index(0);
   if (bc == HcalBarrel) {
@@ -867,13 +869,15 @@ int HcalTopology::phiBin(HcalSubdetector bc, int etaring, double phi) const {
     phi  -= phioff[1];
   } else if (bc == HcalForward) {
     index = (etaring-firstHFRing_);
-    if (index < (int)(dPhiTableHF.size())) {
-      if (unitPhiHF[index] > 2) phi -= phioff[4];
-      else                      phi -= phioff[2];
+    if (index < static_cast<int>(dPhiTableHF.size())) {
+      if (index >= 0 && unitPhiHF[index] > 2) phi -= phioff[4];
+      else                                    phi -= phioff[2];
     }
   }
-  if (phi<0.0)   phi += twopi;
-  if (phi>twopi) phi -= twopi;
+	if (index < 0)
+		index = 0;
+  if (phi < 0.0)   phi += 2._pi;
+  else if (phi > 2._pi) phi -= 2._pi;
   int phibin(1), unit(1);
   if (bc == HcalForward) {
     if (index < (int)(dPhiTableHF.size())) {

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.cc
@@ -19,12 +19,15 @@
 #include <DataFormats/MuonDetId/interface/DTChamberId.h>
 #include <DataFormats/MuonDetId/interface/DTSuperLayerId.h>
 #include <DataFormats/MuonDetId/interface/DTLayerId.h>
-#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include "DetectorDescription/Core/interface/DDUnits.h"
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
 
 /* C++ Headers */
 #include <iostream>
 using namespace std;
+
+using namespace dd;
+using namespace dd::operators;
 
 /* ====================================================================== */
 
@@ -77,21 +80,27 @@ DTGeometryBuilderFromCondDB::build(const std::shared_ptr<DTGeometry>& theGeometr
   if (chamber) theGeometry->add(chamber); // add the last chamber
 }
 
+// Calling function has the responsibility to delete the allocated RectangularPlaneBounds object
+RectangularPlaneBounds* dtGeometryBuilder::getRecPlaneBounds( const std::vector<double>::const_iterator &shapeStart ) {
+  float width =     CONVERT_TO( *(shapeStart), cm );     // r-phi  dimension - different in different chambers
+  float length =    CONVERT_TO( *(shapeStart + 1), cm );    // z      dimension - constant
+  float thickness = CONVERT_TO( *(shapeStart + 2), cm );   // radial thickness - almost constant
+  return new RectangularPlaneBounds(width, length, thickness);
+}
+
+
 DTChamber* DTGeometryBuilderFromCondDB::buildChamber(const DetId& id,
                                                      const RecoIdealGeometry& rig,
 						     size_t idt ) const {
   DTChamberId detId(id);  
 
-
-  float width = (*(rig.shapeStart(idt) + 1))/cm;     // r-phi  dimension - different in different chambers
-  float length = (*(rig.shapeStart(idt) + 2))/cm;    // z      dimension - constant 125.55 cm
-  float thickness = (*(rig.shapeStart(idt) + 3))/cm; // radial thickness - almost constant about 18 cm
-
   ///SL the definition of length, width, thickness depends on the local reference frame of the Det
   // width is along local X
   // length is along local Y
-  // thickness is long local Z
-  RCPPlane surf(plane(rig.tranStart(idt), rig.rotStart(idt), new RectangularPlaneBounds(width, length, thickness) ));
+  // length z      dimension - constant 125.55 cm
+  // thickness is along local Z
+  // radial thickness - almost constant about 18 cm
+  RCPPlane surf(plane(rig.tranStart(idt), rig.rotStart(idt), dtGeometryBuilder::getRecPlaneBounds(++rig.shapeStart(idt))));
 
   DTChamber* chamber = new DTChamber(detId, surf);
 
@@ -106,12 +115,12 @@ DTGeometryBuilderFromCondDB::buildSuperLayer(DTChamber* chamber,
 
   DTSuperLayerId slId(id);
 
-  float width = (*(rig.shapeStart(idt) + 1))/cm;     // r-phi  dimension - different in different chambers
-  float length = (*(rig.shapeStart(idt) + 2))/cm;    // z      dimension - constant 126.8 cm
-  float thickness = (*(rig.shapeStart(idt) + 3))/cm; // radial thickness - almost constant about 5 cm
+  // r-phi  dimension - different in different chambers
+  // z      dimension - constant 126.8 cm
+  // radial thickness - almost constant about 5 cm
 
   // Ok this is the slayer position...
-  RCPPlane surf(plane(rig.tranStart(idt), rig.rotStart(idt), new RectangularPlaneBounds(width, length, thickness) ));
+  RCPPlane surf(plane(rig.tranStart(idt), rig.rotStart(idt), dtGeometryBuilder::getRecPlaneBounds(++rig.shapeStart(idt))));
 
   DTSuperLayer* slayer = new DTSuperLayer(slId, surf, chamber);
 
@@ -130,18 +139,19 @@ DTGeometryBuilderFromCondDB::buildLayer(DTSuperLayer* sl,
   DTLayerId layId(id);
 
   // Layer specific parameter (size)
-  float width = (*(rig.shapeStart(idt) + 1))/cm;     // r-phi  dimension - changes in different chambers
-  float length = (*(rig.shapeStart(idt) + 2))/cm;    // z      dimension - constant 126.8 cm
-  float thickness = (*(rig.shapeStart(idt) + 3))/cm; // radial thickness - almost constant about 20 cm
+  // r-phi  dimension - different in different chambers
+  // z      dimension - constant 126.8 cm
+  // radial thickness - almost constant about 20 cm
 
 
-  RCPPlane surf(plane(rig.tranStart(idt), rig.rotStart(idt), new RectangularPlaneBounds(width, length, thickness) ));
+  auto shapeStartPtr = rig.shapeStart(idt);
+  RCPPlane surf(plane(rig.tranStart(idt), rig.rotStart(idt), dtGeometryBuilder::getRecPlaneBounds((shapeStartPtr + 1))));
 
   // Loop on wires
-  int firstWire=int(*(rig.shapeStart(idt) + 4 ));//par[4]);
-  int WCounter=int(*(rig.shapeStart(idt) + 5 ));//par[5]);
-  double sensibleLenght=(*(rig.shapeStart(idt) + 6 ))/cm;//par[6]/cm;
-  DTTopology topology(firstWire, WCounter, sensibleLenght);
+  int firstWire = static_cast<int>(*(shapeStartPtr + 4 )); //par[4]);
+  int WCounter = static_cast<int>(*(shapeStartPtr  + 5 )); //par[5]);
+  double sensibleLength = CONVERT_TO( *(shapeStartPtr  + 6 ), cm ); //par[6] in cm;
+  DTTopology topology(firstWire, WCounter, sensibleLength);
 
   DTLayerType layerType;
 

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.h
@@ -23,10 +23,17 @@ class DTSuperLayer;
 class DTLayer;
 class DetId;
 #include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 
 /* C++ Headers */
 #include <memory>
 #include <vector>
+
+
+namespace dtGeometryBuilder {
+    RectangularPlaneBounds* getRecPlaneBounds( const std::vector<double>::const_iterator &shapeStart );
+}
+
 
 /* ====================================================================== */
 
@@ -45,6 +52,7 @@ class DTGeometryBuilderFromCondDB{
 /* Operations */ 
     void build(const std::shared_ptr<DTGeometry>& theGeometry,
                const RecoIdealGeometry& rig);
+
 
   private:
     DTChamber* buildChamber(const DetId& id,

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
@@ -11,11 +11,11 @@
 #include <DetectorDescription/Core/interface/DDFilter.h>
 #include <DetectorDescription/Core/interface/DDFilteredView.h>
 #include <DetectorDescription/Core/interface/DDSolid.h>
+#include "DetectorDescription/Core/interface/DDUnits.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDNumbering.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/DTNumberingScheme.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
 
 
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
@@ -23,6 +23,8 @@
 #include <string>
 
 using namespace std;
+using namespace dd;
+using namespace dd::operators;
 
 #include <string>
 #include <utility>
@@ -55,7 +57,6 @@ void DTGeometryBuilderFromDDD::build(DTGeometry& theGeometry,
 void DTGeometryBuilderFromDDD::buildGeometry(DTGeometry& theGeometry,
                                              DDFilteredView& fv,
                                              const MuonDDDConstants& muonConstants) const {
-
   bool doChamber = fv.firstChild();
 
   // Loop on chambers
@@ -113,16 +114,13 @@ DTChamber* DTGeometryBuilderFromDDD::buildChamber(DDFilteredView& fv,
   // FIXME: some trouble for boolean solids?
   vector<double> par = extractParameters(fv);
 
-  float width = par[0]/cm;     // r-phi  dimension - different in different chambers
-  float length = par[1]/cm;    // z      dimension - constant 125.55 cm
-  float thickness = par[2]/cm; // radial thickness - almost constant about 18 cm
-
   ///SL the definition of length, width, thickness depends on the local reference frame of the Det
-  // width is along local X
-  // length is along local Y
-  // thickness is long local Z
+  // width is along local X. r-phi  dimension - different in different chambers
+  // length is along local Y. z      dimension - constant 125.55 cm
+  // thickness is long local Z. radial thickness - almost constant about 18 cm
 
-  RCPPlane surf(plane(fv, new RectangularPlaneBounds(width, length, thickness) ));
+
+  RCPPlane surf(plane(fv, dtGeometryBuilder::getRecPlaneBounds(par.begin())));
 
   DTChamber* chamber = new DTChamber(detId, surf);
 
@@ -142,12 +140,12 @@ DTSuperLayer* DTGeometryBuilderFromDDD::buildSuperLayer(DDFilteredView& fv,
   // Slayer specific parameter (size)
   vector<double> par = extractParameters(fv);
 
-  float width = par[0]/cm;     // r-phi  dimension - changes in different chambers
-  float length = par[1]/cm;    // z      dimension - constant 126.8 cm
-  float thickness = par[2]/cm; // radial thickness - almost constant about 20 cm
+  // r-phi  dimension - different in different chambers
+  // z      dimension - constant 126.8 cm
+  // radial thickness - almost constant about 20 cm
 
-  // Ok this is the slayer position...
-  RCPPlane surf(plane(fv, new RectangularPlaneBounds(width, length, thickness) ));
+  // Ok this is the s-layer position...
+  RCPPlane surf(plane(fv, dtGeometryBuilder::getRecPlaneBounds(par.begin())));
 
   DTSuperLayer* slayer = new DTSuperLayer(slId, surf, chamber);
 
@@ -172,18 +170,18 @@ DTLayer* DTGeometryBuilderFromDDD::buildLayer(DDFilteredView& fv,
 
   // Layer specific parameter (size)
   vector<double> par = extractParameters(fv);
-  float width = par[0]/cm;     // r-phi  dimension - changes in different chambers
-  float length = par[1]/cm;    // z      dimension - constant 126.8 cm
-  float thickness = par[2]/cm; // radial thickness - almost constant about 20 cm
+  // width -- r-phi  dimension - different in different chambers
+  // length -- z      dimension - constant 126.8 cm
+  // thickness -- radial thickness - almost constant about 20 cm
 
-  RCPPlane surf(plane(fv, new RectangularPlaneBounds(width, length, thickness) ));
+  RCPPlane surf(plane(fv, dtGeometryBuilder::getRecPlaneBounds(par.begin())));
 
   // Loop on wires
   bool doWire = fv.firstChild();
   int WCounter=0;
   int firstWire=fv.copyno();
   par = extractParameters(fv);
-  float wireLength = par[1]/cm;
+  float wireLength = CONVERT_TO( par[1], cm );
   while (doWire) {
     WCounter++;
     doWire = fv.nextSibling(); // next wire
@@ -222,15 +220,13 @@ DTGeometryBuilderFromDDD::plane(const DDFilteredView& fv,
   // extract the position
   const DDTranslation & trans(fv.translation());
 
-  const Surface::PositionType posResult(float(trans.x()/cm), 
-                                        float(trans.y()/cm), 
-                                        float(trans.z()/cm));
+  const Surface::PositionType posResult(float(CONVERT_TO( trans.x(), cm )), 
+                                        float(CONVERT_TO( trans.y(), cm )), 
+                                        float(CONVERT_TO( trans.z(), cm ))); 
+  LogTrace("DTGeometryBuilderFromDDD") << "DTGeometryBuilderFromDDD::plane " <<" posResult: "
+		<< posResult << std::endl;
   // now the rotation
-  //  DDRotationMatrix tmp = fv.rotation();
-  // === DDD uses 'active' rotations - see CLHEP user guide ===
-  //     ORCA uses 'passive' rotation. 
   //     'active' and 'passive' rotations are inverse to each other
-  //  DDRotationMatrix tmp = fv.rotation();
   const DDRotationMatrix& rotation = fv.rotation();//REMOVED .Inverse();
   DD3Vector x, y, z;
   rotation.GetComponents(x,y,z);

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.h
@@ -10,6 +10,7 @@
  */
 
 #include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 
 #include <vector>
 
@@ -21,6 +22,11 @@ class DTSuperLayer;
 class DTLayer;
 class Bounds;
 class MuonDDDConstants;
+
+namespace dtGeometryBuilder {
+	// Helper function from DTGeometryBuilderFromCondDB.cc
+  RectangularPlaneBounds* getRecPlaneBounds( const std::vector<double>::const_iterator &shapeStart );
+}
 
 class DTGeometryBuilderFromDDD {
   public:

--- a/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
@@ -16,18 +16,15 @@
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/DTNumberingScheme.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
-
-
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
+#include "DetectorDescription/Core/interface/DDUnits.h"
 
 #include <string>
 
 using namespace std;
 
-#include <string>
-
-using namespace std;
+using namespace dd;
+using namespace dd::operators;
 
 DTGeometryParsFromDD::DTGeometryParsFromDD() {}
 
@@ -212,16 +209,12 @@ DTGeometryParsFromDD::plane(const DDFilteredView& fv) const {
   const DDTranslation & trans(fv.translation());
 
   std::vector<double> gtran( 3 );
-  gtran[0] = (float) 1.0 * (trans.x() / cm);
-  gtran[1] = (float) 1.0 * (trans.y() / cm);
-  gtran[2] = (float) 1.0 * (trans.z() / cm);
+  gtran[0] = CONVERT_TO( trans.x(), cm );
+  gtran[1] = CONVERT_TO( trans.y(), cm );
+  gtran[2] = CONVERT_TO( trans.z(), cm );
 
   // now the rotation
-  //  DDRotationMatrix tmp = fv.rotation();
-  // === DDD uses 'active' rotations - see CLHEP user guide ===
-  //     ORCA uses 'passive' rotation. 
   //     'active' and 'passive' rotations are inverse to each other
-  //  DDRotationMatrix tmp = fv.rotation();
   const DDRotationMatrix& rotation = fv.rotation();//REMOVED .Inverse();
   DD3Vector x, y, z;
   rotation.GetComponents(x,y,z);
@@ -232,17 +225,17 @@ DTGeometryParsFromDD::plane(const DDFilteredView& fv) const {
 // 	    << z.X() << ", " << z.Y() << ", " << z.Z() << std::endl;
 
   std::vector<double> grmat( 9 );
-  grmat[0] = (float) 1.0 * x.X();
-  grmat[1] = (float) 1.0 * x.Y();
-  grmat[2] = (float) 1.0 * x.Z();
+  grmat[0] = x.X();
+  grmat[1] = x.Y();
+  grmat[2] = x.Z();
 
-  grmat[3] = (float) 1.0 * y.X();
-  grmat[4] = (float) 1.0 * y.Y();
-  grmat[5] = (float) 1.0 * y.Z();
+  grmat[3] = y.X();
+  grmat[4] = y.Y();
+  grmat[5] = y.Z();
 
-  grmat[6] = (float) 1.0 * z.X();
-  grmat[7] = (float) 1.0 * z.Y();
-  grmat[8] = (float) 1.0 * z.Z();
+  grmat[6] = z.X();
+  grmat[7] = z.Y();
+  grmat[8] = z.Z();
 
 //   std::cout << "rotation by its own operator: "<< tmp << std::endl;
 //   DD3Vector tx, ty,tz;


### PR DESCRIPTION
Continue migration of Geometry files from using CLHEP/Units/GlobalSystemOfUnits.h to using CMS user-defined literals. These changes should improve performance slightly by eliminating unnecessary multiplications but should otherwise have no effect on program behavior or outputs.