### PR TITLE
Add label for pixel digitizer in SiPixelQualityESProducer

### DIFF
--- a/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
@@ -55,10 +55,11 @@ class SiPixelQualityESProducer : public edm::ESProducer, public edm::EventSetupR
   
  private:
   
+  std::string label;
   edm::FileInPath fp_;
   typedef std::vector< edm::ParameterSet > Parameters;
   Parameters toGet;
   std::unique_ptr<SiPixelQuality> get_pointer(const SiPixelQualityRcd & iRecord, std::string label);
-
+  
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
@@ -44,8 +44,9 @@ class SiPixelQualityESProducer : public edm::ESProducer, public edm::EventSetupR
   
   
   /* virtual*/ std::unique_ptr<SiPixelQuality> produce(const SiPixelQualityRcd & iRecord) ;
+  /* virtual*/ std::unique_ptr<SiPixelQuality> produceWithLabel(const SiPixelQualityRcd & iRecord);
   
-protected:
+ protected:
   
   void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
@@ -57,7 +58,7 @@ protected:
   edm::FileInPath fp_;
   typedef std::vector< edm::ParameterSet > Parameters;
   Parameters toGet;
-
+  std::unique_ptr<SiPixelQuality> get_pointer(const SiPixelQualityRcd & iRecord, std::string label);
 
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
@@ -37,14 +37,16 @@ using namespace edm;
 
 SiPixelQualityESProducer::SiPixelQualityESProducer(const edm::ParameterSet& conf_) 
   : //fp_(conf_.getParameter<edm::FileInPath>("file")),
-    toGet(conf_.getParameter<Parameters>("ListOfRecordToMerge"))
+  label(conf_.exists("siPixelQualityLabel")?conf_.getParameter<std::string>("siPixelQualityLabel"):""),
+  toGet(conf_.getParameter<Parameters>("ListOfRecordToMerge"))
 {
-   edm::LogInfo("SiPixelQualityESProducer::SiPixelQualityESProducer");
+  edm::LogInfo("SiPixelQualityESProducer::SiPixelQualityESProducer");
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this);
-  setWhatProduced(this, &SiPixelQualityESProducer::produceWithLabel, edm::es::Label("forDigitizer"));
-  
+  if (label == "forDigitizer"){
+    setWhatProduced(this, &SiPixelQualityESProducer::produceWithLabel, edm::es::Label(label));
+  }
   findingRecord<SiPixelQualityRcd>();  
 }
 
@@ -105,7 +107,7 @@ std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produce(const SiPixelQ
 }
 std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produceWithLabel(const SiPixelQualityRcd & iRecord)
 {
-  return get_pointer(iRecord,  "forDigitizer");
+  return get_pointer(iRecord, label);
 }
 
 void SiPixelQualityESProducer::setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, 

--- a/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
@@ -1,12 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-siPixelQualityESProducer = cms.ESProducer("SiPixelQualityESProducer",
-                ListOfRecordToMerge = cms.VPSet(
-                cms.PSet(  record = cms.string( "SiPixelQualityFromDbRcd" ),
-                                          tag = cms.string( "" )
-                                       ),
-                    cms.PSet(  record = cms.string( "SiPixelDetVOffRcd" ),
-                                              tag = cms.string( "" )
-                                           )
-                )
-        )
+siPixelQualityESProducer = cms.ESProducer(
+    "SiPixelQualityESProducer",
+    ListOfRecordToMerge = cms.VPSet(
+        cms.PSet(  record = cms.string( "SiPixelQualityFromDbRcd" ),
+                   tag = cms.string( "" )
+                   ),
+        cms.PSet(  record = cms.string( "SiPixelDetVOffRcd" ),
+                   tag = cms.string( "" )
+                   )
+        ),
+    siPixelQualityLabel = cms.string(""),
+    )

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -56,7 +56,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    :  '105X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '103X_upgrade2018_realistic_HI_v11',
+    'phase1_2018_realistic_hi' :  '103X_upgrade2018_realistic_HI_v12',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail' :  '105X_upgrade2018_realistic_HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode

--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -8,5 +8,6 @@ from Configuration.Eras.Modifier_run2_HB_2018_cff import run2_HB_2018
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018
+from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
 
-Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017]), run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018)
+Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017]), run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018)

--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -6,6 +6,8 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
+from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions)
+
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions, run2_SiPixel_2018)
 

--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -6,8 +6,6 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
-from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
 
-
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions, run2_SiPixel_2018)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions)
 

--- a/Configuration/Eras/python/Modifier_run2_SiPixel_2018_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_SiPixel_2018_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for SiPixel-specific changes
+
+run2_SiPixel_2018 =  cms.Modifier()

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -39,6 +39,7 @@ def _modifyPixelDigitizerForPhase1Pixel( digitizer ) :
     
 
 SiPixelSimBlock = cms.PSet(
+    SiPixelQualityLabel = cms.string(''),
     KillBadFEDChannels = cms.bool(False),
     UseReweighting = cms.bool(False),
     PrintClusters = cms.bool(False),
@@ -102,6 +103,10 @@ SiPixelSimBlock = cms.PSet(
 #
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify( SiPixelSimBlock, func=_modifyPixelDigitizerForPhase1Pixel )
+
+# To use the label for 2018 data, uncomment next two lines, new GT needed
+#from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
+#run2_SiPixel_2018.toModify(SiPixelSimBlock, SiPixelQualityLabel = 'forDigitizer',)
 
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 premix_stage1.toModify(SiPixelSimBlock,

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -104,9 +104,11 @@ SiPixelSimBlock = cms.PSet(
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify( SiPixelSimBlock, func=_modifyPixelDigitizerForPhase1Pixel )
 
-# To use the label for 2018 data, uncomment next two lines, new GT needed
-#from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
-#run2_SiPixel_2018.toModify(SiPixelSimBlock, SiPixelQualityLabel = 'forDigitizer',)
+# use Label 'forDigitizer' for years >= 2018
+from CalibTracker.SiPixelESProducers.SiPixelQualityESProducer_cfi import siPixelQualityESProducer
+from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
+run2_SiPixel_2018.toModify(siPixelQualityESProducer,siPixelQualityLabel = 'forDigitizer',)
+run2_SiPixel_2018.toModify(SiPixelSimBlock, SiPixelQualityLabel = 'forDigitizer',)
 
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 premix_stage1.toModify(SiPixelSimBlock,

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -118,7 +118,7 @@ void SiPixelDigitizerAlgorithm::init(const edm::EventSetup& es) {
     theSiPixelGainCalibrationService_->setESObjects( es );
   }
   if(use_deadmodule_DB_) {
-    es.get<SiPixelQualityRcd>().get(SiPixelBadModule_);
+    es.get<SiPixelQualityRcd>().get(siPixelQualityLabel, SiPixelBadModule_);
   }
   if(use_LorentzAngle_DB_) {
     // Get Lorentz angle from DB record
@@ -191,7 +191,8 @@ void SiPixelDigitizerAlgorithm::init(const edm::EventSetup& es) {
 //=========================================================================
 
 SiPixelDigitizerAlgorithm::SiPixelDigitizerAlgorithm(const edm::ParameterSet& conf) :
-
+  
+  siPixelQualityLabel(conf.getParameter<std::string>("SiPixelQualityLabel")), //string to specify SiPixelQuality label
   _signal(),
   makeDigiSimLinks_(conf.getUntrackedParameter<bool>("makeDigiSimLinks", true)),
   use_ineff_from_db_(conf.getParameter<bool>("useDB")),

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -96,6 +96,7 @@ class SiPixelDigitizerAlgorithm  {
   edm::ESHandle<SiPixelLorentzAngle> SiPixelLorentzAngle_;
 
   //Accessing Dead pixel modules from DB:
+  std::string siPixelQualityLabel;
   edm::ESHandle<SiPixelQuality> SiPixelBadModule_;
 
   //Accessing Map and Geom:


### PR DESCRIPTION
This PR introduces the label for the `SiPixelQualityRcd` in order to treat the damaged pixels behind broken DCDC converters the same way in data and in simulation. The PR was explained at the RECO meeting https://indico.cern.ch/event/787904/contributions/3288669/subcontributions/273135/attachments/1785559/2906928/tanjaReco_25012019.pdf.
The feature is switched off by default. In order to switch it on:
 - the new GT  containing `SiPixelQuality` with the label "forDigitizer" is needed 
 - the lines L108-109 in SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py should be uncommented 
The Era mechanism is used to activate the feature only for >= 2018

