### PR TITLE
Use unique_ptr constructor for PluginFactory plugin in RecoLocalFastTime/FTLRecProducers

### DIFF
--- a/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc
@@ -42,11 +42,11 @@ FTLRecHitProducer::FTLRecHitProducer(const edm::ParameterSet& ps) :
 
   const edm::ParameterSet& barrel = ps.getParameterSet("barrel");
   const std::string& barrelAlgo = barrel.getParameter<std::string>("algoName");
-  barrel_.reset( FTLRecHitAlgoFactory::get()->create(barrelAlgo, barrel, sumes) );
+  barrel_ = std::unique_ptr<FTLRecHitAlgoBase>{ FTLRecHitAlgoFactory::get()->create(barrelAlgo, barrel, sumes) };
 
   const edm::ParameterSet& endcap = ps.getParameterSet("endcap");
   const std::string& endcapAlgo = endcap.getParameter<std::string>("algoName");
-  endcap_.reset( FTLRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes) );
+  endcap_ = std::unique_ptr<FTLRecHitAlgoBase>{ FTLRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes) };
 }
 
 FTLRecHitProducer::~FTLRecHitProducer() {

--- a/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc
@@ -42,11 +42,11 @@ FTLUncalibratedRecHitProducer::FTLUncalibratedRecHitProducer(const edm::Paramete
 
   const edm::ParameterSet& barrel = ps.getParameterSet("barrel");
   const std::string& barrelAlgo = barrel.getParameter<std::string>("algoName");
-  barrel_.reset( FTLUncalibratedRecHitAlgoFactory::get()->create(barrelAlgo, barrel, sumes) );
+  barrel_ = std::unique_ptr<FTLUncalibratedRecHitAlgoBase>{ FTLUncalibratedRecHitAlgoFactory::get()->create(barrelAlgo, barrel, sumes) };
 
   const edm::ParameterSet& endcap = ps.getParameterSet("endcap");
   const std::string& endcapAlgo = endcap.getParameter<std::string>("algoName");
-  endcap_.reset( FTLUncalibratedRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes) );
+  endcap_ = std::unique_ptr<FTLUncalibratedRecHitAlgoBase>{ FTLUncalibratedRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes) };
 }
 
 FTLUncalibratedRecHitProducer::~FTLUncalibratedRecHitProducer() {

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDRecHitProducer.cc
@@ -53,11 +53,11 @@ MTDRecHitProducer::MTDRecHitProducer(const edm::ParameterSet& ps) :
 
   const edm::ParameterSet& barrel = ps.getParameterSet("barrel");
   const std::string& barrelAlgo = barrel.getParameter<std::string>("algoName");
-  barrel_.reset( MTDRecHitAlgoFactory::get()->create(barrelAlgo, barrel, sumes) );
+  barrel_ = std::unique_ptr<MTDRecHitAlgoBase>{ MTDRecHitAlgoFactory::get()->create(barrelAlgo, barrel, sumes) };
   
   const edm::ParameterSet& endcap = ps.getParameterSet("endcap");
   const std::string& endcapAlgo = endcap.getParameter<std::string>("algoName");
-  endcap_.reset( MTDRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes) );
+  endcap_ = std::unique_ptr<MTDRecHitAlgoBase>{ MTDRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes) };
 
 }
 

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDUncalibratedRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDUncalibratedRecHitProducer.cc
@@ -43,11 +43,11 @@ MTDUncalibratedRecHitProducer::MTDUncalibratedRecHitProducer(const edm::Paramete
 
   const edm::ParameterSet& barrel = ps.getParameterSet("barrel");
   const std::string& barrelAlgo = barrel.getParameter<std::string>("algoName");
-  barrel_.reset( BTLUncalibratedRecHitAlgoFactory::get()->create(barrelAlgo, barrel, sumes) );
+  barrel_ = std::unique_ptr<BTLUncalibratedRecHitAlgoBase>{ BTLUncalibratedRecHitAlgoFactory::get()->create(barrelAlgo, barrel, sumes) };
 
   const edm::ParameterSet& endcap = ps.getParameterSet("endcap");
   const std::string& endcapAlgo = endcap.getParameter<std::string>("algoName");
-  endcap_.reset( ETLUncalibratedRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes) );
+  endcap_ = std::unique_ptr<ETLUncalibratedRecHitAlgoBase>{ ETLUncalibratedRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes) };
 }
 
 MTDUncalibratedRecHitProducer::~MTDUncalibratedRecHitProducer() {


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested inCMSSW_10_5_X_2019-02-05-1100 , no changes expected.