### PR TITLE
Use unique_ptr in HiEgammaSCCorrectionMaker

### DIFF
--- a/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.cc
@@ -74,18 +74,15 @@ HiEgammaSCCorrectionMaker::HiEgammaSCCorrectionMaker(const edm::ParameterSet& ps
   produces<reco::SuperClusterCollection>(outputCollection_);
 
   // instanciate the correction algo object
-  energyCorrector_ = new HiEgammaSCEnergyCorrectionAlgo(sigmaElectronicNoise_, sCAlgo_, fCorrPset, verbosity_);
+  energyCorrector_ = std::make_unique<HiEgammaSCEnergyCorrectionAlgo>(sigmaElectronicNoise_, sCAlgo_, fCorrPset, verbosity_);
   
 
   // energy correction class
   if (applyEnergyCorrection_ )
-    EnergyCorrection_ = EcalClusterFunctionFactory::get()->create("EcalClusterEnergyCorrection", ps);
+    EnergyCorrection_ = std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create("EcalClusterEnergyCorrection", ps)};
 }
 
-HiEgammaSCCorrectionMaker::~HiEgammaSCCorrectionMaker()
-{
-  delete energyCorrector_;
-}
+HiEgammaSCCorrectionMaker::~HiEgammaSCCorrectionMaker() = default;
 
 void
 HiEgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es)
@@ -151,7 +148,7 @@ HiEgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es)
   {
      reco::SuperCluster newClus;
      if(applyEnergyCorrection_) 
-        newClus = energyCorrector_->applyCorrection(*aClus, *hitCollection, sCAlgo_, geometry_p, topology, EnergyCorrection_);
+        newClus = energyCorrector_->applyCorrection(*aClus, *hitCollection, sCAlgo_, geometry_p, topology, EnergyCorrection_.get());
      else
 	newClus=*aClus;
 

--- a/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.h
+++ b/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.h
@@ -46,13 +46,13 @@ class HiEgammaSCCorrectionMaker : public edm::stream::EDProducer<> {
 
    private:
 
-     EcalClusterFunctionBaseClass* EnergyCorrection_;
+     std::unique_ptr<EcalClusterFunctionBaseClass> EnergyCorrection_;
 
      // the debug level
      HiEgammaSCEnergyCorrectionAlgo::VerbosityLevel verbosity_;
 
      // pointer to the correction algo object
-     HiEgammaSCEnergyCorrectionAlgo *energyCorrector_;
+     std::unique_ptr<HiEgammaSCEnergyCorrectionAlgo> energyCorrector_;
     
      // vars for the correction algo
      bool applyEnergyCorrection_;


### PR DESCRIPTION
This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.