### PR TITLE
fixing missing pointer between lumi boundaries in 102x

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
@@ -98,6 +98,7 @@ bool LHAupLesHouches::setEvent(int inProcId)
     fEvAttributes->clear();
     infoPtr->eventAttributes = fEvAttributes;
   } else {
+    infoPtr->eventAttributes = fEvAttributes;  // make sure still there
     infoPtr->eventAttributes->clear();
   }
 


### PR DESCRIPTION
backport #25850 