### PR TITLE
Use unique_ptr constructor for PluginFactory plugins  in L1Trigger/L1THGCal

### DIFF
--- a/L1Trigger/L1THGCal/plugins/HGCalBackendLayer1Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendLayer1Producer.cc
@@ -43,8 +43,7 @@ input_cell_(consumes<l1t::HGCalTriggerCellBxCollection>(conf.getParameter<edm::I
   //setup Backend parameters
   const edm::ParameterSet& beParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& beProcessorName = beParamConfig.getParameter<std::string>("ProcessorName");
-  HGCalBackendLayer1ProcessorBase* beProc = HGCalBackendLayer1Factory::get()->create(beProcessorName, beParamConfig);
-  backendProcess_.reset(beProc);
+  backendProcess_ = std::unique_ptr<HGCalBackendLayer1ProcessorBase>{HGCalBackendLayer1Factory::get()->create(beProcessorName, beParamConfig)};
 
   produces<l1t::HGCalClusterBxCollection>(backendProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalBackendLayer2Producer.cc
@@ -43,8 +43,7 @@ HGCalBackendLayer2Producer(const edm::ParameterSet& conf):
   //setup Backend parameters
   const edm::ParameterSet& beParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& beProcessorName = beParamConfig.getParameter<std::string>("ProcessorName");
-  HGCalBackendLayer2ProcessorBase* beProc = HGCalBackendLayer2Factory::get()->create(beProcessorName, beParamConfig);
-  backendProcess_.reset(beProc);
+  backendProcess_ = std::unique_ptr<HGCalBackendLayer2ProcessorBase>{HGCalBackendLayer2Factory::get()->create(beProcessorName, beParamConfig)};
 
   produces<l1t::HGCalMulticlusterBxCollection>(backendProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalConcentratorProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalConcentratorProducer.cc
@@ -43,8 +43,7 @@ HGCalConcentratorProducer(const edm::ParameterSet& conf):
   //setup Concentrator parameters
   const edm::ParameterSet& concParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& concProcessorName = concParamConfig.getParameter<std::string>("ProcessorName");
-  HGCalConcentratorProcessorBase* concProc = HGCalConcentratorFactory::get()->create(concProcessorName, concParamConfig);
-  concentratorProcess_.reset(concProc);
+  concentratorProcess_ = std::unique_ptr<HGCalConcentratorProcessorBase>{HGCalConcentratorFactory::get()->create(concProcessorName, concParamConfig)};
 
   produces<l1t::HGCalTriggerCellBxCollection>(concentratorProcess_->name());
   produces<l1t::HGCalTriggerSumsBxCollection>(concentratorProcess_->name());

--- a/L1Trigger/L1THGCal/plugins/HGCalTowerMapProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTowerMapProducer.cc
@@ -41,8 +41,7 @@ HGCalTowerMapProducer(const edm::ParameterSet& conf):
   //setup TowerMap parameters
   const edm::ParameterSet& towerMapParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& towerMapProcessorName = towerMapParamConfig.getParameter<std::string>("ProcessorName");
-  HGCalTowerMapProcessorBase* towerMapProc = HGCalTowerMapFactory::get()->create(towerMapProcessorName, towerMapParamConfig);
-  towersMapProcess_.reset(towerMapProc);
+  towersMapProcess_ = std::unique_ptr<HGCalTowerMapProcessorBase>{HGCalTowerMapFactory::get()->create(towerMapProcessorName, towerMapParamConfig)};
   
   produces<l1t::HGCalTowerMapBxCollection>(towersMapProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalTowerProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTowerProducer.cc
@@ -41,8 +41,7 @@ HGCalTowerProducer(const edm::ParameterSet& conf):
   //setup TowerMap parameters
   const edm::ParameterSet& towerParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& towerProcessorName = towerParamConfig.getParameter<std::string>("ProcessorName");
-  HGCalTowerProcessorBase* towerProc = HGCalTowerFactory::get()->create(towerProcessorName, towerParamConfig);
-  towersProcess_.reset(towerProc);
+  towersProcess_ = std::unique_ptr<HGCalTowerProcessorBase>{HGCalTowerFactory::get()->create(towerProcessorName, towerParamConfig)};
   
   produces<l1t::HGCalTowerBxCollection>(towersProcess_->name());
 }

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
@@ -42,14 +42,13 @@ DEFINE_FWK_MODULE(HGCalTriggerDigiFEReproducer);
 /*****************************************************************/
 HGCalTriggerDigiFEReproducer::HGCalTriggerDigiFEReproducer(const edm::ParameterSet& conf):
     inputdigi_(consumes<l1t::HGCFETriggerDigiCollection>(conf.getParameter<edm::InputTag>("feDigis"))), 
-    backEndProcessor_(new HGCalTriggerBackendProcessor(conf.getParameterSet("BEConfiguration"), consumesCollector())) 
+    backEndProcessor_(std::make_unique<HGCalTriggerBackendProcessor>(conf.getParameterSet("BEConfiguration"), consumesCollector()))
 /*****************************************************************/
 {
     //setup FE codec
     const edm::ParameterSet& feCodecConfig =  conf.getParameterSet("FECodec");
     const std::string& feCodecName = feCodecConfig.getParameter<std::string>("CodecName");
-    HGCalTriggerFECodecBase* codec = HGCalTriggerFECodecFactory::get()->create(feCodecName,feCodecConfig);
-    codec_.reset(codec);
+    codec_ = std::unique_ptr<HGCalTriggerFECodecBase>{HGCalTriggerFECodecFactory::get()->create(feCodecName,feCodecConfig)};
     codec_->unSetDataPayload();
 
     produces<l1t::HGCFETriggerDigiCollection>();

--- a/L1Trigger/L1THGCal/plugins/HGCalVFEProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalVFEProducer.cc
@@ -46,8 +46,7 @@ HGCalVFEProducer(const edm::ParameterSet& conf):
   //setup VFE parameters
   const edm::ParameterSet& vfeParamConfig = conf.getParameterSet("ProcessorParameters");
   const std::string& vfeProcessorName = vfeParamConfig.getParameter<std::string>("ProcessorName");
-  HGCalVFEProcessorBase* vfeProc = HGCalVFEProcessorBaseFactory::get()->create(vfeProcessorName, vfeParamConfig);
-  vfeProcess_.reset(vfeProc);
+  vfeProcess_ = std::unique_ptr<HGCalVFEProcessorBase>{HGCalVFEProcessorBaseFactory::get()->create(vfeProcessorName, vfeParamConfig)};
   
   produces<l1t::HGCalTriggerCellBxCollection>(vfeProcess_->name());
   produces<l1t::HGCalTriggerSumsBxCollection>(vfeProcess_->name());

--- a/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
+++ b/L1Trigger/L1THGCal/plugins/ntuples/HGCalTriggerNtupleHGCMulticlusters.cc
@@ -64,7 +64,7 @@ HGCalTriggerNtupleHGCMulticlusters::
 initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
 {
   multiclusters_token_ = collector.consumes<l1t::HGCalMulticlusterBxCollection>(conf.getParameter<edm::InputTag>("Multiclusters"));
-  id_.reset( HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT") );
+  id_ = std::unique_ptr<HGCalTriggerClusterIdentificationBase>{ HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT") };
   id_->initialize(conf.getParameter<edm::ParameterSet>("EGIdentification")); 
 
   tree.Branch("cl3d_n", &cl3d_n_, "cl3d_n/I");

--- a/L1Trigger/L1THGCal/src/HGCalTriggerBackendProcessor.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerBackendProcessor.cc
@@ -7,9 +7,7 @@ HGCalTriggerBackendProcessor(const edm::ParameterSet& conf, edm::ConsumesCollect
   for( const auto& algo_cfg : be_confs ) {
     const std::string& algo_name = 
       algo_cfg.getParameter<std::string>("AlgorithmName");
-    HGCalTriggerBackendAlgorithmBase* algo = 
-      HGCalTriggerBackendAlgorithmFactory::get()->create(algo_name,algo_cfg,cc);
-    algorithms_.emplace_back(algo);
+    algorithms_.emplace_back(HGCalTriggerBackendAlgorithmFactory::get()->create(algo_name,algo_cfg,cc));
   }
 }
 

--- a/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringHistoImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringHistoImpl.cc
@@ -32,7 +32,7 @@ HGCalMulticlusteringHistoImpl::HGCalMulticlusteringHistoImpl( const edm::Paramet
     <<"\nMulticluster MIPT threshold for histo threshold algorithm: " << histoThreshold_
     <<"\nMulticluster type of multiclustering algortihm: " << multiclusterAlgoType_;
 
-    id_.reset( HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT") );
+    id_ = std::unique_ptr<HGCalTriggerClusterIdentificationBase>{ HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT") };
     id_->initialize(conf.getParameter<edm::ParameterSet>("EGIdentification"));
     if(multiclusterAlgoType_.find("Histo")!=std::string::npos && nBinsRHisto_!=binsSumsHisto_.size()){
       throw cms::Exception("Inconsistent bin size") <<  "Inconsistent nBins_R_histo_multicluster ( " << nBinsRHisto_ << " ) and binSumsHisto ( " << binsSumsHisto_.size() << " ) size in HGCalMulticlustering\n";

--- a/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalMulticlusteringImpl.cc
@@ -15,7 +15,7 @@ HGCalMulticlusteringImpl::HGCalMulticlusteringImpl( const edm::ParameterSet& con
     edm::LogInfo("HGCalMulticlusterParameters") << "Multicluster DBSCAN Clustering distance: " << distDbscan_;
     edm::LogInfo("HGCalMulticlusterParameters") << "Multicluster clustering min number of subclusters: " << minNDbscan_;
     edm::LogInfo("HGCalMulticlusterParameters") << "Multicluster type of multiclustering algortihm: " << multiclusterAlgoType_;
-    id_.reset( HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT") );
+    id_ = std::unique_ptr<HGCalTriggerClusterIdentificationBase>{ HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT") };
     id_->initialize(conf.getParameter<edm::ParameterSet>("EGIdentification")); 
 }
 


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.