### PR TITLE
Impoved edm::ESGetToken

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -161,13 +161,7 @@ namespace edm {
     template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
     auto esConsumes(ESInputTag const& tag)
     {
-      return ESGetTokenT<ESProduct>{tag};
-    }
-
-    template <typename ESProduct, Transition Tr = Transition::Event>
-    auto esConsumes(eventsetup::EventSetupRecordKey const&, ESInputTag const& tag)
-    {
-      return ESGetTokenT<ESProduct>{tag};
+      return ESGetToken<ESProduct, ESRecord>{tag};
     }
 
   private:

--- a/FWCore/Framework/interface/ESConsumesCollector.h
+++ b/FWCore/Framework/interface/ESConsumesCollector.h
@@ -46,7 +46,7 @@ namespace edm {
 
     // ---------- member functions ---------------------------
     template <typename Product, typename Record>
-    auto consumes(ESInputTag const& tag) {
+    auto consumesFrom(ESInputTag const& tag) {
       return ESGetToken<Product,Record>{tag};
     }
 
@@ -72,11 +72,10 @@ namespace edm {
     ESConsumesCollectorT<RECORD>& operator=(ESConsumesCollectorT<RECORD>&&) = default;
     
     // ---------- member functions ---------------------------
-    using ESConsumesCollector::consumes;
     
     template <typename Product>
     auto consumes(ESInputTag const& tag) {
-      return consumes<Product, RECORD>(tag);
+      return consumesFrom<Product, RECORD>(tag);
     }
     
   private:

--- a/FWCore/Framework/interface/ESConsumesCollector.h
+++ b/FWCore/Framework/interface/ESConsumesCollector.h
@@ -45,32 +45,50 @@ namespace edm {
     ESConsumesCollector& operator=(ESConsumesCollector&&) = default;
 
     // ---------- member functions ---------------------------
-    template <typename Product>
-    auto consumes(ESInputTag const& tag) {
-      return ESGetTokenT<Product>{tag};
-    }
-
     template <typename Product, typename Record>
     auto consumes(ESInputTag const& tag) {
-      return ESGetTokenT<Product>{tag};
+      return ESGetToken<Product,Record>{tag};
     }
 
-    template <typename Product>
-    auto consumes(eventsetup::EventSetupRecordKey const&, ESInputTag const& tag) {
-      return ESGetTokenT<Product>{tag};
-    }
+  protected:
+    explicit ESConsumesCollector(ESProducer* const iConsumer) :
+    m_consumer{iConsumer}
+    {}
 
   private:
-    //only ESProducer is allowed to make an instance of this class
-    friend class ESProducer;
-
-    explicit ESConsumesCollector(ESProducer* const iConsumer) :
-      m_consumer{iConsumer}
-    {}
 
     // ---------- member data --------------------------------
     edm::propagate_const<ESProducer*> m_consumer{nullptr};
   };
+  
+  template<typename RECORD>
+  class ESConsumesCollectorT : public ESConsumesCollector {
+  public:
+    
+    ESConsumesCollectorT() = delete;
+    ESConsumesCollectorT(ESConsumesCollectorT<RECORD> const&) = default;
+    ESConsumesCollectorT(ESConsumesCollectorT<RECORD>&&) = default;
+    ESConsumesCollectorT<RECORD>& operator=(ESConsumesCollectorT<RECORD> const&) = default;
+    ESConsumesCollectorT<RECORD>& operator=(ESConsumesCollectorT<RECORD>&&) = default;
+    
+    // ---------- member functions ---------------------------
+    using ESConsumesCollector::consumes;
+    
+    template <typename Product>
+    auto consumes(ESInputTag const& tag) {
+      return consumes<Product, RECORD>(tag);
+    }
+    
+  private:
+    //only ESProducer is allowed to make an instance of this class
+    friend class ESProducer;
+    
+    explicit ESConsumesCollectorT(ESProducer* const iConsumer) :
+    ESConsumesCollector(iConsumer)
+    {}
+    
+  };
+
 }
 
 

--- a/FWCore/Framework/interface/ESHandle.h
+++ b/FWCore/Framework/interface/ESHandle.h
@@ -46,6 +46,14 @@ class ESHandleBase {
 
       bool failedToGet() const { return bool(whyFailedFactory_); }
 
+      explicit operator bool () const {
+         return isValid();
+      }
+  
+      bool operator!() const {
+        return not isValid();
+      }
+
       void swap(ESHandleBase& iOther) {
          std::swap(data_, iOther.data_);
          std::swap(description_, iOther.description_);

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -148,7 +148,7 @@ namespace edm {
         method in order to do the registration with the EventSetup
     */
     template<typename T, typename TReturn, typename TRecord, typename TArg>
-    ESConsumesCollector setWhatProduced(T* iThis,
+    ESConsumesCollectorT<TRecord> setWhatProduced(T* iThis,
                          TReturn (T ::* iMethod)(const TRecord&),
                          const TArg& iDec,
                          const es::Label& iLabel = {}) {
@@ -164,7 +164,7 @@ namespace edm {
                        static_cast<const typename eventsetup::produce::product_traits<TReturn>::type *>(nullptr),
                        static_cast<const TRecord*>(nullptr),
                        iLabel);
-      return ESConsumesCollector{iThis};
+      return ESConsumesCollectorT<TRecord>{iThis};
     }
 
     ESProducer(const ESProducer&) = delete; // stop default

--- a/FWCore/Framework/interface/ESValidHandle.h
+++ b/FWCore/Framework/interface/ESValidHandle.h
@@ -1,0 +1,78 @@
+#ifndef FWCore_Framework_ESValidHandle_h
+#define FWCore_Framework_ESValidHandle_h
+// -*- C++ -*-
+//
+// Package:     Framework
+// Class  :     ESValidHandle
+//
+/**\class ESValidHandle ESValidHandle.h FWCore/Framework/interface/ESValidHandle.h
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Chris Jones
+// Created:     Tue Feb  5 14:47:35 EST 2019
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/ComponentDescription.h"
+
+#include <exception>
+#include <memory>
+#include <utility>
+
+namespace edm {
+
+  namespace esvhhelper {
+    void throwIfNotValid(const void*) noexcept(false);
+  }
+
+template<typename T>
+class ESValidHandle {
+   public:
+      typedef T value_type;
+
+      ESValidHandle() = delete;
+      ESValidHandle(T const& iData, edm::eventsetup::ComponentDescription const* desc) noexcept :
+      data_{&iData},
+      description_{desc} {}
+
+      ESValidHandle(ESValidHandle<T> const&) = default;
+      ESValidHandle(ESValidHandle<T>&&) = default;
+      ESValidHandle& operator=(ESValidHandle<T> const&) = default;
+      ESValidHandle& operator=(ESValidHandle<T>&&) = default;
+
+      // ---------- const member functions ---------------------
+      T const* product() const noexcept { return data_; }
+      T const* operator->() const noexcept { return product(); }
+      T const& operator*() const noexcept { return *product(); }
+      // ---------- static member functions --------------------
+      static constexpr bool transientAccessOnly = false;
+
+      // ---------- member functions ---------------------------
+   private:
+      T const* data_{nullptr};
+      edm::eventsetup::ComponentDescription const* description_{nullptr};
+
+};
+
+  /** Take a handle (e.g. edm::ESHandle<T>) and
+   create a edm::ESValidHandle<T>. If the argument is an invalid handle,
+   an exception will be thrown.
+   */
+  template<typename U>
+  auto
+  makeESValid(const U& iOtherHandleType) noexcept(false) {
+    esvhhelper::throwIfNotValid(iOtherHandleType.product());
+    //because of the check, we know this is valid and do not have to check again
+    return ESValidHandle<typename U::value_type>(*iOtherHandleType.product(), iOtherHandleType.description());
+  }
+
+}
+#endif

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -42,8 +42,8 @@
 namespace edm {
    class ActivityRegistry;
    class ESInputTag;
-   template <class T>
-   class ESGetTokenT;
+   template <class T, class R>
+   class ESGetToken;
    class PileUp;
 
    namespace eventsetup {
@@ -97,9 +97,15 @@ namespace edm {
            return rec.get(iTag, iHolder);
         }
 
-      template <typename T>
-      bool getData(const ESGetTokenT<T>& iToken, ESHandle<T>& iHolder) const {
-        return getData(iToken.m_tag, iHolder);
+      template <typename T, typename R>
+       ESHandle<T> getHandle(const ESGetToken<T, R>& iToken) const {
+          if constexpr ( std::is_same_v<R, edm::DefaultRecord> ) {
+             auto const& rec = this->get<eventsetup::default_record_t<ESHandle<T>>>();
+             return rec.getHandle(iToken);
+          } else {
+             auto const& rec = this->get<R>();
+             return rec.getHandle(iToken);
+          }
       }
 
       std::optional<eventsetup::EventSetupRecordGeneric> find(const eventsetup::EventSetupRecordKey& iKey) const {

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -97,6 +97,17 @@ namespace edm {
            return rec.get(iTag, iHolder);
         }
 
+      template< typename T, typename R>
+        T const& getData(const ESGetToken<T, R>& iToken) const noexcept(false) {
+           return this->get<std::conditional_t<std::is_same_v<R, edm::DefaultRecord>,
+                                               eventsetup::default_record_t<ESHandle<T>>,
+                                               R>>().get(iToken);
+        }
+        template< typename T, typename R>
+        T const& getData(ESGetToken<T, R>& iToken) const noexcept(false) {
+           return this->getData( const_cast<const ESGetToken<T,R>&>(iToken));
+        }
+
       template <typename T, typename R>
        ESHandle<T> getHandle(const ESGetToken<T, R>& iToken) const {
           if constexpr ( std::is_same_v<R, edm::DefaultRecord> ) {

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -147,11 +147,6 @@ namespace edm {
             }
          }
 
-         template<typename T>
-         bool get(ESGetTokenT<T> const& iToken, ESHandle<T>& iHandle) const {
-            return get(iToken.m_tag, iHandle);
-         }
-
          ///returns false if no data available for key
          bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
 
@@ -187,6 +182,14 @@ namespace edm {
            impl_->fillRegisteredDataKeys(oToFill);
          }
       protected:
+
+         template<typename T, typename R>
+         ESHandle<T> getHandleImpl(ESGetToken<T,R> const& iToken) const {
+           ESHandle<T> h;
+           (void) get(iToken.m_tag, h);
+           return h;
+         }
+        
 
          DataProxy const* find(DataKey const& aKey) const ;
 

--- a/FWCore/Framework/interface/EventSetupRecordImplementation.h
+++ b/FWCore/Framework/interface/EventSetupRecordImplementation.h
@@ -57,6 +57,26 @@ namespace edm {
            return getHandleImpl(iToken);
          }
 
+         using EventSetupRecord::get;
+        
+         template<typename PRODUCT>
+         PRODUCT const& get(ESGetToken<PRODUCT,T> const& iToken) const {
+           return *getHandleImpl(iToken);
+         }
+        template<typename PRODUCT>
+        PRODUCT const& get(ESGetToken<PRODUCT,T>& iToken) const {
+          return *getHandleImpl(const_cast<const ESGetToken<PRODUCT,T>&>(iToken));
+        }
+
+         template<typename PRODUCT>
+         PRODUCT const& get(ESGetToken<PRODUCT,edm::DefaultRecord> const& iToken) const {
+           static_assert(std::is_same_v<T, eventsetup::default_record_t<ESHandle<PRODUCT>>>, "The Record being used to retrieve the product is not the default record for the product type");
+           return *getHandleImpl(iToken);
+         }
+        template<typename PRODUCT>
+        PRODUCT const& get(ESGetToken<PRODUCT,edm::DefaultRecord>& iToken) const {
+          return get(const_cast<const ESGetToken<PRODUCT,edm::DefaultRecord>&>(iToken) );
+        }
 
          // ---------- static member functions --------------------
          static EventSetupRecordKey keyForClass()  {

--- a/FWCore/Framework/interface/EventSetupRecordImplementation.h
+++ b/FWCore/Framework/interface/EventSetupRecordImplementation.h
@@ -25,6 +25,8 @@
 
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Framework/interface/data_default_record_trait.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 // system include files
 
@@ -43,6 +45,18 @@ namespace edm {
          EventSetupRecordKey key() const override {
             return EventSetupRecordKey::makeKey<T>();
          }
+
+         template<typename PRODUCT>
+         ESHandle<PRODUCT> getHandle(ESGetToken<PRODUCT,T> const& iToken) const {
+           return getHandleImpl(iToken);
+         }
+
+         template<typename PRODUCT>
+         ESHandle<PRODUCT> getHandle(ESGetToken<PRODUCT,edm::DefaultRecord> const& iToken) const {
+           static_assert(std::is_same_v<T, eventsetup::default_record_t<ESHandle<PRODUCT>>>, "The Record being used to retrieve the product is not the default record for the product type");
+           return getHandleImpl(iToken);
+         }
+
 
          // ---------- static member functions --------------------
          static EventSetupRecordKey keyForClass()  {

--- a/FWCore/Framework/src/ESValidHandle.cc
+++ b/FWCore/Framework/src/ESValidHandle.cc
@@ -1,0 +1,11 @@
+#include "FWCore/Framework/interface/ESValidHandle.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace edm::esvhhelper {
+  void
+  throwIfNotValid(const void* iProduct) noexcept(false) {
+    if(nullptr == iProduct) {
+      throw cms::Exception("Invalid Product")<<"Attempted to fill a edm::ESValidHandle with an invalid product";
+    }
+  }
+}

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/DataProxyProvider.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESValidHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
@@ -201,6 +202,7 @@ void testEventsetupRecord::getTest()
    CPPUNIT_ASSERT(not dummyPtr);
    CPPUNIT_ASSERT(dummyPtr.failedToGet());
    CPPUNIT_ASSERT_THROW(*dummyPtr, NoDataExceptionType) ;
+   CPPUNIT_ASSERT_THROW(makeESValid(dummyPtr), cms::Exception) ;
    //CDJ do this replace
    //CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr),NoDataExceptionType);
 
@@ -227,6 +229,7 @@ void testEventsetupRecord::getTest()
    CPPUNIT_ASSERT(!dummyPtr.failedToGet());
    CPPUNIT_ASSERT(dummyPtr.isValid());
    CPPUNIT_ASSERT(dummyPtr);
+   (void) makeESValid(dummyPtr);
 
    CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
 

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -196,7 +196,9 @@ void testEventsetupRecord::getTest()
    DummyRecord dummyRecord;
    dummyRecord.setImpl(&dummyRecordImpl);
    ESHandle<Dummy> dummyPtr;
-   dummyRecord.get(dummyPtr);
+   CPPUNIT_ASSERT(not dummyRecord.get(dummyPtr));
+   CPPUNIT_ASSERT(not dummyPtr.isValid());
+   CPPUNIT_ASSERT(not dummyPtr);
    CPPUNIT_ASSERT(dummyPtr.failedToGet());
    CPPUNIT_ASSERT_THROW(*dummyPtr, NoDataExceptionType) ;
    //CDJ do this replace
@@ -223,6 +225,8 @@ void testEventsetupRecord::getTest()
 
    dummyRecord.get("working",dummyPtr);
    CPPUNIT_ASSERT(!dummyPtr.failedToGet());
+   CPPUNIT_ASSERT(dummyPtr.isValid());
+   CPPUNIT_ASSERT(dummyPtr);
 
    CPPUNIT_ASSERT(&(*dummyPtr) == &myDummy);
 

--- a/FWCore/Framework/test/stubs/TestESDummyDataAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestESDummyDataAnalyzer.cc
@@ -45,7 +45,7 @@ private:
   int m_counter{};
   int m_totalCounter{};
   int const m_totalNEvents;
-  edm::ESGetTokenT<edm::eventsetup::test::DummyData> const m_esToken;
+  edm::ESGetToken<edm::eventsetup::test::DummyData, edm::DefaultRecord> const m_esToken;
 };
 
 TestESDummyDataAnalyzer::TestESDummyDataAnalyzer(const edm::ParameterSet& iConfig) :
@@ -70,8 +70,7 @@ TestESDummyDataAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetu
     }
   }
 
-  ESHandle<edm::eventsetup::test::DummyData> pData;
-  iSetup.getData(m_esToken, pData);
+  ESHandle<edm::eventsetup::test::DummyData> pData = iSetup.getHandle(m_esToken);
 
   if(m_expectedValue != pData->value_) {
     throw cms::Exception("WrongValue")<<"got value "<<pData->value_<<" but expected "<<m_expectedValue;

--- a/FWCore/Integration/test/WhatsItESProducer.cc
+++ b/FWCore/Integration/test/WhatsItESProducer.cc
@@ -61,11 +61,11 @@ class WhatsItESProducer : public edm::ESProducer {
 
    private:
       // ----------member data ---------------------------
-      edm::ESGetTokenT<edmtest::Doodad> token_;
-      edm::ESGetTokenT<edmtest::Doodad> tokenA_;
-      edm::ESGetTokenT<edmtest::Doodad> tokenB_;
-      edm::ESGetTokenT<edmtest::Doodad> tokenC_;
-      edm::ESGetTokenT<edmtest::Doodad> tokenD_;
+      edm::ESGetToken<edmtest::Doodad,GadgetRcd> token_;
+      edm::ESGetToken<edmtest::Doodad,GadgetRcd> tokenA_;
+      edm::ESGetToken<edmtest::Doodad,GadgetRcd> tokenB_;
+      edm::ESGetToken<edmtest::Doodad,GadgetRcd> tokenC_;
+      edm::ESGetToken<edmtest::Doodad,GadgetRcd> tokenD_;
 };
 
 //
@@ -118,8 +118,7 @@ WhatsItESProducer::~WhatsItESProducer()
 WhatsItESProducer::ReturnType
 WhatsItESProducer::produce(const GadgetRcd& iRecord)
 {
-   edm::ESHandle<Doodad> doodad;
-   iRecord.get(token_, doodad);
+   edm::ESHandle<Doodad> doodad = iRecord.getHandle(token_);
    auto pWhatsIt = std::make_unique<WhatsIt>() ;
    pWhatsIt->a = doodad->a;
    return pWhatsIt ;
@@ -128,8 +127,7 @@ WhatsItESProducer::produce(const GadgetRcd& iRecord)
 WhatsItESProducer::ReturnTypeA
 WhatsItESProducer::produceA(const GadgetRcd& iRecord)
 {
-   edm::ESHandle<Doodad> doodad;
-   iRecord.get(tokenA_, doodad);
+   edm::ESHandle<Doodad> doodad = iRecord.getHandle(tokenA_);
    auto pWhatsIt = std::make_unique<WhatsIt>() ;
    pWhatsIt->a = doodad->a;
    return pWhatsIt ;
@@ -138,8 +136,7 @@ WhatsItESProducer::produceA(const GadgetRcd& iRecord)
 WhatsItESProducer::ReturnTypeB
 WhatsItESProducer::produceB(const GadgetRcd& iRecord)
 {
-   edm::ESHandle<Doodad> doodad;
-   iRecord.get(tokenB_ ,doodad);
+   edm::ESHandle<Doodad> doodad = iRecord.getHandle(tokenB_);
    auto pWhatsIt = std::make_shared<WhatsIt>() ;
    pWhatsIt->a = doodad->a;
    return pWhatsIt ;
@@ -148,8 +145,7 @@ WhatsItESProducer::produceB(const GadgetRcd& iRecord)
 WhatsItESProducer::ReturnTypeC
 WhatsItESProducer::produceC(const GadgetRcd& iRecord)
 {
-   edm::ESHandle<Doodad> doodad;
-   iRecord.get(tokenC_, doodad);
+   edm::ESHandle<Doodad> doodad = iRecord.getHandle(tokenC_);
    auto pWhatsIt = std::make_shared<WhatsIt>() ;
    pWhatsIt->a = doodad->a;
    return pWhatsIt ;
@@ -158,8 +154,7 @@ WhatsItESProducer::produceC(const GadgetRcd& iRecord)
 WhatsItESProducer::ReturnTypeD
 WhatsItESProducer::produceD(const GadgetRcd& iRecord)
 {
-   edm::ESHandle<Doodad> doodad;
-   iRecord.get(tokenD_, doodad);
+   edm::ESHandle<Doodad> doodad = iRecord.getHandle(tokenD_);
    auto pWhatsIt = std::make_optional<WhatsIt>() ;
    pWhatsIt->a = doodad->a;
    return pWhatsIt ;

--- a/FWCore/Utilities/interface/ESGetToken.h
+++ b/FWCore/Utilities/interface/ESGetToken.h
@@ -28,8 +28,8 @@ namespace edm {
 
   // A ESGetToken is created by calls to 'esConsumes' from an EDM
   // module.
-  template<typename ESProduct>
-  class ESGetTokenT {
+  template<typename ESProduct, typename ESRecord>
+  class ESGetToken {
     friend class EDConsumerBase;
     friend class ESProducer;
     friend class ESConsumesCollector;
@@ -38,10 +38,10 @@ namespace edm {
     friend class eventsetup::EventSetupRecord;
 
   public:
-    ESGetTokenT() = default;
+    ESGetToken() = default;
 
   private:
-    explicit ESGetTokenT(ESInputTag const& tag) : m_tag{tag} {}
+    explicit ESGetToken(ESInputTag const& tag) : m_tag{tag} {}
 
     ESInputTag m_tag{};
   };


### PR DESCRIPTION
- Changed name to `ESGetToken` since it requires a type
- Now requires specifying from what Record to do retrieval. The use of `edm::DefaultRecord` is supported.
- Changed name of functions using token to getHandle to match Event case. 
- Functions `EventSetup::getData` and `Record::get` now directly return the product without using a `ESHandle`
- Added a typed consumes collector to make it easier to call consumes from ESProducers
- Added an `edm::ESValidHandle` to mirror `edm::ValidHandle`