### PR TITLE
Manage PluginFactory plugins with unique_ptr in FastSim

### DIFF
--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -42,8 +42,8 @@ PixelTracksProducer::PixelTracksProducer(const edm::ParameterSet& conf) :
 
   const edm::ParameterSet& regfactoryPSet = conf.getParameter<edm::ParameterSet>("RegionFactoryPSet");
   std::string regfactoryName = regfactoryPSet.getParameter<std::string>("ComponentName");
-  theRegionProducer = TrackingRegionProducerFactory::get()->create(regfactoryName,
-	regfactoryPSet, consumesCollector());
+  theRegionProducer = std::unique_ptr<TrackingRegionProducer>{TrackingRegionProducerFactory::get()->create(regfactoryName,
+                                                                                                           regfactoryPSet, consumesCollector())};
   
   fitterToken = consumes<PixelFitter>(conf.getParameter<edm::InputTag>("Fitter"));
   filterToken = consumes<PixelTrackFilter>(conf.getParameter<edm::InputTag>("Filter"));
@@ -56,11 +56,7 @@ PixelTracksProducer::PixelTracksProducer(const edm::ParameterSet& conf) :
 
   
 // Virtual destructor needed.
-PixelTracksProducer::~PixelTracksProducer() {
-
-  delete theRegionProducer;
-
-} 
+PixelTracksProducer::~PixelTracksProducer() = default;
  
 
 // Functions that gets called by framework every event

--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.h
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.h
@@ -31,7 +31,7 @@ public:
 private:
 
   edm::EDGetTokenT<PixelFitter> fitterToken;
-  TrackingRegionProducer* theRegionProducer;
+  std::unique_ptr<TrackingRegionProducer> theRegionProducer;
 
   edm::EDGetTokenT<TrajectorySeedCollection> seedProducerToken;
   edm::EDGetTokenT<PixelTrackFilter> filterToken;

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -134,7 +134,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf)
     // seed finder selector
     if(conf.exists("seedFinderSelector"))
     {
-	seedFinderSelector.reset(new SeedFinderSelector(conf.getParameter<edm::ParameterSet>("seedFinderSelector"),consumesCollector()));
+	seedFinderSelector = std::make_unique<SeedFinderSelector>(conf.getParameter<edm::ParameterSet>("seedFinderSelector"),consumesCollector());
     }
 
     /// regions
@@ -143,7 +143,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf)
     // seed creator
     const edm::ParameterSet & seedCreatorPSet = conf.getParameter<edm::ParameterSet>("SeedCreatorPSet");
     std::string seedCreatorName = seedCreatorPSet.getParameter<std::string>("ComponentName");
-    seedCreator.reset(SeedCreatorFactory::get()->create( seedCreatorName, seedCreatorPSet));
+    seedCreator = std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create( seedCreatorName, seedCreatorPSet)};
 
 }
 

--- a/FastSimulation/Tracking/src/SeedFinderSelector.cc
+++ b/FastSimulation/Tracking/src/SeedFinderSelector.cc
@@ -30,13 +30,13 @@ SeedFinderSelector::SeedFinderSelector(const edm::ParameterSet & cfg,edm::Consum
     if(cfg.exists("pixelTripletGeneratorFactory"))
     {
         const edm::ParameterSet & tripletConfig = cfg.getParameter<edm::ParameterSet>("pixelTripletGeneratorFactory");
-        pixelTripletGenerator_.reset(HitTripletGeneratorFromPairAndLayersFactory::get()->create(tripletConfig.getParameter<std::string>("ComponentName"),tripletConfig,consumesCollector));
+        pixelTripletGenerator_ = std::unique_ptr<HitTripletGeneratorFromPairAndLayers>{HitTripletGeneratorFromPairAndLayersFactory::get()->create(tripletConfig.getParameter<std::string>("ComponentName"),tripletConfig,consumesCollector)};
     }
 
     if(cfg.exists("MultiHitGeneratorFactory"))
     {
         const edm::ParameterSet & tripletConfig = cfg.getParameter<edm::ParameterSet>("MultiHitGeneratorFactory");
-        multiHitGenerator_.reset(MultiHitGeneratorFromPairAndLayersFactory::get()->create(tripletConfig.getParameter<std::string>("ComponentName"),tripletConfig));
+        multiHitGenerator_ = std::unique_ptr<MultiHitGeneratorFromPairAndLayers>{MultiHitGeneratorFromPairAndLayersFactory::get()->create(tripletConfig.getParameter<std::string>("ComponentName"),tripletConfig)};
     }
 
     if(cfg.exists("CAHitTripletGeneratorFactory"))

--- a/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitProducer.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitProducer.cc
@@ -46,7 +46,7 @@ class TrackingRecHitProducer:
 {
     private:
         edm::EDGetTokenT<std::vector<PSimHit>> _simHitToken;
-        std::vector<TrackingRecHitAlgorithm*> _recHitAlgorithms;
+        std::vector<std::unique_ptr<TrackingRecHitAlgorithm>> _recHitAlgorithms;
         unsigned long long _trackerGeometryCacheID = 0;
         unsigned long long _trackerTopologyCacheID = 0;
         std::map<unsigned int, TrackingRecHitPipe> _detIdPipes;
@@ -79,11 +79,11 @@ TrackingRecHitProducer::TrackingRecHitProducer(const edm::ParameterSet& config)
         const std::string pluginType = pluginConfig.getParameter<std::string>("type");
         const std::string pluginName = pluginConfig.getParameter<std::string>("name");
 
-        TrackingRecHitAlgorithm* recHitAlgorithm = TrackingRecHitAlgorithmFactory::get()->tryToCreate(pluginType,pluginName,pluginConfig,consumeCollector);
+        std::unique_ptr<TrackingRecHitAlgorithm> recHitAlgorithm{TrackingRecHitAlgorithmFactory::get()->tryToCreate(pluginType,pluginName,pluginConfig,consumeCollector)};
         if (recHitAlgorithm)
         {
             edm::LogInfo("TrackingRecHitProducer: ")<< "adding plugin type '"<<pluginType<<"' as '"<<pluginName<<"'"<<std::endl;
-            _recHitAlgorithms.push_back(recHitAlgorithm);
+            _recHitAlgorithms.push_back(std::move(recHitAlgorithm));
         }
         else
         {
@@ -100,12 +100,6 @@ TrackingRecHitProducer::TrackingRecHitProducer(const edm::ParameterSet& config)
 
 TrackingRecHitProducer::~TrackingRecHitProducer()
 {
-    for (TrackingRecHitAlgorithm* algo: _recHitAlgorithms)
-    {
-        delete algo;
-    }
-    _recHitAlgorithms.clear();
-
     //--- Delete the templates. This is safe even if thePixelTemp_ vector is empty.
     for (auto x : _pixelTempStore) x.destroy();
 }
@@ -113,7 +107,7 @@ TrackingRecHitProducer::~TrackingRecHitProducer()
 
 void TrackingRecHitProducer::beginStream(edm::StreamID id)
 {
-    for (TrackingRecHitAlgorithm* algo: _recHitAlgorithms)
+    for (auto& algo: _recHitAlgorithms)
     {
         algo->beginStream(id);
     }
@@ -139,7 +133,7 @@ void TrackingRecHitProducer::beginRun(edm::Run const& run, const edm::EventSetup
 	   << "SiPixel Templates not loaded correctly from the DB object!" << std::endl;
     }
 
-    for (TrackingRecHitAlgorithm* algo: _recHitAlgorithms)
+    for (auto& algo: _recHitAlgorithms)
     {
       algo->beginRun(run, eventSetup, pixelTemplateDBObject, _pixelTempStore );
     }
@@ -174,11 +168,11 @@ void TrackingRecHitProducer::setupDetIdPipes(const edm::EventSetup& eventSetup)
             TrackingRecHitPipe pipe;
             for (unsigned int ialgo = 0; ialgo < _recHitAlgorithms.size(); ++ialgo)
             {
-                TrackingRecHitAlgorithm* algo = _recHitAlgorithms[ialgo];
+                auto& algo = _recHitAlgorithms[ialgo];
                 if (selector.passSelection(algo->getSelectionString()))
                 {
                     numberOfDetIdsPerAlgorithm[ialgo]+=1;
-                    pipe.addAlgorithm(algo);
+                    pipe.addAlgorithm(algo.get());
                 }
             }
             if (pipe.size()==0)
@@ -197,7 +191,7 @@ void TrackingRecHitProducer::produce(edm::Event& event, const edm::EventSetup& e
     //resetup pipes if new iov
     setupDetIdPipes(eventSetup);
     //begin event
-    for (TrackingRecHitAlgorithm* algo: _recHitAlgorithms)
+    for (auto& algo: _recHitAlgorithms)
     {
         algo->beginEvent(event,eventSetup);
     }
@@ -206,11 +200,11 @@ void TrackingRecHitProducer::produce(edm::Event& event, const edm::EventSetup& e
     edm::Handle<std::vector<PSimHit>> simHits;
     event.getByToken(_simHitToken,simHits);
 
-    std::unique_ptr<FastTrackerRecHitCollection> output_recHits(new FastTrackerRecHitCollection);
+    auto output_recHits = std::make_unique<FastTrackerRecHitCollection>();
     output_recHits->reserve(simHits->size());
 
     edm::RefProd<FastTrackerRecHitCollection> output_recHits_refProd = event.getRefBeforePut<FastTrackerRecHitCollection>();
-    std::unique_ptr<FastTrackerRecHitRefCollection> output_recHitRefs(new FastTrackerRecHitRefCollection(simHits->size(),FastTrackerRecHitRef()));
+    auto output_recHitRefs = std::make_unique<FastTrackerRecHitRefCollection>(simHits->size(),FastTrackerRecHitRef());
 
     std::map<unsigned int,std::vector<std::pair<unsigned int,const PSimHit*>>> simHitsIdPairPerDetId;
     for (unsigned int ihit = 0; ihit < simHits->size(); ++ihit)
@@ -261,7 +255,7 @@ void TrackingRecHitProducer::produce(edm::Event& event, const edm::EventSetup& e
     }
 
     //end event
-    for (TrackingRecHitAlgorithm* algo: _recHitAlgorithms)
+    for (auto& algo: _recHitAlgorithms)
     {
         algo->endEvent(event,eventSetup);
     }
@@ -280,7 +274,7 @@ void TrackingRecHitProducer::produce(edm::Event& event, const edm::EventSetup& e
 
 void TrackingRecHitProducer::endStream()
 {
-    for (TrackingRecHitAlgorithm* algo: _recHitAlgorithms)
+    for (auto& algo: _recHitAlgorithms)
     {
         algo->endStream();
     }


### PR DESCRIPTION
Also always use the `unique_ptr` constructor. This PR is preparatory work to change the PluginFactory to return a `std::unique_ptr`.

Tested in CMSSW_10_5_X_2019-02-05-1100 , no changes expected.