### PR TITLE
Ecal : to dump the tags based on EcalSimPulseShapeRcd

### DIFF
--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -87,6 +87,7 @@ PAYLOAD_2XML_MODULE( pluginUtilities_payload2xml ){
   PAYLOAD_2XML_CLASS( EcalSRSettings );
   PAYLOAD_2XML_CLASS( EcalSampleMask );
   PAYLOAD_2XML_CLASS( EcalSamplesCorrelation );
+  PAYLOAD_2XML_CLASS( EcalSimPulseShape );
   PAYLOAD_2XML_CLASS( EcalTBWeights );
   PAYLOAD_2XML_CLASS( EcalTPGFineGrainEBGroup );
   PAYLOAD_2XML_CLASS( EcalTPGFineGrainEBIdMap );

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -188,6 +188,7 @@
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightGroup.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightIdMap.h"
 #include "CondFormats/EcalObjects/interface/EcalWeightXtalGroups.h"
+#include "CondFormats/EcalObjects/interface/EcalSimPulseShape.h"
 #include "CondFormats/Common/interface/FileBlob.h"
 //#include "CondFormats/GeometryObjects/interface/GeometryFile.h"
 #include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"

--- a/CondTools/Ecal/interface/XMLTags.h
+++ b/CondTools/Ecal/interface/XMLTags.h
@@ -58,6 +58,7 @@ namespace xuti{
   const std::string rms1_tag("rms_x1");
    
   const std::string PulseShapes_tag("EcalPulseShapes");
+  const std::string SimPulseShape_tag("EcalSimPulseShape");
   const std::string sample0_tag("sample_0");
   const std::string sample1_tag("sample_1");
   const std::string sample2_tag("sample_2");


### PR DESCRIPTION
This recent record didn't have the method to dump the tags.