### PR TITLE
Remove bool cluster argument to fix warning

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
@@ -94,10 +94,10 @@ namespace Rivet {
         // photons from hadrons are vetoed by the PromptFinalState;
         // will be default DressedLeptons behaviour for Rivet >= 2.5.4
         DressedLeptons dressed_leptons(prompt_photons, prompt_leptons, _lepConeSize, 
-                       lepton_cut, /*cluster*/ true, /*useDecayPhotons*/ true);
+                       lepton_cut, /*useDecayPhotons*/ true);
         if (not _usePromptFinalStates)
           dressed_leptons = DressedLeptons(photons, charged_leptons, _lepConeSize, 
-                            lepton_cut, /*cluster*/ true, /*useDecayPhotons*/ true);
+                            lepton_cut, /*useDecayPhotons*/ true);
         addProjection(dressed_leptons, "DressedLeptons");
         
         // Photons


### PR DESCRIPTION
Remove argument as suggested here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc700/CMSSW_10_5_X_2019-02-05-1100/GeneratorInterface/RivetInterface
New warnings makes sense as we updated Rivet on 05.02.19 (yesterday)